### PR TITLE
feat(patterns): self-contained hooks and orchestrator task tracking (#419, #420)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "axum",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.134"
+version = "0.1.135"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.134"
+version = "0.1.135"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -3,7 +3,7 @@ name = "dev2merge"
 description = "Deterministic development pipeline: branch validation, planning, N*(implement+commit), pre-PR review, push, PR, codex-bot merge"
 allowed-tools = "Bash, Read, Edit, Write, Grep, Glob, Task, TaskCreate, TaskUpdate, TaskList, TaskGet"
 tier = "tier-3-complex"
-version = "0.2.0"
+version = "0.3.0"
 ---
 
 # Dev2Merge: Deterministic Development Pipeline
@@ -13,7 +13,7 @@ hard gates (`on_fail = "abort"`). No step can be skipped by the LLM.
 
 Pipeline: Branch Validation → FAST_PATH Detection → mktd (planning) →
 mktsk N*(implement → commit) → Pre-PR Cumulative Review → Push →
-PR Transaction (create/reuse PR + `post-pr-create.sh`, which triggers `pr-codex-bot` when needed) →
+PR Transaction (create/reuse PR + inline pr-codex-bot trigger) →
 Local Sync.
 
 Sub-workflows are included via `## INCLUDE`, not inlined.
@@ -164,7 +164,32 @@ echo "CSA_VAR:MKTD_TODO_TIMESTAMP=${LATEST_TS}"
 echo "CSA_VAR:MKTD_TODO_PATH=${TODO_PATH}"
 ```
 
-## Step 8: Execute Plan with mktsk
+## Step 8: Orchestrator Task Registration
+
+Tool: bash
+OnFail: abort
+
+Print the TODO plan produced by mktd in structured format for the orchestrator
+to parse and register tasks via TaskCreate in SA mode.
+
+```bash
+set -euo pipefail
+if [ ! -f "${MKTD_TODO_PATH}" ]; then
+  echo "ERROR: TODO plan not found at ${MKTD_TODO_PATH}" >&2
+  exit 1
+fi
+echo "=== TODO PLAN FOR TASK REGISTRATION ==="
+# Extract checklist items with executor tags and DONE WHEN clauses
+grep -E '^\s*- \[[ x]\]' "${MKTD_TODO_PATH}" | while IFS= read -r line; do
+  echo "TASK: ${line}"
+done
+echo ""
+echo "=== END TODO PLAN ==="
+echo "INFO: Orchestrator (SA mode) should register each TASK item via TaskCreate."
+echo "INFO: Include executor tag and DONE WHEN in each task description."
+```
+
+## Step 9: Execute Plan with mktsk
 
 Tool: bash
 OnFail: abort
@@ -177,7 +202,7 @@ set -euo pipefail
 timeout 3600 csa run --sa-mode true --skill mktsk "${MKTD_TODO_TIMESTAMP}"
 ```
 
-## Step 9: Ensure Version Bumped
+## Step 10: Ensure Version Bumped
 
 Tool: bash
 OnFail: abort
@@ -193,7 +218,7 @@ if ! just check-version-bumped 2>/dev/null; then
 fi
 ```
 
-## Step 10: Pre-PR Cumulative Review Gate
+## Step 11: Pre-PR Cumulative Review Gate
 
 Tool: bash
 OnFail: abort
@@ -224,7 +249,7 @@ echo "CSA_VAR:REVIEW_COMPLETED=true"
 
 ## ENDIF
 
-## Step 11: Push Gate
+## Step 12: Push Gate
 
 Tool: bash
 OnFail: abort
@@ -242,18 +267,20 @@ git push -u origin "${BRANCH}" --force-with-lease
 echo "CSA_VAR:PUSHED=true"
 ```
 
-## Step 12: Create Pull Request Transaction
+## Step 13: Create Pull Request Transaction
 
 Tool: bash
 OnFail: abort
 
-Create or reuse PR, then run the post-create helper to trigger `pr-codex-bot` when needed.
-If the bot is already running for the same PR/HEAD, the helper may exit early.
+Create or reuse PR, then trigger pr-codex-bot inline (self-contained, no external hook scripts).
+Uses marker files to skip duplicate runs for the same PR/HEAD combination.
 
 ```bash
 set -euo pipefail
 BRANCH="$(git branch --show-current)"
 COMMIT_SUBJECT="$(git log -1 --format=%s)"
+
+# --- Create or reuse PR ---
 set +e
 CREATE_OUTPUT="$(gh pr create --base main --title "${COMMIT_SUBJECT}" --body "Auto-created by dev2merge pipeline." 2>&1)"
 CREATE_RC=$?
@@ -263,12 +290,74 @@ if [ "${CREATE_RC}" -ne 0 ]; then
     echo "ERROR: gh pr create failed: ${CREATE_OUTPUT}" >&2
     exit 1
   fi
-  echo "INFO: PR already exists for ${BRANCH}; continuing with post-create helper."
+  echo "INFO: PR already exists for ${BRANCH}; continuing."
 fi
-scripts/hooks/post-pr-create.sh --base main
+
+# --- Resolve PR number (retry + fallback) ---
+PR_NUMBER=""
+PR_URL=""
+for attempt in 1 2 3; do
+  PR_JSON="$(gh pr view --json number,url,state -q 'select(.state == "OPEN")' 2>/dev/null || true)"
+  PR_NUMBER="$(printf '%s' "${PR_JSON}" | jq -r '.number // empty' 2>/dev/null || true)"
+  if [ -n "${PR_NUMBER}" ] && printf '%s' "${PR_NUMBER}" | grep -Eq '^[0-9]+$'; then
+    PR_URL="$(printf '%s' "${PR_JSON}" | jq -r '.url // empty')"
+    break
+  fi
+  PR_NUMBER=""
+  if [ "${attempt}" -lt 3 ]; then
+    echo "INFO: PR resolution attempt ${attempt} failed, retrying in 5s..."
+    sleep 5
+  fi
+done
+# Fallback: gh pr list --head
+if [ -z "${PR_NUMBER}" ]; then
+  echo "INFO: gh pr view failed; falling back to gh pr list..."
+  PR_NUMBER="$(gh pr list --head "${BRANCH}" --base main --json number -q '.[0].number' 2>/dev/null || true)"
+  if [ -n "${PR_NUMBER}" ] && printf '%s' "${PR_NUMBER}" | grep -Eq '^[0-9]+$'; then
+    PR_URL="$(gh pr view "${PR_NUMBER}" --json url -q '.url' 2>/dev/null || true)"
+  fi
+fi
+if [ -z "${PR_NUMBER}" ] || ! printf '%s' "${PR_NUMBER}" | grep -Eq '^[0-9]+$'; then
+  echo "ERROR: Cannot resolve open PR number for ${BRANCH} after retries." >&2
+  exit 1
+fi
+HEAD_SHA="$(git rev-parse --verify HEAD)"
+
+# --- Lock + Idempotency: skip if pr-codex-bot already ran or is running ---
+MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers"
+mkdir -p "${MARKER_DIR}"
+MARKER_BASE="${MARKER_DIR}/${PR_NUMBER}-${HEAD_SHA}"
+DONE_MARKER="${MARKER_BASE}.done"
+LOCK_DIR="${MARKER_BASE}.lock"
+LOCK_HELD=0
+
+cleanup_lock() {
+  if [ "${LOCK_HELD}" -eq 1 ]; then
+    rmdir "${LOCK_DIR}" 2>/dev/null || true
+  fi
+}
+trap cleanup_lock EXIT
+
+if [ -f "${DONE_MARKER}" ]; then
+  echo "pr-codex-bot already completed for PR #${PR_NUMBER} at HEAD ${HEAD_SHA:0:11}; skipping."
+elif ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+  echo "pr-codex-bot already running for PR #${PR_NUMBER} at HEAD ${HEAD_SHA:0:11}; skipping."
+else
+  LOCK_HELD=1
+  echo "Running pr-codex-bot for PR #${PR_NUMBER} (${PR_URL})..."
+  export CSA_PR_BOT_GUARD=1
+  if csa plan run patterns/pr-codex-bot/workflow.toml; then
+    touch "${DONE_MARKER}"
+    LOCK_HELD=0
+    rmdir "${LOCK_DIR}" 2>/dev/null || true
+  else
+    echo "ERROR: pr-codex-bot workflow failed for PR #${PR_NUMBER}." >&2
+    exit 1
+  fi
+fi
 ```
 
-## Step 13: Post-Merge Local Sync
+## Step 14: Post-Merge Local Sync
 
 Tool: bash
 OnFail: abort

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -35,8 +35,8 @@ Execute the complete development lifecycle as a **deterministic weave workflow**
 Every stage has hard gates (`on_fail = "abort"`) — no step can be skipped by the LLM.
 
 Pipeline: Branch Validation → FAST_PATH Detection → L1/L2 Quality Gates →
-(FAST_PATH: commit → bump → review) or (Full: mktd → mktsk → bump → cumulative review) →
-Push Gate → PR Transaction (create/reuse PR + `post-pr-create.sh`, which triggers `pr-codex-bot` when needed) → Local Sync.
+(FAST_PATH: commit → bump → review) or (Full: mktd → orchestrator TaskCreate → mktsk → bump → cumulative review) →
+Push Gate → PR Transaction (create/reuse PR + inline pr-codex-bot trigger) → Local Sync.
 
 ## Execution Protocol (ORCHESTRATOR ONLY)
 
@@ -85,18 +85,18 @@ All steps use `on_fail = "abort"`. Variables propagate via `CSA_VAR:KEY=value`.
 | 6 | Pre-PR Review | `csa review --range` | bash |
 | **ELSE (Full Pipeline)** | | | |
 | 7 | Plan with mktd | `csa plan run patterns/mktd/workflow.toml` | bash |
-| 8 | Execute with mktsk | `csa run --skill mktsk` | bash |
-| 9 | Version Bump | `just bump-patch` if needed | bash |
-| 10 | Cumulative Review | `csa review --range main...HEAD` | bash |
+| 8 | Orchestrator Task Registration | Orchestrator calls TaskCreate for each TODO item | orchestrator |
+| 9 | Execute with mktsk | `csa run --skill mktsk` | bash |
+| 10 | Version Bump | `just bump-patch` if needed | bash |
+| 11 | Cumulative Review | `csa review --range main...HEAD` | bash |
 | **ENDIF** | | | |
-| 11 | Push Gate | `REVIEW_COMPLETED=true` required | bash |
-| 12 | Create PR Transaction | `gh pr create` or reuse existing, then `scripts/hooks/post-pr-create.sh --base main` | bash |
-| 13 | Post-Merge Sync | `git checkout main && git merge --ff-only` | bash |
+| 12 | Push Gate | `REVIEW_COMPLETED=true` required | bash |
+| 13 | Create PR Transaction | `gh pr create` or reuse existing, then inline pr-codex-bot trigger | bash |
+| 14 | Post-Merge Sync | `git checkout main && git merge --ff-only` | bash |
 
-Step 12 is intentionally a single shell transaction. `scripts/hooks/post-pr-create.sh`
-is responsible for triggering `pr-codex-bot` when appropriate; if the bot is already
-running for the same PR/HEAD, the helper may exit early. There is no separate Step 13
-for `pr-codex-bot` in `workflow.toml`.
+Step 12 is intentionally a single self-contained shell transaction. The pr-codex-bot
+trigger logic is inlined directly in the workflow step (no external hook scripts required).
+Marker files provide idempotency — if the bot already ran for the same PR/HEAD, it skips.
 
 ### FAST_PATH Heuristic
 
@@ -139,7 +139,7 @@ ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
 6. Version bumped if needed.
 7. Pre-PR cumulative review passed (`REVIEW_COMPLETED=true`).
 8. Push completed via `--force-with-lease` (pre-push hook verified review HEAD).
-9. PR transaction completed: PR created or reused on GitHub targeting main, then `scripts/hooks/post-pr-create.sh --base main` ran successfully.
-10. That transaction either triggered `pr-codex-bot` or detected an already-running bot for the same PR/HEAD and exited early.
+9. PR transaction completed: PR created or reused on GitHub targeting main, pr-codex-bot triggered inline.
+10. That transaction either triggered `pr-codex-bot` or detected an already-completed run for the same PR/HEAD and skipped.
 11. Local main synced after the PR merge completed: `git fetch origin && git checkout main && git merge origin/main --ff-only`.
 12. Feature branch deleted (local and remote).

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -42,6 +42,9 @@ name = "LATEST_TS"
 name = "LOCAL_SHA"
 
 [[workflow.variables]]
+name = "MKTD_TODO_PATH"
+
+[[workflow.variables]]
 name = "MKTD_TODO_TIMESTAMP"
 
 [[workflow.variables]]
@@ -229,6 +232,33 @@ condition = "!(${FAST_PATH})"
 
 [[workflow.steps]]
 id = 8
+title = "Orchestrator Task Registration"
+tool = "bash"
+prompt = '''
+Print the TODO plan produced by mktd in structured format for the orchestrator
+to parse and register tasks via TaskCreate in SA mode.
+
+```bash
+set -euo pipefail
+if [ ! -f "${MKTD_TODO_PATH}" ]; then
+  echo "ERROR: TODO plan not found at ${MKTD_TODO_PATH}" >&2
+  exit 1
+fi
+echo "=== TODO PLAN FOR TASK REGISTRATION ==="
+# Extract checklist items with executor tags and DONE WHEN clauses
+grep -E '^\s*- \[[ x]\]' "${MKTD_TODO_PATH}" | while IFS= read -r line; do
+  echo "TASK: ${line}"
+done
+echo ""
+echo "=== END TODO PLAN ==="
+echo "INFO: Orchestrator (SA mode) should register each TASK item via TaskCreate."
+echo "INFO: Include executor tag and DONE WHEN in each task description."
+```'''
+on_fail = "abort"
+condition = "!(${FAST_PATH})"
+
+[[workflow.steps]]
+id = 9
 title = "Execute Plan with mktsk"
 tool = "bash"
 prompt = """
@@ -243,7 +273,7 @@ on_fail = "abort"
 condition = "!(${FAST_PATH})"
 
 [[workflow.steps]]
-id = 9
+id = 10
 title = "Ensure Version Bumped"
 tool = "bash"
 prompt = """
@@ -261,7 +291,7 @@ on_fail = "abort"
 condition = "!(${FAST_PATH})"
 
 [[workflow.steps]]
-id = 10
+id = 11
 title = "Pre-PR Cumulative Review Gate"
 tool = "bash"
 prompt = '''
@@ -292,7 +322,7 @@ on_fail = "abort"
 condition = "!(${FAST_PATH})"
 
 [[workflow.steps]]
-id = 11
+id = 12
 title = "Push Gate"
 tool = "bash"
 prompt = """
@@ -311,17 +341,19 @@ echo "CSA_VAR:PUSHED=true"
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 12
+id = 13
 title = "Create Pull Request Transaction"
 tool = "bash"
 prompt = '''
-Create or reuse PR, then run the post-create helper to trigger `pr-codex-bot` when needed.
-If the bot is already running for the same PR/HEAD, the helper may exit early.
+Create or reuse PR, then trigger pr-codex-bot inline (self-contained, no external hook scripts).
+Uses marker files to skip duplicate runs for the same PR/HEAD combination.
 
 ```bash
 set -euo pipefail
 BRANCH="$(git branch --show-current)"
 COMMIT_SUBJECT="$(git log -1 --format=%s)"
+
+# --- Create or reuse PR ---
 set +e
 CREATE_OUTPUT="$(gh pr create --base main --title "${COMMIT_SUBJECT}" --body "Auto-created by dev2merge pipeline." 2>&1)"
 CREATE_RC=$?
@@ -331,14 +363,76 @@ if [ "${CREATE_RC}" -ne 0 ]; then
     echo "ERROR: gh pr create failed: ${CREATE_OUTPUT}" >&2
     exit 1
   fi
-  echo "INFO: PR already exists for ${BRANCH}; continuing with post-create helper."
+  echo "INFO: PR already exists for ${BRANCH}; continuing."
 fi
-scripts/hooks/post-pr-create.sh --base main
+
+# --- Resolve PR number (retry + fallback) ---
+PR_NUMBER=""
+PR_URL=""
+for attempt in 1 2 3; do
+  PR_JSON="$(gh pr view --json number,url,state -q 'select(.state == "OPEN")' 2>/dev/null || true)"
+  PR_NUMBER="$(printf '%s' "${PR_JSON}" | jq -r '.number // empty' 2>/dev/null || true)"
+  if [ -n "${PR_NUMBER}" ] && printf '%s' "${PR_NUMBER}" | grep -Eq '^[0-9]+$'; then
+    PR_URL="$(printf '%s' "${PR_JSON}" | jq -r '.url // empty')"
+    break
+  fi
+  PR_NUMBER=""
+  if [ "${attempt}" -lt 3 ]; then
+    echo "INFO: PR resolution attempt ${attempt} failed, retrying in 5s..."
+    sleep 5
+  fi
+done
+# Fallback: gh pr list --head
+if [ -z "${PR_NUMBER}" ]; then
+  echo "INFO: gh pr view failed; falling back to gh pr list..."
+  PR_NUMBER="$(gh pr list --head "${BRANCH}" --base main --json number -q '.[0].number' 2>/dev/null || true)"
+  if [ -n "${PR_NUMBER}" ] && printf '%s' "${PR_NUMBER}" | grep -Eq '^[0-9]+$'; then
+    PR_URL="$(gh pr view "${PR_NUMBER}" --json url -q '.url' 2>/dev/null || true)"
+  fi
+fi
+if [ -z "${PR_NUMBER}" ] || ! printf '%s' "${PR_NUMBER}" | grep -Eq '^[0-9]+$'; then
+  echo "ERROR: Cannot resolve open PR number for ${BRANCH} after retries." >&2
+  exit 1
+fi
+HEAD_SHA="$(git rev-parse --verify HEAD)"
+
+# --- Lock + Idempotency: skip if pr-codex-bot already ran or is running ---
+MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers"
+mkdir -p "${MARKER_DIR}"
+MARKER_BASE="${MARKER_DIR}/${PR_NUMBER}-${HEAD_SHA}"
+DONE_MARKER="${MARKER_BASE}.done"
+LOCK_DIR="${MARKER_BASE}.lock"
+LOCK_HELD=0
+
+cleanup_lock() {
+  if [ "${LOCK_HELD}" -eq 1 ]; then
+    rmdir "${LOCK_DIR}" 2>/dev/null || true
+  fi
+}
+trap cleanup_lock EXIT
+
+if [ -f "${DONE_MARKER}" ]; then
+  echo "pr-codex-bot already completed for PR #${PR_NUMBER} at HEAD ${HEAD_SHA:0:11}; skipping."
+elif ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+  echo "pr-codex-bot already running for PR #${PR_NUMBER} at HEAD ${HEAD_SHA:0:11}; skipping."
+else
+  LOCK_HELD=1
+  echo "Running pr-codex-bot for PR #${PR_NUMBER} (${PR_URL})..."
+  export CSA_PR_BOT_GUARD=1
+  if csa plan run patterns/pr-codex-bot/workflow.toml; then
+    touch "${DONE_MARKER}"
+    LOCK_HELD=0
+    rmdir "${LOCK_DIR}" 2>/dev/null || true
+  else
+    echo "ERROR: pr-codex-bot workflow failed for PR #${PR_NUMBER}." >&2
+    exit 1
+  fi
+fi
 ```'''
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 13
+id = 14
 title = "Post-Merge Local Sync"
 tool = "bash"
 prompt = """

--- a/patterns/mktsk/PATTERN.md
+++ b/patterns/mktsk/PATTERN.md
@@ -3,7 +3,7 @@ name = "mktsk"
 description = "Execute TODO plans as deterministic, resumable serial checklists across auto-compaction"
 allowed-tools = "Read, Grep, Glob, Bash, Write, Edit, TaskCreate, TaskUpdate, TaskGet, TaskList"
 tier = "tier-2-standard"
-version = "0.1.0"
+version = "0.2.0"
 ---
 
 # mktsk: Make Task — Plan-to-Execution Bridge
@@ -21,12 +21,17 @@ Extract all unchecked checklist items (`- [ ]`) with:
 
 Fail fast if no executable checklist items are found.
 
-## Step 2: Register Tasks via TaskCreate
+## Step 2: Verify Task Registration
 
 TODO.md is a read-only planning artifact. Progress tracking uses TaskCreate/TaskUpdate.
 
-For each parsed TODO item, use TaskCreate to register a tracked task entry.
-Each task MUST include:
+**When called from dev2merge or another orchestrator workflow**: Tasks are pre-registered
+by the orchestrator via TaskCreate BEFORE mktsk is invoked. The orchestrator owns
+TaskCreate because it runs in the main agent's context where TaskCreate entries persist.
+mktsk (which runs as a CSA subprocess) verifies that tasks exist and picks them up.
+
+**When called standalone** (not via CSA subprocess): mktsk registers tasks itself via
+TaskCreate for each parsed TODO item. Each task MUST include:
 - stable item id
 - source TODO line reference
 - executor tag

--- a/patterns/mktsk/skills/mktsk/SKILL.md
+++ b/patterns/mktsk/skills/mktsk/SKILL.md
@@ -60,9 +60,11 @@ breaks prompt-guard propagation.
    Check for associated references via `csa todo ref list` — if references exist
    (e.g., RECON findings, threat model), consult them for detailed context before
    executing tasks that need deeper understanding of the design rationale.
-2. **Register tasks**: For each parsed TODO item, use TaskCreate to create a tracked task entry.
-   Include the executor tag and `DONE WHEN` condition in the task description.
-   TODO.md remains the read-only source of truth — mktsk reads from it, tracks progress via TaskCreate/TaskUpdate.
+2. **Verify task registration**: When called from an orchestrator workflow (e.g., dev2merge),
+   tasks are pre-registered by the orchestrator via TaskCreate before mktsk is invoked.
+   Verify that tasks exist via TaskList. When called standalone (not as CSA subprocess),
+   register tasks yourself via TaskCreate with executor tag and `DONE WHEN` condition.
+   TODO.md remains the read-only source of truth — mktsk reads from it, tracks progress via TaskUpdate.
 3. **Execute serially with checkpointing**: Process checklist items strictly in order. NEVER parallelize implementation tasks.
    - Before executing each item: use TaskUpdate to set its status to `in_progress`.
    - Treat each item as an atomic transaction: execute one item -> verify -> review -> persist checkpoint.
@@ -92,7 +94,7 @@ breaks prompt-guard propagation.
 
 ## Done Criteria
 
-1. All TODO items parsed and registered via TaskCreate with executor tags.
+1. All TODO items parsed and tasks verified (pre-registered by orchestrator or self-registered if standalone).
 2. All tasks executed in strict serial order with TaskUpdate status transitions.
 3. Each task's DONE WHEN condition verified before marking complete.
 4. Progress checkpoint is updated after each completed item.

--- a/weave.lock
+++ b/weave.lock
@@ -1,7 +1,9 @@
+package = []
+
 [versions]
-csa = "0.1.133"
-weave = "0.1.133"
+csa = "0.1.134"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
+weave = "0.1.134"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

- **#419**: dev2merge step 13 now inlines post-pr-create logic with retry, fallback, and lock mechanism — no external hook scripts required for new projects
- **#420**: New dev2merge step 8 (Orchestrator Task Registration) outputs structured TODO tasks for the main agent to TaskCreate before mktsk runs in CSA subprocess
- mktsk step 2 updated to dual-mode: verify pre-registered tasks (from orchestrator) or self-register (standalone usage)
- Pipeline renumbered from 10 to 14 steps

## Test plan

- [x] `weave compile patterns/dev2merge/PATTERN.md` validates successfully
- [x] `weave compile patterns/mktsk/PATTERN.md` validates successfully  
- [x] `just pre-commit` passes (2536/2536 tests)
- [x] Codex review findings (P1 tool type, P1 lock mechanism, P2 retry) addressed
- [ ] Integration test: run dev2merge full pipeline on a test project

Closes #419, closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)