### PR TITLE
fix(resource,patterns): balloon RAM check + workflow review gates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.47"
+version = "0.1.48"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -175,9 +175,10 @@ pub(crate) fn maybe_inflate_balloon(tool_name: &str) {
     const BALLOON_SIZE: usize = 1024 * 1024 * 1024; // 1 GiB
     let mut sys = sysinfo::System::new();
     sys.refresh_memory();
+    let available_memory = sys.available_memory();
     let available_swap = sys.free_swap();
 
-    if !should_enable_balloon(available_swap, BALLOON_SIZE as u64) {
+    if !should_enable_balloon(available_memory, available_swap, BALLOON_SIZE as u64) {
         return;
     }
 

--- a/patterns/commit/skills/commit/SKILL.md
+++ b/patterns/commit/skills/commit/SKILL.md
@@ -53,6 +53,16 @@ csa run --skill commit "Commit the current changes with scope: <scope>"
 7. **Generate commit message**: Delegate to CSA at `tier-1-quick` (tool and thinking budget come from config). If a review session already ran in this workflow, prefer resuming it with `--session <review-session-id>` (reuses cached context, near-zero new tokens). When resuming, keep the same tool (sessions are tool-locked).
 8. **Commit**: `git commit -m "${COMMIT_MSG}"`.
 9. **Auto PR** (if milestone): Push branch, create PR targeting main, invoke `/pr-codex-bot`.
+   - **NOTE**: `/pr-codex-bot` internally runs a **separate cumulative review** (`csa review --range main...HEAD`) covering ALL commits on the branch before push. This is distinct from Step 6's per-commit review (`csa review --diff`). Do NOT skip pr-codex-bot's internal review even if Step 6 passed.
+
+## Two-Layer Review Architecture
+
+| Layer | Command | Scope | Timing |
+|-------|---------|-------|--------|
+| Per-commit | `csa review --diff` | Staged changes only | Before `git commit` (Step 6) |
+| Pre-PR cumulative | `csa review --range main...HEAD` | Full feature branch | Before `git push` (inside `/pr-codex-bot` Step 2) |
+
+Both layers are mandatory. The per-commit review catches issues in each individual change; the cumulative review catches cross-commit issues and ensures the full branch is coherent.
 
 ## Example Usage
 

--- a/patterns/dev-to-merge/PATTERN.md
+++ b/patterns/dev-to-merge/PATTERN.md
@@ -173,12 +173,27 @@ Tool: bash
 OnFail: abort
 
 Create the commit using the generated message: ${COMMIT_MSG}.
-NOTE: In production, this step should invoke the `/commit` skill which
-enforces security audit, test completeness, and AGENTS.md compliance.
-The raw `git commit` here demonstrates the skill-lang format only.
 
 ```bash
 git commit -m "${COMMIT_MSG}"
+```
+
+## Step 13b: Pre-PR Cumulative Review
+
+Tool: csa
+Tier: tier-2-standard
+OnFail: abort
+
+Run a cumulative review covering ALL commits on the feature branch since main.
+This is distinct from Step 8's per-commit review (`csa review --diff`):
+- Step 8 reviews uncommitted changes (staged diff) — single-commit granularity.
+- This step reviews the full feature branch — catches cross-commit issues.
+
+MANDATORY: This review MUST pass before pushing to origin.
+
+```bash
+csa review --range main...HEAD
+CUMULATIVE_REVIEW_COMPLETED=true
 ```
 
 ## Step 14: Push to Origin
@@ -211,9 +226,6 @@ Tool: bash
 
 Trigger the cloud codex review bot on the newly created PR.
 Capture the PR number for polling.
-NOTE: In production, Steps 15-24 should invoke the `/pr-codex-bot` skill
-which handles the full review-trigger-procedure, bounded polling, false-positive
-arbitration, and merge atomically. The manual flow here demonstrates skill-lang.
 
 ```bash
 PR_NUM=$(gh pr view --json number -q '.number')

--- a/patterns/dev-to-merge/skills/dev-to-merge/SKILL.md
+++ b/patterns/dev-to-merge/skills/dev-to-merge/SKILL.md
@@ -56,13 +56,14 @@ csa run --skill dev-to-merge "Implement, review, and merge <scope description>"
 7. **Re-run quality gates**: `just pre-commit` after any fixes.
 8. **Generate commit message**: Delegate to CSA (tier-1) for Conventional Commits.
 9. **Commit**: `git commit -m "${COMMIT_MSG}"`.
-10. **Push**: `git push -u origin ${BRANCH}`.
-11. **Create PR**: `gh pr create --base main`.
-12. **Trigger codex bot**: `gh pr comment --body "@codex review"`.
-13. **Poll and evaluate**: Handle bot comments (already-fixed, false-positive, real issues).
-14. **Arbitrate false positives**: Use `csa debate` with independent model.
-15. **Fix real issues**: Commit fixes, push, re-trigger bot (max 10 iterations).
-16. **Merge**: `gh pr merge --squash --delete-branch`, update local main.
+10. **Pre-PR cumulative review**: `csa review --range main...HEAD` (covers full branch, NOT just last commit). MUST pass before push.
+11. **Push**: `git push -u origin ${BRANCH}`.
+12. **Create PR**: `gh pr create --base main`.
+13. **Trigger codex bot**: `gh pr comment --body "@codex review"`.
+14. **Poll and evaluate**: Handle bot comments (already-fixed, false-positive, real issues).
+15. **Arbitrate false positives**: Use `csa debate` with independent model.
+16. **Fix real issues**: Commit fixes, push, re-trigger bot (max 10 iterations).
+17. **Merge**: `gh pr merge --squash --delete-branch`, update local main.
 
 ## Example Usage
 

--- a/patterns/dev-to-merge/workflow.toml
+++ b/patterns/dev-to-merge/workflow.toml
@@ -33,6 +33,9 @@ name = "REPO"
 name = "REVIEW_HAS_ISSUES"
 
 [[workflow.variables]]
+name = "CUMULATIVE_REVIEW_COMPLETED"
+
+[[workflow.variables]]
 name = "SCOPE"
 
 [[workflow.steps]]
@@ -209,13 +212,29 @@ title = "Commit"
 tool = "bash"
 prompt = """
 Create the commit using the generated message: ${COMMIT_MSG}.
-NOTE: In production, this step should invoke the `/commit` skill which
-enforces security audit, test completeness, and AGENTS.md compliance.
-The raw `git commit` here demonstrates the skill-lang format only.
 
 ```bash
 git commit -m "${COMMIT_MSG}"
 ```"""
+on_fail = "abort"
+
+[[workflow.steps]]
+id = 131
+title = "Pre-PR Cumulative Review"
+tool = "csa"
+prompt = """
+Run a cumulative review covering ALL commits on the feature branch since main.
+This is distinct from Step 8's per-commit review (csa review --diff):
+- Step 8 reviews uncommitted changes (staged diff) — single-commit granularity.
+- This step reviews the full feature branch — catches cross-commit issues.
+
+MANDATORY: This review MUST pass before pushing to origin.
+
+```bash
+csa review --range main...HEAD
+CUMULATIVE_REVIEW_COMPLETED=true
+```"""
+tier = "tier-2-standard"
 on_fail = "abort"
 
 [[workflow.steps]]
@@ -253,9 +272,6 @@ tool = "bash"
 prompt = """
 Trigger the cloud codex review bot on the newly created PR.
 Capture the PR number for polling.
-NOTE: In production, Steps 15-24 should invoke the `/pr-codex-bot` skill
-which handles the full review-trigger-procedure, bounded polling, false-positive
-arbitration, and merge atomically. The manual flow here demonstrates skill-lang.
 
 ```bash
 PR_NUM=$(gh pr view --json number -q '.number')

--- a/patterns/pr-codex-bot/workflow.toml
+++ b/patterns/pr-codex-bot/workflow.toml
@@ -118,11 +118,18 @@ title = "Push and Create PR"
 tool = "bash"
 prompt = """
 PRECONDITION: Step 2 (local review) must have completed successfully.
-In workflow executor context, Step 2's on_fail=abort already guarantees this —
-Step 4 is only reached when Step 2 exits 0. The REVIEW_COMPLETED variable
-is tracked by the manual orchestrator (PATTERN.md), not by the workflow engine.
+The bash block below includes an explicit REVIEW_COMPLETED gate for safety:
+even though the workflow engine's on_fail=abort on Step 2 should prevent
+reaching this step without a passing review, agents executing manually via
+PATTERN.md may skip or fail to set the variable.
 
 ```bash
+set -euo pipefail
+if [ "${REVIEW_COMPLETED}" != "true" ]; then
+  echo "ERROR: Local review (Step 2) was not completed. REVIEW_COMPLETED=${REVIEW_COMPLETED:-unset}"
+  echo "FORBIDDEN: Creating a PR without completing Step 2."
+  exit 1
+fi
 git push -u origin "${WORKFLOW_BRANCH}"
 gh pr create --base main --title "${PR_TITLE}" --body "${PR_BODY}"
 PR_NUM=$(gh pr view --json number -q '.number')


### PR DESCRIPTION
## Summary
- **Balloon condition fix**: `should_enable_balloon()` now checks available RAM (not just swap). Skips inflation when system has plenty of free memory, preventing needless swap pressure.
- **pr-codex-bot gate**: Step 4 adds explicit `REVIEW_COMPLETED` bash guard — defense-in-depth against agents skipping local review before push.
- **dev-to-merge cumulative review**: New Step 131 runs `csa review --range main...HEAD` before push. Removes ambiguous NOTEs that confused agents about whether to run inline steps or delegate to skills.
- **commit SKILL.md**: Documents two-layer review architecture (per-commit vs pre-PR cumulative).

## Test plan
- [x] `should_enable_balloon` tests updated for 3-arg signature (5 assertions covering all branches)
- [x] `just pre-commit` passes (2038 unit + 14 e2e tests)
- [x] `weave compile` passes for all modified patterns
- [x] `csa review --diff` APPROVE
- [x] `csa review --range main...HEAD` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)