### PR TITLE
fix(scheduler): codex quota failover + ACP broken pipe cleanup (#475, #476)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "axum",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.168"
+version = "0.1.169"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.168"
+version = "0.1.169"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -20,7 +20,9 @@ use crate::pipeline;
 use crate::run_cmd_fork::{
     ForkResolution, cleanup_pre_created_fork_session, pre_create_native_fork_session, resolve_fork,
 };
-use crate::run_cmd_post::{RateLimitAction, evaluate_rate_limit_failover};
+use crate::run_cmd_post::{
+    RateLimitAction, evaluate_error_rate_limit_failover, evaluate_rate_limit_failover,
+};
 use crate::run_cmd_tool_selection::{
     resolve_slot_wait_timeout_seconds, take_next_runtime_fallback_tool,
 };
@@ -561,11 +563,51 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                     );
                     continue;
                 }
-                cleanup_pre_created_fork_session(
-                    &mut pre_created_fork_session_id,
+                // ACP errors (e.g. codex "usage_limit_exceeded") bypass Ok-path
+                // rate-limit detection.  Check error text for quota signals.
+                match evaluate_error_rate_limit_failover(
+                    tool_name_str,
+                    &e.to_string(),
+                    attempts,
+                    max_failover_attempts,
+                    &mut tried_tools,
+                    executed_session_id.as_deref(),
+                    effective_session_arg.as_deref(),
+                    request.ephemeral,
+                    request.prompt_text,
                     request.project_root,
-                );
-                return Err(e);
+                    request.config,
+                    current_model_spec.as_deref(),
+                )? {
+                    RateLimitAction::Retry {
+                        new_tool,
+                        new_model_spec,
+                    } => {
+                        failover_context_addendum = build_failover_context_addendum(
+                            tool_name_str,
+                            executed_session_id.as_deref(),
+                        );
+                        current_tool = new_tool;
+                        current_model_spec = new_model_spec;
+                        current_model = None;
+                        fork_resolution = None;
+                        if is_fork {
+                            effective_session_arg = None;
+                        }
+                        cleanup_pre_created_fork_session(
+                            &mut pre_created_fork_session_id,
+                            request.project_root,
+                        );
+                        continue;
+                    }
+                    _ => {
+                        cleanup_pre_created_fork_session(
+                            &mut pre_created_fork_session_id,
+                            request.project_root,
+                        );
+                        return Err(e);
+                    }
+                }
             }
         };
 
@@ -708,92 +750,5 @@ fn persist_fork_timeout_result_if_missing(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{build_failover_context_addendum, persist_fork_timeout_result_if_missing};
-    use csa_core::types::ToolName;
-    use csa_session::{create_session, load_result};
-
-    #[test]
-    fn persist_fork_timeout_result_if_missing_skips_non_fork_sessions() {
-        let td = tempfile::tempdir().expect("tempdir");
-        let session = create_session(td.path(), Some("regular"), None, Some("codex"))
-            .expect("create session");
-
-        persist_fork_timeout_result_if_missing(
-            td.path(),
-            false,
-            ToolName::Codex,
-            Some(&session.meta_session_id),
-            chrono::Utc::now(),
-            60,
-        );
-
-        assert!(
-            load_result(td.path(), &session.meta_session_id)
-                .expect("load result")
-                .is_none(),
-            "non-fork timeouts should not synthesize fork terminal results"
-        );
-    }
-
-    #[test]
-    fn persist_fork_timeout_result_if_missing_writes_fork_failure() {
-        let td = tempfile::tempdir().expect("tempdir");
-        let parent =
-            create_session(td.path(), Some("parent"), None, Some("codex")).expect("parent");
-        let child = create_session(
-            td.path(),
-            Some("fork child"),
-            Some(&parent.meta_session_id),
-            Some("codex"),
-        )
-        .expect("child");
-
-        persist_fork_timeout_result_if_missing(
-            td.path(),
-            true,
-            ToolName::Codex,
-            Some(&child.meta_session_id),
-            chrono::Utc::now(),
-            60,
-        );
-
-        let result = load_result(td.path(), &child.meta_session_id)
-            .expect("load result")
-            .expect("fork timeout result");
-        assert_eq!(result.status, "failure");
-        assert_eq!(result.exit_code, 1);
-        assert!(
-            result.summary.contains("wall-clock timeout"),
-            "fork timeout result should explain the synthetic failure"
-        );
-    }
-
-    #[test]
-    fn build_failover_context_addendum_includes_xurl_hint() {
-        let addendum = build_failover_context_addendum("gemini-cli", Some("01ABCDEF"));
-        assert!(addendum.is_some());
-        let text = addendum.unwrap();
-        assert!(text.contains("gemini-cli"), "should mention failed tool");
-        assert!(text.contains("01ABCDEF"), "should mention session id");
-        assert!(text.contains("csa xurl"), "should include xurl command");
-        assert!(text.contains("gemini"), "should use gemini provider name");
-    }
-
-    #[test]
-    fn build_failover_context_addendum_none_without_session() {
-        let addendum = build_failover_context_addendum("gemini-cli", None);
-        assert!(addendum.is_none());
-    }
-
-    #[test]
-    fn build_failover_context_addendum_maps_claude_provider() {
-        let addendum = build_failover_context_addendum("claude-code", Some("01XYZ"));
-        assert!(addendum.is_some());
-        let text = addendum.unwrap();
-        assert!(
-            text.contains("claude"),
-            "should map claude-code to claude provider"
-        );
-    }
-}
+#[path = "run_cmd_attempt_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
@@ -1,0 +1,88 @@
+//! Tests for `run_cmd_attempt` helpers (extracted for monolith limit).
+
+use super::{build_failover_context_addendum, persist_fork_timeout_result_if_missing};
+use csa_core::types::ToolName;
+use csa_session::{create_session, load_result};
+
+#[test]
+fn persist_fork_timeout_result_if_missing_skips_non_fork_sessions() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let session =
+        create_session(td.path(), Some("regular"), None, Some("codex")).expect("create session");
+
+    persist_fork_timeout_result_if_missing(
+        td.path(),
+        false,
+        ToolName::Codex,
+        Some(&session.meta_session_id),
+        chrono::Utc::now(),
+        60,
+    );
+
+    assert!(
+        load_result(td.path(), &session.meta_session_id)
+            .expect("load result")
+            .is_none(),
+        "non-fork timeouts should not synthesize fork terminal results"
+    );
+}
+
+#[test]
+fn persist_fork_timeout_result_if_missing_writes_fork_failure() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let parent = create_session(td.path(), Some("parent"), None, Some("codex")).expect("parent");
+    let child = create_session(
+        td.path(),
+        Some("fork child"),
+        Some(&parent.meta_session_id),
+        Some("codex"),
+    )
+    .expect("child");
+
+    persist_fork_timeout_result_if_missing(
+        td.path(),
+        true,
+        ToolName::Codex,
+        Some(&child.meta_session_id),
+        chrono::Utc::now(),
+        60,
+    );
+
+    let result = load_result(td.path(), &child.meta_session_id)
+        .expect("load result")
+        .expect("fork timeout result");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(
+        result.summary.contains("wall-clock timeout"),
+        "fork timeout result should explain the synthetic failure"
+    );
+}
+
+#[test]
+fn build_failover_context_addendum_includes_xurl_hint() {
+    let addendum = build_failover_context_addendum("gemini-cli", Some("01ABCDEF"));
+    assert!(addendum.is_some());
+    let text = addendum.unwrap();
+    assert!(text.contains("gemini-cli"), "should mention failed tool");
+    assert!(text.contains("01ABCDEF"), "should mention session id");
+    assert!(text.contains("csa xurl"), "should include xurl command");
+    assert!(text.contains("gemini"), "should use gemini provider name");
+}
+
+#[test]
+fn build_failover_context_addendum_none_without_session() {
+    let addendum = build_failover_context_addendum("gemini-cli", None);
+    assert!(addendum.is_none());
+}
+
+#[test]
+fn build_failover_context_addendum_maps_claude_provider() {
+    let addendum = build_failover_context_addendum("claude-code", Some("01XYZ"));
+    assert!(addendum.is_some());
+    let text = addendum.unwrap();
+    assert!(
+        text.contains("claude"),
+        "should map claude-code to claude provider"
+    );
+}

--- a/crates/cli-sub-agent/src/run_cmd_post.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post.rs
@@ -255,6 +255,115 @@ pub(crate) fn evaluate_rate_limit_failover(
     }
 }
 
+/// Check an anyhow error message for rate-limit signals and attempt failover.
+///
+/// This handles the case where the execution returned `Err(e)` (e.g. ACP
+/// `PromptFailed` with `usage_limit_exceeded`) instead of a non-zero
+/// `ExecutionResult`. The error text is tested against the same rate-limit
+/// patterns used for normal exit-code-based detection.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn evaluate_error_rate_limit_failover(
+    tool_name_str: &str,
+    error_message: &str,
+    attempts: usize,
+    max_failover_attempts: usize,
+    tried_tools: &mut Vec<String>,
+    executed_session_id: Option<&str>,
+    effective_session_arg: Option<&str>,
+    ephemeral: bool,
+    prompt_text: &str,
+    project_root: &Path,
+    config: Option<&ProjectConfig>,
+    current_model_spec: Option<&str>,
+) -> Result<RateLimitAction> {
+    // Reuse detect_rate_limit by treating the error message as stderr.
+    let rate_limit = match csa_scheduler::detect_rate_limit(
+        tool_name_str,
+        error_message,
+        "",
+        1, // synthetic non-zero exit code
+        current_model_spec,
+    ) {
+        Some(rl) => rl,
+        None => return Ok(RateLimitAction::NoRateLimit),
+    };
+
+    info!(
+        tool = %tool_name_str,
+        pattern = %rate_limit.matched_pattern,
+        attempt = attempts,
+        max = max_failover_attempts,
+        "Rate limit detected in transport error, attempting failover"
+    );
+
+    if attempts >= max_failover_attempts {
+        warn!(
+            "Max failover attempts ({}) reached for error-path rate limit",
+            max_failover_attempts
+        );
+        return Ok(RateLimitAction::ExhaustedFailovers);
+    }
+
+    tried_tools.push(tool_name_str.to_string());
+
+    let failover_session_ref = executed_session_id.or(effective_session_arg);
+    let session_state = if !ephemeral {
+        failover_session_ref.and_then(|sid| {
+            let sessions_dir = csa_session::get_session_root(project_root)
+                .ok()?
+                .join("sessions");
+            let resolved_id = csa_session::resolve_session_prefix(&sessions_dir, sid).ok()?;
+            csa_session::load_session(project_root, &resolved_id).ok()
+        })
+    } else {
+        None
+    };
+
+    let task_needs_edit = crate::run_helpers::infer_task_edit_requirement(prompt_text)
+        .or_else(|| config.map(|cfg| cfg.can_tool_edit_existing(tool_name_str)));
+
+    let Some(cfg) = config else {
+        return Ok(RateLimitAction::ExhaustedFailovers);
+    };
+
+    let action = csa_scheduler::decide_failover(
+        tool_name_str,
+        "default",
+        task_needs_edit,
+        session_state.as_ref(),
+        tried_tools,
+        cfg,
+        &rate_limit.matched_pattern,
+    );
+
+    match action {
+        csa_scheduler::FailoverAction::RetryInSession {
+            new_tool,
+            new_model_spec,
+            session_id: _,
+        }
+        | csa_scheduler::FailoverAction::RetrySiblingSession {
+            new_tool,
+            new_model_spec,
+        } => {
+            info!(
+                from = %tool_name_str,
+                to = %new_tool,
+                "Failing over from transport error to alternative tool"
+            );
+            let tool = crate::run_helpers::parse_tool_name(&new_tool)?;
+            Ok(RateLimitAction::Retry {
+                new_tool: tool,
+                new_model_spec: Some(new_model_spec),
+            })
+        }
+        csa_scheduler::FailoverAction::ReportError { reason, .. } => {
+            warn!(reason = %reason, "Error-path failover not possible");
+            Ok(RateLimitAction::ExhaustedFailovers)
+        }
+    }
+}
+
 /// Mark a successful non-fork session as a seed candidate and run LRU eviction
 /// to retire excess seed sessions.
 pub(crate) fn mark_seed_and_evict(

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -582,7 +582,7 @@ impl Transport for AcpTransport {
                 }
             })
             .await
-            .map_err(|e| anyhow!("ACP transport join error: {e}"))??;
+            .map_err(classify_join_error)??;
 
         let execution = ExecutionResult {
             summary: build_summary(&output.output, &output.stderr, output.exit_code),
@@ -602,6 +602,31 @@ impl Transport for AcpTransport {
     #[cfg(test)]
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+/// Convert a `tokio::task::JoinError` into a descriptive `anyhow::Error`.
+///
+/// Broken-pipe panics (from `eprintln!` after the tool process closes stderr)
+/// are rewritten into a clean message that mentions the tool died, instead of
+/// surfacing the raw tokio panic trace.
+fn classify_join_error(e: tokio::task::JoinError) -> anyhow::Error {
+    if e.is_panic() {
+        let msg = match e.into_panic().downcast::<String>() {
+            Ok(s) => *s,
+            Err(any) => match any.downcast::<&str>() {
+                Ok(s) => s.to_string(),
+                Err(_) => "unknown panic".to_string(),
+            },
+        };
+        if msg.contains("Broken pipe") || msg.contains("os error 32") {
+            return anyhow!(
+                "ACP transport: tool process terminated unexpectedly (broken pipe on stderr)"
+            );
+        }
+        anyhow!("ACP transport: task panicked: {msg}")
+    } else {
+        anyhow!("ACP transport: task cancelled: {e}")
     }
 }
 
@@ -760,32 +785,6 @@ mod tests {
             AcpTransport::acp_command_for_tool("gemini-cli"),
             ("gemini-cli-acp".to_string(), vec![])
         );
-    }
-
-    #[test]
-    fn test_build_summary_uses_last_stdout_line_on_success() {
-        let stdout = "line1\nfinal line\n";
-        let summary = build_summary(stdout, "", 0);
-        assert_eq!(summary, "final line");
-    }
-
-    #[test]
-    fn test_build_summary_uses_stdout_on_failure_when_present() {
-        let stdout = "details\nreason from stdout\n";
-        let summary = build_summary(stdout, "stderr message", 2);
-        assert_eq!(summary, "reason from stdout");
-    }
-
-    #[test]
-    fn test_build_summary_falls_back_to_stderr_on_failure() {
-        let summary = build_summary("\n", "stderr reason\n", 3);
-        assert_eq!(summary, "stderr reason");
-    }
-
-    #[test]
-    fn test_build_summary_falls_back_to_exit_code_when_no_output() {
-        let summary = build_summary("", "   \n", -1);
-        assert_eq!(summary, "exit code -1");
     }
 
     include!("transport_tests_tail.rs");

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -629,3 +629,67 @@ async fn test_execute_best_effort_sandbox_fallback_preserves_attempt_model_overr
         "best-effort fallback path must preserve per-attempt model override"
     );
 }
+
+// --- classify_join_error tests ---
+
+#[tokio::test]
+async fn test_classify_join_error_broken_pipe_message() {
+    let handle = tokio::task::spawn(async {
+        panic!("failed printing to stderr: Broken pipe (os error 32)")
+    });
+    let join_err = handle.await.unwrap_err();
+    let err = super::classify_join_error(join_err);
+    let msg = err.to_string();
+    assert!(
+        msg.contains("tool process terminated unexpectedly"),
+        "broken pipe should get a clean message, got: {msg}"
+    );
+    assert!(
+        msg.contains("broken pipe"),
+        "message should mention broken pipe, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_classify_join_error_generic_panic() {
+    let handle = tokio::task::spawn(async { panic!("something else went wrong") });
+    let join_err = handle.await.unwrap_err();
+    let err = super::classify_join_error(join_err);
+    let msg = err.to_string();
+    assert!(
+        msg.contains("task panicked"),
+        "generic panic should say 'task panicked', got: {msg}"
+    );
+    assert!(
+        msg.contains("something else went wrong"),
+        "should include panic message, got: {msg}"
+    );
+}
+
+// --- build_summary tests (moved from transport.rs) ---
+
+#[test]
+fn test_build_summary_uses_last_stdout_line_on_success() {
+    let stdout = "line1\nfinal line\n";
+    let summary = super::build_summary(stdout, "", 0);
+    assert_eq!(summary, "final line");
+}
+
+#[test]
+fn test_build_summary_uses_stdout_on_failure_when_present() {
+    let stdout = "details\nreason from stdout\n";
+    let summary = super::build_summary(stdout, "stderr message", 2);
+    assert_eq!(summary, "reason from stdout");
+}
+
+#[test]
+fn test_build_summary_falls_back_to_stderr_on_failure() {
+    let summary = super::build_summary("\n", "stderr reason\n", 3);
+    assert_eq!(summary, "stderr reason");
+}
+
+#[test]
+fn test_build_summary_falls_back_to_exit_code_when_no_output() {
+    let summary = super::build_summary("", "   \n", -1);
+    assert_eq!(summary, "exit code -1");
+}

--- a/crates/csa-scheduler/src/rate_limit.rs
+++ b/crates/csa-scheduler/src/rate_limit.rs
@@ -50,7 +50,13 @@ fn patterns_for_tool(tool: &str) -> &'static [&'static str] {
     match tool {
         "gemini-cli" => GEMINI_RATE_LIMIT_PATTERNS,
         "opencode" => &["rate limit", "429", "too many requests"],
-        "codex" => &["rate_limit_exceeded", "429", "ratelimiterror"],
+        "codex" => &[
+            "rate_limit_exceeded",
+            "usage_limit_exceeded",
+            "usage limit",
+            "429",
+            "ratelimiterror",
+        ],
         "claude-code" => &["rate limit", "529", "429", "overloaded"],
         _ => &["429", "rate limit"],
     }
@@ -200,6 +206,32 @@ mod tests {
             result.is_none(),
             "Split pattern across stderr/stdout should not match"
         );
+    }
+
+    #[test]
+    fn test_codex_usage_limit_exceeded() {
+        let result = detect_rate_limit(
+            "codex",
+            r#"Internal error: {"codex_error_info": "usage_limit_exceeded", "message": "You've hit your usage limit."}"#,
+            "",
+            1,
+            None,
+        );
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().matched_pattern, "usage_limit_exceeded");
+    }
+
+    #[test]
+    fn test_codex_usage_limit_plain_text() {
+        let result = detect_rate_limit(
+            "codex",
+            "Error: Usage limit exceeded for this account",
+            "",
+            1,
+            None,
+        );
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().matched_pattern, "usage limit");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `usage_limit_exceeded` and `usage limit` to codex rate-limit detection patterns — 3 failed sessions in mandate-monorepo had no failover because the pattern was missing
- Route ACP `PromptFailed` errors (Err path) through tier-based rate-limit failover via new `evaluate_error_rate_limit_failover()` — previously only the Ok-path (non-zero exit) got multi-tool failover
- Classify ACP broken pipe `JoinError` panics into clean error messages instead of raw tokio panic traces

## Test plan

- [x] 2797 tests pass (`just test`)
- [x] `just pre-commit` exit 0
- [x] `csa review --diff` verdict: PASS
- [x] 4 new tests: 2 for `usage_limit_exceeded` patterns, 2 for `classify_join_error`
- [ ] Manual: run `csa run` with codex when quota is exhausted → verify failover to gemini-cli

Closes #475, closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)