### PR TITLE
feat(scheduler): cross-tier failover on 429 quota exhaustion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "axum",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.178"
+version = "0.1.179"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.178"
+version = "0.1.179"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_resolve.rs
@@ -98,7 +98,7 @@ pub(crate) fn resolve_debate_tool(
     if let Some(ref tier) = tier_name {
         if let Some(cfg) = project_config
             && let Some(resolution) =
-                crate::run_helpers::resolve_tool_from_tier(tier, cfg, parent_tool, whitelist)
+                crate::run_helpers::resolve_tool_from_tier(tier, cfg, parent_tool, whitelist, &[])
         {
             return Ok((
                 resolution.tool,

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -163,7 +163,7 @@ pub(crate) fn resolve_review_tool(
     if let Some(ref tier) = tier_name {
         if let Some(cfg) = project_config
             && let Some(resolution) =
-                crate::run_helpers::resolve_tool_from_tier(tier, cfg, parent_tool, whitelist)
+                crate::run_helpers::resolve_tool_from_tier(tier, cfg, parent_tool, whitelist, &[])
         {
             return Ok((resolution.tool, Some(resolution.model_spec)));
         }

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -90,18 +90,19 @@ pub(crate) struct RunLoopOutcome {
 }
 
 pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunLoopCompletion> {
+    // Compute max failover attempts: count total models across ALL tiers to
+    // allow cross-tier failover when the primary tier is exhausted (#493).
     let max_failover_attempts = if request.no_failover {
         1
     } else {
         request
             .config
-            .and_then(|cfg| {
-                let tier_name = cfg
-                    .tier_mapping
-                    .get("default")
-                    .cloned()
-                    .unwrap_or_else(|| "tier3".to_string());
-                cfg.tiers.get(&tier_name).map(|t| t.models.len())
+            .map(|cfg| {
+                cfg.tiers
+                    .values()
+                    .map(|t| t.models.len())
+                    .sum::<usize>()
+                    .max(1)
             })
             .unwrap_or(1)
     };
@@ -111,6 +112,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
     let mut current_model_spec = request.initial_model_spec;
     let mut current_model = request.initial_model;
     let mut tried_tools: Vec<String> = Vec::new();
+    let mut tried_specs: Vec<String> = Vec::new();
     let mut attempts = 0;
     let runtime_fallback_enabled = matches!(
         request.strategy,
@@ -571,6 +573,8 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                     attempts,
                     max_failover_attempts,
                     &mut tried_tools,
+                    &mut tried_specs,
+                    request.resolved_tier_name,
                     executed_session_id.as_deref(),
                     effective_session_arg.as_deref(),
                     request.ephemeral,
@@ -655,6 +659,8 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             attempts,
             max_failover_attempts,
             &mut tried_tools,
+            &mut tried_specs,
+            request.resolved_tier_name,
             executed_session_id.as_deref(),
             effective_session_arg.as_deref(),
             request.ephemeral,

--- a/crates/cli-sub-agent/src/run_cmd_post.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post.rs
@@ -150,6 +150,10 @@ pub(crate) enum RateLimitAction {
 /// Check for 429 rate-limit signals and decide whether to failover.
 ///
 /// Returns `RateLimitAction` to drive `continue`/`break` in the caller loop.
+///
+/// `resolved_tier_name` and `tried_specs` enable intra-tier failover: when the
+/// caller is running under a named tier, we pass spec-level exclusion so that
+/// a different model within the same tier can be selected.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn evaluate_rate_limit_failover(
     tool_name_str: &str,
@@ -157,6 +161,8 @@ pub(crate) fn evaluate_rate_limit_failover(
     attempts: usize,
     max_failover_attempts: usize,
     tried_tools: &mut Vec<String>,
+    tried_specs: &mut Vec<String>,
+    resolved_tier_name: Option<&str>,
     executed_session_id: Option<&str>,
     effective_session_arg: Option<&str>,
     ephemeral: bool,
@@ -193,6 +199,9 @@ pub(crate) fn evaluate_rate_limit_failover(
     }
 
     tried_tools.push(tool_name_str.to_string());
+    if let Some(spec) = current_model_spec {
+        tried_specs.push(spec.to_string());
+    }
 
     // Prefer the actually-executed session (important for forks where
     // effective_session_arg starts as None) so decide_failover evaluates
@@ -220,9 +229,11 @@ pub(crate) fn evaluate_rate_limit_failover(
     let action = csa_scheduler::decide_failover(
         tool_name_str,
         "default",
+        resolved_tier_name,
         task_needs_edit,
         session_state.as_ref(),
         tried_tools,
+        tried_specs,
         cfg,
         &rate_limit.matched_pattern,
     );
@@ -237,10 +248,12 @@ pub(crate) fn evaluate_rate_limit_failover(
             new_tool,
             new_model_spec,
         } => {
-            info!(
-                from = %tool_name_str,
-                to = %new_tool,
-                "Failing over to alternative tool"
+            warn!(
+                from_tool = %tool_name_str,
+                from_spec = %current_model_spec.unwrap_or("none"),
+                to_tool = %new_tool,
+                to_spec = %new_model_spec,
+                "[csa-failover] intra-tier failover"
             );
             let tool = crate::run_helpers::parse_tool_name(&new_tool)?;
             Ok(RateLimitAction::Retry {
@@ -268,6 +281,8 @@ pub(crate) fn evaluate_error_rate_limit_failover(
     attempts: usize,
     max_failover_attempts: usize,
     tried_tools: &mut Vec<String>,
+    tried_specs: &mut Vec<String>,
+    resolved_tier_name: Option<&str>,
     executed_session_id: Option<&str>,
     effective_session_arg: Option<&str>,
     ephemeral: bool,
@@ -305,6 +320,9 @@ pub(crate) fn evaluate_error_rate_limit_failover(
     }
 
     tried_tools.push(tool_name_str.to_string());
+    if let Some(spec) = current_model_spec {
+        tried_specs.push(spec.to_string());
+    }
 
     let failover_session_ref = executed_session_id.or(effective_session_arg);
     let session_state = if !ephemeral {
@@ -329,9 +347,11 @@ pub(crate) fn evaluate_error_rate_limit_failover(
     let action = csa_scheduler::decide_failover(
         tool_name_str,
         "default",
+        resolved_tier_name,
         task_needs_edit,
         session_state.as_ref(),
         tried_tools,
+        tried_specs,
         cfg,
         &rate_limit.matched_pattern,
     );
@@ -346,10 +366,12 @@ pub(crate) fn evaluate_error_rate_limit_failover(
             new_tool,
             new_model_spec,
         } => {
-            info!(
-                from = %tool_name_str,
-                to = %new_tool,
-                "Failing over from transport error to alternative tool"
+            warn!(
+                from_tool = %tool_name_str,
+                from_spec = %current_model_spec.unwrap_or("none"),
+                to_tool = %new_tool,
+                to_spec = %new_model_spec,
+                "[csa-failover] intra-tier failover (transport error)"
             );
             let tool = crate::run_helpers::parse_tool_name(&new_tool)?;
             Ok(RateLimitAction::Retry {

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -101,7 +101,7 @@ pub(crate) fn resolve_tool_and_model(
     if let Some(ref canonical_name) = canonical_tier
         && let Some(cfg) = config
     {
-        if let Some(resolution) = resolve_tool_from_tier(canonical_name, cfg, None, None) {
+        if let Some(resolution) = resolve_tool_from_tier(canonical_name, cfg, None, None, &[]) {
             // Flow resolved tool through existing enforcement checks
             cfg.enforce_tool_enabled(resolution.tool.as_str(), force_override_user_config)?;
             if !force {
@@ -471,12 +471,16 @@ pub(crate) struct TierToolResolution {
 /// a different `ModelFamily` than `parent_tool`. Falls back to any available tool
 /// in the tier when no heterogeneous option exists.
 ///
+/// `skip_specs` excludes model specs that have already been tried (e.g. due to
+/// 429 rate-limit failover within the same tier).
+///
 /// Returns `None` if no enabled, available tool is found in the tier.
 pub(crate) fn resolve_tool_from_tier(
     tier_name: &str,
     config: &ProjectConfig,
     parent_tool: Option<&str>,
     whitelist: Option<&[String]>,
+    skip_specs: &[String],
 ) -> Option<TierToolResolution> {
     let tier = config.tiers.get(tier_name)?;
 
@@ -489,6 +493,10 @@ pub(crate) fn resolve_tool_from_tier(
         .models
         .iter()
         .filter_map(|spec| {
+            // Skip specs that have already been tried in the failover chain
+            if skip_specs.iter().any(|s| s == spec) {
+                return None;
+            }
             let parts: Vec<&str> = spec.splitn(4, '/').collect();
             if parts.len() != 4 {
                 return None;

--- a/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
@@ -222,7 +222,7 @@ fn resolve_tool_from_tier_returns_none_for_missing_tier() {
         vec!["gemini-cli/google/default/xhigh"],
         &["gemini-cli"],
     );
-    let result = super::resolve_tool_from_tier("nonexistent-tier", &cfg, None, None);
+    let result = super::resolve_tool_from_tier("nonexistent-tier", &cfg, None, None, &[]);
     assert!(result.is_none());
 }
 
@@ -233,7 +233,7 @@ fn resolve_tool_from_tier_returns_first_available_when_no_parent() {
         vec!["gemini-cli/google/default/xhigh"],
         &["gemini-cli"],
     );
-    let result = super::resolve_tool_from_tier("test-tier", &cfg, None, None);
+    let result = super::resolve_tool_from_tier("test-tier", &cfg, None, None, &[]);
     assert!(result.is_some());
     let res = result.unwrap();
     assert_eq!(res.tool, ToolName::GeminiCli);
@@ -251,7 +251,7 @@ fn resolve_tool_from_tier_prefers_heterogeneous() {
         ],
         &["claude-code", "gemini-cli"],
     );
-    let result = super::resolve_tool_from_tier("test-tier", &cfg, Some("claude-code"), None);
+    let result = super::resolve_tool_from_tier("test-tier", &cfg, Some("claude-code"), None, &[]);
     assert!(result.is_some());
     let res = result.unwrap();
     assert_eq!(res.tool, ToolName::GeminiCli);
@@ -267,7 +267,7 @@ fn resolve_tool_from_tier_falls_back_to_same_family_when_no_heterogeneous() {
         vec!["claude-code/anthropic/default/xhigh"],
         &["claude-code"],
     );
-    let result = super::resolve_tool_from_tier("test-tier", &cfg, Some("claude-code"), None);
+    let result = super::resolve_tool_from_tier("test-tier", &cfg, Some("claude-code"), None, &[]);
     assert!(result.is_some());
     let res = result.unwrap();
     assert_eq!(res.tool, ToolName::ClaudeCode);
@@ -284,7 +284,7 @@ fn resolve_tool_from_tier_skips_disabled_tools() {
         ],
         &["claude-code"],
     );
-    let result = super::resolve_tool_from_tier("test-tier", &cfg, None, None);
+    let result = super::resolve_tool_from_tier("test-tier", &cfg, None, None, &[]);
     assert!(result.is_some());
     let res = result.unwrap();
     assert_eq!(res.tool, ToolName::ClaudeCode);
@@ -298,7 +298,7 @@ fn resolve_tool_from_tier_returns_none_when_all_disabled() {
         vec!["gemini-cli/google/default/xhigh"],
         &[], // no enabled tools
     );
-    let result = super::resolve_tool_from_tier("test-tier", &cfg, None, None);
+    let result = super::resolve_tool_from_tier("test-tier", &cfg, None, None, &[]);
     assert!(result.is_none());
 }
 

--- a/crates/csa-core/src/gemini.rs
+++ b/crates/csa-core/src/gemini.rs
@@ -17,6 +17,8 @@ pub const RATE_LIMIT_PATTERNS: &[&str] = &[
     "429",
     "resource exhausted",
     "resource_exhausted",
+    "capacity exhausted",
+    "capacity_exhausted",
     "quota exhausted",
     "quota_exhausted",
     "quota exceeded",

--- a/crates/csa-scheduler/src/failover.rs
+++ b/crates/csa-scheduler/src/failover.rs
@@ -29,29 +29,35 @@ pub enum FailoverAction {
 /// Decide what to do after a 429 rate-limit is detected.
 ///
 /// - `failed_tool`: the tool that was rate-limited.
-/// - `task_type`: used to find the correct tier.
+/// - `task_type`: used to find the correct tier (via `tier_mapping`).
+/// - `resolved_tier_name`: when the caller already knows the exact tier
+///   (e.g. from `--tier`), pass it here to bypass `tier_mapping` lookup.
 /// - `task_needs_edit`: whether the task requires file editing.
 ///   - `Some(true)`: task must be routed to tools that can edit existing files.
 ///   - `Some(false)`: task does not require edits.
 ///   - `None`: unknown; do not filter alternatives by edit capability.
 /// - `session`: the current session (if any).
 /// - `tried_tools`: tools already attempted in this failover chain.
+/// - `tried_specs`: model specs already attempted (enables intra-tier failover
+///   when the same tool has multiple models in the tier).
 /// - `config`: project configuration.
 /// - `original_error`: the error message from the rate-limited tool.
+#[allow(clippy::too_many_arguments)]
 pub fn decide_failover(
     failed_tool: &str,
     task_type: &str,
+    resolved_tier_name: Option<&str>,
     task_needs_edit: Option<bool>,
     session: Option<&MetaSessionState>,
     tried_tools: &[String],
+    tried_specs: &[String],
     config: &ProjectConfig,
     original_error: &str,
 ) -> FailoverAction {
-    // 1. Find the tier for this task_type
-    let tier_name = config
-        .tier_mapping
-        .get(task_type)
-        .cloned()
+    // 1. Find the tier — prefer explicit tier name, fall back to tier_mapping
+    let tier_name = resolved_tier_name
+        .map(String::from)
+        .or_else(|| config.tier_mapping.get(task_type).cloned())
         .unwrap_or_else(|| "tier3".to_string());
 
     let tier = match config.tiers.get(&tier_name) {
@@ -64,21 +70,27 @@ pub fn decide_failover(
         }
     };
 
-    // 2. Find eligible alternative tools (not tried, enabled, edit-compatible)
+    // 2. Find eligible alternative models (not tried, enabled, edit-compatible).
+    //    When tried_specs is non-empty, filter at spec granularity so that the
+    //    same tool with a different model can be selected (intra-tier failover).
+    //    When tried_specs is empty, fall back to tool-level filtering for
+    //    backward compatibility.
+    let use_spec_level = !tried_specs.is_empty();
     let alternatives: Vec<(String, String)> = tier
         .models
         .iter()
         .filter_map(|spec| {
             let tool = spec.split('/').next()?;
-            // Skip the failed tool and already-tried tools
-            if tool == failed_tool || tried_tools.iter().any(|t| t == tool) {
+            if use_spec_level {
+                if tried_specs.iter().any(|s| s == spec) {
+                    return None;
+                }
+            } else if tool == failed_tool || tried_tools.iter().any(|t| t == tool) {
                 return None;
             }
-            // Skip disabled
             if !config.is_tool_enabled(tool) {
                 return None;
             }
-            // Only enforce edit-capable tools when task requirement is known.
             if matches!(task_needs_edit, Some(true)) && !config.can_tool_edit_existing(tool) {
                 return None;
             }
@@ -87,8 +99,41 @@ pub fn decide_failover(
         .collect();
 
     if alternatives.is_empty() {
+        // Cross-tier fallback: try models from adjacent tiers when current tier
+        // is fully exhausted (issue #493). Sort tier names for deterministic order.
+        let mut sorted_tiers: Vec<_> = config.tiers.iter().collect();
+        sorted_tiers.sort_by_key(|(name, _)| (*name).clone());
+        for (other_tier_name, other_tier) in sorted_tiers {
+            if other_tier_name == &tier_name {
+                continue;
+            }
+            for spec in &other_tier.models {
+                let Some(tool) = spec.split('/').next() else {
+                    continue;
+                };
+                if tried_specs.iter().any(|s| s == spec) || tried_tools.iter().any(|t| t == tool) {
+                    continue;
+                }
+                if !config.is_tool_enabled(tool) {
+                    continue;
+                }
+                if matches!(task_needs_edit, Some(true)) && !config.can_tool_edit_existing(tool) {
+                    continue;
+                }
+                info!(
+                    from_tier = %tier_name,
+                    to_tier = %other_tier_name,
+                    new_tool = %tool,
+                    "Cross-tier failover: current tier exhausted, trying adjacent tier"
+                );
+                return FailoverAction::RetrySiblingSession {
+                    new_tool: tool.to_string(),
+                    new_model_spec: spec.clone(),
+                };
+            }
+        }
         return FailoverAction::ReportError {
-            reason: format!("All tools in tier '{tier_name}' exhausted"),
+            reason: format!("All tools in tier '{tier_name}' and adjacent tiers exhausted"),
             original_error: original_error.to_string(),
         };
     }
@@ -97,14 +142,10 @@ pub fn decide_failover(
 
     // 3. Check if we can reuse the current session
     if let Some(sess) = session {
-        // If session has valuable context (not compacted + has meaningful work),
-        // try to stay in the same session
         if has_valuable_context(sess) {
-            // Check if the new tool's slot is available in this session
             if !sess.tools.contains_key(&new_tool) {
                 info!(
-                    failed = %failed_tool,
-                    new = %new_tool,
+                    failed = %failed_tool, new = %new_tool,
                     session = %sess.meta_session_id,
                     "Failover: retry in same session (valuable context)"
                 );
@@ -114,14 +155,8 @@ pub fn decide_failover(
                     session_id: sess.meta_session_id.clone(),
                 };
             }
-
-            // Tool slot occupied — create sibling session instead of
-            // reporting an error. Transparent failover is more important
-            // than preserving a single session's context: the caller
-            // should never see a rate-limit error it cannot act on.
             info!(
-                failed = %failed_tool,
-                new = %new_tool,
+                failed = %failed_tool, new = %new_tool,
                 session = %sess.meta_session_id,
                 "Failover: valuable context but slot occupied, using sibling session"
             );
@@ -131,11 +166,9 @@ pub fn decide_failover(
             };
         }
 
-        // No valuable context → try same session first, fall back to sibling
         if !sess.tools.contains_key(&new_tool) {
             info!(
-                failed = %failed_tool,
-                new = %new_tool,
+                failed = %failed_tool, new = %new_tool,
                 session = %sess.meta_session_id,
                 "Failover: retry in same session"
             );
@@ -148,11 +181,7 @@ pub fn decide_failover(
     }
 
     // 4. Create sibling session
-    info!(
-        failed = %failed_tool,
-        new = %new_tool,
-        "Failover: retry in sibling session"
-    );
+    info!(failed = %failed_tool, new = %new_tool, "Failover: retry in sibling session");
     FailoverAction::RetrySiblingSession {
         new_tool,
         new_model_spec: new_spec,
@@ -160,16 +189,10 @@ pub fn decide_failover(
 }
 
 /// Check if a session has accumulated valuable context worth preserving.
-///
-/// A session is considered "valuable" if:
-/// - It is not compacted (active work in progress)
-/// - It has a summary containing keywords suggesting deep analysis
-fn has_valuable_context(session: &MetaSessionState) -> bool {
+pub(crate) fn has_valuable_context(session: &MetaSessionState) -> bool {
     if session.context_status.is_compacted {
         return false;
     }
-
-    // Check if any tool has done meaningful work
     let valuable_keywords = [
         "review",
         "analysis",
@@ -178,578 +201,10 @@ fn has_valuable_context(session: &MetaSessionState) -> bool {
         "bug",
         "debug",
     ];
-
     session.tools.values().any(|tool_state| {
         let summary_lower = tool_state.last_action_summary.to_lowercase();
         valuable_keywords
             .iter()
             .any(|kw| summary_lower.contains(kw))
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use chrono::Utc;
-    use csa_config::{ProjectMeta, TierConfig, TierStrategy, ToolConfig};
-    use std::collections::HashMap;
-
-    fn make_config(models: Vec<&str>, disabled: Vec<&str>) -> ProjectConfig {
-        let mut tools = HashMap::new();
-        for t in disabled {
-            tools.insert(
-                t.to_string(),
-                ToolConfig {
-                    enabled: false,
-                    restrictions: None,
-                    suppress_notify: true,
-                    ..Default::default()
-                },
-            );
-        }
-        let mut tiers = HashMap::new();
-        tiers.insert(
-            "tier3".to_string(),
-            TierConfig {
-                description: "test".to_string(),
-                models: models.iter().map(|s| s.to_string()).collect(),
-                strategy: TierStrategy::default(),
-
-                token_budget: None,
-                max_turns: None,
-            },
-        );
-        let mut tier_mapping = HashMap::new();
-        tier_mapping.insert("default".to_string(), "tier3".to_string());
-
-        ProjectConfig {
-            schema_version: 1,
-            project: ProjectMeta {
-                name: "test".to_string(),
-                created_at: Utc::now(),
-                max_recursion_depth: 5,
-            },
-            resources: Default::default(),
-            acp: Default::default(),
-            tools,
-            review: None,
-            debate: None,
-            tiers,
-            tier_mapping,
-            aliases: HashMap::new(),
-            tool_aliases: HashMap::new(),
-            preferences: None,
-            session: Default::default(),
-            memory: Default::default(),
-            hooks: Default::default(),
-            execution: Default::default(),
-            vcs: Default::default(),
-            filesystem_sandbox: Default::default(),
-        }
-    }
-
-    fn make_session(tools: Vec<(&str, &str)>, compacted: bool) -> MetaSessionState {
-        let mut tool_map = HashMap::new();
-        for (name, summary) in tools {
-            tool_map.insert(
-                name.to_string(),
-                csa_session::ToolState {
-                    provider_session_id: None,
-                    last_action_summary: summary.to_string(),
-                    last_exit_code: 0,
-                    updated_at: Utc::now(),
-                    token_usage: None,
-                },
-            );
-        }
-        MetaSessionState {
-            meta_session_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
-            description: None,
-            project_path: "/tmp".to_string(),
-            branch: None,
-            created_at: Utc::now(),
-            last_accessed: Utc::now(),
-            genealogy: Default::default(),
-            tools: tool_map,
-            context_status: csa_session::ContextStatus {
-                is_compacted: compacted,
-                last_compacted_at: None,
-            },
-            total_token_usage: None,
-            phase: Default::default(),
-            task_context: Default::default(),
-            turn_count: 0,
-            token_budget: None,
-            sandbox_info: None,
-
-            termination_reason: None,
-            is_seed_candidate: false,
-            git_head_at_creation: None,
-            last_return_packet: None,
-            change_id: None,
-            spec_id: None,
-            fork_call_timestamps: Vec::new(),
-            vcs_identity: None,
-            identity_version: 1,
-        }
-    }
-
-    #[test]
-    fn test_failover_to_next_tool() {
-        let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
-        let action = decide_failover(
-            "gemini-cli",
-            "default",
-            Some(false),
-            None,
-            &[],
-            &config,
-            "429 Resource exhausted",
-        );
-        match action {
-            FailoverAction::RetrySiblingSession { new_tool, .. } => {
-                assert_eq!(new_tool, "codex");
-            }
-            other => panic!("Expected RetrySiblingSession, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_failover_all_exhausted() {
-        let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
-        let action = decide_failover(
-            "gemini-cli",
-            "default",
-            Some(false),
-            None,
-            &["codex".to_string()],
-            &config,
-            "429",
-        );
-        match action {
-            FailoverAction::ReportError { reason, .. } => {
-                assert!(reason.contains("exhausted"));
-            }
-            other => panic!("Expected ReportError, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_failover_retry_in_session() {
-        let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
-        let session = make_session(vec![("gemini-cli", "code review in progress")], false);
-
-        let action = decide_failover(
-            "gemini-cli",
-            "default",
-            Some(false),
-            Some(&session),
-            &[],
-            &config,
-            "429",
-        );
-        match action {
-            FailoverAction::RetryInSession {
-                new_tool,
-                session_id,
-                ..
-            } => {
-                assert_eq!(new_tool, "codex");
-                assert_eq!(session_id, session.meta_session_id);
-            }
-            other => panic!("Expected RetryInSession, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_valuable_context_detection() {
-        let session_valuable =
-            make_session(vec![("gemini-cli", "Code review analysis complete")], false);
-        assert!(has_valuable_context(&session_valuable));
-
-        let session_compacted =
-            make_session(vec![("gemini-cli", "Code review analysis complete")], true);
-        assert!(!has_valuable_context(&session_compacted));
-
-        let session_trivial = make_session(vec![("gemini-cli", "Hello world test")], false);
-        assert!(!has_valuable_context(&session_trivial));
-    }
-
-    #[test]
-    fn test_failover_on_cooldown_error() {
-        let config = make_config(
-            vec![
-                "gemini-cli/g/m/0",
-                "codex/openai/o4-mini/0",
-                "claude-code/anthropic/sonnet/0",
-            ],
-            vec![],
-        );
-        let action = decide_failover(
-            "gemini-cli",
-            "default",
-            Some(false),
-            None,
-            &[],
-            &config,
-            "429 Too Many Requests: cooldown for 60 seconds",
-        );
-        match action {
-            FailoverAction::RetrySiblingSession { new_tool, .. } => {
-                assert_eq!(new_tool, "codex");
-            }
-            other => panic!("Expected RetrySiblingSession, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_failover_on_quota_error() {
-        let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
-        let action = decide_failover(
-            "codex",
-            "default",
-            Some(false),
-            None,
-            &[],
-            &config,
-            "Error: quota exceeded for model o4-mini",
-        );
-        match action {
-            FailoverAction::RetrySiblingSession { new_tool, .. } => {
-                assert_eq!(new_tool, "gemini-cli");
-            }
-            other => panic!("Expected RetrySiblingSession, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_failover_normal_error_no_match() {
-        // A non-rate-limit error should still go through failover logic
-        // (the caller decides whether to invoke failover; this function just picks next tool)
-        let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
-        let action = decide_failover(
-            "gemini-cli",
-            "default",
-            Some(false),
-            None,
-            &[],
-            &config,
-            "Internal server error",
-        );
-        match action {
-            FailoverAction::RetrySiblingSession { new_tool, .. } => {
-                assert_eq!(new_tool, "codex");
-            }
-            other => panic!("Expected RetrySiblingSession, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_failover_disabled_tool_skipped() {
-        let config = make_config(
-            vec![
-                "gemini-cli/g/m/0",
-                "codex/openai/o4-mini/0",
-                "claude-code/anthropic/sonnet/0",
-            ],
-            vec!["codex"],
-        );
-        let action = decide_failover(
-            "gemini-cli",
-            "default",
-            Some(false),
-            None,
-            &[],
-            &config,
-            "429",
-        );
-        match action {
-            FailoverAction::RetrySiblingSession { new_tool, .. } => {
-                assert_eq!(new_tool, "claude-code");
-            }
-            other => panic!("Expected RetrySiblingSession, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_failover_missing_tier_returns_error() {
-        let config = make_config(vec!["gemini-cli/g/m/0"], vec![]);
-        // Use a task_type that maps to a non-existent tier
-        let mut config_with_bad_mapping = config;
-        config_with_bad_mapping
-            .tier_mapping
-            .insert("special".to_string(), "tier99".to_string());
-        let action = decide_failover(
-            "gemini-cli",
-            "special",
-            Some(false),
-            None,
-            &[],
-            &config_with_bad_mapping,
-            "429",
-        );
-        match action {
-            FailoverAction::ReportError { reason, .. } => {
-                assert!(reason.contains("tier99"), "reason: {reason}");
-                assert!(reason.contains("not found"), "reason: {reason}");
-            }
-            other => panic!("Expected ReportError, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_failover_valuable_session_tool_slot_occupied_uses_sibling() {
-        let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
-        // Session has valuable context (review keyword) + codex slot already occupied
-        // → should create sibling session instead of reporting error (transparent failover)
-        let session = make_session(
-            vec![
-                ("gemini-cli", "deep security audit in progress"),
-                ("codex", "prior audit run"),
-            ],
-            false,
-        );
-        let action = decide_failover(
-            "gemini-cli",
-            "default",
-            Some(false),
-            Some(&session),
-            &[],
-            &config,
-            "429",
-        );
-        match action {
-            FailoverAction::RetrySiblingSession { new_tool, .. } => {
-                assert_eq!(new_tool, "codex");
-            }
-            other => panic!("Expected RetrySiblingSession, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_failover_no_session_no_valuable_context() {
-        // Session exists but has no valuable context (trivial summary, not compacted)
-        // and tool slot is occupied → falls through to sibling session
-        let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
-        let session = make_session(
-            vec![
-                ("gemini-cli", "simple hello world"),
-                ("codex", "simple run"),
-            ],
-            false,
-        );
-        let action = decide_failover(
-            "gemini-cli",
-            "default",
-            Some(false),
-            Some(&session),
-            &[],
-            &config,
-            "429",
-        );
-        match action {
-            FailoverAction::RetrySiblingSession { new_tool, .. } => {
-                assert_eq!(new_tool, "codex");
-            }
-            other => panic!("Expected RetrySiblingSession, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_failover_needs_edit_none_skips_filter() {
-        // When task_needs_edit is None, no edit capability filtering happens
-        let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
-        let action = decide_failover(
-            "gemini-cli",
-            "default",
-            None, // unknown edit requirement
-            None,
-            &[],
-            &config,
-            "429",
-        );
-        match action {
-            FailoverAction::RetrySiblingSession { new_tool, .. } => {
-                assert_eq!(new_tool, "codex");
-            }
-            other => panic!("Expected RetrySiblingSession, got {other:?}"),
-        }
-    }
-
-    // --- Quota failover transparency tests ---
-
-    fn make_multi_tier_config(
-        tier1_models: Vec<&str>,
-        tier3_models: Vec<&str>,
-        disabled: Vec<&str>,
-    ) -> ProjectConfig {
-        let mut tools = HashMap::new();
-        for t in disabled {
-            tools.insert(
-                t.to_string(),
-                ToolConfig {
-                    enabled: false,
-                    restrictions: None,
-                    suppress_notify: true,
-                    ..Default::default()
-                },
-            );
-        }
-        let mut tiers = HashMap::new();
-        tiers.insert(
-            "tier1".to_string(),
-            TierConfig {
-                description: "frontier".to_string(),
-                models: tier1_models.iter().map(|s| s.to_string()).collect(),
-                strategy: TierStrategy::default(),
-
-                token_budget: None,
-                max_turns: None,
-            },
-        );
-        tiers.insert(
-            "tier3".to_string(),
-            TierConfig {
-                description: "fast".to_string(),
-                models: tier3_models.iter().map(|s| s.to_string()).collect(),
-                strategy: TierStrategy::default(),
-
-                token_budget: None,
-                max_turns: None,
-            },
-        );
-        let mut tier_mapping = HashMap::new();
-        tier_mapping.insert("default".to_string(), "tier3".to_string());
-        tier_mapping.insert("review".to_string(), "tier1".to_string());
-
-        ProjectConfig {
-            schema_version: 1,
-            project: ProjectMeta {
-                name: "test".to_string(),
-                created_at: Utc::now(),
-                max_recursion_depth: 5,
-            },
-            resources: Default::default(),
-            acp: Default::default(),
-            tools,
-            review: None,
-            debate: None,
-            tiers,
-            tier_mapping,
-            aliases: HashMap::new(),
-            tool_aliases: HashMap::new(),
-            preferences: None,
-            session: Default::default(),
-            memory: Default::default(),
-            hooks: Default::default(),
-            execution: Default::default(),
-            vcs: Default::default(),
-            filesystem_sandbox: Default::default(),
-        }
-    }
-
-    #[test]
-    fn test_gemini_pro_failover_to_claude_in_same_tier() {
-        // tier1: gemini-pro + claude-opus → gemini-pro fails → picks claude-opus
-        let config = make_multi_tier_config(
-            vec![
-                "gemini-cli/google/gemini-2.5-pro/high",
-                "claude-code/anthropic/claude-sonnet-4-20250514/high",
-            ],
-            vec!["gemini-cli/google/gemini-2.5-flash/0"],
-            vec![],
-        );
-        let action = decide_failover(
-            "gemini-cli",
-            "review", // maps to tier1
-            Some(false),
-            None,
-            &[],
-            &config,
-            "Resource exhausted",
-        );
-        match action {
-            FailoverAction::RetrySiblingSession {
-                new_tool,
-                new_model_spec,
-            } => {
-                assert_eq!(new_tool, "claude-code");
-                assert!(new_model_spec.contains("claude"), "spec: {new_model_spec}");
-            }
-            other => panic!("Expected RetrySiblingSession to claude, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_gemini_flash_failover_to_claude_in_same_tier() {
-        // tier3: gemini-flash + claude-haiku → gemini-flash fails → picks claude-haiku
-        let config = make_multi_tier_config(
-            vec!["gemini-cli/google/gemini-2.5-pro/high"],
-            vec![
-                "gemini-cli/google/gemini-2.5-flash/0",
-                "claude-code/anthropic/claude-haiku-4-5-20251001/0",
-            ],
-            vec![],
-        );
-        let action = decide_failover(
-            "gemini-cli",
-            "default", // maps to tier3
-            Some(false),
-            None,
-            &[],
-            &config,
-            "quota exceeded",
-        );
-        match action {
-            FailoverAction::RetrySiblingSession {
-                new_tool,
-                new_model_spec,
-            } => {
-                assert_eq!(new_tool, "claude-code");
-                assert!(new_model_spec.contains("haiku"), "spec: {new_model_spec}");
-            }
-            other => panic!("Expected RetrySiblingSession to claude-haiku, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_failover_never_reports_error_when_alternatives_exist() {
-        // Even with valuable context + occupied slot, should retry via sibling
-        let config = make_multi_tier_config(
-            vec![
-                "gemini-cli/google/gemini-2.5-pro/high",
-                "claude-code/anthropic/claude-sonnet-4-20250514/high",
-            ],
-            vec![],
-            vec![],
-        );
-        let session = make_session(
-            vec![
-                ("gemini-cli", "deep code review analysis"),
-                ("claude-code", "prior run"),
-            ],
-            false,
-        );
-        let action = decide_failover(
-            "gemini-cli",
-            "review",
-            Some(false),
-            Some(&session),
-            &[],
-            &config,
-            "RESOURCE_EXHAUSTED",
-        );
-        // Should NOT be ReportError — should be RetrySiblingSession
-        match action {
-            FailoverAction::RetrySiblingSession { new_tool, .. } => {
-                assert_eq!(new_tool, "claude-code");
-            }
-            FailoverAction::RetryInSession { .. } => {
-                // Also acceptable if slot happens to be free
-            }
-            FailoverAction::ReportError { reason, .. } => {
-                panic!("Should not report error when alternatives exist: {reason}");
-            }
-        }
-    }
 }

--- a/crates/csa-scheduler/src/failover_tests.rs
+++ b/crates/csa-scheduler/src/failover_tests.rs
@@ -1,0 +1,609 @@
+use super::failover::*;
+use chrono::Utc;
+use csa_config::{ProjectConfig, ProjectMeta, TierConfig, TierStrategy, ToolConfig};
+use csa_session::MetaSessionState;
+use std::collections::HashMap;
+
+fn make_config(models: Vec<&str>, disabled: Vec<&str>) -> ProjectConfig {
+    let mut tools = HashMap::new();
+    for t in disabled {
+        tools.insert(
+            t.to_string(),
+            ToolConfig {
+                enabled: false,
+                restrictions: None,
+                suppress_notify: true,
+                ..Default::default()
+            },
+        );
+    }
+    let mut tiers = HashMap::new();
+    tiers.insert(
+        "tier3".to_string(),
+        TierConfig {
+            description: "test".to_string(),
+            models: models.iter().map(|s| s.to_string()).collect(),
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    let mut tier_mapping = HashMap::new();
+    tier_mapping.insert("default".to_string(), "tier3".to_string());
+
+    ProjectConfig {
+        schema_version: 1,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: Default::default(),
+        acp: Default::default(),
+        tools,
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping,
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    }
+}
+
+fn make_session(tools: Vec<(&str, &str)>, compacted: bool) -> MetaSessionState {
+    let mut tool_map = HashMap::new();
+    for (name, summary) in tools {
+        tool_map.insert(
+            name.to_string(),
+            csa_session::ToolState {
+                provider_session_id: None,
+                last_action_summary: summary.to_string(),
+                last_exit_code: 0,
+                updated_at: Utc::now(),
+                token_usage: None,
+            },
+        );
+    }
+    MetaSessionState {
+        meta_session_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+        description: None,
+        project_path: "/tmp".to_string(),
+        branch: None,
+        created_at: Utc::now(),
+        last_accessed: Utc::now(),
+        genealogy: Default::default(),
+        tools: tool_map,
+        context_status: csa_session::ContextStatus {
+            is_compacted: compacted,
+            last_compacted_at: None,
+        },
+        total_token_usage: None,
+        phase: Default::default(),
+        task_context: Default::default(),
+        turn_count: 0,
+        token_budget: None,
+        sandbox_info: None,
+        termination_reason: None,
+        is_seed_candidate: false,
+        git_head_at_creation: None,
+        last_return_packet: None,
+        change_id: None,
+        spec_id: None,
+        fork_call_timestamps: Vec::new(),
+        vcs_identity: None,
+        identity_version: 1,
+    }
+}
+
+fn make_multi_tier_config(
+    tier1_models: Vec<&str>,
+    tier3_models: Vec<&str>,
+    disabled: Vec<&str>,
+) -> ProjectConfig {
+    let mut tools = HashMap::new();
+    for t in disabled {
+        tools.insert(
+            t.to_string(),
+            ToolConfig {
+                enabled: false,
+                restrictions: None,
+                suppress_notify: true,
+                ..Default::default()
+            },
+        );
+    }
+    let mut tiers = HashMap::new();
+    tiers.insert(
+        "tier1".to_string(),
+        TierConfig {
+            description: "frontier".to_string(),
+            models: tier1_models.iter().map(|s| s.to_string()).collect(),
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    tiers.insert(
+        "tier3".to_string(),
+        TierConfig {
+            description: "fast".to_string(),
+            models: tier3_models.iter().map(|s| s.to_string()).collect(),
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    let mut tier_mapping = HashMap::new();
+    tier_mapping.insert("default".to_string(), "tier3".to_string());
+    tier_mapping.insert("review".to_string(), "tier1".to_string());
+
+    ProjectConfig {
+        schema_version: 1,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: Default::default(),
+        acp: Default::default(),
+        tools,
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping,
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    }
+}
+
+#[test]
+fn test_failover_to_next_tool() {
+    let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        None,
+        &[],
+        &[],
+        &config,
+        "429 Resource exhausted",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession { new_tool, .. } => assert_eq!(new_tool, "codex"),
+        other => panic!("Expected RetrySiblingSession, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_failover_all_exhausted() {
+    let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        None,
+        &["codex".to_string()],
+        &[],
+        &config,
+        "429",
+    );
+    match action {
+        FailoverAction::ReportError { reason, .. } => assert!(reason.contains("exhausted")),
+        other => panic!("Expected ReportError, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_failover_retry_in_session() {
+    let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
+    let session = make_session(vec![("gemini-cli", "code review in progress")], false);
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        Some(&session),
+        &[],
+        &[],
+        &config,
+        "429",
+    );
+    match action {
+        FailoverAction::RetryInSession {
+            new_tool,
+            session_id,
+            ..
+        } => {
+            assert_eq!(new_tool, "codex");
+            assert_eq!(session_id, session.meta_session_id);
+        }
+        other => panic!("Expected RetryInSession, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_valuable_context_detection() {
+    let valuable = make_session(vec![("gemini-cli", "Code review analysis complete")], false);
+    assert!(has_valuable_context(&valuable));
+    let compacted = make_session(vec![("gemini-cli", "Code review analysis complete")], true);
+    assert!(!has_valuable_context(&compacted));
+    let trivial = make_session(vec![("gemini-cli", "Hello world test")], false);
+    assert!(!has_valuable_context(&trivial));
+}
+
+#[test]
+fn test_failover_on_cooldown_error() {
+    let config = make_config(
+        vec![
+            "gemini-cli/g/m/0",
+            "codex/openai/o4-mini/0",
+            "claude-code/anthropic/sonnet/0",
+        ],
+        vec![],
+    );
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        None,
+        &[],
+        &[],
+        &config,
+        "429 Too Many Requests: cooldown for 60 seconds",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession { new_tool, .. } => assert_eq!(new_tool, "codex"),
+        other => panic!("Expected RetrySiblingSession, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_failover_on_quota_error() {
+    let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
+    let action = decide_failover(
+        "codex",
+        "default",
+        None,
+        Some(false),
+        None,
+        &[],
+        &[],
+        &config,
+        "Error: quota exceeded for model o4-mini",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession { new_tool, .. } => assert_eq!(new_tool, "gemini-cli"),
+        other => panic!("Expected RetrySiblingSession, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_failover_normal_error_no_match() {
+    let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        None,
+        &[],
+        &[],
+        &config,
+        "Internal server error",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession { new_tool, .. } => assert_eq!(new_tool, "codex"),
+        other => panic!("Expected RetrySiblingSession, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_failover_disabled_tool_skipped() {
+    let config = make_config(
+        vec![
+            "gemini-cli/g/m/0",
+            "codex/openai/o4-mini/0",
+            "claude-code/anthropic/sonnet/0",
+        ],
+        vec!["codex"],
+    );
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        None,
+        &[],
+        &[],
+        &config,
+        "429",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession { new_tool, .. } => assert_eq!(new_tool, "claude-code"),
+        other => panic!("Expected RetrySiblingSession, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_failover_missing_tier_returns_error() {
+    let mut config = make_config(vec!["gemini-cli/g/m/0"], vec![]);
+    config
+        .tier_mapping
+        .insert("special".to_string(), "tier99".to_string());
+    let action = decide_failover(
+        "gemini-cli",
+        "special",
+        None,
+        Some(false),
+        None,
+        &[],
+        &[],
+        &config,
+        "429",
+    );
+    match action {
+        FailoverAction::ReportError { reason, .. } => {
+            assert!(reason.contains("tier99"), "reason: {reason}");
+            assert!(reason.contains("not found"), "reason: {reason}");
+        }
+        other => panic!("Expected ReportError, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_failover_valuable_session_tool_slot_occupied_uses_sibling() {
+    let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
+    let session = make_session(
+        vec![
+            ("gemini-cli", "deep security audit in progress"),
+            ("codex", "prior audit run"),
+        ],
+        false,
+    );
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        Some(&session),
+        &[],
+        &[],
+        &config,
+        "429",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession { new_tool, .. } => assert_eq!(new_tool, "codex"),
+        other => panic!("Expected RetrySiblingSession, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_failover_no_session_no_valuable_context() {
+    let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
+    let session = make_session(
+        vec![
+            ("gemini-cli", "simple hello world"),
+            ("codex", "simple run"),
+        ],
+        false,
+    );
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        Some(&session),
+        &[],
+        &[],
+        &config,
+        "429",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession { new_tool, .. } => assert_eq!(new_tool, "codex"),
+        other => panic!("Expected RetrySiblingSession, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_failover_needs_edit_none_skips_filter() {
+    let config = make_config(vec!["gemini-cli/g/m/0", "codex/openai/o4-mini/0"], vec![]);
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        None,
+        None,
+        &[],
+        &[],
+        &config,
+        "429",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession { new_tool, .. } => assert_eq!(new_tool, "codex"),
+        other => panic!("Expected RetrySiblingSession, got {other:?}"),
+    }
+}
+
+// --- Quota failover transparency tests ---
+
+#[test]
+fn test_gemini_pro_failover_to_claude_in_same_tier() {
+    let config = make_multi_tier_config(
+        vec![
+            "gemini-cli/google/gemini-2.5-pro/high",
+            "claude-code/anthropic/claude-sonnet-4-20250514/high",
+        ],
+        vec!["gemini-cli/google/gemini-2.5-flash/0"],
+        vec![],
+    );
+    let action = decide_failover(
+        "gemini-cli",
+        "review",
+        None,
+        Some(false),
+        None,
+        &[],
+        &[],
+        &config,
+        "Resource exhausted",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession {
+            new_tool,
+            new_model_spec,
+        } => {
+            assert_eq!(new_tool, "claude-code");
+            assert!(new_model_spec.contains("claude"), "spec: {new_model_spec}");
+        }
+        other => panic!("Expected RetrySiblingSession to claude, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_gemini_flash_failover_to_claude_in_same_tier() {
+    let config = make_multi_tier_config(
+        vec!["gemini-cli/google/gemini-2.5-pro/high"],
+        vec![
+            "gemini-cli/google/gemini-2.5-flash/0",
+            "claude-code/anthropic/claude-haiku-4-5-20251001/0",
+        ],
+        vec![],
+    );
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        None,
+        &[],
+        &[],
+        &config,
+        "quota exceeded",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession {
+            new_tool,
+            new_model_spec,
+        } => {
+            assert_eq!(new_tool, "claude-code");
+            assert!(new_model_spec.contains("haiku"), "spec: {new_model_spec}");
+        }
+        other => panic!("Expected RetrySiblingSession to claude-haiku, got {other:?}"),
+    }
+}
+
+// --- Cross-tier failover tests ---
+
+#[test]
+fn test_cross_tier_fallback_when_current_tier_exhausted() {
+    let config = make_multi_tier_config(
+        vec!["claude-code/anthropic/claude-sonnet-4-20250514/high"],
+        vec!["gemini-cli/google/gemini-2.5-flash/0"],
+        vec![],
+    );
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        None,
+        &[],
+        &["gemini-cli/google/gemini-2.5-flash/0".to_string()],
+        &config,
+        "429 MODEL_CAPACITY_EXHAUSTED",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession {
+            new_tool,
+            new_model_spec,
+        } => {
+            assert_eq!(new_tool, "claude-code");
+            assert!(new_model_spec.contains("claude"), "spec: {new_model_spec}");
+        }
+        other => panic!("Expected cross-tier failover to claude-code, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_cross_tier_all_tiers_exhausted_reports_error() {
+    let config = make_multi_tier_config(
+        vec!["claude-code/anthropic/claude-sonnet-4-20250514/high"],
+        vec!["gemini-cli/google/gemini-2.5-flash/0"],
+        vec![],
+    );
+    let action = decide_failover(
+        "gemini-cli",
+        "default",
+        None,
+        Some(false),
+        None,
+        &[],
+        &[
+            "gemini-cli/google/gemini-2.5-flash/0".to_string(),
+            "claude-code/anthropic/claude-sonnet-4-20250514/high".to_string(),
+        ],
+        &config,
+        "429",
+    );
+    match action {
+        FailoverAction::ReportError { reason, .. } => {
+            assert!(reason.contains("adjacent tiers"), "reason: {reason}")
+        }
+        other => panic!("Expected all-exhausted error, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_failover_never_reports_error_when_alternatives_exist() {
+    let config = make_multi_tier_config(
+        vec![
+            "gemini-cli/google/gemini-2.5-pro/high",
+            "claude-code/anthropic/claude-sonnet-4-20250514/high",
+        ],
+        vec![],
+        vec![],
+    );
+    let session = make_session(
+        vec![
+            ("gemini-cli", "deep code review analysis"),
+            ("claude-code", "prior run"),
+        ],
+        false,
+    );
+    let action = decide_failover(
+        "gemini-cli",
+        "review",
+        None,
+        Some(false),
+        Some(&session),
+        &[],
+        &[],
+        &config,
+        "RESOURCE_EXHAUSTED",
+    );
+    match action {
+        FailoverAction::RetrySiblingSession { new_tool, .. } => assert_eq!(new_tool, "claude-code"),
+        FailoverAction::RetryInSession { .. } => {} // acceptable
+        FailoverAction::ReportError { reason, .. } => {
+            panic!("Should not report error when alternatives exist: {reason}");
+        }
+    }
+}

--- a/crates/csa-scheduler/src/lib.rs
+++ b/crates/csa-scheduler/src/lib.rs
@@ -1,6 +1,8 @@
 //! Scheduler: tool selection (round-robin), session reuse, seed management, and 429 failover.
 
 pub mod failover;
+#[cfg(test)]
+mod failover_tests;
 pub mod rate_limit;
 pub mod rotation;
 pub mod seed_session;

--- a/crates/csa-scheduler/src/rate_limit.rs
+++ b/crates/csa-scheduler/src/rate_limit.rs
@@ -274,6 +274,38 @@ mod tests {
     }
 
     #[test]
+    fn test_gemini_model_capacity_exhausted() {
+        let result = detect_rate_limit(
+            "gemini-cli",
+            "429 MODEL_CAPACITY_EXHAUSTED: No capacity available for model gemini-3-flash-preview",
+            "",
+            1,
+            Some("gemini-cli/google/gemini-3-flash-preview/xhigh"),
+        );
+        assert!(result.is_some());
+        // Should match "429" first (patterns are checked in order)
+        let detected = result.unwrap();
+        assert_eq!(detected.matched_pattern, "429");
+        assert_eq!(
+            detected.model_spec.as_deref(),
+            Some("gemini-cli/google/gemini-3-flash-preview/xhigh")
+        );
+    }
+
+    #[test]
+    fn test_gemini_capacity_exhausted_without_429_prefix() {
+        let result = detect_rate_limit(
+            "gemini-cli",
+            "Error: capacity_exhausted for model",
+            "",
+            1,
+            None,
+        );
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().matched_pattern, "capacity_exhausted");
+    }
+
+    #[test]
     fn test_gemini_quota_exhausted_case_insensitive() {
         let result = detect_rate_limit("gemini-cli", "reason: 'QUOTA_EXHAUSTED'", "", 1, None);
         assert!(result.is_some());

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.178"
+csa = "0.1.179"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.178"
+weave = "0.1.179"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary
- Add cross-tier fallback in `decide_failover()` when all models in the current tier are exhausted (429/quota)
- Add `capacity_exhausted` / `capacity exhausted` to gemini rate-limit detection patterns
- Fix `max_failover_attempts` to count models across ALL tiers (was limited to current tier, blocking cross-tier)
- Sort tier names for deterministic cross-tier iteration order
- Extract failover tests to `failover_tests.rs` (failover.rs 899→214 lines)

Closes #493

## Test plan
- [x] 77 scheduler tests pass (including 4 new: cross-tier fallback, all-exhausted, capacity patterns)
- [x] `just pre-commit` passes (all 2812+ tests)
- [x] `csa review --range main...HEAD --tool codex` — review findings addressed (max_failover fix, sorted iteration)

### Known limitation (pre-existing, not introduced here)
`resolved_tier_name` in `run_cmd_execute.rs` is derived from `skill_agent.tier` / `tier_mapping["default"]` rather than the user's `--tier` CLI flag. This means cross-tier failover may use the wrong tier context when `--tier` is explicitly specified. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)