### PR TITLE
fix(patterns): remove nested csa run from tool=csa step prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "directories",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/patterns/ai-reviewed-commit/workflow.toml
+++ b/patterns/ai-reviewed-commit/workflow.toml
@@ -122,11 +122,8 @@ id = 10
 title = "Generate Commit Message"
 tool = "csa"
 prompt = """
-Delegate commit message generation to cheaper tool.
-
-```bash
-csa run "Run 'git diff --staged' and generate a Conventional Commits message"
-```"""
+Run 'git diff --staged' and generate a Conventional Commits message.
+Output ONLY the commit message, nothing else."""
 tier = "tier-1-quick"
 on_fail = "abort"
 

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -185,16 +185,8 @@ id = 14
 title = "Generate Commit Message"
 tool = "csa"
 prompt = """
-Delegate message generation to a cheaper tool with low thinking budget.
-Priority: (1) Resume prior review session with --tool codex --thinking low (MUST specify --tool to match session; reuses cached context).
-(2) Explicit --tool codex --thinking low (cheapest for mechanical tasks).
-NEVER --tool auto (may waste round-trip on broken auth).
-NEVER --tool any-available (may select same model family).
-NEVER switch models on resumed session (invalidates prompt cache).
-
-```bash
-csa run --tool codex --thinking low "Run 'git diff --staged' and generate a Conventional Commits message. Scope: ${SCOPE}. Output ONLY the commit message, nothing else."
-```"""
+Run 'git diff --staged' and generate a Conventional Commits message.
+Scope: ${SCOPE}. Output ONLY the commit message, nothing else."""
 tier = "tier-1-quick"
 on_fail = "abort"
 

--- a/patterns/csa-review/workflow.toml
+++ b/patterns/csa-review/workflow.toml
@@ -81,9 +81,9 @@ id = 5
 title = "Execute Review via CSA"
 tool = "csa"
 prompt = """
-```bash
-csa run --tool ${REVIEW_TOOL} --description "code-review: ${SCOPE}" "${REVIEW_PROMPT}"
-```"""
+Perform code review: ${SCOPE}.
+
+${REVIEW_PROMPT}"""
 tier = "tier-2-standard"
 on_fail = "abort"
 
@@ -101,14 +101,12 @@ id = 7
 title = "Fix Mode"
 tool = "csa"
 prompt = """
-Resume same CSA session to fix all P0 and P1 issues.
+Fix all P0 and P1 issues from the review.
 Generate $CSA_SESSION_DIR/reviewer-{N}/fix-summary.md and
 $CSA_SESSION_DIR/reviewer-{N}/post-fix-review-findings.json.
 Mark remaining P0/P1 as incomplete.
 
-```bash
-csa run --tool ${REVIEW_TOOL} --session ${SESSION_ID} "${FIX_PROMPT}"
-```"""
+${FIX_PROMPT}"""
 tier = "tier-2-standard"
 on_fail = "abort"
 condition = "${MODE_IS_REVIEW_AND_FIX}"

--- a/patterns/dev-to-merge/workflow.toml
+++ b/patterns/dev-to-merge/workflow.toml
@@ -151,11 +151,6 @@ tool = "csa"
 prompt = """
 Run heterogeneous code review on all uncommitted changes versus HEAD.
 The reviewer MUST be a different model family than the code author.
-
-```bash
-csa review --diff
-```
-
 Review output includes AGENTS.md compliance checklist."""
 tier = "tier-2-standard"
 on_fail = "abort"
@@ -191,7 +186,7 @@ id = 11
 title = "Re-review"
 tool = "csa"
 prompt = """
-Run `csa review --diff` again to verify all issues are resolved.
+Re-review all changes to verify all issues are resolved.
 Loop back to Step 9 if issues persist (max 3 rounds)."""
 tier = "tier-2-standard"
 on_fail = "abort"
@@ -202,12 +197,9 @@ id = 12
 title = "Generate Commit Message"
 tool = "csa"
 prompt = """
-Generate a Conventional Commits message from the staged diff.
+Run 'git diff --staged' and generate a Conventional Commits message.
 The message must follow the format: `type(${SCOPE}): description`.
-
-```bash
-csa run "Run 'git diff --staged' and generate a Conventional Commits message. Scope: ${SCOPE}"
-```"""
+Output ONLY the commit message, nothing else."""
 tier = "tier-1-quick"
 on_fail = "abort"
 
@@ -327,12 +319,11 @@ id = 20
 title = "Arbitrate False Positive"
 tool = "csa"
 prompt = """
-Run `csa debate` to get an independent second opinion on the suspected
-false positive. The arbiter MUST be a different model family.
+Evaluate the following code reviewer finding independently.
+The arbiter MUST be a different model family.
 
-```bash
-csa debate "A code reviewer flagged: ${COMMENT_TEXT}. Evaluate independently."
-```"""
+A code reviewer flagged: ${COMMENT_TEXT}. Evaluate independently.
+Is this a real issue or a false positive? Provide reasoning."""
 tier = "tier-2-standard"
 on_fail = "abort"
 condition = "${BOT_HAS_ISSUES}"

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -19,40 +19,27 @@ Mandatory adversarial review catches blind spots.
 Tool: csa
 Tier: tier-1-quick
 
-Explore codebase structure relevant to the feature.
-Main agent MUST NOT use Read/Glob/Grep/Bash for exploration in Phase 1.
-
-```bash
-csa run "Analyze codebase structure relevant to ${FEATURE}.
+Analyze codebase structure relevant to ${FEATURE}.
 Report: relevant files (path + purpose, max 20), key types, module dependencies, entry points.
-Working directory: ${CWD}"
-```
+Working directory: ${CWD}
 
 ## Step 2: Phase 1 — RECON Dimension 2 (Patterns)
 
 Tool: csa
 Tier: tier-1-quick
 
-Find existing patterns similar to the feature.
-
-```bash
-csa run "Find existing patterns or similar features to ${FEATURE} in this codebase.
+Find existing patterns or similar features to ${FEATURE} in this codebase.
 Report: file paths with approach, reusable components, conventions to follow.
-Working directory: ${CWD}"
-```
+Working directory: ${CWD}
 
 ## Step 3: Phase 1 — RECON Dimension 3 (Constraints)
 
 Tool: csa
 Tier: tier-1-quick
 
-Identify constraints and risks.
-
-```bash
-csa run "Identify constraints and risks for implementing ${FEATURE}.
+Identify constraints and risks for implementing ${FEATURE}.
 Report: potential breaking changes, security considerations, performance, compatibility.
-Working directory: ${CWD}"
-```
+Working directory: ${CWD}
 
 ## Step 4: Phase 2 — DRAFT TODO
 
@@ -72,10 +59,6 @@ Tier: tier-2-standard
 
 Mandatory adversarial review of the TODO draft.
 No exceptions — even "simple" plans benefit from challenge.
-
-```bash
-csa debate "Review this TODO plan for ${FEATURE}. Challenge assumptions, identify gaps, suggest improvements."
-```
 
 ## Step 6: Revise TODO
 

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -20,14 +20,9 @@ id = 1
 title = "Phase 1 — RECON Dimension 1 (Structure)"
 tool = "csa"
 prompt = """
-Explore codebase structure relevant to the feature.
-Main agent MUST NOT use Read/Glob/Grep/Bash for exploration in Phase 1.
-
-```bash
-csa run "Analyze codebase structure relevant to ${FEATURE}.
+Analyze codebase structure relevant to ${FEATURE}.
 Report: relevant files (path + purpose, max 20), key types, module dependencies, entry points.
-Working directory: ${CWD}"
-```"""
+Working directory: ${CWD}"""
 tier = "tier-1-quick"
 on_fail = "abort"
 
@@ -36,13 +31,9 @@ id = 2
 title = "Phase 1 — RECON Dimension 2 (Patterns)"
 tool = "csa"
 prompt = """
-Find existing patterns similar to the feature.
-
-```bash
-csa run "Find existing patterns or similar features to ${FEATURE} in this codebase.
+Find existing patterns or similar features to ${FEATURE} in this codebase.
 Report: file paths with approach, reusable components, conventions to follow.
-Working directory: ${CWD}"
-```"""
+Working directory: ${CWD}"""
 tier = "tier-1-quick"
 on_fail = "abort"
 
@@ -51,13 +42,9 @@ id = 3
 title = "Phase 1 — RECON Dimension 3 (Constraints)"
 tool = "csa"
 prompt = """
-Identify constraints and risks.
-
-```bash
-csa run "Identify constraints and risks for implementing ${FEATURE}.
+Identify constraints and risks for implementing ${FEATURE}.
 Report: potential breaking changes, security considerations, performance, compatibility.
-Working directory: ${CWD}"
-```"""
+Working directory: ${CWD}"""
 tier = "tier-1-quick"
 on_fail = "abort"
 

--- a/patterns/security-audit/workflow.toml
+++ b/patterns/security-audit/workflow.toml
@@ -47,14 +47,10 @@ id = 3
 title = "Step 3a: Delegate Audit to CSA"
 tool = "csa"
 prompt = """
-Module too large for local audit. Delegate entire audit to CSA.
-
-```bash
-csa run "Perform security audit following security-audit skill protocol.
-         Review changed files and associated tests.
-         Three phases: test completeness, vulnerability scan, code quality.
-         Output structured audit report."
-```"""
+Perform security audit following security-audit skill protocol.
+Review changed files and associated tests.
+Three phases: test completeness, vulnerability scan, code quality.
+Output structured audit report."""
 tier = "tier-2-standard"
 on_fail = "abort"
 condition = "${NEEDS_CSA_DELEGATION}"


### PR DESCRIPTION
## Summary
- Remove `csa run` / `csa review` / `csa debate` bash block wrappers from all `tool = "csa"` step prompts across 7 workflow files
- When `tool = "csa"` is set, the plan executor already dispatches directly to the AI tool (codex/claude-code) via `execute_csa_step()`. Prompts containing nested `csa run` commands caused the sandboxed tool to attempt re-execution of `csa`, which was blocked by sandbox lock file restrictions on `~/.local/state/csa/`
- Affected patterns: mktd (Steps 1-3), security-audit (Step 3a), csa-review (Steps 5, 7), ai-reviewed-commit (Step 10), dev-to-merge (Steps 8, 11, 12, 20), commit (Step 14)

## Root Cause
```
csa plan run → execute_csa_step() → codex (sandboxed)
  → codex sees "csa run ..." in prompt
  → codex tries to execute csa run
  → sandbox blocks lock file write to ~/.local/state/csa/
  → step fails with exit 144
```

## Fix
Prompts now describe the task directly. The plan executor handles tool routing via tier config.

```diff
- prompt = """
- ```bash
- csa run "Analyze codebase structure relevant to ${FEATURE}..."
- ```"""
+ prompt = """
+ Analyze codebase structure relevant to ${FEATURE}..."""
```

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-features` clean
- [x] Verified all 7 modified workflow.toml files parse correctly (no syntax errors)
- [x] No code changes — only workflow prompt text and PATTERN.md documentation
- [x] Pre-existing monolith file (`executor_build_cmd_tests.rs` 823 lines) is NOT introduced by this PR

Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)