### PR TITLE
feat(run): require tools to be configured in tiers for auto availability

### DIFF
--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -199,11 +199,14 @@ pub(crate) async fn handle_run(
                 let enabled_tools = if let Some(ref cfg) = config {
                     csa_config::global::all_known_tools()
                         .iter()
-                        .filter(|t| cfg.is_tool_enabled(t.as_str()))
+                        .filter(|t| {
+                            cfg.is_tool_auto_selectable(t.as_str())
+                                && is_tool_binary_available(t.as_str())
+                        })
                         .copied()
                         .collect::<Vec<_>>()
                 } else {
-                    csa_config::global::all_known_tools().to_vec()
+                    Vec::new()
                 };
 
                 match csa_config::global::select_heterogeneous_tool(&parent_tool, &enabled_tools) {
@@ -251,11 +254,14 @@ pub(crate) async fn handle_run(
                 let enabled_tools = if let Some(ref cfg) = config {
                     csa_config::global::all_known_tools()
                         .iter()
-                        .filter(|t| cfg.is_tool_enabled(t.as_str()))
+                        .filter(|t| {
+                            cfg.is_tool_auto_selectable(t.as_str())
+                                && is_tool_binary_available(t.as_str())
+                        })
                         .copied()
                         .collect::<Vec<_>>()
                 } else {
-                    csa_config::global::all_known_tools().to_vec()
+                    Vec::new()
                 };
 
                 match csa_config::global::select_heterogeneous_tool(&parent_tool, &enabled_tools) {
@@ -402,8 +408,8 @@ pub(crate) async fn handle_run(
                             && !tried_tools.contains(&s.tool_name)
                             && config
                                 .as_ref()
-                                .map(|c| c.is_tool_enabled(&s.tool_name))
-                                .unwrap_or(true)
+                                .map(|c| c.is_tool_auto_selectable(&s.tool_name))
+                                .unwrap_or(false)
                             && is_tool_binary_available(&s.tool_name)
                     });
 

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -330,6 +330,27 @@ impl ProjectConfig {
         self.tools.get(tool).map(|t| t.enabled).unwrap_or(true)
     }
 
+    /// Check whether a tool appears in at least one tier model spec.
+    pub fn is_tool_configured_in_tiers(&self, tool: &str) -> bool {
+        self.tiers.values().any(|tier| {
+            tier.models.iter().any(|model_spec| {
+                model_spec
+                    .split('/')
+                    .next()
+                    .is_some_and(|model_tool| model_tool == tool)
+            })
+        })
+    }
+
+    /// Check whether a tool is eligible for auto/heterogeneous selection.
+    ///
+    /// Rules:
+    /// - Tool must be enabled (or unconfigured in `[tools]`, which defaults to enabled)
+    /// - Tool must be explicitly referenced by at least one tier model spec
+    pub fn is_tool_auto_selectable(&self, tool: &str) -> bool {
+        self.is_tool_enabled(tool) && self.is_tool_configured_in_tiers(tool)
+    }
+
     /// Check if notification hooks should be suppressed for a tool.
     ///
     /// Defaults to `true` (suppress) since CSA always runs tools as


### PR DESCRIPTION
## Summary
- Added `is_tool_configured_in_tiers()` and `is_tool_auto_selectable()` to ProjectConfig
- Auto/heterogeneous selection now requires both binary existence AND tier configuration
- Explicit `--tool` still bypasses tier config check
- Unit tests added/updated

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)