### PR TITLE
fix(patterns,todo): address issues #360, #361, #362 — skill improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "chrono",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "chrono",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "chrono",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "axum",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "chrono",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "chrono",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.93"
+version = "0.1.94"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_todo.rs
+++ b/crates/cli-sub-agent/src/cli_todo.rs
@@ -13,6 +13,10 @@ pub enum TodoCommands {
         #[arg(short, long)]
         branch: Option<String>,
 
+        /// Language for TODO content (e.g., "Chinese (Simplified)", "English")
+        #[arg(short, long)]
+        language: Option<String>,
+
         /// Working directory
         #[arg(long)]
         cd: Option<String>,

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -490,8 +490,13 @@ async fn run() -> Result<()> {
             }
         },
         Commands::Todo { cmd } => match cmd {
-            TodoCommands::Create { title, branch, cd } => {
-                todo_cmd::handle_create(title, branch, cd, output_format)?;
+            TodoCommands::Create {
+                title,
+                branch,
+                language,
+                cd,
+            } => {
+                todo_cmd::handle_create(title, branch, language, cd, output_format)?;
             }
             TodoCommands::Save {
                 timestamp,

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -23,9 +23,11 @@ use csa_config::global::{heterogeneous_counterpart, select_heterogeneous_tool};
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::consensus::AgentResponse;
 use csa_core::types::{OutputFormat, ToolName};
-use csa_session::{
-    output_parser::parse_sections, output_section::OutputSection, review_artifact::ReviewArtifact,
-};
+use csa_session::review_artifact::ReviewArtifact;
+
+#[path = "review_cmd_output.rs"]
+mod output;
+use output::sanitize_review_output;
 
 #[derive(Debug, Clone)]
 struct ReviewerOutcome {
@@ -455,77 +457,6 @@ fn resolve_review_stream_mode(
     } else {
         csa_process::StreamMode::BufferOnly
     }
-}
-
-/// Prefer structured review sections (summary/details) when available to avoid
-/// leaking unrelated provider noise into caller-facing review output.
-fn sanitize_review_output(output: &str) -> String {
-    let sections = parse_sections(output);
-    if sections.is_empty() {
-        return output.to_string();
-    }
-
-    let summary = last_non_empty_section_content(output, &sections, "summary");
-    let details = last_non_empty_section_content(output, &sections, "details");
-    if summary.is_none() && details.is_none() {
-        return output.to_string();
-    }
-
-    let mut rendered = String::new();
-    if let Some(content) = summary {
-        rendered.push_str("<!-- CSA:SECTION:summary -->\n");
-        rendered.push_str(&content);
-        if !content.ends_with('\n') {
-            rendered.push('\n');
-        }
-        rendered.push_str("<!-- CSA:SECTION:summary:END -->\n");
-    }
-    if let Some(content) = details {
-        if !rendered.is_empty() && !rendered.ends_with('\n') {
-            rendered.push('\n');
-        }
-        rendered.push_str("<!-- CSA:SECTION:details -->\n");
-        rendered.push_str(&content);
-        if !content.ends_with('\n') {
-            rendered.push('\n');
-        }
-        rendered.push_str("<!-- CSA:SECTION:details:END -->\n");
-    }
-    rendered
-}
-
-fn last_non_empty_section_content(
-    output: &str,
-    sections: &[OutputSection],
-    section_id: &str,
-) -> Option<String> {
-    sections
-        .iter()
-        .rev()
-        .filter(|section| section.id == section_id)
-        .find_map(|section| {
-            let content = extract_section_content(output, section);
-            if content.trim().is_empty() {
-                None
-            } else {
-                Some(content)
-            }
-        })
-}
-
-fn extract_section_content(output: &str, section: &OutputSection) -> String {
-    if section.line_start == 0 || section.line_end < section.line_start {
-        return String::new();
-    }
-
-    let lines: Vec<&str> = output.lines().collect();
-    if lines.is_empty() || section.line_start > lines.len() {
-        return String::new();
-    }
-
-    let start = section.line_start - 1;
-    let end_exclusive = section.line_end.min(lines.len());
-    lines[start..end_exclusive].join("\n")
 }
 
 /// Returns (tool, optional_model_spec). When tier resolves, model_spec is set.

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -1,0 +1,72 @@
+use csa_session::{output_parser::parse_sections, output_section::OutputSection};
+
+/// Prefer structured review sections (summary/details) when available to avoid
+/// leaking unrelated provider noise into caller-facing review output.
+pub(super) fn sanitize_review_output(output: &str) -> String {
+    let sections = parse_sections(output);
+    if sections.is_empty() {
+        return output.to_string();
+    }
+
+    let summary = last_non_empty_section_content(output, &sections, "summary");
+    let details = last_non_empty_section_content(output, &sections, "details");
+    if summary.is_none() && details.is_none() {
+        return output.to_string();
+    }
+
+    let mut rendered = String::new();
+    if let Some(content) = summary {
+        rendered.push_str("<!-- CSA:SECTION:summary -->\n");
+        rendered.push_str(&content);
+        if !content.ends_with('\n') {
+            rendered.push('\n');
+        }
+        rendered.push_str("<!-- CSA:SECTION:summary:END -->\n");
+    }
+    if let Some(content) = details {
+        if !rendered.is_empty() && !rendered.ends_with('\n') {
+            rendered.push('\n');
+        }
+        rendered.push_str("<!-- CSA:SECTION:details -->\n");
+        rendered.push_str(&content);
+        if !content.ends_with('\n') {
+            rendered.push('\n');
+        }
+        rendered.push_str("<!-- CSA:SECTION:details:END -->\n");
+    }
+    rendered
+}
+
+fn last_non_empty_section_content(
+    output: &str,
+    sections: &[OutputSection],
+    section_id: &str,
+) -> Option<String> {
+    sections
+        .iter()
+        .rev()
+        .filter(|section| section.id == section_id)
+        .find_map(|section| {
+            let content = extract_section_content(output, section);
+            if content.trim().is_empty() {
+                None
+            } else {
+                Some(content)
+            }
+        })
+}
+
+fn extract_section_content(output: &str, section: &OutputSection) -> String {
+    if section.line_start == 0 || section.line_end < section.line_start {
+        return String::new();
+    }
+
+    let lines: Vec<&str> = output.lines().collect();
+    if lines.is_empty() || section.line_start > lines.len() {
+        return String::new();
+    }
+
+    let start = section.line_start - 1;
+    let end_exclusive = section.line_end.min(lines.len());
+    lines[start..end_exclusive].join("\n")
+}

--- a/crates/cli-sub-agent/src/todo_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_cmd.rs
@@ -10,6 +10,7 @@ use tracing::warn;
 pub(crate) fn handle_create(
     title: String,
     branch: Option<String>,
+    language: Option<String>,
     cd: Option<String>,
     format: OutputFormat,
 ) -> Result<()> {
@@ -19,7 +20,7 @@ pub(crate) fn handle_create(
     // Ensure git repo is initialized for the todos directory
     csa_todo::git::ensure_git_init(manager.todos_dir())?;
 
-    let plan = manager.create(&title, branch.as_deref())?;
+    let plan = manager.create_with_language(&title, branch.as_deref(), language.as_deref())?;
 
     // Auto-commit the initial plan (freshly created, should always have changes)
     let commit_msg = format!("create: {}", title);

--- a/crates/csa-todo/src/lib.rs
+++ b/crates/csa-todo/src/lib.rs
@@ -111,6 +111,10 @@ pub struct TodoMetadata {
     pub title: String,
     /// CSA session IDs linked to this plan.
     pub sessions: Vec<String>,
+    /// Language for TODO content (e.g., "Chinese (Simplified)", "English").
+    /// Patterns use this to enforce language consistency in plan content.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -176,7 +180,17 @@ impl TodoManager {
 
     /// Create a new TODO plan.
     pub fn create(&self, title: &str, branch: Option<&str>) -> Result<TodoPlan> {
-        self.with_write_lock(|| self.create_inner(title, branch))
+        self.create_with_language(title, branch, None)
+    }
+
+    /// Create a new TODO plan with an optional language tag.
+    pub fn create_with_language(
+        &self,
+        title: &str,
+        branch: Option<&str>,
+        language: Option<&str>,
+    ) -> Result<TodoPlan> {
+        self.with_write_lock(|| self.create_inner(title, branch, language))
     }
 
     /// Update the status of a TODO plan.
@@ -337,7 +351,12 @@ impl TodoManager {
 
     // -- Internal helpers --------------------------------------------------
 
-    fn create_inner(&self, title: &str, branch: Option<&str>) -> Result<TodoPlan> {
+    fn create_inner(
+        &self,
+        title: &str,
+        branch: Option<&str>,
+        language: Option<&str>,
+    ) -> Result<TodoPlan> {
         let base_timestamp = Utc::now().format("%Y%m%dT%H%M%S").to_string();
 
         // Detect collision (multiple creates within the same second) and append suffix
@@ -359,6 +378,7 @@ impl TodoManager {
             status: TodoStatus::Draft,
             title: title.to_string(),
             sessions: Vec::new(),
+            language: language.map(|s| s.to_string()),
             created_at: now,
             updated_at: now,
         };

--- a/crates/csa-todo/src/lib_ext_tests.rs
+++ b/crates/csa-todo/src/lib_ext_tests.rs
@@ -79,6 +79,7 @@ fn test_list_sorted_newest_first() {
             status: TodoStatus::Draft,
             title: title.to_string(),
             sessions: Vec::new(),
+            language: None,
             created_at: now,
             updated_at: now,
         };

--- a/crates/csa-todo/src/lib_tests.rs
+++ b/crates/csa-todo/src/lib_tests.rs
@@ -221,6 +221,7 @@ fn test_metadata_serialization() {
         status: TodoStatus::Draft,
         title: "Test".to_string(),
         sessions: vec!["01ABC".to_string()],
+        language: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     };
@@ -347,6 +348,74 @@ fn test_status_lifecycle() {
         .update_status(&plan.timestamp, TodoStatus::Done)
         .unwrap();
     assert_eq!(plan.metadata.status, TodoStatus::Done);
+}
+
+#[test]
+fn test_create_with_language() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+    let plan = manager
+        .create_with_language("Lang Plan", Some("feat/lang"), Some("Chinese (Simplified)"))
+        .unwrap();
+
+    assert_eq!(
+        plan.metadata.language.as_deref(),
+        Some("Chinese (Simplified)")
+    );
+
+    let reloaded = manager.load(&plan.timestamp).unwrap();
+    assert_eq!(
+        reloaded.metadata.language.as_deref(),
+        Some("Chinese (Simplified)")
+    );
+}
+
+#[test]
+fn test_create_without_language() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+    let plan = manager.create("No Lang", None).unwrap();
+    assert!(plan.metadata.language.is_none());
+
+    let reloaded = manager.load(&plan.timestamp).unwrap();
+    assert!(reloaded.metadata.language.is_none());
+}
+
+#[test]
+fn test_language_field_serde_backward_compat() {
+    // Verify that metadata without a language field deserializes correctly
+    // (backward compatibility with existing plans).
+    let toml_str = r#"
+status = "draft"
+title = "Old Plan"
+sessions = []
+created_at = "2025-01-01T00:00:00Z"
+updated_at = "2025-01-01T00:00:00Z"
+"#;
+    let metadata: TodoMetadata = toml::from_str(toml_str).unwrap();
+    assert!(metadata.language.is_none());
+    assert_eq!(metadata.title, "Old Plan");
+}
+
+#[test]
+fn test_language_field_skip_serializing_if_none() {
+    let metadata = TodoMetadata {
+        branch: None,
+        status: TodoStatus::Draft,
+        title: "Test".to_string(),
+        sessions: Vec::new(),
+        language: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+
+    let toml_str = toml::to_string_pretty(&metadata).unwrap();
+    assert!(
+        !toml_str.contains("language"),
+        "language = None should not appear in serialized TOML"
+    );
 }
 
 include!("lib_ext_tests.rs");

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -160,6 +160,27 @@ ${STEP_4_OUTPUT}
 
 ### Instructions
 
+#### TODO Structure Requirements
+
+The TODO plan MUST include the following sections for context recovery:
+
+a) **"## Design Overview" section** at the top with:
+   - Problem statement (1-2 sentences)
+   - Key design decisions with rationale
+   - Architecture constraints discovered during recon
+
+b) Each task item MUST include:
+   - A descriptive title (not just "Implement X")
+   - Context sub-bullet explaining WHY this task exists and HOW it relates to the design
+   - Dependencies on other tasks with specific details (not just "depends on task 1")
+   - Each task description MUST be >= 20 words to provide sufficient context
+
+c) **"## Debate Findings" section** (left empty in draft, populated after Phase 3):
+   - Which debate points were adopted
+   - Which were deferred and why
+
+#### Formatting Rules
+
 Each item is a [ ] checkbox with executor tag.
 Write all TODO descriptions, section headers, and task names in `${STEP_1_OUTPUT}`.
 Technical terms, code snippets, commit scope strings, and executor tags remain in English.
@@ -324,6 +345,14 @@ Use the generated spec as an acceptance contract.
 If the debate reveals missing coverage, add TODO work that restores alignment
 instead of silently diverging from the spec.
 
+Enrich task descriptions with debate rationale. Each task MUST have enough context
+that a fresh agent (post-compaction) can understand the full design intent without
+any prior conversation history.
+
+Populate the "## Debate Findings" section with:
+- Which debate points were adopted and how they changed the plan
+- Which were deferred and why (with brief justification)
+
 ### Prior Context
 
 ### Draft TODO (Step 5)
@@ -387,7 +416,11 @@ elif printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'han script'; then
   [[ "${CJK_COUNT_DRAFT:-0}" -ge "${MIN_CJK}" ]] || { echo "STEP_10_OUTPUT language mismatch: expected CJK-script content (CJK chars >= ${MIN_CJK})" >&2; exit 1; }
 fi
 CURRENT_BRANCH=$(git branch --show-current) || { echo "detect branch failed" >&2; exit 1; }
-TODO_TS=$(csa todo create --branch "${CURRENT_BRANCH}" -- "${FEATURE}") || { echo "csa todo create failed" >&2; exit 1; }
+LANG_ARGS=()
+if [[ -n "${RESOLVED_LANGUAGE:-}" ]]; then
+  LANG_ARGS+=("--language" "${RESOLVED_LANGUAGE}")
+fi
+TODO_TS=$(csa todo create --branch "${CURRENT_BRANCH}" "${LANG_ARGS[@]}" -- "${FEATURE}") || { echo "csa todo create failed" >&2; exit 1; }
 TODO_PATH=$(csa todo show -t "${TODO_TS}" --path) || { echo "csa todo show failed" >&2; exit 1; }
 SPEC_PATH="$(dirname "${TODO_PATH}")/spec.toml"
 printf '%s\n' "${STEP_10_OUTPUT}" > "${TODO_PATH}" || { echo "write TODO failed" >&2; exit 1; }
@@ -407,6 +440,14 @@ if printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'chinese'; then
 elif printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'han script'; then
   CJK_COUNT_SAVED=$(rg -o '[\p{Han}\p{Hiragana}\p{Katakana}]' "${TODO_PATH}" | wc -l | tr -d '[:space:]')
   [[ "${CJK_COUNT_SAVED:-0}" -ge "${MIN_CJK:-2}" ]] || { echo "saved TODO language mismatch: expected CJK-script content (CJK chars >= ${MIN_CJK:-2})" >&2; exit 1; }
+fi
+# Validate language metadata consistency: if metadata.language is set,
+# verify TODO content matches (e.g., Chinese plan should have Chinese descriptions)
+if [[ -n "${RESOLVED_LANGUAGE:-}" ]]; then
+  if printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'chinese'; then
+    HAN_META_CHECK=$(rg -o '[\p{Han}]' "${TODO_PATH}" | wc -l | tr -d '[:space:]')
+    [[ "${HAN_META_CHECK:-0}" -ge 2 ]] || { echo "language metadata mismatch: plan language is ${RESOLVED_LANGUAGE} but content lacks Han characters" >&2; exit 1; }
+  fi
 fi
 csa todo save -t "${TODO_TS}" "finalize: ${FEATURE}" || { echo "csa todo save failed" >&2; exit 1; }
 SPEC_RENDERED=$(csa todo show -t "${TODO_TS}" --spec) || { echo "csa todo show --spec failed" >&2; exit 1; }

--- a/patterns/mktd/skills/mktd/SKILL.md
+++ b/patterns/mktd/skills/mktd/SKILL.md
@@ -79,10 +79,13 @@ csa run --skill mktd "Plan the implementation of <feature description>"
 1. Three RECON dimensions completed via CSA (structure, patterns, constraints).
 2. Main agent performed zero file reads during Phase 1.
 3. TODO draft synthesized with executor tags and checkbox items.
-4. Threat model completed for all new API surfaces.
-5. Adversarial debate completed via explicit `csa debate`.
-6. Debate evidence packet validated (includes mapped verdict, raw verdict, and confidence).
-7. TODO revised to incorporate debate feedback and threat model findings.
-8. TODO saved via `csa todo create` + `csa todo save` with branch association.
-9. Save gate validated task completeness (`- [ ] ...`, `DONE WHEN`) and language consistency.
-10. User presented with plan for approval decision in resolved language.
+4. Each task has >= 20 words of context/description.
+5. Design Overview section is present with key decisions.
+6. Threat model completed for all new API surfaces.
+7. Adversarial debate completed via explicit `csa debate`.
+8. Debate evidence packet validated (includes mapped verdict, raw verdict, and confidence).
+9. Debate Findings section captures adopted vs deferred points.
+10. TODO revised to incorporate debate feedback and threat model findings.
+11. TODO saved via `csa todo create` + `csa todo save` with branch and language association.
+12. Save gate validated task completeness (`- [ ] ...`, `DONE WHEN`) and language consistency.
+13. User presented with plan for approval decision in resolved language.

--- a/patterns/mktsk/PATTERN.md
+++ b/patterns/mktsk/PATTERN.md
@@ -1,7 +1,7 @@
 ---
 name = "mktsk"
 description = "Execute TODO plans as deterministic, resumable serial checklists across auto-compaction"
-allowed-tools = "Read, Grep, Glob, Bash, Write, Edit"
+allowed-tools = "Read, Grep, Glob, Bash, Write, Edit, TaskCreate, TaskUpdate, TaskGet, TaskList"
 tier = "tier-2-standard"
 version = "0.1.0"
 ---
@@ -21,26 +21,30 @@ Extract all unchecked checklist items (`- [ ]`) with:
 
 Fail fast if no executable checklist items are found.
 
-## Step 2: Build Resumable Execution Checklist
+## Step 2: Register Tasks via TaskCreate
 
-Normalize extracted items into a serial execution checklist.
-Each normalized item MUST include:
+TODO.md is a read-only planning artifact. Progress tracking uses TaskCreate/TaskUpdate.
+
+For each parsed TODO item, use TaskCreate to register a tracked task entry.
+Each task MUST include:
 - stable item id
 - source TODO line reference
 - executor tag
 - concrete action
 - mechanically verifiable `DONE WHEN`
 
-Output the full checklist as markdown text.
+Do NOT modify TODO.md checkboxes — task progress is tracked via TaskUpdate status.
 
-## Step 3: Execute Checklist Serially
+## Step 3: Execute Tasks Serially
 
-Execute checklist items strictly in order.
-Do not parallelize implementation work.
-Treat each checklist item as an atomic transaction:
+Execute tasks strictly in order. Do not parallelize implementation work.
+
+Before each task: use TaskUpdate to set status to `in_progress`.
+
+Treat each task as an atomic transaction:
 1. Execute exactly one item.
 2. Run verification/review.
-3. Persist completion in TODO.
+3. Use TaskUpdate to set status to `completed`.
 4. Persist checkpoint before next item.
 
 Dispatch policy by executor tag:
@@ -52,13 +56,13 @@ Dispatch policy by executor tag:
 Checkpoint policy (mandatory):
 - Use `.csa/state/mktsk/checkpoint.json` as progress checkpoint.
 - Write latest completed item id after each completed item.
-- On interruption, resume from unchecked TODO items + checkpoint state.
+- On interruption, resume from TaskList status and checkpoint state.
 
 After each item:
 1. Run quality gates (`just fmt`, `just clippy`, `just test`).
 2. Run `csa review --diff`.
 3. Apply fixes if review reports blocking issues.
-4. Mark the item as completed in the TODO file (`- [x]`), preserving text.
+4. Use TaskUpdate to mark the task as `completed`.
 
 ## Step 4: Compact Context (Conditional)
 

--- a/patterns/mktsk/skills/mktsk/SKILL.md
+++ b/patterns/mktsk/skills/mktsk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mktsk
 description: Convert TODO plans into deterministic, resumable serial execution checklists across auto-compaction
-allowed-tools: Bash, Read, Grep, Glob, Write, Edit
+allowed-tools: Bash, Read, Grep, Glob, Write, Edit, TaskCreate, TaskUpdate, TaskGet, TaskList
 triggers:
   - "mktsk"
   - "/mktsk"
@@ -47,16 +47,14 @@ csa run --skill mktsk "Execute the TODO plan at <path or csa todo show -t <times
 ### Step-by-Step
 
 1. **Parse TODO plan**: Read the TODO file. Extract each `[ ]` item with executor tag and `DONE WHEN`.
-2. **Build checklist entries**: Normalize each item into a serial execution entry with:
-   - Stable item id
-   - Source TODO line reference
-   - Subject with executor tag: `[Sub:developer]`, `[Skill:commit]`, `[CSA:tool]`
-   - Description with clear scope
-   - DONE WHEN condition (mechanically verifiable)
+2. **Register tasks**: For each parsed TODO item, use TaskCreate to create a tracked task entry.
+   Include the executor tag and `DONE WHEN` condition in the task description.
+   TODO.md remains the read-only source of truth — mktsk reads from it, tracks progress via TaskCreate/TaskUpdate.
 3. **Execute serially with checkpointing**: Process checklist items strictly in order. NEVER parallelize implementation tasks.
-   - Treat each item as an atomic transaction: execute one item -> verify -> review -> persist TODO/checkpoint.
+   - Before executing each item: use TaskUpdate to set its status to `in_progress`.
+   - Treat each item as an atomic transaction: execute one item -> verify -> review -> persist checkpoint.
    - After each implementation item: run `just fmt`, `just clippy`, `just test`, then `csa review --diff`.
-   - Mark each completed item in the TODO checklist.
+   - After completing each item: use TaskUpdate to set its status to `completed`.
    - Write latest completed item id to `.csa/state/mktsk/checkpoint.json` after each completed item.
    - On interruption, resume from unchecked TODO items and checkpoint state.
 4. **Compact if needed**: If context > 80%, compact while preserving remaining items and review findings.
@@ -78,10 +76,10 @@ csa run --skill mktsk "Execute the TODO plan at <path or csa todo show -t <times
 
 ## Done Criteria
 
-1. All TODO items parsed and converted to checklist entries with executor tags.
-2. All checklist items executed in strict serial order.
+1. All TODO items parsed and registered via TaskCreate with executor tags.
+2. All tasks executed in strict serial order with TaskUpdate status transitions.
 3. Each task's DONE WHEN condition verified before marking complete.
-4. Completed items are marked in TODO.
-5. Progress checkpoint is updated after each completed item.
-6. `just fmt`, `just clippy`, and `just test` exit 0 after final task.
-7. `git status` shows clean working tree.
+4. Progress checkpoint is updated after each completed item.
+5. `just fmt`, `just clippy`, and `just test` exit 0 after final task.
+6. `git status` shows clean working tree.
+7. All TaskCreate entries show status `completed` in TaskList.

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.92"
-weave = "0.1.92"
+csa = "0.1.94"
+weave = "0.1.94"
 
 [migrations]
 applied = []


### PR DESCRIPTION
## Summary

- **#360**: Add `language` field to `TodoMetadata` and `--language` CLI flag to `csa todo create`, enabling language-aware TODO plan creation. mktd PATTERN passes detected language during save phase.
- **#361**: Enrich mktd DRAFT phase to require Design Overview section, per-task context sub-bullets (≥20 words), and Debate Findings section for post-compaction context recovery.
- **#362**: Update mktsk to use `TaskCreate`/`TaskUpdate` for progress tracking. `TODO.md` becomes a read-only planning artifact.
- **Bonus**: Split `review_cmd.rs` monolith (834→765 lines) by extracting output sanitization to `review_cmd_output.rs`.

## Changes

| File | Change |
|------|--------|
| `crates/csa-todo/src/lib.rs` | Add `language: Option<String>` to `TodoMetadata` |
| `crates/cli-sub-agent/src/cli_todo.rs` | Add `--language` CLI flag |
| `crates/cli-sub-agent/src/todo_cmd.rs` | Propagate language to create |
| `crates/csa-todo/src/lib_tests.rs` | 4 new tests for language support |
| `patterns/mktd/PATTERN.md` | Design Overview, task detail, Debate Findings requirements |
| `patterns/mktd/skills/mktd/SKILL.md` | Updated Done Criteria |
| `patterns/mktsk/PATTERN.md` | TaskCreate/TaskUpdate integration, TODO.md read-only |
| `patterns/mktsk/skills/mktsk/SKILL.md` | allowed-tools + updated workflow |
| `crates/cli-sub-agent/src/review_cmd.rs` | Extract output sanitization |
| `crates/cli-sub-agent/src/review_cmd_output.rs` | New module for sanitization |

## Test plan

- [x] `just pre-commit` passes (2316 tests + 16 E2E)
- [x] Pre-commit heterogeneous review (gemini-cli): CLEAN
- [x] Pre-PR cumulative review (main...HEAD): CLEAN
- [x] Security scan: no secrets found
- [x] `weave compile-all`: patterns valid

Closes #360, closes #361, closes #362

Generated with [Claude Code](https://claude.com/claude-code)