### PR TITLE
fix(weave): stop installing skills to .gemini/skills, add cleanup command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "chrono",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "chrono",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "chrono",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "axum",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "chrono",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "chrono",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.88"
+version = "0.1.89"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/weave/src/check.rs
+++ b/crates/weave/src/check.rs
@@ -9,6 +9,8 @@ use anyhow::{Context, Result};
 use tracing::warn;
 
 use crate::package::AuditIssue;
+/// Default directories where weave manages companion skill symlinks.
+pub const DEFAULT_LINK_DIRS: &[&str] = &[".claude/skills", ".codex/skills", ".agents/skills"];
 
 /// Default directories to scan for broken symlinks.
 pub const DEFAULT_CHECK_DIRS: &[&str] = &[
@@ -17,6 +19,10 @@ pub const DEFAULT_CHECK_DIRS: &[&str] = &[
     ".agents/skills",
     ".gemini/skills",
 ];
+
+const GEMINI_SKILLS_DIR: &str = ".gemini/skills";
+const AGENTS_SKILLS_DIR: &str = ".agents/skills";
+const PATTERNS_DIR: &str = "patterns";
 
 /// Result of checking a single directory for broken symlinks.
 #[derive(Debug)]
@@ -29,6 +35,63 @@ pub struct CheckResult {
     pub fixed: usize,
     /// Number of symlinks that could not be removed (permission errors, etc.).
     pub fix_failures: usize,
+}
+
+/// A Gemini duplicate symlink that was removed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeminiCleanupEntry {
+    /// Symlink path that was removed.
+    pub path: PathBuf,
+    /// Original symlink target as stored on disk.
+    pub target: PathBuf,
+}
+
+/// A Gemini duplicate symlink that could not be removed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeminiCleanupFailure {
+    /// Symlink path that could not be removed.
+    pub path: PathBuf,
+    /// Human-readable failure reason.
+    pub error: String,
+}
+
+/// Result of cleaning duplicate Gemini skill symlinks.
+#[derive(Debug, Default)]
+pub struct GeminiCleanupResult {
+    /// Gemini skills directory that was scanned.
+    pub dir: PathBuf,
+    /// True when the Gemini skills directory did not exist.
+    pub missing_dir: bool,
+    /// Duplicate symlinks that were removed.
+    pub removed: Vec<GeminiCleanupEntry>,
+    /// Duplicate symlinks that could not be removed.
+    pub remove_failures: Vec<GeminiCleanupFailure>,
+    /// Number of regular files/directories that were ignored.
+    pub skipped_non_symlink: usize,
+    /// Number of symlinks whose names had no managed skill counterpart.
+    pub skipped_non_duplicate: usize,
+    /// Number of symlinks preserved because they point outside weave-managed paths.
+    pub skipped_non_weave_target: usize,
+}
+
+fn resolve_symlink_target(link_path: &Path, target: &Path) -> PathBuf {
+    if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        link_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(target)
+    }
+}
+
+fn canonicalize_existing_target(path: &Path) -> std::io::Result<Option<PathBuf>> {
+    match path.try_exists() {
+        Ok(true) => std::fs::canonicalize(path).map(Some),
+        Ok(false) => Ok(None),
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => Err(err),
+        Err(_) => Ok(None),
+    }
 }
 
 /// Scan directories for broken symlinks.
@@ -152,6 +215,118 @@ pub fn check_symlinks(
     Ok(results)
 }
 
+/// Remove duplicate Gemini skill symlinks whose names already exist in `.agents/skills/`.
+///
+/// A Gemini symlink is removed only when both of these conditions hold:
+/// 1. Its file name already exists under `.agents/skills/`.
+/// 2. Its resolved target is weave-managed (inside `patterns/` or `.agents/skills/`)
+///    or the symlink is broken.
+///
+/// This catches both historical direct links to source skill directories and
+/// the newer indirect links that point at `.agents/skills/`, while preserving
+/// user-defined overrides that happen to share the same name.
+pub fn clean_gemini_duplicate_symlinks(project_root: &Path) -> Result<GeminiCleanupResult> {
+    let gemini_dir = project_root.join(GEMINI_SKILLS_DIR);
+    let agents_dir = project_root.join(AGENTS_SKILLS_DIR);
+    let patterns_dir = project_root.join(PATTERNS_DIR);
+    let canonical_agents_dir = agents_dir.canonicalize().ok();
+    let canonical_patterns_dir = patterns_dir.canonicalize().ok();
+    let mut result = GeminiCleanupResult {
+        dir: gemini_dir.clone(),
+        missing_dir: !gemini_dir.is_dir(),
+        ..GeminiCleanupResult::default()
+    };
+
+    if result.missing_dir {
+        return Ok(result);
+    }
+
+    let entries = std::fs::read_dir(&gemini_dir)
+        .with_context(|| format!("failed to read {}", gemini_dir.display()))?;
+
+    for entry in entries.filter_map(|e| {
+        e.map_err(|err| warn!("failed to read directory entry: {err}"))
+            .ok()
+    }) {
+        let path = entry.path();
+        let meta = match std::fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(err) => {
+                warn!("cannot stat {}: {err}", path.display());
+                continue;
+            }
+        };
+
+        if !meta.file_type().is_symlink() {
+            result.skipped_non_symlink += 1;
+            continue;
+        }
+
+        let target = match std::fs::read_link(&path) {
+            Ok(target) => target,
+            Err(err) => {
+                warn!("cannot read symlink {}: {err}", path.display());
+                continue;
+            }
+        };
+
+        let managed_skill = agents_dir.join(entry.file_name());
+        let is_duplicate = match std::fs::symlink_metadata(&managed_skill) {
+            Ok(_) => true,
+            Err(err) => {
+                warn!(
+                    "cannot check managed skill counterpart {}: {err}",
+                    managed_skill.display()
+                );
+                false
+            }
+        };
+        if !is_duplicate {
+            result.skipped_non_duplicate += 1;
+            continue;
+        }
+
+        let resolved_target = resolve_symlink_target(&path, &target);
+        let canonical_target = match canonicalize_existing_target(&resolved_target) {
+            Ok(target) => target,
+            Err(err) => {
+                warn!(
+                    "cannot resolve Gemini symlink target {}: {err}",
+                    resolved_target.display()
+                );
+                continue;
+            }
+        };
+        let is_weave_managed = canonical_target.as_ref().is_none_or(|resolved| {
+            canonical_patterns_dir
+                .as_ref()
+                .is_some_and(|patterns| resolved.starts_with(patterns))
+                || canonical_agents_dir
+                    .as_ref()
+                    .is_some_and(|agents| resolved.starts_with(agents))
+        });
+        if !is_weave_managed {
+            let non_weave_target = canonical_target.as_ref().unwrap_or(&resolved_target);
+            warn!(
+                "Skipping {}: points to non-weave target {}",
+                path.display(),
+                non_weave_target.display()
+            );
+            result.skipped_non_weave_target += 1;
+            continue;
+        }
+
+        match std::fs::remove_file(&path).or_else(|_| std::fs::remove_dir(&path)) {
+            Ok(()) => result.removed.push(GeminiCleanupEntry { path, target }),
+            Err(err) => result.remove_failures.push(GeminiCleanupFailure {
+                path,
+                error: err.to_string(),
+            }),
+        }
+    }
+
+    Ok(result)
+}
 #[cfg(test)]
 #[path = "check_tests.rs"]
 mod tests;

--- a/crates/weave/src/check_tests.rs
+++ b/crates/weave/src/check_tests.rs
@@ -15,6 +15,16 @@ fn make_symlink(link: &Path, target: &Path) {
     std::os::unix::fs::symlink(target, link).unwrap();
 }
 
+#[test]
+fn default_skill_directories_split_linking_from_checking() {
+    assert_eq!(
+        DEFAULT_LINK_DIRS,
+        &[".claude/skills", ".codex/skills", ".agents/skills"]
+    );
+    assert!(DEFAULT_CHECK_DIRS.contains(&".gemini/skills"));
+    assert!(!DEFAULT_LINK_DIRS.contains(&".gemini/skills"));
+}
+
 #[cfg(unix)]
 #[test]
 fn check_finds_broken_symlinks() {
@@ -102,4 +112,145 @@ fn check_ignores_regular_files() {
     let results = check_symlinks(tmp.path(), &[PathBuf::from("skills")], true).unwrap();
     assert!(results.is_empty());
     assert!(skill_dir.join("not-a-link").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn clean_gemini_duplicate_symlinks_removes_weave_managed_duplicates() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join(".agents").join("skills");
+    let gemini_dir = tmp.path().join(".gemini").join("skills");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::create_dir_all(&gemini_dir).unwrap();
+
+    let indirect_agents_skill = agents_dir.join("commit");
+    std::fs::create_dir_all(&indirect_agents_skill).unwrap();
+
+    let direct_agents_skill = agents_dir.join("review");
+    std::fs::create_dir_all(&direct_agents_skill).unwrap();
+
+    let duplicate_link = gemini_dir.join("commit");
+    let relative_duplicate = pathdiff::diff_paths(&indirect_agents_skill, &gemini_dir).unwrap();
+    make_symlink(&duplicate_link, &relative_duplicate);
+
+    let source_skill = tmp
+        .path()
+        .join("patterns")
+        .join("review")
+        .join("skills")
+        .join("review");
+    std::fs::create_dir_all(&source_skill).unwrap();
+
+    let direct_link = gemini_dir.join("review");
+    let relative_direct = pathdiff::diff_paths(&source_skill, &gemini_dir).unwrap();
+    make_symlink(&direct_link, &relative_direct);
+
+    let foreign_target = tmp.path().join("external-skill");
+    std::fs::create_dir_all(&foreign_target).unwrap();
+    let foreign_link = gemini_dir.join("external");
+    make_symlink(&foreign_link, &foreign_target);
+
+    std::fs::write(gemini_dir.join("README.md"), "not a symlink").unwrap();
+
+    let result = clean_gemini_duplicate_symlinks(tmp.path()).unwrap();
+
+    assert!(!result.missing_dir);
+    assert_eq!(result.removed.len(), 2);
+    assert!(
+        result
+            .removed
+            .iter()
+            .any(|entry| entry.path == duplicate_link && entry.target == relative_duplicate)
+    );
+    assert!(
+        result
+            .removed
+            .iter()
+            .any(|entry| entry.path == direct_link && entry.target == relative_direct)
+    );
+    assert_eq!(result.skipped_non_duplicate, 1);
+    assert_eq!(result.skipped_non_weave_target, 0);
+    assert_eq!(result.skipped_non_symlink, 1);
+    assert!(result.remove_failures.is_empty());
+    assert!(duplicate_link.symlink_metadata().is_err());
+    assert!(direct_link.symlink_metadata().is_err());
+    assert!(
+        foreign_link
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn clean_gemini_duplicate_symlinks_preserves_user_custom_override() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join(".agents").join("skills");
+    let gemini_dir = tmp.path().join(".gemini").join("skills");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::create_dir_all(&gemini_dir).unwrap();
+
+    std::fs::create_dir_all(agents_dir.join("commit")).unwrap();
+
+    let custom_target = tmp.path().join("custom-skills").join("commit");
+    std::fs::create_dir_all(&custom_target).unwrap();
+
+    let custom_link = gemini_dir.join("commit");
+    make_symlink(&custom_link, &custom_target);
+
+    let result = clean_gemini_duplicate_symlinks(tmp.path()).unwrap();
+
+    assert!(!result.missing_dir);
+    assert!(result.removed.is_empty());
+    assert!(result.remove_failures.is_empty());
+    assert_eq!(result.skipped_non_duplicate, 0);
+    assert_eq!(result.skipped_non_weave_target, 1);
+    assert!(
+        custom_link
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn clean_gemini_duplicate_symlinks_removes_broken_duplicate() {
+    let tmp = TempDir::new().unwrap();
+    let agents_dir = tmp.path().join(".agents").join("skills");
+    let gemini_dir = tmp.path().join(".gemini").join("skills");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::create_dir_all(&gemini_dir).unwrap();
+
+    std::fs::create_dir_all(agents_dir.join("commit")).unwrap();
+
+    let broken_link = gemini_dir.join("commit");
+    let broken_target = PathBuf::from("../../patterns/commit/skills/commit");
+    make_symlink(&broken_link, &broken_target);
+
+    let result = clean_gemini_duplicate_symlinks(tmp.path()).unwrap();
+
+    assert!(!result.missing_dir);
+    assert_eq!(result.removed.len(), 1);
+    assert_eq!(result.removed[0].path, broken_link);
+    assert_eq!(result.removed[0].target, broken_target);
+    assert!(result.remove_failures.is_empty());
+    assert_eq!(result.skipped_non_duplicate, 0);
+    assert_eq!(result.skipped_non_weave_target, 0);
+    assert!(gemini_dir.join("commit").symlink_metadata().is_err());
+}
+
+#[test]
+fn clean_gemini_duplicate_symlinks_handles_missing_directory() {
+    let tmp = TempDir::new().unwrap();
+
+    let result = clean_gemini_duplicate_symlinks(tmp.path()).unwrap();
+
+    assert!(result.missing_dir);
+    assert_eq!(result.dir, tmp.path().join(".gemini").join("skills"));
+    assert!(result.removed.is_empty());
+    assert!(result.remove_failures.is_empty());
 }

--- a/crates/weave/src/lib.rs
+++ b/crates/weave/src/lib.rs
@@ -4,4 +4,5 @@ pub mod compiler;
 pub mod link;
 pub mod package;
 pub mod parser;
+pub(crate) mod path_utils;
 pub mod visualize;

--- a/crates/weave/src/link.rs
+++ b/crates/weave/src/link.rs
@@ -13,10 +13,11 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use tracing::{debug, warn};
 
-use crate::check::DEFAULT_CHECK_DIRS;
+use crate::check::DEFAULT_LINK_DIRS;
 use crate::package::{
     Lockfile, SourceKind, find_lockfile, global_store_root, load_lockfile, package_dir,
 };
+use crate::path_utils::{normalize_path, resolve_symlink_target};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -369,7 +370,7 @@ pub fn link_skills(project_root: &Path, scope: LinkScope, force: bool) -> Result
 
     let mut report = LinkReport::default();
 
-    for target_dir_name in DEFAULT_CHECK_DIRS {
+    for target_dir_name in DEFAULT_LINK_DIRS {
         let target_dir = base_dir.join(target_dir_name);
 
         // Decide whether to create this target directory.
@@ -377,7 +378,7 @@ pub fn link_skills(project_root: &Path, scope: LinkScope, force: bool) -> Result
         //   the standard discovery path and must exist for first-time setups.
         // - Other tool directories are only created if their parent already
         //   exists (e.g., create .codex/skills/ only if .codex/ is present).
-        let is_primary = *target_dir_name == DEFAULT_CHECK_DIRS[0];
+        let is_primary = *target_dir_name == DEFAULT_LINK_DIRS[0];
         let should_create =
             target_dir.is_dir() || is_primary || target_dir.parent().is_some_and(|p| p.is_dir());
 
@@ -435,17 +436,8 @@ fn create_skill_link(
                 reason: LinkErrorKind::Io(format!("cannot read symlink: {e}")),
             })?;
 
-            let resolved_existing = if existing_target.is_absolute() {
-                existing_target.clone()
-            } else {
-                link_parent.join(&existing_target)
-            };
-
-            let resolved_new = if relative_target.is_absolute() {
-                relative_target.clone()
-            } else {
-                link_parent.join(&relative_target)
-            };
+            let resolved_existing = resolve_symlink_target(link_parent, &existing_target);
+            let resolved_new = resolve_symlink_target(link_parent, &relative_target);
 
             // Same effective target → skip.
             if paths_equivalent(&resolved_existing, &resolved_new) {
@@ -571,7 +563,7 @@ pub fn detect_stale_links(project_root: &Path, scope: LinkScope) -> Result<Vec<P
 
     let mut stale = Vec::new();
 
-    for dir_name in DEFAULT_CHECK_DIRS {
+    for dir_name in DEFAULT_LINK_DIRS {
         let dir = base_dir.join(dir_name);
         if !dir.is_dir() {
             continue;
@@ -653,12 +645,7 @@ fn is_stale_link(
         Err(_) => return false,
     };
 
-    let resolved = if target.is_absolute() {
-        target
-    } else {
-        let parent = path.parent().unwrap_or(Path::new("."));
-        parent.join(&target)
-    };
+    let resolved = resolve_symlink_target(path.parent().unwrap_or(Path::new(".")), &target);
 
     if !is_weave_managed_path(&resolved, store_root) {
         return false;
@@ -707,21 +694,6 @@ fn is_weave_managed_path(path: &Path, store_root: &Path) -> bool {
             np.starts_with(&ns)
         }
     }
-}
-
-/// Normalize a path by resolving `.` and `..` components lexically (no I/O).
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::ParentDir => {
-                out.pop();
-            }
-            std::path::Component::CurDir => {}
-            c => out.push(c.as_os_str()),
-        }
-    }
-    out
 }
 
 /// Create a symlink (platform-specific).

--- a/crates/weave/src/link_tests.rs
+++ b/crates/weave/src/link_tests.rs
@@ -576,18 +576,13 @@ fn unique_created_names_preserves_order_and_deduplicates() {
 }
 
 #[test]
-fn unique_counts_with_four_dirs_simulation() {
-    // Simulate the real scenario: 3 unique skills × 4 directories.
+fn unique_counts_with_default_link_dirs_simulation() {
+    // Simulate the real scenario across the default managed link directories.
     let mut outcomes = Vec::new();
     let skill_names = ["commit", "mktd", "sa"];
-    let dirs = [
-        ".claude/skills",
-        ".codex/skills",
-        ".agents/skills",
-        ".gemini/skills",
-    ];
+    let dirs = crate::check::DEFAULT_LINK_DIRS;
 
-    for dir in &dirs {
+    for dir in dirs {
         for name in &skill_names {
             outcomes.push(LinkOutcome::Skipped {
                 name: name.to_string(),
@@ -603,8 +598,8 @@ fn unique_counts_with_four_dirs_simulation() {
         errors: Vec::new(),
     };
 
-    // Raw count: 3 skills × 4 dirs = 12
-    assert_eq!(report.skipped_count(), 12);
+    // Raw count: 3 skills × 3 dirs = 9
+    assert_eq!(report.skipped_count(), 9);
     // Unique: only 3 distinct skills
     assert_eq!(report.unique_skipped_count(), 3);
     assert_eq!(report.unique_created_count(), 0);

--- a/crates/weave/src/main.rs
+++ b/crates/weave/src/main.rs
@@ -141,6 +141,9 @@ enum Commands {
         fix: bool,
     },
 
+    /// Remove Gemini skill symlinks whose names match `.agents/skills/` and whose targets are weave-managed or broken.
+    CleanGeminiSkills,
+
     /// Reconcile skill symlinks: create missing, remove stale, fix broken.
     Link {
         #[command(subcommand)]
@@ -571,6 +574,64 @@ fn main() -> Result<()> {
                 }
             }
         }
+        Commands::CleanGeminiSkills => {
+            let project_root = std::env::current_dir().context("cannot determine CWD")?;
+            let result = check::clean_gemini_duplicate_symlinks(&project_root)?;
+
+            if result.missing_dir {
+                eprintln!(
+                    "no Gemini skills directory found at {}",
+                    result.dir.display()
+                );
+                return Ok(());
+            }
+
+            if result.removed.is_empty() {
+                eprintln!(
+                    "no duplicate Gemini skill symlinks found in {}",
+                    result.dir.display()
+                );
+            } else {
+                for entry in &result.removed {
+                    eprintln!(
+                        "  removed {} -> {}",
+                        entry.path.display(),
+                        entry.target.display()
+                    );
+                }
+                eprintln!(
+                    "removed {} duplicate Gemini symlink(s)",
+                    result.removed.len()
+                );
+            }
+
+            if result.skipped_non_duplicate > 0 {
+                eprintln!(
+                    "skipped {} non-duplicate Gemini symlink(s)",
+                    result.skipped_non_duplicate
+                );
+            }
+            if result.skipped_non_weave_target > 0 {
+                eprintln!(
+                    "skipped {} Gemini symlink(s) with non-weave targets",
+                    result.skipped_non_weave_target
+                );
+            }
+            if result.skipped_non_symlink > 0 {
+                eprintln!("skipped {} non-symlink entries", result.skipped_non_symlink);
+            }
+
+            if !result.remove_failures.is_empty() {
+                for failure in &result.remove_failures {
+                    eprintln!(
+                        "warning: failed to remove {}: {}",
+                        failure.path.display(),
+                        failure.error
+                    );
+                }
+                std::process::exit(1);
+            }
+        }
         Commands::Visualize { plan, png, mermaid } => {
             let target = if mermaid {
                 VisualizeTarget::Mermaid
@@ -666,4 +727,15 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_clean_gemini_skills_command() {
+        let cli = Cli::try_parse_from(["weave", "clean-gemini-skills"]).unwrap();
+        assert!(matches!(cli.command, Commands::CleanGeminiSkills));
+    }
 }

--- a/crates/weave/src/path_utils.rs
+++ b/crates/weave/src/path_utils.rs
@@ -1,0 +1,25 @@
+use std::path::{Path, PathBuf};
+
+/// Resolve a symlink target against the directory that contains the link.
+pub(crate) fn resolve_symlink_target(link_parent: &Path, target: &Path) -> PathBuf {
+    if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        link_parent.join(target)
+    }
+}
+
+/// Normalize a path by resolving `.` and `..` components lexically (no I/O).
+pub(crate) fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::CurDir => {}
+            part => normalized.push(part.as_os_str()),
+        }
+    }
+    normalized
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,8 +1,6 @@
-package = []
-
 [versions]
-csa = "0.1.86"
-weave = "0.1.86"
+csa = "0.1.88"
+weave = "0.1.88"
 
 [migrations]
 applied = []


### PR DESCRIPTION
## Summary

- Remove `.gemini/skills` from weave's link target directories, preventing duplicate skill detection errors in gemini-cli (which reads both `.gemini/skills/` and `.agents/skills/`)
- Add `weave clean-gemini-skills` subcommand to clean up existing `.gemini/skills/` symlinks that duplicate skills in `.agents/skills/` (name-based matching covers both historical direct links and indirect links)
- Extract shared path utilities to `path_utils.rs` module

## Changes

| File | Change |
|------|--------|
| `link.rs` | Remove `.gemini/skills` from `LINK_DIRS`, keeping only `.claude/skills`, `.codex/skills`, `.agents/skills` |
| `check.rs` | Add `clean_gemini_duplicate_symlinks()` with name-based dedup logic |
| `main.rs` | Wire `clean-gemini-skills` CLI subcommand |
| `path_utils.rs` | New shared module for `normalize_path` and `resolve_symlink_target` |
| `check_tests.rs` | Tests for both direct-link and indirect-link cleanup scenarios |

## Test plan

- [x] `cargo test -p weave` — 182 tests pass
- [x] `just pre-commit` — full gate passes
- [x] Heterogeneous review (`csa review --range main...HEAD`) — P1 finding fixed in amend

🤖 Generated with [Claude Code](https://claude.com/claude-code)