### PR TITLE
feat(workspace): opt-in cc-sdk feature passthrough (#sprint6)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ csa-resource = { path = "crates/csa-resource" }
 csa-scheduler = { path = "crates/csa-scheduler" }
 csa-todo = { path = "crates/csa-todo" }
 csa-hooks = { path = "crates/csa-hooks" }
-agent-teams = { path = "../agent-teams-rs" }
+agent-teams = { path = "../agent-teams-rs", default-features = false }
 
 # CLI & Async
 clap = { version = "4.5", features = ["derive"] }

--- a/crates/cli-sub-agent/Cargo.toml
+++ b/crates/cli-sub-agent/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace = true
 name = "csa"
 path = "src/main.rs"
 
+[features]
+cc-sdk = ["csa-executor/cc-sdk"]
+
 [dependencies]
 csa-core.workspace = true
 csa-session.workspace = true

--- a/crates/csa-executor/Cargo.toml
+++ b/crates/csa-executor/Cargo.toml
@@ -20,6 +20,9 @@ tracing-appender.workspace = true
 chrono.workspace = true
 regex.workspace = true
 
+[features]
+cc-sdk = ["agent-teams/cc-sdk"]
+
 [dev-dependencies]
 tempfile.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION
## Summary
- Make `agent-teams` cc-sdk dependency optional via Cargo feature flags
- Forward `cc-sdk` feature through the crate chain: `cli-sub-agent → csa-executor → agent-teams`
- Workspace root imports `agent-teams` with `default-features = false` to avoid pulling in cc-sdk at compile time
- CSA uses subprocess execution (not the SDK library), so cc-sdk is never needed at runtime

## Test plan
- [x] `cargo check` — compiles without cc-sdk (default)
- [x] `cargo check --features cc-sdk` — compiles with cc-sdk enabled
- [x] `just pre-commit` — 849 unit + 8 E2E tests pass, clippy clean
- [x] `csa review --diff` — zero findings
- [x] `csa review --branch main` — zero findings, low risk
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)