### PR TITLE
fix(review,debate,pipeline): relax tier whitelist for review/debate tool selection (#129)

### DIFF
--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
@@ -50,6 +50,7 @@ pub(crate) async fn handle_claude_sub_agent(
         resolved_model.as_deref(),
         None, // thinking budget
         config.as_ref(),
+        true, // enforce tier whitelist for sub-agent execution
     )
     .await?;
 

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -42,6 +42,7 @@ pub(crate) async fn handle_debate(args: DebateArgs, current_depth: u32) -> Resul
         args.model.as_deref(),
         None,
         config.as_ref(),
+        false, // skip tier whitelist for debate tool selection
     )
     .await?;
 
@@ -97,10 +98,6 @@ fn resolve_debate_tool(
 ) -> Result<ToolName> {
     // CLI --tool override always wins
     if let Some(tool) = arg_tool {
-        // Enforce tier whitelist for explicit --tool
-        if let Some(cfg) = project_config {
-            cfg.enforce_tier_whitelist(tool.as_str(), None)?;
-        }
         return Ok(tool);
     }
 

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -205,6 +205,7 @@ async fn execute_review(
         model.as_deref(),
         None,
         project_config,
+        false, // skip tier whitelist for review tool selection
     )
     .await?;
 
@@ -249,10 +250,6 @@ fn resolve_review_tool(
     project_root: &Path,
 ) -> Result<ToolName> {
     if let Some(tool) = arg_tool {
-        // Enforce tier whitelist for explicit --tool
-        if let Some(cfg) = project_config {
-            cfg.enforce_tier_whitelist(tool.as_str(), None)?;
-        }
         return Ok(tool);
     }
 

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -422,6 +422,7 @@ pub(crate) async fn handle_run(
             current_model.as_deref(),
             thinking.as_deref(),
             config.as_ref(),
+            true, // enforce tier whitelist for run commands
         )
         .await?;
 


### PR DESCRIPTION
## Summary
- Added `enforce_tier: bool` parameter to `build_and_validate_executor` in pipeline.rs
  - `true` for run/sub-agent execution paths (cost control)
  - `false` for review/debate paths (heterogeneous tool selection)
- Removed redundant `enforce_tier_whitelist` from explicit `--tool` paths in review/debate
- Auto-selection continues using `is_tool_auto_selectable` (tier-aware) to prevent selecting uninstalled/unconfigured tools

## Context
When `tool_priority` was merged (PR #120), review/debate auto-selection still enforced tier whitelist at the execution boundary. This prevented users from selecting heterogeneous reviewer tools not in the project's tier config.

## Test plan
- [x] `cargo clippy -p cli-sub-agent -- -D warnings`
- [x] `cargo test -p cli-sub-agent` (1103 tests passed)
- [x] `just pre-commit` (all checks pass)
- [x] Local review (`csa review --branch main`)
- [ ] @codex review

Clean resubmission of #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)