### PR TITLE
fix(executor): map Xhigh thinking budget to xhigh codex effort

### DIFF
--- a/crates/csa-executor/src/executor_build_cmd_tests.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests.rs
@@ -519,7 +519,7 @@ fn test_codex_effort_all_variants() {
     assert_eq!(ThinkingBudget::Low.codex_effort(), "low");
     assert_eq!(ThinkingBudget::Medium.codex_effort(), "medium");
     assert_eq!(ThinkingBudget::High.codex_effort(), "high");
-    assert_eq!(ThinkingBudget::Xhigh.codex_effort(), "high");
+    assert_eq!(ThinkingBudget::Xhigh.codex_effort(), "xhigh");
     assert_eq!(ThinkingBudget::Custom(0).codex_effort(), "high");
     assert_eq!(ThinkingBudget::Custom(100000).codex_effort(), "high");
 }

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -90,7 +90,7 @@ impl ThinkingBudget {
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
-            Self::Xhigh => "high", // codex doesn't support xhigh, fallback to high
+            Self::Xhigh => "xhigh",
             Self::Custom(_) => "high", // custom values map to high
         }
     }
@@ -232,7 +232,7 @@ mod tests {
         assert_eq!(ThinkingBudget::Low.codex_effort(), "low");
         assert_eq!(ThinkingBudget::Medium.codex_effort(), "medium");
         assert_eq!(ThinkingBudget::High.codex_effort(), "high");
-        assert_eq!(ThinkingBudget::Xhigh.codex_effort(), "high"); // fallback to high
+        assert_eq!(ThinkingBudget::Xhigh.codex_effort(), "xhigh");
         assert_eq!(ThinkingBudget::Custom(10000).codex_effort(), "high"); // fallback to high
     }
 }


### PR DESCRIPTION
## Summary
- Fixed `ThinkingBudget::Xhigh.codex_effort()` to return `"xhigh"` instead of incorrectly falling back to `"high"`
- Codex CLI supports `xhigh` as its highest reasoning effort level — the previous mapping was wrong
- Updated tests in both `model_spec.rs` and `executor_build_cmd_tests.rs`

## Test plan
- [x] `cargo test -p csa-executor -- model_spec` — all 13 tests pass
- [x] `cargo test -p csa-executor -- test_codex_effort_all_variants` — assertion updated
- [x] `just pre-commit` — full 849 test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)