### PR TITLE
feat(skills): add generated_outputs to review schema

### DIFF
--- a/skills/csa-review/references/output-schema.md
+++ b/skills/csa-review/references/output-schema.md
@@ -47,9 +47,20 @@
     "adversarial_pass_executed": true,
     "triggered_by": ["string"]
   },
-  "suggested_next_actions": ["string"]
+  "suggested_next_actions": ["string"],
+  "generated_outputs": {
+    "commit_message": "string or null",
+    "pr_body": "string or null"
+  }
 }
 ```
+
+### generated_outputs
+
+Optional outputs generated when the review finds **no P0 or P1 issues**:
+
+- **commit_message**: A Conventional Commits message (English) summarizing the changes. Only generated for per-commit reviews (`uncommitted` scope). Set to `null` if P0/P1 issues exist or scope is not per-commit.
+- **pr_body**: A PR description with `## Summary` (bullet points) and `## Test plan` (checklist). Only generated for pre-PR reviews (`base:<branch>` or `range:` scope). Set to `null` if P0/P1 issues exist or scope is not pre-PR.
 
 ## review-report.md
 
@@ -87,6 +98,18 @@
 
 ## Recommended Actions
 1. <action>
+
+## Suggested Commit Message
+<!-- Only present when no P0/P1 findings and scope is per-commit -->
+<type>(<scope>): <description>
+
+## Suggested PR Body
+<!-- Only present when no P0/P1 findings and scope is pre-PR -->
+## Summary
+- <bullet points>
+
+## Test plan
+- [ ] <checklist items>
 ```
 
 Write both files to the current working directory (or a designated output location).

--- a/skills/csa-review/references/review-protocol.md
+++ b/skills/csa-review/references/review-protocol.md
@@ -120,6 +120,28 @@ When executing, reason from attacker perspective and evaluate exploitability for
 
 High-impact security suspicion without concrete exploit path -> list under open_questions, not findings.
 
+## Step 4: Generate Outputs (when review is clean)
+
+After the three-pass review, if there are **no P0 or P1 findings**, generate additional outputs:
+
+### Commit Message (per-commit scope only)
+
+When scope is `uncommitted` (per-commit review), generate a suggested commit message:
+- Follow Conventional Commits format: `<type>(<scope>): <description>`
+- Type: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
+- Scope: the primary crate or module affected
+- Description: concise summary of what changed and why (not how)
+- Include in `generated_outputs.commit_message` in review-findings.json
+
+### PR Body (pre-PR scope only)
+
+When scope is `base:<branch>` or `range:` (pre-PR review), generate a suggested PR body:
+- `## Summary` with 2-4 bullet points describing the changes
+- `## Test plan` with a checklist of verification steps
+- Include in `generated_outputs.pr_body` in review-findings.json
+
+If P0 or P1 findings exist, set both fields to `null` — the developer needs to fix issues first.
+
 ## Non-Negotiable Rules
 
 1. Always read CLAUDE.md before any review reasoning.


### PR DESCRIPTION
## Summary
- Add `generated_outputs` field to `review-findings.json` schema with `commit_message` and `pr_body` sub-fields
- Document generation conditions: outputs only populated when no P0/P1 findings exist
- Extend review report template with optional Suggested Commit Message and Suggested PR Body sections
- Add Step 4 (Generate Outputs) to review protocol for per-commit and pre-PR scopes

## Test plan
- [ ] `just pre-commit` passes (334 unit + 3 E2E)
- [ ] `csa review --branch main` local review returns zero findings
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)