### PR TITLE
fix(skills): simplify pr-codex-bot quota-exhausted behavior

### DIFF
--- a/skills/pr-codex-bot/references/clean-resubmission-flow.md
+++ b/skills/pr-codex-bot/references/clean-resubmission-flow.md
@@ -52,7 +52,7 @@ PR_NUM="${NEW_PR_NUM}"
 TMP_PREFIX="/tmp/codex-bot-${REPO//\//-}-${PR_NUM}"
 # NOTE: Do NOT trigger @codex review here.
 # Step 12 handles review via the Review Trigger Procedure
-# (baseline capture + trigger + poll + fallback) to avoid double-triggering.
+# (baseline capture + trigger + poll) to avoid double-triggering.
 ```
 
 ## Commit Grouping Strategy


### PR DESCRIPTION
## Summary

- Remove fallback marker concept and `fallback.cloud_review_exhausted` config policy
- `UNAVAILABLE(quota/timeout)` → merge directly (pre-PR local review already covers `main...HEAD`)
- Separate `ESCALATE(api_error)` from `UNAVAILABLE` (transient failures are not conclusive — notify user)
- Add `LOCAL_REVIEW_MARKER` gate in direct-merge path (shell check before merge)
- Require Step 9 to refresh local review marker after fix cycles
- Strengthen Step 2 language: absolute prerequisite, no PR without completing local review
- Add FORBIDDEN rule: never create/submit PR without completing Step 2

## Test plan
- [ ] Manual: Verify skill renders correctly in Claude Code
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)