### PR TITLE
fix(executor): use -c model_reasoning_effort= instead of --reasoning-effort for codex

### DIFF
--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -413,7 +413,8 @@ impl Executor {
                     cmd.arg("--model").arg(model);
                 }
                 if let Some(budget) = thinking_budget {
-                    cmd.arg("--reasoning-effort").arg(budget.codex_effort());
+                    cmd.arg("-c")
+                        .arg(format!("model_reasoning_effort={}", budget.codex_effort()));
                 }
             }
             Self::ClaudeCode {

--- a/crates/csa-executor/src/executor_build_cmd_tests.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests.rs
@@ -279,10 +279,13 @@ fn test_build_command_codex_args_structure() {
     assert!(args.contains(&"--model".to_string()), "Should have --model");
     assert!(args.contains(&"gpt-5".to_string()), "Should have model");
     assert!(
-        args.contains(&"--reasoning-effort".to_string()),
-        "Should have --reasoning-effort"
+        args.contains(&"-c".to_string()),
+        "Should have -c flag for reasoning effort"
     );
-    assert!(args.contains(&"low".to_string()), "Low budget = low effort");
+    assert!(
+        args.contains(&"model_reasoning_effort=low".to_string()),
+        "Low budget = low effort via -c model_reasoning_effort=low"
+    );
     assert!(args.contains(&"fix bug".to_string()), "Should have prompt");
 }
 

--- a/crates/csa-executor/src/executor_tests.rs
+++ b/crates/csa-executor/src/executor_tests.rs
@@ -221,11 +221,11 @@ fn test_from_tool_name_with_model_and_thinking() {
         "Missing model in args: {debug_str}"
     );
     assert!(
-        debug_str.contains("--reasoning-effort"),
-        "Missing reasoning-effort in args: {debug_str}"
+        debug_str.contains("model_reasoning_effort="),
+        "Missing model_reasoning_effort in args: {debug_str}"
     );
     assert!(
-        debug_str.contains("\"low\""),
+        debug_str.contains("model_reasoning_effort=low"),
         "Expected low reasoning effort: {debug_str}"
     );
 }
@@ -294,10 +294,9 @@ fn test_thinking_budget_in_codex_args() {
     let mut cmd = Command::new(exec.executable_name());
     exec.append_tool_args(&mut cmd, "test prompt", None);
 
-    // Check that the command contains --reasoning-effort low
+    // Check that the command contains -c model_reasoning_effort=low
     let debug_str = format!("{:?}", cmd);
-    assert!(debug_str.contains("--reasoning-effort"));
-    assert!(debug_str.contains("\"low\""));
+    assert!(debug_str.contains("model_reasoning_effort=low"));
 }
 
 #[test]
@@ -322,8 +321,7 @@ fn test_thinking_budget_from_spec_codex() {
     exec.append_tool_args(&mut cmd, "test prompt", None);
 
     let debug_str = format!("{:?}", cmd);
-    assert!(debug_str.contains("--reasoning-effort"));
-    assert!(debug_str.contains("\"low\""));
+    assert!(debug_str.contains("model_reasoning_effort=low"));
 }
 
 #[test]
@@ -519,7 +517,7 @@ fn test_execute_in_preserves_model_override() {
                     "Codex missing model: {debug_str}"
                 );
                 assert!(
-                    debug_str.contains("--reasoning-effort"),
+                    debug_str.contains("model_reasoning_effort="),
                     "Codex missing thinking: {debug_str}"
                 );
             }

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -83,7 +83,7 @@ impl ThinkingBudget {
 
     /// Returns the reasoning effort level for codex-style tools.
     ///
-    /// Maps thinking budget levels to codex's --reasoning-effort values.
+    /// Maps thinking budget levels to codex's `-c model_reasoning_effort=` values.
     pub fn codex_effort(&self) -> &'static str {
         match self {
             Self::DefaultBudget => "medium",


### PR DESCRIPTION
## Summary
- Replace deprecated `--reasoning-effort` CLI flag with `-c model_reasoning_effort=<level>` for codex executor
- Update all related tests to assert the new flag format

## Test plan
- [x] All existing codex reasoning effort tests updated and passing
- [x] `just pre-commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)