### PR TITLE
fix(executor): pass thinking_budget from tier config to codex

### DIFF
--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -78,8 +78,7 @@ pub(crate) fn build_executor(
 ) -> Result<Executor> {
     let mut executor = if let Some(spec) = model_spec {
         let parsed = ModelSpec::parse(spec)?;
-        let tool_name = parse_tool_name(&parsed.tool)?;
-        Executor::from_tool_name(&tool_name, Some(parsed.model))
+        Executor::from_spec(&parsed)?
     } else {
         let mut final_model = model.map(|s| s.to_string());
 


### PR DESCRIPTION
## Summary
- `build_executor()` was calling `Executor::from_tool_name()` which drops the `thinking_budget` parsed from the model spec string
- Changed to use `Executor::from_spec()` which preserves the full `ModelSpec` including `thinking_budget`
- This ensures codex is launched with `--reasoning-effort` matching the tier config (e.g., `low` for tier-1-quick)

## Root Cause
When tier-based selection returns a model spec like `codex/openai/gpt-5-codex-mini/low`, the code parsed it correctly into a `ModelSpec` with `ThinkingBudget::Low`, but then called `from_tool_name()` which creates a new executor with `thinking_budget: None` — discarding the parsed value.

## Test plan
- [x] `cargo clippy -p cli-sub-agent -- -D warnings`
- [x] `cargo test -p cli-sub-agent` (84 tests pass)
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)