### PR TITLE
docs(commit): add explicit tool selection strategy for commit message generation

### DIFF
--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -154,10 +154,12 @@ Delegate message generation to a cheaper tool. Commit messages are mechanical
 
 1. **Resume prior review session** (PREFERRED): If a review session already ran
    in this workflow (e.g., `csa review --diff` produced a session ID), resume it
-   with low thinking budget. This reuses the cached diff context — the model
-   already "saw" the changes, so generating a message costs near-zero new tokens.
+   with the same tool and low thinking budget. Sessions are tool-locked — you MUST
+   specify `--tool` matching the session's tool to avoid mismatch errors. This
+   reuses the cached diff context — the model already "saw" the changes, so
+   generating a message costs near-zero new tokens.
    ```bash
-   csa run --session <REVIEW_SESSION_ID> --thinking low \
+   csa run --tool codex --session <REVIEW_SESSION_ID> --thinking low \
      "Generate a Conventional Commits message for the staged changes. Output ONLY the message."
    ```
 

--- a/patterns/commit/plan.toml
+++ b/patterns/commit/plan.toml
@@ -186,7 +186,7 @@ title = "Generate Commit Message"
 tool = "csa"
 prompt = """
 Delegate message generation to a cheaper tool with low thinking budget.
-Priority: (1) Resume prior review session with --thinking low (reuses cached context).
+Priority: (1) Resume prior review session with --tool codex --thinking low (MUST specify --tool to match session; reuses cached context).
 (2) Explicit --tool codex --thinking low (cheapest for mechanical tasks).
 NEVER --tool auto (may waste round-trip on broken auth).
 NEVER --tool any-available (may select same model family).

--- a/patterns/commit/skills/commit/SKILL.md
+++ b/patterns/commit/skills/commit/SKILL.md
@@ -50,7 +50,7 @@ csa run --skill commit "Commit the current changes with scope: <scope>"
 4. **Security scan**: Grep staged files for hardcoded secrets (API_KEY, SECRET, PASSWORD, PRIVATE_KEY).
 5. **Security audit**: Invoke the `security-audit` pattern via CSA -- three-phase audit (test completeness, vulnerability scan, code quality).
 6. **Pre-commit review**: Invoke the `ai-reviewed-commit` pattern via CSA -- authorship-aware review (debate for self-authored, csa review for others). Fix-and-retry up to 3 rounds.
-7. **Generate commit message**: Delegate to CSA with low thinking budget. Prefer `--session <review-session-id> --thinking low` (reuses cached context); fallback to `--tool codex --thinking low`. NEVER `--tool auto` (broken auth waste), NEVER `--tool any-available` (same family), NEVER switch models on resumed session (invalidates cache).
+7. **Generate commit message**: Delegate to CSA with low thinking budget. Prefer `--tool codex --session <review-session-id> --thinking low` (MUST specify `--tool` matching session to avoid tool-lock mismatch; reuses cached context); fallback to `--tool codex --thinking low`. NEVER `--tool auto` (broken auth waste), NEVER `--tool any-available` (same family), NEVER switch models on resumed session (invalidates cache).
 8. **Commit**: `git commit -m "${COMMIT_MSG}"`.
 9. **Auto PR** (if milestone): Push branch, create PR targeting main, invoke `/pr-codex-bot`.
 


### PR DESCRIPTION
## Summary

- Add prioritized tool selection rules to commit pattern Step 10
- Prefer resuming prior review session with `--thinking low` (reuses prompt cache)
- Fallback to `--tool codex --thinking low` (cheapest for mechanical tasks)
- Prohibit `--tool auto` (wastes round-trip on broken auth), `--tool any-available` (same model family)
- Prohibit switching models on resumed sessions (invalidates prompt cache, increases cost)

## Motivation

Using bare `csa run` without explicit `--tool` for commit message generation caused:
1. Wasted round-trips when `auto` mode attempted gemini-cli (broken OAuth auth)
2. No session resume strategy (missed opportunity to reuse cached context)

## Files changed

| File | Change |
|------|--------|
| `patterns/commit/PATTERN.md` | Detailed tool selection rules with rationale |
| `patterns/commit/plan.toml` | Updated Step 14 csa command |
| `patterns/commit/skills/commit/SKILL.md` | Updated Step 7 description |

## Test plan

- [x] `just pre-commit` — all tests pass (docs-only change, no code impact)
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)