### PR TITLE
feat(skills): add cloud Codex quota fallback to pr-codex-bot

### DIFF
--- a/skills/pr-codex-bot/SKILL.md
+++ b/skills/pr-codex-bot/SKILL.md
@@ -20,10 +20,12 @@ Step 2: Local review (codex-noninteractive-review-orchestrator)
 Step 3: Fix local review issues (loop until clean)
        |
        v
-Step 4: Submit PR + @codex review
+Step 4: Submit PR + Review Trigger Procedure
+       |                    |
+       |        (UNAVAILABLE? → User confirms → Local CSA fallback)
        |
        v
-Step 5: Poll for bot response (NEVER assume, ALWAYS poll)
+Step 5: (Handled by Review Trigger Procedure — bounded poll + timeout)
        |
        v
 Step 6: No issues? ──> Merge (remote + local) ✅ DONE
@@ -31,12 +33,12 @@ Step 6: No issues? ──> Merge (remote + local) ✅ DONE
        Has issues
        |
        v
-Step 7: Evaluate each comment
+Step 7: Evaluate each comment (cloud bot OR local CSA findings)
        ├── False positive → Step 8: Debate (@codex in reply)
-       └── Real issue ────→ Step 9: Fix + push + @codex review
+       └── Real issue ────→ Step 9: Fix + push + Review Trigger Procedure
                                     |
                                     v
-                             Step 10: Poll → Has issues? → Back to Step 7
+                             Step 10: Review result → Has issues? → Back to Step 7
                                     |
                                     No issues
                                     |
@@ -44,7 +46,7 @@ Step 7: Evaluate each comment
                              Step 11: Clean resubmission (new branch + new PR)
                                     |
                                     v
-                             Step 12: Poll new PR → Has issues? → Back to Step 7
+                             Step 12: Review Trigger Procedure → Has issues? → Back to Step 7
                                     |
                                     No issues
                                     |
@@ -78,6 +80,12 @@ Extract from user message or PR context:
 | `REPO` | PR URL or git remote | `user/repo` |
 | `PR_NUM` | PR URL or `gh pr view` | `1` |
 | `BRANCH` | Current git branch | `feat/hooks-system` |
+| `WORKFLOW_BRANCH` | Set once in Step 1 (= `BRANCH` at start) | `feat/hooks-system` |
+
+**CRITICAL**: `WORKFLOW_BRANCH` is the original branch name set once at
+workflow start. It MUST NOT be re-derived from `git branch --show-current`
+after Step 11 branch switches (e.g., `${BRANCH}-clean`). The fallback
+marker uses `WORKFLOW_BRANCH` to persist across clean resubmission branches.
 
 > **See**: [Baseline Capture Template](references/baseline-template.md) — run this before every `@codex review` trigger.
 
@@ -85,6 +93,11 @@ Extract from user message or PR context:
 
 Commit work using proper commit workflow. Ensure all changes are staged
 and committed before proceeding.
+
+```bash
+# Set WORKFLOW_BRANCH once — persists through Step 11 clean branch switches
+WORKFLOW_BRANCH="$(git branch --show-current)"
+```
 
 ## Step 2: Local Review (MUST BLOCK)
 
@@ -127,6 +140,27 @@ If the local review found issues:
 **GATE: Only proceed to Step 4 when local review returns zero issues.
 This is a hard gate — no exceptions, no "review is probably fine", no skipping.**
 
+## Review Trigger Procedure (Single Entry Point)
+
+**All review triggers (Steps 4, 9, 11/12) MUST use this unified procedure.**
+
+> **See**: [Review Trigger Procedure](references/review-trigger-procedure.md) — complete procedure with baseline capture, bounded poll loop, quota detection, and local CSA fallback.
+
+**Quick reference** — Normalized review outcomes:
+
+| Outcome | Meaning | Next Action |
+|---------|---------|-------------|
+| `CLEAN` | No issues found | Proceed to merge path |
+| `HAS_ISSUES` | Reviewer found issues | Proceed to Step 7 (evaluate) |
+| `UNAVAILABLE(reason)` | Cloud bot did not respond | User confirms local fallback |
+
+**Phases**: (1) Check fallback marker → (2) Cloud path: baseline + `@codex review` + bounded poll (max 10 min, max 5 API failures) → (3) If `UNAVAILABLE`: notify user, confirm fallback, run local `csa review --diff` instead.
+
+**CRITICAL**: Do NOT silently fall back. User MUST confirm before switching
+to local CSA review. Fallback marker uses `BRANCH` (not `PR_NUM`) so it
+persists across PRs within the same workflow (e.g., Step 11 clean
+resubmission). A new workflow on a different branch starts fresh.
+
 ## Step 4: Submit PR
 
 ```bash
@@ -153,91 +187,18 @@ gh pr create --title "[type](scope): [description]" \
 PREOF
 )"
 
-# Use Baseline Capture Template (see above)
+# Initialize TMP_PREFIX for this PR
 TMP_PREFIX="/tmp/codex-bot-${REPO//\//-}-${PR_NUM}"
-
-gh api "repos/${REPO}/pulls/${PR_NUM}/comments?per_page=100" --paginate --slurp \
-  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort' \
-  > "${TMP_PREFIX}-baseline.json" || {
-  echo "ERROR: Failed to capture PR comments baseline"
-  exit 1
-}
-gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" --paginate --slurp \
-  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort' \
-  > "${TMP_PREFIX}-issue-baseline.json" || {
-  echo "ERROR: Failed to capture issue comments baseline"
-  exit 1
-}
-BASELINE_REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" --paginate --slurp \
-  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]")] | length') || {
-  echo "ERROR: Failed to capture baseline review count"
-  exit 1
-}
-case "${BASELINE_REVIEW_COUNT}" in
-  ''|*[!0-9]*) echo "ERROR: Invalid BASELINE_REVIEW_COUNT: ${BASELINE_REVIEW_COUNT}"; exit 1 ;;
-esac
-echo "${BASELINE_REVIEW_COUNT}" > "${TMP_PREFIX}-review-count.txt"
-
-gh pr comment "${PR_NUM}" --repo "${REPO}" --body "@codex review"
 ```
+
+**Now follow the [Review Trigger Procedure](#review-trigger-procedure-single-entry-point)**
+to trigger review (cloud or local fallback) and wait for results.
 
 ## Step 5: Poll for Bot Response
 
-**CRITICAL: NEVER assume the bot has replied. ALWAYS actively poll.**
-
-The baseline was captured in Step 4 before triggering `@codex review`.
-This prevents a race condition where a fast bot response gets included
-in the baseline, making the polling loop miss it.
-
-```bash
-# Ensure variables from prior steps are available (defensive re-init for separate shell invocations)
-TMP_PREFIX="${TMP_PREFIX:-/tmp/codex-bot-${REPO//\//-}-${PR_NUM}}"
-
-# Recover baseline from file (defensive — variable may be lost across shell sessions)
-: "${TMP_PREFIX:?TMP_PREFIX not set}"
-if [ ! -f "${TMP_PREFIX}-review-count.txt" ]; then
-  echo "ERROR: Missing baseline review count file: ${TMP_PREFIX}-review-count.txt"
-  exit 1
-fi
-BASELINE_REVIEW_COUNT="${BASELINE_REVIEW_COUNT:-$(cat "${TMP_PREFIX}-review-count.txt")}"
-case "${BASELINE_REVIEW_COUNT}" in
-  ''|*[!0-9]*) echo "ERROR: Invalid BASELINE_REVIEW_COUNT: ${BASELINE_REVIEW_COUNT}"; exit 1 ;;
-esac
-
-# Poll every 45-60s (within GitHub rate limits: 5000 req/hour authenticated)
-while true; do
-  sleep 45
-
-  # Check PR review comments (inline code comments)
-  CURRENT=$(gh api "repos/${REPO}/pulls/${PR_NUM}/comments?per_page=100" --paginate --slurp \
-    --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort') || continue
-  BASELINE=$(cat "${TMP_PREFIX}-baseline.json")
-  if [ "$CURRENT" != "$BASELINE" ]; then
-    echo "NEW_COMMENTS_DETECTED"
-    break
-  fi
-
-  # Check issue-level comments (general PR comments — bot's primary channel)
-  ISSUE_CURRENT=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" --paginate --slurp \
-    --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort') || continue
-  ISSUE_BASELINE=$(cat "${TMP_PREFIX}-issue-baseline.json")
-  if [ "$ISSUE_CURRENT" != "$ISSUE_BASELINE" ]; then
-    echo "NEW_COMMENTS_DETECTED"
-    break
-  fi
-
-  # Check for new reviews (compare count against baseline, not just > 0)
-  CURRENT_REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" --paginate --slurp \
-    --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]")] | length') || continue
-  if [ "$CURRENT_REVIEW_COUNT" -gt "$BASELINE_REVIEW_COUNT" ] 2>/dev/null; then
-    echo "NEW_COMMENTS_DETECTED"
-    break
-  fi
-done
-```
-
-**Timeout**: If no response after 10 minutes, **notify the user** instead of
-guessing or acting on stale data.
+Handled by the **Review Trigger Procedure** (Phase 2c). The procedure
+implements a bounded poll loop (max 10 min) with API error retry limits.
+See the procedure for the complete polling code with timeout.
 
 ## Step 6: First-Pass Clean → Merge
 
@@ -533,7 +494,9 @@ models were used and assess the quality of the arbitration.
 - **NEVER `@codex` in real issue / already-fixed replies** — the fix commit
   + `@codex review` in Step 9 will trigger re-evaluation
 - **The ONLY place to `@codex`** is `gh pr comment` to trigger a full
-  re-review (Steps 4, 9, 11)
+  re-review (Steps 4, 9, 11) — handled by the Review Trigger Procedure
+- **When cloud fallback is active** (marker exists), `@codex` is NOT
+  triggered at all — local CSA review is used instead
 
 ## Step 9: Fix Real Issues
 
@@ -552,42 +515,18 @@ git commit -m "fix(scope): [description]
 
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
 git push origin "${BRANCH}"
-
-# Use Baseline Capture Template (see above) — ensure TMP_PREFIX is set
-TMP_PREFIX="${TMP_PREFIX:-/tmp/codex-bot-${REPO//\//-}-${PR_NUM}}"
-
-gh api "repos/${REPO}/pulls/${PR_NUM}/comments?per_page=100" --paginate --slurp \
-  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort' \
-  > "${TMP_PREFIX}-baseline.json" || {
-  echo "ERROR: Failed to capture PR comments baseline"
-  exit 1
-}
-gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" --paginate --slurp \
-  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort' \
-  > "${TMP_PREFIX}-issue-baseline.json" || {
-  echo "ERROR: Failed to capture issue comments baseline"
-  exit 1
-}
-BASELINE_REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" --paginate --slurp \
-  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]")] | length') || {
-  echo "ERROR: Failed to capture baseline review count"
-  exit 1
-}
-case "${BASELINE_REVIEW_COUNT}" in
-  ''|*[!0-9]*) echo "ERROR: Invalid BASELINE_REVIEW_COUNT: ${BASELINE_REVIEW_COUNT}"; exit 1 ;;
-esac
-echo "${BASELINE_REVIEW_COUNT}" > "${TMP_PREFIX}-review-count.txt"
-
-gh pr comment "${PR_NUM}" --repo "${REPO}" --body "@codex review"
 ```
 
-**Then poll (Step 5) and re-evaluate (Step 7).**
+**Now follow the [Review Trigger Procedure](#review-trigger-procedure-single-entry-point)**
+to trigger review (cloud or local fallback) and wait for results.
+Then re-evaluate (Step 7).
 
 ## Step 10: Re-Review Loop
 
-After pushing fixes, poll for bot response (Step 5):
-- **Has issues** → back to Step 7 (evaluate, debate/fix)
-- **No issues** → proceed to Step 11 (clean resubmission)
+After pushing fixes, follow the **[Review Trigger Procedure](#review-trigger-procedure-single-entry-point)**:
+- Result is `HAS_ISSUES` → back to Step 7 (evaluate, debate/fix)
+- Result is `CLEAN` → proceed to Step 11 (clean resubmission)
+- Result is `UNAVAILABLE` → user confirms fallback, local CSA review takes over
 
 ## Step 11: Clean Resubmission
 
@@ -598,12 +537,14 @@ incremental fix commits. Create a clean PR for audit-friendly history.
 
 ## Step 12: Review New PR
 
-Poll for bot response on the new clean PR (Step 5):
-- **No issues** → Step 13 (merge)
-- **Has issues** → back to Step 7 (evaluate each comment, debate/fix)
+Follow the **[Review Trigger Procedure](#review-trigger-procedure-single-entry-point)**
+on the new clean PR (update `PR_NUM` and `TMP_PREFIX` for the new PR first):
+- Result is `CLEAN` → Step 13 (merge)
+- Result is `HAS_ISSUES` → back to Step 7 (evaluate each comment, debate/fix)
   - If fixes are needed again, repeat the full cycle including
     another clean resubmission (Step 11) with incrementing branch
     names: `${BRANCH}-clean-2`, `${BRANCH}-clean-3`, etc.
+- Result is `UNAVAILABLE` → user confirms fallback, local CSA review takes over
 
 ## Step 13: Merge
 
@@ -634,7 +575,10 @@ git checkout main && git pull origin main
 | Max iterations reached | **Escalate** - report to user |
 | Same issue re-flagged after fix | **Escalate** - root cause missed |
 | Bot flags architectural issue | **Escalate** - needs human decision |
-| Poll timeout (10 min) | **Notify user** - don't act on stale data |
+| Poll timeout (10 min) | **UNAVAILABLE(timeout)** - notify user, offer local fallback |
+| Bot replies with quota message | **UNAVAILABLE(quota)** - notify user, offer local fallback |
+| API errors (5 consecutive) | **UNAVAILABLE(api_error)** - notify user, offer local fallback |
+| Cloud fallback active | **Local CSA review** - skip cloud, use local for remainder |
 
 ## Anti-Trust Protocol
 
@@ -685,3 +629,4 @@ Bot user login: `chatgpt-codex-connector[bot]`
 | `debate` | Step 8: adversarial arbitration for suspected false positives |
 | `commit` | After fixing issues |
 | `csa run --tier tier-4-critical` | If bot flags security issue (deep analysis) |
+| `csa review --diff` | Cloud fallback: local CSA review when `@codex` is unavailable |

--- a/skills/pr-codex-bot/references/review-trigger-procedure.md
+++ b/skills/pr-codex-bot/references/review-trigger-procedure.md
@@ -1,0 +1,280 @@
+# Review Trigger Procedure (Single Entry Point)
+
+**All review triggers (Steps 4, 9, 11/12) MUST use this unified procedure.**
+It handles cloud `@codex review`, polling with timeout, quota detection,
+and local CSA fallback. This prevents duplicating baseline/poll/fallback
+logic across multiple steps.
+
+## Normalized Review Outcomes
+
+| Outcome | Meaning | Next Action |
+|---------|---------|-------------|
+| `CLEAN` | No issues found | Proceed to merge path |
+| `HAS_ISSUES` | Reviewer found issues | Proceed to Step 7 (evaluate) |
+| `UNAVAILABLE(reason)` | Cloud bot did not respond | User confirms local fallback |
+
+**Note**: The poll loop produces an intermediate result `NEW_COMMENTS_DETECTED`
+which means the bot responded but the main agent must still evaluate the
+response (Step 7) to determine if the final outcome is `CLEAN` or `HAS_ISSUES`.
+This is not a bug — the procedure intentionally defers classification to the
+agent because the bot's response format varies (inline comments, review-level
+approval, issue comments).
+
+## Phase 1: Check Fallback State
+
+The fallback marker uses `WORKFLOW_BRANCH` (the original branch the workflow
+started on, set once in Step 1 and never re-derived). This ensures the marker
+persists even when Step 11 creates clean branches (`${BRANCH}-clean`,
+`${BRANCH}-clean-2`, etc.) — the marker path stays the same because
+`WORKFLOW_BRANCH` doesn't change. A new workflow on a different branch
+starts fresh.
+
+**CRITICAL**: `WORKFLOW_BRANCH` MUST be set once at workflow start (Step 1)
+and passed unchanged through all steps. Do NOT re-derive it from
+`git branch --show-current` after Step 11 branch switches.
+
+```bash
+TMP_PREFIX="${TMP_PREFIX:-/tmp/codex-bot-${REPO//\//-}-${PR_NUM}}"
+# Marker uses WORKFLOW_BRANCH (original branch, not current) for cross-PR persistence
+FALLBACK_MARKER="/tmp/codex-bot-${REPO//\//-}-${WORKFLOW_BRANCH//\//-}-cloud-fallback.marker"
+
+if [ -f "${FALLBACK_MARKER}" ]; then
+  echo "CLOUD_FALLBACK_ACTIVE: Skipping cloud @codex review, using local CSA review"
+  # → Skip Phase 2 entirely, go directly to Phase 3 (Local Fallback Path)
+  # The main agent should run: csa review --diff
+  # Then map output to CLEAN or HAS_ISSUES and proceed to Step 7
+else
+  # → Continue to Phase 2 (Cloud Path)
+  :
+fi
+```
+
+## Phase 2: Cloud Path (Baseline + Trigger + Poll)
+
+### 2a. Baseline Capture
+
+Capture before triggering review to prevent race conditions:
+
+```bash
+gh api "repos/${REPO}/pulls/${PR_NUM}/comments?per_page=100" --paginate --slurp \
+  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort' \
+  > "${TMP_PREFIX}-baseline.json" || {
+  echo "ERROR: Failed to capture PR comments baseline"
+  exit 1
+}
+gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" --paginate --slurp \
+  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort' \
+  > "${TMP_PREFIX}-issue-baseline.json" || {
+  echo "ERROR: Failed to capture issue comments baseline"
+  exit 1
+}
+BASELINE_REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" --paginate --slurp \
+  --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]")] | length') || {
+  echo "ERROR: Failed to capture baseline review count"
+  exit 1
+}
+case "${BASELINE_REVIEW_COUNT}" in
+  ''|*[!0-9]*) echo "ERROR: Invalid BASELINE_REVIEW_COUNT: ${BASELINE_REVIEW_COUNT}"; exit 1 ;;
+esac
+echo "${BASELINE_REVIEW_COUNT}" > "${TMP_PREFIX}-review-count.txt"
+```
+
+### 2b. Trigger Cloud Review
+
+```bash
+gh pr comment "${PR_NUM}" --repo "${REPO}" --body "@codex review" || {
+  echo "ERROR: Failed to trigger @codex review. Check PR access and bot installation."
+  exit 1
+}
+```
+
+### 2c. Poll with Timeout
+
+Max 10 minutes, bounded API error retry:
+
+```bash
+# Verify baseline files exist before polling
+for f in "${TMP_PREFIX}-baseline.json" "${TMP_PREFIX}-issue-baseline.json" "${TMP_PREFIX}-review-count.txt"; do
+  [ -f "$f" ] || { echo "ERROR: Missing baseline file: $f"; exit 1; }
+done
+BASELINE_REVIEW_COUNT="$(cat "${TMP_PREFIX}-review-count.txt")"
+case "${BASELINE_REVIEW_COUNT}" in
+  ''|*[!0-9]*) echo "ERROR: Invalid BASELINE_REVIEW_COUNT: ${BASELINE_REVIEW_COUNT}"; exit 1 ;;
+esac
+MAX_POLLS=13          # 13 * 45s ≈ 10 minutes
+API_FAIL_LIMIT=5      # Max consecutive API failures before escalation
+POLL_COUNT=0
+API_FAIL_COUNT=0
+REVIEW_RESULT=""
+
+while [ "$POLL_COUNT" -lt "$MAX_POLLS" ]; do
+  sleep 45
+  POLL_COUNT=$((POLL_COUNT + 1))
+
+  # Check PR review comments (inline code comments)
+  CURRENT=$(gh api "repos/${REPO}/pulls/${PR_NUM}/comments?per_page=100" --paginate --slurp \
+    --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort') || {
+    API_FAIL_COUNT=$((API_FAIL_COUNT + 1))
+    if [ "$API_FAIL_COUNT" -ge "$API_FAIL_LIMIT" ]; then
+      REVIEW_RESULT="UNAVAILABLE(api_error)"
+      break
+    fi
+    continue
+  }
+  API_FAIL_COUNT=0  # Reset on success
+  BASELINE=$(cat "${TMP_PREFIX}-baseline.json")
+  if [ "$CURRENT" != "$BASELINE" ]; then
+    REVIEW_RESULT="NEW_COMMENTS_DETECTED"
+    break
+  fi
+
+  # Check issue-level comments (general PR comments — bot's primary channel)
+  ISSUE_CURRENT=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" --paginate --slurp \
+    --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]") | .id] | sort') || {
+    API_FAIL_COUNT=$((API_FAIL_COUNT + 1))
+    if [ "$API_FAIL_COUNT" -ge "$API_FAIL_LIMIT" ]; then
+      REVIEW_RESULT="UNAVAILABLE(api_error)"
+      break
+    fi
+    continue
+  }
+  API_FAIL_COUNT=0
+  ISSUE_BASELINE=$(cat "${TMP_PREFIX}-issue-baseline.json")
+  if [ "$ISSUE_CURRENT" != "$ISSUE_BASELINE" ]; then
+    REVIEW_RESULT="NEW_COMMENTS_DETECTED"
+    break
+  fi
+
+  # Check for new reviews (compare count against baseline)
+  CURRENT_REVIEW_COUNT=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" --paginate --slurp \
+    --jq '[.[].[] | select(.user.login == "chatgpt-codex-connector[bot]")] | length') || {
+    API_FAIL_COUNT=$((API_FAIL_COUNT + 1))
+    if [ "$API_FAIL_COUNT" -ge "$API_FAIL_LIMIT" ]; then
+      REVIEW_RESULT="UNAVAILABLE(api_error)"
+      break
+    fi
+    continue
+  }
+  API_FAIL_COUNT=0
+  if [ "$CURRENT_REVIEW_COUNT" -gt "$BASELINE_REVIEW_COUNT" ] 2>/dev/null; then
+    REVIEW_RESULT="NEW_COMMENTS_DETECTED"
+    break
+  fi
+done
+
+# Timeout reached without response
+if [ -z "$REVIEW_RESULT" ]; then
+  REVIEW_RESULT="UNAVAILABLE(timeout)"
+fi
+```
+
+### 2d. Classify Result
+
+- `NEW_COMMENTS_DETECTED` → Check for quota message in bot reply. If bot reply
+  (scoped to `chatgpt-codex-connector[bot]` user only) matches known quota
+  patterns, classify as `UNAVAILABLE(quota)`. Otherwise proceed to Step 7
+  evaluation which will classify as `CLEAN` or `HAS_ISSUES`.
+
+  **Known quota message patterns** (observed from production):
+  - `"You have reached your Codex usage limits for code reviews"`
+  - `"add credits to your account and enable them for code reviews"`
+  - Generic keywords: `"quota exceeded"`, `"subscription required"`,
+    `"rate limit"`, `"usage limits"`, `"add credits"`
+- `UNAVAILABLE(timeout)` → Cloud bot did not respond within 10 minutes.
+- `UNAVAILABLE(api_error)` → GitHub API failed 5+ consecutive times.
+
+### 2e. Handle UNAVAILABLE
+
+**CRITICAL: Do NOT silently fall back.** Notify user with the specific reason
+and ask for confirmation before switching to local CSA review.
+
+```
+UNAVAILABLE detected:
+  Reason: [timeout | quota | api_error]
+
+  Options:
+  1. Fall back to local CSA review for remainder of this workflow
+  2. Retry cloud @codex review (reset poll timer)
+  3. Skip review and proceed manually
+```
+
+If user confirms fallback:
+```bash
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) reason=${REASON}" > "${FALLBACK_MARKER}"
+```
+
+Then proceed to Phase 3 (Local Fallback Path).
+
+## Phase 3: Local Fallback Path
+
+When `${FALLBACK_MARKER}` exists (cloud unavailable for this workflow):
+
+Run local CSA review using the `csa-review` skill with the same scope as the
+cloud bot would review:
+
+```bash
+# Same scope as Step 2 local review, but this replaces cloud bot review
+csa review --diff  # Reviews uncommitted + committed changes vs main
+```
+
+**Map CSA output to normalized outcomes**:
+- CSA finds zero issues → `CLEAN`
+- CSA finds one or more issues → `HAS_ISSUES` (treat each CSA finding like
+  a bot comment — proceed to Step 7 evaluation with the same Category A/B/C
+  classification)
+
+**Key difference from cloud bot**: Local CSA output is structured text (not
+GitHub PR comments). The main agent reads the CSA output directly instead of
+polling GitHub APIs. Step 7 evaluation applies the same logic — classify each
+finding, queue false positives for Step 8 arbitration, fix real issues.
+
+**Next workflow resets**: The fallback marker is scoped to `${WORKFLOW_BRANCH}`.
+A new workflow on a different branch starts fresh with cloud `@codex review`.
+Within the same branch family (including Step 11 clean PRs), the fallback
+state persists so you don't wait another 10 minutes for a known-unavailable bot.
+
+## Fallback State Diagram
+
+```
+@codex review triggered
+       |
+       v
+  Poll (max 10 min)
+       |
+       +── Bot responds ──> Evaluate response
+       |                         |
+       |                    +── Quota message? ──> UNAVAILABLE(quota)
+       |                    |
+       |                    +── Real review ──> CLEAN or HAS_ISSUES
+       |
+       +── Timeout (10 min) ──> UNAVAILABLE(timeout)
+       |
+       +── API errors (5x) ──> UNAVAILABLE(api_error)
+       |
+       v
+  UNAVAILABLE:
+  Notify user + ask confirmation
+       |
+       +── User confirms fallback
+       |         |
+       |         v
+       |    Create ${FALLBACK_MARKER} (WORKFLOW_BRANCH-scoped)
+       |    Run local CSA review
+       |    (all subsequent reviews in this workflow use local)
+       |
+       +── User retries cloud ──> Reset poll timer, try again
+       +── User skips review ──> Manual proceed
+```
+
+## Limitations
+
+- **Per-workflow-branch, not per-session**: Fallback marker uses
+  `${WORKFLOW_BRANCH}` (set once at workflow start) so it persists across
+  PRs and clean branches within the same workflow. Concurrent workflows on
+  the same original branch would share state. Acceptable for single-user usage.
+- **Old markers accumulate**: `/tmp` files are not auto-cleaned between workflows.
+  They are cleaned on system reboot. Non-critical for low-frequency usage.
+- **10 min timeout may be short for large PRs**: The bot may take longer for
+  very large diffs. User confirmation provides an escape hatch to retry.
+- **Approximate timing**: `MAX_POLLS=13 * sleep 45` is approximately 10 minutes.
+  Actual wall time may vary due to API call latency.


### PR DESCRIPTION
## Summary
- Add unified Review Trigger Procedure as single entry point for all `@codex review` triggers
- Implement bounded poll loop (13 × 45s ≈ 10 min) with API error retry limit (max 5)
- Three normalized review outcomes: `CLEAN`, `HAS_ISSUES`, `UNAVAILABLE(reason)`
- WORKFLOW_BRANCH-scoped fallback marker persists across clean resubmission branches
- User-confirmed fallback to local `csa review --diff` (never silent degradation)
- Known quota message patterns from production observation
- Remove duplicated baseline+trigger from clean-resubmission-flow.md

## Background
Clean resubmission of #42. The original PR went through 1 round of iterative review with @codex. Bot found 2 issues (P1: fallback marker instability across clean-branch hops, P2: double-trigger risk). Both fixed. Bot then hit quota limit on re-review. Fixes verified via local CSA review.

See #42 for the full review discussion.

## Test plan
- [x] `just pre-commit` (250 unit + 3 e2e tests pass)
- [x] Local CSA review (CLEAN)
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)