### PR TITLE
fix(executor): strip inherited GEMINI_API_KEY from gemini-cli child process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "axum",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1996,9 +1996,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "matchers"
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.135"
+version = "0.1.136"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.135"
+version = "0.1.136"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/csa-core/src/gemini.rs
+++ b/crates/csa-core/src/gemini.rs
@@ -5,6 +5,13 @@ pub const NO_FLASH_FALLBACK_ENV_KEY: &str = "_CSA_NO_FLASH_FALLBACK";
 pub const AUTH_MODE_ENV_KEY: &str = "_CSA_GEMINI_AUTH_MODE";
 pub const AUTH_MODE_OAUTH: &str = "oauth";
 pub const AUTH_MODE_API_KEY: &str = "api_key";
+pub const BASE_URL_ENV: &str = "GOOGLE_GEMINI_BASE_URL";
+
+/// Environment variables that gemini-cli reads for auth/routing.
+/// CSA must strip these from the inherited process environment so that
+/// auth mode is fully controlled by CSA's extra_env (OAuth-first with
+/// API key fallback only after quota exhaustion).
+pub const INHERITED_ENV_STRIP: &[&str] = &[API_KEY_ENV, BASE_URL_ENV];
 
 pub const RATE_LIMIT_PATTERNS: &[&str] = &[
     "429",

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -248,6 +248,9 @@ impl Executor {
         extra_env: Option<&HashMap<String, String>>,
     ) -> (Command, Option<Vec<u8>>) {
         let mut cmd = self.build_base_command(session);
+        if matches!(self, Self::GeminiCli { .. }) {
+            Self::strip_gemini_inherited_env(&mut cmd);
+        }
         if let Some(env) = extra_env {
             Self::inject_env(&mut cmd, env);
         }
@@ -380,6 +383,9 @@ impl Executor {
         for var in Self::STRIPPED_ENV_VARS {
             cmd.env_remove(var);
         }
+        if matches!(self, Self::GeminiCli { .. }) {
+            Self::strip_gemini_inherited_env(&mut cmd);
+        }
         if let Some(env) = extra_env {
             Self::inject_env(&mut cmd, env);
         }
@@ -409,8 +415,18 @@ impl Executor {
     /// These prevent recursive-invocation guards in CLI tools from blocking
     /// legitimate CSA sub-agent launches.  Mirrors the same list in
     /// `csa-acp::AcpConnection::STRIPPED_ENV_VARS`.
-    /// Env vars stripped from child processes to prevent recursive-invocation guards.
     const STRIPPED_ENV_VARS: &[&str] = &["CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT"];
+
+    /// Strip process-inherited gemini auth/routing env vars so that CSA's
+    /// extra_env controls auth mode exclusively (OAuth-first, API key fallback
+    /// only after quota exhaustion).  Without this, a process-level
+    /// `GEMINI_API_KEY` bypasses the entire OAuth→model-switch→API-key
+    /// degradation chain.
+    fn strip_gemini_inherited_env(cmd: &mut Command) {
+        for var in csa_core::gemini::INHERITED_ENV_STRIP {
+            cmd.env_remove(var);
+        }
+    }
 
     /// Build base command with session environment variables.
     fn build_base_command(&self, session: &MetaSessionState) -> Command {

--- a/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
@@ -366,6 +366,98 @@ fn test_build_execute_in_command_strips_claudecode_for_all_executors() {
     }
 }
 
+// ── gemini: strip inherited auth env vars ───────────────────────
+
+#[test]
+fn test_build_command_gemini_strips_inherited_api_key_env() {
+    let exec = Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    };
+    let session = make_test_session();
+    let (cmd, _) = exec.build_command("test", None, &session, None);
+
+    let envs: Vec<_> = cmd.as_std().get_envs().collect();
+    let env_map: HashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> = envs.into_iter().collect();
+
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("GEMINI_API_KEY")),
+        Some(&None),
+        "GeminiCli should strip inherited GEMINI_API_KEY"
+    );
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("GOOGLE_GEMINI_BASE_URL")),
+        Some(&None),
+        "GeminiCli should strip inherited GOOGLE_GEMINI_BASE_URL"
+    );
+}
+
+#[test]
+fn test_build_command_non_gemini_does_not_strip_gemini_env() {
+    let exec = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+    };
+    let session = make_test_session();
+    let (cmd, _) = exec.build_command("test", None, &session, None);
+
+    let envs: Vec<_> = cmd.as_std().get_envs().collect();
+    let env_map: HashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> = envs.into_iter().collect();
+
+    assert!(
+        !env_map.contains_key(std::ffi::OsStr::new("GEMINI_API_KEY")),
+        "Non-gemini executor should not touch GEMINI_API_KEY"
+    );
+}
+
+#[test]
+fn test_build_command_gemini_extra_env_overrides_strip() {
+    // When extra_env explicitly sets GEMINI_API_KEY (e.g., API key fallback),
+    // it must override the strip — inject_env runs AFTER strip.
+    let exec = Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    };
+    let session = make_test_session();
+    let mut extra = HashMap::new();
+    extra.insert("GEMINI_API_KEY".to_string(), "test-fallback-key".to_string());
+
+    let (cmd, _) = exec.build_command("test", None, &session, Some(&extra));
+    let envs: Vec<_> = cmd.as_std().get_envs().collect();
+    let env_map: HashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> = envs.into_iter().collect();
+
+    // Command env resolution: env_remove(KEY) then env(KEY, val) → final value is Some(val)
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("GEMINI_API_KEY")),
+        Some(&Some(std::ffi::OsStr::new("test-fallback-key"))),
+        "extra_env GEMINI_API_KEY should override the strip"
+    );
+}
+
+#[test]
+fn test_build_execute_in_command_gemini_strips_inherited_api_key_env() {
+    let exec = Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    };
+    let work_dir = std::path::Path::new("/tmp/test-project");
+    let (cmd, _) = exec.build_execute_in_command("test", work_dir, None);
+
+    let envs: Vec<_> = cmd.as_std().get_envs().collect();
+    let env_map: HashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> = envs.into_iter().collect();
+
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("GEMINI_API_KEY")),
+        Some(&None),
+        "build_execute_in: GeminiCli should strip inherited GEMINI_API_KEY"
+    );
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("GOOGLE_GEMINI_BASE_URL")),
+        Some(&None),
+        "build_execute_in: GeminiCli should strip inherited GOOGLE_GEMINI_BASE_URL"
+    );
+}
+
 // NOTE: CSA_SUPPRESS_NOTIFY is injected by the pipeline layer (not executor)
 // based on per-tool config. See pipeline.rs suppress_notify logic.
 // TODO(acp-notify): ACP path currently propagates CSA_SUPPRESS_NOTIFY env only;

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,7 @@
-package = []
-
 [versions]
-csa = "0.1.134"
+csa = "0.1.135"
+weave = "0.1.135"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.134"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

- Strip process-inherited `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` from gemini-cli child processes
- Ensures CSA's OAuth-first auth strategy is not bypassed by parent environment variables
- Preserves the full degradation chain: flash(OAuth) → 3.1-pro(OAuth) → API key fallback
- Upgrades lz4_flex 0.11.5 → 0.11.6 (RUSTSEC-2026-0025)

## Root Cause

CSA spawns gemini-cli as a child process that inherits all env vars. When `GEMINI_API_KEY` exists in the parent (e.g., from a local proxy config), gemini-cli uses API key auth directly, bypassing CSA's OAuth + model-switch + API-key-fallback degradation chain. The user's shell alias `unset GEMINI_API_KEY` only works for direct invocations, not CSA subprocess spawning.

## Fix

- `strip_gemini_inherited_env()` removes `GEMINI_API_KEY` and `GOOGLE_GEMINI_BASE_URL` from the Command builder
- Called in both `build_command()` and `build_execute_in_command()` for GeminiCli executors
- Runs BEFORE `inject_env(extra_env)`, so `inject_api_key_fallback()` can still override when OAuth quota is exhausted

## Test Plan

- [x] 4 new unit tests: strip behavior, non-gemini unaffected, extra_env override, legacy path
- [x] All 2540 existing tests pass
- [x] E2E: `GEMINI_API_KEY=fake GOOGLE_GEMINI_BASE_URL=http://localhost:9999 csa run --tool gemini-cli` succeeds via OAuth
- [x] `csa review --range main...HEAD` passed

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)