### PR TITLE
fix(skills): port robustness fixes from upstream review cycle

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -21,7 +21,7 @@ This skill provides comprehensive code review capabilities by integrating with G
 - `gh` CLI must be installed and authenticated (required — all commands use `gh`)
 - Prefer `gh auth login` over raw `GITHUB_TOKEN` — interactive auth is safer
 - If using `GITHUB_TOKEN`, use fine-grained tokens with minimal scopes (read repo contents, write pull requests)
-- **NEVER** echo, log, or embed tokens in prompts, commit messages, or review output
+- **NEVER** echo, log, or embed tokens in prompts, commit messages, or review output. This applies even when using `gh` CLI (e.g., `gh api --verbose` can leak tokens). Avoid `GH_TOKEN`/`GITHUB_TOKEN` in debug output. Also avoid `set -x`, `env`/`printenv`, and pasting CI debug logs into issues/PRs (tokens often exist as environment variables).
 
 ## Usage
 

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -254,6 +254,18 @@ Is this a meaningful milestone (feature complete, bug fixed, refactor done)?
 2. [Main] Ensure working tree is clean relative to index:
    - No unstaged changes: git diff should be empty
    - No untracked files: git status --porcelain should show no '??' entries
+
+   **Check for untracked files explicitly:**
+   ```bash
+   if git ls-files --others --exclude-standard | grep -q .; then
+     echo "ERROR: Untracked files detected. MUST stage them or add to .gitignore before proceeding."
+     git ls-files --others --exclude-standard
+     exit 1
+   fi
+   ```
+
+   > **Note**: In interactive shells, `exit 1` will close the session. Wrap in a subshell `(...)` or use `return 1` inside functions.
+
    If unstaged changes exist, stage or stash them. If untracked files exist, stage or .gitignore them.
    (Why: csa review --diff uses 'git diff HEAD' which does NOT see untracked files)
    ↓
@@ -261,7 +273,7 @@ Is this a meaningful milestone (feature complete, bug fixed, refactor done)?
    csa review --diff
    ↓
 4. [CSA:run] Generate commit message (if review passes)
-   csa run "Run 'git diff --staged' and generate a Conventional Commits message"
+   csa run 'Run git diff --staged and generate a Conventional Commits message'
    ↓
 5. [Main] Commit with generated message
 ```
@@ -283,7 +295,7 @@ csa review will return:
 If csa review is not available:
 
 ```bash
-csa run "Run 'git diff --staged' and generate a Conventional Commits message"
+csa run 'Run git diff --staged and generate a Conventional Commits message'
 ```
 
 ## Commit Granularity

--- a/skills/csa-analyze/SKILL.md
+++ b/skills/csa-analyze/SKILL.md
@@ -67,7 +67,8 @@ You are in directory: [CWD]
 
 Analyze the current git changes:
 1. Run `git status` to see all changed/untracked files
-2. Run `git diff HEAD` to see all uncommitted changes
+2. Run `git diff HEAD` (includes both staged and unstaged changes; does NOT include untracked files — use `git status --porcelain` for those) to see all uncommitted changes relative to HEAD
+   (To see staged-only: `git diff --cached`; unstaged-only: `git diff`)
 3. For each change, explain:
    - Purpose of the modification
    - Potential impact

--- a/skills/pr-codex-bot/references/baseline-template.md
+++ b/skills/pr-codex-bot/references/baseline-template.md
@@ -1,0 +1,53 @@
+# Baseline Capture Template
+
+**Use this template before every `@codex review` trigger to prevent race conditions:**
+
+```bash
+# Ensure TMP_PREFIX is set (use PR_NUM for the target PR)
+TMP_PREFIX="/tmp/codex-bot-${REPO//\//-}-${PR_NUM}"
+
+# Bot login used in jq filters below:
+CODEX_BOT_LOGIN="chatgpt-codex-connector[bot]"
+
+# Capture baseline BEFORE triggering bot review
+gh api "repos/${REPO}/pulls/${PR_NUM}/comments?per_page=100" --paginate --slurp \
+  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort' \
+  > "${TMP_PREFIX}-baseline.json" || {
+  echo "ERROR: Failed to capture PR comments baseline"
+  exit 1
+}
+gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" --paginate --slurp \
+  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort' \
+  > "${TMP_PREFIX}-issue-baseline.json" || {
+  echo "ERROR: Failed to capture issue comments baseline"
+  exit 1
+}
+BASELINE_REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" --paginate --slurp \
+  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]")] | length') || {
+  echo "ERROR: Failed to capture baseline review count"
+  exit 1
+}
+echo "${BASELINE_REVIEW_COUNT}" > "${TMP_PREFIX}-review-count.txt"
+
+# NOW trigger bot review (after baseline is captured)
+gh pr comment "${PR_NUM}" --repo "${REPO}" --body "@codex review"
+```
+
+**Referenced in:** Steps 4, 9, 11
+
+## Temp File Naming Convention
+
+All temp files are namespaced by `${REPO}` and `${PR_NUM}` to prevent
+collisions when multiple projects use this skill concurrently:
+
+```
+/tmp/codex-bot-${REPO//\//-}-${PR_NUM}-baseline.json          # PR review comments (inline)
+/tmp/codex-bot-${REPO//\//-}-${PR_NUM}-issue-baseline.json    # Issue-level comments (general)
+/tmp/codex-bot-${REPO//\//-}-${PR_NUM}-poll-result.txt
+/tmp/codex-bot-${REPO//\//-}-${PR_NUM}-watch.sh
+```
+
+Example for `user/repo` PR `3`: `/tmp/codex-bot-user-repo-3-baseline.json`
+
+**IMPORTANT**: The bot primarily posts to **issue-level comments** (`issues/{pr}/comments`),
+not PR review comments (`pulls/{pr}/comments`). Both endpoints must be polled.

--- a/skills/pr-codex-bot/references/clean-resubmission-flow.md
+++ b/skills/pr-codex-bot/references/clean-resubmission-flow.md
@@ -1,0 +1,100 @@
+# Clean Resubmission Flow (Step 11)
+
+When the bot converges after fix iterations, the PR has accumulated
+incremental fix commits. Create a clean PR for audit-friendly history.
+
+## Procedure
+
+```bash
+# 1. Create new branch from main
+git checkout -b "${BRANCH}-clean" main
+
+# 2. Squash merge all changes
+git merge --squash "${BRANCH}"
+
+# 3. Unstage for selective re-commit
+git reset HEAD
+
+# 4. Recommit in logical groups by concern
+#    Use `git add <specific files>` to stage by group
+#    Each commit = one logical concern (not one file)
+
+# 5. Push new branch
+git push -u origin "${BRANCH}-clean"
+
+# 6. Create new PR linking to old one
+gh pr create --title "[type](scope): [description]" \
+  --body "$(cat <<'PREOF'
+## Summary
+[description]
+
+## Background
+Clean resubmission of #${OLD_PR_NUM}. The original PR went through
+N rounds of iterative review with @codex. Fix commits have been
+consolidated into logical groups here.
+
+See #${OLD_PR_NUM} for the full review discussion.
+
+## Test plan
+- [ ] `cargo clippy -p [package] -- -D warnings`
+- [ ] `cargo test -p [package]`
+- [ ] @codex review
+PREOF
+)"
+
+# 7. Close old PR
+gh pr comment "${OLD_PR_NUM}" --repo "${REPO}" \
+  --body "Superseded by #${NEW_PR_NUM}. Preserved for review discussion reference."
+gh pr close "${OLD_PR_NUM}" --repo "${REPO}"
+
+# 8. Use Baseline Capture Template (see above) for new PR
+TMP_PREFIX="/tmp/codex-bot-${REPO//\//-}-${NEW_PR_NUM}"
+gh api "repos/${REPO}/pulls/${NEW_PR_NUM}/comments?per_page=100" --paginate --slurp \
+  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort' \
+  > "${TMP_PREFIX}-baseline.json" || {
+  echo "ERROR: Failed to capture PR comments baseline"
+  exit 1
+}
+gh api "repos/${REPO}/issues/${NEW_PR_NUM}/comments?per_page=100" --paginate --slurp \
+  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort' \
+  > "${TMP_PREFIX}-issue-baseline.json" || {
+  echo "ERROR: Failed to capture issue comments baseline"
+  exit 1
+}
+BASELINE_REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${NEW_PR_NUM}/reviews?per_page=100" --paginate --slurp \
+  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]")] | length') || {
+  echo "ERROR: Failed to capture baseline review count"
+  exit 1
+}
+echo "${BASELINE_REVIEW_COUNT}" > "${TMP_PREFIX}-review-count.txt"
+gh pr comment "${NEW_PR_NUM}" --repo "${REPO}" --body "@codex review"
+
+# 9. Update PR_NUM and reset TMP_PREFIX to match new PR
+PR_NUM="${NEW_PR_NUM}"
+TMP_PREFIX="/tmp/codex-bot-${REPO//\//-}-${PR_NUM}"  # Force reset after PR change
+```
+
+## Commit Grouping Strategy
+
+Group by **concern**, not by chronology or file:
+
+| Concern | Typical Files | Commit Convention |
+|---------|--------------|-------------------|
+| Core abstractions | types, mod, registry | `feat(scope): [what the types enable]` |
+| Implementation | executor, engine | `feat(scope): [what the engine does]` |
+| Configuration | config, schema | `feat(scope): [what becomes configurable]` |
+| Integration | router, dispatch | `feat(scope): [where it's wired in]` |
+| Tests | test modules | `test(scope): [what is verified]` |
+| Formatting | (if needed) | `style(scope): apply cargo fmt` |
+
+**Number of commits is flexible** — use as many as needed for logical separation.
+
+## Preservation Policy
+
+| Artifact | Action | Reason |
+|----------|--------|--------|
+| Old branch | Keep | Audit trail |
+| Old commits | Keep | Shows iterative development |
+| Old PR | Close with comment | Links to new PR, preserves discussion |
+| New branch | Active | Clean history for merge |
+| New PR | Active | Fresh review with coherent diff |


### PR DESCRIPTION
## Summary
- Port 4 rounds of CSA review fixes from t4nature/s to generalized skill docs
- pr-codex-bot: `--paginate --slurp` with `per_page=100`, `LOCAL_REVIEW_MARKER` decoupled from PR_NUM, file-backed `BASELINE_REVIEW_COUNT`, error handling on baseline capture, extract baseline template and clean resubmission to `references/`
- commit: explicit untracked file detection via `git ls-files`
- code-review: expanded token security warning (`set -x`, `env`/`printenv`, CI debug log risks)
- csa-analyze: `git diff HEAD` clarification (staged+unstaged but not untracked)

## Test plan
- [ ] Verify `pr-codex-bot` workflow runs correctly with paginated API responses
- [ ] Verify `commit` skill catches untracked files before `csa review --diff`
- [ ] Verify `code-review` skill warns about token leaks via debug commands
- [ ] Verify `csa-analyze` git diff template is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)