### PR TITLE
fix(run_helpers): reduce false positives in edit intent inference

### DIFF
--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -309,9 +309,11 @@ pub(crate) fn infer_task_edit_requirement(prompt: &str) -> Option<bool> {
     }
 
     // Tokenize once: lowercase words with trailing/leading punctuation stripped.
+    // Filter empty tokens to handle prompts starting with emoji/bullets (e.g. "✅ Fix").
     let tokens: Vec<&str> = prompt_lower
         .split_whitespace()
         .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
+        .filter(|w| !w.is_empty())
         .collect();
 
     // Phase 1: Unambiguous multi-word token sequences.
@@ -459,6 +461,18 @@ mod tests {
     #[test]
     fn infer_edit_bare_fix_as_first_verb() {
         let result = infer_task_edit_requirement("Fix issues in the parser");
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn infer_edit_emoji_prefix_does_not_break_verb_detection() {
+        let result = infer_task_edit_requirement("✅ Fix the bug in auth");
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn infer_edit_bullet_prefix_does_not_break_verb_detection() {
+        let result = infer_task_edit_requirement("- Implement the new parser");
         assert_eq!(result, Some(true));
     }
 }


### PR DESCRIPTION
## Summary
- Rewrote `infer_task_edit_requirement()` from substring matching to token-based matching
- Fixes false positives: "prefix the" no longer matches "fix the", "explain the implementation" no longer matches "implement"
- Adds polite prefix skipping (please, can you, could you) for ambiguous verbs
- 17 tests covering false positives, polite prefixes, and all existing behavior

## Test plan
- [x] `cargo clippy -p cli-sub-agent` — clean
- [x] `cargo test -p cli-sub-agent -- infer_edit` — 17/17 passed
- [x] `just test` — 203/203 passed
- [x] `csa review --branch main` — reviewed, fixes applied
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)