### PR TITLE
feat(process): add StreamMode for real-time stdout tee to stderr

### DIFF
--- a/crates/cli-sub-agent/src/batch.rs
+++ b/crates/cli-sub-agent/src/batch.rs
@@ -585,6 +585,7 @@ async fn execute_task(
         extra_env_ref,
         Some("batch"),
         None, // batch does not use tier-based selection
+        csa_process::StreamMode::BufferOnly,
     )
     .await;
 

--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
@@ -75,6 +75,7 @@ pub(crate) async fn handle_claude_sub_agent(
         extra_env,
         Some("run"),
         None, // claude-sub-agent does not use tier-based selection
+        csa_process::StreamMode::BufferOnly,
     )
     .await?;
 

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -67,6 +67,10 @@ pub enum Commands {
         /// Block-wait for a free slot instead of failing when all slots are occupied
         #[arg(long)]
         wait: bool,
+
+        /// Stream child stdout to stderr in real-time (prefix: [stdout])
+        #[arg(long)]
+        stream_stdout: bool,
     },
 
     /// Manage sessions

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -69,6 +69,7 @@ pub(crate) async fn handle_debate(args: DebateArgs, current_depth: u32) -> Resul
         extra_env,
         Some("debate"),
         None, // debate does not use tier-based selection
+        csa_process::StreamMode::BufferOnly,
     )
     .await?;
 

--- a/crates/cli-sub-agent/src/mcp_server.rs
+++ b/crates/cli-sub-agent/src/mcp_server.rs
@@ -574,7 +574,12 @@ async fn handle_run_tool(args: Value) -> Result<Value> {
         // Ephemeral: use temp directory
         let temp_dir = TempDir::new()?;
         executor
-            .execute_in(prompt, temp_dir.path(), extra_env_ref)
+            .execute_in(
+                prompt,
+                temp_dir.path(),
+                extra_env_ref,
+                csa_process::StreamMode::BufferOnly,
+            )
             .await?
     } else {
         // Persistent session
@@ -590,6 +595,7 @@ async fn handle_run_tool(args: Value) -> Result<Value> {
             extra_env_ref,
             Some("run"),
             None, // MCP server does not use tier-based selection
+            csa_process::StreamMode::BufferOnly,
         )
         .await?
     };

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -207,6 +207,7 @@ pub(crate) async fn execute_with_session(
     extra_env: Option<&std::collections::HashMap<String, String>>,
     task_type: Option<&str>,
     tier_name: Option<&str>,
+    stream_mode: csa_process::StreamMode,
 ) -> Result<ExecutionResult> {
     let execution = execute_with_session_and_meta(
         executor,
@@ -220,6 +221,7 @@ pub(crate) async fn execute_with_session(
         extra_env,
         task_type,
         tier_name,
+        stream_mode,
     )
     .await?;
 
@@ -239,6 +241,7 @@ pub(crate) async fn execute_with_session_and_meta(
     extra_env: Option<&std::collections::HashMap<String, String>>,
     task_type: Option<&str>,
     tier_name: Option<&str>,
+    stream_mode: csa_process::StreamMode,
 ) -> Result<SessionExecutionResult> {
     // Check for parent session violation: a child process must not operate on its own session
     if let Some(ref session_id) = session_arg {
@@ -395,7 +398,7 @@ pub(crate) async fn execute_with_session_and_meta(
     let mut sigint = signal(SignalKind::interrupt()).context("Failed to install SIGINT handler")?;
 
     // Wait for either child completion or signal
-    let wait_future = csa_process::wait_and_capture(child);
+    let wait_future = csa_process::wait_and_capture(child, stream_mode);
     tokio::pin!(wait_future);
 
     let result = tokio::select! {

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -226,6 +226,7 @@ async fn execute_review(
         extra_env,
         Some("review"),
         None,
+        csa_process::StreamMode::BufferOnly,
     )
     .await
 }

--- a/crates/csa-executor/src/agent_backend_adapter.rs
+++ b/crates/csa-executor/src/agent_backend_adapter.rs
@@ -219,7 +219,12 @@ impl AgentSession for ExecutorAgentSession {
 
         match self
             .executor
-            .execute_in(&prompt, &self.cwd, extra_env)
+            .execute_in(
+                &prompt,
+                &self.cwd,
+                extra_env,
+                csa_process::StreamMode::BufferOnly,
+            )
             .await
         {
             Ok(result) => {

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -207,9 +207,10 @@ impl Executor {
         tool_state: Option<&ToolState>,
         session: &MetaSessionState,
         extra_env: Option<&HashMap<String, String>>,
+        stream_mode: csa_process::StreamMode,
     ) -> Result<ExecutionResult> {
         let (cmd, stdin_data) = self.build_command(prompt, tool_state, session, extra_env);
-        csa_process::run_and_capture_with_stdin(cmd, stdin_data).await
+        csa_process::run_and_capture_with_stdin(cmd, stdin_data, stream_mode).await
     }
 
     /// Execute in a specific directory (for ephemeral sessions).
@@ -220,6 +221,7 @@ impl Executor {
         prompt: &str,
         work_dir: &Path,
         extra_env: Option<&HashMap<String, String>>,
+        stream_mode: csa_process::StreamMode,
     ) -> Result<ExecutionResult> {
         let mut cmd = Command::new(self.executable_name());
         cmd.current_dir(work_dir);
@@ -242,7 +244,7 @@ impl Executor {
         } else {
             self.append_prompt_args_with_transport(&mut cmd, prompt, prompt_transport);
         }
-        csa_process::run_and_capture_with_stdin(cmd, stdin_data).await
+        csa_process::run_and_capture_with_stdin(cmd, stdin_data, stream_mode).await
     }
 
     /// Build base command with session environment variables.


### PR DESCRIPTION
## Summary
- Add `StreamMode` enum (`BufferOnly`/`TeeToStderr`) to `csa-process` for real-time stdout forwarding
- Thread `StreamMode` through the entire execution chain: `wait_and_capture` → `run_and_capture_with_stdin` → `Executor::execute`/`execute_in` → `pipeline::execute_with_session`
- Auto-detect interactive TTY (text format + stderr is terminal) for `TeeToStderr`
- Add `--stream-stdout` CLI flag for explicit override
- Conservative default: `BufferOnly` preserves backward compat for JSON/pipe/CI
- 8 new unit tests for StreamMode behavior

## Motivation
When CSA spawns long-running tools like codex, callers cannot distinguish "tool is thinking" vs "tool is hung" because stdout is fully buffered. `TeeToStderr` forwards stdout lines to stderr with a `[stdout]` prefix, providing real-time visibility.

## Test plan
- [x] `just pre-commit` — all 820 unit tests + 8 e2e tests pass
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)