### PR TITLE
fix(acp): fix Issue #375 regression (zero stdout) and enforce 1200s minimum timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "chrono",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "chrono",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "axum",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "chrono",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.102"
+version = "0.1.103"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -171,10 +171,34 @@ pub fn validate_review_args(args: &ReviewArgs) -> std::result::Result<(), clap::
 }
 
 pub fn validate_command_args(command: &Commands) -> std::result::Result<(), clap::Error> {
-    if let Commands::Review(args) = command {
-        validate_review_args(args)?;
+    match command {
+        Commands::Run { timeout, .. } => {
+            validate_timeout(*timeout)?;
+        }
+        Commands::Review(args) => {
+            validate_review_args(args)?;
+            validate_timeout(args.timeout)?;
+        }
+        Commands::Debate(args) => {
+            validate_timeout(args.timeout)?;
+        }
+        _ => {}
     }
 
+    Ok(())
+}
+
+fn validate_timeout(timeout: Option<u64>) -> std::result::Result<(), clap::Error> {
+    if let Some(t) = timeout {
+        if t < 1200 {
+            return Err(clap::Error::raw(
+                clap::error::ErrorKind::ValueValidation,
+                "Absolute timeout (--timeout) must be at least 1200 seconds (20 minutes). \
+                 Short timeouts waste tokens because the agent starts working but gets killed before producing output. \
+                 Record this in your CLAUDE.md or memory: CSA minimum timeout is 1200 seconds",
+            ));
+        }
+    }
     Ok(())
 }
 

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -414,7 +414,10 @@ pub(crate) fn handle_session_list(
                     println!(
                         "{:<11}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {}{}",
                         short_id,
-                        session.last_accessed.format("%Y-%m-%d %H:%M"),
+                        session
+                            .last_accessed
+                            .with_timezone(&chrono::Local)
+                            .format("%Y-%m-%d %H:%M"),
                         status_str,
                         desc_display,
                         tools_str,

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -307,14 +307,7 @@ impl AcpConnection {
                                 idle_timeout,
                             );
                             if self.last_activity.borrow().elapsed() >= idle_timeout {
-                                // Check if the child process is still working before
-                                // killing.  Model thinking phases produce no output
-                                // but the process is still alive.
-                                if is_child_working(&self.child) {
-                                    *self.last_activity.borrow_mut() = Instant::now();
-                                } else {
-                                    break PromptOutcome::IdleTimeout;
-                                }
+                                break PromptOutcome::IdleTimeout;
                             }
                         }
                     }
@@ -490,37 +483,60 @@ fn stream_new_agent_messages(
     stream_stdout_to_stderr: bool,
     output_spool: &mut Option<std::fs::File>,
 ) {
-    let new_messages = {
+    let new_events = {
         let events_ref = events.borrow();
         if *processed_index >= events_ref.len() {
             return;
         }
 
-        let mut messages = Vec::new();
-        for event in &events_ref[*processed_index..] {
-            match event {
-                SessionEvent::AgentMessage(chunk) => {
-                    messages.push((chunk.clone(), false));
-                }
-                SessionEvent::AgentThought(chunk) => {
-                    messages.push((chunk.clone(), true));
-                }
-                _ => {}
-            }
-        }
+        let events = events_ref[*processed_index..].to_vec();
         *processed_index = events_ref.len();
-        messages
+        events
     };
 
-    for (chunk, is_thought) in &new_messages {
-        if stream_stdout_to_stderr {
-            if *is_thought {
-                eprint!("[thought] {chunk}");
-            } else {
-                eprint!("[stdout] {chunk}");
+    for event in new_events {
+        match event {
+            SessionEvent::AgentMessage(chunk) => {
+                if stream_stdout_to_stderr {
+                    eprint!("[stdout] {chunk}");
+                }
+                spool_chunk(output_spool, chunk.as_bytes());
+            }
+            SessionEvent::AgentThought(chunk) => {
+                if stream_stdout_to_stderr {
+                    eprint!("[thought] {chunk}");
+                }
+                spool_chunk(output_spool, chunk.as_bytes());
+            }
+            SessionEvent::PlanUpdate(plan) => {
+                let msg = format!("[plan] {plan}\n");
+                if stream_stdout_to_stderr {
+                    eprint!("{msg}");
+                }
+                spool_chunk(output_spool, msg.as_bytes());
+            }
+            SessionEvent::ToolCallStarted { title, kind, .. } => {
+                let msg = format!("[tool:started] {title} ({kind})\n");
+                if stream_stdout_to_stderr {
+                    eprint!("{msg}");
+                }
+                spool_chunk(output_spool, msg.as_bytes());
+            }
+            SessionEvent::ToolCallCompleted { status, .. } => {
+                let msg = format!("[tool:completed] {status}\n");
+                if stream_stdout_to_stderr {
+                    eprint!("{msg}");
+                }
+                spool_chunk(output_spool, msg.as_bytes());
+            }
+            SessionEvent::Other(payload) => {
+                let msg = format!("[other] {payload}\n");
+                if stream_stdout_to_stderr {
+                    eprint!("{msg}");
+                }
+                spool_chunk(output_spool, msg.as_bytes());
             }
         }
-        spool_chunk(output_spool, chunk.as_bytes());
     }
 }
 
@@ -539,45 +555,21 @@ fn collect_agent_output(events: &[SessionEvent]) -> String {
             SessionEvent::AgentMessage(chunk) | SessionEvent::AgentThought(chunk) => {
                 output.push_str(chunk);
             }
-            _ => {}
+            SessionEvent::PlanUpdate(plan) => {
+                output.push_str(&format!("[plan] {plan}\n"));
+            }
+            SessionEvent::ToolCallStarted { title, kind, .. } => {
+                output.push_str(&format!("[tool:started] {title} ({kind})\n"));
+            }
+            SessionEvent::ToolCallCompleted { status, .. } => {
+                output.push_str(&format!("[tool:completed] {status}\n"));
+            }
+            SessionEvent::Other(payload) => {
+                output.push_str(&format!("[other] {payload}\n"));
+            }
         }
     }
     output
-}
-
-/// Check if the ACP child process is still actively working.
-///
-/// Reads `/proc/{pid}/stat` for the process state. States R (running),
-/// S (sleeping), D (disk sleep) indicate the process is working (e.g. model
-/// thinking). Falls back to `kill(pid, 0)` when `/proc` is unavailable.
-fn is_child_working(child: &Rc<RefCell<Child>>) -> bool {
-    let child_ref = child.borrow();
-    let Some(pid) = child_ref.id() else {
-        return false;
-    };
-
-    #[cfg(unix)]
-    {
-        use std::fs;
-        let stat_path = format!("/proc/{pid}/stat");
-        if let Ok(content) = fs::read_to_string(&stat_path) {
-            if let Some(close_paren) = content.rfind(')') {
-                let after_comm = &content[close_paren + 1..];
-                let state = after_comm.trim_start().chars().next().unwrap_or('X');
-                return matches!(state, 'R' | 'S' | 'D');
-            }
-        }
-        // Fallback: kill(pid, 0) probes process existence.
-        // SAFETY: kill() with signal 0 is a pure existence/permission probe.
-        let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
-        ret == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        false
-    }
 }
 
 fn stop_reason_to_string(reason: StopReason) -> String {

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.101"
-weave = "0.1.101"
+csa = "0.1.102"
+weave = "0.1.102"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
Fix Issue #375 regression (ACP zero stdout), add timeout guard, fix session timezone, and document timeout policy.

Scope:
- ACP Output Capture (crates/csa-acp/src/connection.rs): capture all meaningful SessionEvent types (PlanUpdate, ToolCallStarted, ToolCallCompleted, Other) with prefix labels.
- Idle Timeout Fix (crates/csa-acp/src/connection.rs): track last event timestamp and consider idle regardless of process state if no events received for idle_timeout duration.
- Session Timezone (crates/cli-sub-agent/src/session_cmds.rs): change session.last_accessed format to use chrono::Local.
- Minimum Timeout Enforcement (crates/cli-sub-agent/src/cli_review.rs): enforce 1200s minimum --timeout at CLI level.
- Documentation: update CLAUDE.md to note the 1200s minimum timeout.