### PR TITLE
fix(skills): add blocking constraint, fix review semantics and untracked coverage

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -19,7 +19,9 @@ This skill provides comprehensive code review capabilities by integrating with G
 ## Prerequisites
 
 - `gh` CLI must be installed and authenticated (required — all commands use `gh`)
-- `GITHUB_TOKEN` environment variable should be set if `gh auth` is not configured
+- Prefer `gh auth login` over raw `GITHUB_TOKEN` — interactive auth is safer
+- If using `GITHUB_TOKEN`, use fine-grained tokens with minimal scopes (read repo contents, write pull requests)
+- **NEVER** echo, log, or embed tokens in prompts, commit messages, or review output
 
 ## Usage
 

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -145,7 +145,7 @@ Each commit **must** complete the following steps:
    │   - Phase 3: Code Quality Check
    │   - Returns: PASS / PASS with deferred issues / FAIL
    ↓
-7. ✅ Pre-commit review (csa review --diff)
+7. ✅ Pre-commit review (csa review --diff — reviews all uncommitted changes vs HEAD)
    ↓
 8. Blocking issues found (in current changes)?
    ├─ YES → Fix issues → Re-run from step 1
@@ -251,13 +251,19 @@ Is this a meaningful milestone (feature complete, bug fixed, refactor done)?
 ```
 1. [Main] Stage changes: git add <files>
    ↓
-2. [CSA:review] Review staged changes
+2. [Main] Ensure working tree is clean relative to index:
+   - No unstaged changes: git diff should be empty
+   - No untracked files: git status --porcelain should show no '??' entries
+   If unstaged changes exist, stage or stash them. If untracked files exist, stage or .gitignore them.
+   (Why: csa review --diff uses 'git diff HEAD' which does NOT see untracked files)
+   ↓
+3. [CSA:review] Review staged changes (working tree clean, so git diff HEAD = staged diff)
    csa review --diff
    ↓
-3. [CSA:run] Generate commit message (if review passes)
-   csa run "Run git diff --staged and generate a Conventional Commits message"
+4. [CSA:run] Generate commit message (if review passes)
+   csa run "Run 'git diff --staged' and generate a Conventional Commits message"
    ↓
-4. [Main] Commit with generated message
+5. [Main] Commit with generated message
 ```
 
 ### CSA Review Output Format
@@ -270,7 +276,7 @@ csa review will return:
 1. Use `csa run --tool codex` in same session to fix
 2. Run `csa review --diff` again (use `--session <ID>` to resume previous review session)
 3. Loop until no issues
-4. Generate commit message (see Step 3 above)
+4. Generate commit message (see Step 4 in Recommended Workflow above)
 
 ### Alternative: CSA
 


### PR DESCRIPTION
## Summary

- **pr-codex-bot**: Added MUST BLOCK constraint for local review (Step 2), FORBIDDEN background task rule, hardened GATE for Step 3
- **commit**: Added no-unstaged/no-untracked gate before review, fixed `csa review --diff` semantic to "vs HEAD", corrected step reference, single quotes in csa run
- **code-review**: Added token security guidance (prefer `gh auth login`, fine-grained tokens, NEVER log tokens)

## Background

Clean resubmission of #35. The original PR went through 1 round of iterative review with @codex. The P2 finding (untracked file gap) was fixed. Fix commits have been consolidated into a single logical commit here.

See #35 for the full review discussion.

## Test plan

- [ ] Verify pr-codex-bot/SKILL.md Step 2 says MUST BLOCK and FORBIDDEN background
- [ ] Verify commit/SKILL.md Step 2 requires `git status --porcelain` no `??` entries
- [ ] Verify commit/SKILL.md step reference says "Step 4 in Recommended Workflow"
- [ ] Verify code-review/SKILL.md prerequisites include token security guidance
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)