### PR TITLE
fix(sandbox): bwrap extra-writable ordering + gemini thought fallback (#496)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "axum",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.179"
+version = "0.1.180"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.179"
+version = "0.1.180"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_output.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_output.rs
@@ -363,6 +363,7 @@ fn is_non_summary_line(line: &str) -> bool {
         || line.starts_with("- ")
         || line.starts_with("* ")
         || line.starts_with("<!-- CSA:SECTION:")
+        || line.starts_with("[thought-fallback]")
         || line.starts_with("CSA Meta Session ID:")
         || line.starts_with("Position:")
         || line.starts_with("Key Arguments:")

--- a/crates/csa-acp/src/client.rs
+++ b/crates/csa-acp/src/client.rs
@@ -57,6 +57,12 @@ pub struct StreamingMetadata {
     pub extracted_commands: Vec<String>,
     /// Tail buffer of agent message/thought text (bounded by [`TAIL_BUFFER_MAX_BYTES`]).
     pub tail_text: String,
+    /// Tail buffer of agent message text only (bounded by [`TAIL_BUFFER_MAX_BYTES`]).
+    pub message_text: String,
+    /// Tail buffer of agent thought text only (bounded by [`TAIL_BUFFER_MAX_BYTES`]).
+    pub thought_text: String,
+    /// Whether the output used thought text as fallback (no message text was produced).
+    pub has_thought_fallback: bool,
     /// Total bytes written to the output spool file.
     pub(crate) spool_bytes_written: u64,
 }
@@ -71,23 +77,33 @@ impl StreamingMetadata {
         self.extracted_commands = store.extracted_commands();
     }
 
-    /// Append agent text to the tail buffer, trimming from the front if needed.
-    ///
-    /// Uses a high-water mark ([`TAIL_BUFFER_HIGH_WATER`]) so trimming occurs
-    /// once per MiB of new text rather than once per chunk, amortising the
-    /// O(N) cost of `String::drain` and avoiding O(N²) behaviour.
-    pub(crate) fn append_text(&mut self, text: &str) {
+    /// Append agent message text to both the message-specific and combined tail buffers.
+    pub(crate) fn append_message_text(&mut self, text: &str) {
         self.tail_text.push_str(text);
-        if self.tail_text.len() > TAIL_BUFFER_HIGH_WATER {
-            // Trim back to TAIL_BUFFER_MAX_BYTES.  Find a char boundary
-            // at or after the excess point to avoid splitting multi-byte chars.
-            let excess = self.tail_text.len() - TAIL_BUFFER_MAX_BYTES;
-            let mut trim_at = excess;
-            while trim_at < self.tail_text.len() && !self.tail_text.is_char_boundary(trim_at) {
-                trim_at += 1;
-            }
-            self.tail_text.drain(..trim_at);
+        trim_tail_buffer(&mut self.tail_text);
+        self.message_text.push_str(text);
+        trim_tail_buffer(&mut self.message_text);
+    }
+
+    /// Append agent thought text to both the thought-specific and combined tail buffers.
+    pub(crate) fn append_thought_text(&mut self, text: &str) {
+        self.tail_text.push_str(text);
+        trim_tail_buffer(&mut self.tail_text);
+        self.thought_text.push_str(text);
+        trim_tail_buffer(&mut self.thought_text);
+    }
+}
+
+/// Trim a tail buffer back to [`TAIL_BUFFER_MAX_BYTES`] when it exceeds
+/// [`TAIL_BUFFER_HIGH_WATER`], respecting UTF-8 char boundaries.
+fn trim_tail_buffer(buf: &mut String) {
+    if buf.len() > TAIL_BUFFER_HIGH_WATER {
+        let excess = buf.len() - TAIL_BUFFER_MAX_BYTES;
+        let mut trim_at = excess;
+        while trim_at < buf.len() && !buf.is_char_boundary(trim_at) {
+            trim_at += 1;
         }
+        buf.drain(..trim_at);
     }
 }
 

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -391,7 +391,7 @@ impl AcpConnection {
             metadata.sync_from_store(&events_ref);
         }
         let events = self.events.borrow_mut().take_events();
-        let output = collect_agent_output(&metadata);
+        let output = collect_agent_output(&mut metadata);
         match outcome {
             PromptOutcome::Completed(Ok(response)) => Ok(PromptResult {
                 output,
@@ -633,7 +633,7 @@ fn stream_new_agent_messages(
                     flush_complete_lines(stdout_line_buf, "[stdout] ");
                 }
                 spool_chunk(output_spool, chunk.as_bytes(), metadata);
-                metadata.append_text(chunk);
+                metadata.append_message_text(chunk);
             }
             SessionEvent::AgentThought(chunk) => {
                 if stream_stdout_to_stderr {
@@ -643,7 +643,7 @@ fn stream_new_agent_messages(
                     flush_complete_lines(thought_line_buf, "[thought] ");
                 }
                 spool_chunk(output_spool, chunk.as_bytes(), metadata);
-                metadata.append_text(chunk);
+                metadata.append_thought_text(chunk);
             }
             SessionEvent::PlanUpdate(plan) => {
                 metadata.has_plan_updates = true;
@@ -715,11 +715,28 @@ fn spool_chunk(spool: &mut Option<SpoolRotator>, bytes: &[u8], metadata: &mut St
 
 /// Collect agent output for the caller (stdout / summary extraction).
 ///
-/// Returns the tail text buffer from [`StreamingMetadata`], which contains
-/// only `AgentMessage` and `AgentThought` text, bounded to ~1 MiB.
-/// The full output is on disk in the output spool file.
-fn collect_agent_output(metadata: &StreamingMetadata) -> String {
-    metadata.tail_text.clone()
+/// Prefers `message_text` (actual agent output).  When no message text was
+/// produced but thought text exists, falls back to thought text with a
+/// `[thought-fallback]` prefix so callers know the output is derived from
+/// internal reasoning rather than visible agent messages.  This handles
+/// models (e.g. gemini) that produce thoughts but no visible message content.
+fn collect_agent_output(metadata: &mut StreamingMetadata) -> String {
+    let message = metadata.message_text.trim();
+    if !message.is_empty() {
+        return metadata.message_text.clone();
+    }
+    let thought = metadata.thought_text.trim();
+    if !thought.is_empty() {
+        metadata.has_thought_fallback = true;
+        tracing::warn!(
+            thought_bytes = metadata.thought_text.len(),
+            "agent produced no message output; falling back to thought text"
+        );
+        // Put the marker on its own line so CSA section markers
+        // (<!-- CSA:SECTION:... -->) in the thought text remain parseable.
+        return format!("[thought-fallback]\n{}", metadata.thought_text);
+    }
+    String::new()
 }
 
 fn stop_reason_to_string(reason: StopReason) -> String {

--- a/crates/csa-acp/src/connection_tests.rs
+++ b/crates/csa-acp/src/connection_tests.rs
@@ -150,8 +150,11 @@ fn test_collect_agent_output_includes_thoughts() {
         &mut String::new(),
         &mut String::new(),
     );
-    let output = collect_agent_output(&metadata);
-    assert_eq!(output, "HelloThinking... world");
+    // tail_text still captures both messages and thoughts for backward compat.
+    assert_eq!(metadata.tail_text, "HelloThinking... world");
+    // collect_agent_output now prefers message_text when available.
+    let output = collect_agent_output(&mut metadata);
+    assert_eq!(output, "Hello world");
 }
 
 #[test]
@@ -308,10 +311,16 @@ fn collect_agent_output_excludes_diagnostic_events() {
         &mut String::new(),
         &mut String::new(),
     );
-    let output = collect_agent_output(&metadata);
+    // tail_text still captures both messages and thoughts.
     assert_eq!(
-        output, "Hellohmm world",
-        "collect_agent_output must only include AgentMessage and AgentThought"
+        metadata.tail_text, "Hellohmm world",
+        "tail_text must include AgentMessage and AgentThought"
+    );
+    // collect_agent_output prefers message_text when messages exist.
+    let output = collect_agent_output(&mut metadata);
+    assert_eq!(
+        output, "Hello world",
+        "collect_agent_output must return message_text when messages exist"
     );
     assert!(metadata.has_tool_calls);
     assert!(metadata.has_plan_updates);
@@ -611,6 +620,103 @@ fn thought_buffer_flushes_on_stream_type_switch() {
     );
     // stdout buffer also flushed because "answer\n" contains newline.
     assert!(stdout_buf.is_empty());
+}
+
+#[test]
+fn test_collect_agent_output_thought_fallback() {
+    let events = shared_events(vec![SessionEvent::AgentThought(
+        "deep thinking about the problem".to_string(),
+    )]);
+    let mut index = 0;
+    let mut spool: Option<SpoolRotator> = None;
+    let mut metadata = StreamingMetadata::default();
+
+    stream_new_agent_messages(
+        &events,
+        &mut index,
+        false,
+        &mut spool,
+        &mut metadata,
+        &mut String::new(),
+        &mut String::new(),
+    );
+    let output = collect_agent_output(&mut metadata);
+    assert!(
+        output.starts_with("[thought-fallback]\n"),
+        "thought-only output must have [thought-fallback] prefix on its own line, got: {output}"
+    );
+    assert!(
+        output.contains("deep thinking about the problem"),
+        "thought fallback must contain the thought text"
+    );
+    assert!(
+        metadata.has_thought_fallback,
+        "has_thought_fallback must be set"
+    );
+}
+
+#[test]
+fn test_collect_agent_output_message_preferred() {
+    let events = shared_events(vec![
+        SessionEvent::AgentThought("internal reasoning".to_string()),
+        SessionEvent::AgentMessage("visible answer".to_string()),
+    ]);
+    let mut index = 0;
+    let mut spool: Option<SpoolRotator> = None;
+    let mut metadata = StreamingMetadata::default();
+
+    stream_new_agent_messages(
+        &events,
+        &mut index,
+        false,
+        &mut spool,
+        &mut metadata,
+        &mut String::new(),
+        &mut String::new(),
+    );
+    let output = collect_agent_output(&mut metadata);
+    assert_eq!(
+        output, "visible answer",
+        "when messages exist, output must be message_text (no prefix)"
+    );
+    assert!(
+        !metadata.has_thought_fallback,
+        "has_thought_fallback must NOT be set when messages exist"
+    );
+}
+
+#[test]
+fn test_collect_agent_output_empty_when_neither() {
+    let events = shared_events(vec![
+        SessionEvent::PlanUpdate("step 1".to_string()),
+        SessionEvent::ToolCallStarted {
+            id: "t1".to_string(),
+            title: "Read".to_string(),
+            kind: "tool_use".to_string(),
+        },
+    ]);
+    let mut index = 0;
+    let mut spool: Option<SpoolRotator> = None;
+    let mut metadata = StreamingMetadata::default();
+
+    stream_new_agent_messages(
+        &events,
+        &mut index,
+        false,
+        &mut spool,
+        &mut metadata,
+        &mut String::new(),
+        &mut String::new(),
+    );
+    let output = collect_agent_output(&mut metadata);
+    assert!(
+        output.is_empty(),
+        "output must be empty when no messages or thoughts, got: {output}"
+    );
+    assert!(
+        !metadata.has_thought_fallback,
+        "has_thought_fallback must NOT be set when nothing exists"
+    );
 }
 
 #[test]

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -69,21 +69,49 @@ impl BwrapCommandBuilder {
         // Read-only root filesystem
         cmd.args(["--ro-bind", "/", "/"]);
 
-        // Writable bind mounts
+        // Standard virtual filesystems MUST come before bind mounts so that
+        // writable paths under /tmp are not hidden by the fresh tmpfs overlay.
+        cmd.args(["--tmpfs", "/tmp"]);
+        cmd.args(["--dev", "/dev"]);
+        cmd.args(["--proc", "/proc"]);
+
+        // Writable bind mounts (after tmpfs so /tmp/* mounts are visible).
+        //
+        // Special handling for /tmp paths:
+        // - "/tmp" itself is SKIPPED: --tmpfs /tmp already provides a writable
+        //   /tmp.  Bind-mounting the host's /tmp would expose host temp files,
+        //   sockets and caches to the sandbox — a security/isolation regression.
+        // - Sub-paths (e.g. /tmp/foo) get --dir to create the mount-point
+        //   directory inside the fresh tmpfs (which starts empty), then --bind
+        //   to overlay the host directory.  This is correct for the common case
+        //   where writable paths are directories.  For nested paths (/tmp/a/b)
+        //   we also create intermediate parent directories.
+        let tmp_prefix = Path::new("/tmp");
         for path in &self.writable_paths {
             let s = path.to_string_lossy();
-            cmd.args(["--bind", &s, &s]);
+            if path == tmp_prefix {
+                // /tmp itself is already writable via --tmpfs; skip to avoid
+                // exposing host /tmp content inside the sandbox.
+                continue;
+            } else if path.starts_with(tmp_prefix) {
+                // Create intermediate parent directories if deeper than /tmp/.
+                if let Some(parent) = path.parent()
+                    && parent != tmp_prefix
+                {
+                    let p = parent.to_string_lossy();
+                    cmd.args(["--dir", &p]);
+                }
+                cmd.args(["--dir", &s]);
+                cmd.args(["--bind", &s, &s]);
+            } else {
+                cmd.args(["--bind", &s, &s]);
+            }
         }
 
         // Extra read-only bind mounts
         for (src, dest) in &self.ro_binds {
             cmd.args(["--ro-bind", &src.to_string_lossy(), &dest.to_string_lossy()]);
         }
-
-        // Standard virtual filesystems
-        cmd.args(["--tmpfs", "/tmp"]);
-        cmd.args(["--dev", "/dev"]);
-        cmd.args(["--proc", "/proc"]);
 
         // Namespace configuration
         cmd.arg("--share-net");
@@ -329,6 +357,157 @@ mod tests {
         assert!(
             session_after_bind,
             "/tmp/session should be --bind (writable); args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn test_bwrap_extra_writable_under_tmp_ordering() {
+        let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+        builder.with_writable_path(Path::new("/home/user/project"));
+        builder.with_writable_path(Path::new("/tmp/foo"));
+        let cmd = builder.build();
+        let args = command_args(&cmd);
+
+        // Locate key positions
+        let pos = |needle: &str| args.iter().position(|a| a == needle);
+
+        let tmpfs_pos = args
+            .iter()
+            .enumerate()
+            .find(|(_, a)| *a == "--tmpfs")
+            .map(|(i, _)| i)
+            .expect("--tmpfs must be present");
+        assert_eq!(
+            args[tmpfs_pos + 1],
+            "/tmp",
+            "--tmpfs must be followed by /tmp"
+        );
+
+        // --tmpfs /tmp must appear BEFORE --bind /tmp/foo /tmp/foo
+        let bind_tmp_foo_pos = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "--bind")
+            .find(|(i, _)| args.get(i + 1).map(|s| s.as_str()) == Some("/tmp/foo"))
+            .map(|(i, _)| i)
+            .expect("--bind /tmp/foo must be present");
+        assert!(
+            tmpfs_pos < bind_tmp_foo_pos,
+            "--tmpfs /tmp (pos {tmpfs_pos}) must come BEFORE --bind /tmp/foo (pos {bind_tmp_foo_pos}); args: {args:?}"
+        );
+
+        // --dir /tmp/foo must appear between --tmpfs and --bind for /tmp paths
+        let dir_tmp_foo_pos = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "--dir")
+            .find(|(i, _)| args.get(i + 1).map(|s| s.as_str()) == Some("/tmp/foo"))
+            .map(|(i, _)| i)
+            .expect("--dir /tmp/foo must be present for /tmp sub-paths");
+        assert!(
+            tmpfs_pos < dir_tmp_foo_pos && dir_tmp_foo_pos < bind_tmp_foo_pos,
+            "--dir /tmp/foo (pos {dir_tmp_foo_pos}) must be between --tmpfs (pos {tmpfs_pos}) and --bind (pos {bind_tmp_foo_pos}); args: {args:?}"
+        );
+
+        // Non-/tmp writable path should NOT have --dir
+        let dir_project = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "--dir")
+            .any(|(i, _)| args.get(i + 1).map(|s| s.as_str()) == Some("/home/user/project"));
+        assert!(
+            !dir_project,
+            "non-/tmp path /home/user/project should NOT have --dir; args: {args:?}"
+        );
+
+        // Non-/tmp writable path should still have --bind
+        let bind_project = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "--bind")
+            .any(|(i, _)| args.get(i + 1).map(|s| s.as_str()) == Some("/home/user/project"));
+        assert!(
+            bind_project,
+            "/home/user/project should have --bind; args: {args:?}"
+        );
+
+        // Verify --ro-bind / / is still first
+        assert_eq!(args[1], "--ro-bind");
+        assert_eq!(args[2], "/");
+        assert_eq!(args[3], "/");
+
+        // Verify overall order: --ro-bind < --tmpfs < --bind < --
+        let separator_pos = pos("--").expect("-- separator must be present");
+        assert!(
+            bind_tmp_foo_pos < separator_pos,
+            "--bind must come before -- separator"
+        );
+    }
+
+    #[test]
+    fn test_bwrap_nested_tmp_path_creates_intermediate_dirs() {
+        let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+        builder.with_writable_path(Path::new("/tmp/deep/nested/dir"));
+        let cmd = builder.build();
+        let args = command_args(&cmd);
+
+        // Must have --dir for intermediate parent
+        let has_parent_dir = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "--dir")
+            .any(|(i, _)| args.get(i + 1).map(|s| s.as_str()) == Some("/tmp/deep/nested"));
+        assert!(
+            has_parent_dir,
+            "nested /tmp path must have --dir for parent /tmp/deep/nested; args: {args:?}"
+        );
+
+        // Must have --dir for the path itself
+        let has_path_dir = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "--dir")
+            .any(|(i, _)| args.get(i + 1).map(|s| s.as_str()) == Some("/tmp/deep/nested/dir"));
+        assert!(
+            has_path_dir,
+            "nested /tmp path must have --dir for /tmp/deep/nested/dir; args: {args:?}"
+        );
+
+        // Must have --bind
+        let has_bind = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "--bind")
+            .any(|(i, _)| args.get(i + 1).map(|s| s.as_str()) == Some("/tmp/deep/nested/dir"));
+        assert!(
+            has_bind,
+            "/tmp/deep/nested/dir must have --bind; args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn test_bwrap_bare_tmp_is_not_bind_mounted() {
+        // writable_paths = ["/tmp"] should NOT produce --bind /tmp /tmp,
+        // because --tmpfs /tmp already makes /tmp writable.  Bind-mounting
+        // host /tmp would leak host temp files into the sandbox.
+        let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+        builder.with_writable_path(Path::new("/tmp"));
+        let cmd = builder.build();
+        let args = command_args(&cmd);
+
+        // --tmpfs /tmp must exist
+        assert!(
+            args.windows(2).any(|w| w[0] == "--tmpfs" && w[1] == "/tmp"),
+            "--tmpfs /tmp must be present; args: {args:?}"
+        );
+
+        // --bind /tmp /tmp must NOT exist
+        let has_bind_tmp = args
+            .windows(3)
+            .any(|w| w[0] == "--bind" && w[1] == "/tmp" && w[2] == "/tmp");
+        assert!(
+            !has_bind_tmp,
+            "bare /tmp must NOT be --bind mounted (would expose host /tmp); args: {args:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Bug 1**: Reorder bwrap arguments so `--tmpfs /tmp` comes before writable `--bind` mounts, preventing the tmpfs from covering bind-mounted paths under `/tmp`. Add `--dir` for `/tmp` subpaths to create mount points in the fresh tmpfs. Skip bare `/tmp` to avoid exposing host temp files.
- **Bug 2**: Track `AgentMessage` and `AgentThought` text separately in `StreamingMetadata`. When a model produces thoughts but no visible output (output=0), fall back to thought text with `[thought-fallback]` prefix instead of returning empty results.
- Add `[thought-fallback]` to debate summary filter to prevent marker from appearing in user-visible output.

## Changes

| File | Change |
|------|--------|
| `crates/csa-resource/src/bwrap.rs` | Reorder virtual FS mounts before bind mounts; add `--dir` for `/tmp` subpaths; skip bare `/tmp` |
| `crates/csa-acp/src/client.rs` | Add `message_text`, `thought_text`, `has_thought_fallback` fields to `StreamingMetadata` |
| `crates/csa-acp/src/connection.rs` | Separate message/thought tracking; thought fallback in `collect_agent_output` |
| `crates/csa-acp/src/connection_tests.rs` | 3 new tests for thought fallback behavior |
| `crates/cli-sub-agent/src/debate_cmd_output.rs` | Filter `[thought-fallback]` marker from debate summaries |

## Test plan

- [x] `cargo test -p csa-resource -- bwrap` — 11 tests pass (3 new: ordering, nested dirs, bare `/tmp` skip)
- [x] `cargo test -p csa-acp` — 64 tests pass (3 new: thought fallback, message preferred, empty when neither)
- [x] `just pre-commit` — exit 0 (2827 unit + 16 e2e tests)
- [x] `csa review --tier tier-4-critical --range main...HEAD` — reviewed (medium/low findings addressed)

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)