### PR TITLE
refactor(config): lower all default timeouts from 300s to 250s

### DIFF
--- a/.claude/rules/csa-architecture-ref.md
+++ b/.claude/rules/csa-architecture-ref.md
@@ -1,0 +1,65 @@
+# CSA Architecture Reference
+
+These are condensed architecture summaries for CSA subsystems. For full details,
+see the linked reference documents.
+
+## Core Architecture
+
+Fractal recursion (max depth 5 via `CSA_DEPTH`), ULID-based sessions in `~/.local/state/cli-sub-agent/`, TOML serialization, `flock(2)` locking, `setsid` + negative-PID signal propagation, two-phase termination (SIGTERM→SIGKILL). ACP transport (JSON-RPC 2.0 via stdio) for claude-code/codex; legacy CLI for gemini-cli/opencode. Context env vars: `CSA_SESSION_ID`, `CSA_DEPTH`, `CSA_PROJECT_ROOT`, `CSA_SESSION_DIR`. Auto-strips `CLAUDECODE`/`CLAUDE_CODE_ENTRYPOINT` on child spawn.
+→ `.agents/project-rules-ref/architecture.md`
+
+## MCP Hub
+
+Shared daemon (`csa mcp-hub serve`) over Unix socket, fanning out to backend MCP servers. `BackendTransport`: Stdio + Http (rmcp). `McpTransport` tagged union (`stdio`/`http`/`sse`). HTTPS enforced, SSRF pre-flight DNS check. Per-server FIFO dispatch queue (capacity 64). Stateful pooling with `project_root`+`toolchain_hash` keys. Socket activation via systemd.
+→ `.agents/project-rules-ref/mcp-hub.md`
+
+## Resource Sandbox
+
+Dual-axis isolation model: `ResourceCapability` (CgroupV2/Setrlimit/None) for memory/PID limits + `FilesystemCapability` (Bwrap/Landlock/None) for filesystem access control. `IsolationPlan` unifies both axes and covers all three spawn paths (ACP, legacy CLI, MCP hub). Resource axis: cgroup v2 scopes → setrlimit → OOM score adj fallback. Filesystem axis: bwrap (user namespace, best isolation) → Landlock LSM (kernel-level, no namespace needed) → none. `MemoryBalloon` pre-warms RAM via `mmap MAP_POPULATE`. `ResourceGuard::check_availability()`: `available_memory + available_swap >= reserve_mb` (4096MB default). Claude-code: `MemorySwapMax=0` prevents swap thrash. `cleanup_orphan_scopes()` removes stale `csa-*.scope` units. Config: `[filesystem_sandbox]` section in `.csa/config.toml` with `enforcement_mode` (required/best-effort/off) and `extra_writable` paths. CLI: `--no-fs-sandbox` flag disables filesystem isolation. `csa doctor` reports both resource and filesystem capability detection. Per-tool FS sandbox: `[tools.<name>.filesystem_sandbox]` with `writable_paths` (REPLACE semantics — project root becomes read-only) and `enforcement_mode` override. Path validation rejects paths outside project root, home dir, and `/tmp`. Review/debate: `readonly_sandbox` config makes project root read-only. EACCES diagnostics emit hints when sandbox causes permission errors.
+→ `.agents/project-rules-ref/resource-sandbox.md`
+
+## Session Management
+
+`Genealogy` parent-child tracking. Two fork methods: `Native` (ACP session reload, saves 30-60K tokens) and `Soft` (context summary injection). `ReturnPacket` protocol for fork-call return. Fork rate limit: 10/minute per parent. `SessionPhase` state machine: Active↔Available↔Retired. Seed sessions for warm fork. Idle timeout → liveness poll → two-phase kill. Defaults: idle 250s, dead 600s, grace 5s. **Process lifetime**: ALL child processes (including `nohup`/`disown`) are killed on session end via process group kill + cgroup scope cleanup. To outlive CSA, start processes from the caller (`systemd-run --user --scope`).
+→ `.agents/project-rules-ref/session-management.md`
+
+## Debate & Review
+
+Heterogeneous model selection via `ModelFamily` enum ensures cognitive diversity. Consensus: `majority`/`unanimous`/`weighted` via `agent-teams-rs`. `detect_rate_limit` + `decide_failover` for 429 errors. Pattern resolution from `patterns/csa-review/` and `patterns/debate/`. Four-value review verdict: `ReviewDecision` enum (Pass/Fail/Skip/Uncertain) with backward-compatible aliases (CLEAN→Pass, HAS_ISSUES→Fail). Multi-layer quality gates (`GateStep` pipeline: L1 lint → L2 type → L3 test) run before AI review. Contract Alignment dimension checks spec intent, boundary compliance, and completion criteria when `--spec` is provided.
+→ `.agents/project-rules-ref/debate-review.md`
+
+## VCS Abstraction
+
+`VcsBackend` trait in `csa-core::vcs` abstracts git and jj (Jujutsu) operations. `detect_vcs_kind()` auto-detects: `.jj/` → Jj, `.git/` → Git. Concrete implementations `GitBackend`/`JjBackend` in `csa-session::vcs_backends`. Session creation auto-detects `change_id` (jj change-id or git HEAD). `--spec` flag on `csa run` and `csa review` for agent-spec contract files (`.toml` or `.spec` extension).
+
+## TODO References
+
+Progressive disclosure: TODO.md summary + `references/` detail files with `index.toml`. Token estimation: <32KB → `chars/3`, ≥32KB → tiktoken-rs. Transcript import via `xurl` (7 providers) with redaction pipeline. CLI: `csa todo ref list|show|add|import-transcript`.
+→ `.agents/project-rules-ref/todo-references.md`
+
+## Workspace Architecture
+
+14-crate Cargo workspace in 7 layers. L0: `csa-core` (domain types), `csa-lock` (flock). L1: `csa-config`, `csa-resource`. L2: `csa-session`, `csa-scheduler`, `csa-todo`. L3: `csa-acp`, `csa-process`. L4: `csa-executor`, `csa-hooks`. L5: `csa-mcp-hub`, `weave`. L6: `cli-sub-agent` (binary).
+→ `.agents/project-rules-ref/workspace.md`
+
+## Code Style & Conventions
+
+Rust edition 2024, rust-version 1.88. `anyhow` (app) + `thiserror` (lib). `tokio` async, `tracing` logging, `serde` serialization, ULID sessions. Sum types (Enum with data) over dynamic dispatch for closed sets. 800-line soft module limit. Every `unsafe` has `// SAFETY:` comment. `cc-sdk` opt-in, `rmcp-sdk` default on.
+→ `.agents/project-rules-ref/code-style.md`
+
+## Configuration
+
+Project: `.csa/config.toml` (project metadata, tiers, resources, MCP). Global: `~/.config/cli-sub-agent/config.toml` (API keys, concurrency, defaults). Project overrides global via merge. Key sections: `[tools]`, `[tiers]`, `[resources]`, `[review]`, `[debate]`, `[session]`, `[mcp_servers]`, `[setting_sources]`, `[pr_review]`, `[gc]`.
+→ `.agents/project-rules-ref/config.md`
+
+**tier-routing** — When `[tiers]` are configured, direct `--tool`/`--model`/`--thinking` is blocked by default across `csa run`, `csa review`, and `csa debate`. Callers must use `--tier <name>` to select a tier by name, which resolves tool/model/thinking from the tier definition. Override with `--force-ignore-tier-setting` (alias: `--force-tier`) to bypass. The existing `--force` flag also bypasses tier enforcement. When no tiers are configured (empty `[tiers]`), all existing behavior is preserved. Priority chain: CLI `--tier` > config tier > CLI `--tool` (with force) > config tool > auto-select.
+
+## Patterns & Skills
+
+Patterns in `patterns/` (weave packages). Skills in `.claude/skills/` (SKILL.md + .skill.toml). **MANDATORY**: every pattern needs companion skill symlink; pattern changes MUST pass `weave compile`; workflow variables MUST sync between PATTERN.md and workflow.toml (PR #257: 17 review rounds from orphaned variable). **dev2merge** is the primary deterministic pipeline (`csa plan run patterns/dev2merge/workflow.toml`): branch validation → FAST_PATH detection → L1/L2 gates → mktd → mktsk → cumulative review → push gate → PR → pr-bot → merge. All steps enforced via `on_fail = "abort"` and git pre-push hook (`scripts/hooks/pre-push`).
+→ `.agents/project-rules-ref/patterns-skills.md`
+
+## Implementation Status
+
+Version 0.1.54. 4 tools (claude-code, codex, gemini-cli, opencode). ACP + legacy transport. Native fork (claude-code), soft fork (others), codex PTY fork behind feature gate. Fork-call-return protocol. Resource sandbox. MCP hub. Seed sessions. Structured output sections. TODO/workflow with spec intent flow. Config at `.csa/config.toml` + `~/.config/cli-sub-agent/config.toml`.
+→ `.agents/project-rules-ref/implementation-status.md`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "axum",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.192"
+version = "0.1.193"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -620,12 +620,12 @@ fn debate_cli_parses_both_timeouts() {
         "csa",
         "debate",
         "--timeout",
-        "300",
+        "250",
         "--idle-timeout",
         "30",
         "question",
     ]);
-    assert_eq!(args.timeout, Some(300));
+    assert_eq!(args.timeout, Some(250));
     assert_eq!(args.idle_timeout, Some(30));
 }
 

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -39,7 +39,7 @@ pub(crate) use session_exec::{
     execute_with_session_and_meta_with_parent_source,
 };
 
-pub(crate) const DEFAULT_IDLE_TIMEOUT_SECONDS: u64 = 300;
+pub(crate) const DEFAULT_IDLE_TIMEOUT_SECONDS: u64 = 250;
 pub(crate) const DEFAULT_LIVENESS_DEAD_SECONDS: u64 = csa_process::DEFAULT_LIVENESS_DEAD_SECS;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/cli-sub-agent/src/pipeline_gate_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_gate_tests.rs
@@ -91,7 +91,7 @@ async fn test_gate_skipped_when_csa_depth_set() {
     let result = evaluate_quality_gate(
         dir.path(),
         Some("echo should-not-run"),
-        300,
+        250,
         &GateMode::Full,
     )
     .await
@@ -119,7 +119,7 @@ async fn test_gate_skipped_when_no_command_and_no_hooks_path() {
         .await
         .unwrap();
 
-    let result = evaluate_quality_gate(dir.path(), None, 300, &GateMode::Full)
+    let result = evaluate_quality_gate(dir.path(), None, 250, &GateMode::Full)
         .await
         .unwrap();
 
@@ -137,7 +137,7 @@ async fn test_gate_runs_explicit_command_success() {
     let dir = tempfile::tempdir().unwrap();
 
     let result =
-        evaluate_quality_gate(dir.path(), Some("echo 'gate passed'"), 300, &GateMode::Full)
+        evaluate_quality_gate(dir.path(), Some("echo 'gate passed'"), 250, &GateMode::Full)
             .await
             .unwrap();
 
@@ -159,7 +159,7 @@ async fn test_gate_runs_explicit_command_failure() {
     let result = evaluate_quality_gate(
         dir.path(),
         Some("echo 'lint error' >&2; exit 1"),
-        300,
+        250,
         &GateMode::Full,
     )
     .await
@@ -205,7 +205,7 @@ async fn test_gate_monitor_mode_still_runs() {
 
     // Even in monitor mode, the gate runs — the mode only affects how callers
     // handle the result.
-    let result = evaluate_quality_gate(dir.path(), Some("exit 1"), 300, &GateMode::Monitor)
+    let result = evaluate_quality_gate(dir.path(), Some("exit 1"), 250, &GateMode::Monitor)
         .await
         .unwrap();
 
@@ -226,7 +226,7 @@ async fn test_gate_captures_stdout_and_stderr() {
     let result = evaluate_quality_gate(
         dir.path(),
         Some("echo 'stdout-content'; echo 'stderr-content' >&2"),
-        300,
+        250,
         &GateMode::Full,
     )
     .await
@@ -355,7 +355,7 @@ async fn test_pipeline_skipped_when_csa_depth_set() {
         level: 1,
     }];
 
-    let result = evaluate_quality_gates(dir.path(), &steps, 300, &GateMode::Full)
+    let result = evaluate_quality_gates(dir.path(), &steps, 250, &GateMode::Full)
         .await
         .unwrap();
 
@@ -373,7 +373,7 @@ async fn test_pipeline_empty_steps_skipped() {
     unsafe { set_depth("0") };
 
     let dir = tempfile::tempdir().unwrap();
-    let result = evaluate_quality_gates(dir.path(), &[], 300, &GateMode::Full)
+    let result = evaluate_quality_gates(dir.path(), &[], 250, &GateMode::Full)
         .await
         .unwrap();
 
@@ -408,7 +408,7 @@ async fn test_pipeline_sequential_all_pass() {
         },
     ];
 
-    let result = evaluate_quality_gates(dir.path(), &steps, 300, &GateMode::Full)
+    let result = evaluate_quality_gates(dir.path(), &steps, 250, &GateMode::Full)
         .await
         .unwrap();
 
@@ -446,7 +446,7 @@ async fn test_pipeline_fail_fast_on_first_failure() {
         },
     ];
 
-    let result = evaluate_quality_gates(dir.path(), &steps, 300, &GateMode::Full)
+    let result = evaluate_quality_gates(dir.path(), &steps, 250, &GateMode::Full)
         .await
         .unwrap();
 
@@ -478,7 +478,7 @@ async fn test_pipeline_summary_for_review() {
         },
     ];
 
-    let result = evaluate_quality_gates(dir.path(), &steps, 300, &GateMode::Full)
+    let result = evaluate_quality_gates(dir.path(), &steps, 250, &GateMode::Full)
         .await
         .unwrap();
 

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -697,11 +697,11 @@ fn review_cli_parses_both_timeouts() {
         "review",
         "--diff",
         "--timeout",
-        "300",
+        "250",
         "--idle-timeout",
         "30",
     ]);
-    assert_eq!(args.timeout, Some(300));
+    assert_eq!(args.timeout, Some(250));
     assert_eq!(args.idle_timeout, Some(30));
 }
 

--- a/crates/csa-acp/src/transport.rs
+++ b/crates/csa-acp/src/transport.rs
@@ -66,7 +66,7 @@ pub struct AcpRunOptions<'a> {
 impl Default for AcpRunOptions<'_> {
     fn default() -> Self {
         Self {
-            idle_timeout: Duration::from_secs(300),
+            idle_timeout: Duration::from_secs(250),
             initial_response_timeout: None,
             init_timeout: Duration::from_secs(120),
             termination_grace_period: Duration::from_secs(5),
@@ -183,7 +183,7 @@ impl AcpSession {
 
     pub async fn prompt(&self, prompt: &str) -> AcpResult<PromptResult> {
         self.connection
-            .prompt(&self.session_id, prompt, Duration::from_secs(300), None)
+            .prompt(&self.session_id, prompt, Duration::from_secs(250), None)
             .await
     }
 

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -566,9 +566,9 @@ transcript_redaction = true
 # require_commit_on_mutation = true
 [resources]
 min_free_memory_mb = 4096
-idle_timeout_seconds = 300
+idle_timeout_seconds = 250
 liveness_dead_seconds = 600
-slot_wait_timeout_seconds = 300
+slot_wait_timeout_seconds = 250
 stdin_write_timeout_seconds = 30
 termination_grace_period_seconds = 5
 [gc]

--- a/crates/csa-config/src/config_merge_tests.rs
+++ b/crates/csa-config/src/config_merge_tests.rs
@@ -480,13 +480,13 @@ name = "test"
             .is_none_or(|r| r.gate_command.is_none()),
         "global gate_command must not be inherited by project config"
     );
-    // gate_timeout_secs from global must be stripped, falling back to default 300
+    // gate_timeout_secs from global must be stripped, falling back to default 250
     assert!(
         config
             .review
             .as_ref()
-            .is_none_or(|r| r.gate_timeout_secs == 300),
-        "global gate_timeout_secs must not be inherited; should be default 300"
+            .is_none_or(|r| r.gate_timeout_secs == 250),
+        "global gate_timeout_secs must not be inherited; should be default 250"
     );
 }
 

--- a/crates/csa-config/src/config_resources.rs
+++ b/crates/csa-config/src/config_resources.rs
@@ -57,11 +57,11 @@ fn default_min_mem() -> u64 {
 }
 
 fn default_idle_timeout_seconds() -> u64 {
-    300
+    250
 }
 
 fn default_slot_wait_timeout_seconds() -> u64 {
-    300
+    250
 }
 
 fn default_liveness_dead_seconds() -> Option<u64> {

--- a/crates/csa-config/src/config_tests.rs
+++ b/crates/csa-config/src/config_tests.rs
@@ -545,7 +545,7 @@ created_at = "2024-01-01T00:00:00Z"
     let loaded = loaded.unwrap();
 
     assert_eq!(loaded.project.max_recursion_depth, 5);
-    assert_eq!(loaded.resources.idle_timeout_seconds, 300);
+    assert_eq!(loaded.resources.idle_timeout_seconds, 250);
 }
 
 #[test]

--- a/crates/csa-config/src/config_tests_tail.rs
+++ b/crates/csa-config/src/config_tests_tail.rs
@@ -226,7 +226,7 @@ initial_response_timeout_seconds = 0
 #[test]
 fn test_resources_config_deser_initial_response_timeout_omitted_defaults_to_120() {
     let toml_str = r#"
-idle_timeout_seconds = 300
+idle_timeout_seconds = 250
 "#;
     let cfg: ResourcesConfig = toml::from_str(toml_str).unwrap();
     assert_eq!(cfg.initial_response_timeout_seconds, Some(120));

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -152,7 +152,7 @@ pub struct ReviewConfig {
 }
 
 const fn default_gate_timeout_secs() -> u64 {
-    300
+    250
 }
 
 fn is_default_gate_timeout(val: &u64) -> bool {

--- a/crates/csa-config/src/global_tests.rs
+++ b/crates/csa-config/src/global_tests.rs
@@ -321,7 +321,7 @@ gate_timeout_secs = 600
 fn test_review_config_gate_fields_default() {
     let config = ReviewConfig::default();
     assert!(config.gate_command.is_none());
-    assert_eq!(config.gate_timeout_secs, 300);
+    assert_eq!(config.gate_timeout_secs, 250);
 }
 
 #[test]
@@ -352,7 +352,7 @@ fn test_review_config_is_not_default_with_gate_timeout() {
 fn test_review_config_gate_timeout_default_skipped_in_serialization() {
     let config = ReviewConfig::default();
     let toml_str = toml::to_string(&config).unwrap();
-    // Default gate_timeout_secs (300) should be skipped via skip_serializing_if
+    // Default gate_timeout_secs (250) should be skipped via skip_serializing_if
     assert!(
         !toml_str.contains("gate_timeout_secs"),
         "Default gate_timeout_secs should be omitted from TOML output"

--- a/crates/csa-config/src/init.rs
+++ b/crates/csa-config/src/init.rs
@@ -257,7 +257,7 @@ pub fn init_project(
             },
             resources: ResourcesConfig {
                 min_free_memory_mb: 4096,
-                idle_timeout_seconds: 300,
+                idle_timeout_seconds: 250,
                 ..Default::default()
             },
             acp: Default::default(),

--- a/crates/csa-config/src/validate_tests_deprecated.rs
+++ b/crates/csa-config/src/validate_tests_deprecated.rs
@@ -14,7 +14,7 @@ max_recursion_depth = 5
 
 [resources]
 min_free_memory_mb = 4096
-idle_timeout_seconds = 300
+idle_timeout_seconds = 250
 
 [resources.initial_estimates]
 gemini-cli = 150
@@ -58,7 +58,7 @@ max_recursion_depth = 5
 
 [resources]
 min_free_memory_mb = 4096
-idle_timeout_seconds = 300
+idle_timeout_seconds = 250
 
 [resources.initial_estimates]
 codex = 800

--- a/crates/csa-executor/src/executor_tests.rs
+++ b/crates/csa-executor/src/executor_tests.rs
@@ -663,6 +663,6 @@ fn override_thinking_budget_works_for_all_tools() {
 #[test]
 fn default_acp_init_timeout_is_120() {
     use csa_process::StreamMode;
-    let opts = ExecuteOptions::new(StreamMode::TeeToStderr, 300);
+    let opts = ExecuteOptions::new(StreamMode::TeeToStderr, 250);
     assert_eq!(opts.acp_init_timeout_seconds, 120);
 }

--- a/crates/csa-process/src/lib.rs
+++ b/crates/csa-process/src/lib.rs
@@ -154,7 +154,7 @@ fn is_retry_noise(line: &str) -> bool {
     false
 }
 
-pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 300;
+pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 250;
 pub const DEFAULT_STDIN_WRITE_TIMEOUT_SECS: u64 = 30;
 pub const DEFAULT_TERMINATION_GRACE_PERIOD_SECS: u64 = 5;
 const WORKSPACE_BOUNDARY_ERROR_THRESHOLD: usize = 3;

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -400,9 +400,9 @@ else
   WAIT_BASE_TS="$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-10M +%Y-%m-%dT%H:%M:%SZ)"
 fi
 
-# --- Initial quiet wait (5 min) — bot responses rarely arrive faster ---
-echo "Waiting 5 minutes before polling (bot responses rarely arrive faster)..."
-sleep 300
+# --- Initial quiet wait (~4 min) — bot responses rarely arrive faster ---
+echo "Waiting ~4 minutes before polling (bot responses rarely arrive faster)..."
+sleep 250
 
 # --- Delegate remaining polling to CSA-managed step (max 10 min) ---
 BOT_UNAVAILABLE=true

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -418,9 +418,9 @@ else
   WAIT_BASE_TS="$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-10M +%Y-%m-%dT%H:%M:%SZ)"
 fi
 
-# --- Initial quiet wait (5 min) — bot responses rarely arrive faster ---
-echo "Waiting 5 minutes before polling (bot responses rarely arrive faster)..."
-sleep 300
+# --- Initial quiet wait (~4 min) — bot responses rarely arrive faster ---
+echo "Waiting ~4 minutes before polling (bot responses rarely arrive faster)..."
+sleep 250
 
 # --- Delegate remaining polling to CSA-managed step (max 10 min) ---
 BOT_UNAVAILABLE=true
@@ -1140,9 +1140,9 @@ RETRIGGER_BODY="${CLOUD_BOT_RETRIGGER_CMD}
 gh pr comment "${PR_NUM}" --repo "${REPO}" --body "${RETRIGGER_BODY}"
 echo "Re-triggered review via '${CLOUD_BOT_RETRIGGER_CMD}' for HEAD ${CURRENT_SHA} at ${RETRIGGER_TS}"
 
-# --- Initial quiet wait (5 min) — bot responses rarely arrive faster ---
-echo "Waiting 5 minutes before polling post-fix review (bot responses rarely arrive faster)..."
-sleep 300
+# --- Initial quiet wait (~4 min) — bot responses rarely arrive faster ---
+echo "Waiting ~4 minutes before polling post-fix review (bot responses rarely arrive faster)..."
+sleep 250
 
 # --- Delegate remaining polling to CSA (max 10 min) ---
 BOT_CLEAN=false


### PR DESCRIPTION
## Summary

- Lower all timeout defaults (idle_timeout, gate_timeout, slot_wait_timeout, pr-bot poll intervals) from 300s to 250s
- 50s safety margin below KV cache TTL (5min), preventing cache misses that incur 12.5x prompt caching cost
- Updated 19 source files: production constants, config defaults, test assertions, pattern scripts, architecture docs

## Changes

| Category | Files | What changed |
|----------|-------|-------------|
| Core constants | csa-process, pipeline.rs | DEFAULT_IDLE_TIMEOUT_SECS |
| ACP defaults | csa-acp/transport.rs | AcpRunOptions::default(), prompt() |
| Config defaults | config_resources, global, init | idle/gate/slot_wait timeout |
| Patterns | pr-bot workflow.toml, PATTERN.md | sleep intervals |
| Tests | 7 test files | assertion values synchronized |
| Docs | csa-architecture-ref.md | idle default reference |

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — 2861 tests pass, 0 failures
- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` — PASS verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)