### PR TITLE
fix(workflow): add deterministic post-PR-create hook (#399)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "axum",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -969,7 +969,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1038,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1105,7 +1105,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2132,7 +2132,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2793,7 +2793,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2806,7 +2806,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3444,7 +3444,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.117"
+version = "0.1.118"
 dependencies = [
  "anyhow",
  "clap",
@@ -4188,7 +4188,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4414,15 +4414,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.117"
+version = "0.1.118"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/justfile
+++ b/justfile
@@ -198,26 +198,32 @@ review:
     @echo ""
     @echo "Review the above before committing."
 
-# Reviewed push: run csa review --range base...HEAD, then push and create PR.
-# Enforces the mandatory pre-push review (see GitHub issue #276).
+# Reviewed push: run csa review --range base...HEAD, then push, create/reuse PR,
+# and synchronously trigger the post-create review transaction.
 push-reviewed base="main":
     #!/usr/bin/env bash
     set -euo pipefail
+    if [ "{{base}}" != "main" ]; then
+        echo "ERROR: push-reviewed currently supports base=main only."
+        exit 1
+    fi
     echo "=== Pre-push review: csa review --sa-mode false --range {{base}}...HEAD ==="
     csa review --sa-mode false --range "{{base}}...HEAD"
     echo "=== Review passed. Pushing... ==="
     git push -u origin HEAD
-    echo "=== Creating PR targeting {{base}}... ==="
-    if ! gh pr create --base "{{base}}" 2>&1; then
-        # Only tolerate "already exists" — fail on other errors.
-        if gh pr view --json state -q '.state' 2>/dev/null | grep -qi 'open'; then
-            echo "PR already exists. Continuing."
-        else
-            echo "ERROR: gh pr create failed and no open PR found."
+    echo "=== Creating or reusing PR targeting {{base}}... ==="
+    set +e
+    CREATE_OUTPUT="$(gh pr create --base "{{base}}" 2>&1)"
+    CREATE_RC=$?
+    set -e
+    if [ "${CREATE_RC}" -ne 0 ]; then
+        if ! printf '%s\n' "${CREATE_OUTPUT}" | grep -Eiq 'already exists|a pull request already exists'; then
+            echo "ERROR: gh pr create failed: ${CREATE_OUTPUT}"
             exit 1
         fi
+        echo "PR already exists. Continuing with post-create helper."
     fi
-    echo "=== Done. Run /pr-codex-bot to complete the review loop. ==="
+    scripts/hooks/post-pr-create.sh --base "{{base}}"
 
 # Push to all submodules and the main repo (useful for monorepos).
 git-push-all:

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -333,41 +333,41 @@ This catches cross-commit issues that per-commit reviews might miss.
 csa review --range main...HEAD
 ```
 
-## Step 19: Auto PR
+## Step 19: Auto PR Transaction
 
 Tool: bash
 OnFail: abort
 
-Push and create PR when feature complete, bug fixed, or refactor done.
-Steps 18-19 are ATOMIC — do not stop after PR creation.
+Push, create or reuse the PR, then synchronously run the post-create helper.
+This makes PR creation + pr-codex-bot a single shell-enforced transaction.
 
 ```bash
+set -euo pipefail
 if [ -z "${COMMIT_SUBJECT:-}" ]; then
   echo "ERROR: PR title is empty." >&2
   exit 1
 fi
 
 git push -u origin "${BRANCH}"
-gh pr create --base main --title "${COMMIT_SUBJECT}" --body "${PR_BODY}"
+set +e
+CREATE_OUTPUT="$(gh pr create --base main --title "${COMMIT_SUBJECT}" --body "${PR_BODY}" 2>&1)"
+CREATE_RC=$?
+set -e
+if [ "${CREATE_RC}" -ne 0 ]; then
+  if ! printf '%s\n' "${CREATE_OUTPUT}" | grep -Eiq 'already exists|a pull request already exists'; then
+    echo "ERROR: gh pr create failed: ${CREATE_OUTPUT}" >&2
+    exit 1
+  fi
+  echo "INFO: PR already exists for ${BRANCH}; continuing with post-create helper."
+fi
+scripts/hooks/post-pr-create.sh --base main
 ```
-
-## Step 20: Invoke PR Codex Bot
-
-Tool: csa
-OnFail: abort
-
-run --skill pr-codex-bot
-
-## INCLUDE pr-codex-bot
-
-IMMEDIATELY invoke pr-codex-bot after PR creation.
-Handles local review, cloud bot trigger, false-positive arbitration, merge.
 
 ## ENDIF
 
 ## IF ${HAS_DEFERRED_ISSUES}
 
-## Step 21: Fix Deferred Issues
+## Step 20: Fix Deferred Issues
 
 Fix deferred issues by priority (Critical > High > Medium).
 Each fix goes through full commit workflow (Steps 1-17).

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -30,6 +30,12 @@ name = "COMMIT_SUBJECT"
 name = "COMMIT_SUBJECT_LOCAL"
 
 [[workflow.variables]]
+name = "CREATE_OUTPUT"
+
+[[workflow.variables]]
+name = "CREATE_RC"
+
+[[workflow.variables]]
 name = "CRITERIA_SUMMARY"
 
 [[workflow.variables]]
@@ -401,42 +407,38 @@ condition = "${IS_MILESTONE}"
 
 [[workflow.steps]]
 id = 22
-title = "Auto PR"
+title = "Auto PR Transaction"
 tool = "bash"
-prompt = """
-Push and create PR when feature complete, bug fixed, or refactor done.
-Steps 18-19 are ATOMIC — do not stop after PR creation.
+prompt = '''
+Push, create or reuse the PR, then synchronously run the post-create helper.
+This makes PR creation + pr-codex-bot a single shell-enforced transaction.
 
 ```bash
+set -euo pipefail
 if [ -z "${COMMIT_SUBJECT:-}" ]; then
   echo "ERROR: PR title is empty." >&2
   exit 1
 fi
 
 git push -u origin "${BRANCH}"
-gh pr create --base main --title "${COMMIT_SUBJECT}" --body "${PR_BODY}"
-```"""
+set +e
+CREATE_OUTPUT="$(gh pr create --base main --title "${COMMIT_SUBJECT}" --body "${PR_BODY}" 2>&1)"
+CREATE_RC=$?
+set -e
+if [ "${CREATE_RC}" -ne 0 ]; then
+  if ! printf '%s\n' "${CREATE_OUTPUT}" | grep -Eiq 'already exists|a pull request already exists'; then
+    echo "ERROR: gh pr create failed: ${CREATE_OUTPUT}" >&2
+    exit 1
+  fi
+  echo "INFO: PR already exists for ${BRANCH}; continuing with post-create helper."
+fi
+scripts/hooks/post-pr-create.sh --base main
+```'''
 on_fail = "abort"
 condition = "${IS_MILESTONE}"
 
 [[workflow.steps]]
 id = 23
-title = "Invoke PR Codex Bot"
-tool = "csa"
-prompt = "run --skill pr-codex-bot"
-on_fail = "abort"
-condition = "${IS_MILESTONE}"
-
-[[workflow.steps]]
-id = 24
-title = "Include pr-codex-bot"
-tool = "weave"
-prompt = "pr-codex-bot"
-on_fail = "abort"
-condition = "${IS_MILESTONE}"
-
-[[workflow.steps]]
-id = 25
 title = "Fix Deferred Issues"
 prompt = """
 Fix deferred issues by priority (Critical > High > Medium).

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -241,34 +241,31 @@ git push -u origin "${BRANCH}" --force-with-lease
 echo "CSA_VAR:PUSHED=true"
 ```
 
-## Step 12: Create Pull Request
+## Step 12: Create Pull Request Transaction
 
 Tool: bash
 OnFail: abort
 
-Create or reuse PR. Derives source owner from origin URL.
+Create or reuse PR, then synchronously run the post-create helper.
+This makes PR creation + pr-codex-bot a single shell-enforced transaction.
 
 ```bash
 set -euo pipefail
 BRANCH="$(git branch --show-current)"
-ORIGIN_URL="$(git remote get-url origin 2>/dev/null || true)"
-SOURCE_OWNER="$(printf '%s' "${ORIGIN_URL}" | sed -nE 's#(git@github\.com:|https://github\.com/)([^/]+)/.*#\2#p')"
-EXISTING_PR="$(gh pr list --state open --head "${SOURCE_OWNER}:${BRANCH}" --json number --jq '.[0].number' 2>/dev/null || true)"
-if [ -n "${EXISTING_PR}" ] && [ "${EXISTING_PR}" != "null" ]; then
-  echo "INFO: Reusing existing PR #${EXISTING_PR}."
-  echo "CSA_VAR:PR_NUMBER=${EXISTING_PR}"
-  exit 0
-fi
 COMMIT_SUBJECT="$(git log -1 --format=%s)"
-gh pr create --base main --title "${COMMIT_SUBJECT}" --body "Auto-created by dev2merge pipeline."
-NEW_PR="$(gh pr list --state open --head "${SOURCE_OWNER}:${BRANCH}" --json number --jq '.[0].number' 2>/dev/null || true)"
-echo "CSA_VAR:PR_NUMBER=${NEW_PR:-unknown}"
+set +e
+CREATE_OUTPUT="$(gh pr create --base main --title "${COMMIT_SUBJECT}" --body "Auto-created by dev2merge pipeline." 2>&1)"
+CREATE_RC=$?
+set -e
+if [ "${CREATE_RC}" -ne 0 ]; then
+  if ! printf '%s\n' "${CREATE_OUTPUT}" | grep -Eiq 'already exists|a pull request already exists'; then
+    echo "ERROR: gh pr create failed: ${CREATE_OUTPUT}" >&2
+    exit 1
+  fi
+  echo "INFO: PR already exists for ${BRANCH}; continuing with post-create helper."
+fi
+scripts/hooks/post-pr-create.sh --base main
 ```
-
-## INCLUDE pr-codex-bot
-
-Handles cloud review loop, false-positive arbitration, fix cycles, and merge.
-This is an atomic sub-workflow — it runs to completion or aborts.
 
 ## Step 13: Post-Merge Local Sync
 

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -15,13 +15,16 @@ name = "COMMIT_MSG"
 name = "COMMIT_SUBJECT"
 
 [[workflow.variables]]
+name = "CREATE_OUTPUT"
+
+[[workflow.variables]]
+name = "CREATE_RC"
+
+[[workflow.variables]]
 name = "CURRENT_BRANCH"
 
 [[workflow.variables]]
 name = "DEFAULT_BRANCH"
-
-[[workflow.variables]]
-name = "EXISTING_PR"
 
 [[workflow.variables]]
 name = "FAST_PATH"
@@ -45,9 +48,6 @@ name = "MKTD_TODO_TIMESTAMP"
 name = "MKTD_TOOL_EFFECTIVE"
 
 [[workflow.variables]]
-name = "ORIGIN_URL"
-
-[[workflow.variables]]
 name = "REMOTE_SHA"
 
 [[workflow.variables]]
@@ -58,9 +58,6 @@ name = "REVIEW_OUTPUT_FILE"
 
 [[workflow.variables]]
 name = "REVIEW_STATUS"
-
-[[workflow.variables]]
-name = "SOURCE_OWNER"
 
 [[workflow.variables]]
 name = "TODO_PATH"
@@ -112,7 +109,7 @@ skip mktd/mktsk/debate but keep L1/L2 quality checks.
 ```bash
 set -euo pipefail
 CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
-TOTAL_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oP '\d+ insertion' | grep -oP '\d+' || echo 0)"
+TOTAL_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
 if [ "${CODE_FILES}" -eq 0 ] && [ "${TOTAL_INSERTIONS:-0}" -lt 100 ]; then
   echo "FAST_PATH: docs/config-only changes detected. Skipping mktd/mktsk."
   echo "CSA_VAR:FAST_PATH=true"
@@ -315,45 +312,33 @@ on_fail = "abort"
 
 [[workflow.steps]]
 id = 12
-title = "Create Pull Request"
+title = "Create Pull Request Transaction"
 tool = "bash"
 prompt = '''
-Create or reuse PR. Derives source owner from origin URL.
+Create or reuse PR, then synchronously run the post-create helper.
+This makes PR creation + pr-codex-bot a single shell-enforced transaction.
 
 ```bash
 set -euo pipefail
 BRANCH="$(git branch --show-current)"
-ORIGIN_URL="$(git remote get-url origin 2>/dev/null || true)"
-SOURCE_OWNER="$(printf '%s' "${ORIGIN_URL}" | sed -nE 's#(git@github\.com:|https://github\.com/)([^/]+)/.*#\2#p')"
-EXISTING_PR="$(gh pr list --state open --head "${SOURCE_OWNER}:${BRANCH}" --json number --jq '.[0].number' 2>/dev/null || true)"
-if [ -n "${EXISTING_PR}" ] && [ "${EXISTING_PR}" != "null" ]; then
-  echo "INFO: Reusing existing PR #${EXISTING_PR}."
-  echo "CSA_VAR:PR_NUMBER=${EXISTING_PR}"
-  exit 0
-fi
 COMMIT_SUBJECT="$(git log -1 --format=%s)"
-gh pr create --base main --title "${COMMIT_SUBJECT}" --body "Auto-created by dev2merge pipeline."
-NEW_PR="$(gh pr list --state open --head "${SOURCE_OWNER}:${BRANCH}" --json number --jq '.[0].number' 2>/dev/null || true)"
-echo "CSA_VAR:PR_NUMBER=${NEW_PR:-unknown}"
+set +e
+CREATE_OUTPUT="$(gh pr create --base main --title "${COMMIT_SUBJECT}" --body "Auto-created by dev2merge pipeline." 2>&1)"
+CREATE_RC=$?
+set -e
+if [ "${CREATE_RC}" -ne 0 ]; then
+  if ! printf '%s\n' "${CREATE_OUTPUT}" | grep -Eiq 'already exists|a pull request already exists'; then
+    echo "ERROR: gh pr create failed: ${CREATE_OUTPUT}" >&2
+    exit 1
+  fi
+  echo "INFO: PR already exists for ${BRANCH}; continuing with post-create helper."
+fi
+scripts/hooks/post-pr-create.sh --base main
 ```'''
 on_fail = "abort"
 
 [[workflow.steps]]
 id = 13
-title = "Delegate to pr-codex-bot"
-tool = "csa"
-prompt = ""
-on_fail = "abort"
-
-[[workflow.steps]]
-id = 14
-title = "Include pr-codex-bot"
-tool = "weave"
-prompt = "pr-codex-bot"
-on_fail = "abort"
-
-[[workflow.steps]]
-id = 15
 title = "Post-Merge Local Sync"
 tool = "bash"
 prompt = """

--- a/patterns/sa/PATTERN.md
+++ b/patterns/sa/PATTERN.md
@@ -186,27 +186,14 @@ number of tasks completed. If HAS_ISSUES, iterate.
 
 ## IF ${REVIEW_IS_CLEAN}
 
-## Step 12: Auto PR
+## Step 12: Auto PR Transaction
 
 ## INCLUDE commit
 
 Evaluate whether to push and create PR (if milestone complete).
-
-## Step 13: Invoke pr-codex-bot (MANDATORY)
-
-> **Layer**: 0 (Orchestrator) -- dispatches /pr-codex-bot skill.
-> Layer 1 executors MUST invoke /pr-codex-bot after PR creation.
-> This is NOT optional — polling for bot review is part of the PR lifecycle.
-
-Tool: skill
-OnFail: abort
-
-After PR creation, invoke the pr-codex-bot skill to trigger cloud review,
-poll for response (with 10 min timeout), and handle the full review loop.
-This ensures the bot review is never forgotten or skipped.
-
-```
-/pr-codex-bot
-```
+The nested `commit` pattern now owns the full PR transaction:
+push → create/reuse PR → `scripts/hooks/post-pr-create.sh` → `pr-codex-bot`.
+Layer 1 executors MUST rely on that transaction instead of dispatching a
+separate follow-up skill step.
 
 ## ENDIF

--- a/patterns/sa/workflow.toml
+++ b/patterns/sa/workflow.toml
@@ -240,7 +240,7 @@ on_fail = "abort"
 
 [[workflow.steps]]
 id = 12
-title = "Auto PR"
+title = "Auto PR Transaction"
 prompt = ""
 on_fail = "abort"
 condition = "${REVIEW_IS_CLEAN}"
@@ -250,26 +250,5 @@ id = 13
 title = "Include commit"
 tool = "weave"
 prompt = "commit"
-on_fail = "abort"
-condition = "${REVIEW_IS_CLEAN}"
-
-[[workflow.steps]]
-id = 14
-title = "Invoke pr-codex-bot (MANDATORY)"
-prompt = """
-> **Layer**: 0 (Orchestrator) -- dispatches /pr-codex-bot skill.
-> Layer 1 executors MUST invoke /pr-codex-bot after PR creation.
-> This is NOT optional — polling for bot review is part of the PR lifecycle.
-
-Tool: skill
-OnFail: abort
-
-After PR creation, invoke the pr-codex-bot skill to trigger cloud review,
-poll for response (with 10 min timeout), and handle the full review loop.
-This ensures the bot review is never forgotten or skipped.
-
-```
-/pr-codex-bot
-```"""
 on_fail = "abort"
 condition = "${REVIEW_IS_CLEAN}"

--- a/scripts/hooks/post-pr-create.sh
+++ b/scripts/hooks/post-pr-create.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/hooks/post-pr-create.sh [--base <branch>]
+
+Confirms that the current feature branch has an open PR, then runs the
+pr-codex-bot workflow as a synchronous post-create transaction.
+EOF
+}
+
+BASE_BRANCH="main"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "ERROR: Missing value for --base." >&2
+        exit 1
+      fi
+      BASE_BRANCH="$1"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh is required for post-pr-create transaction." >&2
+  exit 1
+fi
+
+if ! command -v csa >/dev/null 2>&1; then
+  echo "ERROR: csa is required for post-pr-create transaction." >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || true)"
+if [ -z "${CURRENT_BRANCH}" ] || [ "${CURRENT_BRANCH}" = "HEAD" ]; then
+  echo "ERROR: Cannot determine current branch." >&2
+  exit 1
+fi
+
+DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+if [ -z "${DEFAULT_BRANCH}" ]; then
+  DEFAULT_BRANCH="main"
+fi
+
+if [ "${CURRENT_BRANCH}" = "${DEFAULT_BRANCH}" ] || [ "${CURRENT_BRANCH}" = "dev" ]; then
+  echo "ERROR: post-pr-create must run from a feature branch, not ${CURRENT_BRANCH}." >&2
+  exit 1
+fi
+
+if [ "${BASE_BRANCH}" != "main" ]; then
+  echo "ERROR: post-pr-create currently supports base branch 'main' only." >&2
+  exit 1
+fi
+
+resolve_current_pr() {
+  local pr_view pr_list pr_count
+
+  if pr_view="$(gh pr view --json number,url,headRefName,baseRefName,state 2>/dev/null)"; then
+    if [ "$(printf '%s' "${pr_view}" | jq -r '.headRefName')" = "${CURRENT_BRANCH}" ] \
+      && [ "$(printf '%s' "${pr_view}" | jq -r '.baseRefName')" = "${BASE_BRANCH}" ] \
+      && [ "$(printf '%s' "${pr_view}" | jq -r '.state')" = "OPEN" ]; then
+      printf '%s\n' "${pr_view}"
+      return 0
+    fi
+  fi
+
+  pr_list="$(
+    gh pr list --state open --base "${BASE_BRANCH}" --head "${CURRENT_BRANCH}" \
+      --json number,url,headRefName,baseRefName,state 2>/dev/null || true
+  )"
+  pr_count="$(printf '%s' "${pr_list}" | jq 'length')"
+
+  if [ "${pr_count}" = "1" ]; then
+    printf '%s\n' "${pr_list}" | jq '.[0]'
+    return 0
+  fi
+
+  if [ "${pr_count}" = "0" ]; then
+    return 1
+  fi
+
+  echo "ERROR: Multiple open PRs found for branch ${CURRENT_BRANCH} targeting ${BASE_BRANCH}." >&2
+  return 2
+}
+
+PR_JSON=""
+for attempt in 1 2 3 4 5; do
+  set +e
+  PR_JSON="$(resolve_current_pr)"
+  rc=$?
+  set -e
+
+  if [ "${rc}" -eq 0 ]; then
+    break
+  fi
+
+  if [ "${rc}" -eq 2 ]; then
+    exit 1
+  fi
+
+  if [ "${attempt}" -lt 5 ]; then
+    sleep 2
+  fi
+done
+
+if [ -z "${PR_JSON}" ]; then
+  echo "ERROR: No open PR found for branch ${CURRENT_BRANCH} targeting ${BASE_BRANCH}." >&2
+  exit 1
+fi
+
+PR_NUMBER="$(printf '%s' "${PR_JSON}" | jq -r '.number')"
+PR_URL="$(printf '%s' "${PR_JSON}" | jq -r '.url')"
+
+if ! printf '%s' "${PR_NUMBER}" | grep -Eq '^[0-9]+$'; then
+  echo "ERROR: Failed to resolve a numeric PR number for ${CURRENT_BRANCH}." >&2
+  exit 1
+fi
+
+echo "Confirmed PR #${PR_NUMBER} (${PR_URL}) for branch ${CURRENT_BRANCH}."
+echo "Running pr-codex-bot transaction..."
+csa plan run patterns/pr-codex-bot/workflow.toml

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -4,7 +4,7 @@
 # Install: ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
 #
 # This hook prevents pushing code that hasn't been reviewed by csa.
-# It checks that the most recent csa review session's commit hash matches HEAD.
+# It checks for a review session recorded for the current branch and HEAD.
 
 set -euo pipefail
 
@@ -21,26 +21,48 @@ if [ "${CURRENT_BRANCH}" = "main" ] || [ "${CURRENT_BRANCH}" = "dev" ]; then
   exit 0
 fi
 
-# Find the most recent review session for this project
+REVIEW_DESCRIPTION_PATTERN='^review(\[[0-9]+\])?: '
+
+# Query review sessions for the current branch.
 REVIEW_SESSION_HEAD=""
-if csa session list --json >/dev/null 2>&1; then
-  REVIEW_SESSION_HEAD="$(csa session list --json 2>/dev/null \
-    | jq -r '[.[] | select(.command | test("review"))] | sort_by(.created) | last | .change_id // empty' \
-    2>/dev/null || true)"
+LATEST_BRANCH_REVIEW=""
+if csa session list --format json >/dev/null 2>&1; then
+  REVIEW_SESSION_HEAD="$(
+    csa session list --format json 2>/dev/null \
+      | jq -r --arg branch "${CURRENT_BRANCH}" --arg head "${CURRENT_HEAD}" --arg review_pattern "${REVIEW_DESCRIPTION_PATTERN}" '
+          [
+            .[]
+            | select((.description // "") | test($review_pattern))
+            | select((.branch // "") == $branch)
+            | select((.change_id // "") == $head)
+            | .change_id
+          ]
+          | first // empty
+        ' 2>/dev/null || true
+  )"
+  LATEST_BRANCH_REVIEW="$(
+    csa session list --format json 2>/dev/null \
+      | jq -r --arg branch "${CURRENT_BRANCH}" --arg review_pattern "${REVIEW_DESCRIPTION_PATTERN}" '
+          [
+            .[]
+            | select((.description // "") | test($review_pattern))
+            | select((.branch // "") == $branch)
+            | .change_id
+          ]
+          | first // empty
+        ' 2>/dev/null || true
+  )"
 fi
 
-if [ -z "${REVIEW_SESSION_HEAD}" ]; then
-  echo "WARNING: No csa review session found. Push allowed (review tracking not available)." >&2
-  exit 0
-fi
-
-# Compare: review session's change_id should match or be a prefix of current HEAD
-if [ "${CURRENT_HEAD}" = "${REVIEW_SESSION_HEAD}" ] || \
-   [ "${CURRENT_HEAD#"${REVIEW_SESSION_HEAD}"}" != "${CURRENT_HEAD}" ]; then
+if [ -n "${REVIEW_SESSION_HEAD}" ]; then
   echo "pre-push: Review verified for HEAD ${CURRENT_HEAD:0:11}."
   exit 0
 fi
 
-echo "ERROR: Push blocked — csa review HEAD (${REVIEW_SESSION_HEAD:0:11}) does not match current HEAD (${CURRENT_HEAD:0:11})." >&2
+if [ -n "${LATEST_BRANCH_REVIEW}" ]; then
+  echo "ERROR: Push blocked — latest recorded review for ${CURRENT_BRANCH} is ${LATEST_BRANCH_REVIEW:0:11}, not ${CURRENT_HEAD:0:11}." >&2
+else
+  echo "ERROR: Push blocked — no csa review session recorded for ${CURRENT_BRANCH} at HEAD ${CURRENT_HEAD:0:11}." >&2
+fi
 echo "Run 'csa review --range main...HEAD' before pushing." >&2
 exit 1

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.116"
+csa = "0.1.118"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.116"
+weave = "0.1.118"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

- Add `scripts/hooks/post-pr-create.sh` — a reusable shell helper that makes PR creation and pr-codex-bot invocation a single shell-enforced transaction
- Route commit/dev2merge/sa workflow patterns through the shared helper instead of prompt-based pr-codex-bot invocation
- Repair stale `scripts/hooks/pre-push` (fix `--format json` flag and jq filters for actual session JSON fields)
- Update justfile `push-reviewed` to call the helper

## Root Cause

LLM instruction-following is not 100% reliable. Under context pressure in long sa/mktsk sessions, the pr-codex-bot step was being skipped despite being mandated by AGENTS.md rule #015 and the commit skill's Step 9. The fix replaces prompt-based enforcement with shell-enforced determinism.

## Test plan

- [ ] `weave compile` passes on all modified patterns (verified)
- [ ] `just pre-commit` passes (verified)
- [ ] Smoke test: create PR on feature branch → helper auto-launches pr-codex-bot workflow
- [ ] Verify pre-push hook correctly blocks unreviewed pushes

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)