### PR TITLE
fix(acp): use standalone Zed ACP adapter binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ strix_runs
 review-findings.json
 review-findings.json.tmp
 review-report.md
+.letta/

--- a/crates/cli-sub-agent/src/batch.rs
+++ b/crates/cli-sub-agent/src/batch.rs
@@ -458,17 +458,6 @@ async fn execute_task(
         }
     };
 
-    // Check tool is installed
-    if let Err(e) = check_tool_installed(tool_name.as_str()).await {
-        error!("{} - Tool not installed: {}", task_label, e);
-        return TaskResult {
-            name: task.name.clone(),
-            exit_code: 1,
-            duration_secs: start.elapsed().as_secs_f64(),
-            error: Some(format!("Tool not installed: {}", e)),
-        };
-    }
-
     // Check tool is enabled
     if let Some(cfg) = config {
         if !cfg.is_tool_enabled(tool_name.as_str()) {
@@ -495,6 +484,17 @@ async fn execute_task(
             };
         }
     };
+
+    // Check tool is installed (using runtime binary name for ACP-aware check)
+    if let Err(e) = check_tool_installed(executor.runtime_binary_name()).await {
+        error!("{} - Tool not installed: {}", task_label, e);
+        return TaskResult {
+            name: task.name.clone(),
+            exit_code: 1,
+            duration_secs: start.elapsed().as_secs_f64(),
+            error: Some(format!("Tool not installed: {}", e)),
+        };
+    }
 
     // Check resource availability
     if let Some(guard) = resource_guard {

--- a/crates/cli-sub-agent/src/doctor.rs
+++ b/crates/cli-sub-agent/src/doctor.rs
@@ -20,8 +20,8 @@ fn install_hint(tool_name: &str) -> &'static str {
     match tool_name {
         "gemini-cli" => "npm install -g @google/gemini-cli",
         "opencode" => "go install github.com/sst/opencode@latest",
-        "codex" => "npm install -g @openai/codex",
-        "claude-code" => "npm install -g @anthropic-ai/claude-code",
+        "codex" => "npm install -g @zed-industries/codex-acp",
+        "claude-code" => "npm install -g @zed-industries/claude-code-acp",
         _ => "unknown tool",
     }
 }
@@ -69,8 +69,8 @@ async fn run_doctor_json() -> Result<()> {
     let tools = [
         ("gemini-cli", "gemini"),
         ("opencode", "opencode"),
-        ("codex", "codex"),
-        ("claude-code", "claude"),
+        ("codex", "codex-acp"),
+        ("claude-code", "claude-code-acp"),
     ];
 
     let tool_statuses: Vec<serde_json::Value> = tools
@@ -171,8 +171,8 @@ async fn print_tool_availability() {
     let tools = [
         ("gemini-cli", "gemini"),
         ("opencode", "opencode"),
-        ("codex", "codex"),
-        ("claude-code", "claude"),
+        ("codex", "codex-acp"),
+        ("claude-code", "claude-code-acp"),
     ];
 
     let mut installed_count = 0;

--- a/crates/cli-sub-agent/src/mcp_server.rs
+++ b/crates/cli-sub-agent/src/mcp_server.rs
@@ -498,7 +498,7 @@ async fn handle_run_tool(args: Value) -> Result<Value> {
     )?;
 
     // Check tool is installed
-    if csa_process::check_tool_installed(executor.executable_name())
+    if csa_process::check_tool_installed(executor.runtime_binary_name())
         .await
         .is_err()
     {

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -118,7 +118,7 @@ pub(crate) async fn build_and_validate_executor(
     }
 
     // Check tool is installed
-    if let Err(e) = check_tool_installed(executor.executable_name()).await {
+    if let Err(e) = check_tool_installed(executor.runtime_binary_name()).await {
         error!(
             "Tool '{}' is not installed.\n\n{}\n\nOr disable it in .csa/config.toml:\n  [tools.{}]\n  enabled = false",
             executor.tool_name(),

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -262,12 +262,17 @@ pub(crate) fn read_prompt(prompt: Option<String>) -> Result<String> {
 }
 
 /// Check if a tool's binary is available on PATH (synchronous).
+///
+/// For ACP-routed tools (codex, claude-code), checks for the ACP adapter
+/// binary (`codex-acp`, `claude-code-acp`). For legacy tools, checks the
+/// native CLI binary.
 pub(crate) fn is_tool_binary_available(tool_name: &str) -> bool {
     let binary = match tool_name {
         "gemini-cli" => "gemini",
         "opencode" => "opencode",
-        "codex" => "codex",
-        "claude-code" => "claude",
+        // ACP adapter binaries (npm: @zed-industries/codex-acp, @zed-industries/claude-code-acp)
+        "codex" => "codex-acp",
+        "claude-code" => "claude-code-acp",
         _ => return false,
     };
     std::process::Command::new("which")

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -51,7 +51,10 @@ impl Executor {
         }
     }
 
-    /// Get the executable name for the tool.
+    /// Get the executable name for legacy CLI transport.
+    ///
+    /// Used only by `LegacyTransport` to build the CLI command.
+    /// For pre-flight availability checks, use `runtime_binary_name()` instead.
     pub fn executable_name(&self) -> &'static str {
         match self {
             Self::GeminiCli { .. } => "gemini",
@@ -61,13 +64,29 @@ impl Executor {
         }
     }
 
+    /// Get the binary name that will actually be spawned at runtime.
+    ///
+    /// ACP-routed tools use standalone adapter binaries (`codex-acp`,
+    /// `claude-code-acp`). Legacy tools use the native CLI binary.
+    /// Use this for pre-flight `check_tool_installed` calls.
+    pub fn runtime_binary_name(&self) -> &'static str {
+        match self {
+            Self::GeminiCli { .. } => "gemini",
+            Self::Opencode { .. } => "opencode",
+            Self::Codex { .. } => "codex-acp",
+            Self::ClaudeCode { .. } => "claude-code-acp",
+        }
+    }
+
     /// Get installation instructions for the tool.
     pub fn install_hint(&self) -> &'static str {
         match self {
             Self::GeminiCli { .. } => "Install: npm install -g @anthropic-ai/gemini-cli",
             Self::Opencode { .. } => "Install: go install github.com/anthropics/opencode@latest",
-            Self::Codex { .. } => "Install: npm install -g @openai/codex",
-            Self::ClaudeCode { .. } => "Install: npm install -g @anthropic-ai/claude-code",
+            Self::Codex { .. } => "Install ACP adapter: npm install -g @zed-industries/codex-acp",
+            Self::ClaudeCode { .. } => {
+                "Install ACP adapter: npm install -g @zed-industries/claude-code-acp"
+            }
         }
     }
 

--- a/crates/csa-executor/src/executor_tests.rs
+++ b/crates/csa-executor/src/executor_tests.rs
@@ -99,7 +99,7 @@ fn test_install_hint() {
             thinking_budget: None,
         }
         .install_hint(),
-        "Install: npm install -g @openai/codex"
+        "Install ACP adapter: npm install -g @zed-industries/codex-acp"
     );
     assert_eq!(
         Executor::ClaudeCode {
@@ -107,7 +107,46 @@ fn test_install_hint() {
             thinking_budget: None,
         }
         .install_hint(),
-        "Install: npm install -g @anthropic-ai/claude-code"
+        "Install ACP adapter: npm install -g @zed-industries/claude-code-acp"
+    );
+}
+
+#[test]
+fn test_runtime_binary_name() {
+    // Legacy tools: runtime binary = executable name
+    assert_eq!(
+        Executor::GeminiCli {
+            model_override: None,
+            thinking_budget: None,
+        }
+        .runtime_binary_name(),
+        "gemini"
+    );
+    assert_eq!(
+        Executor::Opencode {
+            model_override: None,
+            agent: None,
+            thinking_budget: None,
+        }
+        .runtime_binary_name(),
+        "opencode"
+    );
+    // ACP tools: runtime binary = ACP adapter
+    assert_eq!(
+        Executor::Codex {
+            model_override: None,
+            thinking_budget: None,
+        }
+        .runtime_binary_name(),
+        "codex-acp"
+    );
+    assert_eq!(
+        Executor::ClaudeCode {
+            model_override: None,
+            thinking_budget: None,
+        }
+        .runtime_binary_name(),
+        "claude-code-acp"
     );
 }
 

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -122,12 +122,13 @@ impl AcpTransport {
     }
 
     fn acp_command_for_tool(tool_name: &str) -> (String, Vec<String>) {
+        // ACP adapters are standalone binaries from Zed Industries:
+        //   npm: @zed-industries/codex-acp, @zed-industries/claude-code-acp
+        // They bridge the tool's SDK to ACP protocol over stdio.
         match tool_name {
-            "claude-code" => ("claude".into(), vec!["--acp".into()]),
-            "codex" => ("codex".into(), vec!["acp".into()]),
-            "opencode" => ("opencode".into(), vec!["acp".into()]),
-            "gemini-cli" => ("gemini".into(), vec!["--experimental-acp".into()]),
-            _ => (tool_name.into(), vec!["--acp".into()]),
+            "claude-code" => ("claude-code-acp".into(), vec![]),
+            "codex" => ("codex-acp".into(), vec![]),
+            _ => (format!("{tool_name}-acp"), vec![]),
         }
     }
 
@@ -411,19 +412,20 @@ mod tests {
     fn test_acp_command_for_tool_mappings() {
         assert_eq!(
             AcpTransport::acp_command_for_tool("claude-code"),
-            ("claude".to_string(), vec!["--acp".to_string()])
+            ("claude-code-acp".to_string(), vec![])
         );
         assert_eq!(
             AcpTransport::acp_command_for_tool("codex"),
-            ("codex".to_string(), vec!["acp".to_string()])
+            ("codex-acp".to_string(), vec![])
         );
+        // Unknown tools get "{name}-acp" convention
         assert_eq!(
             AcpTransport::acp_command_for_tool("opencode"),
-            ("opencode".to_string(), vec!["acp".to_string()])
+            ("opencode-acp".to_string(), vec![])
         );
         assert_eq!(
             AcpTransport::acp_command_for_tool("gemini-cli"),
-            ("gemini".to_string(), vec!["--experimental-acp".to_string()])
+            ("gemini-cli-acp".to_string(), vec![])
         );
     }
 


### PR DESCRIPTION
## Summary
- ACP transport was launching `codex acp` and `claude --acp` which are invalid subcommands
- The ACP protocol requires standalone adapter binaries from Zed Industries: `codex-acp` (`@zed-industries/codex-acp`) and `claude-code-acp` (`@zed-industries/claude-code-acp`)
- Fixed `acp_command_for_tool()` mapping, added `runtime_binary_name()` for ACP-aware preflight checks, synced doctor/install hints

## Test plan
- [x] `just pre-commit` passes (872 unit + 8 e2e tests)
- [x] `csa run --tool codex` via ACP transport succeeds
- [x] `csa run --tool claude-code` via ACP transport succeeds
- [x] `csa session list/compress/checkpoint` work correctly
- [x] `csa review --diff` completes successfully
- [x] `csa doctor` shows correct adapter binary names
- [ ] Deferred: update `process_tree.rs` for ACP adapter names
- [ ] Deferred: add cross-module binary name consistency test

🤖 Generated with [Claude Code](https://claude.com/claude-code)