### PR TITLE
fix(skill): make pr-codex-bot self-contained with polling

### DIFF
--- a/patterns/pr-codex-bot/workflow.toml
+++ b/patterns/pr-codex-bot/workflow.toml
@@ -92,23 +92,46 @@ on_fail = "abort"
 
 [[workflow.steps]]
 id = 5
-title = "Trigger Cloud Bot Review"
+title = "Trigger Cloud Bot Review and Poll for Response"
 tool = "bash"
 prompt = """
-Trigger the cloud review bot. Capture PR number for polling.
+Trigger @codex review (idempotent — skip if already commented on this HEAD),
+then poll for bot response with bounded timeout (max 10 min, 30s interval).
+If bot times out, set BOT_UNAVAILABLE and fall through — local review
+(Step 2) already covers main...HEAD. On timeout, run fallback local review:
+csa review --range main..HEAD.
 
 ```bash
-gh pr comment "${PR_NUM}" --repo "${REPO}" --body "@codex review"
-```"""
-on_fail = "abort"
+# --- Trigger @codex review (idempotent) ---
+CURRENT_SHA="$(git rev-parse HEAD)"
+EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" \\
+  --jq "[.[] | select(.body | test(\\"@codex review\\")) | select(.body | test(\\"${CURRENT_SHA}\\") or (.updated_at > \\"$(git log -1 --format=%cI HEAD~1 2>/dev/null || echo 1970-01-01)\\"))] | length" 2>/dev/null || echo "0")
+if [ "${EXISTING}" = "0" ]; then
+  gh pr comment "${PR_NUM}" --repo "${REPO}" --body "@codex review"
+fi
 
-[[workflow.steps]]
-id = 6
-title = "Poll for Bot Response"
-tool = "bash"
-prompt = """
-Bounded poll (max 10 minutes). If bot unavailable, fall through —
-local review (Step 2) already covers main...HEAD."""
+# --- Poll for bot response (max 10 min) ---
+BOT_UNAVAILABLE=true
+POLL_INTERVAL=30
+MAX_WAIT=600
+WAITED=0
+while [ "${WAITED}" -lt "${MAX_WAIT}" ]; do
+  sleep "${POLL_INTERVAL}"
+  WAITED=$((WAITED + POLL_INTERVAL))
+  BOT_REPLY=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" \\
+    --jq "[.[] | select(.user.type == \\"Bot\\" or .user.login == \\"codex[bot]\\" or .user.login == \\"codex-bot\\") | select(.created_at > \\"$(git log -1 --format=%cI HEAD)\\")] | length" 2>/dev/null || echo "0")
+  if [ "${BOT_REPLY}" -gt 0 ] 2>/dev/null; then
+    BOT_UNAVAILABLE=false
+    break
+  fi
+  echo "Polling... ${WAITED}s / ${MAX_WAIT}s"
+done
+
+if [ "${BOT_UNAVAILABLE}" = "true" ]; then
+  echo "Bot timed out after ${MAX_WAIT}s. Falling back to local review."
+  csa review --range main..HEAD 2>/dev/null || true
+fi
+```"""
 on_fail = "skip"
 
 [[workflow.steps]]

--- a/patterns/sa/PATTERN.md
+++ b/patterns/sa/PATTERN.md
@@ -144,4 +144,21 @@ number of tasks completed. If HAS_ISSUES, iterate.
 
 Evaluate whether to push and create PR (if milestone complete).
 
+## Step 10: Invoke pr-codex-bot (MANDATORY)
+
+> **Tier**: 0 (Orchestrator) -- dispatches /pr-codex-bot skill.
+> Tier 1 executors MUST invoke /pr-codex-bot after PR creation.
+> This is NOT optional — polling for bot review is part of the PR lifecycle.
+
+Tool: skill
+OnFail: abort
+
+After PR creation, invoke the pr-codex-bot skill to trigger cloud review,
+poll for response (with 10 min timeout), and handle the full review loop.
+This ensures the bot review is never forgotten or skipped.
+
+```
+/pr-codex-bot
+```
+
 ## ENDIF

--- a/patterns/sa/skills/sa/SKILL.md
+++ b/patterns/sa/skills/sa/SKILL.md
@@ -55,6 +55,7 @@ This skill exists to keep the main agent out of code-level work.
 3. Base decisions on reports, not direct code inspection.
 4. Gate transitions: APPROVE / MODIFY / REJECT / ESCALATE.
 5. If confidence is low, trigger cross-review by another employee.
+6. **After PR creation, invoke `/pr-codex-bot`** — this is MANDATORY. The pr-codex-bot skill handles `@codex review` triggering, polling (10 min timeout), fallback to local review, and the full bot review loop. Tier 1 executors MUST invoke this skill; it is NOT optional.
 
 ### Tier 0 Manager: What You MUST NEVER Do
 

--- a/patterns/sa/workflow.toml
+++ b/patterns/sa/workflow.toml
@@ -171,3 +171,18 @@ tool = "weave"
 prompt = "commit"
 on_fail = "abort"
 condition = "${REVIEW_IS_CLEAN}"
+
+[[workflow.steps]]
+id = 13
+title = "Invoke pr-codex-bot (MANDATORY)"
+tool = "skill"
+prompt = """
+After PR creation, invoke /pr-codex-bot to trigger cloud review, poll for
+response (with 10 min timeout), and handle the full review loop. This ensures
+the bot review is never forgotten or skipped.
+
+```
+/pr-codex-bot
+```"""
+on_fail = "abort"
+condition = "${REVIEW_IS_CLEAN}"


### PR DESCRIPTION
Fixes #194

Makes pr-codex-bot skill self-contained:
- Built-in @codex review trigger (idempotent — skips if already commented on HEAD)
- Polling loop with 10 min timeout (30s interval)
- Fallback to local `csa review --range main..HEAD` on timeout
- Updated sa skill to mandate `/pr-codex-bot` invocation after PR creation

## Changes

### pr-codex-bot pattern
- **PATTERN.md**: Merged Steps 5 (trigger) and 6 (poll) into a single self-contained Step 5 with concrete bash polling script
- **workflow.toml**: Combined steps 5+6 into single step with full trigger+poll implementation
- **SKILL.md**: Updated execution protocol to reflect combined step, renumbered steps 4-11

### sa pattern  
- **PATTERN.md**: Added mandatory Step 10 — invoke `/pr-codex-bot` after PR creation
- **workflow.toml**: Added step 13 gating pr-codex-bot invocation on `REVIEW_IS_CLEAN`
- **SKILL.md**: Added rule 6 to Tier 0 operating contract mandating `/pr-codex-bot` invocation

## Test plan
- [ ] Verify TOML files parse correctly (`python3 -c "import tomllib; ..."`)
- [ ] Verify `weave compile` accepts updated PATTERN.md files
- [ ] Run `/pr-codex-bot` on a test PR to confirm trigger+poll loop works end-to-end
- [ ] Verify sa workflow correctly invokes pr-codex-bot after PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)