### PR TITLE
feat(mcp-proxy): Phase 0 baseline memory measurement

### DIFF
--- a/dev/mcp-memory-baseline.md
+++ b/dev/mcp-memory-baseline.md
@@ -1,0 +1,79 @@
+# MCP Memory Baseline — Phase 0 (Issue #191)
+
+## Objective
+
+Measure per-instance memory overhead of MCP server loading in claude-code
+to determine whether an MCP wrapper daemon is justified (gate: delta >= 200 MB).
+
+## Methodology
+
+Two ACP session modes are compared:
+
+| Mode | `settingSources` | MCP servers |
+|------|-------------------|-------------|
+| **Lean** | `[]` | None loaded |
+| **Full** | `["user", "project"]` | All configured MCPs loaded |
+
+Measurement:
+- Launch via `csa run --tool claude-code` (or raw `claude-code-acp`)
+- Wait for full initialization (default: 15s settle time)
+- Measure process tree RSS via `/proc/<pid>/status` (VmRSS) + descendants
+- Average over 3 samples per mode
+- Delta = Full RSS − Lean RSS = MCP overhead per instance
+
+## Expected Results
+
+Based on observed MCP server behavior:
+
+| Component | Estimated RSS |
+|-----------|---------------|
+| claude-code base (lean) | ~150-250 MB |
+| Each MCP server (Node.js) | ~50-80 MB |
+| Typical setup (3-5 MCPs) | ~150-400 MB additional |
+
+### Projected Savings
+
+With N concurrent `csa` instances sharing MCP servers via daemon:
+
+| Instances | Current waste (est.) | With daemon | Savings |
+|-----------|---------------------|-------------|---------|
+| 3 | ~450-1200 MB | ~150-400 MB | ~300-800 MB |
+| 5 | ~750-2000 MB | ~150-400 MB | ~600-1600 MB |
+
+## Running the Measurement
+
+```bash
+# Default: 3 samples, 15s settle, project for 3 instances
+./dev/measure-mcp-memory.sh
+
+# Custom: 5 instances, 20s settle
+./dev/measure-mcp-memory.sh --instances 5 --settle-secs 20
+```
+
+Output: `dev/mcp-memory-result.toml` (structured TOML report).
+
+## Actual Results
+
+> **Status**: PENDING — run `./dev/measure-mcp-memory.sh` to populate.
+>
+> Results will be written to `dev/mcp-memory-result.toml`.
+
+## Gate Decision
+
+| Condition | Action |
+|-----------|--------|
+| Delta >= 200 MB per instance | **GO** — proceed to Phase 1 (daemon design) |
+| Delta < 200 MB per instance | **NO-GO** — close #191, savings insufficient to justify daemon complexity |
+
+## Architecture Context
+
+The MCP wrapper daemon (if approved) would:
+
+1. Run MCP servers once in a long-lived daemon process
+2. Multiplex tool calls from N concurrent claude-code instances
+3. Expose MCP tools via a local socket to each ACP session
+4. Eliminate N×(MCP RSS) duplication → 1×(MCP RSS) + N×(proxy overhead)
+
+Key constraint: MCP protocol is stateless per-tool-call, so multiplexing
+is straightforward. The daemon manages server lifecycle (start/stop/restart)
+independently of any single AI tool session.

--- a/dev/measure-mcp-memory.sh
+++ b/dev/measure-mcp-memory.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# measure-mcp-memory.sh — Phase 0 baseline measurement for issue #191
+#
+# Measures RSS delta between lean-mode (settingSources: []) and full-mode
+# (settingSources: ["user","project"]) ACP sessions to determine MCP server
+# memory overhead per claude-code instance.
+#
+# Usage:
+#   ./dev/measure-mcp-memory.sh [--instances N] [--settle-secs S]
+#
+# Requirements:
+#   - claude-code-acp on PATH
+#   - ANTHROPIC_API_KEY set (or equivalent auth)
+#   - /proc filesystem (Linux)
+
+set -euo pipefail
+
+# --- Configuration -----------------------------------------------------------
+
+INSTANCES=3                  # concurrent instances to project savings for
+SETTLE_SECS=15               # seconds to wait for tool to fully initialize
+SAMPLES=3                    # number of measurement samples per mode
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --instances) INSTANCES="$2"; shift 2 ;;
+        --settle-secs) SETTLE_SECS="$2"; shift 2 ;;
+        --samples) SAMPLES="$2"; shift 2 ;;
+        -h|--help)
+            printf 'Usage: %s [--instances N] [--settle-secs S] [--samples N]\n' "$0"
+            exit 0 ;;
+        *) printf 'Unknown option: %s\n' "$1" >&2; exit 1 ;;
+    esac
+done
+
+# --- Helpers -----------------------------------------------------------------
+
+log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*" >&2; }
+
+die() { log "FATAL: $*"; exit 1; }
+
+# Get VmRSS in KB for a PID from /proc.
+# Falls back to ps if /proc is unavailable.
+get_rss_kb() {
+    local pid="$1"
+    if [[ -r "/proc/$pid/status" ]]; then
+        awk '/^VmRSS:/ { print $2 }' "/proc/$pid/status"
+    else
+        ps -o rss= -p "$pid" 2>/dev/null | tr -d ' '
+    fi
+}
+
+# Sum RSS of a process and all descendants (MCP servers are child processes).
+get_tree_rss_kb() {
+    local root_pid="$1"
+    local total=0
+    local pids
+
+    # Collect process tree: root + all descendants
+    pids=$(pstree -p "$root_pid" 2>/dev/null \
+        | grep -oP '\(\K[0-9]+(?=\))' \
+        || echo "$root_pid")
+
+    for pid in $pids; do
+        local rss
+        rss=$(get_rss_kb "$pid" 2>/dev/null || echo 0)
+        if [[ -n "$rss" && "$rss" -gt 0 ]]; then
+            total=$((total + rss))
+        fi
+    done
+    echo "$total"
+}
+
+# Launch claude-code via ACP with specified settingSources, measure RSS.
+# Args: mode_label, json_meta
+measure_mode() {
+    local label="$1"
+    local meta_json="$2"
+    local total_rss=0
+    local sample_count=0
+
+    log "Measuring mode=$label (${SAMPLES} samples, settle=${SETTLE_SECS}s)"
+
+    for i in $(seq 1 "$SAMPLES"); do
+        log "  Sample $i/$SAMPLES ..."
+
+        # Create a temp file for the ACP process to write to
+        local tmpdir
+        tmpdir=$(mktemp -d)
+        local pid_file="$tmpdir/acp.pid"
+
+        # Spawn claude-code-acp in background
+        claude-code-acp &
+        local acp_pid=$!
+        echo "$acp_pid" > "$pid_file"
+
+        # Wait for process to exist and stabilize
+        local waited=0
+        while ! kill -0 "$acp_pid" 2>/dev/null && [[ $waited -lt 5 ]]; do
+            sleep 0.5
+            waited=$((waited + 1))
+        done
+
+        if ! kill -0 "$acp_pid" 2>/dev/null; then
+            log "  WARN: ACP process $acp_pid exited before measurement"
+            rm -rf "$tmpdir"
+            continue
+        fi
+
+        # Send initialize + new_session with meta via stdin (JSON-RPC)
+        # The ACP protocol expects JSON-RPC 2.0 messages on stdin.
+        local init_msg='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}'
+        local session_msg
+        session_msg=$(printf '{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"workingDirectory":"%s","meta":%s}}' \
+            "$(pwd)" "$meta_json")
+
+        # Send init, then session/new
+        {
+            printf '%s\n' "$init_msg"
+            sleep 2
+            printf '%s\n' "$session_msg"
+        } > "/proc/$acp_pid/fd/0" 2>/dev/null || true
+
+        # Allow MCP servers to start and settle
+        log "  Waiting ${SETTLE_SECS}s for initialization..."
+        sleep "$SETTLE_SECS"
+
+        if ! kill -0 "$acp_pid" 2>/dev/null; then
+            log "  WARN: ACP process exited during settle period"
+            rm -rf "$tmpdir"
+            continue
+        fi
+
+        # Measure full process tree RSS
+        local rss_kb
+        rss_kb=$(get_tree_rss_kb "$acp_pid")
+        local rss_mb=$(( rss_kb / 1024 ))
+        log "  Sample $i: tree RSS = ${rss_kb} KB (${rss_mb} MB)"
+
+        total_rss=$((total_rss + rss_kb))
+        sample_count=$((sample_count + 1))
+
+        # Cleanup: kill process tree
+        kill -- -"$acp_pid" 2>/dev/null || kill "$acp_pid" 2>/dev/null || true
+        wait "$acp_pid" 2>/dev/null || true
+        rm -rf "$tmpdir"
+    done
+
+    if [[ $sample_count -eq 0 ]]; then
+        die "No successful samples for mode=$label"
+    fi
+
+    local avg_rss_kb=$((total_rss / sample_count))
+    echo "$avg_rss_kb"
+}
+
+# --- Alternative: csa-based measurement -------------------------------------
+# If csa binary is available, use it for more accurate measurement since
+# it handles the full ACP lifecycle properly.
+
+measure_via_csa() {
+    local label="$1"
+    local lean_flag="$2"  # "" or "--lean"
+    local total_rss=0
+    local sample_count=0
+
+    log "Measuring mode=$label via csa (${SAMPLES} samples, settle=${SETTLE_SECS}s)"
+
+    for i in $(seq 1 "$SAMPLES"); do
+        log "  Sample $i/$SAMPLES ..."
+
+        # Launch csa in background with a simple prompt that keeps it alive
+        local tmpdir
+        tmpdir=$(mktemp -d)
+
+        # shellcheck disable=SC2086
+        env -u CLAUDECODE csa run --tool claude-code $lean_flag \
+            --no-stream-stdout \
+            "Respond with exactly: READY" \
+            > "$tmpdir/stdout" 2>"$tmpdir/stderr" &
+        local csa_pid=$!
+
+        # Wait for the ACP subprocess to appear
+        sleep "$SETTLE_SECS"
+
+        # Find the claude-code-acp child process
+        local acp_pid
+        acp_pid=$(pgrep -P "$csa_pid" -f "claude-code-acp" 2>/dev/null | head -1 || true)
+
+        if [[ -z "$acp_pid" ]]; then
+            # Try finding any child of csa
+            acp_pid=$(pgrep -P "$csa_pid" 2>/dev/null | head -1 || true)
+        fi
+
+        local rss_kb=0
+        if [[ -n "$acp_pid" ]] && kill -0 "$acp_pid" 2>/dev/null; then
+            rss_kb=$(get_tree_rss_kb "$acp_pid")
+        elif kill -0 "$csa_pid" 2>/dev/null; then
+            # Measure csa's full tree as fallback
+            rss_kb=$(get_tree_rss_kb "$csa_pid")
+        fi
+
+        local rss_mb=$(( rss_kb / 1024 ))
+        log "  Sample $i: tree RSS = ${rss_kb} KB (${rss_mb} MB)"
+
+        if [[ $rss_kb -gt 0 ]]; then
+            total_rss=$((total_rss + rss_kb))
+            sample_count=$((sample_count + 1))
+        fi
+
+        # Cleanup
+        kill -- -"$csa_pid" 2>/dev/null || kill "$csa_pid" 2>/dev/null || true
+        wait "$csa_pid" 2>/dev/null || true
+        rm -rf "$tmpdir"
+    done
+
+    if [[ $sample_count -eq 0 ]]; then
+        log "WARN: No successful csa samples for mode=$label — returning 0"
+        echo "0"
+        return
+    fi
+
+    local avg_rss_kb=$((total_rss / sample_count))
+    echo "$avg_rss_kb"
+}
+
+# --- Main --------------------------------------------------------------------
+
+main() {
+    log "=== MCP Memory Baseline Measurement (Issue #191) ==="
+    log "Configuration: instances=$INSTANCES settle=${SETTLE_SECS}s samples=$SAMPLES"
+    log ""
+
+    local use_csa=false
+    if command -v csa >/dev/null 2>&1; then
+        use_csa=true
+        log "Using csa binary for measurement (preferred)"
+    elif command -v claude-code-acp >/dev/null 2>&1; then
+        log "Using claude-code-acp directly"
+    else
+        die "Neither 'csa' nor 'claude-code-acp' found on PATH.
+Install ACP adapter: npm install -g @zed-industries/claude-code-acp
+Or build csa: cargo build --release -p cli-sub-agent"
+    fi
+
+    log ""
+
+    # --- Lean mode (settingSources: []) — no MCP servers loaded ---
+    local lean_rss_kb
+    if [[ "$use_csa" == "true" ]]; then
+        lean_rss_kb=$(measure_via_csa "lean" "--lean")
+    else
+        lean_rss_kb=$(measure_mode "lean" '{"claudeCode":{"options":{"settingSources":[]}}}')
+    fi
+    local lean_rss_mb=$(( lean_rss_kb / 1024 ))
+    log ""
+    log "Lean mode avg RSS: ${lean_rss_kb} KB (${lean_rss_mb} MB)"
+
+    # --- Full mode (settingSources: ["user","project"]) — all MCPs loaded ---
+    local full_rss_kb
+    if [[ "$use_csa" == "true" ]]; then
+        full_rss_kb=$(measure_via_csa "full" "")
+    else
+        full_rss_kb=$(measure_mode "full" '{"claudeCode":{"options":{"settingSources":["user","project"]}}}')
+    fi
+    local full_rss_mb=$(( full_rss_kb / 1024 ))
+    log ""
+    log "Full mode avg RSS: ${full_rss_kb} KB (${full_rss_mb} MB)"
+
+    # --- Compute delta ---
+    local delta_kb=$((full_rss_kb - lean_rss_kb))
+    local delta_mb=$((delta_kb / 1024))
+    local total_waste_mb=$((delta_mb * INSTANCES))
+
+    log ""
+    log "================================================================"
+    log "                   RESULTS SUMMARY"
+    log "================================================================"
+    log ""
+    log "  Lean mode (no MCPs):    ${lean_rss_mb} MB"
+    log "  Full mode (all MCPs):   ${full_rss_mb} MB"
+    log "  Delta per instance:     ${delta_mb} MB"
+    log "  Projected waste (×${INSTANCES}): ${total_waste_mb} MB"
+    log ""
+
+    if [[ $delta_mb -ge 200 ]]; then
+        log "  GATE: PASS — delta >= 200 MB. Proceed to Phase 1."
+    else
+        log "  GATE: FAIL — delta < 200 MB. Savings insufficient."
+        log "  Recommendation: Close issue, daemon complexity not justified."
+    fi
+    log ""
+    log "================================================================"
+
+    # --- Output structured TOML report ---
+    local report_file
+    report_file="$(cd "$(dirname "$0")/.." && pwd)/dev/mcp-memory-result.toml"
+
+    cat > "$report_file" <<EOF
+# MCP Memory Baseline Measurement — Issue #191
+# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+[measurement]
+samples = $SAMPLES
+settle_seconds = $SETTLE_SECS
+projected_instances = $INSTANCES
+
+[results]
+lean_mode_rss_kb = $lean_rss_kb
+lean_mode_rss_mb = $lean_rss_mb
+full_mode_rss_kb = $full_rss_kb
+full_mode_rss_mb = $full_rss_mb
+delta_per_instance_kb = $delta_kb
+delta_per_instance_mb = $delta_mb
+total_projected_waste_mb = $total_waste_mb
+
+[gate]
+threshold_mb = 200
+passed = $(if [[ $delta_mb -ge 200 ]]; then echo "true"; else echo "false"; fi)
+recommendation = "$(if [[ $delta_mb -ge 200 ]]; then echo "proceed_to_phase_1"; else echo "close_insufficient_savings"; fi)"
+EOF
+
+    log "Report written to: $report_file"
+    echo "$report_file"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Adds `dev/measure-mcp-memory.sh` to measure per-instance MCP server memory overhead by comparing lean mode (`settingSources: []`) vs full mode ACP sessions
- Adds `dev/mcp-memory-baseline.md` documenting methodology, expected results, and go/no-go gate criteria (delta >= 200 MB)
- Script supports both `csa run` and raw `claude-code-acp` paths, measures full process tree RSS via `/proc`

## Test plan
- [ ] Run `./dev/measure-mcp-memory.sh` with `ANTHROPIC_API_KEY` set
- [ ] Verify TOML report generated at `dev/mcp-memory-result.toml`
- [ ] Review gate decision: delta >= 200 MB → proceed to Phase 1

Part of #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)