### PR TITLE
fix(csa-config): XDG migration skipped when lock version > migration version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "axum",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.98"
+version = "0.1.99"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -214,17 +214,26 @@ async fn run() -> Result<()> {
 
     let legacy_xdg_paths = csa_config::paths::legacy_paths_requiring_migration();
     if !legacy_xdg_paths.is_empty() {
-        eprintln!(
-            "WARNING: legacy XDG paths detected ({}). Run `csa migrate` to unify paths.",
-            legacy_xdg_paths.len()
-        );
         for path in &legacy_xdg_paths {
-            eprintln!(
-                "  - {}: legacy={} -> new={}",
-                path.label,
-                path.legacy_path.display(),
-                path.new_path.display()
+            tracing::debug!(
+                label = path.label,
+                legacy = %path.legacy_path.display(),
+                new = %path.new_path.display(),
+                "legacy XDG path detected, auto-migrating"
             );
+        }
+        match csa_config::migrate::run_xdg_migration() {
+            Ok(()) => {
+                tracing::debug!(
+                    "auto-migrated {} legacy XDG path(s)",
+                    legacy_xdg_paths.len()
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "WARNING: failed to auto-migrate legacy XDG paths: {e:#}. Run `csa migrate` manually."
+                );
+            }
         }
     }
 

--- a/crates/csa-config/src/migrate.rs
+++ b/crates/csa-config/src/migrate.rs
@@ -128,21 +128,23 @@ impl MigrationRegistry {
         &self.migrations
     }
 
-    /// Find migrations that need to run to get from `current` to `target`,
+    /// Find migrations that need to run to reach `target`,
     /// excluding those already applied (by id).
+    ///
+    /// Previous versions incorrectly filtered by `m.from_version >= current`,
+    /// which skipped unapplied migrations when the lock was created at a
+    /// version higher than the migration's `from_version` (e.g., lock at
+    /// 0.1.97 would skip a migration with from_version 0.1.27). The
+    /// `applied` list is the authoritative record of what has run.
     pub fn pending(
         &self,
-        current: &Version,
+        _current: &Version,
         target: &Version,
         applied: &[String],
     ) -> Vec<&Migration> {
         self.migrations
             .iter()
-            .filter(|m| {
-                m.from_version >= *current
-                    && m.to_version <= *target
-                    && !applied.iter().any(|id| id == &m.id)
-            })
+            .filter(|m| m.to_version <= *target && !applied.iter().any(|id| id == &m.id))
             .collect()
     }
 }
@@ -484,6 +486,11 @@ fn migrate_xdg_paths_for_pairs(pairs: Vec<paths::XdgPathPair>, admin_dir: &Path)
                 continue;
             }
 
+            // Already a correct symlink — nothing to do.
+            if paths::is_symlink_to(&pair.legacy_path, &pair.new_path) {
+                continue;
+            }
+
             if pair.new_path.exists() {
                 let should_merge = if pair.legacy_path.is_dir() {
                     !is_directory_empty(&pair.legacy_path)?
@@ -574,6 +581,14 @@ fn migrate_xdg_paths_for_pairs(pairs: Vec<paths::XdgPathPair>, admin_dir: &Path)
 }
 
 fn migrate_xdg_paths(_project_root: &Path) -> Result<()> {
+    run_xdg_migration()
+}
+
+/// Run the XDG paths migration directly (idempotent).
+///
+/// This can be called from startup code to proactively fix legacy paths
+/// without requiring `csa migrate`. Safe to call multiple times.
+pub fn run_xdg_migration() -> Result<()> {
     migrate_xdg_paths_for_pairs(paths::xdg_path_pairs(), &migration_admin_dir())
 }
 

--- a/crates/csa-config/src/migrate_tests.rs
+++ b/crates/csa-config/src/migrate_tests.rs
@@ -644,3 +644,36 @@ fn test_xdg_migration_concurrent_flock_blocks_second_migration() {
 
     handle.join().unwrap();
 }
+
+#[test]
+fn test_pending_includes_old_unapplied_migrations_when_lock_version_is_higher() {
+    // Regression test: lock created at 0.1.97 with empty applied list.
+    // Migrations from 0.1.27 should still be pending (not filtered by from_version).
+    let mut registry = MigrationRegistry::new();
+    registry.register(Migration {
+        id: "0.1.27-xdg-paths".to_string(),
+        from_version: Version::new(0, 1, 27),
+        to_version: Version::new(0, 1, 27),
+        description: "XDG paths unification".to_string(),
+        steps: vec![],
+    });
+
+    // Lock is at 0.1.97, binary is at 0.1.98, nothing applied.
+    let current = Version::new(0, 1, 97);
+    let target = Version::new(0, 1, 98);
+    let pending = registry.pending(&current, &target, &[]);
+    assert_eq!(
+        pending.len(),
+        1,
+        "migration with from_version < current should still be pending when not in applied list"
+    );
+    assert_eq!(pending[0].id, "0.1.27-xdg-paths");
+
+    // Once applied, it should not be pending.
+    let applied = vec!["0.1.27-xdg-paths".to_string()];
+    let pending = registry.pending(&current, &target, &applied);
+    assert!(
+        pending.is_empty(),
+        "applied migration should not be pending"
+    );
+}

--- a/crates/csa-config/src/paths.rs
+++ b/crates/csa-config/src/paths.rs
@@ -136,7 +136,7 @@ pub fn xdg_path_pairs() -> Vec<XdgPathPair> {
     pairs
 }
 
-fn is_symlink_to(legacy_path: &std::path::Path, new_path: &std::path::Path) -> bool {
+pub fn is_symlink_to(legacy_path: &std::path::Path, new_path: &std::path::Path) -> bool {
     let Ok(metadata) = std::fs::symlink_metadata(legacy_path) else {
         return false;
     };

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,10 @@
 [versions]
-csa = "0.1.97"
-weave = "0.1.97"
+csa = "0.1.98"
+weave = "0.1.98"
+last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]
-applied = []
+applied = [
+    "0.1.2-plan-to-workflow",
+    "0.1.27-xdg-paths-unification",
+]


### PR DESCRIPTION
## Summary
- Fix `pending()` filter that incorrectly skipped unapplied migrations when weave.lock version exceeded migration's `from_version` (e.g., lock at 0.1.97 skipped 0.1.27 XDG migration)
- Auto-run XDG migration at startup instead of just warning, eliminating the persistent "legacy XDG paths detected" message
- Make migration idempotent by skipping already-correct symlinks

## Root Cause
`MigrationRegistry::pending()` used `m.from_version >= *current` which filtered out migrations whose `from_version` was lower than the lock version — even when `applied = []` (never run). The `applied` list is the authoritative record, not the version comparison.

## Test plan
- [x] Regression test: `test_pending_includes_old_unapplied_migrations_when_lock_version_is_higher`
- [x] All 35 migration tests pass
- [x] Full pre-commit suite passes
- [x] Verified auto-migration works: legacy path converted to symlink on startup
- [x] `csa migrate` runs successfully with correct symlink skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)