### PR TITLE
docs(readme): add agent-assisted setup section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "axum",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.126"
+version = "0.1.127"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.126"
+version = "0.1.127"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ csa review --sa-mode false --red-team --context .csa/spec.toml
 csa debate --sa-mode false "Should we use Redis or Memcached for caching?"
 ```
 
+### Agent-Assisted Setup
+
+Have your AI agent (Claude Code, Codex, Openclaw, etc.) read the setup guide directly:
+
+```
+Read https://raw.githubusercontent.com/RyderFreeman4Logos/cli-sub-agent/main/skill.md
+```
+
+The guide walks the agent through installing CSA, Weave, patterns, and configuration step by step.
+
 See [Getting Started](docs/getting-started.md) for full installation and setup instructions.
 
 ## Architecture


### PR DESCRIPTION
## Summary
- Add "Agent-Assisted Setup" section to README.md
- Points AI agents (Claude Code, Codex, Openclaw) to read `skill.md` from raw GitHub URL for guided installation

## Test plan
- [ ] Verify the raw URL resolves correctly
- [ ] Verify skill.md content is up-to-date (updated in PR #408)

🤖 Generated with [Claude Code](https://claude.com/claude-code)