### PR TITLE
docs(skill): update skill.md for current CLI state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "axum",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.125"
+version = "0.1.126"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.125"
+version = "0.1.126"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/skill.md
+++ b/skill.md
@@ -255,7 +255,7 @@ weave install user/repo --no-link                # Skip linking entirely
 
 ## Step 5: Programming Patterns (Interactive)
 
-CSA ships with 13 compiled workflow patterns for coding tasks. Not all projects
+CSA ships with 18 compiled workflow patterns for coding tasks. Not all projects
 need all patterns.
 
 **ASK THE USER**: Present the following categories and let the user choose which
@@ -298,12 +298,15 @@ done
 | `security-audit` | Pre-commit vulnerability scan and test-completeness check |
 | `file-audit` | Per-file AGENTS.md compliance audit with report generation |
 | `csa-review` | Independent CSA-driven code review with structured output |
+| `codebase-audit` | Bottom-up per-module security audit with structured reports |
+| `codebase-blog` | Generate technical deep-dive blogs from audit results |
+| `review-loop` | Bounded iterative review-fix loop until clean or max rounds |
 
 **Install**:
 
 ```bash
 mkdir -p .csa/plans
-for pattern in security-audit file-audit csa-review; do
+for pattern in security-audit file-audit csa-review codebase-audit codebase-blog review-loop; do
   weave compile .weave/deps/cli-sub-agent/patterns/$pattern/PATTERN.md \
     --output .csa/plans/$pattern.toml
 done
@@ -343,12 +346,13 @@ done
 | `dev2merge` | Branch-to-merge: plan (mktd+debate), implement, validate, PR, review, merge |
 | `dev-to-merge` | Backward-compatible alias of `dev2merge` |
 | `csa-issue-reporter` | Structured GitHub issue filing for CSA errors |
+| `migrate` | Configuration and state migration workflows |
 
 **Install**:
 
 ```bash
 mkdir -p .csa/plans
-for pattern in sa dev2merge dev-to-merge csa-issue-reporter; do
+for pattern in sa dev2merge dev-to-merge csa-issue-reporter migrate; do
   weave compile .weave/deps/cli-sub-agent/patterns/$pattern/PATTERN.md \
     --output .csa/plans/$pattern.toml
 done
@@ -501,14 +505,29 @@ csa run --sa-mode false --tool codex "echo hello from CSA"
 ### CSA Commands
 
 ```bash
+# Execution (--sa-mode REQUIRED for root callers; auto-detected for CSA children)
 csa run --sa-mode false --tool <tool> "prompt"          # Run a task
 csa run --sa-mode false --tool auto "prompt"            # Auto-select tool
-csa run --sa-mode false --last "continue"               # Resume last session
+csa run --sa-mode false --fork-last "continue"          # Fork most recent session
+csa run --sa-mode false --fork-from <ULID> "continue"   # Fork specific session
+csa run --sa-mode false --fork-call "task"              # Fork-call (child returns to parent)
+csa run --sa-mode false --ephemeral "quick task"        # Ephemeral (no project files)
+csa run --sa-mode false --model-spec gemini-cli/google/gemini-2.5-pro/xhigh "task"  # Model spec
 csa review --sa-mode false --diff                       # Review uncommitted changes
-csa review --sa-mode false --reviewers 3                # Multi-reviewer consensus
+csa review --sa-mode false --range main...HEAD          # Review commit range
+csa review --sa-mode false --fix                        # Review-and-fix mode
+csa review --sa-mode false --red-team                   # Red-team security review
 csa debate --sa-mode false "design question"            # Adversarial model debate
+csa debate --sa-mode false --thinking xhigh "question"  # Debate with high thinking budget
+
+# Session & management
 csa session list --tree                 # List session tree
+csa memory list                         # List cross-session memories
+csa tiers list                          # List model tiers
+csa tokuin estimate <file>              # Estimate token count
+csa doctor                              # Check environment and tools
 csa gc --dry-run                        # Preview garbage collection
+csa self-update                         # Update to latest release
 ```
 
 ### Weave Commands


### PR DESCRIPTION
## Summary
- Update pattern count from 13 to 18 (add codebase-audit, codebase-blog, review-loop, migrate)
- Replace deprecated `--session`/`--last` with `--fork-from`/`--fork-last`
- Add new Quick Reference commands: fork-call, ephemeral, model-spec, review --fix/--red-team, debate --thinking, memory, tiers, tokuin

## Test plan
- [ ] Verify all 18 patterns exist in `patterns/` directory
- [ ] Verify all Quick Reference commands are valid against `csa --help`
- [ ] Verify no deprecated flags remain in examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)