### PR TITLE
fix(csa-config): guard empty tier selector and update help text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "chrono",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "chrono",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "axum",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "chrono",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.161"
+version = "0.1.162"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.161"
+version = "0.1.162"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -206,7 +206,7 @@ pub enum Commands {
         #[arg(long, value_name = "PATH")]
         spec: Option<String>,
 
-        /// Tier name or tier_mapping alias for tool/model routing
+        /// Tier name, alias, or unambiguous prefix for tool/model routing
         #[arg(long)]
         tier: Option<String>,
 

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -145,7 +145,7 @@ pub struct ReviewArgs {
     #[arg(long, value_name = "PATH")]
     pub spec: Option<String>,
 
-    /// Tier name or tier_mapping alias for tool/model routing
+    /// Tier name, alias, or unambiguous prefix for tool/model routing
     #[arg(long)]
     pub tier: Option<String>,
 
@@ -301,7 +301,7 @@ pub struct DebateArgs {
     #[arg(long)]
     pub cd: Option<String>,
 
-    /// Tier name or tier_mapping alias for tool/model routing
+    /// Tier name, alias, or unambiguous prefix for tool/model routing
     #[arg(long)]
     pub tier: Option<String>,
 

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -414,6 +414,11 @@ impl ProjectConfig {
     /// Resolve a tier selector (direct name, `tier_mapping` alias, or unambiguous prefix)
     /// to canonical tier name. Priority: exact name > alias > unique prefix. No tier3 fallback.
     pub fn resolve_tier_selector(&self, selector: &str) -> Option<String> {
+        // Reject empty/whitespace-only selectors early — prevents prefix matching
+        // from silently resolving "" to the sole tier in single-tier configs.
+        if selector.trim().is_empty() {
+            return None;
+        }
         // 1. Exact tier name match
         if self.tiers.contains_key(selector) {
             return Some(selector.to_string());
@@ -441,6 +446,9 @@ impl ProjectConfig {
     /// Returns `Some(name)` when exactly one tier starts with the selector,
     /// or the selector is a substring of exactly one tier name.
     pub fn suggest_tier(&self, selector: &str) -> Option<String> {
+        if selector.trim().is_empty() {
+            return None;
+        }
         // Try prefix match first
         let prefix_matches: Vec<&String> = self
             .tiers

--- a/crates/csa-config/src/config_tests_tier_selector.rs
+++ b/crates/csa-config/src/config_tests_tier_selector.rs
@@ -475,3 +475,49 @@ fn test_suggest_tier_no_match() {
 
     assert_eq!(config.suggest_tier("anything"), None);
 }
+
+// ---------------------------------------------------------------------------
+// Empty selector regression tests (PR #460 review finding)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_resolve_tier_selector_empty_string_rejected() {
+    let mut tiers = HashMap::new();
+    tiers.insert(
+        "tier-1-quick".to_string(),
+        TierConfig {
+            description: "test".to_string(),
+            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+
+    let config = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    // Empty string must NOT resolve via prefix matching (regression: PR #460)
+    assert_eq!(config.resolve_tier_selector(""), None);
+    assert_eq!(config.resolve_tier_selector("  "), None);
+    assert_eq!(config.suggest_tier(""), None);
+    assert_eq!(config.suggest_tier("  "), None);
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.161"
+csa = "0.1.162"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.161"
+weave = "0.1.162"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

- Guard `resolve_tier_selector()` and `suggest_tier()` against empty/whitespace selectors that would prefix-match the sole tier in single-tier configs (regression from PR #460)
- Update CLI `--tier` help text to reflect prefix matching feature: "Tier name, alias, or unambiguous prefix"
- Add regression test `test_resolve_tier_selector_empty_string_rejected`

## Context

Post-merge review of PR #460 (via `csa review --tier tier-4-critical`) caught this regression: empty string `""` is a prefix of every tier name, so `--tier ""` would silently resolve in single-tier configs instead of erroring.

## Test plan

- [x] `cargo test -p csa-config -- empty_string_rejected` passes
- [x] `just pre-commit` all checks pass
- [ ] CSA review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)