### PR TITLE
fix(patterns): add early-push detection to pr-codex-bot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "axum",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.109"
+version = "0.1.110"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/patterns/pr-codex-bot/PATTERN.md
+++ b/patterns/pr-codex-bot/PATTERN.md
@@ -123,7 +123,14 @@ if [ "${REVIEW_COMPLETED:-}" != "true" ]; then
 fi
 
 set -euo pipefail
-git push -u origin "${WORKFLOW_BRANCH}"
+
+# --- Early-push detection: warn if branch was already pushed before review ---
+if git ls-remote --heads origin "${WORKFLOW_BRANCH}" 2>/dev/null | grep -q .; then
+  echo "WARNING: Branch '${WORKFLOW_BRANCH}' was already pushed to remote before this skill ran."
+  echo "Unreviewed code may have been visible to CI/reviewers. Continuing with force-push of reviewed code."
+fi
+
+git push --force-with-lease -u origin "${WORKFLOW_BRANCH}"
 ORIGIN_URL="$(git remote get-url origin)"
 SOURCE_OWNER="$(
   printf '%s\n' "${ORIGIN_URL}" | sed -nE \

--- a/patterns/pr-codex-bot/skills/pr-codex-bot/SKILL.md
+++ b/patterns/pr-codex-bot/skills/pr-codex-bot/SKILL.md
@@ -116,6 +116,10 @@ Layer 0 (Orchestrator)
 - `gh` CLI MUST be authenticated: `gh auth status`
 - All changes must be committed on a feature branch
 - Feature branch must be ahead of main
+- **FORBIDDEN**: Pushing the feature branch to remote BEFORE invoking this skill.
+  Step 2 (local review) MUST complete before any push. If you push first,
+  unreviewed code reaches the remote and CI/reviewers may act on it prematurely.
+  The skill's Step 4 handles push after review passes.
 
 ### Configuration
 
@@ -156,7 +160,7 @@ breaks prompt-guard propagation.
 
 1. **Commit check**: Ensure all changes are committed. Record `WORKFLOW_BRANCH`.
 2. **Local pre-PR review** (SYNCHRONOUS -- MUST NOT background): use SHA-verified fast-path first (`CURRENT_HEAD` vs latest reviewed session HEAD SHA). If matched, skip review; if mismatched/missing, run full `csa review --branch main`. This is the foundation -- without it, bot unavailability cannot safely merge. Fix any issues found (max 3 rounds). Sets `REVIEW_COMPLETED=true` on success.
-3. **Push and ensure PR** (PRECONDITION: `REVIEW_COMPLETED=true`): `git push -u origin`, derive `source_owner` from `origin` remote URL, then resolve PR strictly by owner-aware lookup (`base=main + head=<source_owner>:${WORKFLOW_BRANCH}`). If none exists, create with `--head <source_owner>:<branch>` and re-resolve; handle create races where PR was created concurrently. FORBIDDEN: creating/reusing PR without Step 2 completion.
+3. **Push and ensure PR** (PRECONDITION: `REVIEW_COMPLETED=true`): Detect if branch was already pushed (early-push warning). Push with `--force-with-lease`, derive `source_owner` from `origin` remote URL, then resolve PR strictly by owner-aware lookup (`base=main + head=<source_owner>:${WORKFLOW_BRANCH}`). If none exists, create with `--head <source_owner>:<branch>` and re-resolve; handle create races where PR was created concurrently. FORBIDDEN: creating/reusing PR without Step 2 completion.
 3a. **Check cloud bot config**: Run `csa config get pr_review.cloud_bot --default true`.
     If `false` → skip Steps 4-9. Apply the same SHA-verified fast-path before
     supplementary review. If SHA matches, skip review; if SHA mismatches/missing


### PR DESCRIPTION
## Summary
- Add early-push detection guard to pr-codex-bot Step 4 that warns when branch was already pushed before review
- Change push command to `--force-with-lease` to ensure reviewed code overwrites any pre-pushed unreviewed code
- Add explicit FORBIDDEN prerequisite in SKILL.md about pushing before invoking the skill

## Context
The pr-codex-bot pattern enforces review-before-push via a `REVIEW_COMPLETED` precondition gate in Step 4. However, the orchestrator could push the branch before invoking the skill, bypassing this ordering. This fix adds runtime detection and documentation.

## Test plan
- [x] `weave compile` passes for modified pattern
- [x] All 2453 unit tests + 16 E2E tests pass
- [x] Pattern/skill documentation synchronized

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)