### PR TITLE
refactor(patterns): remove redundant CSA install checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "axum",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.173"
+version = "0.1.174"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.173"
+version = "0.1.174"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/debate/PATTERN.md
+++ b/patterns/debate/PATTERN.md
@@ -19,36 +19,26 @@ If initial prompt contains "Use the debate skill" → participant mode.
 If invoked by user via /debate → orchestrator mode.
 Participants MUST NOT run any csa commands (infinite recursion).
 
-## Step 2: Verify Prerequisites
+## Step 2: Discover Available Models
 
 Tool: bash
 OnFail: abort
 
-Verify csa binary is available and tiers are configured.
+List configured tiers and parse JSON to get available models.
+At least one tier needs >= 2 models for debate. Record ordered
+tier list for escalation.
 
 ```bash
 csa --format json tiers list
 ```
 
-## Step 3: Discover Available Models
-
-Tool: bash
-OnFail: abort
-
-Parse tiers JSON to get available models. At least one tier needs
->= 2 models for debate. Record ordered tier list for escalation.
-
-```bash
-csa --format json tiers list
-```
-
-## Step 4: Resolve Debate Tool
+## Step 3: Resolve Debate Tool
 
 CSA auto-selects heterogeneous tool: claude-code caller → codex reviewer,
 codex caller → claude-code reviewer. Override with explicit --tool if needed
 (requires --force-ignore-tier-setting when tiers are configured).
 
-## Step 5: Select Starting Tier
+## Step 4: Select Starting Tier
 
 Use tier mapped to default in tier_mapping, or user-specified tier.
 Filter models to those matching the debate tool.
@@ -75,7 +65,7 @@ resulting in faster convergence and deeper arguments from round 1.
 
 > **Planned**: Native `csa debate --fork-from` support is tracked for a future release.
 
-## Step 6: Round 1 — Proposal
+## Step 5: Round 1 — Proposal
 
 Tool: csa
 Tier: ${CURRENT_TIER}
@@ -90,7 +80,7 @@ Proposer presents concrete, actionable strategy with:
 csa run --model-spec "${PROPOSER_MODEL}" --ephemeral "${PROPOSAL_PROMPT}"
 ```
 
-## Step 7: Round 1 — Critique
+## Step 6: Round 1 — Critique
 
 Tool: csa
 Tier: ${CURRENT_TIER}
@@ -105,7 +95,7 @@ Critic rigorously evaluates the proposal:
 csa run --model-spec "${CRITIC_MODEL}" --ephemeral "${CRITIQUE_PROMPT}"
 ```
 
-## Step 8: Round 1 — Response
+## Step 7: Round 1 — Response
 
 Tool: csa
 Tier: ${CURRENT_TIER}
@@ -119,7 +109,7 @@ Proposer responds to each criticism:
 csa run --model-spec "${PROPOSER_MODEL}" --ephemeral "${RESPONSE_PROMPT}"
 ```
 
-## Step 9: Convergence Evaluation
+## Step 8: Convergence Evaluation
 
 Orchestrator evaluates after each critique-response pair:
 - Both sides agree on core strategy → end debate
@@ -129,7 +119,7 @@ Orchestrator evaluates after each critique-response pair:
 
 ## IF ${NEEDS_ESCALATION}
 
-## Step 10: Tier Escalation
+## Step 9: Tier Escalation
 
 Find next higher tier. Summarize debate so far as context.
 Restart debate loop with higher tier models.
@@ -141,7 +131,7 @@ csa run --model-spec "${HIGHER_TIER_MODEL}" --ephemeral "${ESCALATION_PROMPT}"
 
 ## ENDIF
 
-## Step 11: Final Synthesis
+## Step 10: Final Synthesis
 
 Produce debate result document with:
 - Final Strategy

--- a/patterns/debate/skills/debate/SKILL.md
+++ b/patterns/debate/skills/debate/SKILL.md
@@ -110,16 +110,10 @@ Skip debate for: trivial changes, typo fixes, single-line edits, test additions.
 - `session` (optional): Resume existing debate session (ULID or prefix)
 - `model` (optional): Override model within selected tool
 
-## Prerequisites (MANDATORY — verify before ANY debate action)
+## Prerequisites
 
-1. For orchestrated debates: project MUST have tiers configured. Verify: `csa --format json tiers list`
+1. For orchestrated debates: project MUST have tiers configured (checked at runtime by Step 2)
 2. For default workflow: only `csa debate` needs to work (tiers not required)
-
-If ANY prerequisite fails:
-- **STOP IMMEDIATELY**
-- Report the specific failure to the user
-- Suggest remediation (e.g., "Run `csa init` to configure tiers")
-- **DO NOT attempt to execute tools directly**
 
 ## FORBIDDEN Actions
 
@@ -131,7 +125,6 @@ If ANY prerequisite fails:
 
 If CSA invocation fails (non-zero exit, timeout, parsing error):
 - Report the exact error to the user
-- Suggest `csa doctor` or manual investigation
 - **STOP the debate** — do NOT retry with direct tool calls
 
 ## Execution Protocol (Orchestrated Deep Debate)

--- a/patterns/debate/workflow.toml
+++ b/patterns/debate/workflow.toml
@@ -41,10 +41,12 @@ on_fail = "abort"
 
 [[workflow.steps]]
 id = 2
-title = "Verify Prerequisites"
+title = "Discover Available Models"
 tool = "bash"
 prompt = """
-Verify csa binary is available and tiers are configured.
+List configured tiers and parse JSON to get available models.
+At least one tier needs >= 2 models for debate. Record ordered
+tier list for escalation.
 
 ```bash
 csa --format json tiers list
@@ -53,19 +55,6 @@ on_fail = "abort"
 
 [[workflow.steps]]
 id = 3
-title = "Discover Available Models"
-tool = "bash"
-prompt = """
-Parse tiers JSON to get available models. At least one tier needs
->= 2 models for debate. Record ordered tier list for escalation.
-
-```bash
-csa --format json tiers list
-```"""
-on_fail = "abort"
-
-[[workflow.steps]]
-id = 4
 title = "Resolve Debate Tool"
 prompt = """
 CSA auto-selects heterogeneous tool: claude-code caller → codex reviewer,
@@ -74,7 +63,7 @@ codex caller → claude-code reviewer. Override with explicit --tool if needed
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 5
+id = 4
 title = "Select Starting Tier"
 prompt = """
 Use tier mapped to default in tier_mapping, or user-specified tier.
@@ -83,7 +72,7 @@ Validate >= 2 models available. If < 2, try next higher tier."""
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 6
+id = 5
 title = "Round 1 — Proposal"
 tool = "csa"
 prompt = """
@@ -100,7 +89,7 @@ tier = "${CURRENT_TIER}"
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 7
+id = 6
 title = "Round 1 — Critique"
 tool = "csa"
 prompt = """
@@ -117,7 +106,7 @@ tier = "${CURRENT_TIER}"
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 8
+id = 7
 title = "Round 1 — Response"
 tool = "csa"
 prompt = """
@@ -133,7 +122,7 @@ tier = "${CURRENT_TIER}"
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 9
+id = 8
 title = "Convergence Evaluation"
 prompt = """
 Orchestrator evaluates after each critique-response pair:
@@ -144,7 +133,7 @@ Orchestrator evaluates after each critique-response pair:
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 10
+id = 9
 title = "Tier Escalation"
 prompt = """
 Find next higher tier. Summarize debate so far as context.
@@ -158,7 +147,7 @@ on_fail = "abort"
 condition = "${NEEDS_ESCALATION}"
 
 [[workflow.steps]]
-id = 11
+id = 10
 title = "Final Synthesis"
 prompt = """
 Produce debate result document with:

--- a/scripts/hooks/post-pr-create.sh
+++ b/scripts/hooks/post-pr-create.sh
@@ -49,11 +49,6 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! command -v csa >/dev/null 2>&1; then
-  echo "ERROR: csa is required for post-pr-create transaction." >&2
-  exit 1
-fi
-
 CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || true)"
 if [ -z "${CURRENT_BRANCH}" ] || [ "${CURRENT_BRANCH}" = "HEAD" ]; then
   echo "ERROR: Cannot determine current branch." >&2

--- a/skills/pattern-creator/references/companion-skill.md
+++ b/skills/pattern-creator/references/companion-skill.md
@@ -45,7 +45,6 @@ triggers:
 
 ### Prerequisites
 
-- `csa` binary MUST be in PATH: `which csa`
 - <other prerequisites>
 
 ### Quick Start

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.173"
+csa = "0.1.174"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.173"
+weave = "0.1.174"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

- Merge debate workflow Step 2+3 (both ran identical `csa --format json tiers list`) into single Step 2
- Remove tautological "csa MUST be in PATH" prerequisites from codebase-audit, codebase-blog, and pattern-creator skills
- Remove `command -v csa` guard from post-pr-create.sh hook
- Renumber debate steps 1-10 (was 1-11), PATTERN.md and workflow.toml kept in sync per Rule 027

These pre-flight checks waste tokens and inflate agent context without catching real errors, since CSA is always installed when these files are executed.

## Test plan

- [x] `just fmt` passes
- [x] `just clippy` passes
- [x] 2802 unit tests pass
- [x] CSA review (tier-4-critical) passes with no findings
- [x] PATTERN.md and workflow.toml step numbers verified 1:1 aligned