### PR TITLE
chore(skills): move sa skill to project directory

### DIFF
--- a/skills/sa/SKILL.md
+++ b/skills/sa/SKILL.md
@@ -144,7 +144,7 @@ csa debate "evaluate whether this bot comment is a false positive: ..."
 | Run pr-codex-bot workflow | Tier 1's job |
 | Pre-fetch data for CSA | CSA reads files natively |
 
-**The ONLY Bash Tier 0 may run**: `csa run`, `csa session show`, reading
+**The ONLY Bash Tier 0 may run**: `csa run`, `csa session result`, reading
 result.toml. Nothing else.
 
 ## Tier 1: End-to-End Executor


### PR DESCRIPTION
## Summary
- Move sa skill from ~/.claude/skills/sa/ to ./skills/sa/
- Create symlink for backward compatibility
- Verify all CSA-related skills have proper symlinks

## Test plan
- [x] ls -la ~/.claude/skills/sa/ shows symlink to project dir
- [x] All CSA skills accessible via ~/.claude/skills/

Generated with CSA codex