### PR TITLE
feat(executor): 3-phase Gemini retry + heartbeat 15s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "axum",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.189"
+version = "0.1.193"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.192"
+version = "0.1.193"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -12,7 +12,7 @@ use csa_process::check_tool_installed;
 use crate::pipeline::execute_with_session_and_meta;
 use crate::run_helpers::build_executor;
 
-const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(20);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 
 pub(super) struct StepExecutionOutcome {
     pub(super) exit_code: i32,

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -28,7 +28,7 @@ use crate::{
     error::{AcpError, AcpResult},
 };
 
-const DEFAULT_HEARTBEAT_SECS: u64 = 20;
+const DEFAULT_HEARTBEAT_SECS: u64 = 15;
 const HEARTBEAT_INTERVAL_ENV: &str = "CSA_TOOL_HEARTBEAT_SECS";
 
 #[derive(Debug, Clone, Default)]

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -5,7 +5,8 @@ use std::time::Duration;
 use crate::executor::Executor;
 use crate::transport_gemini_retry::{
     gemini_inject_api_key_fallback, gemini_max_attempts, gemini_rate_limit_backoff,
-    gemini_retry_model, is_gemini_rate_limited_error, is_gemini_rate_limited_result,
+    gemini_retry_model, gemini_should_use_api_key, is_gemini_rate_limited_error,
+    is_gemini_rate_limited_result,
 };
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
@@ -236,15 +237,25 @@ impl LegacyTransport {
         stream_mode: StreamMode,
         idle_timeout_seconds: u64,
     ) -> Result<TransportResult> {
+        // 3-phase fallback: OAuth(original) → APIKey(original) → APIKey(flash)
         let mut attempt = 1u8;
         loop {
             let executor = self.executor_for_attempt(attempt);
+
+            // Phase 2+: inject API key auth if available, otherwise keep original env.
+            let api_key_env = if gemini_should_use_api_key(attempt) {
+                gemini_inject_api_key_fallback(extra_env)
+            } else {
+                None
+            };
+            let attempt_env = api_key_env.as_ref().map_or(extra_env, Some);
+
             let result = self
                 .execute_in_single_attempt(
                     &executor,
                     prompt,
                     work_dir,
-                    extra_env,
+                    attempt_env,
                     stream_mode,
                     idle_timeout_seconds,
                 )
@@ -252,26 +263,19 @@ impl LegacyTransport {
             if let Some(backoff) =
                 self.should_retry_gemini_rate_limited(&result.execution, attempt, extra_env)
             {
-                tracing::debug!(attempt, "gemini-cli rate limit; retrying with model switch");
+                let phase_desc = match attempt {
+                    1 => "OAuth→APIKey(same model)",
+                    2 => "APIKey(same model)→APIKey(flash)",
+                    _ => "final",
+                };
+                tracing::info!(
+                    attempt,
+                    phase_desc,
+                    "gemini-cli rate limited; advancing phase"
+                );
                 tokio::time::sleep(backoff).await;
                 attempt = attempt.saturating_add(1);
                 continue;
-            }
-            // API key fallback: all model retries exhausted, still quota error.
-            if is_gemini_rate_limited_result(&result.execution)
-                && let Some(env_with_key) = gemini_inject_api_key_fallback(extra_env)
-            {
-                tracing::info!("gemini-cli quota exhausted; falling back to API key auth");
-                return self
-                    .execute_in_single_attempt(
-                        &self.executor,
-                        prompt,
-                        work_dir,
-                        Some(&env_with_key),
-                        stream_mode,
-                        idle_timeout_seconds,
-                    )
-                    .await;
             }
             return Ok(result);
         }
@@ -288,42 +292,45 @@ impl Transport for LegacyTransport {
         extra_env: Option<&HashMap<String, String>>,
         options: TransportOptions<'_>,
     ) -> Result<TransportResult> {
+        // 3-phase fallback: OAuth(original) → APIKey(original) → APIKey(flash)
         let mut attempt = 1u8;
         loop {
             let executor = self.executor_for_attempt(attempt);
+
+            // Phase 2+: inject API key auth if available, otherwise keep original env.
+            let api_key_env = if gemini_should_use_api_key(attempt) {
+                gemini_inject_api_key_fallback(extra_env)
+            } else {
+                None
+            };
+            let attempt_env = api_key_env.as_ref().map_or(extra_env, Some);
+
             let result = self
                 .execute_single_attempt(
                     &executor,
                     prompt,
                     tool_state,
                     session,
-                    extra_env,
+                    attempt_env,
                     options.clone(),
                 )
                 .await?;
             if let Some(backoff) =
                 self.should_retry_gemini_rate_limited(&result.execution, attempt, extra_env)
             {
-                tracing::debug!(attempt, "gemini-cli rate limit; retrying with model switch");
+                let phase_desc = match attempt {
+                    1 => "OAuth→APIKey(same model)",
+                    2 => "APIKey(same model)→APIKey(flash)",
+                    _ => "final",
+                };
+                tracing::info!(
+                    attempt,
+                    phase_desc,
+                    "gemini-cli rate limited; advancing phase"
+                );
                 tokio::time::sleep(backoff).await;
                 attempt = attempt.saturating_add(1);
                 continue;
-            }
-            // API key fallback: all model retries exhausted, still quota error.
-            if is_gemini_rate_limited_result(&result.execution)
-                && let Some(env_with_key) = gemini_inject_api_key_fallback(extra_env)
-            {
-                tracing::info!("gemini-cli quota exhausted; falling back to API key auth");
-                return self
-                    .execute_single_attempt(
-                        &self.executor,
-                        prompt,
-                        tool_state,
-                        session,
-                        Some(&env_with_key),
-                        options,
-                    )
-                    .await;
             }
             return Ok(result);
         }
@@ -567,15 +574,24 @@ impl Transport for AcpTransport {
                 .await;
         }
 
-        // Gemini-cli: retry loop with model switching and API key fallback.
+        // Gemini-cli: 3-phase fallback: OAuth(original) → APIKey(original) → APIKey(flash)
         let max_attempts = gemini_max_attempts(extra_env);
         let mut attempt = 1u8;
         loop {
-            // Build ACP args for this attempt, injecting model override on retries.
+            // Build ACP args for this attempt, injecting model override in phase 3.
             let mut args = self.acp_args.clone();
             if let Some(model) = gemini_retry_model(attempt) {
                 args.extend(["-m".into(), model.into()]);
             }
+
+            // Phase 2+: inject API key auth if available, otherwise keep original env.
+            let api_key_env = if gemini_should_use_api_key(attempt) {
+                gemini_inject_api_key_fallback(extra_env)
+            } else {
+                None
+            };
+            let attempt_env: Option<&HashMap<String, String>> =
+                api_key_env.as_ref().map_or(extra_env, Some);
 
             // Only resume a provider session on the first attempt; retries start fresh.
             let resume_session_id = if attempt == 1 {
@@ -591,7 +607,7 @@ impl Transport for AcpTransport {
                 .execute_acp_attempt(
                     prompt,
                     session,
-                    extra_env,
+                    attempt_env,
                     &options,
                     &args,
                     resume_session_id.as_deref(),
@@ -604,28 +620,19 @@ impl Transport for AcpTransport {
             };
 
             if should_retry && attempt < max_attempts {
+                let phase_desc = match attempt {
+                    1 => "OAuth→APIKey(same model)",
+                    2 => "APIKey(same model)→APIKey(flash)",
+                    _ => "final",
+                };
                 tracing::info!(
                     attempt,
-                    "gemini-cli ACP quota exhausted; retrying with model switch"
+                    phase_desc,
+                    "gemini-cli ACP rate limited; advancing phase"
                 );
                 tokio::time::sleep(gemini_rate_limit_backoff(attempt)).await;
                 attempt = attempt.saturating_add(1);
                 continue;
-            }
-
-            // API key fallback: all model retries exhausted, still quota error.
-            if should_retry && let Some(env_with_key) = gemini_inject_api_key_fallback(extra_env) {
-                tracing::info!("gemini-cli ACP quota exhausted; falling back to API key auth");
-                return self
-                    .execute_acp_attempt(
-                        prompt,
-                        session,
-                        Some(&env_with_key),
-                        &options,
-                        &self.acp_args,
-                        None,
-                    )
-                    .await;
             }
 
             return result;
@@ -718,6 +725,7 @@ mod tests {
     use crate::transport_gemini_retry::*;
 
     include!("transport_tests_tail.rs");
+    include!("transport_tests_extra.rs");
 }
 
 #[cfg(test)]

--- a/crates/csa-executor/src/transport_gemini_retry.rs
+++ b/crates/csa-executor/src/transport_gemini_retry.rs
@@ -8,14 +8,19 @@ use csa_core::gemini::{
 };
 use csa_process::ExecutionResult;
 
+/// Total retry attempts for the 3-phase fallback chain:
+///   Phase 1 (attempt 1): Original model + OAuth auth
+///   Phase 2 (attempt 2): Original model + API key auth
+///   Phase 3 (attempt 3): Flash model  + API key auth
 pub(crate) const GEMINI_RATE_LIMIT_MAX_ATTEMPTS: u8 = 3;
+/// When `_CSA_NO_FLASH_FALLBACK` is set, skip phase 3 (flash model).
 pub(crate) const GEMINI_RATE_LIMIT_NO_FLASH_ATTEMPTS: u8 = 2;
 #[cfg(test)]
 pub(crate) const GEMINI_RATE_LIMIT_BASE_BACKOFF_MS: u64 = 10;
 #[cfg(not(test))]
 pub(crate) const GEMINI_RATE_LIMIT_BASE_BACKOFF_MS: u64 = 1_000;
-pub(crate) const GEMINI_RATE_LIMIT_RETRY_MODEL_FIRST: &str = "gemini-3.1-pro-preview";
-pub(crate) const GEMINI_RATE_LIMIT_RETRY_MODEL_SECOND: &str = "gemini-3-flash-preview";
+/// Flash model used in phase 3 of the fallback chain.
+pub(crate) const GEMINI_RATE_LIMIT_FLASH_MODEL: &str = "gemini-3-flash-preview";
 
 pub(crate) fn gemini_is_no_flash(extra_env: Option<&HashMap<String, String>>) -> bool {
     extra_env.is_some_and(|env| env.contains_key(NO_FLASH_FALLBACK_ENV_KEY))
@@ -27,12 +32,24 @@ pub(crate) fn gemini_rate_limit_backoff(attempt: u8) -> Duration {
     Duration::from_millis(GEMINI_RATE_LIMIT_BASE_BACKOFF_MS.saturating_mul(multiplier))
 }
 
+/// Return the model override for a given retry attempt.
+///
+/// Phase 1 (attempt 1): None — keep original model.
+/// Phase 2 (attempt 2): None — keep original model (auth changes instead).
+/// Phase 3 (attempt 3): Flash model.
 pub(crate) fn gemini_retry_model(attempt: u8) -> Option<&'static str> {
     match attempt {
-        2 => Some(GEMINI_RATE_LIMIT_RETRY_MODEL_FIRST),
-        3 => Some(GEMINI_RATE_LIMIT_RETRY_MODEL_SECOND),
+        3 => Some(GEMINI_RATE_LIMIT_FLASH_MODEL),
         _ => None,
     }
+}
+
+/// Whether this attempt should use API key auth instead of OAuth.
+///
+/// Phase 1 (attempt 1): false — use original OAuth auth.
+/// Phase 2+ (attempt 2, 3): true — switch to API key auth.
+pub(crate) fn gemini_should_use_api_key(attempt: u8) -> bool {
+    attempt >= 2
 }
 
 pub(crate) fn gemini_max_attempts(extra_env: Option<&HashMap<String, String>>) -> u8 {

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -1,0 +1,228 @@
+// --- classify_join_error tests ---
+
+#[tokio::test]
+async fn test_classify_join_error_broken_pipe_message() {
+    let handle = tokio::task::spawn(async {
+        panic!("failed printing to stderr: Broken pipe (os error 32)")
+    });
+    let join_err = handle.await.unwrap_err();
+    let err = super::classify_join_error(join_err);
+    let msg = err.to_string();
+    assert!(
+        msg.contains("tool process terminated unexpectedly"),
+        "broken pipe should get a clean message, got: {msg}"
+    );
+    assert!(
+        msg.contains("broken pipe"),
+        "message should mention broken pipe, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_classify_join_error_generic_panic() {
+    let handle = tokio::task::spawn(async { panic!("something else went wrong") });
+    let join_err = handle.await.unwrap_err();
+    let err = super::classify_join_error(join_err);
+    let msg = err.to_string();
+    assert!(
+        msg.contains("task panicked"),
+        "generic panic should say 'task panicked', got: {msg}"
+    );
+    assert!(
+        msg.contains("something else went wrong"),
+        "should include panic message, got: {msg}"
+    );
+}
+
+// --- build_summary tests (moved from transport.rs) ---
+
+#[test]
+fn test_build_summary_uses_last_stdout_line_on_success() {
+    let stdout = "line1\nfinal line\n";
+    let summary = super::build_summary(stdout, "", 0);
+    assert_eq!(summary, "final line");
+}
+
+#[test]
+fn test_build_summary_uses_stdout_on_failure_when_present() {
+    let stdout = "details\nreason from stdout\n";
+    let summary = super::build_summary(stdout, "stderr message", 2);
+    assert_eq!(summary, "reason from stdout");
+}
+
+#[test]
+fn test_build_summary_falls_back_to_stderr_on_failure() {
+    let summary = super::build_summary("\n", "stderr reason\n", 3);
+    assert_eq!(summary, "stderr reason");
+}
+
+#[test]
+fn test_build_summary_falls_back_to_exit_code_when_no_output() {
+    let summary = super::build_summary("", "   \n", -1);
+    assert_eq!(summary, "exit code -1");
+}
+
+// --- 3-phase Gemini fallback chain integration tests ---
+
+/// Phase 1 (OAuth) fails with rate-limit, Phase 2 (API key, same model) succeeds.
+/// Verifies: model log shows [inherit, inherit], API key was injected on attempt 2.
+#[tokio::test]
+async fn test_gemini_3phase_oauth_fails_apikey_same_model_succeeds() {
+    let (_temp, mut env, model_log_path) = setup_fake_gemini_environment(2);
+    // Enable the 3-phase chain by providing API key fallback and OAuth auth mode.
+    env.insert("_CSA_API_KEY_FALLBACK".to_string(), "test-key-3phase".to_string());
+    env.insert("_CSA_GEMINI_AUTH_MODE".to_string(), "oauth".to_string());
+
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+
+    let result = transport
+        .execute_in(
+            "test 3phase oauth-fail apikey-succeed",
+            std::path::Path::new("/tmp"),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+        )
+        .await
+        .expect("execute_in should succeed on attempt 2 (API key, same model)");
+
+    assert_eq!(result.execution.exit_code, 0);
+    assert!(
+        result.execution.output.contains("ok attempt=2"),
+        "expected success on attempt 2, got: {}",
+        result.execution.output
+    );
+
+    // Model log: both attempts keep original model (inherit)
+    let models = read_model_log(&model_log_path);
+    assert_eq!(
+        models,
+        vec!["inherit".to_string(), "inherit".to_string()],
+        "phase 1 and 2 should both use original model"
+    );
+
+    // Auth log: attempt 1 = oauth, attempt 2 = api_key
+    let auths = read_auth_log(&model_log_path);
+    assert_eq!(
+        auths,
+        vec!["oauth".to_string(), "api_key".to_string()],
+        "phase 1 should use OAuth, phase 2 should inject API key"
+    );
+}
+
+/// Phase 1 (OAuth) and Phase 2 (API key, same model) both fail.
+/// Phase 3 (API key, flash model) succeeds.
+/// Verifies: model log shows [inherit, inherit, flash], API key injected on attempts 2,3.
+#[tokio::test]
+async fn test_gemini_3phase_all_oauth_and_apikey_same_fail_flash_succeeds() {
+    let (_temp, mut env, model_log_path) = setup_fake_gemini_environment(3);
+    env.insert("_CSA_API_KEY_FALLBACK".to_string(), "test-key-3phase".to_string());
+    env.insert("_CSA_GEMINI_AUTH_MODE".to_string(), "oauth".to_string());
+
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+
+    let result = transport
+        .execute_in(
+            "test 3phase all-fail-until-flash",
+            std::path::Path::new("/tmp"),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+        )
+        .await
+        .expect("execute_in should succeed on attempt 3 (API key, flash model)");
+
+    assert_eq!(result.execution.exit_code, 0);
+    assert!(
+        result.execution.output.contains("ok attempt=3"),
+        "expected success on attempt 3, got: {}",
+        result.execution.output
+    );
+
+    // Model log: phase 1,2 keep original, phase 3 switches to flash
+    let models = read_model_log(&model_log_path);
+    assert_eq!(
+        models,
+        vec![
+            "inherit".to_string(),
+            "inherit".to_string(),
+            "gemini-3-flash-preview".to_string(),
+        ],
+        "phase 3 should downgrade to flash model"
+    );
+
+    // Auth log: attempt 1 = oauth, attempts 2,3 = api_key
+    let auths = read_auth_log(&model_log_path);
+    assert_eq!(
+        auths,
+        vec![
+            "oauth".to_string(),
+            "api_key".to_string(),
+            "api_key".to_string(),
+        ],
+        "phase 2 and 3 should both use API key auth"
+    );
+}
+
+/// All 3 phases fail with rate-limit. Verifies: returns error, model log shows
+/// all 3 attempts, API key was injected on attempts 2 and 3.
+#[tokio::test]
+async fn test_gemini_3phase_all_fail_returns_last_error() {
+    let (_temp, mut env, model_log_path) = setup_fake_gemini_environment(99);
+    env.insert("_CSA_API_KEY_FALLBACK".to_string(), "test-key-3phase".to_string());
+    env.insert("_CSA_GEMINI_AUTH_MODE".to_string(), "oauth".to_string());
+
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+
+    let result = transport
+        .execute_in(
+            "test 3phase all-fail",
+            std::path::Path::new("/tmp"),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+        )
+        .await
+        .expect("execute_in should return final failed attempt result");
+
+    // Final result is the last (3rd) attempt failure
+    assert_ne!(result.execution.exit_code, 0);
+    assert!(
+        result.execution.stderr_output.contains("QUOTA_EXHAUSTED"),
+        "expected QUOTA_EXHAUSTED in stderr, got: {}",
+        result.execution.stderr_output
+    );
+
+    // Model log: all 3 phases attempted
+    let models = read_model_log(&model_log_path);
+    assert_eq!(
+        models,
+        vec![
+            "inherit".to_string(),
+            "inherit".to_string(),
+            "gemini-3-flash-preview".to_string(),
+        ],
+        "retry loop should execute all 3 phases before giving up"
+    );
+
+    // Auth log: attempt 1 = oauth, attempts 2,3 = api_key
+    let auths = read_auth_log(&model_log_path);
+    assert_eq!(
+        auths,
+        vec![
+            "oauth".to_string(),
+            "api_key".to_string(),
+            "api_key".to_string(),
+        ],
+        "API key should be injected on attempts 2 and 3"
+    );
+}

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -237,18 +237,23 @@
 
 #[test]
 fn test_gemini_retry_model_sequence_matches_policy() {
+    // Phase 1: original model + OAuth
     assert_eq!(
         gemini_retry_model(1),
         None,
-        "first attempt keeps original model"
+        "phase 1 keeps original model"
     );
+    // Phase 2: original model + API key (no model switch)
     assert_eq!(
         gemini_retry_model(2),
-        Some("gemini-3.1-pro-preview")
+        None,
+        "phase 2 keeps original model (auth changes instead)"
     );
+    // Phase 3: flash model + API key
     assert_eq!(
         gemini_retry_model(3),
-        Some("gemini-3-flash-preview")
+        Some("gemini-3-flash-preview"),
+        "phase 3 downgrades to flash model"
     );
     assert_eq!(gemini_retry_model(4), None);
 }
@@ -264,18 +269,21 @@ fn test_executor_for_attempt_overrides_gemini_retry_models() {
     let second = transport.executor_for_attempt(2);
     let third = transport.executor_for_attempt(3);
 
+    // Phase 1: keep original model
     match first {
         Executor::GeminiCli { model_override, .. } => {
             assert_eq!(model_override.as_deref(), Some("default"));
         }
         _ => panic!("expected GeminiCli executor"),
     }
+    // Phase 2: still original model (auth changes, not model)
     match second {
         Executor::GeminiCli { model_override, .. } => {
-            assert_eq!(model_override.as_deref(), Some("gemini-3.1-pro-preview"));
+            assert_eq!(model_override.as_deref(), Some("default"));
         }
         _ => panic!("expected GeminiCli executor"),
     }
+    // Phase 3: flash model
     match third {
         Executor::GeminiCli { model_override, .. } => {
             assert_eq!(model_override.as_deref(), Some("gemini-3-flash-preview"));
@@ -327,12 +335,14 @@ fn setup_fake_gemini_environment(
     let script_path = temp.path().join("gemini");
     let state_file = temp.path().join("attempts.txt");
     let model_log = temp.path().join("models.log");
+    let auth_log = temp.path().join("auth.log");
     std::fs::write(
         &script_path,
         r#"#!/usr/bin/env bash
 set -euo pipefail
 STATE_FILE="${CSA_FAKE_GEMINI_STATE_FILE:?}"
 MODEL_LOG_FILE="${CSA_FAKE_GEMINI_MODEL_LOG_FILE:?}"
+AUTH_LOG_FILE="${CSA_FAKE_GEMINI_AUTH_LOG_FILE:?}"
 SUCCESS_ON="${CSA_FAKE_GEMINI_SUCCESS_ON:-999}"
 
 count=0
@@ -354,6 +364,13 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 printf '%s\n' "${model}" >>"${MODEL_LOG_FILE}"
+
+# Log auth mode: if GEMINI_API_KEY is set, auth is api_key; otherwise oauth
+if [ -n "${GEMINI_API_KEY:-}" ]; then
+  printf 'api_key\n' >>"${AUTH_LOG_FILE}"
+else
+  printf 'oauth\n' >>"${AUTH_LOG_FILE}"
+fi
 
 if [ "${count}" -lt "${SUCCESS_ON}" ]; then
   printf "reason: 'QUOTA_EXHAUSTED' (attempt=%s)\n" "${count}" >&2
@@ -385,6 +402,10 @@ printf 'ok attempt=%s model=%s\n' "${count}" "${model}"
         model_log.display().to_string(),
     );
     env.insert(
+        "CSA_FAKE_GEMINI_AUTH_LOG_FILE".to_string(),
+        auth_log.display().to_string(),
+    );
+    env.insert(
         "CSA_FAKE_GEMINI_SUCCESS_ON".to_string(),
         success_on.to_string(),
     );
@@ -395,6 +416,20 @@ printf 'ok attempt=%s model=%s\n' "${count}" "${model}"
 fn read_model_log(path: &std::path::Path) -> Vec<String> {
     std::fs::read_to_string(path)
         .expect("read model log")
+        .lines()
+        .map(|line| line.trim().to_string())
+        .filter(|line| !line.is_empty())
+        .collect()
+}
+
+fn auth_log_path(model_log: &std::path::Path) -> std::path::PathBuf {
+    model_log.with_file_name("auth.log")
+}
+
+fn read_auth_log(model_log: &std::path::Path) -> Vec<String> {
+    let path = auth_log_path(model_log);
+    std::fs::read_to_string(&path)
+        .expect("read auth log")
         .lines()
         .map(|line| line.trim().to_string())
         .filter(|line| !line.is_empty())
@@ -427,11 +462,12 @@ async fn test_execute_in_retries_until_success_with_expected_model_chain() {
         result.execution.output
     );
     let models = read_model_log(&model_log_path);
+    // Phase 1: original model (OAuth), Phase 2: original model (API key), Phase 3: flash (API key)
     assert_eq!(
         models,
         vec![
             "inherit".to_string(),
-            "gemini-3.1-pro-preview".to_string(),
+            "inherit".to_string(),
             "gemini-3-flash-preview".to_string()
         ]
     );
@@ -472,11 +508,12 @@ async fn test_execute_stops_after_max_attempts_and_returns_last_failure() {
         result.execution.stderr_output
     );
     let models = read_model_log(&model_log_path);
+    // Phase 1: original model (OAuth), Phase 2: original model (API key), Phase 3: flash (API key)
     assert_eq!(
         models,
         vec![
             "inherit".to_string(),
-            "gemini-3.1-pro-preview".to_string(),
+            "inherit".to_string(),
             "gemini-3-flash-preview".to_string()
         ],
         "retry loop should stop after 3 attempts"
@@ -545,12 +582,22 @@ fn test_no_flash_fallback_stops_retry_after_attempt_2() {
     };
     let mut env = HashMap::new();
     env.insert("_CSA_NO_FLASH_FALLBACK".to_string(), "1".to_string());
-    // Attempt 1 retries (switches to pro)
+    // Attempt 1 retries (advances to phase 2: same model + API key)
     assert!(transport.should_retry_gemini_rate_limited(&execution, 1, Some(&env)).is_some());
-    // Attempt 2 does NOT retry (would switch to flash, which is forbidden)
+    // Attempt 2 does NOT retry (phase 3 = flash, which is forbidden by no_flash)
     assert!(transport.should_retry_gemini_rate_limited(&execution, 2, Some(&env)).is_none());
-    // Without the flag, attempt 2 would still retry
+    // Without the flag, attempt 2 would still retry (advances to phase 3: flash)
     assert!(transport.should_retry_gemini_rate_limited(&execution, 2, None).is_some());
+}
+
+#[test]
+fn test_gemini_should_use_api_key_by_phase() {
+    // Phase 1: OAuth auth
+    assert!(!gemini_should_use_api_key(1));
+    // Phase 2: API key auth (same model)
+    assert!(gemini_should_use_api_key(2));
+    // Phase 3: API key auth (flash model)
+    assert!(gemini_should_use_api_key(3));
 }
 
 #[test]
@@ -725,74 +772,7 @@ async fn test_execute_best_effort_sandbox_fallback_preserves_attempt_model_overr
     let models = read_model_log(&model_log_path);
     assert_eq!(
         models,
-        vec![
-            "inherit".to_string(),
-            "gemini-3.1-pro-preview".to_string()
-        ],
-        "best-effort fallback path must preserve per-attempt model override"
+        vec!["inherit".to_string(), "inherit".to_string()],
+        "best-effort fallback path: phase 2 keeps original model (switches to API key auth)"
     );
-}
-
-// --- classify_join_error tests ---
-
-#[tokio::test]
-async fn test_classify_join_error_broken_pipe_message() {
-    let handle = tokio::task::spawn(async {
-        panic!("failed printing to stderr: Broken pipe (os error 32)")
-    });
-    let join_err = handle.await.unwrap_err();
-    let err = super::classify_join_error(join_err);
-    let msg = err.to_string();
-    assert!(
-        msg.contains("tool process terminated unexpectedly"),
-        "broken pipe should get a clean message, got: {msg}"
-    );
-    assert!(
-        msg.contains("broken pipe"),
-        "message should mention broken pipe, got: {msg}"
-    );
-}
-
-#[tokio::test]
-async fn test_classify_join_error_generic_panic() {
-    let handle = tokio::task::spawn(async { panic!("something else went wrong") });
-    let join_err = handle.await.unwrap_err();
-    let err = super::classify_join_error(join_err);
-    let msg = err.to_string();
-    assert!(
-        msg.contains("task panicked"),
-        "generic panic should say 'task panicked', got: {msg}"
-    );
-    assert!(
-        msg.contains("something else went wrong"),
-        "should include panic message, got: {msg}"
-    );
-}
-
-// --- build_summary tests (moved from transport.rs) ---
-
-#[test]
-fn test_build_summary_uses_last_stdout_line_on_success() {
-    let stdout = "line1\nfinal line\n";
-    let summary = super::build_summary(stdout, "", 0);
-    assert_eq!(summary, "final line");
-}
-
-#[test]
-fn test_build_summary_uses_stdout_on_failure_when_present() {
-    let stdout = "details\nreason from stdout\n";
-    let summary = super::build_summary(stdout, "stderr message", 2);
-    assert_eq!(summary, "reason from stdout");
-}
-
-#[test]
-fn test_build_summary_falls_back_to_stderr_on_failure() {
-    let summary = super::build_summary("\n", "stderr reason\n", 3);
-    assert_eq!(summary, "stderr reason");
-}
-
-#[test]
-fn test_build_summary_falls_back_to_exit_code_when_no_output() {
-    let summary = super::build_summary("", "   \n", -1);
-    assert_eq!(summary, "exit code -1");
 }

--- a/crates/csa-process/src/lib_output_helpers.rs
+++ b/crates/csa-process/src/lib_output_helpers.rs
@@ -20,7 +20,7 @@ pub(super) const TAIL_BUFFER_MAX_BYTES: usize = 1024 * 1024; // 1 MiB
 /// per chunk, avoiding O(N²) behaviour.
 pub(super) const TAIL_BUFFER_HIGH_WATER: usize = TAIL_BUFFER_MAX_BYTES * 2; // 2 MiB
 
-pub(super) const DEFAULT_HEARTBEAT_SECS: u64 = 20;
+pub(super) const DEFAULT_HEARTBEAT_SECS: u64 = 15;
 pub(super) const HEARTBEAT_INTERVAL_ENV: &str = "CSA_TOOL_HEARTBEAT_SECS";
 pub const DEFAULT_SPOOL_MAX_BYTES: u64 = 32 * 1024 * 1024;
 pub const DEFAULT_SPOOL_KEEP_ROTATED: bool = true;


### PR DESCRIPTION
## Summary

- **P0: Gemini fallback optimization** — Restructure retry chain: OAuth→APIKey(same model)→APIKey(flash). First rate-limit error now immediately tries API key auth instead of cycling through 3 OAuth models (~15 min wasted)
- **P3: Heartbeat interval** — Reduce from 20s to 15s for more responsive ACP status reporting
- Split `transport_tests_tail.rs` (1007→778 lines) to satisfy 800-line monolith check

## 3-Phase Fallback Chain

| Phase | Attempt | Model | Auth | Previous behavior |
|-------|---------|-------|------|-------------------|
| 1 | 1 | Original | OAuth | Same |
| 2 | 2 | Original | API Key | Was: different model + OAuth |
| 3 | 3 | Flash | API Key | Was: flash + OAuth |

## Test plan

- [x] `cargo test -p csa-executor` — 193 tests pass
- [x] 3 new integration tests: `test_gemini_3phase_*` covering OAuth→APIKey→flash chain
- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` — PASS

Closes part of the v0.2 TODO plan (P0 + P3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)