### PR TITLE
chore: sync Cargo.lock workspace versions to 0.1.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "axum",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Summary\n- update workspace package versions in Cargo.lock from 0.1.47 to 0.1.48\n\n## Scope\n- only Cargo.lock\n