### PR TITLE
fix(timeout): respect explicit --idle-timeout over initial_response_timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.189"
+version = "0.1.190"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -239,11 +239,11 @@ pub(crate) async fn handle_debate(
     let extra_env = extra_env_owned.as_ref();
     let idle_timeout_seconds =
         crate::pipeline::resolve_idle_timeout_seconds(config.as_ref(), args.idle_timeout);
-    let initial_response_timeout_seconds =
-        crate::pipeline::resolve_initial_response_timeout_seconds(
-            config.as_ref(),
-            args.initial_response_timeout,
-        );
+    let initial_response_timeout_seconds = crate::pipeline::resolve_initial_response_timeout(
+        config.as_ref(),
+        args.initial_response_timeout,
+        args.idle_timeout,
+    );
 
     // Resolve stream mode from CLI flags (default: BufferOnly for debate)
     let stream_mode = resolve_debate_stream_mode(args.stream_stdout, args.no_stream_stdout);

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -39,7 +39,7 @@ pub(crate) use session_exec::{
     execute_with_session_and_meta_with_parent_source,
 };
 
-pub(crate) const DEFAULT_IDLE_TIMEOUT_SECONDS: u64 = 120;
+pub(crate) const DEFAULT_IDLE_TIMEOUT_SECONDS: u64 = 300;
 pub(crate) const DEFAULT_LIVENESS_DEAD_SECONDS: u64 = csa_process::DEFAULT_LIVENESS_DEAD_SECS;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -72,6 +72,26 @@ pub(crate) fn resolve_initial_response_timeout_seconds(
         .or_else(|| config.and_then(|cfg| cfg.resources.initial_response_timeout_seconds));
     // 0 means explicitly disabled.
     raw.filter(|&v| v > 0)
+}
+
+/// Resolve the initial-response timeout with idle-timeout awareness.
+///
+/// When the user explicitly sets `--idle-timeout` but does NOT set
+/// `--initial-response-timeout`, the initial-response timeout is disabled
+/// so that the user's explicit idle timeout is always respected.
+/// This prevents the config default (120s) from silently overriding a
+/// longer `--idle-timeout` value (e.g., 1200s).
+pub(crate) fn resolve_initial_response_timeout(
+    config: Option<&ProjectConfig>,
+    cli_initial_response_timeout: Option<u64>,
+    cli_idle_timeout: Option<u64>,
+) -> Option<u64> {
+    if cli_idle_timeout.is_some() && cli_initial_response_timeout.is_none() {
+        // User explicitly set --idle-timeout but not --initial-response-timeout.
+        // Disable the two-phase timeout to honor the user's intent.
+        return None;
+    }
+    resolve_initial_response_timeout_seconds(config, cli_initial_response_timeout)
 }
 
 pub(crate) fn resolve_liveness_dead_seconds(config: Option<&ProjectConfig>) -> u64 {

--- a/crates/cli-sub-agent/src/pipeline_tests_initial_response.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_initial_response.rs
@@ -123,3 +123,106 @@ fn test_resolve_initial_response_timeout_uses_config_value() {
         Some(90)
     );
 }
+
+// ---------------------------------------------------------------------------
+// resolve_initial_response_timeout (idle-timeout–aware variant)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_resolve_initial_response_timeout_disabled_when_idle_timeout_explicit() {
+    // User set --idle-timeout but NOT --initial-response-timeout → disabled.
+    let cfg = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig {
+            initial_response_timeout_seconds: Some(120),
+            ..Default::default()
+        },
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+    // cli_idle_timeout=Some(1200), cli_initial_response_timeout=None → disabled.
+    assert_eq!(
+        resolve_initial_response_timeout(Some(&cfg), None, Some(1200)),
+        None
+    );
+}
+
+#[test]
+fn test_resolve_initial_response_timeout_kept_when_both_explicit() {
+    // User set both --idle-timeout AND --initial-response-timeout → both respected.
+    let cfg = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig {
+            initial_response_timeout_seconds: Some(120),
+            ..Default::default()
+        },
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+    // Both explicit → initial_response_timeout=60 wins.
+    assert_eq!(
+        resolve_initial_response_timeout(Some(&cfg), Some(60), Some(1200)),
+        Some(60)
+    );
+}
+
+#[test]
+fn test_resolve_initial_response_timeout_falls_through_without_idle_timeout() {
+    // No --idle-timeout → falls through to normal resolution.
+    let cfg = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig {
+            initial_response_timeout_seconds: Some(120),
+            ..Default::default()
+        },
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+    // No cli_idle_timeout → config default applies.
+    assert_eq!(
+        resolve_initial_response_timeout(Some(&cfg), None, None),
+        Some(120)
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -251,11 +251,11 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
     let stream_mode = resolve_review_stream_mode(args.stream_stdout, args.no_stream_stdout);
     let idle_timeout_seconds =
         crate::pipeline::resolve_idle_timeout_seconds(config.as_ref(), args.idle_timeout);
-    let initial_response_timeout_seconds =
-        crate::pipeline::resolve_initial_response_timeout_seconds(
-            config.as_ref(),
-            args.initial_response_timeout,
-        );
+    let initial_response_timeout_seconds = crate::pipeline::resolve_initial_response_timeout(
+        config.as_ref(),
+        args.initial_response_timeout,
+        args.idle_timeout,
+    );
 
     // Resolve readonly_project_root from config (default: false).
     let readonly_project_root = global_config.review.readonly_sandbox.unwrap_or(false);

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -217,9 +217,10 @@ pub(crate) async fn handle_run(
         // --no-idle-timeout disables both idle and initial-response timeouts.
         None
     } else {
-        pipeline::resolve_initial_response_timeout_seconds(
+        pipeline::resolve_initial_response_timeout(
             config.as_ref(),
             initial_response_timeout,
+            idle_timeout,
         )
     };
     let run_timeout_seconds = resolve_run_timeout_seconds(timeout, skill.as_deref());

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -341,17 +341,23 @@ impl AcpConnection {
                                 &mut stdout_line_buf,
                                 &mut thought_line_buf,
                             );
-                            let effective_timeout = if processed_event_count == 0 {
-                                initial_response_timeout.unwrap_or(idle_timeout)
-                            } else {
-                                idle_timeout
-                            };
+                            let (effective_timeout, timeout_phase) =
+                                if processed_event_count == 0 {
+                                    if let Some(irt) = initial_response_timeout {
+                                        (irt, TimeoutPhase::InitialResponse)
+                                    } else {
+                                        (idle_timeout, TimeoutPhase::Idle)
+                                    }
+                                } else {
+                                    (idle_timeout, TimeoutPhase::Idle)
+                                };
                             maybe_emit_heartbeat(
                                 heartbeat_interval,
                                 execution_start,
                                 *self.last_activity.borrow(),
                                 &mut last_heartbeat,
                                 effective_timeout,
+                                timeout_phase,
                             );
                             if self.last_activity.borrow().elapsed() >= effective_timeout {
                                 break PromptOutcome::IdleTimeout;
@@ -539,12 +545,22 @@ fn resolve_heartbeat_interval() -> Option<Duration> {
     Some(Duration::from_secs(secs))
 }
 
+/// Indicates which timeout phase the heartbeat is reporting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TimeoutPhase {
+    /// Waiting for the first response from the backend tool.
+    InitialResponse,
+    /// Normal idle timeout (after first output received, or no initial-response-timeout configured).
+    Idle,
+}
+
 fn maybe_emit_heartbeat(
     heartbeat_interval: Option<Duration>,
     execution_start: Instant,
     last_activity: Instant,
     last_heartbeat: &mut Instant,
-    idle_timeout: Duration,
+    effective_timeout: Duration,
+    phase: TimeoutPhase,
 ) {
     let Some(interval) = heartbeat_interval else {
         return;
@@ -560,11 +576,15 @@ fn maybe_emit_heartbeat(
     }
 
     let elapsed = now.saturating_duration_since(execution_start);
+    let phase_label = match phase {
+        TimeoutPhase::InitialResponse => "initial-response-timeout",
+        TimeoutPhase::Idle => "idle-timeout",
+    };
     eprintln!(
-        "[csa-heartbeat] ACP prompt still running: elapsed={}s idle={}s idle-timeout={}s",
+        "[csa-heartbeat] ACP prompt still running: elapsed={}s idle={}s {phase_label}={}s",
         elapsed.as_secs(),
         idle_for.as_secs(),
-        idle_timeout.as_secs()
+        effective_timeout.as_secs()
     );
     *last_heartbeat = now;
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.189"
+csa = "0.1.190"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.189"
+weave = "0.1.190"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary
- When user explicitly sets `--idle-timeout` but NOT `--initial-response-timeout`, disable the two-phase timeout so the user's explicit idle timeout is always respected
- Fix heartbeat to distinguish `initial-response-timeout` vs `idle-timeout` labels
- Align `DEFAULT_IDLE_TIMEOUT_SECONDS` (was 120s) with config default (300s)

## Root Cause (#517)
The config default `initial_response_timeout_seconds = 120s` silently overrode the user's explicit `--idle-timeout 1200s`, killing the ACP process at 120s instead of 1200s. The heartbeat also misleadingly displayed `idle-timeout=120s` when it was actually the initial_response_timeout.

## Test plan
- [x] 3 new unit tests for `resolve_initial_response_timeout` covering all branches
- [x] All 2861 existing tests pass
- [x] 16 E2E tests pass
- [x] `csa review` with new binary confirms heartbeat shows correct timeout
- [x] `just pre-commit` passes

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)