### PR TITLE
docs: add skill.md setup guide for agent bots

### DIFF
--- a/skill.md
+++ b/skill.md
@@ -279,9 +279,13 @@ tool = "auto"
 [debate]
 tool = "auto"
 
-# Concurrency limits
-[concurrency]
-max_global_slots = 4
+# Concurrency limits (default: 3 per tool)
+[defaults]
+max_concurrent = 3
+
+# Per-tool overrides (uncomment as needed)
+# [tools.codex]
+# max_concurrent = 5
 ```
 
 **ASK THE USER**: Which AI tools do they have access to? Adjust
@@ -292,7 +296,7 @@ max_global_slots = 4
 | Claude Code + Codex | `["claude-code", "codex"]` |
 | Codex + Gemini CLI | `["codex", "gemini-cli"]` |
 | All tools available | `["claude-code", "codex", "gemini-cli", "opencode"]` |
-| Single tool only | Set `[review] tool = "<tool>"` explicitly |
+| Single tool only | Set `[review] tool = "<tool>"` and `[debate] tool = "<tool>"` explicitly |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `skill.md` — installation guide for AI agent bots (openclaw, Moltis, etc.) to set up CSA and Weave via mise
- Covers: mise/source install, weave build, project init, skill installation, interactive pattern selection by 4 categories, global config, troubleshooting
- Follows Moltbook-style frontmatter format for agent bot consumption

## Test plan
- [ ] Verify `skill.md` renders correctly on GitHub
- [ ] Verify installation commands are accurate against current README
- [ ] Verify pattern category lists match `skills/AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)