### PR TITLE
docs(skills): update pr-codex-bot Step 8 to use csa debate

### DIFF
--- a/skills/pr-codex-bot/SKILL.md
+++ b/skills/pr-codex-bot/SKILL.md
@@ -292,7 +292,9 @@ independent assessment based on the actual code."
 
 **NOTE**: `csa debate` reads `[debate]` config for tool selection. If `tool = "auto"`
 (default), it auto-detects your tool from `CSA_PARENT_TOOL` and picks the
-heterogeneous counterpart. No manual model-spec needed.
+heterogeneous counterpart. Auto mode only maps `claude-code <-> codex`. If you
+are a **gemini-cli** or **opencode** caller, auto will error — you must pass
+`--tool codex` or `--tool claude-code` explicitly (or set `[debate].tool` in config).
 
 **CRITICAL**: Do NOT tell the arbiter your own opinion. Let it form
 an independent judgment.


### PR DESCRIPTION
## Summary
- Replace manual `csa run --model-spec --ephemeral` in pr-codex-bot Step 8 (Local Arbitration) with `csa debate`
- `csa debate` auto-selects heterogeneous counterpart based on caller identity (no manual model-spec needed)
- Session continuation uses `csa debate --session` instead of `csa run --session`

## Background
The `csa debate` subcommand was merged in #18 but the pr-codex-bot skill still referenced the old manual arbitration pattern. This update ensures the skill uses the purpose-built command.

## Test plan
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)