### PR TITLE
feat(weave): implement skill-lang compiler (Markdown → execution plan)

### DIFF
--- a/crates/weave/src/compiler.rs
+++ b/crates/weave/src/compiler.rs
@@ -1,1 +1,390 @@
-// Weave skill compiler.
+//! Weave skill-lang compiler.
+//!
+//! Transforms a parsed [`SkillDocument`] AST into an [`ExecutionPlan`] that
+//! can be serialized to TOML for inspection or consumed by a runtime.
+
+use anyhow::{Result, bail};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+
+use crate::parser::{Block, SkillDocument};
+
+// ---------------------------------------------------------------------------
+// Plan types
+// ---------------------------------------------------------------------------
+
+/// An executable plan produced by compiling a skill document.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionPlan {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub variables: Vec<VariableDecl>,
+    pub steps: Vec<PlanStep>,
+}
+
+/// A single step in the execution plan.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlanStep {
+    pub id: usize,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    pub prompt: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tier: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<usize>,
+    #[serde(default)]
+    pub on_fail: FailAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loop_var: Option<LoopSpec>,
+}
+
+/// How to handle a step failure.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FailAction {
+    #[default]
+    Abort,
+    Retry(u32),
+    Skip,
+    Delegate(String),
+}
+
+/// Loop specification for FOR blocks.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LoopSpec {
+    pub variable: String,
+    pub collection: String,
+}
+
+/// A variable declaration collected from the plan.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VariableDecl {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Regex for tool-hint extraction
+// ---------------------------------------------------------------------------
+
+/// Matches a `Tool: <name>` line at the start of a step body.
+static TOOL_HINT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^Tool:\s*(\S+)\s*$").expect("valid regex"));
+
+/// Matches a `Tier: <name>` line at the start of a step body.
+static TIER_HINT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^Tier:\s*(\S+)\s*$").expect("valid regex"));
+
+/// Matches a `OnFail: <action>` line at the start of a step body.
+static ONFAIL_HINT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^OnFail:\s*(.+)\s*$").expect("valid regex"));
+
+/// Matches `${VAR_NAME}` placeholders.
+static VAR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}").expect("valid regex"));
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Compile a parsed skill document into an execution plan.
+pub fn compile(doc: &SkillDocument) -> Result<ExecutionPlan> {
+    let mut ctx = CompileCtx::new();
+    compile_blocks(&doc.body, &mut ctx)?;
+
+    let mut all_vars: Vec<String> = ctx.variables;
+    all_vars.sort();
+    all_vars.dedup();
+
+    let variables = all_vars
+        .into_iter()
+        .map(|name| VariableDecl {
+            name,
+            default: None,
+        })
+        .collect();
+
+    Ok(ExecutionPlan {
+        name: doc.meta.name.clone(),
+        description: doc.meta.description.clone().unwrap_or_default(),
+        variables,
+        steps: ctx.steps,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal compilation context
+// ---------------------------------------------------------------------------
+
+struct CompileCtx {
+    steps: Vec<PlanStep>,
+    variables: Vec<String>,
+    next_id: usize,
+}
+
+impl CompileCtx {
+    fn new() -> Self {
+        Self {
+            steps: Vec::new(),
+            variables: Vec::new(),
+            next_id: 1,
+        }
+    }
+
+    fn alloc_id(&mut self) -> usize {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    fn collect_vars(&mut self, text: &str) {
+        for cap in VAR_RE.captures_iter(text) {
+            self.variables.push(cap[1].to_string());
+        }
+    }
+}
+
+/// Compile a slice of AST blocks into plan steps.
+fn compile_blocks(blocks: &[Block], ctx: &mut CompileCtx) -> Result<()> {
+    for block in blocks {
+        match block {
+            Block::Step {
+                title,
+                body,
+                variables,
+            } => {
+                compile_step(title, body, variables, ctx)?;
+            }
+            Block::If {
+                condition,
+                then_blocks,
+                else_blocks,
+            } => {
+                compile_if(condition, then_blocks, else_blocks, ctx)?;
+            }
+            Block::For {
+                variable,
+                collection,
+                body,
+            } => {
+                compile_for(variable, collection, body, ctx)?;
+            }
+            Block::Include { path } => {
+                compile_include(path, ctx);
+            }
+            Block::RawMarkdown(_) => {
+                // Raw markdown is informational; not compiled into steps.
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Extract metadata hints (Tool, Tier, OnFail) from the first lines of a step
+/// body and return the remaining prompt text.
+fn extract_hints(body: &str) -> (Option<String>, Option<String>, FailAction, String) {
+    let mut tool = None;
+    let mut tier = None;
+    let mut on_fail = FailAction::Abort;
+    let mut prompt_lines = Vec::new();
+    let mut in_hints = true;
+
+    for line in body.lines() {
+        if in_hints {
+            if let Some(caps) = TOOL_HINT_RE.captures(line) {
+                tool = Some(caps[1].to_string());
+                continue;
+            }
+            if let Some(caps) = TIER_HINT_RE.captures(line) {
+                tier = Some(caps[1].to_string());
+                continue;
+            }
+            if let Some(caps) = ONFAIL_HINT_RE.captures(line) {
+                on_fail = parse_fail_action(caps[1].trim());
+                continue;
+            }
+            // First non-hint line ends hint extraction.
+            if !line.trim().is_empty() {
+                in_hints = false;
+            }
+        }
+        prompt_lines.push(line);
+    }
+
+    let prompt = prompt_lines.join("\n").trim().to_string();
+    (tool, tier, on_fail, prompt)
+}
+
+/// Parse a fail action string.
+fn parse_fail_action(s: &str) -> FailAction {
+    let lower = s.to_lowercase();
+    if lower == "skip" {
+        return FailAction::Skip;
+    }
+    if lower == "abort" {
+        return FailAction::Abort;
+    }
+    if let Some(rest) = lower.strip_prefix("retry") {
+        let count: u32 = rest.trim().parse().unwrap_or(3);
+        return FailAction::Retry(count);
+    }
+    if let Some(rest) = lower.strip_prefix("delegate") {
+        let target = rest.trim().to_string();
+        return FailAction::Delegate(if target.is_empty() {
+            "auto".to_string()
+        } else {
+            target
+        });
+    }
+    FailAction::Abort
+}
+
+fn compile_step(title: &str, body: &str, variables: &[String], ctx: &mut CompileCtx) -> Result<()> {
+    let id = ctx.alloc_id();
+    let (tool, tier, on_fail, prompt) = extract_hints(body);
+
+    for var in variables {
+        ctx.variables.push(var.clone());
+    }
+
+    ctx.steps.push(PlanStep {
+        id,
+        title: title.to_string(),
+        tool,
+        prompt,
+        tier,
+        depends_on: Vec::new(),
+        on_fail,
+        condition: None,
+        loop_var: None,
+    });
+    Ok(())
+}
+
+fn compile_if(
+    condition: &str,
+    then_blocks: &[Block],
+    else_blocks: &[Block],
+    ctx: &mut CompileCtx,
+) -> Result<()> {
+    ctx.collect_vars(condition);
+
+    // Compile then-branch steps with the condition.
+    let then_start = ctx.steps.len();
+    compile_blocks(then_blocks, ctx)?;
+    let then_end = ctx.steps.len();
+
+    // Tag all then-branch steps with the condition.
+    for step in &mut ctx.steps[then_start..then_end] {
+        step.condition = Some(condition.to_string());
+    }
+
+    if then_start == then_end {
+        // Empty then-branch: emit a placeholder step.
+        let id = ctx.alloc_id();
+        ctx.steps.push(PlanStep {
+            id,
+            title: format!("(if {condition})"),
+            tool: None,
+            prompt: String::new(),
+            tier: None,
+            depends_on: Vec::new(),
+            on_fail: FailAction::Skip,
+            condition: Some(condition.to_string()),
+            loop_var: None,
+        });
+    }
+
+    // Compile else-branch with negated condition.
+    if !else_blocks.is_empty() {
+        let negated = format!("!({condition})");
+        let else_start = ctx.steps.len();
+        compile_blocks(else_blocks, ctx)?;
+        let else_end = ctx.steps.len();
+
+        for step in &mut ctx.steps[else_start..else_end] {
+            step.condition = Some(negated.clone());
+        }
+    }
+
+    Ok(())
+}
+
+fn compile_for(
+    variable: &str,
+    collection: &str,
+    body: &[Block],
+    ctx: &mut CompileCtx,
+) -> Result<()> {
+    ctx.collect_vars(collection);
+
+    let for_start = ctx.steps.len();
+    compile_blocks(body, ctx)?;
+    let for_end = ctx.steps.len();
+
+    if for_start == for_end {
+        bail!("FOR block over `{collection}` has no compilable steps");
+    }
+
+    let loop_spec = LoopSpec {
+        variable: variable.to_string(),
+        collection: collection.to_string(),
+    };
+
+    // Tag all loop body steps with the loop spec.
+    for step in &mut ctx.steps[for_start..for_end] {
+        step.loop_var = Some(loop_spec.clone());
+    }
+
+    Ok(())
+}
+
+fn compile_include(path: &str, ctx: &mut CompileCtx) {
+    let id = ctx.alloc_id();
+    ctx.steps.push(PlanStep {
+        id,
+        title: format!("Include {path}"),
+        tool: Some("weave".to_string()),
+        prompt: path.to_string(),
+        tier: None,
+        depends_on: Vec::new(),
+        on_fail: FailAction::Abort,
+        condition: None,
+        loop_var: None,
+    });
+}
+
+// ---------------------------------------------------------------------------
+// TOML serialization wrapper
+// ---------------------------------------------------------------------------
+
+/// Wrapper for TOML serialization of the execution plan.
+#[derive(Serialize, Deserialize)]
+struct PlanWrapper {
+    plan: ExecutionPlan,
+}
+
+/// Serialize an execution plan to TOML.
+pub fn plan_to_toml(plan: &ExecutionPlan) -> Result<String> {
+    let wrapper = PlanWrapper { plan: plan.clone() };
+    toml::to_string_pretty(&wrapper).map_err(|e| anyhow::anyhow!("TOML serialization failed: {e}"))
+}
+
+/// Deserialize an execution plan from TOML.
+pub fn plan_from_toml(toml_str: &str) -> Result<ExecutionPlan> {
+    let wrapper: PlanWrapper = toml::from_str(toml_str)
+        .map_err(|e| anyhow::anyhow!("TOML deserialization failed: {e}"))?;
+    Ok(wrapper.plan)
+}
+
+#[cfg(test)]
+#[path = "compiler_tests.rs"]
+mod tests;

--- a/crates/weave/src/compiler_tests.rs
+++ b/crates/weave/src/compiler_tests.rs
@@ -1,0 +1,436 @@
+use super::*;
+use crate::parser::parse_skill;
+
+// ---------------------------------------------------------------------------
+// Empty document
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compile_empty_document() {
+    let input = "---\nname = \"empty\"\n---\n";
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.name, "empty");
+    assert!(plan.steps.is_empty());
+    assert!(plan.variables.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Single step
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compile_single_step() {
+    let input = r#"---
+name = "single"
+description = "A single step"
+---
+## Greet
+Hello world.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.name, "single");
+    assert_eq!(plan.description, "A single step");
+    assert_eq!(plan.steps.len(), 1);
+
+    let step = &plan.steps[0];
+    assert_eq!(step.id, 1);
+    assert_eq!(step.title, "Greet");
+    assert_eq!(step.prompt, "Hello world.");
+    assert!(step.tool.is_none());
+    assert!(step.condition.is_none());
+    assert!(step.loop_var.is_none());
+    assert_eq!(step.on_fail, FailAction::Abort);
+}
+
+// ---------------------------------------------------------------------------
+// Tool hint extraction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compile_step_with_tool_hint() {
+    let input = r#"---
+name = "tooled"
+---
+## Build
+Tool: codex
+Build the project with cargo.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.steps.len(), 1);
+    let step = &plan.steps[0];
+    assert_eq!(step.tool.as_deref(), Some("codex"));
+    assert_eq!(step.prompt, "Build the project with cargo.");
+}
+
+#[test]
+fn test_compile_step_with_tier_hint() {
+    let input = r#"---
+name = "tiered"
+---
+## Analyze
+Tier: tier-3-complex
+Tool: claude-code
+Deep analysis of the codebase.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    let step = &plan.steps[0];
+    assert_eq!(step.tier.as_deref(), Some("tier-3-complex"));
+    assert_eq!(step.tool.as_deref(), Some("claude-code"));
+    assert_eq!(step.prompt, "Deep analysis of the codebase.");
+}
+
+#[test]
+fn test_compile_step_with_onfail_skip() {
+    let input = r#"---
+name = "resilient"
+---
+## Optional Step
+OnFail: skip
+Try this but it's okay if it fails.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.steps[0].on_fail, FailAction::Skip);
+}
+
+#[test]
+fn test_compile_step_with_onfail_retry() {
+    let input = r#"---
+name = "retry-test"
+---
+## Flaky Step
+OnFail: retry 5
+Might need retries.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.steps[0].on_fail, FailAction::Retry(5));
+}
+
+// ---------------------------------------------------------------------------
+// IF / ELSE → conditional steps
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compile_if_else() {
+    let input = r#"---
+name = "conditional"
+---
+## IF has_tests
+## Run Tests
+Run the test suite.
+## ELSE
+## Skip Tests
+No tests available.
+## ENDIF
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.steps.len(), 2);
+
+    let then_step = &plan.steps[0];
+    assert_eq!(then_step.title, "Run Tests");
+    assert_eq!(then_step.condition.as_deref(), Some("has_tests"));
+
+    let else_step = &plan.steps[1];
+    assert_eq!(else_step.title, "Skip Tests");
+    assert_eq!(else_step.condition.as_deref(), Some("!(has_tests)"));
+}
+
+#[test]
+fn test_compile_if_without_else() {
+    let input = r#"---
+name = "if-only"
+---
+## IF debug_mode
+## Debug Output
+Print debug info.
+## ENDIF
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.steps.len(), 1);
+    let step = &plan.steps[0];
+    assert_eq!(step.condition.as_deref(), Some("debug_mode"));
+}
+
+// ---------------------------------------------------------------------------
+// FOR → loop steps
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compile_for_loop() {
+    let input = r#"---
+name = "loop"
+---
+## FOR file IN source_files
+## Process
+Handle ${file}.
+## ENDFOR
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.steps.len(), 1);
+    let step = &plan.steps[0];
+    assert_eq!(step.title, "Process");
+    assert!(step.loop_var.is_some());
+    let lv = step.loop_var.as_ref().unwrap();
+    assert_eq!(lv.variable, "file");
+    assert_eq!(lv.collection, "source_files");
+}
+
+// ---------------------------------------------------------------------------
+// INCLUDE → weave sub-step
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compile_include() {
+    let input = r#"---
+name = "composed"
+---
+## INCLUDE shared/setup.md
+## Main Work
+Do the main thing.
+## INCLUDE shared/teardown.md
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.steps.len(), 3);
+
+    assert_eq!(plan.steps[0].tool.as_deref(), Some("weave"));
+    assert_eq!(plan.steps[0].prompt, "shared/setup.md");
+    assert_eq!(plan.steps[0].title, "Include shared/setup.md");
+
+    assert_eq!(plan.steps[1].title, "Main Work");
+
+    assert_eq!(plan.steps[2].tool.as_deref(), Some("weave"));
+    assert_eq!(plan.steps[2].prompt, "shared/teardown.md");
+}
+
+// ---------------------------------------------------------------------------
+// Variable collection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_variable_collection_across_steps() {
+    let input = r#"---
+name = "vars"
+---
+## Deploy
+Deploy ${APP_NAME} to ${ENVIRONMENT}.
+
+## Verify
+Check ${APP_NAME} on ${ENDPOINT}.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    let var_names: Vec<&str> = plan.variables.iter().map(|v| v.name.as_str()).collect();
+    assert_eq!(var_names, vec!["APP_NAME", "ENDPOINT", "ENVIRONMENT"]);
+}
+
+#[test]
+fn test_variable_deduplication() {
+    let input = r#"---
+name = "dedup"
+---
+## Step A
+Use ${VAR} here.
+
+## Step B
+Use ${VAR} again and ${VAR} once more.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.variables.len(), 1);
+    assert_eq!(plan.variables[0].name, "VAR");
+}
+
+// ---------------------------------------------------------------------------
+// Sequential IDs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_sequential_step_ids() {
+    let input = r#"---
+name = "multi"
+---
+## Step 1: First
+Do first.
+
+## Step 2: Second
+Do second.
+
+## Step 3: Third
+Do third.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    let ids: Vec<usize> = plan.steps.iter().map(|s| s.id).collect();
+    assert_eq!(ids, vec![1, 2, 3]);
+}
+
+// ---------------------------------------------------------------------------
+// Raw markdown is skipped
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_raw_markdown_ignored() {
+    let input = r#"---
+name = "raw"
+---
+Some intro text that is not a step.
+
+## Actual Step
+Do something.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.steps.len(), 1);
+    assert_eq!(plan.steps[0].title, "Actual Step");
+}
+
+// ---------------------------------------------------------------------------
+// TOML round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_toml_round_trip() {
+    let input = r#"---
+name = "roundtrip"
+description = "Test TOML serialization"
+---
+## INCLUDE shared/setup.md
+
+## Build
+Tool: codex
+OnFail: retry 3
+Build ${PROJECT} with cargo.
+
+## IF has_tests
+## Test
+Tool: claude-code
+Tier: tier-2-standard
+Run tests for ${PROJECT}.
+## ENDIF
+
+## FOR mod IN modules
+## Lint Module
+Tool: codex
+Lint ${mod}.
+## ENDFOR
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    // Serialize to TOML.
+    let toml_str = plan_to_toml(&plan).unwrap();
+
+    // Deserialize back.
+    let restored = plan_from_toml(&toml_str).unwrap();
+
+    assert_eq!(plan.name, restored.name);
+    assert_eq!(plan.description, restored.description);
+    assert_eq!(plan.steps.len(), restored.steps.len());
+    assert_eq!(plan.variables.len(), restored.variables.len());
+
+    // Verify key fields survive the round trip.
+    for (orig, rest) in plan.steps.iter().zip(restored.steps.iter()) {
+        assert_eq!(orig.id, rest.id);
+        assert_eq!(orig.title, rest.title);
+        assert_eq!(orig.tool, rest.tool);
+        assert_eq!(orig.prompt, rest.prompt);
+        assert_eq!(orig.condition, rest.condition);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Full workflow
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compile_full_workflow() {
+    let input = r#"---
+name = "deploy-pipeline"
+description = "Full deployment workflow"
+---
+## INCLUDE shared/prereqs.md
+
+## Build
+Tool: codex
+Build the application.
+
+## IF needs_migration
+## Migrate
+Tool: claude-code
+Tier: tier-3-complex
+Run database migrations for ${DB_NAME}.
+## ELSE
+## Skip Migration
+No migration needed.
+## ENDIF
+
+## FOR svc IN services
+## Deploy Service
+Tool: codex
+OnFail: retry 2
+Deploy ${svc} to ${ENVIRONMENT}.
+## ENDFOR
+
+## Verify
+Check deployment health.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.name, "deploy-pipeline");
+    // Steps: include(1) + build(2) + migrate(3) + skip(4) + deploy(5) + verify(6)
+    assert_eq!(plan.steps.len(), 6);
+
+    // Include step
+    assert_eq!(plan.steps[0].tool.as_deref(), Some("weave"));
+
+    // Build step
+    assert_eq!(plan.steps[1].tool.as_deref(), Some("codex"));
+
+    // Conditional then-step
+    assert_eq!(plan.steps[2].condition.as_deref(), Some("needs_migration"));
+    assert_eq!(plan.steps[2].tier.as_deref(), Some("tier-3-complex"));
+
+    // Conditional else-step
+    assert_eq!(
+        plan.steps[3].condition.as_deref(),
+        Some("!(needs_migration)")
+    );
+
+    // Loop step
+    assert!(plan.steps[4].loop_var.is_some());
+    assert_eq!(plan.steps[4].on_fail, FailAction::Retry(2));
+
+    // Final verify (no tool, no condition)
+    assert!(plan.steps[5].tool.is_none());
+    assert!(plan.steps[5].condition.is_none());
+
+    // Variables from across all steps
+    let var_names: Vec<&str> = plan.variables.iter().map(|v| v.name.as_str()).collect();
+    assert!(var_names.contains(&"DB_NAME"));
+    assert!(var_names.contains(&"ENVIRONMENT"));
+    assert!(var_names.contains(&"svc"));
+}


### PR DESCRIPTION
## Summary
- Add `compiler.rs` module that transforms parsed `SkillDocument` AST into a TOML-serializable `ExecutionPlan`
- Support Step compilation with tool/tier/on-fail hint extraction, IF/ELSE conditional steps, FOR loop steps, INCLUDE as weave sub-workflow invocations, and variable collection across all steps
- Wire up `weave compile <input.md> [-o output.toml]` CLI command with file I/O and stdout fallback

## Test plan
- [x] 15 compiler unit tests covering: empty doc, single step, tool/tier/on-fail hints, IF/ELSE conditionals, FOR loops, INCLUDE, variable collection/dedup, sequential IDs, raw markdown skip, TOML round-trip, full workflow
- [x] All 933 unit tests pass (`just pre-commit`)
- [x] All 8 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)