### PR TITLE
feat(hooks): add built-in prompt guards for branch protection and dirty tree

### DIFF
--- a/crates/csa-hooks/src/lib.rs
+++ b/crates/csa-hooks/src/lib.rs
@@ -50,6 +50,7 @@ pub mod runner;
 pub use config::{HookConfig, HooksConfig, global_hooks_path, load_hooks_config};
 pub use event::HookEvent;
 pub use guard::{
-    GuardContext, PromptGuardEntry, PromptGuardResult, format_guard_output, run_prompt_guards,
+    GuardContext, PromptGuardEntry, PromptGuardResult, builtin_prompt_guards, format_guard_output,
+    run_prompt_guards,
 };
 pub use runner::{run_hook, run_hooks_for_event};


### PR DESCRIPTION
## Summary
- Add two default prompt guard scripts that ship with CSA out of the box:
  - **branch-protection**: Warns when working on protected branches (main/master/dev/develop/release/*)
  - **dirty-tree-reminder**: Reminds about uncommitted changes with file count
- Built-in guards are active by default, disabled with `builtin_guards = false` in hooks.toml
- User-defined `[[prompt_guard]]` entries replace built-ins entirely

## Test plan
- [x] `test_builtin_prompt_guards_returns_two_entries` — verifies count, names, timeouts
- [x] `test_builtin_branch_protection_on_feature_branch` — no warning on non-protected branch
- [x] `test_builtin_dirty_tree_reminder_on_clean_tree` — guard executes without error
- [x] `test_builtin_guards_loaded_by_default` — config loads 2 guards with no user config
- [x] `test_builtin_guards_replaced_by_user_config` — user guards replace built-ins
- [x] `test_builtin_guards_disabled_explicitly` — `builtin_guards = false` disables all
- [x] `just pre-commit` passes (1123 tests, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)