### PR TITLE
fix(skills): close delegation gap - route /sa mode through proper skill chain

### DIFF
--- a/patterns/mktsk/PATTERN.md
+++ b/patterns/mktsk/PATTERN.md
@@ -45,9 +45,34 @@ Only read-only/analysis tasks may run in parallel.
 
 ## IF ${TASK_IS_IMPLEMENTATION}
 
-## Step 4a: Implement
+## Step 4a: Dispatch by Executor Tag
 
-Write code for the current task.
+Route execution based on the task's executor tag:
+
+### IF tag matches `[CSA:tool]` (e.g., `[CSA:gemini]`, `[CSA:codex]`, `[CSA:auto]`)
+
+Execute via CSA sub-agent:
+
+```bash
+csa run --tool <tool> "prompt with task description and DONE WHEN condition"
+```
+
+### ELIF tag matches `[Sub:developer]` (e.g., `[Sub:rust-sonnet-developer]`, `[Sub:developer]`)
+
+Execute via Claude Code Sub-Agent (Task tool):
+- Spawn a Task with appropriate `subagent_type` matching the developer role
+- Pass full task description including files to modify, scope, and DONE WHEN
+
+### ELIF tag matches `[Skill:xxx]` (e.g., `[Skill:commit]`, `[Skill:mktsk]`)
+
+Execute via Skill tool:
+- Invoke `Skill(xxx)` with the task arguments
+- Wait for skill completion before proceeding
+
+### ELSE (no tag or trivial task)
+
+Write code directly — ONLY for trivial tasks (< 5 lines, single clear operation).
+If the task is non-trivial and has no tag, default to `[Sub:developer]` dispatch.
 
 ## Step 4b: Quality Gates
 


### PR DESCRIPTION
## Summary

- **mktsk PATTERN.md**: Add executor tag dispatch logic to Step 4a - routes `[CSA:tool]` tags to `csa run`, `[Sub:developer]` tags to Claude Code Task tool, `[Skill:xxx]` tags to Skill tool, and defaults to direct code writing only for trivial tasks
- **goo.md** (symlinked): Detect "sa"/"--sa" in arguments and route to `Skill(sa)` three-tier delegation mode instead of always using task-dispatcher
- **task-dispatcher SKILL.md** (symlinked): Add `Bash` and `Task` to allowed-tools so it can actually execute `csa run` commands and spawn sub-agents
- **New /sa command** (symlinked): Direct slash command wrapper for three-tier sub-agent delegation
- **New /pr-codex-bot command** (symlinked): Slash command wrapper for PR review workflow

## Root Cause

`/goo` hardcoded the task-dispatcher path, ignoring `/sa` mode entirely. The task-dispatcher skill lacked `Bash` and `Task` tool permissions, preventing it from executing CSA commands or spawning sub-agents. The mktsk pattern had no executor tag dispatch, so all tasks were executed directly instead of being routed to the appropriate executor.

## Note on Symlinked Files

Fixes 1/2/4/5 modify files under `.claude/` which is symlinked to external shared directories and gitignored. Only Fix 3 (mktsk PATTERN.md) is tracked in this repository. The symlinked changes are applied directly and take effect immediately for all projects using the shared skill/command directory.

## Test plan

- [ ] Verify `/goo sa "implement feature X"` routes to Skill(sa) instead of task-dispatcher
- [ ] Verify `/goo "implement feature X"` (without sa) still uses task-dispatcher
- [ ] Verify task-dispatcher can now execute `csa run` commands (Bash tool available)
- [ ] Verify task-dispatcher can spawn sub-agents (Task tool available)
- [ ] Verify mktsk executor tag dispatch: `[CSA:gemini]` -> `csa run --tool gemini`
- [ ] Verify mktsk executor tag dispatch: `[Sub:developer]` -> Task tool
- [ ] Verify mktsk executor tag dispatch: `[Skill:commit]` -> Skill tool
- [ ] Verify `/sa` command invokes Skill(sa) correctly
- [ ] Verify `/pr-codex-bot` command triggers PR review workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)