### PR TITLE
fix(acp): improve ACP transport diagnostics and retry resilience

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.191"
+version = "0.1.192"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use anyhow::Result;
 use clap::Parser;
 
@@ -182,6 +184,8 @@ async fn main() {
             eprintln!();
             eprintln!("{hint}");
         }
+        let _ = std::io::stdout().flush();
+        let _ = std::io::stderr().flush();
         std::process::exit(1);
     }
 }
@@ -430,6 +434,8 @@ async fn run() -> Result<()> {
                 extra_writable,
             )
             .await?;
+            let _ = std::io::stdout().flush();
+            let _ = std::io::stderr().flush();
             std::process::exit(exit_code);
         }
         Commands::Session { cmd } => match cmd {
@@ -465,6 +471,8 @@ async fn run() -> Result<()> {
             }
             SessionCommands::IsAlive { session, cd } => {
                 let alive = session_cmds::handle_session_is_alive(session, cd)?;
+                let _ = std::io::stdout().flush();
+                let _ = std::io::stderr().flush();
                 std::process::exit(if alive { 0 } else { 1 });
             }
             SessionCommands::Result {
@@ -556,10 +564,14 @@ async fn run() -> Result<()> {
         }
         Commands::Review(args) => {
             let exit_code = review_cmd::handle_review(args, current_depth).await?;
+            let _ = std::io::stdout().flush();
+            let _ = std::io::stderr().flush();
             std::process::exit(exit_code);
         }
         Commands::Debate(args) => {
             let exit_code = debate_cmd::handle_debate(args, current_depth, output_format).await?;
+            let _ = std::io::stdout().flush();
+            let _ = std::io::stderr().flush();
             std::process::exit(exit_code);
         }
         Commands::Eval {
@@ -756,6 +768,8 @@ async fn run() -> Result<()> {
         Commands::ClaudeSubAgent(args) => {
             let exit_code =
                 claude_sub_agent_cmd::handle_claude_sub_agent(args, current_depth).await?;
+            let _ = std::io::stdout().flush();
+            let _ = std::io::stderr().flush();
             std::process::exit(exit_code);
         }
         Commands::Tokuin { cmd } => {

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -406,7 +406,10 @@ impl AcpConnection {
                 timed_out: false,
                 metadata,
             }),
-            PromptOutcome::Completed(Err(err)) => Err(AcpError::PromptFailed(err.to_string())),
+            PromptOutcome::Completed(Err(err)) => {
+                let stderr_detail = Self::format_stderr(&self.stderr());
+                Err(AcpError::PromptFailed(format!("{err}{stderr_detail}")))
+            }
             PromptOutcome::IdleTimeout => {
                 let _ = self.kill().await;
                 let exit_reason =

--- a/crates/csa-core/src/gemini.rs
+++ b/crates/csa-core/src/gemini.rs
@@ -19,6 +19,7 @@ pub const RATE_LIMIT_PATTERNS: &[&str] = &[
     "resource_exhausted",
     "capacity exhausted",
     "capacity_exhausted",
+    "no capacity available",
     "quota exhausted",
     "quota_exhausted",
     "quota exceeded",

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -394,7 +394,11 @@ impl AcpTransport {
         let sandbox_session_id = options.sandbox.map(|s| s.session_id.clone());
         let sandbox_best_effort = options.sandbox.is_some_and(|s| s.best_effort);
         let idle_timeout_seconds = options.idle_timeout_seconds;
-        let initial_response_timeout_seconds = options.initial_response_timeout_seconds;
+        // ACP transport: skip initial_response_timeout. ACP init_timeout
+        // already catches startup failures, and idle_timeout handles
+        // post-start hangs. IRT causes false positives with tools that
+        // do heavy post-initialization (gemini-cli loading extensions/MCP).
+        let initial_response_timeout_seconds: Option<u64> = None;
         let acp_init_timeout_seconds = options.acp_init_timeout_seconds;
         let termination_grace_period_seconds = options.termination_grace_period_seconds;
         let session_meta = Self::build_session_meta(

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.191"
+csa = "0.1.192"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.191"
+weave = "0.1.192"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary
Re-apply of #523 (reverted for pr-bot compliance).

- Include captured stderr in `PromptFailed` ACP errors for better diagnostics
- Skip `initial_response_timeout` for ACP transport (false positives with slow post-init tools)
- Add "no capacity available" to Gemini rate limit patterns for correct retry
- Flush stdout/stderr before `process::exit()` to prevent output loss

## Test plan
- [x] `just pre-commit` passes (2861 tests + 16 e2e)
- [x] `csa review --tool claude-code --range main...HEAD` → PASS

Closes #521
Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)