### PR TITLE
feat(weave): add broken symlink check and local path installation

### DIFF
--- a/crates/weave/src/check.rs
+++ b/crates/weave/src/check.rs
@@ -1,0 +1,157 @@
+//! Symlink health checking for skill directories.
+//!
+//! Scans tool-specific skill directories (`.claude/skills/`, `.codex/skills/`,
+//! etc.) for broken symlinks and optionally removes them.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::warn;
+
+use crate::package::AuditIssue;
+
+/// Default directories to scan for broken symlinks.
+pub const DEFAULT_CHECK_DIRS: &[&str] = &[
+    ".claude/skills",
+    ".codex/skills",
+    ".agents/skills",
+    ".gemini/skills",
+];
+
+/// Result of checking a single directory for broken symlinks.
+#[derive(Debug)]
+pub struct CheckResult {
+    /// Directory that was scanned.
+    pub dir: PathBuf,
+    /// Broken symlinks found.
+    pub issues: Vec<AuditIssue>,
+    /// Number of symlinks that were removed (when fix=true).
+    pub fixed: usize,
+    /// Number of symlinks that could not be removed (permission errors, etc.).
+    pub fix_failures: usize,
+}
+
+/// Scan directories for broken symlinks.
+///
+/// When `fix` is true, broken symlinks are removed and the count is returned
+/// in `CheckResult::fixed`. Only actual symlinks are removed — regular files
+/// and directories are never touched.
+pub fn check_symlinks(
+    project_root: &Path,
+    dirs: &[PathBuf],
+    fix: bool,
+) -> Result<Vec<CheckResult>> {
+    let mut results = Vec::new();
+
+    for dir in dirs {
+        let abs_dir = if dir.is_absolute() {
+            dir.clone()
+        } else {
+            project_root.join(dir)
+        };
+
+        if !abs_dir.is_dir() {
+            continue;
+        }
+
+        let mut issues = Vec::new();
+        let mut fixed = 0;
+        let mut fix_failures = 0;
+
+        let entries = std::fs::read_dir(&abs_dir)
+            .with_context(|| format!("failed to read {}", abs_dir.display()))?;
+
+        for entry in entries.filter_map(|e| {
+            e.map_err(|err| warn!("failed to read directory entry: {err}"))
+                .ok()
+        }) {
+            let path = entry.path();
+
+            // Use symlink_metadata to inspect the link itself, not its target.
+            let meta = match std::fs::symlink_metadata(&path) {
+                Ok(m) => m,
+                Err(err) => {
+                    warn!("cannot stat {}: {err}", path.display());
+                    continue;
+                }
+            };
+
+            if !meta.file_type().is_symlink() {
+                continue;
+            }
+
+            let target = match std::fs::read_link(&path) {
+                Ok(t) => t,
+                Err(err) => {
+                    warn!("cannot read symlink {}: {err}", path.display());
+                    continue;
+                }
+            };
+
+            // Resolve relative targets against the symlink's parent directory.
+            let resolved = if target.is_absolute() {
+                target.clone()
+            } else {
+                abs_dir.join(&target)
+            };
+
+            // Check if target exists.  Use try_exists() to distinguish
+            // "not found" from "permission denied".  Only skip on
+            // PermissionDenied (target is inaccessible, not necessarily
+            // broken).  Other I/O errors (ENOTDIR, EIO, etc.) mean the
+            // target path is structurally invalid → treat as broken.
+            let target_exists = match resolved.try_exists() {
+                Ok(exists) => exists,
+                Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+                    warn!("cannot check symlink target {}: {err}", resolved.display());
+                    continue;
+                }
+                Err(err) => {
+                    warn!(
+                        "symlink target unreachable, treating as broken {}: {err}",
+                        resolved.display()
+                    );
+                    false
+                }
+            };
+            if !target_exists {
+                issues.push(AuditIssue::BrokenSymlink {
+                    path: path.clone(),
+                    target: target.clone(),
+                });
+
+                if fix {
+                    // Only remove the symlink itself, never follow it.
+                    if let Ok(m) = std::fs::symlink_metadata(&path) {
+                        if m.file_type().is_symlink() {
+                            // Try remove_file first (works for file symlinks
+                            // on all platforms).  Fall back to remove_dir for
+                            // Windows directory symlinks/junctions.
+                            match std::fs::remove_file(&path)
+                                .or_else(|_| std::fs::remove_dir(&path))
+                            {
+                                Ok(()) => fixed += 1,
+                                Err(_) => fix_failures += 1,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if !issues.is_empty() || fixed > 0 || fix_failures > 0 {
+            results.push(CheckResult {
+                dir: abs_dir,
+                issues,
+                fixed,
+                fix_failures,
+            });
+        }
+    }
+
+    Ok(results)
+}
+
+#[cfg(test)]
+#[path = "check_tests.rs"]
+mod tests;

--- a/crates/weave/src/check_tests.rs
+++ b/crates/weave/src/check_tests.rs
@@ -1,0 +1,105 @@
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use crate::package::AuditIssue;
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// check_symlinks tests
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+fn make_symlink(link: &Path, target: &Path) {
+    std::os::unix::fs::symlink(target, link).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn check_finds_broken_symlinks() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("skills");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+
+    // Create a broken symlink (target doesn't exist).
+    let link = skill_dir.join("broken-skill");
+    make_symlink(&link, Path::new("/nonexistent/path/to/skill"));
+
+    let results = check_symlinks(tmp.path(), &[PathBuf::from("skills")], false).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].issues.len(), 1);
+    assert!(matches!(
+        &results[0].issues[0],
+        AuditIssue::BrokenSymlink { path, .. } if path == &link
+    ));
+    assert_eq!(results[0].fixed, 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn check_preserves_valid_symlinks() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("skills");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+
+    // Create a valid target and symlink.
+    let target = tmp.path().join("real-skill");
+    std::fs::create_dir_all(&target).unwrap();
+    let link = skill_dir.join("good-skill");
+    make_symlink(&link, &target);
+
+    let results = check_symlinks(tmp.path(), &[PathBuf::from("skills")], false).unwrap();
+    // No issues found — result list is empty (only populated when issues exist).
+    assert!(results.is_empty());
+    // Symlink still exists.
+    assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+}
+
+#[cfg(unix)]
+#[test]
+fn check_fix_removes_broken_symlinks() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("skills");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+
+    // Create broken and valid symlinks.
+    let broken = skill_dir.join("broken");
+    make_symlink(&broken, Path::new("/nonexistent"));
+
+    let target = tmp.path().join("real");
+    std::fs::create_dir_all(&target).unwrap();
+    let valid = skill_dir.join("valid");
+    make_symlink(&valid, &target);
+
+    let results = check_symlinks(tmp.path(), &[PathBuf::from("skills")], true).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].fixed, 1);
+
+    // Broken symlink removed, valid symlink preserved.
+    assert!(!broken.exists() && broken.symlink_metadata().is_err());
+    assert!(valid.symlink_metadata().unwrap().file_type().is_symlink());
+}
+
+#[cfg(unix)]
+#[test]
+fn check_skips_nonexistent_directories() {
+    let tmp = TempDir::new().unwrap();
+    let results = check_symlinks(tmp.path(), &[PathBuf::from("does-not-exist")], false).unwrap();
+    assert!(results.is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn check_ignores_regular_files() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("skills");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+
+    // Regular file — should not be touched.
+    std::fs::write(skill_dir.join("not-a-link"), "content").unwrap();
+
+    let results = check_symlinks(tmp.path(), &[PathBuf::from("skills")], true).unwrap();
+    assert!(results.is_empty());
+    assert!(skill_dir.join("not-a-link").exists());
+}

--- a/crates/weave/src/lib.rs
+++ b/crates/weave/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod check;
 pub mod compiler;
 pub mod package;
 pub mod parser;

--- a/crates/weave/src/main.rs
+++ b/crates/weave/src/main.rs
@@ -1,9 +1,10 @@
 use std::io::Read;
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand, ValueEnum};
 
+use weave::check;
 use weave::compiler::{compile, plan_to_toml};
 use weave::package;
 use weave::parser::parse_skill;
@@ -43,10 +44,14 @@ enum Commands {
         output: Option<PathBuf>,
     },
 
-    /// Install a skill from a git repository.
+    /// Install a skill from a git repository or local path.
     Install {
-        /// Git URL or user/repo shorthand.
-        source: String,
+        /// Git URL or user/repo shorthand (mutually exclusive with --path).
+        source: Option<String>,
+
+        /// Install from a local directory instead of git.
+        #[arg(long, value_name = "DIR", conflicts_with = "source")]
+        path: Option<PathBuf>,
     },
 
     /// Lock current skill dependencies.
@@ -60,6 +65,17 @@ enum Commands {
 
     /// Audit installed skills for issues.
     Audit,
+
+    /// Check for broken symlinks in skill directories.
+    Check {
+        /// Directories to scan (default: .claude/skills, .codex/skills, .agents/skills, .gemini/skills).
+        #[arg(long = "dir", value_name = "DIR")]
+        dirs: Vec<PathBuf>,
+
+        /// Remove broken symlinks.
+        #[arg(long)]
+        fix: bool,
+    },
 
     /// Visualize a compiled plan.toml as ASCII (default), Mermaid, or PNG.
     Visualize {
@@ -102,16 +118,27 @@ fn main() -> Result<()> {
                 print!("{toml_str}");
             }
         }
-        Commands::Install { source } => {
+        Commands::Install { source, path } => {
             let project_root = std::env::current_dir().context("cannot determine CWD")?;
-            let cache_root = package::default_cache_root()?;
-            let pkg = package::install(&source, &project_root, &cache_root)?;
-            eprintln!(
-                "installed {} ({}) -> .weave/deps/{}/",
-                pkg.name,
-                &pkg.commit[..pkg.commit.len().min(12)],
-                pkg.name
-            );
+
+            if let Some(local_path) = path {
+                let pkg = package::install_from_local(&local_path, &project_root)?;
+                eprintln!(
+                    "installed {} (local) -> .weave/deps/{}/",
+                    pkg.name, pkg.name
+                );
+            } else if let Some(git_source) = source {
+                let cache_root = package::default_cache_root()?;
+                let pkg = package::install(&git_source, &project_root, &cache_root)?;
+                eprintln!(
+                    "installed {} ({}) -> .weave/deps/{}/",
+                    pkg.name,
+                    &pkg.commit[..pkg.commit.len().min(12)],
+                    pkg.name
+                );
+            } else {
+                bail!("either <SOURCE> or --path <DIR> is required");
+            }
         }
         Commands::Lock => {
             let project_root = std::env::current_dir().context("cannot determine CWD")?;
@@ -152,6 +179,43 @@ fn main() -> Result<()> {
                     }
                 }
                 std::process::exit(1);
+            }
+        }
+        Commands::Check { dirs, fix } => {
+            let project_root = std::env::current_dir().context("cannot determine CWD")?;
+            let scan_dirs = if dirs.is_empty() {
+                check::DEFAULT_CHECK_DIRS
+                    .iter()
+                    .map(PathBuf::from)
+                    .collect()
+            } else {
+                dirs
+            };
+            let results = check::check_symlinks(&project_root, &scan_dirs, fix)?;
+            let total_broken: usize = results.iter().map(|r| r.issues.len()).sum();
+            let total_fixed: usize = results.iter().map(|r| r.fixed).sum();
+            let total_failures: usize = results.iter().map(|r| r.fix_failures).sum();
+
+            if total_broken == 0 {
+                eprintln!("check passed: no broken symlinks found");
+            } else {
+                for result in &results {
+                    for issue in &result.issues {
+                        eprintln!("  [!] {issue}");
+                    }
+                }
+                if fix {
+                    eprintln!("fixed {total_fixed} broken symlink(s)");
+                    if total_failures > 0 {
+                        eprintln!(
+                            "warning: failed to remove {total_failures} symlink(s) (permission denied?)"
+                        );
+                        std::process::exit(1);
+                    }
+                } else {
+                    eprintln!("found {total_broken} broken symlink(s) — run with --fix to remove");
+                    std::process::exit(1);
+                }
             }
         }
         Commands::Visualize { plan, png, mermaid } => {

--- a/crates/weave/src/package_tests.rs
+++ b/crates/weave/src/package_tests.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use tempfile::TempDir;
 
 use super::*;
@@ -62,12 +60,14 @@ fn lockfile_round_trip() {
                 repo: "https://github.com/org/audit.git".to_string(),
                 commit: "abc123def456".to_string(),
                 version: Some("1.0.0".to_string()),
+                source_kind: SourceKind::default(),
             },
             LockedPackage {
                 name: "review".to_string(),
                 repo: "https://github.com/org/review.git".to_string(),
                 commit: "789abc".to_string(),
                 version: None,
+                source_kind: SourceKind::default(),
             },
         ],
     };
@@ -88,6 +88,7 @@ fn upsert_adds_new_package() {
             repo: "https://example.com/existing.git".to_string(),
             commit: "aaa".to_string(),
             version: None,
+            source_kind: SourceKind::default(),
         }],
     };
 
@@ -96,6 +97,7 @@ fn upsert_adds_new_package() {
         repo: "https://example.com/new.git".to_string(),
         commit: "bbb".to_string(),
         version: Some("2.0".to_string()),
+        source_kind: SourceKind::default(),
     };
 
     upsert_package(&mut lockfile, &new_pkg);
@@ -111,6 +113,7 @@ fn upsert_updates_existing_package() {
             repo: "https://example.com/pkg.git".to_string(),
             commit: "old-commit".to_string(),
             version: None,
+            source_kind: SourceKind::default(),
         }],
     };
 
@@ -119,6 +122,7 @@ fn upsert_updates_existing_package() {
         repo: "https://example.com/pkg.git".to_string(),
         commit: "new-commit".to_string(),
         version: Some("3.0".to_string()),
+        source_kind: SourceKind::default(),
     };
 
     upsert_package(&mut lockfile, &updated);
@@ -179,6 +183,7 @@ fn lock_preserves_existing_lockfile_entries() {
             repo: "https://github.com/org/audit.git".to_string(),
             commit: "abc123".to_string(),
             version: Some("1.0".to_string()),
+            source_kind: SourceKind::default(),
         }],
     };
     let lock_path = tmp.path().join(".weave").join("lock.toml");
@@ -209,6 +214,7 @@ fn audit_detects_missing_dep() {
             repo: "https://example.com/ghost.git".to_string(),
             commit: "abc".to_string(),
             version: None,
+            source_kind: SourceKind::default(),
         }],
     };
     let lock_path = tmp.path().join(".weave").join("lock.toml");
@@ -259,6 +265,7 @@ fn audit_detects_missing_skill_md() {
             repo: "https://example.com/broken.git".to_string(),
             commit: "abc".to_string(),
             version: None,
+            source_kind: SourceKind::default(),
         }],
     };
     let lock_path = tmp.path().join(".weave").join("lock.toml");
@@ -288,6 +295,7 @@ fn audit_detects_unknown_repo() {
             repo: String::new(),
             commit: String::new(),
             version: None,
+            source_kind: SourceKind::Git, // Git source with empty repo → UnknownRepo
         }],
     };
     let lock_path = tmp.path().join(".weave").join("lock.toml");
@@ -301,4 +309,272 @@ fn audit_detects_unknown_repo() {
             .iter()
             .any(|i| matches!(i, AuditIssue::UnknownRepo))
     );
+}
+
+// ---------------------------------------------------------------------------
+// install_from_local tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn install_from_local_succeeds() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    // Create a local skill directory.
+    let skill_src = tmp.path().join("my-skill");
+    std::fs::create_dir_all(&skill_src).unwrap();
+    std::fs::write(skill_src.join("SKILL.md"), "# My Skill").unwrap();
+    std::fs::write(skill_src.join("helper.txt"), "data").unwrap();
+
+    let pkg = install_from_local(&skill_src, &project).unwrap();
+    assert_eq!(pkg.name, "my-skill");
+    assert_eq!(pkg.source_kind, SourceKind::Local);
+    assert!(pkg.repo.is_empty());
+    assert!(pkg.commit.is_empty());
+
+    // Files were copied to deps.
+    let dest = project.join(".weave").join("deps").join("my-skill");
+    assert!(dest.join("SKILL.md").is_file());
+    assert!(dest.join("helper.txt").is_file());
+
+    // Lockfile was written.
+    let lockfile = load_lockfile(&project.join(".weave").join("lock.toml")).unwrap();
+    assert_eq!(lockfile.package.len(), 1);
+    assert_eq!(lockfile.package[0].source_kind, SourceKind::Local);
+}
+
+#[test]
+fn install_from_local_excludes_git_dir() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    let skill_src = tmp.path().join("git-skill");
+    std::fs::create_dir_all(skill_src.join(".git")).unwrap();
+    std::fs::write(skill_src.join("SKILL.md"), "# Git Skill").unwrap();
+    std::fs::write(skill_src.join(".git").join("config"), "core").unwrap();
+
+    install_from_local(&skill_src, &project).unwrap();
+
+    let dest = project.join(".weave").join("deps").join("git-skill");
+    assert!(dest.join("SKILL.md").is_file());
+    assert!(!dest.join(".git").exists());
+}
+
+#[test]
+fn install_from_local_rejects_missing_skill_md() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    let skill_src = tmp.path().join("no-skill");
+    std::fs::create_dir_all(&skill_src).unwrap();
+    std::fs::write(skill_src.join("README.md"), "# No Skill").unwrap();
+
+    let result = install_from_local(&skill_src, &project);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("SKILL.md not found"), "error: {err}");
+}
+
+#[cfg(unix)]
+#[test]
+fn install_from_local_rejects_symlinked_skill_md() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    let skill_src = tmp.path().join("symlink-skill");
+    std::fs::create_dir_all(&skill_src).unwrap();
+    // Create a real SKILL.md elsewhere and symlink to it.
+    let real_skill = tmp.path().join("real-SKILL.md");
+    std::fs::write(&real_skill, "# Real Skill").unwrap();
+    std::os::unix::fs::symlink(&real_skill, skill_src.join("SKILL.md")).unwrap();
+
+    let result = install_from_local(&skill_src, &project);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("symlink"), "error: {err}");
+}
+
+#[test]
+fn install_from_local_rejects_self_overwrite() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    // Pre-populate .weave/deps/overlap-skill as if it was already installed.
+    let dest = project.join(".weave").join("deps").join("overlap-skill");
+    std::fs::create_dir_all(&dest).unwrap();
+    std::fs::write(dest.join("SKILL.md"), "# Overlap Skill").unwrap();
+
+    // Try installing from the destination itself — must fail.
+    let result = install_from_local(&dest, &project);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("overlap"), "error: {err}");
+
+    // Original content must survive.
+    assert!(dest.join("SKILL.md").is_file());
+}
+
+#[test]
+fn install_from_local_rejects_overlap_when_dest_not_exists() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    // Source is inside project but dest (.weave/deps/project) does NOT exist yet.
+    // This must still be caught: source contains the would-be destination.
+    let skill_src = tmp.path().join("new-skill");
+    std::fs::create_dir_all(&skill_src).unwrap();
+    std::fs::write(skill_src.join("SKILL.md"), "# New Skill").unwrap();
+
+    // Name the skill the same as its own dest to force overlap when dest
+    // doesn't exist yet — craft source as .weave/deps/new-skill inside a
+    // fresh project where .weave/deps doesn't exist.
+    let nested_project = skill_src.clone(); // project root == skill_src
+    let result = install_from_local(&skill_src, &nested_project);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("overlap"), "error: {err}");
+}
+
+#[cfg(unix)]
+#[test]
+fn install_from_local_rejects_overlap_through_weave_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    // Create a source skill outside the project.
+    let skill_src = tmp.path().join("my-skill");
+    std::fs::create_dir_all(&skill_src).unwrap();
+    std::fs::write(skill_src.join("SKILL.md"), "# Skill").unwrap();
+
+    // Make .weave a symlink pointing INTO the source skill directory.
+    // Without the symlink-resolving fix, the overlap guard would miss this.
+    let weave_target = skill_src.join("nested");
+    std::fs::create_dir_all(&weave_target).unwrap();
+    symlink(&weave_target, project.join(".weave")).unwrap();
+
+    let result = install_from_local(&skill_src, &project);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("overlap"),
+        "expected overlap error, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SourceKind serialization tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn source_kind_serde_roundtrip() {
+    let lockfile = Lockfile {
+        package: vec![
+            LockedPackage {
+                name: "from-git".to_string(),
+                repo: "https://github.com/org/from-git.git".to_string(),
+                commit: "abc123".to_string(),
+                version: None,
+                source_kind: SourceKind::Git,
+            },
+            LockedPackage {
+                name: "from-local".to_string(),
+                repo: String::new(),
+                commit: String::new(),
+                version: Some("1.0".to_string()),
+                source_kind: SourceKind::Local,
+            },
+        ],
+    };
+
+    let tmp = TempDir::new().unwrap();
+    let lock_path = tmp.path().join("lock.toml");
+
+    save_lockfile(&lock_path, &lockfile).unwrap();
+    let loaded = load_lockfile(&lock_path).unwrap();
+    assert_eq!(lockfile, loaded);
+    assert_eq!(loaded.package[0].source_kind, SourceKind::Git);
+    assert_eq!(loaded.package[1].source_kind, SourceKind::Local);
+}
+
+#[test]
+fn source_kind_defaults_to_git_for_old_lockfiles() {
+    // Simulate an old lockfile without source_kind field.
+    let toml_str = r#"
+[[package]]
+name = "legacy"
+repo = "https://github.com/org/legacy.git"
+commit = "abc"
+"#;
+    let lockfile: Lockfile = toml::from_str(toml_str).unwrap();
+    assert_eq!(lockfile.package[0].source_kind, SourceKind::Git);
+}
+
+// ---------------------------------------------------------------------------
+// audit + Local source tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn audit_skips_unknown_repo_for_local_source() {
+    let tmp = TempDir::new().unwrap();
+
+    let deps = tmp.path().join(".weave").join("deps").join("local-skill");
+    std::fs::create_dir_all(&deps).unwrap();
+    std::fs::write(deps.join("SKILL.md"), "# Local Skill").unwrap();
+
+    let lockfile = Lockfile {
+        package: vec![LockedPackage {
+            name: "local-skill".to_string(),
+            repo: String::new(),
+            commit: String::new(),
+            version: None,
+            source_kind: SourceKind::Local,
+        }],
+    };
+    let lock_path = tmp.path().join(".weave").join("lock.toml");
+    save_lockfile(&lock_path, &lockfile).unwrap();
+
+    let results = audit(tmp.path()).unwrap();
+    // No issues — empty repo is expected for Local sources.
+    assert!(results.is_empty(), "expected no issues, got: {results:?}");
+}
+
+// ---------------------------------------------------------------------------
+// lock preserves source_kind tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lock_preserves_source_kind_from_existing_lockfile() {
+    let tmp = TempDir::new().unwrap();
+
+    // Create dep directory.
+    let deps = tmp.path().join(".weave").join("deps").join("local-dep");
+    std::fs::create_dir_all(&deps).unwrap();
+    std::fs::write(deps.join("SKILL.md"), "# Local").unwrap();
+
+    // Create lockfile with Local source_kind.
+    let initial = Lockfile {
+        package: vec![LockedPackage {
+            name: "local-dep".to_string(),
+            repo: String::new(),
+            commit: String::new(),
+            version: None,
+            source_kind: SourceKind::Local,
+        }],
+    };
+    let lock_path = tmp.path().join(".weave").join("lock.toml");
+    save_lockfile(&lock_path, &initial).unwrap();
+
+    // Re-lock — should preserve source_kind.
+    let result = lock(tmp.path()).unwrap();
+    assert_eq!(result.package.len(), 1);
+    assert_eq!(result.package[0].source_kind, SourceKind::Local);
 }


### PR DESCRIPTION
## Summary
- Add `weave check` subcommand to detect/fix broken symlinks across skill directories (.claude/skills, .codex/skills, .agents/skills, .gemini/skills)
- Add `weave install --path <DIR>` for local directory installation with `SourceKind` (Git/Local) tracking in lockfile
- Extract check logic into dedicated `check.rs` module
- Atomic staging for local installs (copy to staging dir first, swap on success)
- Permission-aware symlink checking (try_exists to distinguish EACCES from broken)
- Source/dest overlap guard works even when destination doesn't exist yet
- Rejects symlinked SKILL.md since copy_dir_recursive skips all symlinks

## Test plan
- [x] `cargo clippy -p weave -- -D warnings` — zero warnings
- [x] `cargo test -p weave` — 90 tests pass (20 new)
- [x] `just pre-commit` — 1071 tests pass, all checks green
- [ ] @codex review

Clean resubmission of #125 (squashed 7 commits into 1 clean commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)