### PR TITLE
fix(patterns): add PATTERN.md fallback for legacy pattern layouts

### DIFF
--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -298,7 +298,7 @@ fn verify_debate_skill_available(project_root: &Path) -> Result<()> {
                  {resolve_err}\n\n\
                  Install the debate pattern with one of:\n\
                  1) csa skill install RyderFreeman4Logos/cli-sub-agent\n\
-                 2) Manually place skills/debate/SKILL.md inside .csa/patterns/debate/ or patterns/debate/\n\n\
+                 2) Manually place skills/debate/SKILL.md (or PATTERN.md) inside .csa/patterns/debate/ or patterns/debate/\n\n\
                  Without the pattern, the debate tool cannot follow the structured debate protocol."
             )
         }

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -322,7 +322,7 @@ fn verify_review_skill_available(project_root: &Path) -> Result<()> {
                  {resolve_err}\n\n\
                  Install the review pattern with one of:\n\
                  1) csa skill install RyderFreeman4Logos/cli-sub-agent\n\
-                 2) Manually place skills/csa-review/SKILL.md inside .csa/patterns/csa-review/ or patterns/csa-review/\n\n\
+                 2) Manually place skills/csa-review/SKILL.md (or PATTERN.md) inside .csa/patterns/csa-review/ or patterns/csa-review/\n\n\
                  Without the pattern, the review tool cannot follow the structured review protocol."
             )
         }


### PR DESCRIPTION
## Summary
- Adds `PATTERN.md` fallback in `resolve_pattern()` for legacy weave-locked packages that don't have `skills/<name>/SKILL.md` (#199)
- Priority: `skills/<name>/SKILL.md` > `PATTERN.md` (new layout wins when both exist)
- Updates error messages and manual-install guidance in `debate_cmd.rs` and `review_cmd.rs` to mention both file options

## Test plan
- [x] `resolve_pattern_falls_back_to_pattern_md` — verifies resolution from PATTERN.md when no skills/ dir exists
- [x] `resolve_pattern_skill_md_takes_priority` — verifies SKILL.md content returned when both files exist
- [x] All 20 pattern_resolver tests pass
- [x] `cargo clippy -p cli-sub-agent` clean

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)