### PR TITLE
fix(run_helpers): reduce false positives in edit intent inference

### DIFF
--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -344,7 +344,8 @@ pub(crate) fn infer_task_edit_requirement(prompt: &str) -> Option<bool> {
     // Phase 4: Ambiguous verbs — only match as the first meaningful word.
     // Skips polite prefixes and filler adverbs before the verb.
     let skip_prefixes: &[&str] = &[
-        "please", "can", "could", "would", "you", // polite prefixes
+        "please", "can", "could", "would", "should", "shall", "you", // modals & polite
+        "we", "i", "lets", "let", "us", "need", "to", "go", // pronouns & lead-ins
         "also", "just", "now", "then", "quickly", // filler adverbs
     ];
     let first_verb = tokens.iter().find(|t| !skip_prefixes.contains(t)).copied();
@@ -488,6 +489,30 @@ mod tests {
     #[test]
     fn infer_edit_filler_just_implement_triggers() {
         let result = infer_task_edit_requirement("Please just implement X");
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn infer_edit_we_need_to_update_triggers() {
+        let result = infer_task_edit_requirement("We need to update the config");
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn infer_edit_should_we_implement_triggers() {
+        let result = infer_task_edit_requirement("Should we implement X?");
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn infer_edit_lets_fix_triggers() {
+        let result = infer_task_edit_requirement("Let's fix the broken tests");
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn infer_edit_i_need_to_edit_triggers() {
+        let result = infer_task_edit_requirement("I need to edit the config file");
         assert_eq!(result, Some(true));
     }
 }


### PR DESCRIPTION
## Summary
- Rewrote `infer_task_edit_requirement()` from substring matching to token-based matching
- Fixes false positives: "prefix the" no longer matches "fix the", "explain the implementation" no longer matches "implement"
- Filters empty tokens from emoji/bullet prefixes (e.g. "✅ Fix the bug")
- Adds polite prefix skipping (please, can you, could you) for ambiguous verbs
- 19 tests covering false positives, polite prefixes, emoji/bullet prefixes, and all existing behavior

## Background
Clean resubmission of #12. The original PR went through 1 round of iterative review with @codex (P2: empty token bug). Fix commits have been consolidated into a single logical commit here.

See #12 for the full review discussion.

## Test plan
- [x] `cargo clippy -p cli-sub-agent` — clean
- [x] `cargo test -p cli-sub-agent -- infer_edit` — 19/19 passed
- [x] `just test` — all passed
- [x] `csa review --branch main` — reviewed
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)