### PR TITLE
fix(pattern): configurable merge strategy and branch deletion (#480)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "axum",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.171"
+version = "0.1.172"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.171"
+version = "0.1.172"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -186,6 +186,8 @@ max_recursion_depth = 5
 # cloud_bot = true       # Set to false to skip @codex cloud review
 #                        # and use local codex (csa review) instead.
 #                        # Useful for repos without cloud bot access.
+# merge_strategy = "merge"  # "merge" | "rebase" | "squash" (default: "merge")
+# delete_branch = false     # Delete remote branch after merge (default: false)
 
 # ─── Aliases ────────────────────────────────────────────────────
 # [aliases]

--- a/patterns/pr-codex-bot/PATTERN.md
+++ b/patterns/pr-codex-bot/PATTERN.md
@@ -561,7 +561,13 @@ git push origin "${WORKFLOW_BRANCH}"
 gh pr comment "${PR_NUM}" --repo "${REPO}" --body \
   "**Merge rationale**: Cloud bot (@codex) is disabled or unavailable. Local \`csa review --branch main\` passed CLEAN (or issues were fixed in fallback cycle). Proceeding to merge with local review as the review layer."
 
-gh pr merge "${PR_NUM}" --repo "${REPO}" --merge --delete-branch
+MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
+DELETE_BRANCH_FLAG=""
+if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
+  DELETE_BRANCH_FLAG="--delete-branch"
+fi
+# shellcheck disable=SC2086
+gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG}
 
 # Post-merge: sync local main with remote
 git fetch origin
@@ -1192,7 +1198,13 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
 fi
 
 git push origin "${WORKFLOW_BRANCH}"
-gh pr merge "${WORKFLOW_BRANCH}-clean" --repo "${REPO}" --merge --delete-branch
+MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
+DELETE_BRANCH_FLAG=""
+if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
+  DELETE_BRANCH_FLAG="--delete-branch"
+fi
+# shellcheck disable=SC2086
+gh pr merge "${WORKFLOW_BRANCH}-clean" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG}
 
 # Post-merge: sync local main with remote
 git fetch origin
@@ -1226,7 +1238,13 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
 fi
 
 git push origin "${WORKFLOW_BRANCH}"
-gh pr merge "${PR_NUM}" --repo "${REPO}" --merge --delete-branch
+MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
+DELETE_BRANCH_FLAG=""
+if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
+  DELETE_BRANCH_FLAG="--delete-branch"
+fi
+# shellcheck disable=SC2086
+gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG}
 
 # Post-merge: sync local main with remote
 git fetch origin

--- a/patterns/pr-codex-bot/skills/pr-codex-bot/SKILL.md
+++ b/patterns/pr-codex-bot/skills/pr-codex-bot/SKILL.md
@@ -125,7 +125,9 @@ The cloud bot trigger can be disabled per-project via `.csa/config.toml`:
 
 ```toml
 [pr_review]
-cloud_bot = false   # skip @codex cloud review, use local codex instead
+cloud_bot = false          # skip @codex cloud review, use local codex instead
+merge_strategy = "merge"   # "merge" | "rebase" | "squash" (default: "merge")
+delete_branch = false      # delete remote branch after merge (default: false)
 ```
 
 **Check at runtime**: `csa config get pr_review.cloud_bot --default true`
@@ -179,7 +181,7 @@ breaks prompt-guard propagation.
 9. **Continue loop**: Push fixes and loop back (next trigger is issued in Step 4). Track iteration count via `REVIEW_ROUND`. When `REVIEW_ROUND` reaches `MAX_REVIEW_ROUNDS` (default: 10), STOP and present options to the user: (A) Merge now, (B) Continue for more rounds, (C) Abort and investigate manually. The workflow MUST NOT auto-merge or auto-abort at the round limit.
 10. **Clean resubmission** (if fixes accumulated): Create clean branch for final review.
 10.5. ~~**Rebase for clean history**~~: DISABLED. With merge commits (not squash), rebase destroys per-commit audit trail. Set `REBASE_ENABLED=true` to re-enable for squash-merge workflows.
-11. **Merge**: Leave audit trail comment if bot was unavailable (explaining merge rationale: bot timeout + local review CLEAN). Then `gh pr merge --merge --delete-branch`, then `git fetch origin && git checkout main && git merge origin/main --ff-only`.
+11. **Merge**: Leave audit trail comment if bot was unavailable (explaining merge rationale: bot timeout + local review CLEAN). Read merge strategy from `csa config get pr_review.merge_strategy --default merge` and branch deletion from `csa config get pr_review.delete_branch --default false`. Then `gh pr merge --${MERGE_STRATEGY} [--delete-branch]`, then `git fetch origin && git checkout main && git merge origin/main --ff-only`.
 
 ## Example Usage
 
@@ -215,5 +217,5 @@ breaks prompt-guard propagation.
 10b. **Round limit**: If `REVIEW_ROUND` reaches `MAX_REVIEW_ROUNDS` (default: 10), user was prompted with options (merge/continue/abort) and explicitly chose before proceeding.
 10c. ~~**Rebase for clean history**~~ (Step 10.5): DISABLED — merge commits preserve audit trail directly.
 11. **Audit trail**: Every dismissed PR-page finding (for example, a bot finding) has a corresponding explanatory PR comment posted by an explicit workflow step BEFORE proceeding or merging.
-12. PR merged via merge commit (full history preserved) with branch cleanup.
-13. Local main updated: `git fetch origin && git checkout main && git merge origin/main --ff-only`. Remote feature branch deleted by `--delete-branch` (local branch preserved for audit).
+12. PR merged via configured strategy (default: merge commit, full history preserved). Branch deletion controlled by `pr_review.delete_branch` config (default: false — branches preserved for audit).
+13. Local main updated: `git fetch origin && git checkout main && git merge origin/main --ff-only`.

--- a/patterns/pr-codex-bot/workflow.toml
+++ b/patterns/pr-codex-bot/workflow.toml
@@ -555,7 +555,13 @@ git push origin "${WORKFLOW_BRANCH}"
 gh pr comment "${PR_NUM}" --repo "${REPO}" --body \
   "**Merge rationale**: Cloud bot (@codex) is disabled or unavailable. Local csa review --branch main passed CLEAN (or issues were fixed in fallback cycle). Proceeding to merge with local review as the review layer."
 
-gh pr merge "${PR_NUM}" --repo "${REPO}" --merge --delete-branch
+MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
+DELETE_BRANCH_FLAG=""
+if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
+  DELETE_BRANCH_FLAG="--delete-branch"
+fi
+# shellcheck disable=SC2086
+gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG}
 
 # Post-merge: sync local main with remote
 git fetch origin
@@ -1298,7 +1304,13 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
 fi
 
 git push origin "${WORKFLOW_BRANCH}"
-gh pr merge "${WORKFLOW_BRANCH}-clean" --repo "${REPO}" --merge --delete-branch
+MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
+DELETE_BRANCH_FLAG=""
+if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
+  DELETE_BRANCH_FLAG="--delete-branch"
+fi
+# shellcheck disable=SC2086
+gh pr merge "${WORKFLOW_BRANCH}-clean" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG}
 
 # Post-merge: sync local main with remote
 git fetch origin
@@ -1329,7 +1341,13 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
 fi
 
 git push origin "${WORKFLOW_BRANCH}"
-gh pr merge "${PR_NUM}" --repo "${REPO}" --merge --delete-branch
+MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
+DELETE_BRANCH_FLAG=""
+if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
+  DELETE_BRANCH_FLAG="--delete-branch"
+fi
+# shellcheck disable=SC2086
+gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG}
 
 # Post-merge: sync local main with remote
 git fetch origin

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.171"
+csa = "0.1.172"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.171"
+weave = "0.1.172"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary
- Replace hardcoded `--merge --delete-branch` in pr-codex-bot merge steps with config-driven values
- Add `pr_review.merge_strategy` ("merge"|"rebase"|"squash", default "merge") and `pr_review.delete_branch` (default false — branches preserved for audit trail)
- Updated all 3 merge paths (Step 6a, Step 12, Step 12b) in PATTERN.md and workflow.toml, kept in sync per rule 027

Closes #480

## Test plan
- [x] `just pre-commit` passes (2801 unit + 16 E2E tests)
- [x] CSA review with tier-4-critical — no findings on the diff
- [ ] Verify `csa config get pr_review.merge_strategy --default merge` returns expected value
- [ ] Verify `csa config get pr_review.delete_branch --default false` returns expected value

🤖 Generated with [Claude Code](https://claude.com/claude-code)