### PR TITLE
fix(process-tree): recognize ACP adapter binary names

### DIFF
--- a/crates/cli-sub-agent/src/process_tree.rs
+++ b/crates/cli-sub-agent/src/process_tree.rs
@@ -344,12 +344,15 @@ mod tests {
         for executor in &executors {
             let binary = executor.runtime_binary_name();
             let result = match_tool_by_comm(binary);
-            assert!(
-                result.is_some(),
-                "Executor {:?} runtime_binary_name() '{}' is not recognized by match_tool_by_comm(). \
-                 Add it to KNOWN_TOOL_EXECUTABLES.",
+            assert_eq!(
+                result,
+                Some(executor.tool_name()),
+                "Executor '{}' runtime_binary_name() '{}' maps to {:?}, expected Some(\"{}\"). \
+                 Update KNOWN_TOOL_EXECUTABLES to match.",
                 executor.tool_name(),
                 binary,
+                result,
+                executor.tool_name(),
             );
         }
     }


### PR DESCRIPTION
## Summary
- Add `codex-acp` and `claude-code-acp` to `KNOWN_TOOL_EXECUTABLES` so ancestor tool detection works with standalone Zed ACP adapter binaries
- Add unit tests for ACP adapter comm matching
- Add cross-module consistency test verifying all `Executor::runtime_binary_name()` values are recognized by `match_tool_by_comm()`

## Context
Deferred follow-up from PR #76 (ACP adapter migration). The process tree detection module was still only aware of native CLI binary names, missing the new ACP adapter binaries that are actually spawned at runtime.

## Test plan
- [x] `just pre-commit` passes (875 unit + 8 e2e tests)
- [x] `csa review --diff` clean (0 findings)
- [ ] `/pr-codex-bot` review

🤖 Generated with [Claude Code](https://claude.com/claude-code)