### PR TITLE
feat(weave): global registry redesign — lockfile, global store, config cascade, migrate, gc

### DIFF
--- a/crates/cli-sub-agent/src/pattern_resolver.rs
+++ b/crates/cli-sub-agent/src/pattern_resolver.rs
@@ -146,8 +146,9 @@ fn search_paths_with_store(
                         SourceKind::Git if pkg.commit.is_empty() => continue,
                         SourceKind::Git => &pkg.commit,
                     };
-                    let pkg_dir = package::package_dir(store, &pkg.name, commit_key);
-                    paths.push(pkg_dir.join("patterns").join(name));
+                    if let Ok(pkg_dir) = package::package_dir(store, &pkg.name, commit_key) {
+                        paths.push(pkg_dir.join("patterns").join(name));
+                    }
                 }
             }
         }

--- a/crates/cli-sub-agent/src/pattern_resolver_tests.rs
+++ b/crates/cli-sub-agent/src/pattern_resolver_tests.rs
@@ -101,7 +101,7 @@ fn resolve_pattern_from_global_store() {
     let store = TempDir::new().unwrap();
     let commit = "abcdef1234567890";
 
-    let pkg_dir = package::package_dir(store.path(), "some-pkg", commit);
+    let pkg_dir = package::package_dir(store.path(), "some-pkg", commit).unwrap();
     make_pattern_dir(
         &pkg_dir,
         "patterns/csa-review",
@@ -160,7 +160,7 @@ fn resolve_pattern_repo_takes_priority_over_global_store() {
         None,
     );
 
-    let pkg_dir = package::package_dir(store.path(), "pkg", commit);
+    let pkg_dir = package::package_dir(store.path(), "pkg", commit).unwrap();
     make_pattern_dir(
         &pkg_dir,
         "patterns/debate",

--- a/crates/cli-sub-agent/src/skill_resolver.rs
+++ b/crates/cli-sub-agent/src/skill_resolver.rs
@@ -109,7 +109,9 @@ fn search_paths_with_store(
                         SourceKind::Git if pkg.commit.is_empty() => continue,
                         SourceKind::Git => &pkg.commit,
                     };
-                    paths.push(package::package_dir(store, &pkg.name, commit_key));
+                    if let Ok(pkg_dir) = package::package_dir(store, &pkg.name, commit_key) {
+                        paths.push(pkg_dir);
+                    }
                 }
             }
         }
@@ -190,7 +192,7 @@ commit = "{commit}"
         let commit = "abcdef1234567890";
 
         // Create skill in global store at <store>/audit/<prefix>/
-        let pkg_dir = package::package_dir(store.path(), "audit", commit);
+        let pkg_dir = package::package_dir(store.path(), "audit", commit).unwrap();
         make_skill_dir(
             &pkg_dir,
             ".",
@@ -233,7 +235,7 @@ tool = "claude-code"
 
         make_skill_dir(tmp.path(), ".csa/skills/review", "# CSA Review", None);
 
-        let pkg_dir = package::package_dir(store.path(), "review", commit);
+        let pkg_dir = package::package_dir(store.path(), "review", commit).unwrap();
         make_skill_dir(&pkg_dir, ".", "# Global Store Review", None);
         write_lockfile(tmp.path(), "review", commit);
 

--- a/crates/weave/src/main.rs
+++ b/crates/weave/src/main.rs
@@ -234,9 +234,22 @@ fn main() -> Result<()> {
                 package::MigrateResult::NothingToMigrate => {
                     eprintln!("nothing to migrate — no .weave/lock.toml found");
                 }
-                package::MigrateResult::Migrated { count, .. } => {
+                package::MigrateResult::Migrated {
+                    count,
+                    local_skipped,
+                    ..
+                } => {
                     eprintln!("Migrated {count} package(s) to global store");
-                    eprintln!("You can now safely remove .weave/deps/ with: rm -rf .weave/deps/");
+                    if local_skipped > 0 {
+                        eprintln!(
+                            "WARNING: {local_skipped} local-source package(s) were not migrated. \
+                             DO NOT remove .weave/deps/ until they are reinstalled."
+                        );
+                    } else {
+                        eprintln!(
+                            "You can now safely remove .weave/deps/ with: rm -rf .weave/deps/"
+                        );
+                    }
                 }
             }
         }

--- a/crates/weave/src/package_audit.rs
+++ b/crates/weave/src/package_audit.rs
@@ -98,7 +98,7 @@ pub fn audit(project_root: &Path, store_root: &Path) -> Result<Vec<AuditResult>>
             }
             issues.push(AuditIssue::MissingFromDeps);
         } else {
-            let dep_path = package_dir(store_root, &pkg.name, commit_key);
+            let dep_path = package_dir(store_root, &pkg.name, commit_key)?;
 
             if !dep_path.is_dir() {
                 issues.push(AuditIssue::MissingFromDeps);

--- a/crates/weave/src/package_install_tests.rs
+++ b/crates/weave/src/package_install_tests.rs
@@ -64,7 +64,7 @@ fn install_from_local_succeeds() {
     assert!(pkg.commit.is_empty());
 
     // Files were copied to global store.
-    let dest = package_dir(&store, "my-skill", "local");
+    let dest = package_dir(&store, "my-skill", "local").unwrap();
     assert!(dest.join("SKILL.md").is_file());
     assert!(dest.join("helper.txt").is_file());
 
@@ -88,7 +88,7 @@ fn install_from_local_excludes_git_dir() {
 
     install_from_local(&skill_src, &project, &store).unwrap();
 
-    let dest = package_dir(&store, "git-skill", "local");
+    let dest = package_dir(&store, "git-skill", "local").unwrap();
     assert!(dest.join("SKILL.md").is_file());
     assert!(!dest.join(".git").exists());
 }
@@ -142,7 +142,7 @@ fn install_from_local_rejects_self_overwrite() {
     // we need: source == package_dir(store, name, "local").
     // package_dir(store, "local", "local") = store/local/local
     // So create source at store/local/local and install from it.
-    let dest = package_dir(&store, "local", "local");
+    let dest = package_dir(&store, "local", "local").unwrap();
     std::fs::create_dir_all(&dest).unwrap();
     std::fs::write(dest.join("SKILL.md"), "# Self Overwrite").unwrap();
 
@@ -176,7 +176,7 @@ fn install_from_local_rejects_overlap_when_dest_not_exists() {
     // and source = store/tricky/local, there is no overlap.
     // Test the case where source IS the dest.
     let real_store = tmp.path().join("real-store");
-    let real_dest = package_dir(&real_store, "local", "local");
+    let real_dest = package_dir(&real_store, "local", "local").unwrap();
     std::fs::create_dir_all(&real_dest).unwrap();
     std::fs::write(real_dest.join("SKILL.md"), "# Self").unwrap();
 
@@ -371,7 +371,7 @@ fn lock_preserves_requested_version_from_existing_lockfile() {
     let store = tmp.path().join("store");
 
     // Create package checkout in global store.
-    let checkout = package_dir(&store, "pinned-dep", "abc123");
+    let checkout = package_dir(&store, "pinned-dep", "abc123").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
     std::fs::write(checkout.join("SKILL.md"), "# Pinned").unwrap();
 

--- a/crates/weave/src/package_security_tests.rs
+++ b/crates/weave/src/package_security_tests.rs
@@ -1,0 +1,119 @@
+//! Security and path traversal validation tests.
+//!
+//! Split from `package_tests.rs` to stay under the monolith-file limit.
+
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Path traversal validation tests (P1-1)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_package_name_accepts_valid_names() {
+    assert!(validate_package_name("my-skill").is_ok());
+    assert!(validate_package_name("audit_tool").is_ok());
+    assert!(validate_package_name("Skill123").is_ok());
+    assert!(validate_package_name("a").is_ok());
+}
+
+#[test]
+fn validate_package_name_rejects_traversal() {
+    assert!(validate_package_name("../../../etc").is_err());
+    assert!(validate_package_name("..").is_err());
+    assert!(validate_package_name(".").is_err());
+    assert!(validate_package_name("foo/bar").is_err());
+    assert!(validate_package_name("").is_err());
+    assert!(validate_package_name("name with spaces").is_err());
+}
+
+#[test]
+fn package_dir_rejects_traversal_in_name() {
+    let store = Path::new("/store");
+    let result = package_dir(store, "../../../etc", "aabbccdd");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("invalid package name"), "got: {err}");
+}
+
+#[test]
+fn package_dir_rejects_traversal_in_commit() {
+    let store = Path::new("/store");
+    let result = package_dir(store, "safe-name", "../../foo");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("hex characters"), "got: {err}");
+}
+
+#[test]
+fn package_dir_accepts_local_commit_key() {
+    let store = Path::new("/store");
+    let result = package_dir(store, "my-skill", "local");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), Path::new("/store/my-skill/local"));
+}
+
+// ---------------------------------------------------------------------------
+// migrate local-source skip test (P2-2)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn migrate_skips_local_and_migrates_git() {
+    let tmp = TempDir::new().unwrap();
+    let cache = tmp.path().join("cache");
+    let store = tmp.path().join("store");
+
+    // Pre-create a valid git checkout so migrate doesn't need real git.
+    let checkout = package_dir(&store, "git-dep", "deadbeef").unwrap();
+    std::fs::create_dir_all(&checkout).unwrap();
+    std::fs::write(checkout.join("SKILL.md"), "# Git Dep").unwrap();
+
+    // Write legacy lockfile with both Local and Git source.
+    let legacy = tmp.path().join(".weave").join("lock.toml");
+    std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+    let lockfile = Lockfile {
+        package: vec![
+            LockedPackage {
+                name: "local-dep".to_string(),
+                repo: String::new(),
+                commit: String::new(),
+                version: None,
+                source_kind: SourceKind::Local,
+                requested_version: None,
+                resolved_ref: None,
+            },
+            LockedPackage {
+                name: "git-dep".to_string(),
+                repo: "https://github.com/org/git-dep.git".to_string(),
+                commit: "deadbeef".to_string(),
+                version: None,
+                source_kind: SourceKind::Git,
+                requested_version: None,
+                resolved_ref: None,
+            },
+        ],
+    };
+    save_lockfile(&legacy, &lockfile).unwrap();
+
+    let result = migrate(tmp.path(), &cache, &store).unwrap();
+    match result {
+        MigrateResult::Migrated {
+            count,
+            local_skipped,
+            ..
+        } => {
+            assert_eq!(count, 2, "total package count");
+            assert_eq!(local_skipped, 1, "local packages skipped");
+        }
+        other => panic!("expected Migrated, got: {other:?}"),
+    }
+
+    // New lockfile must exist with both packages preserved.
+    let new_path = lockfile_path(tmp.path());
+    assert!(new_path.is_file());
+    let loaded = load_lockfile(&new_path).unwrap();
+    assert_eq!(loaded.package.len(), 2);
+}

--- a/crates/weave/src/package_tests.rs
+++ b/crates/weave/src/package_tests.rs
@@ -217,7 +217,7 @@ fn lock_reads_from_legacy_and_writes_to_new() {
     let store = tmp.path().join("store");
 
     // Create package checkout in global store.
-    let checkout = package_dir(&store, "migrated", "abc123");
+    let checkout = package_dir(&store, "migrated", "abc123").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
     std::fs::write(checkout.join("SKILL.md"), "# Migrated").unwrap();
 
@@ -263,14 +263,14 @@ fn global_store_root_returns_expected_path() {
 #[test]
 fn package_dir_uses_commit_prefix() {
     let store = Path::new("/store");
-    let dir = package_dir(store, "my-skill", "abcdef1234567890");
+    let dir = package_dir(store, "my-skill", "abcdef1234567890").unwrap();
     assert_eq!(dir, Path::new("/store/my-skill/abcdef12"));
 }
 
 #[test]
 fn package_dir_short_commit_uses_full_hash() {
     let store = Path::new("/store");
-    let dir = package_dir(store, "skill", "abc");
+    let dir = package_dir(store, "skill", "abc").unwrap();
     assert_eq!(dir, Path::new("/store/skill/abc"));
 }
 
@@ -302,7 +302,7 @@ fn lock_preserves_existing_lockfile_entries() {
     let store = tmp.path().join("store");
 
     // Create package checkout in global store.
-    let checkout = package_dir(&store, "audit", "abc123");
+    let checkout = package_dir(&store, "audit", "abc123").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
     std::fs::write(checkout.join("SKILL.md"), "# Audit").unwrap();
 
@@ -373,7 +373,7 @@ fn audit_detects_missing_skill_md() {
     let store = tmp.path().join("store");
 
     // Create checkout dir in store but without SKILL.md.
-    let checkout = package_dir(&store, "broken", "abc12345");
+    let checkout = package_dir(&store, "broken", "abc12345").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
 
     let lockfile = Lockfile {
@@ -405,7 +405,7 @@ fn audit_detects_unknown_repo() {
     let tmp = TempDir::new().unwrap();
     let store = tmp.path().join("store");
 
-    let checkout = package_dir(&store, "local", "abc12345");
+    let checkout = package_dir(&store, "local", "abc12345").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
     std::fs::write(checkout.join("SKILL.md"), "# Local").unwrap();
 
@@ -443,7 +443,7 @@ fn audit_detects_case_mismatch_skill_md() {
     let store = tmp.path().join("store");
 
     // Checkout in store with lowercase `skill.md` instead of `SKILL.md`.
-    let checkout = package_dir(&store, "bad-case", "abc12345");
+    let checkout = package_dir(&store, "bad-case", "abc12345").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
     std::fs::write(checkout.join("skill.md"), "# Wrong Case").unwrap();
 
@@ -494,7 +494,7 @@ fn audit_correct_skill_md_no_case_issue() {
     let store = tmp.path().join("store");
 
     // Checkout with the correct `SKILL.md`.
-    let checkout = package_dir(&store, "good", "abc12345");
+    let checkout = package_dir(&store, "good", "abc12345").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
     std::fs::write(checkout.join("SKILL.md"), "# Good Skill").unwrap();
 
@@ -522,7 +522,7 @@ fn audit_neither_skill_md_variant_is_missing() {
     let store = tmp.path().join("store");
 
     // Checkout exists but has NO skill.md variant at all.
-    let checkout = package_dir(&store, "empty", "abc12345");
+    let checkout = package_dir(&store, "empty", "abc12345").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
 
     let lockfile = Lockfile {
@@ -585,7 +585,7 @@ fn migrate_creates_weave_lock_from_legacy() {
     let store = tmp.path().join("store");
 
     // Create checkout that already exists in global store (skip git ops).
-    let checkout = package_dir(&store, "test-skill", "abc12345");
+    let checkout = package_dir(&store, "test-skill", "abc12345").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
     std::fs::write(checkout.join("SKILL.md"), "# Test").unwrap();
 
@@ -628,7 +628,7 @@ fn migrate_skips_valid_checkout_in_global_store() {
     let store = tmp.path().join("store");
 
     // Pre-create a valid checkout in global store.
-    let checkout = package_dir(&store, "pre-existing", "deadbeef");
+    let checkout = package_dir(&store, "pre-existing", "deadbeef").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
     std::fs::write(checkout.join("SKILL.md"), "# Pre-existing").unwrap();
 
@@ -656,7 +656,8 @@ fn migrate_skips_valid_checkout_in_global_store() {
             result,
             MigrateResult::Migrated {
                 count: 1,
-                checkouts: 0
+                checkouts: 0,
+                ..
             }
         ),
         "expected Migrated(count=1, checkouts=0) since checkout valid, got: {result:?}"
@@ -728,7 +729,7 @@ fn audit_skips_unknown_repo_for_local_source() {
     let store = tmp.path().join("store");
 
     // Create local source checkout in global store.
-    let checkout = package_dir(&store, "local-skill", "local");
+    let checkout = package_dir(&store, "local-skill", "local").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
     std::fs::write(checkout.join("SKILL.md"), "# Local Skill").unwrap();
 
@@ -761,7 +762,7 @@ fn lock_preserves_source_kind_from_existing_lockfile() {
     let store = tmp.path().join("store");
 
     // Create local-source checkout in global store.
-    let checkout = package_dir(&store, "local-dep", "local");
+    let checkout = package_dir(&store, "local-dep", "local").unwrap();
     std::fs::create_dir_all(&checkout).unwrap();
     std::fs::write(checkout.join("SKILL.md"), "# Local").unwrap();
 


### PR DESCRIPTION
## Summary

Migrates Weave from per-project `.weave/deps/` (npm model) to user-level global package store (cargo model).

### Changes

- **Lockfile**: Moved from `.weave/lock.toml` to `weave.lock` in project root (backward-compat read from legacy path)
- **Global store**: Checkouts now go to `~/.local/share/weave/packages/<name>/<commit-prefix>/` (content-addressed, idempotent)
- **Resolvers**: Both pattern and skill resolvers read `weave.lock` → global store paths instead of `.weave/deps/`
- **Config cascade**: Three-tier config resolution: package `.skill.toml` → user `~/.config/.../patterns/<name>.toml` → project `.csa/patterns/<name>.toml` with TOML-level merge
- **`weave migrate`**: Converts legacy `.weave/lock.toml` + `.weave/deps/` to new global store layout
- **`weave gc`**: Garbage collection for unreferenced global store checkouts (with `--dry-run`)
- **Deprecation warnings**: Warns when legacy `.weave/deps/` or `.weave/lock.toml` detected
- **Security**: Path traversal validation on lockfile name/commit fields; gc fails closed on corrupt lockfile

### Review findings addressed

- P1 security: Added `validate_package_name()` and hex-only commit prefix validation
- P1 correctness: `weave migrate` now warns about local-source packages
- P1 correctness: `weave gc` propagates lockfile errors instead of fail-open

## Test plan

- [x] `cargo test -p weave` — all package/lockfile/migrate/gc/security tests pass
- [x] `cargo test -p cli-sub-agent` — resolver + config cascade tests pass
- [x] `just pre-commit` — fmt + clippy + deny + nextest + e2e
- [x] Heterogeneous review (codex) — 3 P1s found and fixed
- [ ] Cloud review via pr-codex-bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)