### PR TITLE
fix(mktd): anchor RECON exploration to user-specified constraints (#385)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "axum",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.110"
+version = "0.1.111"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.110"
+version = "0.1.111"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -120,6 +120,9 @@ Session: ${STEP_0_OUTPUT}
 Tier: tier-1-quick
 
 Analyze codebase structure relevant to ${FEATURE}.
+
+CONSTRAINT ANCHOR: The user prompt above may specify target crates, key files, integration points, or architectural approach. If so, these are HARD CONSTRAINTS — start exploration from the specified files/modules and expand outward only as needed. Do NOT explore unrelated crates as primary targets. If the user specified key files, those MUST appear in your report.
+
 Report: relevant files (path + purpose, max 20), key types, module dependencies, entry points.
 Working directory: ${CWD}
 
@@ -130,6 +133,9 @@ Session: ${STEP_0_OUTPUT}
 Tier: tier-1-quick
 
 Find existing patterns or similar features to ${FEATURE} in this codebase.
+
+CONSTRAINT ANCHOR: If the user prompt specifies an architectural approach or target crate, pattern discovery MUST be scoped to that context first. Do NOT let codebase pattern matching override the user's explicit requirements. Report patterns that SUPPORT the user's specified approach, not patterns that suggest a different approach.
+
 Report: file paths with approach, reusable components, conventions to follow.
 Working directory: ${CWD}
 
@@ -140,6 +146,9 @@ Session: ${STEP_0_OUTPUT}
 Tier: tier-1-quick
 
 Identify constraints and risks for implementing ${FEATURE}.
+
+CONSTRAINT ANCHOR: If the user prompt specifies scope boundaries (target crate, specific modules), evaluate constraints WITHIN that scope. Flag risks that affect the user's specified approach, not risks that argue for a different approach.
+
 Report: potential breaking changes, security considerations, performance, compatibility.
 Working directory: ${CWD}
 
@@ -189,6 +198,8 @@ ${STEP_3_OUTPUT}
 ${STEP_4_OUTPUT}
 
 ### Instructions
+
+CONSTRAINT VERIFICATION: Before drafting, check that RECON findings align with the user's original feature request (${FEATURE}). If the user specified a target crate, architecture, or key files, the plan MUST target those — not alternatives suggested by codebase pattern matching. If RECON findings contradict user constraints, note the conflict and follow the user's intent.
 
 #### TODO Structure Requirements
 

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -204,6 +204,9 @@ title = "Phase 1 — RECON Dimension 1 (Structure)"
 tool = "csa"
 prompt = """
 Analyze codebase structure relevant to ${FEATURE}.
+
+CONSTRAINT ANCHOR: The user prompt above may specify target crates, key files, integration points, or architectural approach. If so, these are HARD CONSTRAINTS — start exploration from the specified files/modules and expand outward only as needed. Do NOT explore unrelated crates as primary targets. If the user specified key files, those MUST appear in your report.
+
 Report: relevant files (path + purpose, max 20), key types, module dependencies, entry points.
 Working directory: ${CWD}"""
 tier = "tier-1-quick"
@@ -216,6 +219,9 @@ title = "Phase 1 — RECON Dimension 2 (Patterns)"
 tool = "csa"
 prompt = """
 Find existing patterns or similar features to ${FEATURE} in this codebase.
+
+CONSTRAINT ANCHOR: If the user prompt specifies an architectural approach or target crate, pattern discovery MUST be scoped to that context first. Do NOT let codebase pattern matching override the user's explicit requirements. Report patterns that SUPPORT the user's specified approach, not patterns that suggest a different approach.
+
 Report: file paths with approach, reusable components, conventions to follow.
 Working directory: ${CWD}"""
 tier = "tier-1-quick"
@@ -228,6 +234,9 @@ title = "Phase 1 — RECON Dimension 3 (Constraints)"
 tool = "csa"
 prompt = """
 Identify constraints and risks for implementing ${FEATURE}.
+
+CONSTRAINT ANCHOR: If the user prompt specifies scope boundaries (target crate, specific modules), evaluate constraints WITHIN that scope. Flag risks that affect the user's specified approach, not risks that argue for a different approach.
+
 Report: potential breaking changes, security considerations, performance, compatibility.
 Working directory: ${CWD}"""
 tier = "tier-1-quick"
@@ -252,6 +261,8 @@ ${STEP_3_OUTPUT}
 ${STEP_4_OUTPUT}
 
 ### Instructions
+
+CONSTRAINT VERIFICATION: Before drafting, check that RECON findings align with the user's original feature request (${FEATURE}). If the user specified a target crate, architecture, or key files, the plan MUST target those — not alternatives suggested by codebase pattern matching. If RECON findings contradict user constraints, note the conflict and follow the user's intent.
 
 Each item is a [ ] checkbox with executor tag.
 Write all TODO descriptions, section headers, and task names in `${STEP_1_OUTPUT}`.

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.107"
-weave = "0.1.107"
+csa = "0.1.110"
+weave = "0.1.110"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Add CONSTRAINT ANCHOR instructions to all three RECON dimension prompts (structure, patterns, constraints) so CSA sub-agents treat user-specified target crates, files, and architectural approach as hard constraints rather than suggestions from codebase pattern matching
- Add CONSTRAINT VERIFICATION to the DRAFT step to catch remaining drift before plan generation
- Sync PATTERN.md and workflow.toml per rule 027

Closes #385

## Test plan

- [x] `weave compile patterns/mktd/PATTERN.md` passes
- [x] `just pre-commit` passes (fmt, clippy, test, e2e)
- [ ] Manual: run `/mktd` with explicit target crate — verify RECON stays scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)