### PR TITLE
fix(resource,acp,process): combine setsid+rlimits into single pre_exec closure

### DIFF
--- a/crates/csa-resource/src/sandbox.rs
+++ b/crates/csa-resource/src/sandbox.rs
@@ -58,10 +58,13 @@ fn has_cgroup_v2() -> bool {
 
 /// Check whether `systemd-run --user --scope` is functional.
 ///
-/// Uses `--dry-run` (systemd >= 236) so nothing is actually created.
+/// Runs a trivial command (`/bin/true`) inside a transient scope to verify
+/// that the systemd user instance is available and scope creation works.
+/// Previously used `--dry-run` which requires systemd >= 253 (not 236 as
+/// documented) and silently fails on older versions like Debian 12 (systemd 252).
 fn has_systemd_user_scope() -> bool {
     Command::new("systemd-run")
-        .args(["--user", "--scope", "--dry-run", "true"])
+        .args(["--user", "--scope", "--quiet", "/bin/true"])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())


### PR DESCRIPTION
## Summary
- Fix `Command::pre_exec()` overwrite bug: Rust's API replaces previous closures rather than chaining them. When both `setsid` and `apply_rlimits` were installed as separate hooks, only the last one executed — causing inconsistent resource enforcement.
- Introduce `PreExecPolicy` enum in csa-process and `build_cmd_base` helper in csa-acp to merge both operations into a single `pre_exec` closure.
- Fix systemd scope detection: replace `--dry-run` (requires systemd >= 253) with `--quiet /bin/true` for compatibility with systemd 252 (Debian 12).

## Test plan
- [x] `just fmt` — pass
- [x] `just clippy` — pass
- [x] `just test` — 1269 tests pass, 0 failures
- [x] `csa review --diff` — no P0/P1 issues
- [x] `csa review --range main...HEAD` — no P0/P1 issues
- [ ] Verify sandbox capability detection on systemd host with cgroup v2
- [ ] Verify Setrlimit fallback when cgroup scope unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)