### PR TITLE
feat(config): replace lean_mode with setting_sources (#190)

### DIFF
--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -131,6 +131,9 @@ max_recursion_depth = 5
 # pids_max = 512                     # Max PIDs per tool process tree (>= 10)
 
 # ─── Tool Configuration ────────────────────────────────────────
+# setting_sources: controls which MCP settings to load for ACP-backed tools.
+#   [] = load nothing (lean mode), ["project"] = project only, omit = load all.
+#
 # [tools.codex]
 # enabled = true
 # suppress_notify = true
@@ -138,6 +141,7 @@ max_recursion_depth = 5
 # [tools.claude-code]
 # enabled = true
 # suppress_notify = true
+# setting_sources = ["project"]    # load only project-level settings
 #
 # [tools.gemini-cli]
 # enabled = true

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -36,7 +36,7 @@ pub(crate) fn resolve_sandbox_options(
     let Some(cfg) = config else {
         // No project config — apply profile-based defaults for heavyweight tools.
         let defaults = csa_config::default_sandbox_for_tool(tool_name);
-        execute_options = execute_options.with_lean_mode(defaults.lean_mode);
+        execute_options = execute_options.with_setting_sources(defaults.setting_sources);
 
         if matches!(defaults.enforcement, csa_config::EnforcementMode::Off) {
             return SandboxResolution::Ok(execute_options);
@@ -71,7 +71,7 @@ pub(crate) fn resolve_sandbox_options(
         return SandboxResolution::Ok(execute_options);
     };
 
-    execute_options = execute_options.with_lean_mode(cfg.tool_lean_mode(tool_name));
+    execute_options = execute_options.with_setting_sources(cfg.tool_setting_sources(tool_name));
 
     // Use per-tool enforcement mode (profile-aware) instead of global-only.
     let enforcement = cfg.tool_enforcement_mode(tool_name);

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 
-/// Heavyweight tools (claude-code) with no project config should get lean_mode=true.
+/// Heavyweight tools (claude-code) with no project config should get setting_sources=Some(vec![]).
 #[test]
-fn test_none_config_sets_lean_mode_for_heavyweight() {
+fn test_none_config_sets_setting_sources_for_heavyweight() {
     let result = resolve_sandbox_options(
         None,
         "claude-code",
@@ -15,9 +15,10 @@ fn test_none_config_sets_lean_mode_for_heavyweight() {
         panic!("Expected SandboxResolution::Ok");
     };
 
-    assert!(
-        opts.lean_mode,
-        "Heavyweight tool should have lean_mode=true"
+    assert_eq!(
+        opts.setting_sources,
+        Some(vec![]),
+        "Heavyweight tool should have setting_sources=Some(vec![]) (lean mode)"
     );
 }
 
@@ -31,9 +32,9 @@ fn test_none_config_lightweight_skips_sandbox() {
         panic!("Expected SandboxResolution::Ok");
     };
 
-    assert!(
-        !opts.lean_mode,
-        "Lightweight tool should have lean_mode=false"
+    assert_eq!(
+        opts.setting_sources, None,
+        "Lightweight tool should have setting_sources=None (load everything)"
     );
     assert!(
         opts.sandbox.is_none(),
@@ -42,7 +43,7 @@ fn test_none_config_lightweight_skips_sandbox() {
 }
 
 /// Heavyweight tools (claude-code) with no project config should get a sandbox context
-/// when sandbox capability is available, or at least lean_mode when it is not.
+/// when sandbox capability is available, or at least setting_sources when it is not.
 #[test]
 fn test_none_config_heavyweight_gets_sandbox() {
     let result = resolve_sandbox_options(
@@ -57,10 +58,11 @@ fn test_none_config_heavyweight_gets_sandbox() {
         panic!("Expected SandboxResolution::Ok");
     };
 
-    // lean_mode is always set for heavyweight regardless of sandbox capability
-    assert!(
-        opts.lean_mode,
-        "Heavyweight tool should have lean_mode=true"
+    // setting_sources is always set for heavyweight regardless of sandbox capability
+    assert_eq!(
+        opts.setting_sources,
+        Some(vec![]),
+        "Heavyweight tool should have setting_sources=Some(vec![])"
     );
 
     let capability = csa_resource::detect_sandbox_capability();

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -148,9 +148,17 @@ pub struct ToolConfig {
     /// Per-tool Node.js heap size limit (MB). Takes precedence over project resources.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub node_heap_limit_mb: Option<u64>,
-    /// Opt-in lean mode for ACP-backed tools.
+    /// Deprecated: use `setting_sources` instead.
+    /// When `true`, equivalent to `setting_sources = []` (load nothing).
+    /// When `false` or absent, no override.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lean_mode: Option<bool>,
+    /// Selective MCP/setting sources to load for ACP-backed tools.
+    /// `Some(vec![])` = load nothing (equivalent to old `lean_mode = true`).
+    /// `Some(vec!["project"])` = load only project-level settings.
+    /// `None` = default (load everything).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setting_sources: Option<Vec<String>>,
 }
 
 impl Default for ToolConfig {
@@ -164,6 +172,7 @@ impl Default for ToolConfig {
             memory_swap_max_mb: None,
             node_heap_limit_mb: None,
             lean_mode: None,
+            setting_sources: None,
         }
     }
 }

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -24,7 +24,10 @@ pub struct ExecuteOptions {
     pub stream_mode: StreamMode,
     pub idle_timeout_seconds: u64,
     pub output_spool: Option<PathBuf>,
-    pub lean_mode: bool,
+    /// Selective MCP/setting sources for ACP session meta.
+    /// `Some(sources)` → inject `settingSources` into session meta.
+    /// `None` → no override (load everything).
+    pub setting_sources: Option<Vec<String>>,
     /// Optional resource sandbox config (cgroup/rlimit limits).
     /// When `Some`, the spawned tool process will be wrapped in resource isolation.
     pub sandbox: Option<SandboxContext>,
@@ -52,14 +55,14 @@ impl ExecuteOptions {
             stream_mode,
             idle_timeout_seconds,
             output_spool: None,
-            lean_mode: false,
+            setting_sources: None,
             sandbox: None,
         }
     }
 
-    /// Set ACP lean mode metadata behavior.
-    pub fn with_lean_mode(mut self, lean_mode: bool) -> Self {
-        self.lean_mode = lean_mode;
+    /// Set selective MCP/setting sources for ACP session meta.
+    pub fn with_setting_sources(mut self, setting_sources: Option<Vec<String>>) -> Self {
+        self.setting_sources = setting_sources;
         self
     }
 
@@ -310,7 +313,7 @@ impl Executor {
             stream_mode: options.stream_mode,
             idle_timeout_seconds: options.idle_timeout_seconds,
             output_spool: options.output_spool.as_deref(),
-            lean_mode: options.lean_mode,
+            setting_sources: options.setting_sources.clone(),
             sandbox: sandbox_transport.as_ref(),
         };
         let transport = self.transport(session_config);

--- a/crates/csa-executor/src/transport_lean_mode_tests.rs
+++ b/crates/csa-executor/src/transport_lean_mode_tests.rs
@@ -3,8 +3,9 @@ use serde_json::json;
 use super::AcpTransport;
 
 #[test]
-fn test_build_lean_mode_meta_enabled() {
-    let meta = AcpTransport::build_lean_mode_meta(true).expect("meta should exist");
+fn test_build_session_meta_with_empty_sources() {
+    let sources: Vec<String> = vec![];
+    let meta = AcpTransport::build_session_meta(Some(&sources)).expect("meta should exist");
     assert_eq!(
         serde_json::Value::Object(meta),
         json!({"claudeCode": {"options": {"settingSources": []}}})
@@ -12,9 +13,19 @@ fn test_build_lean_mode_meta_enabled() {
 }
 
 #[test]
-fn test_build_lean_mode_meta_disabled() {
+fn test_build_session_meta_with_project_source() {
+    let sources = vec!["project".to_string()];
+    let meta = AcpTransport::build_session_meta(Some(&sources)).expect("meta should exist");
+    assert_eq!(
+        serde_json::Value::Object(meta),
+        json!({"claudeCode": {"options": {"settingSources": ["project"]}}})
+    );
+}
+
+#[test]
+fn test_build_session_meta_none_returns_none() {
     assert!(
-        AcpTransport::build_lean_mode_meta(false).is_none(),
-        "meta should be absent when lean mode is off"
+        AcpTransport::build_session_meta(None).is_none(),
+        "meta should be absent when setting_sources is None"
     );
 }


### PR DESCRIPTION
## Summary

Replace the boolean `lean_mode` with `setting_sources: Option<Vec<String>>` across the config→executor→transport pipeline, enabling **selective MCP/setting source loading** instead of all-or-nothing lean mode.

- `setting_sources = []` → load nothing (equivalent to old `lean_mode = true`)
- `setting_sources = ["project"]` → load only project-level settings
- Omit → load everything (default for lightweight tools)

### Changes

- **csa-config**: Add `setting_sources` to `ToolConfig`, add `tool_setting_sources()` resolver with `setting_sources > lean_mode > profile default` priority
- **csa-executor**: `ExecuteOptions.lean_mode: bool` → `setting_sources: Option<Vec<String>>`, rename `with_lean_mode()` → `with_setting_sources()`
- **transport**: `build_lean_mode_meta(bool)` → `build_session_meta(Option<&[String]>)`, `TransportOptions.lean_mode` → `setting_sources`
- **pipeline_sandbox**: Wire through new resolution path
- **DefaultSandboxOptions**: `lean_mode: bool` → `setting_sources: Option<Vec<String>>`
- **config template**: Document `setting_sources` values in commented examples
- **Backward compat**: `lean_mode` still works via deprecated fallback with `eprintln!` warning

### Test plan

- [x] 6 new tests for `tool_setting_sources()` resolution (both set, only lean, only sources, neither, profile defaults)
- [x] 3 transport tests for `build_session_meta()` (empty sources, project source, None)
- [x] 3 pipeline_sandbox tests updated for `setting_sources`
- [x] 2 `default_sandbox_for_tool` tests updated
- [x] All 1493 existing tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Fixes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)