### PR TITLE
fix(pr-codex-bot): detect bot setup/config messages and abort instead of skipping review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "axum",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.175"
+version = "0.1.176"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.175"
+version = "0.1.176"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-codex-bot/PATTERN.md
+++ b/patterns/pr-codex-bot/PATTERN.md
@@ -29,7 +29,9 @@ already-fixed issues.
 FORBIDDEN: self-dismissing bot comments, skipping debate for arbitration,
 running Step 2 in background, creating PR without Step 2 completion,
 debating stale comments without staleness check, trusting `reviewed=true`
-without SHA verification, auto-merging or auto-aborting at round limit.
+without SHA verification, auto-merging or auto-aborting at round limit,
+proceeding when bot responds with environment/configuration setup message
+instead of an actual code review (MUST stop and ask user to configure).
 
 ## Dispatcher Model Note
 
@@ -397,6 +399,24 @@ else
     if [ "${ACTIONABLE_COMMENT_COUNT}" -gt 0 ]; then
       echo "Detected ${ACTIONABLE_COMMENT_COUNT} actionable bot comment(s) after trigger window; marking BOT_HAS_ISSUES=true."
       BOT_HAS_ISSUES=true
+    else
+      # Bot replied but no P0/P1/P2 findings — verify it actually reviewed
+      # (detect environment/configuration messages that are NOT real reviews)
+      BOT_NEEDS_SETUP=false
+      set +e
+      SETUP_BODY="$(
+        gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
+          --jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]") | select(.created_at > "'"${WAIT_BASE_TS}"'")] | .[0].body // ""' \
+          2>/dev/null
+      )"
+      set -e
+      if [ -n "${SETUP_BODY}" ] && echo "${SETUP_BODY}" | grep -qEi 'configur|set.?up.*(environment|repo)|environment.*(set.?up|configur|need)|unable.to.(review|access)|cannot.*(complete|access|review)|not.*configured|permission|credential'; then
+        echo "ERROR: Codex bot responded with a setup/configuration message instead of a code review." >&2
+        echo "Bot response (truncated): $(echo "${SETUP_BODY}" | head -c 500)" >&2
+        echo "" >&2
+        echo "ACTION REQUIRED: Configure the Codex bot environment, then re-run pr-codex-bot." >&2
+        BOT_NEEDS_SETUP=true
+      fi
     fi
   elif [ "${WAIT_MARKER}" = "BOT_REPLY=timeout" ]; then
     BOT_UNAVAILABLE=true
@@ -414,9 +434,29 @@ if [ "${BOT_UNAVAILABLE}" = "true" ]; then
 fi
 echo "CSA_VAR:BOT_REVIEW_WINDOW_START=$WAIT_BASE_TS"
 echo "CSA_VAR:BOT_UNAVAILABLE=$BOT_UNAVAILABLE"
+echo "CSA_VAR:BOT_NEEDS_SETUP=${BOT_NEEDS_SETUP:-false}"
 echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
 echo "CSA_VAR:BOT_HAS_ISSUES=$BOT_HAS_ISSUES"
 ```
+
+## IF ${BOT_NEEDS_SETUP}
+
+## Step 5a: Abort — Bot Needs Environment Configuration
+
+Tool: none (orchestrator action)
+OnFail: abort
+
+The Codex bot responded but did not perform an actual code review — it sent a
+message indicating environment configuration is needed. The workflow MUST stop
+here and report to the user. FORBIDDEN: falling back to local review, skipping
+the bot review, or proceeding in any way.
+
+**Orchestrator action**: Report the bot's response to the user and STOP. The
+user must:
+1. Configure the Codex bot environment (follow the bot's instructions)
+2. Re-run `pr-codex-bot` after configuration is complete
+
+## ENDIF
 
 ## IF ${BOT_UNAVAILABLE}
 

--- a/patterns/pr-codex-bot/skills/pr-codex-bot/SKILL.md
+++ b/patterns/pr-codex-bot/skills/pr-codex-bot/SKILL.md
@@ -39,7 +39,7 @@ Local pre-PR review findings must be fixed before PR creation; they do not use
 the PR-page audit trail because no PR page exists yet. FORBIDDEN: merging with
 dismissed PR-page findings without explanatory PR comments.
 
-FORBIDDEN: self-dismissing bot comments, skipping debate for arbitration, auto-merging at round limit.
+FORBIDDEN: self-dismissing bot comments, skipping debate for arbitration, auto-merging at round limit, proceeding when bot responds with environment/configuration setup message instead of an actual code review (MUST stop and ask user to configure).
 
 ## Dispatcher Model
 
@@ -205,7 +205,7 @@ breaks prompt-guard propagation.
 2. Any local review issues are fixed before PR creation.
 3. PR resolved for the workflow branch (existing PR reused or a new PR created via strict owner-aware match, with create-race recovery and Step 4 precondition verified: `REVIEW_COMPLETED=true`).
 4. Cloud bot config checked (`csa config get pr_review.cloud_bot --default true`).
-5. **If cloud_bot enabled (default)**: cloud bot triggered, wait handled by delegated CSA gate with hard timeout and explicit marker checks, and timeout path handled.
+5. **If cloud_bot enabled (default)**: cloud bot triggered, wait handled by delegated CSA gate with hard timeout and explicit marker checks, and timeout path handled. If bot responds with environment/configuration setup message instead of actual review, workflow STOPS and reports to user (Step 5a).
 6. **If cloud_bot disabled**: supplementary check completed via one of:
    - fast-path: SHA match, review skipped, or
    - fallback path: SHA mismatch/missing (HEAD drift) and full `csa review --branch main` executed.

--- a/patterns/pr-codex-bot/workflow.toml
+++ b/patterns/pr-codex-bot/workflow.toml
@@ -9,6 +9,9 @@ name = "CLOUD_BOT"
 name = "BOT_HAS_ISSUES"
 
 [[workflow.variables]]
+name = "BOT_NEEDS_SETUP"
+
+[[workflow.variables]]
 name = "BOT_UNAVAILABLE"
 
 [[workflow.variables]]
@@ -403,6 +406,24 @@ else
     if [ "${ACTIONABLE_COMMENT_COUNT}" -gt 0 ]; then
       echo "Detected ${ACTIONABLE_COMMENT_COUNT} actionable bot comment(s) after trigger window; marking BOT_HAS_ISSUES=true."
       BOT_HAS_ISSUES=true
+    else
+      # Bot replied but no P0/P1/P2 findings — verify it actually reviewed
+      # (detect environment/configuration messages that are NOT real reviews)
+      BOT_NEEDS_SETUP=false
+      set +e
+      SETUP_BODY="$(
+        gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
+          --jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]") | select(.created_at > "'"${WAIT_BASE_TS}"'")] | .[0].body // ""' \
+          2>/dev/null
+      )"
+      set -e
+      if [ -n "${SETUP_BODY}" ] && echo "${SETUP_BODY}" | grep -qEi 'configur|set.?up.*(environment|repo)|environment.*(set.?up|configur|need)|unable.to.(review|access)|cannot.*(complete|access|review)|not.*configured|permission|credential'; then
+        echo "ERROR: Codex bot responded with a setup/configuration message instead of a code review." >&2
+        echo "Bot response (truncated): $(echo "${SETUP_BODY}" | head -c 500)" >&2
+        echo "" >&2
+        echo "ACTION REQUIRED: Configure the Codex bot environment, then re-run pr-codex-bot." >&2
+        BOT_NEEDS_SETUP=true
+      fi
     fi
   elif [ "${WAIT_MARKER}" = "BOT_REPLY=timeout" ]; then
     BOT_UNAVAILABLE=true
@@ -420,11 +441,33 @@ if [ "${BOT_UNAVAILABLE}" = "true" ]; then
 fi
 echo "CSA_VAR:BOT_REVIEW_WINDOW_START=$WAIT_BASE_TS"
 echo "CSA_VAR:BOT_UNAVAILABLE=$BOT_UNAVAILABLE"
+echo "CSA_VAR:BOT_NEEDS_SETUP=${BOT_NEEDS_SETUP:-false}"
 echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
 echo "CSA_VAR:BOT_HAS_ISSUES=$BOT_HAS_ISSUES"
 ```"""
 on_fail = "abort"
 condition = "!(${BOT_UNAVAILABLE})"
+
+[[workflow.steps]]
+id = 25
+title = "Step 5a: Abort — Bot Needs Environment Configuration"
+tool = "bash"
+prompt = """
+The Codex bot responded but did not perform an actual code review — it sent a
+message indicating environment configuration is needed. ABORT the workflow.
+
+```bash
+set -euo pipefail
+echo "ERROR: Codex bot needs environment configuration before it can review." >&2
+echo "The bot responded with a setup/configuration message instead of a code review." >&2
+echo "" >&2
+echo "ACTION REQUIRED:" >&2
+echo "  1. Configure the Codex bot environment (follow the bot's instructions on the PR page)" >&2
+echo "  2. Re-run pr-codex-bot after configuration is complete" >&2
+exit 1
+```"""
+on_fail = "abort"
+condition = "${BOT_NEEDS_SETUP}"
 
 [[workflow.steps]]
 id = 18
@@ -1027,6 +1070,21 @@ else
       echo "ERROR: Post-fix re-review found ${ACTIONABLE_COUNT} new actionable finding(s). Cannot merge." >&2
       echo "Re-run pr-codex-bot to start a new fix cycle."
       exit 1
+    else
+      # Bot replied clean — but verify it actually reviewed (not a setup message)
+      set +e
+      SETUP_BODY="$(
+        gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
+          --jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]") | select(.created_at > "'"${RETRIGGER_TS}"'")] | .[0].body // ""' \
+          2>/dev/null
+      )"
+      set -e
+      if [ -n "${SETUP_BODY}" ] && echo "${SETUP_BODY}" | grep -qEi 'configur|set.?up.*(environment|repo)|environment.*(set.?up|configur|need)|unable.to.(review|access)|cannot.*(complete|access|review)|not.*configured|permission|credential'; then
+        echo "ERROR: Codex bot responded with a setup/configuration message instead of a code review." >&2
+        echo "Bot response (truncated): $(echo "${SETUP_BODY}" | head -c 500)" >&2
+        echo "ACTION REQUIRED: Configure the Codex bot environment, then re-run pr-codex-bot." >&2
+        exit 1
+      fi
     fi
     BOT_CLEAN=true
   else
@@ -1256,6 +1314,25 @@ if [ "${COMMIT_COUNT}" -gt 3 ]; then
     echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
     echo "ERROR: Detected ${LATE_ACTIONABLE_COUNT} actionable bot comment(s) after post-rebase trigger window." >&2
     exit 1
+  else
+    # Bot replied clean — verify it actually reviewed (not a setup message)
+    set +e
+    SETUP_BODY="$(
+      gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
+        --jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]") | select(.created_at > "'"${REBASE_TRIGGER_TS}"'")] | .[0].body // ""' \
+        2>/dev/null
+    )"
+    set -e
+    if [ -n "${SETUP_BODY}" ] && echo "${SETUP_BODY}" | grep -qEi 'configur|set.?up.*(environment|repo)|environment.*(set.?up|configur|need)|unable.to.(review|access)|cannot.*(complete|access|review)|not.*configured|permission|credential'; then
+      REBASE_REVIEW_HAS_ISSUES=true
+      FALLBACK_REVIEW_HAS_ISSUES=true
+      echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
+      echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
+      echo "ERROR: Codex bot responded with a setup/configuration message instead of a code review." >&2
+      echo "Bot response (truncated): $(echo "${SETUP_BODY}" | head -c 500)" >&2
+      echo "ACTION REQUIRED: Configure the Codex bot environment, then re-run pr-codex-bot." >&2
+      exit 1
+    fi
   fi
 
   REBASE_REVIEW_HAS_ISSUES=false


### PR DESCRIPTION
## Summary

- When Codex bot responds with an environment/configuration setup message instead of an actual code review, the workflow now **detects and aborts** instead of silently skipping
- Detection via issue-comment keyword matching (configur, environment, setup, unable to review, etc.)
- Added to all 3 bot-response checkpoints: initial trigger (Step 5), post-fix re-review gate, post-rebase gate
- New `BOT_NEEDS_SETUP` variable and Step 5a abort gate in workflow.toml
- FORBIDDEN clause updated in PATTERN.md, SKILL.md, and workflow.toml

## Test plan

- [ ] Verify `weave compile-all` passes (17/17 OK)
- [ ] Verify `just pre-commit` passes (2812 tests + 16 e2e)
- [ ] Manual: trigger `@codex review` on a repo where bot needs setup → workflow should abort with ACTION REQUIRED message
- [ ] Manual: trigger `@codex review` on a properly configured repo → workflow should proceed normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)