### PR TITLE
fix(context): wire skip_context from .skill.toml to context loader

### DIFF
--- a/crates/cli-sub-agent/src/batch.rs
+++ b/crates/cli-sub-agent/src/batch.rs
@@ -586,6 +586,7 @@ async fn execute_task(
         extra_env_ref,
         Some("batch"),
         None, // batch does not use tier-based selection
+        None, // batch does not override context loading options
         csa_process::StreamMode::BufferOnly,
         idle_timeout_seconds,
         None, // batch does not inject MCP (callers don't have global_config)

--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
@@ -76,6 +76,7 @@ pub(crate) async fn handle_claude_sub_agent(
         extra_env,
         Some("run"),
         None, // claude-sub-agent does not use tier-based selection
+        None, // claude-sub-agent does not override context loading options
         csa_process::StreamMode::BufferOnly,
         idle_timeout_seconds,
         Some(&global_config),

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -69,6 +69,7 @@ pub(crate) async fn handle_debate(args: DebateArgs, current_depth: u32) -> Resul
         extra_env,
         Some("debate"),
         None, // debate does not use tier-based selection
+        None, // debate does not override context loading options
         csa_process::StreamMode::BufferOnly,
         idle_timeout_seconds,
         Some(&global_config),

--- a/crates/cli-sub-agent/src/mcp_server.rs
+++ b/crates/cli-sub-agent/src/mcp_server.rs
@@ -597,6 +597,7 @@ async fn handle_run_tool(args: Value) -> Result<Value> {
             extra_env_ref,
             Some("run"),
             None, // MCP server does not use tier-based selection
+            None, // MCP server does not override context loading options
             csa_process::StreamMode::BufferOnly,
             idle_timeout_seconds,
             Some(&global_config),

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -200,6 +200,21 @@ fn resolve_idle_timeout_uses_config_then_default() {
     );
 }
 
+#[test]
+fn context_load_options_with_skips_empty_returns_none() {
+    let skip_files: Vec<String> = Vec::new();
+    let options = context_load_options_with_skips(&skip_files);
+    assert!(options.is_none());
+}
+
+#[test]
+fn context_load_options_with_skips_propagates_files() {
+    let skip_files = vec!["AGENTS.md".to_string(), "rules/private.md".to_string()];
+    let options = context_load_options_with_skips(&skip_files).expect("must return options");
+    assert_eq!(options.skip_files, skip_files);
+    assert_eq!(options.max_bytes, None);
+}
+
 /// Verify that `SessionCleanupGuard` removes the directory on drop when not defused.
 #[test]
 fn cleanup_guard_removes_orphan_dir_on_drop() {

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -227,6 +227,7 @@ async fn execute_review(
         extra_env,
         Some("review"),
         None,
+        None,
         csa_process::StreamMode::BufferOnly,
         idle_timeout_seconds,
         Some(global_config),

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -302,6 +302,8 @@ pub(crate) async fn handle_run(
                 })
             })
         });
+    let context_load_options = skill_agent
+        .and_then(|agent| pipeline::context_load_options_with_skips(&agent.skip_context));
 
     // Resolve slots directory
     let slots_dir = GlobalConfig::slots_dir()?;
@@ -433,6 +435,7 @@ pub(crate) async fn handle_run(
                 extra_env.as_ref(),
                 Some("run"),
                 resolved_tier_name.as_deref(),
+                context_load_options.as_ref(),
                 stream_mode,
                 idle_timeout_seconds,
                 Some(&global_config),


### PR DESCRIPTION
## Summary
- Wire `skip_context` from `.skill.toml` `[agent]` section through pipeline to context loader
- Other callers pass `None` to preserve default behavior
- 2 unit tests added for skip file option mapping

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)