### PR TITLE
fix(hooks): add PostRun hook for system-level pr-codex-bot enforcement

### DIFF
--- a/.csa/config.toml
+++ b/.csa/config.toml
@@ -1,0 +1,15 @@
+# Project-level CSA configuration for cli-sub-agent.
+#
+# These [hooks] entries are injected as runtime overrides and take
+# priority over ~/.config/cli-sub-agent/hooks.toml and session-root
+# hooks.toml entries for PreRun/PostRun events.
+
+[hooks]
+# Safety-net: after every `csa run` session, check whether the current
+# branch has an open PR that hasn't been reviewed by pr-codex-bot yet.
+# Catches cases where `gh pr create` was invoked outside a weave
+# workflow step.
+# CSA sets cwd to project root before hook execution, so relative paths
+# are safe.  The script also resolves project root internally as fallback.
+post_run = "scripts/hooks/post-pr-create-check.sh --base main"
+timeout_secs = 120

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ CLAUDE.md
 system_prompt.rs.md
 
 # Other
-.csa
 strix_runs
 .playwright-mcp/
 .claude
@@ -78,7 +77,10 @@ strix_runs
 **/repomix-output.*
 **/*.repomix.lock
 .repomix/
-.csa/
+# CSA local state (plans, sessions, markers) is per-installation.
+# Project-level config (.csa/config.toml) IS tracked for shared hook config.
+.csa/*
+!.csa/config.toml
 
 # Review artifacts
 result.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "axum",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.120"
+version = "0.1.121"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.120"
+version = "0.1.121"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/scripts/hooks/post-pr-create-check.sh
+++ b/scripts/hooks/post-pr-create-check.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# PostRun hook: detect whether the current branch has an open PR that
+# hasn't been reviewed by pr-codex-bot yet.  Safety net for cases where
+# `gh pr create` was invoked outside a weave workflow step.
+#
+# Called automatically after every `csa run` session via the [hooks]
+# post_run entry in `.csa/config.toml`.
+
+# ── Recursion guard ──────────────────────────────────────────────────
+# Set by both this script and post-pr-create.sh before launching
+# pr-codex-bot.  Prevents re-entrant triggering from inner CSA sessions.
+if [ -n "${CSA_PR_BOT_GUARD:-}" ]; then
+    exit 0
+fi
+
+# ── Parse args ───────────────────────────────────────────────────────
+BASE_BRANCH="main"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --base) shift; BASE_BRANCH="${1:-main}" ;;
+        *) ;;
+    esac
+    shift
+done
+
+# ── Feature branch check ────────────────────────────────────────────
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+case "$BRANCH" in
+    main|master|dev|develop|HEAD) exit 0 ;;
+esac
+
+# ── Prerequisite: gh CLI ─────────────────────────────────────────────
+command -v gh >/dev/null 2>&1 || exit 0
+
+# ── Check for open PR ───────────────────────────────────────────────
+PR_NUMBER=$(
+    gh pr view --json number,state,baseRefName \
+        -q "select(.state == \"OPEN\" and .baseRefName == \"${BASE_BRANCH}\") | .number" \
+        2>/dev/null
+) || exit 0
+
+if [ -z "$PR_NUMBER" ] || ! printf '%s' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+    exit 0
+fi
+
+# ── Marker: prevent double-trigger for same PR + HEAD ────────────────
+HEAD_SHA=$(git rev-parse --short HEAD 2>/dev/null) || exit 0
+MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers"
+MARKER="${MARKER_DIR}/${PR_NUMBER}-${HEAD_SHA}"
+
+if [ -f "$MARKER" ]; then
+    exit 0
+fi
+
+mkdir -p "$MARKER_DIR"
+
+echo "[post-run hook] PR #${PR_NUMBER} detected without pr-codex-bot run." >&2
+echo "[post-run hook] Triggering pr-codex-bot in background..." >&2
+
+# Resolve script location relative to project root (not cwd) so the hook
+# works even when CSA is invoked from a different directory (csa run --cd).
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+SCRIPT="${REPO_ROOT}/scripts/hooks/post-pr-create.sh"
+if [ ! -x "$SCRIPT" ]; then
+    echo "[post-run hook] WARNING: $SCRIPT not found or not executable" >&2
+    exit 0
+fi
+
+export CSA_PR_BOT_GUARD=1
+# Detach into own session so CSA's process-group cleanup won't kill the
+# background workflow.  Use setsid where available (Linux); fall back to
+# nohup-only on macOS where setsid is not shipped by default.  Redirect
+# stdin from /dev/null to avoid blocking if the hook runner pipes stdio.
+if command -v setsid >/dev/null 2>&1; then
+    setsid nohup "$SCRIPT" --base "$BASE_BRANCH" \
+        > "${MARKER_DIR}/${PR_NUMBER}-bot.log" 2>&1 < /dev/null &
+else
+    nohup "$SCRIPT" --base "$BASE_BRANCH" \
+        > "${MARKER_DIR}/${PR_NUMBER}-bot.log" 2>&1 < /dev/null &
+fi
+BOT_PID=$!
+
+# Only create deduplication marker if the background process was spawned.
+# If launch failed, omitting the marker allows the next PostRun hook
+# invocation to retry.
+if kill -0 "$BOT_PID" 2>/dev/null; then
+    touch "$MARKER"
+else
+    echo "[post-run hook] WARNING: Failed to launch pr-codex-bot (PID $BOT_PID)" >&2
+fi
+
+exit 0

--- a/scripts/hooks/post-pr-create.sh
+++ b/scripts/hooks/post-pr-create.sh
@@ -132,4 +132,9 @@ fi
 
 echo "Confirmed PR #${PR_NUMBER} (${PR_URL}) for branch ${CURRENT_BRANCH}."
 echo "Running pr-codex-bot transaction..."
+
+# Recursion guard: prevent PostRun hook from re-triggering pr-codex-bot
+# while inner CSA sessions spawned by this workflow complete.
+export CSA_PR_BOT_GUARD=1
+
 csa plan run patterns/pr-codex-bot/workflow.toml

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.119"
-weave = "0.1.119"
+csa = "0.1.121"
+weave = "0.1.121"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Add `scripts/hooks/post-pr-create-check.sh` as a PostRun hook that detects open PRs without pr-codex-bot review after every `csa run` session
- Configure via `.csa/config.toml` [hooks] section (now git-tracked)
- Add `CSA_PR_BOT_GUARD` env var recursion guard to prevent re-entrant triggering from inner CSA sessions
- Marker files at `~/.local/state/cli-sub-agent/pr-bot-markers/` prevent double-trigger for same PR + HEAD

## Test plan

- [ ] Verify `post-pr-create-check.sh` exits 0 on protected branches (main/dev)
- [ ] Verify `post-pr-create-check.sh` exits 0 when no PR exists
- [ ] Verify `post-pr-create-check.sh` exits 0 when `CSA_PR_BOT_GUARD` is set
- [ ] Verify marker file prevents double-triggering
- [ ] Verify `.csa/config.toml` is tracked while `.csa/plans/` remains ignored

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)