### PR TITLE
feat(pr-codex-bot): SHA-verified fast-path merge when cloud_bot=false

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "directories",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/patterns/pr-codex-bot/workflow.toml
+++ b/patterns/pr-codex-bot/workflow.toml
@@ -62,11 +62,19 @@ id = 2
 title = "Local Pre-PR Review (SYNCHRONOUS — MUST NOT background)"
 tool = "bash"
 prompt = """
-Run cumulative local review covering all commits since main.
-This is the FOUNDATION — without it, bot unavailability cannot safely merge.
+Run cumulative local review covering all commits since main, with SHA-verified
+fast-path. This is the FOUNDATION — without it, bot unavailability cannot
+safely merge.
 
 ```bash
-csa review --branch main
+CURRENT_HEAD="$(git rev-parse HEAD)"
+REVIEW_HEAD="$(csa session list --recent-review 2>/dev/null | parse_head_sha || true)"
+if [ -n "${REVIEW_HEAD}" ] && [ "${CURRENT_HEAD}" = "${REVIEW_HEAD}" ]; then
+  echo "Fast-path: latest local review already covers HEAD ${CURRENT_HEAD}; skip Step 2 review."
+else
+  echo "No matching review HEAD found (or HEAD drift detected). Running full local review."
+  csa review --branch main
+fi
 ```"""
 on_fail = "abort"
 
@@ -99,14 +107,21 @@ title = "Check Cloud Bot Configuration"
 tool = "bash"
 prompt = """
 Check whether cloud bot review is enabled for this project.
-If disabled, set BOT_UNAVAILABLE and run supplementary local review.
+If disabled, set BOT_UNAVAILABLE and apply the same SHA-verified fast-path
+before deciding whether supplementary local review is needed.
 
 ```bash
 CLOUD_BOT=$(csa config get pr_review.cloud_bot --default true)
 if [ "${CLOUD_BOT}" = "false" ]; then
   BOT_UNAVAILABLE=true
-  echo "Cloud bot disabled via project config. Running local review instead."
-  csa review --range main...HEAD 2>/dev/null || true
+  CURRENT_HEAD="$(git rev-parse HEAD)"
+  REVIEW_HEAD="$(csa session list --recent-review 2>/dev/null | parse_head_sha || true)"
+  if [ -n "${REVIEW_HEAD}" ] && [ "${CURRENT_HEAD}" = "${REVIEW_HEAD}" ]; then
+    echo "Cloud bot disabled, fast-path active: local review already covers HEAD ${CURRENT_HEAD}."
+  else
+    echo "Cloud bot disabled and fast-path invalid. Running full local review."
+    csa review --branch main
+  fi
 fi
 ```"""
 on_fail = "skip"


### PR DESCRIPTION
## Summary
- Add SHA-based fast-path: compare current HEAD with last csa review session HEAD
- HEAD drift auto-invalidates fast-path (including amend)
- Update workflow.toml, PATTERN.md, and SKILL.md consistently

Closes #220