### PR TITLE
fix(skills): add missing YAML frontmatter to 7 SKILL.md files

### DIFF
--- a/skills/csa-async-debug/SKILL.md
+++ b/skills/csa-async-debug/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: csa-async-debug
+description: Expert diagnosis for Tokio/async Rust issues including deadlocks, task leaks, performance bottlenecks, and cancellation safety
+allowed-tools: Bash, Read, Grep, Glob
+---
+
 # Async/Tokio Debugging Guide
 
 Expert diagnosis for Tokio/async Rust issues: deadlocks, task leaks, performance bottlenecks, and cancellation safety.

--- a/skills/csa-cc/SKILL.md
+++ b/skills/csa-cc/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: csa-cc
+description: Thin routing skill that replaces all 14 Claude Code agents with csa claude-sub-agent
+allowed-tools: Bash, Read, Grep, Glob, Task
+---
+
 # csa-cc: Claude Code Sub-Agent Router
 
 Thin routing skill that replaces all 14 Claude Code agents with `csa claude-sub-agent`.

--- a/skills/csa-doc-writing/SKILL.md
+++ b/skills/csa-doc-writing/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: csa-doc-writing
+description: Clear, practical documentation for APIs, README, architecture decisions, and changelogs
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
 # Technical Documentation Writing
 
 Clear, practical documentation for APIs, README, architecture decisions, and changelogs.

--- a/skills/csa-rust-dev/SKILL.md
+++ b/skills/csa-rust-dev/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: csa-rust-dev
+description: Comprehensive guide for professional Rust development combining implementation expertise, architectural depth, and project standards
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
 # Rust Development Excellence
 
 Comprehensive guide for professional Rust development combining implementation expertise, architectural depth, and project standards.

--- a/skills/csa-security/SKILL.md
+++ b/skills/csa-security/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: csa-security
+description: Adversarial security analysis expertise for identifying vulnerabilities before attackers do
+allowed-tools: Bash, Read, Grep, Glob
+---
+
 # Security Audit & Code Review
 
 Adversarial security analysis expertise for identifying vulnerabilities before attackers do.

--- a/skills/csa-test-gen/SKILL.md
+++ b/skills/csa-test-gen/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: csa-test-gen
+description: Comprehensive test design for Rust projects following Core-first TDD and test pyramid principles
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
 # Test Generation & TDD Excellence
 
 Comprehensive test design for Rust projects following Core-first TDD and test pyramid principles.

--- a/skills/sa/SKILL.md
+++ b/skills/sa/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: sa
+description: Three-tier recursive delegation for planning and implementing features with main agent dispatching and child CSA building
+allowed-tools: Bash, Read, Grep, Glob, Task
+---
+
 # sa: Sub-Agent Orchestration (Three-Tier Architecture)
 
 Three-tier recursive delegation for planning and implementing features.


### PR DESCRIPTION
## Summary
- Add YAML frontmatter (`name`, `description`, `allowed-tools`) to 7 SKILL.md files that were missing it
- Fixes Codex startup warnings: "missing YAML frontmatter delimited by ---"
- Affected skills: `csa-async-debug`, `csa-cc`, `csa-doc-writing`, `csa-rust-dev`, `csa-security`, `csa-test-gen`, `sa`

## Test plan
- [ ] Open Codex in this repo and verify no "Skipped loading skill" warnings appear
- [ ] Verify all 7 skills are now loaded successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)