### PR TITLE
feat(cli): detect parent tool via /proc process tree walking

### DIFF
--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -25,9 +25,7 @@ pub(crate) async fn handle_debate(args: DebateArgs, current_depth: u32) -> Resul
     let prompt = construct_debate_prompt(&question, args.session.is_some());
 
     // 5. Determine tool (heterogeneous enforcement)
-    let parent_tool = std::env::var("CSA_TOOL")
-        .ok()
-        .or_else(|| std::env::var("CSA_PARENT_TOOL").ok());
+    let parent_tool = crate::run_helpers::detect_parent_tool();
     let tool = resolve_debate_tool(
         args.tool,
         config.as_ref(),

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -11,6 +11,7 @@ mod doctor;
 mod gc;
 mod mcp_server;
 mod pipeline;
+mod process_tree;
 mod review_cmd;
 mod run_helpers;
 mod self_update;
@@ -251,10 +252,8 @@ async fn handle_run(
             )?
         }
         ToolSelectionStrategy::HeterogeneousStrict => {
-            // Get parent tool from environment
-            let parent_tool_name = std::env::var("CSA_TOOL")
-                .or_else(|_| std::env::var("CSA_PARENT_TOOL"))
-                .ok();
+            // Detect parent tool (env vars → process tree fallback)
+            let parent_tool_name = run_helpers::detect_parent_tool();
 
             if let Some(parent_str) = parent_tool_name.as_deref() {
                 // Have parent context, resolve heterogeneous tool

--- a/crates/cli-sub-agent/src/process_tree.rs
+++ b/crates/cli-sub-agent/src/process_tree.rs
@@ -1,0 +1,155 @@
+//! Detect ancestor tool processes by walking the process tree.
+//!
+//! When CSA is invoked directly from a tool (e.g., `claude` running
+//! `csa review --diff`), the `CSA_TOOL` environment variable is not set.
+//! This module provides a fallback by reading `/proc` to find an ancestor
+//! process whose executable matches a known tool.
+//!
+//! Linux-only: returns `None` on other platforms or on any error.
+
+/// Maximum number of ancestor levels to walk before giving up.
+const MAX_ANCESTOR_DEPTH: usize = 16;
+
+/// Mapping from `/proc/<pid>/comm` basenames to CSA tool names.
+///
+/// Must stay in sync with `Executor::executable_name()` in csa-executor
+/// and `is_tool_binary_available()` in run_helpers.rs.
+const KNOWN_TOOL_EXECUTABLES: &[(&str, &str)] = &[
+    ("claude", "claude-code"),
+    ("gemini", "gemini-cli"),
+    ("codex", "codex"),
+    ("opencode", "opencode"),
+];
+
+/// Detect the calling tool by walking the process tree via `/proc`.
+///
+/// Starts from the current process's parent and walks upward, checking
+/// each ancestor's `comm` (executable basename) against known tools.
+///
+/// Returns the tool name string (e.g., `"claude-code"`) if found,
+/// or `None` on any failure (non-Linux, permission denied, no match).
+pub(crate) fn detect_ancestor_tool() -> Option<String> {
+    let mut current_pid = read_ppid(std::process::id())?;
+
+    for depth in 0..MAX_ANCESTOR_DEPTH {
+        if current_pid <= 1 {
+            return None;
+        }
+
+        let comm = read_comm(current_pid)?;
+
+        if let Some(tool_name) = match_tool_by_comm(&comm) {
+            tracing::debug!(
+                tool = tool_name,
+                ancestor_pid = current_pid,
+                depth,
+                "Detected calling tool from process tree"
+            );
+            return Some(tool_name.to_string());
+        }
+
+        current_pid = read_ppid(current_pid)?;
+    }
+
+    None
+}
+
+/// Read the parent PID from `/proc/<pid>/stat`.
+///
+/// The stat file format is: `pid (comm) state ppid ...`
+/// The comm field can contain spaces and parentheses, so we find the
+/// last `)` to safely skip it.
+fn read_ppid(pid: u32) -> Option<u32> {
+    let stat = std::fs::read_to_string(format!("/proc/{}/stat", pid)).ok()?;
+    let idx = stat.rfind(')')?;
+    let after_comm = stat.get(idx + 2..)?; // skip ") "
+                                           // Fields after comm: state ppid ...
+    after_comm.split_whitespace().nth(1)?.parse().ok()
+}
+
+/// Read the command name from `/proc/<pid>/comm`.
+///
+/// Returns the basename of the executable, truncated to 15 chars by the
+/// kernel. All known tool names are <= 8 chars, so truncation is not
+/// a concern.
+fn read_comm(pid: u32) -> Option<String> {
+    let comm = std::fs::read_to_string(format!("/proc/{}/comm", pid)).ok()?;
+    Some(comm.trim().to_string())
+}
+
+/// Match a comm field against known tool executables.
+fn match_tool_by_comm(comm: &str) -> Option<&'static str> {
+    KNOWN_TOOL_EXECUTABLES
+        .iter()
+        .find(|(exe, _)| *exe == comm)
+        .map(|(_, name)| *name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_match_tool_by_comm_claude() {
+        assert_eq!(match_tool_by_comm("claude"), Some("claude-code"));
+    }
+
+    #[test]
+    fn test_match_tool_by_comm_gemini() {
+        assert_eq!(match_tool_by_comm("gemini"), Some("gemini-cli"));
+    }
+
+    #[test]
+    fn test_match_tool_by_comm_codex() {
+        assert_eq!(match_tool_by_comm("codex"), Some("codex"));
+    }
+
+    #[test]
+    fn test_match_tool_by_comm_opencode() {
+        assert_eq!(match_tool_by_comm("opencode"), Some("opencode"));
+    }
+
+    #[test]
+    fn test_match_tool_by_comm_unknown() {
+        assert_eq!(match_tool_by_comm("bash"), None);
+        assert_eq!(match_tool_by_comm("zsh"), None);
+        assert_eq!(match_tool_by_comm("python"), None);
+        assert_eq!(match_tool_by_comm(""), None);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_read_ppid_self() {
+        // Current process should have a valid parent PID > 0.
+        let ppid = read_ppid(std::process::id());
+        assert!(ppid.is_some(), "read_ppid(self) should succeed on Linux");
+        assert!(ppid.unwrap() > 0);
+    }
+
+    #[test]
+    fn test_read_ppid_invalid_pid() {
+        let ppid = read_ppid(999_999_999);
+        assert!(ppid.is_none());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_read_comm_self() {
+        let comm = read_comm(std::process::id());
+        assert!(comm.is_some(), "read_comm(self) should succeed on Linux");
+        assert!(!comm.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_read_comm_invalid_pid() {
+        let comm = read_comm(999_999_999);
+        assert!(comm.is_none());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_detect_ancestor_tool_does_not_panic() {
+        // Just verify it doesn't panic. Result depends on runtime context.
+        let _result = detect_ancestor_tool();
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -30,9 +30,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
     let prompt = construct_review_prompt(&args, &diff_output);
 
     // 5. Determine tool
-    let parent_tool = std::env::var("CSA_TOOL")
-        .ok()
-        .or_else(|| std::env::var("CSA_PARENT_TOOL").ok());
+    let parent_tool = crate::run_helpers::detect_parent_tool();
     let tool = resolve_review_tool(
         args.tool,
         config.as_ref(),

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -285,6 +285,24 @@ pub(crate) fn is_tool_binary_available(tool_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Detect the parent tool context.
+///
+/// Resolution order:
+/// 1. `CSA_TOOL` environment variable (set by CSA when spawning children)
+/// 2. `CSA_PARENT_TOOL` environment variable (set for grandchild processes)
+/// 3. Process tree walking via `/proc` (Linux-only fallback)
+pub(crate) fn detect_parent_tool() -> Option<String> {
+    std::env::var("CSA_TOOL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            std::env::var("CSA_PARENT_TOOL")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+        })
+        .or_else(crate::process_tree::detect_ancestor_tool)
+}
+
 /// Infer whether a prompt requires editing existing files.
 ///
 /// Returns:


### PR DESCRIPTION
## Summary
- Add `process_tree` module to detect ancestor tool processes by walking `/proc` on Linux
- Add centralized `detect_parent_tool()` helper combining env vars + process tree fallback
- Replace 3 duplicated env-var-reading patterns with the centralized helper
- Gate `/proc`-dependent tests with `#[cfg(target_os = "linux")]`

## Background
Clean resubmission of #24. The original PR went through 1 round of iterative review with @codex (added `#[cfg(target_os = "linux")]` for macOS CI compatibility). Fix commit has been consolidated here.

See #24 for the full review discussion.

## Test plan
- [x] `cargo clippy -p cli-sub-agent -- -D warnings`
- [x] `cargo test -p cli-sub-agent`
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)