### PR TITLE
fix(run): warn when --last is ambiguous with concurrent sessions

### DIFF
--- a/crates/cli-sub-agent/src/run_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests.rs
@@ -1,0 +1,91 @@
+use super::*;
+use chrono::{TimeZone, Utc};
+use csa_session::{Genealogy, MetaSessionState, SessionPhase, TaskContext};
+use std::collections::HashMap;
+
+fn test_session(
+    meta_session_id: &str,
+    last_accessed: chrono::DateTime<Utc>,
+    phase: SessionPhase,
+) -> MetaSessionState {
+    MetaSessionState {
+        meta_session_id: meta_session_id.to_string(),
+        description: None,
+        project_path: "/tmp/project".to_string(),
+        created_at: last_accessed,
+        last_accessed,
+        genealogy: Genealogy {
+            parent_session_id: None,
+            depth: 0,
+        },
+        tools: HashMap::new(),
+        context_status: Default::default(),
+        total_token_usage: None,
+        phase,
+        task_context: TaskContext::default(),
+        turn_count: 0,
+        token_budget: None,
+    }
+}
+
+#[test]
+fn test_resolve_last_session_selection_errors_on_empty_sessions() {
+    let err = resolve_last_session_selection(Vec::new()).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("No sessions found. Run a task first to create one.")
+    );
+}
+
+#[test]
+fn test_resolve_last_session_selection_warns_when_multiple_active_sessions_exist() {
+    let latest = Utc
+        .with_ymd_and_hms(2026, 2, 15, 10, 30, 0)
+        .single()
+        .unwrap();
+    let older = Utc.with_ymd_and_hms(2026, 2, 15, 9, 0, 0).single().unwrap();
+    let available = Utc.with_ymd_and_hms(2026, 2, 14, 8, 0, 0).single().unwrap();
+
+    let sessions = vec![
+        test_session("01ARZ3NDEKTSV4RRFFQ69G5FAV", older, SessionPhase::Active),
+        test_session("01ARZ3NDEKTSV4RRFFQ69G5FAW", latest, SessionPhase::Active),
+        test_session(
+            "01ARZ3NDEKTSV4RRFFQ69G5FAX",
+            available,
+            SessionPhase::Available,
+        ),
+    ];
+
+    let (selected_id, warning) = resolve_last_session_selection(sessions).unwrap();
+    assert_eq!(selected_id, "01ARZ3NDEKTSV4RRFFQ69G5FAW");
+
+    let warning = warning.expect("warning should be present");
+    assert!(warning.contains("`--last` is ambiguous"));
+    assert!(warning.contains("01ARZ3NDEKTSV4RRFFQ69G5FAV"));
+    assert!(warning.contains("01ARZ3NDEKTSV4RRFFQ69G5FAW"));
+    assert!(warning.contains(&latest.to_rfc3339()));
+    assert!(warning.contains(&older.to_rfc3339()));
+    assert!(warning.contains("--session <session-id>"));
+}
+
+#[test]
+fn test_resolve_last_session_selection_has_no_warning_with_single_active_session() {
+    let latest = Utc
+        .with_ymd_and_hms(2026, 2, 15, 11, 0, 0)
+        .single()
+        .unwrap();
+    let older = Utc.with_ymd_and_hms(2026, 2, 15, 9, 0, 0).single().unwrap();
+
+    let sessions = vec![
+        test_session("01ARZ3NDEKTSV4RRFFQ69G5FAV", older, SessionPhase::Active),
+        test_session(
+            "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+            latest,
+            SessionPhase::Available,
+        ),
+    ];
+
+    let (selected_id, warning) = resolve_last_session_selection(sessions).unwrap();
+    assert_eq!(selected_id, "01ARZ3NDEKTSV4RRFFQ69G5FAW");
+    assert!(warning.is_none());
+}


### PR DESCRIPTION
## Summary
- Extracted `--last` resolution into testable helper
- Warns when multiple Active sessions exist (prints IDs + timestamps)
- Still resumes most recent session (non-breaking)
- 3 unit tests added

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)