### PR TITLE
fix(review): correct pattern missing error and add --allow-fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "directories",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -318,6 +318,10 @@ pub struct ReviewArgs {
     #[arg(long)]
     pub no_stream_stdout: bool,
 
+    /// Continue without csa-review pattern (warn instead of hard error)
+    #[arg(long)]
+    pub allow_fallback: bool,
+
     /// Working directory
     #[arg(long)]
     pub cd: Option<String>,

--- a/patterns/ai-reviewed-commit/PATTERN.md
+++ b/patterns/ai-reviewed-commit/PATTERN.md
@@ -35,7 +35,7 @@ git diff --stat --staged
 
 Determine who authored the staged code:
 - Self-authored (generated in this session) → use csa debate
-- Other tool/human authored → use csa review --diff
+- Other tool/human authored → use csa review --diff --allow-fallback
 
 ## IF ${SELF_AUTHORED}
 
@@ -54,7 +54,7 @@ csa debate "Review my staged changes for correctness, security, and test gaps. R
 Tool: bash
 
 ```bash
-csa review --diff
+csa review --diff --allow-fallback
 ```
 
 ## ENDIF
@@ -85,7 +85,7 @@ Tool: bash
 Loop back to review. Maximum 3 review-fix cycles.
 
 ```bash
-csa review --diff
+csa review --diff --allow-fallback
 ```
 
 ## ENDIF

--- a/patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md
+++ b/patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md
@@ -27,7 +27,7 @@ triggers:
 
 ## Purpose
 
-Ensure every commit is reviewed by an independent model before creation. Uses authorship-aware strategy: self-authored code gets adversarial debate review (`csa debate`), while other-authored code gets standard `csa review --diff`. Includes automated fix-and-retry loop (max 3 rounds), mandatory AGENTS.md compliance checking, and Conventional Commits message generation.
+Ensure every commit is reviewed by an independent model before creation. Uses authorship-aware strategy: self-authored code gets adversarial debate review (`csa debate`), while other-authored code gets standard `csa review --diff --allow-fallback`. Includes automated fix-and-retry loop (max 3 rounds), mandatory AGENTS.md compliance checking, and Conventional Commits message generation.
 
 ## Execution Protocol (ORCHESTRATOR ONLY)
 
@@ -49,7 +49,7 @@ csa run --skill ai-reviewed-commit "Review and commit the staged changes"
 3. **Authorship detection**: Determine if staged code is self-authored (generated in this session) or by another tool/human.
 4. **Review**:
    - Self-authored: `csa debate "Review my staged changes for correctness, security, and test gaps. Run 'git diff --staged' yourself."`
-   - Other-authored: `csa review --diff`
+   - Other-authored: `csa review --diff --allow-fallback`
 5. **Fix loop** (if issues found, max 3 rounds): Dispatch sub-agent to fix issues, re-stage, re-review. Preserve original code intent -- do NOT delete code to silence warnings.
 6. **AGENTS.md compliance**: Discover AGENTS.md chain for each staged file. Check every applicable rule. Zero unchecked items before proceeding.
 7. **Generate commit message**: `csa run "Run 'git diff --staged' and generate a Conventional Commits message"` (tier-1).

--- a/patterns/ai-reviewed-commit/workflow.toml
+++ b/patterns/ai-reviewed-commit/workflow.toml
@@ -45,7 +45,7 @@ title = "Authorship-Aware Review Strategy"
 prompt = """
 Determine who authored the staged code:
 - Self-authored (generated in this session) → use csa debate
-- Other tool/human authored → use csa review --diff"""
+- Other tool/human authored → use csa review --diff --allow-fallback"""
 on_fail = "abort"
 
 [[workflow.steps]]
@@ -65,7 +65,7 @@ title = "Step 4b: Run CSA Review"
 tool = "bash"
 prompt = """
 ```bash
-csa review --diff
+csa review --diff --allow-fallback
 ```"""
 on_fail = "abort"
 condition = "!(${SELF_AUTHORED})"
@@ -102,7 +102,7 @@ prompt = """
 Loop back to review. Maximum 3 review-fix cycles.
 
 ```bash
-csa review --diff
+csa review --diff --allow-fallback
 ```"""
 on_fail = "abort"
 condition = "${REVIEW_HAS_ISSUES}"

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -122,7 +122,7 @@ Tier: tier-2-standard
 
 ## INCLUDE ai-reviewed-commit
 
-Run csa review --diff (or csa debate if self-authored).
+Run csa review --diff --allow-fallback (or csa debate if self-authored).
 MUST include AGENTS.md compliance checklist.
 Fix-and-retry loop (max 3 rounds).
 

--- a/patterns/commit/skills/commit/SKILL.md
+++ b/patterns/commit/skills/commit/SKILL.md
@@ -49,7 +49,7 @@ csa run --skill commit "Commit the current changes with scope: <scope>"
 3. **Stage changes**: `git add` relevant files. Verify no untracked files remain.
 4. **Security scan**: Grep staged files for hardcoded secrets (API_KEY, SECRET, PASSWORD, PRIVATE_KEY).
 5. **Security audit**: Invoke the `security-audit` pattern via CSA -- three-phase audit (test completeness, vulnerability scan, code quality).
-6. **Pre-commit review**: Invoke the `ai-reviewed-commit` pattern via CSA -- authorship-aware review (debate for self-authored, csa review for others). Fix-and-retry up to 3 rounds.
+6. **Pre-commit review**: Invoke the `ai-reviewed-commit` pattern via CSA -- authorship-aware review (debate for self-authored, `csa review --diff --allow-fallback` for others). Fix-and-retry up to 3 rounds.
 7. **Generate commit message**: Delegate to CSA at `tier-1-quick` (tool and thinking budget come from config). If a review session already ran in this workflow, prefer resuming it with `--session <review-session-id>` (reuses cached context, near-zero new tokens). When resuming, keep the same tool (sessions are tool-locked).
 8. **Commit**: `git commit -m "${COMMIT_MSG}"`.
 9. **Auto PR** (if milestone): Push branch, create PR targeting main, invoke `/pr-codex-bot`.


### PR DESCRIPTION
## Summary
- Fix verify_review_skill_available error message: csa skill install → weave install
- Add --allow-fallback flag: pattern missing → warning instead of error
- Update /commit and ai-reviewed-commit patterns to use --allow-fallback

Closes #205