### PR TITLE
docs(sa): add exploration tool preference to SA skill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "axum",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.100"
+version = "0.1.101"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/patterns/sa/skills/sa/SKILL.md
+++ b/patterns/sa/skills/sa/SKILL.md
@@ -105,6 +105,14 @@ Employees are professionals with subjective agency.
 - Employee may delegate to lower tiers as needed.
 - If requirements are ambiguous, employee returns `status = "needs_clarification"` with concrete questions.
 
+### Exploration Tool Preference (MANDATORY)
+
+For codebase exploration (searching code, reading multiple files, understanding architecture),
+Layer 1 and Layer 2 employees **MUST prefer `csa run` over Claude Code's built-in `Agent` tool
+with `subagent_type=Explore`**. CSA tokens (gemini-cli/codex) are significantly cheaper than
+Claude tokens, and CSA tools have larger context windows for processing many files simultaneously.
+Reserve the built-in Explore agent only for quick searches that need <3 queries.
+
 ## Structured Communication Protocol
 
 ### Manager -> Employee (Dispatch Packet)

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.99"
-weave = "0.1.99"
+csa = "0.1.100"
+weave = "0.1.100"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Add "Exploration Tool Preference (MANDATORY)" rule to SA skill (`patterns/sa/skills/sa/SKILL.md`)
- Layer 1/Layer 2 employees must prefer `csa run` over Claude Code's built-in Explore agent for codebase exploration
- This rule was previously in CLAUDE.md but needs to be in the SA skill so it's shared across all Claude Code sessions

## Test plan
- [x] `weave compile` passes
- [x] `just pre-commit` passes
- [ ] Verify SA skill loads the new section in a fresh Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)