### PR TITLE
fix(plan): add step output forwarding for cross-step context

### DIFF
--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -18,6 +18,7 @@ mod pipeline_execute;
 mod pipeline_sandbox;
 mod plan_cmd;
 mod plan_condition;
+mod plan_display;
 mod process_tree;
 mod review_cmd;
 mod review_consensus;

--- a/crates/cli-sub-agent/src/plan_display.rs
+++ b/crates/cli-sub-agent/src/plan_display.rs
@@ -1,0 +1,115 @@
+//! Display helpers for `csa plan run` dry-run and execution summary.
+
+use std::collections::HashMap;
+
+use csa_config::ProjectConfig;
+use weave::compiler::{ExecutionPlan, FailAction};
+
+use crate::plan_cmd::{StepResult, StepTarget, resolve_step_tool};
+
+/// Print the execution plan for dry-run mode.
+pub(crate) fn print_plan(
+    plan: &ExecutionPlan,
+    variables: &HashMap<String, String>,
+    config: Option<&ProjectConfig>,
+) {
+    println!("Workflow: {}", plan.name);
+    if !plan.description.is_empty() {
+        println!("  {}", plan.description);
+    }
+    println!();
+
+    if !variables.is_empty() {
+        println!("Variables:");
+        for (k, v) in variables {
+            println!("  ${{{k}}} = {v}");
+        }
+        println!();
+    }
+
+    println!("Steps ({}):", plan.steps.len());
+    for step in &plan.steps {
+        let tool_info = match resolve_step_tool(step, config) {
+            Ok(StepTarget::DirectBash) => "bash (direct)".into(),
+            Ok(StepTarget::WeaveInclude) => "weave (include)".into(),
+            Ok(StepTarget::CsaTool {
+                tool_name,
+                model_spec,
+            }) => match model_spec {
+                Some(s) => format!("{} ({})", tool_name.as_str(), s),
+                None => tool_name.as_str().to_string(),
+            },
+            Err(e) => format!("<error: {e}>"),
+        };
+
+        let on_fail = match &step.on_fail {
+            FailAction::Abort => "abort",
+            FailAction::Skip => "skip",
+            FailAction::Retry(n) => &format!("retry({})", n),
+            FailAction::Delegate(t) => &format!("delegate({})", t),
+        };
+
+        let flags = [
+            step.condition.as_ref().map(|c| format!("IF {}", c)),
+            step.loop_var
+                .as_ref()
+                .map(|l| format!("FOR {}", l.variable)),
+        ];
+        let flag_str: Vec<String> = flags.into_iter().flatten().collect();
+        let flag_display = if flag_str.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", flag_str.join(", "))
+        };
+
+        println!(
+            "  {}. {} [tool={}, on_fail={}]{}",
+            step.id, step.title, tool_info, on_fail, flag_display,
+        );
+        println!(
+            "     -> sets ${{STEP_{}_OUTPUT}} for subsequent steps",
+            step.id
+        );
+    }
+}
+
+/// Print execution summary.
+pub(crate) fn print_summary(results: &[StepResult], total_duration: f64) {
+    println!();
+    println!("=== Workflow Execution Summary ===");
+    println!();
+
+    let mut pass = 0;
+    let mut fail = 0;
+    let mut skip = 0;
+
+    for r in results {
+        let status = if r.skipped {
+            skip += 1;
+            "- SKIP"
+        } else if r.exit_code == 0 {
+            pass += 1;
+            "✓ PASS"
+        } else {
+            fail += 1;
+            "✗ FAIL"
+        };
+
+        println!(
+            "{:8} Step {} - {} ({:.2}s){}",
+            status,
+            r.step_id,
+            r.title,
+            r.duration_secs,
+            r.error
+                .as_ref()
+                .map(|e| format!(" — {}", e))
+                .unwrap_or_default(),
+        );
+    }
+
+    println!();
+    println!("Total: {} steps", results.len());
+    println!("Passed: {pass}, Failed: {fail}, Skipped: {skip}");
+    println!("Duration: {:.2}s", total_duration);
+}

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -66,6 +66,19 @@ id = 4
 title = "Phase 2 — DRAFT TODO"
 prompt = """
 Synthesize CSA findings into a structured TODO plan.
+
+## RECON Findings (from prior steps)
+
+### Structure (Step 1)
+${STEP_1_OUTPUT}
+
+### Patterns (Step 2)
+${STEP_2_OUTPUT}
+
+### Constraints (Step 3)
+${STEP_3_OUTPUT}
+
+## Instructions
 Each item is a [ ] checkbox with executor tag.
 Write all TODO descriptions, section headers, and task names in ${USER_LANGUAGE}.
 Technical terms, code snippets, commit scope strings, and executor tags remain in English.
@@ -93,7 +106,18 @@ id = 7
 title = "Revise TODO"
 prompt = """
 Incorporate debate feedback. Update plan based on valid criticisms.
-Concede valid points, defend sound decisions with evidence."""
+Concede valid points, defend sound decisions with evidence.
+
+## Prior Context
+
+### Draft TODO (Step 4)
+${STEP_4_OUTPUT}
+
+### Adversarial Debate (Step 5)
+${STEP_5_OUTPUT}
+
+### Debate Include (Step 6)
+${STEP_6_OUTPUT}"""
 on_fail = "abort"
 
 [[workflow.steps]]


### PR DESCRIPTION
## Summary

- Steps in `csa plan run` now capture their stdout (bash) or output/summary (CSA tools) and inject it as `${STEP_<id>_OUTPUT}` variables for subsequent steps
- This enables multi-step patterns like mktd where RECON findings must feed into DRAFT and REVISE steps
- `plan_display.rs` extracted from `plan_cmd.rs` for cleaner module structure
- mktd `workflow.toml` updated to use `${STEP_N_OUTPUT}` references

## Test plan

- [ ] `cargo check -p cli-sub-agent` passes
- [ ] New tests: `execute_step_bash_captures_stdout_in_output`, `execute_plan_injects_step_output_variables`, `execute_plan_skipped_step_injects_empty_output`
- [ ] CI: all 5 checks pass
- [ ] Manual: `csa plan run patterns/mktd/workflow.toml --dry-run` shows `${STEP_N_OUTPUT}` availability

Fixes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)