### PR TITLE
fix(skills): resolve companion pattern paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "axum",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.116"
+version = "0.1.117"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.116"
+version = "0.1.117"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/audit_cmds.rs
+++ b/crates/cli-sub-agent/src/audit_cmds.rs
@@ -143,7 +143,7 @@ pub(crate) fn handle_audit_approve(files: Vec<String>, approved_by: String) -> R
     }
 
     io::save(&path, &manifest)?;
-    println!("Approved {} file(s).", approved_count);
+    println!("Approved {approved_count} file(s).");
     Ok(())
 }
 
@@ -198,7 +198,7 @@ pub(crate) fn handle_audit_update(
     }
 
     io::save(&path, &manifest)?;
-    println!("Updated {} file(s).", updated_count);
+    println!("Updated {updated_count} file(s).");
     Ok(())
 }
 
@@ -222,7 +222,7 @@ pub(crate) fn handle_audit_reset(files: Vec<String>) -> Result<()> {
     }
 
     io::save(&path, &manifest)?;
-    println!("Reset {} file(s) to pending.", reset_count);
+    println!("Reset {reset_count} file(s) to pending.");
     Ok(())
 }
 

--- a/crates/cli-sub-agent/src/batch.rs
+++ b/crates/cli-sub-agent/src/batch.rs
@@ -94,14 +94,14 @@ pub(crate) async fn handle_batch(
     // 4. Load and parse batch TOML file
     let batch_path = PathBuf::from(&file);
     if !batch_path.exists() {
-        anyhow::bail!("Batch file not found: {}", file);
+        anyhow::bail!("Batch file not found: {file}");
     }
 
     let batch_content = std::fs::read_to_string(&batch_path)
-        .with_context(|| format!("Failed to read batch file: {}", file))?;
+        .with_context(|| format!("Failed to read batch file: {file}"))?;
 
     let batch_config: BatchConfig = toml::from_str(&batch_content)
-        .with_context(|| format!("Failed to parse batch file: {}", file))?;
+        .with_context(|| format!("Failed to parse batch file: {file}"))?;
 
     if batch_config.tasks.is_empty() {
         warn!("No tasks found in batch file");
@@ -139,7 +139,7 @@ pub(crate) async fn handle_batch(
     // 10. Exit with non-zero if any task failed
     let failed_count = results.iter().filter(|r| r.exit_code != 0).count();
     if failed_count > 0 {
-        anyhow::bail!("{} tasks failed", failed_count);
+        anyhow::bail!("{failed_count} tasks failed");
     }
 
     Ok(())
@@ -448,7 +448,7 @@ async fn execute_task(
                 name: task.name.clone(),
                 exit_code: 1,
                 duration_secs: start.elapsed().as_secs_f64(),
-                error: Some(format!("Invalid tool name: {}", e)),
+                error: Some(format!("Invalid tool name: {e}")),
             };
         }
     };
@@ -472,7 +472,7 @@ async fn execute_task(
                 name: task.name.clone(),
                 exit_code: 1,
                 duration_secs: start.elapsed().as_secs_f64(),
-                error: Some(format!("{}", e)),
+                error: Some(format!("{e}")),
             };
         }
         if let Err(e) = cfg.enforce_tier_model_name(tool_name.as_str(), task.model.as_deref()) {
@@ -481,7 +481,7 @@ async fn execute_task(
                 name: task.name.clone(),
                 exit_code: 1,
                 duration_secs: start.elapsed().as_secs_f64(),
-                error: Some(format!("{}", e)),
+                error: Some(format!("{e}")),
             };
         }
     }
@@ -496,7 +496,7 @@ async fn execute_task(
                     name: task.name.clone(),
                     exit_code: 1,
                     duration_secs: start.elapsed().as_secs_f64(),
-                    error: Some(format!("Failed to build executor: {}", e)),
+                    error: Some(format!("Failed to build executor: {e}")),
                 };
             }
         };
@@ -508,7 +508,7 @@ async fn execute_task(
             name: task.name.clone(),
             exit_code: 1,
             duration_secs: start.elapsed().as_secs_f64(),
-            error: Some(format!("Tool not installed: {}", e)),
+            error: Some(format!("Tool not installed: {e}")),
         };
     }
 
@@ -520,7 +520,7 @@ async fn execute_task(
                 name: task.name.clone(),
                 exit_code: 1,
                 duration_secs: start.elapsed().as_secs_f64(),
-                error: Some(format!("Resource check failed: {}", e)),
+                error: Some(format!("Resource check failed: {e}")),
             };
         }
     }
@@ -533,7 +533,7 @@ async fn execute_task(
                 name: task.name.clone(),
                 exit_code: 1,
                 duration_secs: start.elapsed().as_secs_f64(),
-                error: Some(format!("Failed to load global config: {}", e)),
+                error: Some(format!("Failed to load global config: {e}")),
             };
         }
     };
@@ -550,7 +550,7 @@ async fn execute_task(
                 name: task.name.clone(),
                 exit_code: 1,
                 duration_secs: start.elapsed().as_secs_f64(),
-                error: Some(format!("Failed to resolve slots directory: {}", e)),
+                error: Some(format!("Failed to resolve slots directory: {e}")),
             };
         }
     };
@@ -653,7 +653,7 @@ fn parse_tool_name(tool: &str) -> Result<ToolName> {
         "opencode" => Ok(ToolName::Opencode),
         "codex" => Ok(ToolName::Codex),
         "claude-code" => Ok(ToolName::ClaudeCode),
-        _ => anyhow::bail!("Unknown tool: {}", tool),
+        _ => anyhow::bail!("Unknown tool: {tool}"),
     }
 }
 
@@ -686,7 +686,7 @@ fn print_summary(results: &[TaskResult]) {
             result.name,
             result.duration_secs,
             if let Some(ref err) = result.error {
-                format!(" - {}", err)
+                format!(" - {err}")
             } else {
                 String::new()
             }
@@ -695,7 +695,7 @@ fn print_summary(results: &[TaskResult]) {
 
     println!();
     println!("Total: {} tasks", results.len());
-    println!("Success: {}", success_count);
-    println!("Failed: {}", failed_count);
-    println!("Total duration: {:.2}s", total_duration);
+    println!("Success: {success_count}");
+    println!("Failed: {failed_count}");
+    println!("Total duration: {total_duration:.2}s");
 }

--- a/crates/cli-sub-agent/src/batch_tests.rs
+++ b/crates/cli-sub-agent/src/batch_tests.rs
@@ -33,8 +33,7 @@ fn parse_tool_name_unknown_tool_errors() {
     let err_msg = result.unwrap_err().to_string();
     assert!(
         err_msg.contains("Unknown tool"),
-        "expected 'Unknown tool' in: {}",
-        err_msg
+        "expected 'Unknown tool' in: {err_msg}"
     );
 }
 
@@ -49,7 +48,7 @@ fn make_task(name: &str, tool: &str, depends_on: Vec<&str>) -> BatchTask {
     BatchTask {
         name: name.to_string(),
         tool: tool.to_string(),
-        prompt: format!("do {}", name),
+        prompt: format!("do {name}"),
         mode: TaskMode::default(),
         depends_on: depends_on.into_iter().map(String::from).collect(),
         model: None,
@@ -104,8 +103,7 @@ fn validate_tasks_self_dependency_cycle_errors() {
     let err_msg = result.unwrap_err().to_string();
     assert!(
         err_msg.contains("cycle") || err_msg.contains("Cycle"),
-        "expected cycle error in: {}",
-        err_msg
+        "expected cycle error in: {err_msg}"
     );
 }
 
@@ -120,8 +118,7 @@ fn validate_tasks_two_node_cycle_errors() {
     let err_msg = result.unwrap_err().to_string();
     assert!(
         err_msg.to_lowercase().contains("cycle"),
-        "expected cycle error in: {}",
-        err_msg
+        "expected cycle error in: {err_msg}"
     );
 }
 
@@ -137,8 +134,7 @@ fn validate_tasks_three_node_cycle_errors() {
     let err_msg = result.unwrap_err().to_string();
     assert!(
         err_msg.to_lowercase().contains("cycle"),
-        "expected cycle error in: {}",
-        err_msg
+        "expected cycle error in: {err_msg}"
     );
 }
 

--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
@@ -144,7 +144,7 @@ fn resolve_claude_tool(
         }
         let resolved = tool_arg
             .resolve_alias(&merged_aliases)
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
         return match resolved {
             ToolArg::Specific(t) => Ok(t),
             ToolArg::Auto => resolve_auto_tool(parent_tool, project_config, project_root),

--- a/crates/cli-sub-agent/src/cli_xurl.rs
+++ b/crates/cli-sub-agent/src/cli_xurl.rs
@@ -139,10 +139,7 @@ fn handle_threads(
                 .chars()
                 .take(40)
                 .collect::<String>();
-            println!(
-                "{:<12} {:<40} {:<20} {}",
-                provider, thread_id_display, updated_display, preview
-            );
+            println!("{provider:<12} {thread_id_display:<40} {updated_display:<20} {preview}");
         }
         println!("\nTotal: {} thread(s)", all_items.len());
     }

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -14,11 +14,11 @@ pub(crate) fn handle_config_show(cd: Option<String>, format: OutputFormat) -> Re
     match format {
         OutputFormat::Json => {
             let json_str = serde_json::to_string_pretty(&config)?;
-            println!("{}", json_str);
+            println!("{json_str}");
         }
         OutputFormat::Text => {
             let toml_str = toml::to_string_pretty(&config)?;
-            print!("{}", toml_str);
+            print!("{toml_str}");
         }
     }
     Ok(())

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -488,8 +488,7 @@ fn resolve_debate_tool(
             }
             let tool = crate::run_helpers::parse_tool_name(&tool_name).map_err(|_| {
                 anyhow::anyhow!(
-                    "Invalid [debate].tool value '{}'. Supported values: gemini-cli, opencode, codex, claude-code.",
-                    tool_name
+                    "Invalid [debate].tool value '{tool_name}'. Supported values: gemini-cli, opencode, codex, claude-code."
                 )
             })?;
             Ok((tool, DebateMode::Heterogeneous, None))
@@ -521,8 +520,7 @@ fn resolve_debate_tool_from_value(
             if counterpart_enabled {
                 let tool = crate::run_helpers::parse_tool_name(resolved).map_err(|_| {
                     anyhow::anyhow!(
-                        "BUG: auto debate tool resolution returned invalid tool '{}'",
-                        resolved
+                        "BUG: auto debate tool resolution returned invalid tool '{resolved}'"
                     )
                 })?;
                 return Ok((tool, DebateMode::Heterogeneous));
@@ -540,8 +538,7 @@ fn resolve_debate_tool_from_value(
 
     let tool = crate::run_helpers::parse_tool_name(tool_value).map_err(|_| {
         anyhow::anyhow!(
-            "Invalid project [debate].tool value '{}'. Supported values: auto, gemini-cli, opencode, codex, claude-code.",
-            tool_value
+            "Invalid project [debate].tool value '{tool_value}'. Supported values: auto, gemini-cli, opencode, codex, claude-code."
         )
     })?;
     Ok((tool, DebateMode::Heterogeneous))

--- a/crates/cli-sub-agent/src/debate_errors.rs
+++ b/crates/cli-sub-agent/src/debate_errors.rs
@@ -29,13 +29,11 @@ pub(crate) fn classify_execution_outcome(
             || sandbox_memory_limit.is_some()
         {
             return DebateErrorKind::Transient(format!(
-                "exit 137 (termination_reason={:?}, sandbox_memory_max_mb={:?})",
-                termination_reason, sandbox_memory_limit
+                "exit 137 (termination_reason={termination_reason:?}, sandbox_memory_max_mb={sandbox_memory_limit:?})"
             ));
         }
         return DebateErrorKind::Deterministic(format!(
-            "exit 137 without transient signal (termination_reason={:?})",
-            termination_reason
+            "exit 137 without transient signal (termination_reason={termination_reason:?})"
         ));
     }
 

--- a/crates/cli-sub-agent/src/doctor.rs
+++ b/crates/cli-sub-agent/src/doctor.rs
@@ -174,8 +174,8 @@ fn print_platform_info() {
     let arch = env::consts::ARCH;
     let version = env!("CARGO_PKG_VERSION");
 
-    println!("Platform:    {} {}", os, arch);
-    println!("CSA Version: {}", version);
+    println!("Platform:    {os} {arch}");
+    println!("CSA Version: {version}");
 }
 
 /// Print CSA state directory path.
@@ -209,7 +209,7 @@ async fn print_tool_availability() {
 
     // Print summary
     println!();
-    println!("{}/{} tools ready", installed_count, total_count);
+    println!("{installed_count}/{total_count} tools ready");
 }
 
 /// Check if a tool is installed and get its version.
@@ -257,7 +257,7 @@ fn print_tool_status(status: &ToolStatus) {
     let checkmark = if status.installed { "✓" } else { "✗" };
     let status_msg = if status.installed {
         if let Some(ref version) = status.version {
-            format!("installed ({})", version)
+            format!("installed ({version})")
         } else {
             "installed (version unknown)".to_string()
         }
@@ -275,7 +275,7 @@ fn print_tool_status(status: &ToolStatus) {
     // Print install hint if not found
     if !status.installed {
         let hint = install_hint(status.name);
-        println!("             Install: {}", hint);
+        println!("             Install: {hint}");
     }
 }
 
@@ -319,7 +319,7 @@ fn print_project_config() -> Result<()> {
         }
         Err(e) => {
             println!("Config:      .csa/config.toml (invalid)");
-            println!("             Error: {}", e);
+            println!("             Error: {e}");
         }
     }
 
@@ -346,19 +346,19 @@ fn print_resource_status() {
 /// Print sandbox capability status.
 fn print_sandbox_status() {
     let cap = detect_sandbox_capability();
-    println!("Capability:  {}", cap);
+    println!("Capability:  {cap}");
 
     match cap {
         SandboxCapability::CgroupV2 => {
             if let Some(ver) = systemd_version() {
-                println!("Systemd:     {}", ver);
+                println!("Systemd:     {ver}");
             }
             println!("User scope:  supported");
         }
         SandboxCapability::Setrlimit => {
             println!("Enforces:    PID limit only (RLIMIT_NPROC)");
             match current_rlimit_nproc() {
-                Some(n) => println!("RLIMIT_NPROC: {}", n),
+                Some(n) => println!("RLIMIT_NPROC: {n}"),
                 None => println!("RLIMIT_NPROC: unlimited"),
             }
             println!("Memory:      via MemoryBalloon (not setrlimit)");
@@ -373,7 +373,7 @@ fn print_sandbox_status() {
 /// Format bytes as human-readable string (GB).
 fn format_bytes(bytes: u64) -> String {
     let gb = bytes as f64 / 1024.0 / 1024.0 / 1024.0;
-    format!("{:.1} GB", gb)
+    format!("{gb:.1} GB")
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/edit_restriction_guard.rs
+++ b/crates/cli-sub-agent/src/edit_restriction_guard.rs
@@ -58,8 +58,7 @@ impl EditRestrictionViolation {
             .join(", ");
 
         format!(
-            "Edit restriction violated (allow_edit_existing_files=false). Modified tracked files: [{}]. Restored files: [{}].",
-            modified, restored
+            "Edit restriction violated (allow_edit_existing_files=false). Modified tracked files: [{modified}]. Restored files: [{restored}]."
         )
     }
 }

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -153,7 +153,7 @@ pub(crate) fn handle_gc(
         let remaining = list_sessions(&project_root, None)?;
         if remaining.is_empty() {
             if dry_run {
-                eprintln!("[dry-run] Would remove rotation state: {:?}", rotation_path);
+                eprintln!("[dry-run] Would remove rotation state: {rotation_path:?}");
             } else if fs::remove_file(&rotation_path).is_ok() {
                 info!("Removed rotation state (no sessions remain)");
             }
@@ -255,29 +255,20 @@ pub(crate) fn handle_gc(
                 prefix,
                 if dry_run { "preview" } else { "complete" }
             );
-            eprintln!("{}  Stale locks removed: {}", prefix, stale_locks_removed);
-            eprintln!(
-                "{}  Empty sessions removed: {}",
-                prefix, empty_sessions_removed
-            );
+            eprintln!("{prefix}  Stale locks removed: {stale_locks_removed}");
+            eprintln!("{prefix}  Empty sessions removed: {empty_sessions_removed}");
             if sessions_retired > 0 {
-                eprintln!("{}  Sessions retired: {}", prefix, sessions_retired);
+                eprintln!("{prefix}  Sessions retired: {sessions_retired}");
             }
             if max_age_days.is_some() {
-                eprintln!(
-                    "{}  Expired sessions removed: {}",
-                    prefix, expired_sessions_removed
-                );
+                eprintln!("{prefix}  Expired sessions removed: {expired_sessions_removed}");
             }
-            eprintln!(
-                "{}  Orphan directories removed: {}",
-                prefix, orphan_dirs_removed
-            );
+            eprintln!("{prefix}  Orphan directories removed: {orphan_dirs_removed}");
             eprintln!(
                 "{}  Transcript files removed: {} ({} bytes)",
                 prefix, transcript_stats.files_removed, transcript_stats.bytes_reclaimed
             );
-            eprintln!("{}  Stale slots cleaned: {}", prefix, stale_slots_cleaned);
+            eprintln!("{prefix}  Stale slots cleaned: {stale_slots_cleaned}");
         }
     }
 
@@ -509,7 +500,7 @@ pub(crate) fn handle_gc_global(
             };
             if no_sessions_remain {
                 if dry_run {
-                    eprintln!("[dry-run] Would remove rotation state: {:?}", rotation_path);
+                    eprintln!("[dry-run] Would remove rotation state: {rotation_path:?}");
                 } else if fs::remove_file(&rotation_path).is_ok() {
                     info!(
                         "Removed rotation state (no sessions remain): {:?}",
@@ -601,31 +592,21 @@ pub(crate) fn handle_gc_global(
             );
             eprintln!("{}  Projects scanned: {}", prefix, project_roots.len());
             if projects_failed > 0 {
-                eprintln!("{}  Projects failed: {}", prefix, projects_failed);
+                eprintln!("{prefix}  Projects failed: {projects_failed}");
             }
-            eprintln!("{}  Stale locks removed: {}", prefix, total_stale_locks);
-            eprintln!(
-                "{}  Empty sessions removed: {}",
-                prefix, total_empty_sessions
-            );
+            eprintln!("{prefix}  Stale locks removed: {total_stale_locks}");
+            eprintln!("{prefix}  Empty sessions removed: {total_empty_sessions}");
             if total_sessions_retired > 0 {
-                eprintln!("{}  Sessions retired: {}", prefix, total_sessions_retired);
+                eprintln!("{prefix}  Sessions retired: {total_sessions_retired}");
             }
             if max_age_days.is_some() {
-                eprintln!(
-                    "{}  Expired sessions removed: {}",
-                    prefix, total_expired_sessions
-                );
+                eprintln!("{prefix}  Expired sessions removed: {total_expired_sessions}");
             }
+            eprintln!("{prefix}  Orphan directories removed: {total_orphan_dirs}");
             eprintln!(
-                "{}  Orphan directories removed: {}",
-                prefix, total_orphan_dirs
+                "{prefix}  Transcript files removed: {total_transcripts_removed} ({total_transcript_bytes_reclaimed} bytes)"
             );
-            eprintln!(
-                "{}  Transcript files removed: {} ({} bytes)",
-                prefix, total_transcripts_removed, total_transcript_bytes_reclaimed
-            );
-            eprintln!("{}  Stale slots cleaned: {}", prefix, stale_slots_cleaned);
+            eprintln!("{prefix}  Stale slots cleaned: {stale_slots_cleaned}");
         }
     }
 

--- a/crates/cli-sub-agent/src/mcp_server.rs
+++ b/crates/cli-sub-agent/src/mcp_server.rs
@@ -40,7 +40,7 @@ pub(crate) async fn run_mcp_server() -> Result<()> {
                     result: None,
                     error: Some(JsonRpcError {
                         code: -32700,
-                        message: format!("Parse error: {}", e),
+                        message: format!("Parse error: {e}"),
                     }),
                     id: None,
                 };
@@ -281,7 +281,7 @@ async fn handle_tool_call(params: Option<Value>) -> Result<Value> {
         "csa_session_delete" => handle_session_delete_tool(arguments).await,
         "csa_gc" => handle_gc_tool(arguments).await,
         "csa_run" => handle_run_tool(arguments).await,
-        _ => anyhow::bail!("Unknown tool: {}", name),
+        _ => anyhow::bail!("Unknown tool: {name}"),
     }
 }
 
@@ -332,18 +332,18 @@ async fn handle_session_list_tool(args: Value) -> Result<Value> {
             let tokens_str = if let Some(ref usage) = session.total_token_usage {
                 if let Some(total) = usage.total_tokens {
                     if let Some(cost) = usage.estimated_cost_usd {
-                        format!("{}tok ${:.4}", total, cost)
+                        format!("{total}tok ${cost:.4}")
                     } else {
-                        format!("{}tok", total)
+                        format!("{total}tok")
                     }
                 } else if let (Some(input), Some(output)) =
                     (usage.input_tokens, usage.output_tokens)
                 {
                     let total = input + output;
                     if let Some(cost) = usage.estimated_cost_usd {
-                        format!("{}tok ${:.4}", total, cost)
+                        format!("{total}tok ${cost:.4}")
                     } else {
-                        format!("{}tok", total)
+                        format!("{total}tok")
                     }
                 } else {
                     "-".to_string()
@@ -618,7 +618,7 @@ async fn handle_run_tool(args: Value) -> Result<Value> {
     response_text.push_str("\n\n--- Execution Metadata ---\n");
     if !ephemeral {
         if let Some(ref sid) = session_arg {
-            response_text.push_str(&format!("Session ID: {}\n", sid));
+            response_text.push_str(&format!("Session ID: {sid}\n"));
         } else {
             // For new sessions, we don't have the session ID here
             // since execute_with_session doesn't return it
@@ -653,7 +653,7 @@ fn parse_tool_name(tool_str: &str) -> Result<ToolName> {
         "opencode" => Ok(ToolName::Opencode),
         "codex" => Ok(ToolName::Codex),
         "claude-code" => Ok(ToolName::ClaudeCode),
-        _ => anyhow::bail!("Unknown tool: {}", tool_str),
+        _ => anyhow::bail!("Unknown tool: {tool_str}"),
     }
 }
 

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -254,7 +254,7 @@ pub(crate) async fn build_and_validate_executor(
             executor.install_hint(),
             executor.tool_name()
         );
-        anyhow::bail!("{}", e);
+        anyhow::bail!("{e}");
     }
     ensure_tool_runtime_prerequisites(executor.tool_name()).await?;
 

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -97,9 +97,8 @@ pub(crate) fn resolve_sandbox_options(
     let Some(memory_max_mb) = cfg.sandbox_memory_max_mb(tool_name) else {
         if matches!(enforcement, csa_config::EnforcementMode::Required) {
             return SandboxResolution::RequiredButUnavailable(format!(
-                "Sandbox enforcement is required for tool '{}' but no memory_max_mb is configured. \
-                 Set resources.memory_max_mb or tools.{}.memory_max_mb in config.",
-                tool_name, tool_name
+                "Sandbox enforcement is required for tool '{tool_name}' but no memory_max_mb is configured. \
+                 Set resources.memory_max_mb or tools.{tool_name}.memory_max_mb in config."
             ));
         }
         info!(

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -325,11 +325,7 @@ pub(crate) async fn handle_plan_run(
         .map(|c| c.project.max_recursion_depth)
         .unwrap_or(5u32);
     if current_depth > max_depth {
-        bail!(
-            "Max recursion depth ({}) exceeded. Current: {}",
-            max_depth,
-            current_depth
-        );
+        bail!("Max recursion depth ({max_depth}) exceeded. Current: {current_depth}");
     }
 
     // 4. Load and parse workflow TOML (resolve relative to project root)
@@ -345,9 +341,9 @@ pub(crate) async fn handle_plan_run(
         bail!("Workflow file not found: {}", workflow_path.display());
     }
     let content = std::fs::read_to_string(&workflow_path)
-        .with_context(|| format!("Failed to read workflow file: {}", file))?;
+        .with_context(|| format!("Failed to read workflow file: {file}"))?;
     let plan = plan_from_toml(&content)
-        .with_context(|| format!("Failed to parse workflow file: {}", file))?;
+        .with_context(|| format!("Failed to parse workflow file: {file}"))?;
 
     // 5. Parse --var KEY=VALUE into HashMap
     let cli_variables = parse_variables(&vars, &plan)?;
@@ -441,16 +437,12 @@ pub(crate) async fn handle_plan_run(
     if total_failures > 0 {
         journal.status = "failed".to_string();
         journal.last_error = Some(format!(
-            "{} step(s) failed ({} execution, {} unsupported-skip)",
-            total_failures, execution_failures, unsupported_skips
+            "{total_failures} step(s) failed ({execution_failures} execution, {unsupported_skips} unsupported-skip)"
         ));
         apply_repo_fingerprint(&mut journal, &detect_repo_fingerprint(&project_root));
         persist_plan_journal(&journal_path, &journal)?;
         bail!(
-            "{} step(s) failed ({} execution, {} unsupported-skip)",
-            total_failures,
-            execution_failures,
-            unsupported_skips
+            "{total_failures} step(s) failed ({execution_failures} execution, {unsupported_skips} unsupported-skip)"
         );
     }
 
@@ -480,7 +472,7 @@ fn parse_variables(cli_vars: &[String], plan: &ExecutionPlan) -> Result<HashMap<
     for entry in cli_vars {
         let (key, value) = entry
             .split_once('=')
-            .with_context(|| format!("Invalid --var format '{}': expected KEY=VALUE", entry))?;
+            .with_context(|| format!("Invalid --var format '{entry}': expected KEY=VALUE"))?;
         validate_variable_name(key)?;
         vars.insert(key.to_string(), value.to_string());
     }
@@ -496,19 +488,13 @@ fn validate_variable_name(name: &str) -> Result<()> {
     };
 
     if !(first == '_' || first.is_ascii_alphabetic()) {
-        bail!(
-            "Invalid variable name '{}': must match [A-Za-z_][A-Za-z0-9_]*",
-            name
-        );
+        bail!("Invalid variable name '{name}': must match [A-Za-z_][A-Za-z0-9_]*");
     }
 
     if chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric()) {
         Ok(())
     } else {
-        bail!(
-            "Invalid variable name '{}': must match [A-Za-z_][A-Za-z0-9_]*",
-            name
-        );
+        bail!("Invalid variable name '{name}': must match [A-Za-z_][A-Za-z0-9_]*");
     }
 }
 
@@ -516,7 +502,7 @@ fn validate_variable_name(name: &str) -> Result<()> {
 fn substitute_vars(template: &str, vars: &HashMap<String, String>) -> String {
     let mut result = template.to_string();
     for (key, value) in vars {
-        let placeholder = format!("${{{}}}", key);
+        let placeholder = format!("${{{key}}}");
         result = result.replace(&placeholder, value);
     }
     result

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -88,7 +88,7 @@ pub(super) async fn execute_bash_step(
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     if !stdout.is_empty() {
-        eprint!("{}", stdout);
+        eprint!("{stdout}");
     }
     Ok(StepExecutionOutcome {
         exit_code: output.status.code().unwrap_or(1),

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -165,7 +165,7 @@ fn parse_tool_name(tool: &str) -> Result<ToolName> {
         "opencode" => Ok(ToolName::Opencode),
         "codex" => Ok(ToolName::Codex),
         "claude-code" => Ok(ToolName::ClaudeCode),
-        other => bail!("Unknown tool: {}", other),
+        other => bail!("Unknown tool: {other}"),
     }
 }
 
@@ -311,7 +311,7 @@ pub(crate) async fn execute_step(
 ) -> StepResult {
     let start = Instant::now();
     let label = format!("[{}/{}]", step.id, step.title);
-    eprintln!("{} - START", label);
+    eprintln!("{label} - START");
 
     // Evaluate condition: skip step when condition evaluates to false.
     // Steps whose condition is true (or absent) proceed to execution.
@@ -322,7 +322,7 @@ pub(crate) async fn execute_step(
                 "{} - SKIP (condition '{}' evaluated to false)",
                 label, condition
             );
-            eprintln!("{} - SKIP (condition not met)", label);
+            eprintln!("{label} - SKIP (condition not met)");
             return StepResult {
                 step_id: step.id,
                 title: step.title.clone(),
@@ -361,7 +361,7 @@ pub(crate) async fn execute_step(
                 exit_code: 1,
                 duration_secs: start.elapsed().as_secs_f64(),
                 skipped: false,
-                error: Some(format!("Tool resolution failed: {}", e)),
+                error: Some(format!("Tool resolution failed: {e}")),
                 output: None,
                 session_id: None,
             };
@@ -435,10 +435,7 @@ pub(crate) async fn execute_step(
                  Add a descriptive prompt to step {} in the workflow file.",
                 label, step.id
             );
-            eprintln!(
-                "{} - WARNING: empty prompt for CSA step (tool will have no context)",
-                label
-            );
+            eprintln!("{label} - WARNING: empty prompt for CSA step (tool will have no context)");
         }
     }
 
@@ -453,7 +450,7 @@ pub(crate) async fn execute_step(
     for attempt in 1..=max_attempts {
         if attempt > 1 {
             info!("{} - Retry attempt {}/{}", label, attempt, max_attempts);
-            eprintln!("{} - RETRY {}/{}", label, attempt, max_attempts);
+            eprintln!("{label} - RETRY {attempt}/{max_attempts}");
         }
 
         let execution_result = match &target {
@@ -536,14 +533,14 @@ pub(crate) async fn execute_step(
                 "{} - Failed (exit {}), skipping per on_fail=skip",
                 label, exit_code
             );
-            eprintln!("{} - SKIP (exit {}, on_fail=skip)", label, exit_code);
+            eprintln!("{label} - SKIP (exit {exit_code}, on_fail=skip)");
             StepResult {
                 step_id: step.id,
                 title: step.title.clone(),
                 exit_code,
                 duration_secs: duration,
                 skipped: true,
-                error: Some(format!("Skipped after failure (exit code {})", exit_code)),
+                error: Some(format!("Skipped after failure (exit code {exit_code})")),
                 output: None,
                 session_id: None,
             }
@@ -553,10 +550,7 @@ pub(crate) async fn execute_step(
                 "{} - Failed (exit {}), delegate to '{}' not supported in v1 — treating as abort",
                 label, exit_code, target
             );
-            eprintln!(
-                "{} - FAIL (exit {}, delegate '{}' unsupported)",
-                label, exit_code, target
-            );
+            eprintln!("{label} - FAIL (exit {exit_code}, delegate '{target}' unsupported)");
             StepResult {
                 step_id: step.id,
                 title: step.title.clone(),
@@ -564,8 +558,7 @@ pub(crate) async fn execute_step(
                 duration_secs: duration,
                 skipped: false,
                 error: Some(format!(
-                    "Delegate('{}') not supported in v1; step failed with exit code {}",
-                    target, exit_code
+                    "Delegate('{target}') not supported in v1; step failed with exit code {exit_code}"
                 )),
                 output: None,
                 session_id: None,
@@ -574,14 +567,14 @@ pub(crate) async fn execute_step(
         _ => {
             // Abort or Retry (already exhausted retries)
             error!("{} - Failed with exit code {}", label, exit_code);
-            eprintln!("{} - FAIL (exit {})", label, exit_code);
+            eprintln!("{label} - FAIL (exit {exit_code})");
             StepResult {
                 step_id: step.id,
                 title: step.title.clone(),
                 exit_code,
                 duration_secs: duration,
                 skipped: false,
-                error: Some(format!("Exit code {}", exit_code)),
+                error: Some(format!("Exit code {exit_code}")),
                 output: None,
                 session_id: None,
             }

--- a/crates/cli-sub-agent/src/plan_condition.rs
+++ b/crates/cli-sub-agent/src/plan_condition.rs
@@ -175,7 +175,7 @@ fn looks_malformed(s: &str) -> bool {
 fn substitute_vars(template: &str, vars: &HashMap<String, String>) -> String {
     let mut result = template.to_string();
     for (key, value) in vars {
-        let placeholder = format!("${{{}}}", key);
+        let placeholder = format!("${{{key}}}");
         result = result.replace(&placeholder, value);
     }
     result

--- a/crates/cli-sub-agent/src/plan_display.rs
+++ b/crates/cli-sub-agent/src/plan_display.rs
@@ -45,12 +45,12 @@ pub(crate) fn print_plan(
         let on_fail = match &step.on_fail {
             FailAction::Abort => "abort",
             FailAction::Skip => "skip",
-            FailAction::Retry(n) => &format!("retry({})", n),
-            FailAction::Delegate(t) => &format!("delegate({})", t),
+            FailAction::Retry(n) => &format!("retry({n})"),
+            FailAction::Delegate(t) => &format!("delegate({t})"),
         };
 
         let flags = [
-            step.condition.as_ref().map(|c| format!("IF {}", c)),
+            step.condition.as_ref().map(|c| format!("IF {c}")),
             step.loop_var
                 .as_ref()
                 .map(|l| format!("FOR {}", l.variable)),
@@ -103,7 +103,7 @@ pub(crate) fn print_summary(results: &[StepResult], total_duration: f64) {
             r.duration_secs,
             r.error
                 .as_ref()
-                .map(|e| format!(" — {}", e))
+                .map(|e| format!(" — {e}"))
                 .unwrap_or_default(),
         );
     }
@@ -111,5 +111,5 @@ pub(crate) fn print_summary(results: &[StepResult], total_duration: f64) {
     println!();
     println!("Total: {} steps", results.len());
     println!("Passed: {pass}, Failed: {fail}, Skipped: {skip}");
-    println!("Duration: {:.2}s", total_duration);
+    println!("Duration: {total_duration:.2}s");
 }

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -149,8 +149,7 @@ pub(crate) fn resolve_review_tool(
                 .map(|t| (t, None))
                 .map_err(|_| {
                     anyhow::anyhow!(
-                    "Invalid [review].tool value '{}'. Supported values: gemini-cli, opencode, codex, claude-code.",
-                    tool_name
+                    "Invalid [review].tool value '{tool_name}'. Supported values: gemini-cli, opencode, codex, claude-code."
                 )
                 })
         }
@@ -188,8 +187,7 @@ fn resolve_review_tool_from_value(
             if counterpart_enabled {
                 return crate::run_helpers::parse_tool_name(resolved).map_err(|_| {
                     anyhow::anyhow!(
-                        "BUG: auto review tool resolution returned invalid tool '{}'",
-                        resolved
+                        "BUG: auto review tool resolution returned invalid tool '{resolved}'"
                     )
                 });
             }
@@ -201,8 +199,7 @@ fn resolve_review_tool_from_value(
 
     crate::run_helpers::parse_tool_name(tool_value).map_err(|_| {
         anyhow::anyhow!(
-            "Invalid project [review].tool value '{}'. Supported values: auto, gemini-cli, opencode, codex, claude-code.",
-            tool_value
+            "Invalid project [review].tool value '{tool_value}'. Supported values: auto, gemini-cli, opencode, codex, claude-code."
         )
     })
 }

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -220,7 +220,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                     );
                     _slot_guard = Some(slot);
                 } else {
-                    eprintln!("{}", diag_msg);
+                    eprintln!("{diag_msg}");
                     return Ok(RunLoopCompletion::Exit(1));
                 }
             }
@@ -239,7 +239,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             ) {
                 Ok(child_slot) => _slot_guard = Some(child_slot),
                 Err(e) => {
-                    eprintln!("{}", e);
+                    eprintln!("{e}");
                     return Ok(RunLoopCompletion::Exit(1));
                 }
             }
@@ -501,13 +501,11 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                                     request.skill,
                                 );
                                 eprintln!(
-                                    "csa run interrupted by {} (exit {}). Resume with:\n  {}",
-                                    signal_name, signal_exit_code, resume_hint
+                                    "csa run interrupted by {signal_name} (exit {signal_exit_code}). Resume with:\n  {resume_hint}"
                                 );
                             } else {
                                 eprintln!(
-                                    "csa run interrupted by {} (exit {}). Resume by reusing the interrupted session with `csa run --session <session-id> ...`.",
-                                    signal_name, signal_exit_code
+                                    "csa run interrupted by {signal_name} (exit {signal_exit_code}). Resume by reusing the interrupted session with `csa run --session <session-id> ...`."
                                 );
                             }
                         }

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -162,7 +162,7 @@ pub(crate) async fn handle_run(
         .tool
         .unwrap_or(ToolArg::Auto)
         .resolve_alias(&merged_aliases)
-        .map_err(|e| anyhow::anyhow!("{}", e))?
+        .map_err(|e| anyhow::anyhow!("{e}"))?
         .into_strategy();
     let idle_timeout_seconds = if no_idle_timeout {
         info!("Idle timeout disabled via --no-idle-timeout");
@@ -198,8 +198,7 @@ pub(crate) async fn handle_run(
             find_recent_interrupted_skill_session(&project_root, skill_name, &resolved_tool)
     {
         eprintln!(
-            "Auto-resuming interrupted skill session {} for '{}'.",
-            interrupted_session_id, skill_name
+            "Auto-resuming interrupted skill session {interrupted_session_id} for '{skill_name}'."
         );
         session_arg = Some(interrupted_session_id);
     }
@@ -369,7 +368,7 @@ pub(crate) async fn handle_run(
         }
         OutputFormat::Json => {
             let json = serde_json::to_string_pretty(&result)?;
-            println!("{}", json);
+            println!("{json}");
         }
     }
 

--- a/crates/cli-sub-agent/src/run_cmd_fork.rs
+++ b/crates/cli-sub-agent/src/run_cmd_fork.rs
@@ -371,7 +371,7 @@ pub(crate) fn fork_call_slot_handoff(
                     .collect();
                 let all_usage = slot_usage(slots_dir, &all_tools_ref);
                 let diag_msg = format_slot_diagnostic(tool_name_str, &status, &all_usage);
-                anyhow::bail!("fork-call child slot exhausted: {}", diag_msg);
+                anyhow::bail!("fork-call child slot exhausted: {diag_msg}");
             }
         }
     };

--- a/crates/cli-sub-agent/src/run_cmd_resume.rs
+++ b/crates/cli-sub-agent/src/run_cmd_resume.rs
@@ -39,10 +39,8 @@ pub(crate) fn emit_run_timeout(
     skill: Option<&str>,
     session_id: Option<&str>,
 ) -> Result<i32> {
-    let message = format!(
-        "csa run exceeded wall-clock timeout ({}s); execution terminated",
-        timeout_seconds
-    );
+    let message =
+        format!("csa run exceeded wall-clock timeout ({timeout_seconds}s); execution terminated");
     match output_format {
         OutputFormat::Text => {
             if let Some(sid) = session_id {

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
@@ -409,8 +409,7 @@ pub(crate) fn resolve_skill_and_prompt(
                 match std::fs::read_to_string(&extra_path) {
                     Ok(content) => {
                         parts.push(format!(
-                            "<context-file path=\"{}\">\n{}\n</context-file>",
-                            extra, content
+                            "<context-file path=\"{extra}\">\n{content}\n</context-file>"
                         ));
                     }
                     Err(e) => {
@@ -421,7 +420,7 @@ pub(crate) fn resolve_skill_and_prompt(
         }
 
         if let Some(user_prompt) = prompt {
-            parts.push(format!("---\n\n{}", user_prompt));
+            parts.push(format!("---\n\n{user_prompt}"));
         }
 
         parts.join("\n\n")

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -182,7 +182,7 @@ pub(crate) fn parse_tool_name(name: &str) -> Result<ToolName> {
         "codex" => Ok(ToolName::Codex),
         "claude-code" => Ok(ToolName::ClaudeCode),
         "openai-compat" => Ok(ToolName::OpenaiCompat),
-        _ => anyhow::bail!("Unknown tool: {}", name),
+        _ => anyhow::bail!("Unknown tool: {name}"),
     }
 }
 
@@ -210,7 +210,7 @@ pub(crate) fn truncate_prompt(s: &str, max_len: usize) -> String {
             }
         }
 
-        format!("{}...", substring)
+        format!("{substring}...")
     }
 }
 

--- a/crates/cli-sub-agent/src/run_helpers_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tests.rs
@@ -92,7 +92,7 @@ fn build_executor_model_and_thinking_coexist() {
         false,
     )
     .unwrap();
-    let debug = format!("{:?}", exec);
+    let debug = format!("{exec:?}");
     assert!(
         debug.contains("gpt-5.1-codex-mini"),
         "model missing: {debug}"
@@ -103,7 +103,7 @@ fn build_executor_model_and_thinking_coexist() {
 #[test]
 fn build_executor_thinking_only() {
     let exec = build_executor(&ToolName::Codex, None, None, Some("high"), None, false).unwrap();
-    let debug = format!("{:?}", exec);
+    let debug = format!("{exec:?}");
     assert!(debug.contains("High"), "thinking budget missing: {debug}");
 }
 
@@ -138,7 +138,7 @@ fn build_executor_uses_project_tool_defaults_when_cli_missing() {
     };
 
     let exec = build_executor(&ToolName::Codex, None, None, None, Some(&config), true).unwrap();
-    let debug = format!("{:?}", exec);
+    let debug = format!("{exec:?}");
     assert!(debug.contains("gpt-5.4"), "default model missing: {debug}");
     assert!(debug.contains("Xhigh"), "default thinking missing: {debug}");
 }
@@ -174,7 +174,7 @@ fn build_executor_ignores_project_tool_defaults_when_disabled() {
     };
 
     let exec = build_executor(&ToolName::Codex, None, None, None, Some(&config), false).unwrap();
-    let debug = format!("{:?}", exec);
+    let debug = format!("{exec:?}");
     assert!(
         !debug.contains("surprise-model"),
         "tool defaults must not leak when disabled: {debug}"
@@ -224,7 +224,7 @@ fn build_executor_cli_overrides_project_tool_defaults() {
         true,
     )
     .unwrap();
-    let debug = format!("{:?}", exec);
+    let debug = format!("{exec:?}");
     assert!(debug.contains("gpt-5.5"), "cli model should win: {debug}");
     assert!(debug.contains("Medium"), "cli thinking should win: {debug}");
     assert!(!debug.contains("gpt-5.4"), "default model leaked: {debug}");
@@ -467,7 +467,7 @@ fn build_executor_model_spec_overrides_both() {
         true,
     )
     .unwrap();
-    let debug = format!("{:?}", exec);
+    let debug = format!("{exec:?}");
     assert!(
         debug.contains("explicit-model"),
         "explicit model should override model_spec model: {debug}"
@@ -499,7 +499,7 @@ fn build_executor_model_spec_overrides_both() {
         true,
     )
     .unwrap();
-    let debug2 = format!("{:?}", exec2);
+    let debug2 = format!("{exec2:?}");
     assert!(
         debug2.contains("Xhigh"),
         "spec thinking should be preserved when no override: {debug2}"

--- a/crates/cli-sub-agent/src/self_update.rs
+++ b/crates/cli-sub-agent/src/self_update.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 /// Handle self-update command
 pub(crate) fn handle_self_update(check_only: bool) -> Result<()> {
     let current_version = env!("CARGO_PKG_VERSION");
-    eprintln!("Current version: v{}", current_version);
+    eprintln!("Current version: v{current_version}");
 
     // Fetch latest release info from GitHub API
     let release_info = fetch_latest_release()?;
@@ -15,7 +15,7 @@ pub(crate) fn handle_self_update(check_only: bool) -> Result<()> {
         .strip_prefix('v')
         .unwrap_or(&release_info.tag_name);
 
-    eprintln!("Latest version:  v{}", latest_version);
+    eprintln!("Latest version:  v{latest_version}");
 
     // Compare versions
     if current_version == latest_version {
@@ -24,22 +24,16 @@ pub(crate) fn handle_self_update(check_only: bool) -> Result<()> {
     }
 
     if check_only {
-        eprintln!(
-            "\nUpdate available: v{} → v{}",
-            current_version, latest_version
-        );
+        eprintln!("\nUpdate available: v{current_version} → v{latest_version}");
         eprintln!("Run 'csa self-update' to install the latest version.");
         return Ok(());
     }
 
     // Perform update
-    eprintln!("\nUpdating to v{}...", latest_version);
+    eprintln!("\nUpdating to v{latest_version}...");
     perform_update(&release_info, current_version, latest_version)?;
 
-    eprintln!(
-        "\n✓ Successfully updated from v{} to v{}",
-        current_version, latest_version
-    );
+    eprintln!("\n✓ Successfully updated from v{current_version} to v{latest_version}");
     eprintln!("Restart your shell or run 'hash -r' to use the new version.");
 
     Ok(())
@@ -56,7 +50,7 @@ fn fetch_latest_release() -> Result<ReleaseInfo> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Failed to fetch release info: {}", stderr);
+        anyhow::bail!("Failed to fetch release info: {stderr}");
     }
 
     let json = String::from_utf8_lossy(&output.stdout);
@@ -83,10 +77,10 @@ fn perform_update(
 ) -> Result<()> {
     // Determine current platform target
     let target = get_target_triple()?;
-    eprintln!("Detected platform: {}", target);
+    eprintln!("Detected platform: {target}");
 
     // Find matching asset
-    let asset_name = format!("csa-{}.tar.gz", target);
+    let asset_name = format!("csa-{target}.tar.gz");
     let asset = release_info
         .assets
         .iter()
@@ -139,7 +133,7 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Failed to download file: {}", stderr);
+        anyhow::bail!("Failed to download file: {stderr}");
     }
 
     Ok(())
@@ -159,7 +153,7 @@ fn extract_tarball(archive: &Path, dest_dir: &Path) -> Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Failed to extract archive: {}", stderr);
+        anyhow::bail!("Failed to extract archive: {stderr}");
     }
 
     Ok(())
@@ -213,9 +207,7 @@ fn get_target_triple() -> Result<String> {
         ("x86_64", "macos") => "x86_64-apple-darwin",
         ("aarch64", "macos") => "aarch64-apple-darwin",
         _ => anyhow::bail!(
-            "Unsupported platform: {}-{}. Please install manually from GitHub releases.",
-            arch,
-            os
+            "Unsupported platform: {arch}-{os}. Please install manually from GitHub releases."
         ),
     };
 
@@ -256,21 +248,18 @@ mod tests {
                 // Must contain os and arch components
                 assert!(
                     triple.contains("linux") || triple.contains("darwin"),
-                    "expected linux or darwin in: {}",
-                    triple
+                    "expected linux or darwin in: {triple}"
                 );
                 assert!(
                     triple.contains("x86_64") || triple.contains("aarch64"),
-                    "expected x86_64 or aarch64 in: {}",
-                    triple
+                    "expected x86_64 or aarch64 in: {triple}"
                 );
             }
             Err(e) => {
                 // Only acceptable if running on an unsupported platform
                 assert!(
                     e.to_string().contains("Unsupported platform"),
-                    "unexpected error: {}",
-                    e
+                    "unexpected error: {e}"
                 );
             }
         }
@@ -361,7 +350,7 @@ mod tests {
     #[test]
     fn asset_name_format_matches_expected_pattern() {
         let target = "x86_64-unknown-linux-musl";
-        let expected_name = format!("csa-{}.tar.gz", target);
+        let expected_name = format!("csa-{target}.tar.gz");
         assert_eq!(expected_name, "csa-x86_64-unknown-linux-musl.tar.gz");
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -328,7 +328,7 @@ pub(crate) fn handle_session_list(
     if tree {
         let tree_output =
             list_sessions_tree_filtered(&project_root, tool_filter.as_deref(), branch.as_deref())?;
-        print!("{}", tree_output);
+        print!("{tree_output}");
     } else {
         let sessions =
             select_sessions_for_list(&project_root, branch.as_deref(), tool_filter.as_deref())?;
@@ -388,18 +388,18 @@ pub(crate) fn handle_session_list(
                     let tokens_str = if let Some(ref usage) = session.total_token_usage {
                         if let Some(total) = usage.total_tokens {
                             if let Some(cost) = usage.estimated_cost_usd {
-                                format!("{}tok ${:.4}", total, cost)
+                                format!("{total}tok ${cost:.4}")
                             } else {
-                                format!("{}tok", total)
+                                format!("{total}tok")
                             }
                         } else if let (Some(input), Some(output)) =
                             (usage.input_tokens, usage.output_tokens)
                         {
                             let total = input + output;
                             if let Some(cost) = usage.estimated_cost_usd {
-                                format!("{}tok ${:.4}", total, cost)
+                                format!("{total}tok ${cost:.4}")
                             } else {
-                                format!("{}tok", total)
+                                format!("{total}tok")
                             }
                         } else {
                             "-".to_string()
@@ -412,7 +412,7 @@ pub(crate) fn handle_session_list(
                     let fork_suffix =
                         if let Some(ref fork_of) = session.genealogy.fork_of_session_id {
                             let short_fork = &fork_of[..11.min(fork_of.len())];
-                            format!("  \u{21B1} fork of {}", short_fork)
+                            format!("  \u{21B1} fork of {short_fork}")
                         } else {
                             String::new()
                         };
@@ -420,7 +420,7 @@ pub(crate) fn handle_session_list(
                     // Change binding indicator
                     let change_suffix = if let Some(ref cid) = session.change_id {
                         let short_cid = &cid[..11.min(cid.len())];
-                        format!("  change:{}", short_cid)
+                        format!("  change:{short_cid}")
                     } else {
                         String::new()
                     };
@@ -459,20 +459,19 @@ pub(crate) fn handle_session_compress(session: String, cd: Option<String>) -> Re
         .tools
         .iter()
         .max_by_key(|(_, state)| &state.updated_at)
-        .ok_or_else(|| anyhow::anyhow!("Session '{}' has no tool history", resolved_id))?;
+        .ok_or_else(|| anyhow::anyhow!("Session '{resolved_id}' has no tool history"))?;
 
     let compress_cmd = match tool_name.as_str() {
         "gemini-cli" => "/compress",
         _ => "/compact",
     };
 
-    println!("Session {} uses tool: {}", resolved_id, tool_name);
-    println!("Compress command: {}", compress_cmd);
+    println!("Session {resolved_id} uses tool: {tool_name}");
+    println!("Compress command: {compress_cmd}");
     println!();
     println!("To compress, resume the session and send the command:");
     println!(
-        "  csa run --sa-mode <true|false> --tool {} --session {} \"{}\"",
-        tool_name, resolved_id, compress_cmd
+        "  csa run --sa-mode <true|false> --tool {tool_name} --session {resolved_id} \"{compress_cmd}\""
     );
     println!();
     println!("Note: context status will be updated after the tool confirms compression.");
@@ -489,7 +488,7 @@ pub(crate) fn handle_session_delete(session: String, cd: Option<String>) -> Resu
     let resolved = resolve_session_prefix_with_fallback(&project_root, &session)?;
     let resolved_id = resolved.session_id;
     delete_session(&project_root, &resolved_id)?;
-    eprintln!("Deleted session: {}", resolved_id);
+    eprintln!("Deleted session: {resolved_id}");
     Ok(())
 }
 
@@ -524,7 +523,7 @@ pub(crate) fn handle_session_logs(
         }
     }
 
-    eprintln!("No logs found for session {}", resolved_id);
+    eprintln!("No logs found for session {resolved_id}");
     eprintln!("Hint: use --events to view ACP transcript events (if available)");
     Ok(())
 }
@@ -563,7 +562,7 @@ fn display_log_files(session_dir: &Path, session_id: &str, tail: Option<usize>) 
     for entry in &log_files {
         let path = entry.path();
         let file_name = path.file_name().unwrap_or_default().to_string_lossy();
-        eprintln!("=== {} ===", file_name);
+        eprintln!("=== {file_name} ===");
 
         let content = fs::read_to_string(&path)?;
         print_content_with_tail(&content, tail);
@@ -577,16 +576,13 @@ fn display_log_files(session_dir: &Path, session_id: &str, tail: Option<usize>) 
 fn display_acp_events(session_dir: &Path, session_id: &str, tail: Option<usize>) -> Result<()> {
     let events_path = session_dir.join("output").join("acp-events.jsonl");
     if !events_path.is_file() {
-        eprintln!(
-            "No ACP events found for session {} (no output/acp-events.jsonl)",
-            session_id
-        );
+        eprintln!("No ACP events found for session {session_id} (no output/acp-events.jsonl)");
         return Ok(());
     }
 
     let content = fs::read_to_string(&events_path)?;
     if content.is_empty() {
-        eprintln!("ACP events file is empty for session {}", session_id);
+        eprintln!("ACP events file is empty for session {session_id}");
         return Ok(());
     }
 
@@ -601,10 +597,10 @@ fn print_content_with_tail(content: &str, tail: Option<usize>) {
         let lines: Vec<&str> = content.lines().collect();
         let start = lines.len().saturating_sub(n);
         for line in &lines[start..] {
-            println!("{}", line);
+            println!("{line}");
         }
     } else {
-        print!("{}", content);
+        print!("{content}");
     }
 }
 
@@ -686,7 +682,7 @@ pub(crate) fn handle_session_clean(
 
 pub(crate) fn format_file_size(bytes: u64) -> String {
     if bytes < 1024 {
-        format!("{} B", bytes)
+        format!("{bytes} B")
     } else if bytes < 1024 * 1024 {
         format!("{:.1} KB", bytes as f64 / 1024.0)
     } else {
@@ -701,7 +697,7 @@ pub(crate) fn handle_session_log(session: String, cd: Option<String>) -> Result<
     if log.is_empty() {
         eprintln!("No git history for session '{}'", resolved.session_id);
     } else {
-        print!("{}", log);
+        print!("{log}");
     }
     Ok(())
 }

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -125,7 +125,7 @@ pub(crate) fn handle_session_result(
             }
         }
         None => {
-            eprintln!("No result found for session '{}'", resolved_id);
+            eprintln!("No result found for session '{resolved_id}'");
         }
     }
     Ok(())
@@ -153,7 +153,7 @@ fn display_result_text(
     result: &SessionResult,
     transcript_summary: Option<&TranscriptSummary>,
 ) {
-    println!("Session: {}", session_id);
+    println!("Session: {session_id}");
     println!("Status:  {}", result.status);
     println!("Exit:    {}", result.exit_code);
     println!("Tool:    {}", result.tool);
@@ -163,7 +163,7 @@ fn display_result_text(
     if !result.artifacts.is_empty() {
         println!("Artifacts:");
         for a in &result.artifacts {
-            println!("  - {}", a);
+            println!("  - {a}");
         }
     }
     if let Some(summary) = transcript_summary {
@@ -238,7 +238,7 @@ pub(crate) fn display_summary_section(
         if is_full_fallback {
             print_truncated_content(&content, FALLBACK_LINES);
         } else {
-            println!("{}", content);
+            println!("{content}");
         }
     }
     Ok(())
@@ -263,7 +263,7 @@ fn display_summary_fallback(session_dir: &Path, session_id: &str, json: bool) ->
             return Ok(());
         }
     }
-    eprintln!("No output found for session '{}'", session_id);
+    eprintln!("No output found for session '{session_id}'");
     Ok(())
 }
 
@@ -295,7 +295,7 @@ pub(crate) fn display_single_section(
                 });
                 println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
-                println!("{}", content);
+                println!("{content}");
             }
         }
         None => {
@@ -313,8 +313,7 @@ pub(crate) fn display_single_section(
                 }
                 None => {
                     anyhow::bail!(
-                        "No structured output for session '{}'. Run without --section to see raw result.",
-                        session_id
+                        "No structured output for session '{session_id}'. Run without --section to see raw result."
                     );
                 }
             }
@@ -342,12 +341,12 @@ pub(crate) fn display_all_sections(session_dir: &Path, session_id: &str, json: b
                     });
                     println!("{}", serde_json::to_string_pretty(&payload)?);
                 } else {
-                    print!("{}", content);
+                    print!("{content}");
                 }
                 return Ok(());
             }
         }
-        eprintln!("No output found for session '{}'", session_id);
+        eprintln!("No output found for session '{session_id}'");
         return Ok(());
     }
 
@@ -371,7 +370,7 @@ pub(crate) fn display_all_sections(session_dir: &Path, session_id: &str, json: b
                 println!();
             }
             println!("=== {} ({}) ===", section.title, section.id);
-            println!("{}", content);
+            println!("{content}");
         }
     }
     Ok(())
@@ -429,7 +428,7 @@ pub(crate) fn handle_session_artifacts(session: String, cd: Option<String>) -> R
         entries.sort_by_key(|e| e.file_name());
 
         if entries.is_empty() {
-            eprintln!("No artifacts for session '{}'", resolved_id);
+            eprintln!("No artifacts for session '{resolved_id}'");
         } else {
             println!("Files:");
             for entry in &entries {
@@ -440,7 +439,7 @@ pub(crate) fn handle_session_artifacts(session: String, cd: Option<String>) -> R
             }
         }
     } else {
-        eprintln!("No artifacts for session '{}'", resolved_id);
+        eprintln!("No artifacts for session '{resolved_id}'");
     }
 
     Ok(())
@@ -475,7 +474,7 @@ pub(crate) fn handle_session_measure(
         println!("{}", serde_json::to_string_pretty(&measurement)?);
     } else {
         let short_id = &resolved_id[..11.min(resolved_id.len())];
-        println!("Session: {}", short_id);
+        println!("Session: {short_id}");
         println!(
             "Total output: {} tokens",
             format_number(measurement.total_tokens)

--- a/crates/cli-sub-agent/src/skill_cmds.rs
+++ b/crates/cli-sub-agent/src/skill_cmds.rs
@@ -9,7 +9,7 @@ use tracing::info;
 pub(crate) fn handle_skill_install(source: String, target: Option<String>) -> Result<()> {
     // 1. Parse source to get user/repo
     let repo = parse_github_source(&source)?;
-    eprintln!("Installing skills from: {}", repo);
+    eprintln!("Installing skills from: {repo}");
 
     // 2. Clone repo to temp directory
     let temp_dir = TempDir::new().context("Failed to create temporary directory")?;
@@ -34,7 +34,7 @@ pub(crate) fn handle_skill_install(source: String, target: Option<String>) -> Re
     } else {
         eprintln!("\nInstalled {} skill(s):", installed.len());
         for skill in installed {
-            eprintln!("  - {}", skill);
+            eprintln!("  - {skill}");
         }
     }
 
@@ -68,7 +68,7 @@ pub(crate) fn handle_skill_list() -> Result<()> {
         // Try to read SKILL.md to get title
         let title = read_skill_title(&skill_path).unwrap_or_else(|| skill_name.clone());
 
-        println!("  {} - {}", skill_name, title);
+        println!("  {skill_name} - {title}");
     }
 
     Ok(())
@@ -95,8 +95,8 @@ fn parse_github_source(source: &str) -> Result<String> {
 
 /// Clone repository using git
 fn clone_repository(repo: &str, dest: &Path) -> Result<()> {
-    let url = format!("https://github.com/{}", repo);
-    eprintln!("Cloning from: {}", url);
+    let url = format!("https://github.com/{repo}");
+    eprintln!("Cloning from: {url}");
 
     let output = Command::new("git")
         .args(["clone", "--depth", "1", &url, "."])
@@ -106,7 +106,7 @@ fn clone_repository(repo: &str, dest: &Path) -> Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Git clone failed: {}", stderr);
+        anyhow::bail!("Git clone failed: {stderr}");
     }
 
     info!("Successfully cloned repository");
@@ -142,14 +142,10 @@ fn determine_target_directory(target: Option<&str>) -> Result<PathBuf> {
             // For now, these tools don't have a standard skills directory
             // We could add support later
             anyhow::bail!(
-                "Skills for '{}' are not yet supported. Only 'claude-code' is supported.",
-                target_tool
+                "Skills for '{target_tool}' are not yet supported. Only 'claude-code' is supported."
             )
         }
-        _ => anyhow::bail!(
-            "Unknown target tool: '{}'. Supported: claude-code",
-            target_tool
-        ),
+        _ => anyhow::bail!("Unknown target tool: '{target_tool}'. Supported: claude-code"),
     }
 }
 
@@ -181,13 +177,13 @@ fn copy_skills(source_dir: &Path, target_dir: &Path) -> Result<Vec<String>> {
 
         // Check if skill already exists
         if dest_path.exists() {
-            eprintln!("Skipping '{}' (already exists)", skill_name);
+            eprintln!("Skipping '{skill_name}' (already exists)");
             continue;
         }
 
         // Copy directory recursively
         copy_dir_recursive(&path, &dest_path)
-            .with_context(|| format!("Failed to copy skill '{}'", skill_name))?;
+            .with_context(|| format!("Failed to copy skill '{skill_name}'"))?;
 
         installed.push(skill_name);
     }
@@ -322,8 +318,7 @@ mod tests {
         let path = result.unwrap();
         assert!(
             path.ends_with(".claude/skills"),
-            "expected .claude/skills suffix, got: {:?}",
-            path
+            "expected .claude/skills suffix, got: {path:?}"
         );
     }
 

--- a/crates/cli-sub-agent/src/tiers_cmd.rs
+++ b/crates/cli-sub-agent/src/tiers_cmd.rs
@@ -43,7 +43,7 @@ fn print_tiers_text(config: &ProjectConfig) {
         // Show disabled models with annotation
         for model in &tier.models {
             if !enabled_models.contains(model) {
-                println!("  -  {} (disabled)", model);
+                println!("  -  {model} (disabled)");
             }
         }
         println!();
@@ -55,7 +55,7 @@ fn print_tiers_text(config: &ProjectConfig) {
         let mut mappings: Vec<(&String, &String)> = config.tier_mapping.iter().collect();
         mappings.sort_by_key(|(k, _)| *k);
         for (task_type, tier_name) in mappings {
-            println!("  {} -> {}", task_type, tier_name);
+            println!("  {task_type} -> {tier_name}");
         }
         println!();
     }

--- a/crates/cli-sub-agent/src/todo_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_cmd.rs
@@ -23,7 +23,7 @@ pub(crate) fn handle_create(
     let plan = manager.create_with_language(&title, branch.as_deref(), language.as_deref())?;
 
     // Auto-commit the initial plan (freshly created, should always have changes)
-    let commit_msg = format!("create: {}", title);
+    let commit_msg = format!("create: {title}");
     csa_todo::git::save(manager.todos_dir(), &plan.timestamp, &commit_msg)?
         .ok_or_else(|| anyhow::anyhow!("BUG: newly created plan had no changes to commit"))?;
 
@@ -86,7 +86,7 @@ pub(crate) fn handle_save(
     let commit_msg = message.unwrap_or_else(|| format!("update: {}", plan.metadata.title));
     match csa_todo::git::save(manager.todos_dir(), &ts, &commit_msg)? {
         Some(hash) => {
-            eprintln!("Saved {} ({})", ts, hash);
+            eprintln!("Saved {ts} ({hash})");
 
             // TodoSave hook: fires after successful save (best-effort)
             let hooks_config = load_hooks_config(
@@ -396,7 +396,7 @@ pub(crate) fn handle_status(timestamp: String, status: String, cd: Option<String
 
     // Idempotent: skip if status unchanged
     if old_status == new_status {
-        eprintln!("Status already '{}' — no change.", old_status);
+        eprintln!("Status already '{old_status}' — no change.");
         return Ok(());
     }
 
@@ -404,7 +404,7 @@ pub(crate) fn handle_status(timestamp: String, status: String, cd: Option<String
 
     // Auto-commit only metadata.toml (don't accidentally commit other changes)
     csa_todo::git::ensure_git_init(manager.todos_dir())?;
-    let metadata_path = format!("{}/metadata.toml", timestamp);
+    let metadata_path = format!("{timestamp}/metadata.toml");
     let commit_msg = format!(
         "status: {} → {} ({})",
         old_status, plan.metadata.status, plan.metadata.title

--- a/crates/cli-sub-agent/tests/mcp_hub_e2e.rs
+++ b/crates/cli-sub-agent/tests/mcp_hub_e2e.rs
@@ -281,10 +281,7 @@ fn hub_forwards_requests_and_proxy_latency_budget_is_within_environment_budget()
                 break;
             }
             if attempt == 19 {
-                bail!(
-                    "hub never registered MCP backend after 5s; last response: {}",
-                    list_response
-                );
+                bail!("hub never registered MCP backend after 5s; last response: {list_response}");
             }
         }
         assert_eq!(list_response["result"]["tools"][0]["name"], "echo_tool");

--- a/crates/csa-acp/src/client.rs
+++ b/crates/csa-acp/src/client.rs
@@ -73,7 +73,7 @@ impl AcpClient {
                 if let Some(status) = tool_call_update.fields.status {
                     Some(SessionEvent::ToolCallCompleted {
                         id,
-                        status: format!("{:?}", status),
+                        status: format!("{status:?}"),
                     })
                 } else {
                     Some(SessionEvent::Other(

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -600,11 +600,10 @@ impl ProjectConfig {
         }
         if !self.is_tool_enabled(tool) {
             anyhow::bail!(
-                "Error: tool '{}' is disabled in user configuration.\n\
+                "Error: tool '{tool}' is disabled in user configuration.\n\
                  The user may have temporarily disabled this tool. Respect their preference.\n\
                  To override, use --force-override-user-config (not recommended unless\n\
-                 the user explicitly requested this specific tool).",
-                tool
+                 the user explicitly requested this specific tool)."
             );
         }
         Ok(())

--- a/crates/csa-config/src/config_merge.rs
+++ b/crates/csa-config/src/config_merge.rs
@@ -3,9 +3,8 @@ pub(crate) fn warn_deprecated_keys(raw: &toml::Value, source: &str) {
     if let Some(resources) = raw.get("resources") {
         if resources.get("min_free_swap_mb").is_some() {
             eprintln!(
-                "warning: config '{}': 'resources.min_free_swap_mb' is deprecated and ignored. \
-                 Use 'resources.min_free_memory_mb' (combined physical + swap threshold) instead.",
-                source
+                "warning: config '{source}': 'resources.min_free_swap_mb' is deprecated and ignored. \
+                 Use 'resources.min_free_memory_mb' (combined physical + swap threshold) instead."
             );
         }
     }

--- a/crates/csa-config/src/config_merge_tests.rs
+++ b/crates/csa-config/src/config_merge_tests.rs
@@ -477,7 +477,7 @@ name = "test"
         config
             .review
             .as_ref()
-            .map_or(true, |r| r.gate_command.is_none()),
+            .is_none_or(|r| r.gate_command.is_none()),
         "global gate_command must not be inherited by project config"
     );
     // gate_timeout_secs from global must be stripped, falling back to default 300
@@ -485,7 +485,7 @@ name = "test"
         config
             .review
             .as_ref()
-            .map_or(true, |r| r.gate_timeout_secs == 300),
+            .is_none_or(|r| r.gate_timeout_secs == 300),
         "global gate_timeout_secs must not be inherited; should be default 300"
     );
 }

--- a/crates/csa-config/src/config_merge_tests_tail.rs
+++ b/crates/csa-config/src/config_merge_tests_tail.rs
@@ -37,15 +37,19 @@ fn test_hooks_section_is_default_returns_false_with_pre_run() {
 
 #[test]
 fn test_hooks_section_is_default_returns_false_with_post_run() {
-    let mut hooks = crate::config::HooksSection::default();
-    hooks.post_run = Some("echo bye".to_string());
+    let hooks = crate::config::HooksSection {
+        post_run: Some("echo bye".to_string()),
+        ..Default::default()
+    };
     assert!(!hooks.is_default());
 }
 
 #[test]
 fn test_hooks_section_is_default_returns_false_with_custom_timeout() {
-    let mut hooks = crate::config::HooksSection::default();
-    hooks.timeout_secs = 120;
+    let hooks = crate::config::HooksSection {
+        timeout_secs: 120,
+        ..Default::default()
+    };
     assert!(!hooks.is_default());
 }
 
@@ -160,8 +164,9 @@ fn test_execution_config_is_default() {
 
 #[test]
 fn test_execution_config_is_not_default_with_custom_value() {
-    let mut exec = crate::config::ExecutionConfig::default();
-    exec.min_timeout_seconds = 2400;
+    let exec = crate::config::ExecutionConfig {
+        min_timeout_seconds: 2400,
+    };
     assert!(!exec.is_default());
 }
 

--- a/crates/csa-config/src/config_tests.rs
+++ b/crates/csa-config/src/config_tests.rs
@@ -511,28 +511,24 @@ fn test_load_actual_project_config() {
         );
         assert!(
             !tier_config.models.is_empty(),
-            "Tier {} should have models",
-            name
+            "Tier {name} should have models"
         );
         for model in &tier_config.models {
             let parts: Vec<&str> = model.split('/').collect();
             assert_eq!(
                 parts.len(),
                 4,
-                "Model spec '{}' should have format 'tool/provider/model/budget'",
-                model
+                "Model spec '{model}' should have format 'tool/provider/model/budget'"
             );
         }
     }
 
     println!("✓ Tier mappings defined: {}", config.tier_mapping.len());
     for (task, tier) in &config.tier_mapping {
-        println!("  - {} -> {}", task, tier);
+        println!("  - {task} -> {tier}");
         assert!(
             config.tiers.contains_key(tier),
-            "Tier mapping {} references undefined tier {}",
-            task,
-            tier
+            "Tier mapping {task} references undefined tier {tier}"
         );
     }
 

--- a/crates/csa-config/src/config_tiers.rs
+++ b/crates/csa-config/src/config_tiers.rs
@@ -99,13 +99,8 @@ impl ProjectConfig {
             if let Some(spec_tool) = spec.split('/').next() {
                 if spec_tool != tool {
                     anyhow::bail!(
-                        "Model spec '{}' belongs to tool '{}', not '{}'. \
-                         Use --tool {} or select a spec for '{}'.",
-                        spec,
-                        spec_tool,
-                        tool,
-                        spec_tool,
-                        tool
+                        "Model spec '{spec}' belongs to tool '{spec_tool}', not '{tool}'. \
+                         Use --tool {spec_tool} or select a spec for '{tool}'."
                     );
                 }
             }

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -771,7 +771,7 @@ fn resolve_auto_tool(section: &str, parent_tool: Option<&str>) -> Result<String>
         Some(counterpart) => Ok(counterpart.to_string()),
         None => {
             let context = match parent_tool {
-                Some(p) => format!("parent is '{}'", p),
+                Some(p) => format!("parent is '{p}'"),
                 None => "no parent tool context".to_string(),
             };
             Err(anyhow::anyhow!(

--- a/crates/csa-config/src/global_tests.rs
+++ b/crates/csa-config/src/global_tests.rs
@@ -274,15 +274,19 @@ fn test_review_config_is_default() {
 
 #[test]
 fn test_review_config_is_not_default_with_gate_command() {
-    let mut config = ReviewConfig::default();
-    config.gate_command = Some("make lint".to_string());
+    let config = ReviewConfig {
+        gate_command: Some("make lint".to_string()),
+        ..Default::default()
+    };
     assert!(!config.is_default());
 }
 
 #[test]
 fn test_review_config_is_not_default_with_gate_timeout() {
-    let mut config = ReviewConfig::default();
-    config.gate_timeout_secs = 600;
+    let config = ReviewConfig {
+        gate_timeout_secs: 600,
+        ..Default::default()
+    };
     assert!(!config.is_default());
 }
 

--- a/crates/csa-config/src/init_tests.rs
+++ b/crates/csa-config/src/init_tests.rs
@@ -180,8 +180,7 @@ fn test_smart_tiers_with_no_tools() {
         let tier = tiers.get(*tier_name).unwrap();
         assert!(
             tier.models[0].starts_with("gemini-cli/"),
-            "Tier {} should fallback to gemini-cli",
-            tier_name
+            "Tier {tier_name} should fallback to gemini-cli"
         );
     }
 }
@@ -330,8 +329,7 @@ fn test_build_smart_tiers_descriptions_not_empty() {
     for (name, tier) in &tiers {
         assert!(
             !tier.description.is_empty(),
-            "Tier '{}' should have a non-empty description",
-            name
+            "Tier '{name}' should have a non-empty description"
         );
     }
 }
@@ -357,8 +355,7 @@ fn test_default_tier_mapping_completeness() {
     for key in &expected_keys {
         assert!(
             mapping.contains_key(*key),
-            "tier_mapping should contain '{}'",
-            key
+            "tier_mapping should contain '{key}'"
         );
     }
 
@@ -367,9 +364,7 @@ fn test_default_tier_mapping_completeness() {
     for (task, tier) in &mapping {
         assert!(
             valid_tiers.contains(&tier.as_str()),
-            "task '{}' maps to unknown tier '{}'",
-            task,
-            tier
+            "task '{task}' maps to unknown tier '{tier}'"
         );
     }
 }
@@ -525,9 +520,7 @@ fn test_build_smart_tiers_skips_globally_disabled() {
         for model in &tier.models {
             assert!(
                 !model.starts_with("gemini-cli/"),
-                "tier '{}' should not contain globally-disabled gemini-cli, found: {}",
-                name,
-                model
+                "tier '{name}' should not contain globally-disabled gemini-cli, found: {model}"
             );
         }
     }

--- a/crates/csa-config/src/migrate_tests.rs
+++ b/crates/csa-config/src/migrate_tests.rs
@@ -638,8 +638,7 @@ fn test_xdg_migration_concurrent_flock_blocks_second_migration() {
     let elapsed = rx.recv_timeout(Duration::from_secs(2)).unwrap();
     assert!(
         elapsed >= Duration::from_millis(150),
-        "expected lock blocking, got {:?}",
-        elapsed
+        "expected lock blocking, got {elapsed:?}"
     );
 
     handle.join().unwrap();

--- a/crates/csa-config/src/validate.rs
+++ b/crates/csa-config/src/validate.rs
@@ -77,27 +77,24 @@ fn validate_resources(config: &ProjectConfig) -> Result<()> {
     if let Some(mem) = config.resources.memory_max_mb {
         if mem < 256 {
             bail!(
-                "resources.memory_max_mb must be >= 256 (got {}). \
-                 Tool processes need at least 256 MB to function.",
-                mem
+                "resources.memory_max_mb must be >= 256 (got {mem}). \
+                 Tool processes need at least 256 MB to function."
             );
         }
     }
     if let Some(heap) = config.resources.node_heap_limit_mb {
         if heap < 512 {
             bail!(
-                "resources.node_heap_limit_mb must be >= 512 (got {}). \
-                 Node-based tools need at least 512 MB heap to function.",
-                heap
+                "resources.node_heap_limit_mb must be >= 512 (got {heap}). \
+                 Node-based tools need at least 512 MB heap to function."
             );
         }
     }
     if let Some(pids) = config.resources.pids_max {
         if pids < 10 {
             bail!(
-                "resources.pids_max must be >= 10 (got {}). \
-                 Tool processes need at least 10 PIDs for process trees.",
-                pids
+                "resources.pids_max must be >= 10 (got {pids}). \
+                 Tool processes need at least 10 PIDs for process trees."
             );
         }
     }
@@ -132,30 +129,22 @@ fn validate_tools(config: &ProjectConfig) -> Result<()> {
     ];
     for (tool_name, tool_config) in &config.tools {
         if !known_tools.contains(&tool_name.as_str()) {
-            bail!(
-                "Unknown tool '{}'. Known tools: {:?}",
-                tool_name,
-                known_tools
-            );
+            bail!("Unknown tool '{tool_name}'. Known tools: {known_tools:?}");
         }
         // Validate per-tool sandbox memory overrides.
         if let Some(mem) = tool_config.memory_max_mb {
             if mem < 256 {
                 bail!(
-                    "tools.{}.memory_max_mb must be >= 256 (got {}). \
-                     Tool processes need at least 256 MB to function.",
-                    tool_name,
-                    mem
+                    "tools.{tool_name}.memory_max_mb must be >= 256 (got {mem}). \
+                     Tool processes need at least 256 MB to function."
                 );
             }
         }
         if let Some(heap) = tool_config.node_heap_limit_mb {
             if heap < 512 {
                 bail!(
-                    "tools.{}.node_heap_limit_mb must be >= 512 (got {}). \
-                     Node-based tools need at least 512 MB heap to function.",
-                    tool_name,
-                    heap
+                    "tools.{tool_name}.node_heap_limit_mb must be >= 512 (got {heap}). \
+                     Node-based tools need at least 512 MB heap to function."
                 );
             }
         }
@@ -168,10 +157,9 @@ fn validate_tools(config: &ProjectConfig) -> Result<()> {
                 tool_config.memory_max_mb.is_some() || config.resources.memory_max_mb.is_some();
             if !has_memory {
                 bail!(
-                    "tools.{}.enforcement_mode = \"required\" but no memory_max_mb is set \
-                     (neither tools.{0}.memory_max_mb nor resources.memory_max_mb). \
-                     Required mode needs an explicit memory limit to enforce.",
-                    tool_name
+                    "tools.{tool_name}.enforcement_mode = \"required\" but no memory_max_mb is set \
+                     (neither tools.{tool_name}.memory_max_mb nor resources.memory_max_mb). \
+                     Required mode needs an explicit memory limit to enforce."
                 );
             }
         }
@@ -238,7 +226,7 @@ fn validate_tiers(config: &ProjectConfig) -> Result<()> {
     // Validate each TierConfig
     for (tier_name, tier_config) in &config.tiers {
         if tier_config.models.is_empty() {
-            bail!("Tier '{}' must have at least one model", tier_name);
+            bail!("Tier '{tier_name}' must have at least one model");
         }
         for model_spec in &tier_config.models {
             validate_model_spec(tier_name, model_spec)?;
@@ -246,12 +234,12 @@ fn validate_tiers(config: &ProjectConfig) -> Result<()> {
         // Validate budget constraints
         if let Some(budget) = tier_config.token_budget {
             if budget == 0 {
-                bail!("Tier '{}': token_budget must be > 0 (got 0)", tier_name);
+                bail!("Tier '{tier_name}': token_budget must be > 0 (got 0)");
             }
         }
         if let Some(turns) = tier_config.max_turns {
             if turns == 0 {
-                bail!("Tier '{}': max_turns must be > 0 (got 0)", tier_name);
+                bail!("Tier '{tier_name}': max_turns must be > 0 (got 0)");
             }
         }
     }
@@ -284,9 +272,8 @@ fn warn_unknown_tool_priority(config: &ProjectConfig) {
         for name in &prefs.tool_priority {
             if !known_tools.contains(&name.as_str()) {
                 eprintln!(
-                    "warning: Unrecognized tool in [preferences].tool_priority: '{}'. \
-                     Known tools: {:?}. Entry will be ignored for sorting.",
-                    name, known_tools
+                    "warning: Unrecognized tool in [preferences].tool_priority: '{name}'. \
+                     Known tools: {known_tools:?}. Entry will be ignored for sorting."
                 );
             }
         }
@@ -297,9 +284,7 @@ fn validate_model_spec(tier_name: &str, model_spec: &str) -> Result<()> {
     let parts: Vec<&str> = model_spec.split('/').collect();
     if parts.len() != 4 {
         bail!(
-            "Tier '{}' has invalid model spec '{}'. Expected format: 'tool/provider/model/budget'",
-            tier_name,
-            model_spec
+            "Tier '{tier_name}' has invalid model spec '{model_spec}'. Expected format: 'tool/provider/model/budget'"
         );
     }
 

--- a/crates/csa-config/src/validate_tests_preferences.rs
+++ b/crates/csa-config/src/validate_tests_preferences.rs
@@ -35,7 +35,6 @@ fn test_validate_config_warns_but_passes_on_unknown_tool_priority() {
     let result = validate_config(dir.path());
     assert!(
         result.is_ok(),
-        "unknown tool_priority entry should warn, not fail: {:?}",
-        result
+        "unknown tool_priority entry should warn, not fail: {result:?}"
     );
 }

--- a/crates/csa-config/src/validate_tests_tail.rs
+++ b/crates/csa-config/src/validate_tests_tail.rs
@@ -176,8 +176,7 @@ fn test_validate_all_known_review_tools_accepted() {
         let result = validate_config(dir.path());
         assert!(
             result.is_ok(),
-            "Review tool '{}' should be accepted",
-            tool_name
+            "Review tool '{tool_name}' should be accepted"
         );
     }
 }
@@ -218,8 +217,7 @@ fn test_validate_all_known_debate_tools_accepted() {
         let result = validate_config(dir.path());
         assert!(
             result.is_ok(),
-            "Debate tool '{}' should be accepted",
-            tool_name
+            "Debate tool '{tool_name}' should be accepted"
         );
     }
 }

--- a/crates/csa-core/src/types.rs
+++ b/crates/csa-core/src/types.rs
@@ -142,18 +142,16 @@ impl ToolArg {
                     let resolved: Self = canonical.parse()?;
                     match resolved {
                         Self::Alias(ref inner) => Err(format!(
-                            "tool alias '{}' maps to '{}' which is not a valid tool name. \
-                             Valid targets: gemini-cli, opencode, codex, claude-code",
-                            alias, inner
+                            "tool alias '{alias}' maps to '{inner}' which is not a valid tool \
+                             name. Valid targets: gemini-cli, opencode, codex, claude-code"
                         )),
                         other => Ok(other),
                     }
                 } else {
                     Err(format!(
-                        "unknown tool '{}'. Valid values: auto, any-available, \
+                        "unknown tool '{alias}'. Valid values: auto, any-available, \
                          gemini-cli, opencode, codex, claude-code, openai-compat. \
-                         Or define it in [tool_aliases] in config.",
-                        alias
+                         Or define it in [tool_aliases] in config."
                     ))
                 }
             }
@@ -172,11 +170,11 @@ impl ToolArg {
             Self::Auto => ToolSelectionStrategy::HeterogeneousPreferred,
             Self::AnyAvailable => ToolSelectionStrategy::AnyAvailable,
             Self::Specific(t) => ToolSelectionStrategy::Explicit(t),
-            Self::Alias(a) => panic!(
-                "BUG: unresolved tool alias '{}' reached into_strategy(); \
-                 resolve_alias() must be called first",
-                a
-            ),
+            Self::Alias(a) => {
+                panic!(
+                    "BUG: unresolved tool alias '{a}' reached into_strategy(); resolve_alias() must be called first"
+                )
+            }
         }
     }
 }
@@ -187,7 +185,7 @@ impl std::fmt::Display for ToolArg {
             Self::Auto => write!(f, "auto"),
             Self::AnyAvailable => write!(f, "any-available"),
             Self::Specific(t) => write!(f, "{}", t.as_str()),
-            Self::Alias(a) => write!(f, "{}", a),
+            Self::Alias(a) => write!(f, "{a}"),
         }
     }
 }

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -234,7 +234,7 @@ impl Executor {
                 model_override: model,
                 thinking_budget: budget,
             }),
-            other => bail!("Unknown tool '{}' in model spec", other),
+            other => bail!("Unknown tool '{other}' in model spec"),
         }
     }
 
@@ -314,8 +314,7 @@ impl Executor {
         if !allow_edit {
             format!(
                 "IMPORTANT RESTRICTION: You MUST NOT edit or modify any existing files. \
-                 You may only create new files or perform read-only analysis.\n\n{}",
-                prompt
+                 You may only create new files or perform read-only analysis.\n\n{prompt}"
             )
         } else {
             prompt.to_string()

--- a/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
@@ -126,7 +126,7 @@ fn test_override_model_replaces_existing() {
         thinking_budget: None,
     };
     exec.override_model("gemini-3.1-pro-preview".to_string());
-    let debug = format!("{:?}", exec);
+    let debug = format!("{exec:?}");
     assert!(
         debug.contains("gemini-3.1-pro-preview"),
         "override_model should replace existing model: {debug}"

--- a/crates/csa-executor/src/executor_tests.rs
+++ b/crates/csa-executor/src/executor_tests.rs
@@ -250,7 +250,7 @@ fn test_from_tool_name_with_model_and_thinking() {
 
     let mut cmd = Command::new(exec.executable_name());
     exec.append_tool_args(&mut cmd, "test prompt", None);
-    let debug_str = format!("{:?}", cmd);
+    let debug_str = format!("{cmd:?}");
     assert!(
         debug_str.contains("gpt-5.1-codex-mini"),
         "Missing model in args: {debug_str}"
@@ -312,7 +312,7 @@ fn test_thinking_budget_in_gemini_cli_args() {
     exec.append_tool_args(&mut cmd, "test prompt", None);
 
     // gemini-cli runtime no longer accepts thinking-budget flags.
-    let debug_str = format!("{:?}", cmd);
+    let debug_str = format!("{cmd:?}");
     assert!(!debug_str.contains("--thinking_budget"));
     assert!(!debug_str.contains("32768"));
 }
@@ -329,7 +329,7 @@ fn test_thinking_budget_in_codex_args() {
     exec.append_tool_args(&mut cmd, "test prompt", None);
 
     // Check that the command contains -c model_reasoning_effort=low
-    let debug_str = format!("{:?}", cmd);
+    let debug_str = format!("{cmd:?}");
     assert!(debug_str.contains("model_reasoning_effort=low"));
 }
 
@@ -341,7 +341,7 @@ fn test_thinking_budget_from_spec_gemini() {
     let mut cmd = Command::new(exec.executable_name());
     exec.append_tool_args(&mut cmd, "test prompt", None);
 
-    let debug_str = format!("{:?}", cmd);
+    let debug_str = format!("{cmd:?}");
     assert!(!debug_str.contains("--thinking_budget"));
     assert!(!debug_str.contains("32768"));
 }
@@ -354,7 +354,7 @@ fn test_thinking_budget_from_spec_codex() {
     let mut cmd = Command::new(exec.executable_name());
     exec.append_tool_args(&mut cmd, "test prompt", None);
 
-    let debug_str = format!("{:?}", cmd);
+    let debug_str = format!("{cmd:?}");
     assert!(debug_str.contains("model_reasoning_effort=low"));
 }
 
@@ -369,7 +369,7 @@ fn test_thinking_budget_custom_value() {
     let mut cmd = Command::new(exec.executable_name());
     exec.append_tool_args(&mut cmd, "test prompt", None);
 
-    let debug_str = format!("{:?}", cmd);
+    let debug_str = format!("{cmd:?}");
     assert!(debug_str.contains("--thinking-budget"));
     assert!(debug_str.contains("10000"));
 }
@@ -453,7 +453,7 @@ fn test_opencode_command_construction() {
     exec.append_tool_args(&mut cmd, "test prompt", None);
 
     // Verify command structure matches opencode run syntax
-    let debug_str = format!("{:?}", cmd);
+    let debug_str = format!("{cmd:?}");
     assert!(debug_str.contains("\"run\""));
     assert!(debug_str.contains("\"--format\""));
     assert!(debug_str.contains("\"json\""));
@@ -488,12 +488,10 @@ fn test_opencode_variant_mapping() {
         let mut cmd = Command::new(exec.executable_name());
         exec.append_tool_args(&mut cmd, "test", None);
 
-        let debug_str = format!("{:?}", cmd);
+        let debug_str = format!("{cmd:?}");
         assert!(
             debug_str.contains(expected_variant),
-            "Expected variant '{}' not found in command: {}",
-            expected_variant,
-            debug_str
+            "Expected variant '{expected_variant}' not found in command: {debug_str}"
         );
     }
 }
@@ -529,7 +527,7 @@ fn test_execute_in_preserves_model_override() {
         exec.append_model_args(&mut cmd);
         exec.append_prompt_args(&mut cmd, "test prompt");
 
-        let debug_str = format!("{:?}", cmd);
+        let debug_str = format!("{cmd:?}");
 
         // Every tool should include its model override
         match exec {

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -31,10 +31,7 @@ impl ModelSpec {
     pub fn parse(spec: &str) -> Result<Self> {
         let parts: Vec<&str> = spec.splitn(4, '/').collect();
         if parts.len() != 4 {
-            bail!(
-                "Invalid model spec '{}': expected tool/provider/model/thinking_budget",
-                spec
-            );
+            bail!("Invalid model spec '{spec}': expected tool/provider/model/thinking_budget");
         }
         Ok(Self {
             tool: parts[0].to_string(),
@@ -61,8 +58,7 @@ impl ThinkingBudget {
                     Ok(Self::Custom(n))
                 } else {
                     bail!(
-                        "Invalid thinking budget '{}': expected default/low/medium/high/xhigh or a number",
-                        other
+                        "Invalid thinking budget '{other}': expected default/low/medium/high/xhigh or a number"
                     )
                 }
             }

--- a/crates/csa-executor/src/transport_openai_compat.rs
+++ b/crates/csa-executor/src/transport_openai_compat.rs
@@ -66,17 +66,15 @@ impl OpenaiCompatTransport {
     ) -> Result<OpenaiCompatConfig> {
         let base_url = Self::resolve_env(ENV_BASE_URL, extra_env).ok_or_else(|| {
             anyhow::anyhow!(
-                "OpenAI-compat base URL not configured. Set {} in [tools.openai-compat.env] \
-                 or as an environment variable.",
-                ENV_BASE_URL
+                "OpenAI-compat base URL not configured. Set {ENV_BASE_URL} in [tools.openai-compat.env] \
+                 or as an environment variable."
             )
         })?;
 
         let api_key = Self::resolve_env(ENV_API_KEY, extra_env).ok_or_else(|| {
             anyhow::anyhow!(
-                "OpenAI-compat API key not configured. Set {} in [tools.openai-compat.env] \
-                 or as an environment variable.",
-                ENV_API_KEY
+                "OpenAI-compat API key not configured. Set {ENV_API_KEY} in [tools.openai-compat.env] \
+                 or as an environment variable."
             )
         })?;
 
@@ -84,9 +82,8 @@ impl OpenaiCompatTransport {
             .or_else(|| self.default_model.clone())
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "OpenAI-compat model not configured. Set {} in [tools.openai-compat.env], \
-                 use --model, or set default_model in [tools.openai-compat].",
-                    ENV_MODEL
+                    "OpenAI-compat model not configured. Set {ENV_MODEL} in [tools.openai-compat.env], \
+                 use --model, or set default_model in [tools.openai-compat]."
                 )
             })?;
 

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -460,7 +460,7 @@ fn test_inject_api_key_fallback_promotes_key_and_removes_internal() {
     env.insert("OTHER_VAR".to_string(), "keep".to_string());
     let result = LegacyTransport::inject_api_key_fallback(Some(&env)).unwrap();
     assert_eq!(result.get("GEMINI_API_KEY").unwrap(), "test-api-key-123");
-    assert!(result.get("_CSA_API_KEY_FALLBACK").is_none());
+    assert!(!result.contains_key("_CSA_API_KEY_FALLBACK"));
     assert_eq!(result.get("OTHER_VAR").unwrap(), "keep");
 }
 

--- a/crates/csa-hooks/src/guard_tests.rs
+++ b/crates/csa-hooks/src/guard_tests.rs
@@ -443,8 +443,7 @@ mod unix_tests {
                     .collect();
                 assert!(
                     live_pids.is_empty(),
-                    "Escaped descendant should be killed after timeout, found PIDs: {:?}",
-                    live_pids
+                    "Escaped descendant should be killed after timeout, found PIDs: {live_pids:?}"
                 );
             }
             Err(_) => {

--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -170,7 +170,7 @@ fn acquire_lock_at_path(lock_path: &Path, lock_name: &str, reason: &str) -> Resu
 /// - Returns error with diagnostic information
 pub fn acquire_lock(session_dir: &Path, tool_name: &str, reason: &str) -> Result<SessionLock> {
     let locks_dir = session_dir.join("locks");
-    let lock_path = locks_dir.join(format!("{}.lock", tool_name));
+    let lock_path = locks_dir.join(format!("{tool_name}.lock"));
     acquire_lock_at_path(&lock_path, tool_name, reason)
 }
 
@@ -359,7 +359,7 @@ mod tests {
 
         let lock = acquire_lock(session_dir, "debug-tool", "test").expect("Lock should succeed");
 
-        let debug = format!("{:?}", lock);
+        let debug = format!("{lock:?}");
         assert!(debug.contains("SessionLock"));
         assert!(debug.contains("lock_path"));
     }

--- a/crates/csa-lock/src/slot.rs
+++ b/crates/csa-lock/src/slot.rs
@@ -128,7 +128,7 @@ pub fn try_acquire_slot(
         .with_context(|| format!("Failed to create slot directory: {}", tool_dir.display()))?;
 
     for index in 0..max_concurrent {
-        let slot_path = tool_dir.join(format!("slot-{:02}.lock", index));
+        let slot_path = tool_dir.join(format!("slot-{index:02}.lock"));
 
         let file = OpenOptions::new()
             .read(true)
@@ -210,11 +210,7 @@ pub fn acquire_slot_blocking(
         }
 
         if start.elapsed() >= timeout {
-            anyhow::bail!(
-                "Timed out waiting for slot '{}' after {:?}",
-                tool_name,
-                timeout
-            );
+            anyhow::bail!("Timed out waiting for slot '{tool_name}' after {timeout:?}");
         }
 
         std::thread::sleep(Duration::from_millis(sleep_ms));
@@ -233,7 +229,7 @@ pub fn slot_usage(slots_dir: &Path, tools: &[(&str, u32)]) -> Vec<SlotStatus> {
             let mut occupied = 0u32;
 
             for index in 0..*max {
-                let slot_path = tool_dir.join(format!("slot-{:02}.lock", index));
+                let slot_path = tool_dir.join(format!("slot-{index:02}.lock"));
                 if let Ok(file) = OpenOptions::new().read(true).write(false).open(&slot_path) {
                     let fd = file.as_raw_fd();
                     // SAFETY: `fd` is valid. LOCK_EX | LOCK_NB to probe.

--- a/crates/csa-mcp-hub/src/serve.rs
+++ b/crates/csa-mcp-hub/src/serve.rs
@@ -237,7 +237,7 @@ impl HttpEndpoint {
 
         let listener = tokio::net::TcpListener::bind(bind_addr)
             .await
-            .with_context(|| format!("failed to bind mcp-hub HTTP endpoint at {}", bind_addr))?;
+            .with_context(|| format!("failed to bind mcp-hub HTTP endpoint at {bind_addr}"))?;
         let local_addr = listener
             .local_addr()
             .context("failed to resolve local mcp-hub HTTP address")?;

--- a/crates/csa-process/src/lib.rs
+++ b/crates/csa-process/src/lib.rs
@@ -460,8 +460,7 @@ pub async fn wait_and_capture_with_idle_timeout(
         liveness_dead_timeout.as_secs()
     );
     let workspace_boundary_note = format!(
-        "workspace boundary timeout: detected {} repeated boundary errors ('Path not in workspace'); process killed",
-        WORKSPACE_BOUNDARY_ERROR_THRESHOLD
+        "workspace boundary timeout: detected {WORKSPACE_BOUNDARY_ERROR_THRESHOLD} repeated boundary errors ('Path not in workspace'); process killed"
     );
 
     if let Some(stderr_handle) = stderr {

--- a/crates/csa-process/src/lib_subprocess_helpers.rs
+++ b/crates/csa-process/src/lib_subprocess_helpers.rs
@@ -40,7 +40,7 @@ pub async fn check_tool_installed(executable: &str) -> Result<()> {
         .context("Failed to execute 'which' command")?;
 
     if !output.status.success() {
-        anyhow::bail!("Tool '{}' is not installed or not in PATH", executable);
+        anyhow::bail!("Tool '{executable}' is not installed or not in PATH");
     }
 
     Ok(())

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -407,7 +407,7 @@ mod tests {
         let own_pid = std::process::id();
         fs::write(
             locks_dir.join("tool.lock"),
-            format!("{{\"pid\": {}}}", own_pid),
+            format!("{{\"pid\": {own_pid}}}"),
         )
         .expect("write lock");
 

--- a/crates/csa-resource/src/guard.rs
+++ b/crates/csa-resource/src/guard.rs
@@ -51,14 +51,9 @@ impl ResourceGuard {
 
         if available_total < reserve {
             bail!(
-                "OOM Risk Prevention: Not enough memory to launch '{}'.\n\
-                Available: {} MB (physical {} + swap {}), Reserve: {} MB\n\
+                "OOM Risk Prevention: Not enough memory to launch '{tool_name}'.\n\
+                Available: {available_total} MB (physical {available_phys} + swap {available_swap}), Reserve: {reserve} MB\n\
                 (Try closing other apps or wait for running agents to finish)",
-                tool_name,
-                available_total,
-                available_phys,
-                available_swap,
-                reserve,
             );
         }
 
@@ -85,7 +80,7 @@ mod tests {
         let mut guard = ResourceGuard::new(limits);
         let result = guard.check_availability("test_tool");
         // 1 MB reserve — any running system has this.
-        assert!(result.is_ok(), "check_availability failed: {:?}", result);
+        assert!(result.is_ok(), "check_availability failed: {result:?}");
     }
 
     #[test]
@@ -99,8 +94,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("OOM Risk Prevention"),
-            "Expected OOM error, got: {}",
-            err_msg
+            "Expected OOM error, got: {err_msg}"
         );
     }
 
@@ -115,8 +109,7 @@ mod tests {
         let result = guard.check_availability("threshold_tool");
         assert!(
             result.is_ok(),
-            "2 MB reserve should pass on any system: {:?}",
-            result,
+            "2 MB reserve should pass on any system: {result:?}",
         );
     }
 
@@ -137,6 +130,6 @@ mod tests {
 
         // The check should pass because combined >= 1 MB
         let result = guard.check_availability("swap_tool");
-        assert!(result.is_ok(), "combined {} MB should be >= 1 MB", combined);
+        assert!(result.is_ok(), "combined {combined} MB should be >= 1 MB");
     }
 }

--- a/crates/csa-resource/src/memory_balloon.rs
+++ b/crates/csa-resource/src/memory_balloon.rs
@@ -53,9 +53,7 @@ impl MemoryBalloon {
 
         if size_bytes as u64 > MAX_BALLOON_SIZE {
             bail!(
-                "balloon size {} bytes exceeds hard limit of {} bytes (16 GiB)",
-                size_bytes,
-                MAX_BALLOON_SIZE
+                "balloon size {size_bytes} bytes exceeds hard limit of {MAX_BALLOON_SIZE} bytes (16 GiB)"
             );
         }
 
@@ -75,7 +73,7 @@ impl MemoryBalloon {
 
         if ptr == libc::MAP_FAILED {
             return Err(std::io::Error::last_os_error())
-                .context(format!("mmap({} bytes) failed", size_bytes));
+                .context(format!("mmap({size_bytes} bytes) failed"));
         }
 
         Ok(Self {

--- a/crates/csa-resource/src/rlimit.rs
+++ b/crates/csa-resource/src/rlimit.rs
@@ -34,7 +34,7 @@ pub fn apply_rlimits(_memory_max_mb: u64, pids_max: Option<u64>) -> Result<()> {
         let ret = unsafe { libc::setrlimit(libc::RLIMIT_NPROC, &rlim_nproc) };
         if ret != 0 {
             return Err(std::io::Error::last_os_error())
-                .context(format!("setrlimit(RLIMIT_NPROC, {}) failed", nproc));
+                .context(format!("setrlimit(RLIMIT_NPROC, {nproc}) failed"));
         }
     }
 

--- a/crates/csa-scheduler/src/failover.rs
+++ b/crates/csa-scheduler/src/failover.rs
@@ -58,7 +58,7 @@ pub fn decide_failover(
         Some(t) => t,
         None => {
             return FailoverAction::ReportError {
-                reason: format!("Tier '{}' not found in config", tier_name),
+                reason: format!("Tier '{tier_name}' not found in config"),
                 original_error: original_error.to_string(),
             };
         }
@@ -88,7 +88,7 @@ pub fn decide_failover(
 
     if alternatives.is_empty() {
         return FailoverAction::ReportError {
-            reason: format!("All tools in tier '{}' exhausted", tier_name),
+            reason: format!("All tools in tier '{tier_name}' exhausted"),
             original_error: original_error.to_string(),
         };
     }
@@ -304,7 +304,7 @@ mod tests {
             FailoverAction::RetrySiblingSession { new_tool, .. } => {
                 assert_eq!(new_tool, "codex");
             }
-            other => panic!("Expected RetrySiblingSession, got {:?}", other),
+            other => panic!("Expected RetrySiblingSession, got {other:?}"),
         }
     }
 
@@ -324,7 +324,7 @@ mod tests {
             FailoverAction::ReportError { reason, .. } => {
                 assert!(reason.contains("exhausted"));
             }
-            other => panic!("Expected ReportError, got {:?}", other),
+            other => panic!("Expected ReportError, got {other:?}"),
         }
     }
 
@@ -351,7 +351,7 @@ mod tests {
                 assert_eq!(new_tool, "codex");
                 assert_eq!(session_id, session.meta_session_id);
             }
-            other => panic!("Expected RetryInSession, got {:?}", other),
+            other => panic!("Expected RetryInSession, got {other:?}"),
         }
     }
 
@@ -392,7 +392,7 @@ mod tests {
             FailoverAction::RetrySiblingSession { new_tool, .. } => {
                 assert_eq!(new_tool, "codex");
             }
-            other => panic!("Expected RetrySiblingSession, got {:?}", other),
+            other => panic!("Expected RetrySiblingSession, got {other:?}"),
         }
     }
 
@@ -412,7 +412,7 @@ mod tests {
             FailoverAction::RetrySiblingSession { new_tool, .. } => {
                 assert_eq!(new_tool, "gemini-cli");
             }
-            other => panic!("Expected RetrySiblingSession, got {:?}", other),
+            other => panic!("Expected RetrySiblingSession, got {other:?}"),
         }
     }
 
@@ -434,7 +434,7 @@ mod tests {
             FailoverAction::RetrySiblingSession { new_tool, .. } => {
                 assert_eq!(new_tool, "codex");
             }
-            other => panic!("Expected RetrySiblingSession, got {:?}", other),
+            other => panic!("Expected RetrySiblingSession, got {other:?}"),
         }
     }
 
@@ -461,7 +461,7 @@ mod tests {
             FailoverAction::RetrySiblingSession { new_tool, .. } => {
                 assert_eq!(new_tool, "claude-code");
             }
-            other => panic!("Expected RetrySiblingSession, got {:?}", other),
+            other => panic!("Expected RetrySiblingSession, got {other:?}"),
         }
     }
 
@@ -484,10 +484,10 @@ mod tests {
         );
         match action {
             FailoverAction::ReportError { reason, .. } => {
-                assert!(reason.contains("tier99"), "reason: {}", reason);
-                assert!(reason.contains("not found"), "reason: {}", reason);
+                assert!(reason.contains("tier99"), "reason: {reason}");
+                assert!(reason.contains("not found"), "reason: {reason}");
             }
-            other => panic!("Expected ReportError, got {:?}", other),
+            other => panic!("Expected ReportError, got {other:?}"),
         }
     }
 
@@ -516,7 +516,7 @@ mod tests {
             FailoverAction::RetrySiblingSession { new_tool, .. } => {
                 assert_eq!(new_tool, "codex");
             }
-            other => panic!("Expected RetrySiblingSession, got {:?}", other),
+            other => panic!("Expected RetrySiblingSession, got {other:?}"),
         }
     }
 
@@ -545,7 +545,7 @@ mod tests {
             FailoverAction::RetrySiblingSession { new_tool, .. } => {
                 assert_eq!(new_tool, "codex");
             }
-            other => panic!("Expected RetrySiblingSession, got {:?}", other),
+            other => panic!("Expected RetrySiblingSession, got {other:?}"),
         }
     }
 
@@ -566,7 +566,7 @@ mod tests {
             FailoverAction::RetrySiblingSession { new_tool, .. } => {
                 assert_eq!(new_tool, "codex");
             }
-            other => panic!("Expected RetrySiblingSession, got {:?}", other),
+            other => panic!("Expected RetrySiblingSession, got {other:?}"),
         }
     }
 
@@ -662,13 +662,9 @@ mod tests {
                 new_model_spec,
             } => {
                 assert_eq!(new_tool, "claude-code");
-                assert!(
-                    new_model_spec.contains("claude"),
-                    "spec: {}",
-                    new_model_spec
-                );
+                assert!(new_model_spec.contains("claude"), "spec: {new_model_spec}");
             }
-            other => panic!("Expected RetrySiblingSession to claude, got {:?}", other),
+            other => panic!("Expected RetrySiblingSession to claude, got {other:?}"),
         }
     }
 
@@ -698,12 +694,9 @@ mod tests {
                 new_model_spec,
             } => {
                 assert_eq!(new_tool, "claude-code");
-                assert!(new_model_spec.contains("haiku"), "spec: {}", new_model_spec);
+                assert!(new_model_spec.contains("haiku"), "spec: {new_model_spec}");
             }
-            other => panic!(
-                "Expected RetrySiblingSession to claude-haiku, got {:?}",
-                other
-            ),
+            other => panic!("Expected RetrySiblingSession to claude-haiku, got {other:?}"),
         }
     }
 
@@ -743,10 +736,7 @@ mod tests {
                 // Also acceptable if slot happens to be free
             }
             FailoverAction::ReportError { reason, .. } => {
-                panic!(
-                    "Should not report error when alternatives exist: {}",
-                    reason
-                );
+                panic!("Should not report error when alternatives exist: {reason}");
             }
         }
     }

--- a/crates/csa-scheduler/src/rate_limit.rs
+++ b/crates/csa-scheduler/src/rate_limit.rs
@@ -29,7 +29,7 @@ pub fn detect_rate_limit(
         return None;
     }
 
-    let combined = format!("{}\n{}", stderr, stdout);
+    let combined = format!("{stderr}\n{stdout}");
     let patterns = patterns_for_tool(tool_name);
 
     for pattern in patterns {

--- a/crates/csa-scheduler/src/session_reuse.rs
+++ b/crates/csa-scheduler/src/session_reuse.rs
@@ -157,7 +157,7 @@ mod tests {
 
         let score = compute_relevance_score(&session, "default", "gemini-cli");
         // Base (0.3) + recency (~0.2 for just-now)
-        assert!(score > 0.4 && score < 0.6, "score was {}", score);
+        assert!(score > 0.4 && score < 0.6, "score was {score}");
     }
 
     #[test]
@@ -193,7 +193,7 @@ mod tests {
 
         let score = compute_relevance_score(&session, "review", "gemini-cli");
         // Base (0.3) + exact match (1.0) + recency (~0.2)
-        assert!(score > 1.4, "score was {}", score);
+        assert!(score > 1.4, "score was {score}");
     }
 
     #[test]
@@ -229,7 +229,7 @@ mod tests {
 
         let score = compute_relevance_score(&session, "fix", "gemini-cli");
         // Base (0.3) + related match (0.5) + recency (~0.2) ≈ 1.0
-        assert!(score > 0.9 && score < 1.1, "score was {}", score);
+        assert!(score > 0.9 && score < 1.1, "score was {score}");
     }
 
     #[test]
@@ -265,7 +265,7 @@ mod tests {
 
         let score = compute_relevance_score(&session, "deploy", "gemini-cli");
         // Base (0.3) + no match (0.0) + recency (~0.2) ≈ 0.5
-        assert!(score > 0.4 && score < 0.6, "score was {}", score);
+        assert!(score > 0.4 && score < 0.6, "score was {score}");
     }
 
     #[test]
@@ -301,8 +301,7 @@ mod tests {
         // Base (0.3) + no task match (0.0) + recency (0.0 for 48h old)
         assert!(
             (0.3..0.35).contains(&score),
-            "Old session score should be near base 0.3, was {}",
-            score
+            "Old session score should be near base 0.3, was {score}"
         );
     }
 

--- a/crates/csa-session/src/checkpoint.rs
+++ b/crates/csa-session/src/checkpoint.rs
@@ -77,7 +77,7 @@ pub fn write_checkpoint(sessions_dir: &Path, note: &CheckpointNote) -> Result<()
 
 /// Find the most recent commit that modified a session's directory.
 fn find_session_commit(sessions_dir: &Path, session_id: &str) -> Result<String> {
-    let session_path = format!("{}/", session_id);
+    let session_path = format!("{session_id}/");
 
     let output = Command::new("git")
         .args(["log", "-1", "--format=%H", "--", &session_path])
@@ -94,10 +94,7 @@ fn find_session_commit(sessions_dir: &Path, session_id: &str) -> Result<String> 
 
     let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if sha.is_empty() {
-        anyhow::bail!(
-            "No commits found for session '{}' — commit the session first",
-            session_id
-        );
+        anyhow::bail!("No commits found for session '{session_id}' — commit the session first");
     }
 
     Ok(sha)

--- a/crates/csa-session/src/genealogy.rs
+++ b/crates/csa-session/src/genealogy.rs
@@ -176,14 +176,10 @@ fn format_session_tree(
     let description = session.description.as_deref().unwrap_or("<no description>");
 
     if fork_marker.is_empty() {
-        output.push_str(&format!(
-            "{}{}  {}  {}\n",
-            prefix, short_id, tools_str, description
-        ));
+        output.push_str(&format!("{prefix}{short_id}  {tools_str}  {description}\n"));
     } else {
         output.push_str(&format!(
-            "{}{}  {}  {}  {}\n",
-            prefix, short_id, tools_str, description, fork_marker
+            "{prefix}{short_id}  {tools_str}  {description}  {fork_marker}\n"
         ));
     }
 
@@ -458,8 +454,7 @@ mod tests {
 
         assert!(
             tree.contains("\u{21B1} fork"),
-            "Tree should contain fork marker. Got:\n{}",
-            tree
+            "Tree should contain fork marker. Got:\n{tree}"
         );
         assert!(tree.contains("Spawn child"));
         assert!(tree.contains("Parent"));
@@ -497,8 +492,7 @@ mod tests {
 
         assert!(
             tree.contains("\u{21B1} fork"),
-            "Tree should contain fork marker. Got:\n{}",
-            tree
+            "Tree should contain fork marker. Got:\n{tree}"
         );
     }
 
@@ -566,16 +560,14 @@ mod tests {
         assert_eq!(
             root_lines.len(),
             1,
-            "Should have exactly 1 root. Got:\n{}",
-            tree
+            "Should have exactly 1 root. Got:\n{tree}"
         );
 
         // Two fork markers
         let fork_marker_count = tree.matches("\u{21B1} fork").count();
         assert_eq!(
             fork_marker_count, 2,
-            "Should have 2 fork markers. Got:\n{}",
-            tree
+            "Should have 2 fork markers. Got:\n{tree}"
         );
     }
 }

--- a/crates/csa-session/src/git.rs
+++ b/crates/csa-session/src/git.rs
@@ -73,7 +73,7 @@ pub fn commit_session(sessions_dir: &Path, session_id: &str, message: &str) -> R
     ensure_git_init(sessions_dir)?;
 
     // Stage the session's files (use `--` to prevent option injection)
-    let session_path = format!("{}/", session_id);
+    let session_path = format!("{session_id}/");
     let output = Command::new("git")
         .args(["add", "--", &session_path])
         .current_dir(sessions_dir)
@@ -157,7 +157,7 @@ pub fn history(sessions_dir: &Path, session_id: &str) -> Result<String> {
         return Ok(String::new()); // No commits yet
     }
 
-    let session_path = format!("{}/", session_id);
+    let session_path = format!("{session_id}/");
 
     let output = Command::new("git")
         .args(["log", "--oneline", "--follow", "--", &session_path])

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -186,7 +186,7 @@ pub(crate) fn load_session_in(base_dir: &Path, session_id: &str) -> Result<MetaS
     let state_path = session_dir.join(STATE_FILE_NAME);
 
     if !state_path.exists() {
-        bail!("Session '{}' not found", session_id);
+        bail!("Session '{session_id}' not found");
     }
 
     let contents = fs::read_to_string(&state_path)
@@ -231,7 +231,7 @@ pub(crate) fn delete_session_in(base_dir: &Path, session_id: &str) -> Result<()>
     let session_dir = get_session_dir_in(base_dir, session_id);
 
     if !session_dir.exists() {
-        bail!("Session '{}' not found", session_id);
+        bail!("Session '{session_id}' not found");
     }
 
     fs::remove_dir_all(&session_dir).with_context(|| {

--- a/crates/csa-session/src/manager_tests_tail.rs
+++ b/crates/csa-session/src/manager_tests_tail.rs
@@ -456,7 +456,7 @@ fn run_git(dir: &std::path::Path, args: &[&str]) {
         .current_dir(dir)
         .status()
         .unwrap();
-    assert!(status.success(), "git {:?} failed", args);
+    assert!(status.success(), "git {args:?} failed");
 }
 
 #[test]

--- a/crates/csa-session/src/output_section.rs
+++ b/crates/csa-session/src/output_section.rs
@@ -118,8 +118,7 @@ impl ReturnPacket {
     pub fn validate(&self) -> Result<()> {
         if self.summary.chars().count() > RETURN_PACKET_MAX_SUMMARY_CHARS {
             return Err(anyhow!(
-                "return packet summary exceeds {} chars",
-                RETURN_PACKET_MAX_SUMMARY_CHARS
+                "return packet summary exceeds {RETURN_PACKET_MAX_SUMMARY_CHARS} chars"
             ));
         }
 

--- a/crates/csa-session/src/soft_fork_tests.rs
+++ b/crates/csa-session/src/soft_fork_tests.rs
@@ -82,8 +82,7 @@ fn test_soft_fork_truncation_on_large_summary() {
     let estimated = estimate_tokens(&ctx.context_summary);
     assert!(
         estimated <= SUMMARY_TOKEN_BUDGET + 50, // small margin for the wrapper text
-        "Summary should be within budget, got {} tokens",
-        estimated
+        "Summary should be within budget, got {estimated} tokens"
     );
     assert!(ctx.context_summary.contains("[truncated]"));
 }

--- a/crates/csa-session/src/state.rs
+++ b/crates/csa-session/src/state.rs
@@ -329,10 +329,7 @@ impl SessionPhase {
             (SessionPhase::Active, PhaseEvent::Retired) => Ok(SessionPhase::Retired),
             (SessionPhase::Available, PhaseEvent::Resumed) => Ok(SessionPhase::Active),
             (SessionPhase::Available, PhaseEvent::Retired) => Ok(SessionPhase::Retired),
-            (current, event) => Err(format!(
-                "invalid phase transition: {:?} + {:?}",
-                current, event
-            )),
+            (current, event) => Err(format!("invalid phase transition: {current:?} + {event:?}")),
         }
     }
 }

--- a/crates/csa-session/src/validate.rs
+++ b/crates/csa-session/src/validate.rs
@@ -20,7 +20,7 @@ pub fn validate_session_id(id: &str) -> Result<()> {
 
     // Try to parse as ULID
     ulid::Ulid::from_string(id)
-        .with_context(|| format!("Invalid session ID '{}': not a valid ULID", id))?;
+        .with_context(|| format!("Invalid session ID '{id}': not a valid ULID"))?;
 
     Ok(())
 }
@@ -31,7 +31,7 @@ pub fn validate_session_id(id: &str) -> Result<()> {
 /// Returns an error if 0 or more than 1 match is found.
 pub fn resolve_session_prefix(sessions_dir: &Path, prefix: &str) -> Result<String> {
     if !sessions_dir.exists() {
-        bail!("No session matching prefix '{}'", prefix);
+        bail!("No session matching prefix '{prefix}'");
     }
 
     let entries = std::fs::read_dir(sessions_dir).with_context(|| {
@@ -58,7 +58,7 @@ pub fn resolve_session_prefix(sessions_dir: &Path, prefix: &str) -> Result<Strin
     }
 
     match matches.len() {
-        0 => bail!("No session matching prefix '{}'", prefix),
+        0 => bail!("No session matching prefix '{prefix}'"),
         1 => Ok(matches.into_iter().next().unwrap()),
         _ => bail!(
             "Ambiguous session prefix '{}': matches multiple sessions: {}",

--- a/crates/csa-todo/src/git.rs
+++ b/crates/csa-todo/src/git.rs
@@ -298,7 +298,7 @@ pub fn diff(todos_dir: &Path, timestamp: &str, revision: Option<&str>) -> Result
         anyhow::bail!("No git repository in todos directory (run `csa todo save` first)");
     }
 
-    let file_path = format!("{}/TODO.md", timestamp);
+    let file_path = format!("{timestamp}/TODO.md");
 
     let rev = match revision {
         Some(r) => {
@@ -419,7 +419,7 @@ pub fn history(todos_dir: &Path, timestamp: &str) -> Result<String> {
         anyhow::bail!("No git repository in todos directory (run `csa todo save` first)");
     }
 
-    let plan_prefix = format!("{}/", timestamp);
+    let plan_prefix = format!("{timestamp}/");
 
     let output = Command::new("git")
         .args(["log", "--oneline", "--", &plan_prefix])
@@ -450,7 +450,7 @@ pub fn list_versions(todos_dir: &Path, timestamp: &str) -> Result<Vec<String>> {
 
     // Track TODO.md specifically — versions correspond to document changes,
     // not metadata-only commits (which show in `history` instead).
-    let file_path = format!("{}/TODO.md", timestamp);
+    let file_path = format!("{timestamp}/TODO.md");
 
     let output = Command::new("git")
         .args(["log", "--format=%H", "--", &file_path])
@@ -495,7 +495,7 @@ pub fn show_version(todos_dir: &Path, timestamp: &str, version: usize) -> Result
     }
 
     let hash = &versions[idx];
-    let file_path = format!("{}/TODO.md", timestamp);
+    let file_path = format!("{timestamp}/TODO.md");
 
     let output = Command::new("git")
         .args(["show", &format!("{hash}:{file_path}")])
@@ -539,7 +539,7 @@ pub fn diff_versions(
 
     let from_hash = &versions[from_version - 1];
     let to_hash = &versions[to_version - 1];
-    let file_path = format!("{}/TODO.md", timestamp);
+    let file_path = format!("{timestamp}/TODO.md");
 
     let output = Command::new("git")
         .args(["diff", from_hash, to_hash, "--", &file_path])
@@ -763,7 +763,7 @@ mod tests {
         .unwrap();
 
         // save_file only the metadata — TODO.md should remain dirty
-        let file_path = format!("{}/metadata.toml", ts);
+        let file_path = format!("{ts}/metadata.toml");
         save_file(todos, ts, &file_path, "metadata only").unwrap();
 
         let status = Command::new("git")

--- a/crates/csa-todo/src/git_ext_tests.rs
+++ b/crates/csa-todo/src/git_ext_tests.rs
@@ -143,7 +143,7 @@ fn test_list_versions_metadata_only_commit_excluded() {
         "title = \"changed\"\nstatus = \"approved\"\n",
     )
     .unwrap();
-    let meta_path = format!("{}/metadata.toml", ts);
+    let meta_path = format!("{ts}/metadata.toml");
     save_file(todos, ts, &meta_path, "metadata update").unwrap();
 
     let versions = list_versions(todos, ts).unwrap();

--- a/patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md
+++ b/patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md
@@ -17,7 +17,7 @@ triggers:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/ai-reviewed-commit/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/patterns/code-review/skills/code-review/SKILL.md
+++ b/patterns/code-review/skills/code-review/SKILL.md
@@ -17,7 +17,7 @@ triggers:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/code-review/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/patterns/codebase-audit/skills/codebase-audit/SKILL.md
+++ b/patterns/codebase-audit/skills/codebase-audit/SKILL.md
@@ -17,7 +17,7 @@ triggers:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/codebase-audit/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/patterns/codebase-blog/skills/codebase-blog/SKILL.md
+++ b/patterns/codebase-blog/skills/codebase-blog/SKILL.md
@@ -18,7 +18,7 @@ triggers:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/codebase-blog/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/patterns/commit/skills/commit/SKILL.md
+++ b/patterns/commit/skills/commit/SKILL.md
@@ -16,7 +16,7 @@ triggers:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/commit/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/patterns/csa-issue-reporter/skills/csa-issue-reporter/SKILL.md
+++ b/patterns/csa-issue-reporter/skills/csa-issue-reporter/SKILL.md
@@ -17,7 +17,7 @@ triggers:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/csa-issue-reporter/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -21,7 +21,7 @@ Treat the run as executor ONLY when initial prompt contains:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/dev2merge/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **RECURSION GUARD**: Do NOT run `csa run --skill dev2merge` or `csa run --skill dev-to-merge` from inside this skill. Other `csa` commands required by the workflow (for example `csa run --skill mktd`, `csa run --skill mktsk`, `csa review`, `csa debate`) are allowed.
 
 **Only if you are the main agent (Claude Code / human user)**:
@@ -71,7 +71,7 @@ When operating under SA mode (e.g., dispatched by `/sa` or any autonomous workfl
 
 ### Pipeline Steps
 
-The workflow is compiled from `patterns/dev2merge/PATTERN.md` into `workflow.toml`.
+The workflow is compiled from the companion `../../PATTERN.md` file (relative to this `SKILL.md`) into `workflow.toml`.
 All steps use `on_fail = "abort"`. Variables propagate via `CSA_VAR:KEY=value`.
 
 | Step | Name | Gate | Tool |

--- a/patterns/file-audit/skills/file-audit/SKILL.md
+++ b/patterns/file-audit/skills/file-audit/SKILL.md
@@ -17,7 +17,7 @@ triggers:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/file-audit/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/patterns/migrate/skills/migrate/SKILL.md
+++ b/patterns/migrate/skills/migrate/SKILL.md
@@ -40,6 +40,6 @@ file that tracks applied migrations.
 
 ## Adding New Migrations
 
-Read the pattern at `patterns/migrate/PATTERN.md` for the full migration
+Read the pattern at `../../PATTERN.md` relative to this `SKILL.md` for the full migration
 definition format, version numbering scheme, testing requirements, and
 code templates.

--- a/patterns/mktd/skills/mktd/SKILL.md
+++ b/patterns/mktd/skills/mktd/SKILL.md
@@ -20,7 +20,7 @@ Treat the run as executor ONLY when initial prompt contains:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/mktd/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/patterns/mktsk/skills/mktsk/SKILL.md
+++ b/patterns/mktsk/skills/mktsk/SKILL.md
@@ -18,7 +18,7 @@ triggers:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/mktsk/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/patterns/pr-codex-bot/skills/pr-codex-bot/SKILL.md
+++ b/patterns/pr-codex-bot/skills/pr-codex-bot/SKILL.md
@@ -18,7 +18,7 @@ triggers:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/pr-codex-bot/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/patterns/security-audit/skills/security-audit/SKILL.md
+++ b/patterns/security-audit/skills/security-audit/SKILL.md
@@ -17,7 +17,7 @@ triggers:
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator, not you.
-2. **Read the pattern** at `patterns/security-audit/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`, or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa` command causes infinite recursion.
 
 **Only if you are the main agent (Claude Code / human user)**:

--- a/skills/pattern-creator/references/architecture.md
+++ b/skills/pattern-creator/references/architecture.md
@@ -60,7 +60,7 @@ would spawn another, creating infinite recursion.
 
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator.
-2. **Read the pattern** at `patterns/<name>/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`,
    or ANY `csa` command. You must perform the work DIRECTLY.
 ```

--- a/skills/pattern-creator/references/companion-skill.md
+++ b/skills/pattern-creator/references/companion-skill.md
@@ -27,7 +27,7 @@ triggers:
 **YOU ARE THE EXECUTOR.** Follow these rules:
 1. **SKIP the "Execution Protocol" section below** -- it is for the orchestrator,
    not you.
-2. **Read the pattern** at `patterns/<name>/PATTERN.md` and follow it step by step.
+2. **Read the pattern** at `../../PATTERN.md` relative to this `SKILL.md`, and follow it step by step.
 3. **ABSOLUTE PROHIBITION**: Do NOT run `csa run`, `csa review`, `csa debate`,
    or ANY `csa` command. You must perform the work DIRECTLY. Running any `csa`
    command causes infinite recursion.
@@ -134,7 +134,7 @@ When CSA spawns an executor with `--skill <name>`:
 2. Reads `skills/<name>/SKILL.md` content
 3. Injects it into the executor's initial prompt with `"Use the <name> skill"`
 4. Executor sees the literal string, enters executor mode
-5. Executor reads `patterns/<name>/PATTERN.md` and follows steps
+5. Executor reads `../../PATTERN.md` relative to `skills/<name>/SKILL.md` and follows steps
 6. Executor performs all work DIRECTLY (no `csa` delegation)
 
 This is why the "ABSOLUTE PROHIBITION" on `csa` commands exists in executor


### PR DESCRIPTION
## Summary

- Fix PATTERN.md path resolution in all companion SKILL.md files (closes #397)
- Changed hardcoded workspace-relative paths (`patterns/<name>/PATTERN.md`) to relative paths (`../../PATTERN.md`) so skills work correctly when installed via weave packages
- Applies modern Rust inline format string style across codebase (Rust 1.58+)
- Version bump: 0.1.116 → 0.1.117

## Affected Skills

All pattern-companion skills: mktsk, mktd, commit, dev2merge, code-review, csa-issue-reporter, file-audit, pr-codex-bot, security-audit, ai-reviewed-commit, codebase-audit, codebase-blog, migrate, pattern-creator

## Test plan

- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` → CLEAN
- [ ] Verify skill executor can resolve PATTERN.md in weave-installed package

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)