### PR TITLE
feat(executor): add Gemini ACP runtime transport with OAuth fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.203"
+version = "0.1.204"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.203"
+version = "0.1.204"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-core/src/gemini.rs
+++ b/crates/csa-core/src/gemini.rs
@@ -19,6 +19,7 @@ pub const RATE_LIMIT_PATTERNS: &[&str] = &[
     "resource_exhausted",
     "capacity exhausted",
     "capacity_exhausted",
+    "exhausted your capacity",
     "no capacity available",
     "quota exhausted",
     "quota_exhausted",

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -22,9 +22,28 @@ use csa_session::state::{MetaSessionState, ToolState};
 mod transport_meta;
 use transport_meta::{build_summary, run_acp_sandboxed};
 
+#[path = "transport_gemini_helpers.rs"]
+mod transport_gemini_helpers;
+#[cfg(test)]
+use transport_gemini_helpers::format_gemini_retry_report;
+use transport_gemini_helpers::{
+    GeminiRetryPhase, annotate_gemini_retry_error, append_gemini_retry_report,
+    apply_gemini_sandbox_runtime_env_overrides, classify_join_error,
+    ensure_gemini_runtime_home_writable_path, gemini_phase_desc,
+    gemini_sandbox_runtime_env_overrides,
+};
+
+#[path = "transport_gemini_acp_runtime.rs"]
+mod transport_gemini_acp_runtime;
+use transport_gemini_acp_runtime::{gemini_runtime_home_from_env, prepare_gemini_acp_runtime};
+
 #[path = "transport_fork.rs"]
 mod transport_fork;
 pub use transport_fork::{ForkInfo, ForkMethod, ForkRequest};
+
+#[path = "transport_factory.rs"]
+mod transport_factory;
+pub use transport_factory::{TransportFactory, TransportMode};
 
 #[derive(Debug, Clone)]
 pub struct SandboxTransportConfig {
@@ -72,6 +91,7 @@ pub struct TransportResult {
     pub events: Vec<SessionEvent>,
     pub metadata: csa_acp::StreamingMetadata,
 }
+
 #[derive(Debug, Clone)]
 pub struct LegacyTransport {
     executor: Executor,
@@ -410,15 +430,35 @@ impl AcpTransport {
         acp_args: &[String],
         resume_session_id: Option<&str>,
     ) -> Result<TransportResult> {
-        let env = self.build_env(session, extra_env);
+        let mut env = self.build_env(session, extra_env);
         let working_dir = Path::new(&session.project_path).to_path_buf();
         let system_prompt = Self::build_system_prompt(self.session_config.as_ref());
-        let acp_command = self.acp_command.clone();
-        let acp_args = acp_args.to_vec();
+        let mut acp_command = self.acp_command.clone();
+        let mut acp_args = acp_args.to_vec();
         let prompt = prompt.to_string();
         let resume_session_id = resume_session_id.map(String::from);
 
-        let sandbox_plan = options.sandbox.map(|s| s.isolation_plan.clone());
+        let mut gemini_runtime_home = None;
+        if self.tool_name == "gemini-cli" {
+            let launch = prepare_gemini_acp_runtime(&mut env, &session.meta_session_id, &acp_args)?;
+            acp_command = launch.command;
+            acp_args = launch.args;
+            gemini_runtime_home = gemini_runtime_home_from_env(&env);
+        }
+        let gemini_sandbox_env_overrides =
+            (self.tool_name == "gemini-cli").then(|| gemini_sandbox_runtime_env_overrides(&env));
+
+        let sandbox_plan = options.sandbox.map(|s| {
+            let mut isolation_plan = s.isolation_plan.clone();
+            if let Some(ref env_overrides) = gemini_sandbox_env_overrides {
+                ensure_gemini_runtime_home_writable_path(
+                    &mut isolation_plan,
+                    gemini_runtime_home.as_deref(),
+                );
+                apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, env_overrides);
+            }
+            isolation_plan
+        });
         let sandbox_tool_name = options.sandbox.map(|s| s.tool_name.clone());
         let sandbox_session_id = options.sandbox.map(|s| s.session_id.clone());
         let sandbox_best_effort = options.sandbox.is_some_and(|s| s.best_effort);
@@ -609,7 +649,9 @@ impl Transport for AcpTransport {
         );
 
         let mut attempt = 1u8;
+        let mut retry_phases = Vec::new();
         loop {
+            retry_phases.push(GeminiRetryPhase::for_attempt(attempt));
             // Build ACP args for this attempt, injecting model override in phase 3.
             let mut args = self.acp_args.clone();
             if let Some(model) = gemini_retry_model(attempt) {
@@ -667,18 +709,13 @@ impl Transport for AcpTransport {
 
             let should_retry = match &result {
                 Ok(tr) => is_gemini_rate_limited_result(&tr.execution),
-                Err(e) => is_gemini_rate_limited_error(&e.to_string()),
+                Err(e) => is_gemini_rate_limited_error(&format!("{e:#}")),
             };
 
             if should_retry && attempt < max_attempts {
-                let phase_desc = match attempt {
-                    1 => "OAuth→APIKey(same model)",
-                    2 => "APIKey(same model)→APIKey(flash)",
-                    _ => "final",
-                };
                 tracing::info!(
                     attempt,
-                    phase_desc,
+                    phase_desc = gemini_phase_desc(attempt),
                     "gemini-cli ACP rate limited; advancing phase"
                 );
                 tokio::time::sleep(gemini_rate_limit_backoff(attempt)).await;
@@ -694,85 +731,19 @@ impl Transport for AcpTransport {
                 );
             }
 
-            return result;
+            return match result {
+                Ok(mut transport_result) => {
+                    append_gemini_retry_report(&mut transport_result.execution, &retry_phases);
+                    Ok(transport_result)
+                }
+                Err(error) => Err(annotate_gemini_retry_error(error, &retry_phases)),
+            };
         }
     }
 
     #[cfg(test)]
     fn as_any(&self) -> &dyn std::any::Any {
         self
-    }
-}
-
-/// Convert a `tokio::task::JoinError` into a descriptive `anyhow::Error`.
-///
-/// Broken-pipe panics (from `eprintln!` after the tool process closes stderr)
-/// are rewritten into a clean message that mentions the tool died, instead of
-/// surfacing the raw tokio panic trace.
-fn classify_join_error(e: tokio::task::JoinError) -> anyhow::Error {
-    if e.is_panic() {
-        let msg = match e.into_panic().downcast::<String>() {
-            Ok(s) => *s,
-            Err(any) => match any.downcast::<&str>() {
-                Ok(s) => s.to_string(),
-                Err(_) => "unknown panic".to_string(),
-            },
-        };
-        if msg.contains("Broken pipe") || msg.contains("os error 32") {
-            return anyhow!(
-                "ACP transport: tool process terminated unexpectedly (broken pipe on stderr)"
-            );
-        }
-        anyhow!("ACP transport: task panicked: {msg}")
-    } else {
-        anyhow!("ACP transport: task cancelled: {e}")
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TransportMode {
-    Legacy,
-    Acp,
-    OpenaiCompat,
-}
-
-pub struct TransportFactory;
-
-impl TransportFactory {
-    pub fn mode_for_tool(tool_name: &str) -> TransportMode {
-        match tool_name {
-            "claude-code" | "codex" | "gemini-cli" => TransportMode::Acp,
-            "openai-compat" => TransportMode::OpenaiCompat,
-            _ => TransportMode::Legacy,
-        }
-    }
-
-    pub fn create(
-        executor: &Executor,
-        session_config: Option<SessionConfig>,
-    ) -> Box<dyn Transport> {
-        match Self::mode_for_tool(executor.tool_name()) {
-            TransportMode::Legacy => Box::new(LegacyTransport::new(executor.clone())),
-            TransportMode::Acp => Box::new(AcpTransport::new(executor.tool_name(), session_config)),
-            TransportMode::OpenaiCompat => {
-                let default_model = if let Executor::OpenaiCompat { model_override, .. } = executor
-                {
-                    model_override.clone()
-                } else {
-                    None
-                };
-                Box::new(crate::transport_openai_compat::OpenaiCompatTransport::new(
-                    default_model,
-                ))
-            }
-        }
-    }
-
-    /// Create an OpenAI-compat transport with explicit config.
-    pub fn create_openai_compat(
-        config: crate::transport_openai_compat::OpenaiCompatConfig,
-    ) -> Box<dyn Transport> {
-        Box::new(crate::transport_openai_compat::OpenaiCompatTransport::with_config(config))
     }
 }
 

--- a/crates/csa-executor/src/transport_factory.rs
+++ b/crates/csa-executor/src/transport_factory.rs
@@ -1,0 +1,50 @@
+use crate::executor::Executor;
+use csa_acp::SessionConfig;
+
+use super::{AcpTransport, LegacyTransport, Transport};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportMode {
+    Legacy,
+    Acp,
+    OpenaiCompat,
+}
+
+pub struct TransportFactory;
+
+impl TransportFactory {
+    pub fn mode_for_tool(tool_name: &str) -> TransportMode {
+        match tool_name {
+            "claude-code" | "codex" | "gemini-cli" => TransportMode::Acp,
+            "openai-compat" => TransportMode::OpenaiCompat,
+            _ => TransportMode::Legacy,
+        }
+    }
+
+    pub fn create(
+        executor: &Executor,
+        session_config: Option<SessionConfig>,
+    ) -> Box<dyn Transport> {
+        match Self::mode_for_tool(executor.tool_name()) {
+            TransportMode::Legacy => Box::new(LegacyTransport::new(executor.clone())),
+            TransportMode::Acp => Box::new(AcpTransport::new(executor.tool_name(), session_config)),
+            TransportMode::OpenaiCompat => {
+                let default_model = if let Executor::OpenaiCompat { model_override, .. } = executor
+                {
+                    model_override.clone()
+                } else {
+                    None
+                };
+                Box::new(crate::transport_openai_compat::OpenaiCompatTransport::new(
+                    default_model,
+                ))
+            }
+        }
+    }
+
+    pub fn create_openai_compat(
+        config: crate::transport_openai_compat::OpenaiCompatConfig,
+    ) -> Box<dyn Transport> {
+        Box::new(crate::transport_openai_compat::OpenaiCompatTransport::with_config(config))
+    }
+}

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -1,0 +1,608 @@
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use serde_json::{Map, Value};
+use tracing::{debug, warn};
+
+const GEMINI_RUNTIME_ROOT_DIR: &str = "cli-sub-agent-gemini";
+const GEMINI_RUNTIME_SETTINGS_PATHS: &[&str] =
+    &[".gemini/settings.json", ".config/gemini-cli/settings.json"];
+const GEMINI_RUNTIME_PINNED_PATH_BINARIES: &[&str] = &["node", "yarn", "gemini"];
+const GEMINI_RUNTIME_SHIM_ENV_VARS: &[&str] = &["MISE_SHIM", "MISE_SHIMS_DIR"];
+const GEMINI_RUNTIME_MISE_CACHE_RELATIVE_PATH: &str = ".cache/mise";
+const GEMINI_RUNTIME_MISE_STATE_RELATIVE_PATH: &str = ".local/state/mise";
+const GEMINI_MIRROR_FILES: &[&str] = &[
+    "oauth_creds.json",
+    "google_accounts.json",
+    "settings.json",
+    "settings.json.orig",
+    "trustedFolders.json",
+    "trusted_hooks.json",
+    "mcp-oauth-tokens-v2.json",
+    "installation_id",
+    "state.json",
+];
+const GEMINI_MIRROR_DIRS: &[&str] = &["extensions", "antigravity"];
+const GEMINI_SELECTED_TYPE_OAUTH: &str = "oauth-personal";
+const GEMINI_SELECTED_TYPE_API_KEY: &str = "gemini-api-key";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GeminiAcpLaunch {
+    pub(crate) command: String,
+    pub(crate) args: Vec<String>,
+}
+
+pub(crate) fn prepare_gemini_acp_runtime(
+    env: &mut HashMap<String, String>,
+    session_id: &str,
+    base_args: &[String],
+) -> Result<GeminiAcpLaunch> {
+    let source_home = env
+        .get("HOME")
+        .cloned()
+        .or_else(|| std::env::var("HOME").ok())
+        .map(PathBuf::from);
+    let runtime_home = std::env::temp_dir()
+        .join(GEMINI_RUNTIME_ROOT_DIR)
+        .join(session_id);
+    seed_runtime_home(&runtime_home, source_home.as_deref())?;
+    align_runtime_auth_selection(&runtime_home, env)?;
+
+    let runtime_home_str = runtime_home.to_string_lossy().into_owned();
+    env.insert("GEMINI_CLI_HOME".to_string(), runtime_home_str.clone());
+    env.insert("HOME".to_string(), runtime_home_str.clone());
+    env.insert(
+        "XDG_CONFIG_HOME".to_string(),
+        runtime_home.join(".config").to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "XDG_CACHE_HOME".to_string(),
+        runtime_home.join(".cache").to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "XDG_STATE_HOME".to_string(),
+        runtime_home
+            .join(".local")
+            .join("state")
+            .to_string_lossy()
+            .into_owned(),
+    );
+    env.insert(
+        "MISE_CACHE_DIR".to_string(),
+        runtime_home
+            .join(GEMINI_RUNTIME_MISE_CACHE_RELATIVE_PATH)
+            .to_string_lossy()
+            .into_owned(),
+    );
+    env.insert(
+        "MISE_STATE_DIR".to_string(),
+        runtime_home
+            .join(GEMINI_RUNTIME_MISE_STATE_RELATIVE_PATH)
+            .to_string_lossy()
+            .into_owned(),
+    );
+
+    let inherited_path = env
+        .get("PATH")
+        .map(OsStr::new)
+        .map(std::ffi::OsString::from)
+        .or_else(|| std::env::var_os("PATH"));
+    if let Some(path) = pin_non_shim_runtime_path(inherited_path.as_deref(), env)? {
+        env.insert("PATH".to_string(), path);
+    }
+    for key in GEMINI_RUNTIME_SHIM_ENV_VARS {
+        env.insert((*key).to_string(), String::new());
+    }
+
+    let path_env = env
+        .get("PATH")
+        .map(OsStr::new)
+        .map(std::ffi::OsString::from)
+        .or(inherited_path);
+
+    if let Some(launch) = resolve_non_shim_gemini_launch(path_env.as_deref(), env, base_args)? {
+        debug!(
+            command = %launch.command,
+            runtime_home = %runtime_home.display(),
+            "prepared gemini ACP runtime using direct launch"
+        );
+        return Ok(launch);
+    }
+
+    debug!(
+        runtime_home = %runtime_home.display(),
+        "prepared gemini ACP runtime without direct launch override"
+    );
+    Ok(GeminiAcpLaunch {
+        command: "gemini".to_string(),
+        args: base_args.to_vec(),
+    })
+}
+
+pub(crate) fn gemini_runtime_home_from_env(env: &HashMap<String, String>) -> Option<PathBuf> {
+    let runtime_root = std::env::temp_dir().join(GEMINI_RUNTIME_ROOT_DIR);
+    let candidates = [
+        env.get("GEMINI_CLI_HOME").map(PathBuf::from),
+        env.get("HOME").map(PathBuf::from),
+        env.get("XDG_CONFIG_HOME")
+            .map(Path::new)
+            .and_then(Path::parent)
+            .and_then(Path::parent)
+            .map(PathBuf::from),
+        env.get("XDG_CACHE_HOME")
+            .map(Path::new)
+            .and_then(Path::parent)
+            .map(PathBuf::from),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|path| path.starts_with(&runtime_root))
+}
+
+fn seed_runtime_home(runtime_home: &Path, source_home: Option<&Path>) -> Result<()> {
+    let gemini_dir = runtime_home.join(".gemini");
+    fs::create_dir_all(&gemini_dir).with_context(|| {
+        format!(
+            "failed to create gemini runtime dir {}",
+            gemini_dir.display()
+        )
+    })?;
+    for directory in [
+        runtime_home.join(".config").join("gemini-cli"),
+        runtime_home.join(".cache"),
+        runtime_home.join(GEMINI_RUNTIME_MISE_CACHE_RELATIVE_PATH),
+        runtime_home.join(".local").join("state"),
+        runtime_home.join(GEMINI_RUNTIME_MISE_STATE_RELATIVE_PATH),
+    ] {
+        fs::create_dir_all(&directory).with_context(|| {
+            format!(
+                "failed to create gemini runtime dir {}",
+                directory.display()
+            )
+        })?;
+    }
+
+    for dir_name in ["history", "logs", "tmp"] {
+        fs::create_dir_all(gemini_dir.join(dir_name)).with_context(|| {
+            format!(
+                "failed to create gemini runtime state dir {}",
+                gemini_dir.join(dir_name).display()
+            )
+        })?;
+    }
+
+    let Some(source_home) = source_home else {
+        return Ok(());
+    };
+
+    let source_gemini_dir = source_home.join(".gemini");
+    let target_gemini_dir = runtime_home.join(".gemini");
+    for file_name in GEMINI_MIRROR_FILES {
+        copy_if_present(
+            &source_gemini_dir.join(file_name),
+            &target_gemini_dir.join(file_name),
+        );
+    }
+
+    copy_tree_contents(
+        &source_home.join(".config").join("gemini-cli"),
+        &runtime_home.join(".config").join("gemini-cli"),
+    );
+
+    for dir_name in GEMINI_MIRROR_DIRS {
+        mirror_directory_link(
+            &source_gemini_dir.join(dir_name),
+            &target_gemini_dir.join(dir_name),
+        );
+    }
+
+    mirror_directory_link(&source_home.join(".agents"), &runtime_home.join(".agents"));
+
+    Ok(())
+}
+
+fn align_runtime_auth_selection(runtime_home: &Path, env: &HashMap<String, String>) -> Result<()> {
+    let Some(selected_type) = runtime_auth_selected_type(env) else {
+        return Ok(());
+    };
+
+    for relative_path in GEMINI_RUNTIME_SETTINGS_PATHS {
+        let settings_path = runtime_home.join(relative_path);
+        write_runtime_selected_auth_type(&settings_path, selected_type)?;
+    }
+
+    debug!(
+        runtime_home = %runtime_home.display(),
+        selected_type,
+        "aligned gemini runtime auth selection"
+    );
+    Ok(())
+}
+
+fn runtime_auth_selected_type(env: &HashMap<String, String>) -> Option<&'static str> {
+    match env
+        .get(csa_core::gemini::AUTH_MODE_ENV_KEY)
+        .map(String::as_str)
+    {
+        Some(csa_core::gemini::AUTH_MODE_API_KEY) => Some(GEMINI_SELECTED_TYPE_API_KEY),
+        Some(csa_core::gemini::AUTH_MODE_OAUTH) => Some(GEMINI_SELECTED_TYPE_OAUTH),
+        _ if env.contains_key(csa_core::gemini::API_KEY_ENV) => Some(GEMINI_SELECTED_TYPE_API_KEY),
+        _ => None,
+    }
+}
+
+fn write_runtime_selected_auth_type(settings_path: &Path, selected_type: &str) -> Result<()> {
+    let mut settings = load_runtime_settings(settings_path);
+    let auth_settings = ensure_auth_settings_mut(&mut settings);
+    auth_settings.insert(
+        "selectedType".to_string(),
+        Value::String(selected_type.to_string()),
+    );
+    auth_settings.insert(
+        "enforcedType".to_string(),
+        Value::String(selected_type.to_string()),
+    );
+
+    if let Some(parent) = settings_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create gemini runtime settings dir {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let serialized =
+        serde_json::to_string_pretty(&settings).context("failed to serialize gemini settings")?;
+    fs::write(settings_path, format!("{serialized}\n")).with_context(|| {
+        format!(
+            "failed to write gemini runtime settings {}",
+            settings_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn load_runtime_settings(settings_path: &Path) -> Value {
+    let Ok(raw) = fs::read_to_string(settings_path) else {
+        return Value::Object(Map::new());
+    };
+
+    match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(error) => {
+            warn!(
+                path = %settings_path.display(),
+                error = %error,
+                "failed to parse mirrored gemini settings; recreating runtime auth override"
+            );
+            Value::Object(Map::new())
+        }
+    }
+}
+
+fn ensure_auth_settings_mut(settings: &mut Value) -> &mut Map<String, Value> {
+    let root = ensure_object_mut(settings);
+    let security = root
+        .entry("security".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let security = ensure_object_mut(security);
+    let auth = security
+        .entry("auth".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    ensure_object_mut(auth)
+}
+
+fn ensure_object_mut(value: &mut Value) -> &mut Map<String, Value> {
+    if !value.is_object() {
+        *value = Value::Object(Map::new());
+    }
+    value
+        .as_object_mut()
+        .expect("value must be an object after initialization")
+}
+
+fn copy_if_present(source: &Path, target: &Path) {
+    if !source.exists() || target.exists() {
+        return;
+    }
+
+    if let Some(parent) = target.parent()
+        && let Err(error) = fs::create_dir_all(parent)
+    {
+        warn!(
+            source = %source.display(),
+            target = %target.display(),
+            error = %error,
+            "failed to create parent directory for mirrored gemini file"
+        );
+        return;
+    }
+
+    if let Err(error) = fs::copy(source, target) {
+        warn!(
+            source = %source.display(),
+            target = %target.display(),
+            error = %error,
+            "failed to mirror gemini runtime file"
+        );
+    }
+}
+
+fn copy_tree_contents(source: &Path, target: &Path) {
+    if !source.exists() {
+        return;
+    }
+
+    let Ok(entries) = fs::read_dir(source) else {
+        warn!(source = %source.display(), "failed to enumerate gemini config directory");
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let Ok(file_type) = entry.file_type() else {
+            warn!(source = %source_path.display(), "failed to inspect gemini config entry");
+            continue;
+        };
+
+        if file_type.is_dir() {
+            if let Err(error) = fs::create_dir_all(&target_path) {
+                warn!(
+                    source = %source_path.display(),
+                    target = %target_path.display(),
+                    error = %error,
+                    "failed to create mirrored gemini config directory"
+                );
+                continue;
+            }
+            copy_tree_contents(&source_path, &target_path);
+            continue;
+        }
+
+        copy_if_present(&source_path, &target_path);
+    }
+}
+
+fn mirror_directory_link(source: &Path, target: &Path) {
+    if !source.exists() || target.exists() {
+        return;
+    }
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = target.parent()
+            && let Err(error) = fs::create_dir_all(parent)
+        {
+            warn!(
+                source = %source.display(),
+                target = %target.display(),
+                error = %error,
+                "failed to create parent directory for mirrored gemini symlink"
+            );
+            return;
+        }
+
+        if let Err(error) = std::os::unix::fs::symlink(source, target) {
+            warn!(
+                source = %source.display(),
+                target = %target.display(),
+                error = %error,
+                "failed to mirror gemini runtime directory as symlink"
+            );
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (source, target);
+    }
+}
+
+fn pin_non_shim_runtime_path(
+    path_env: Option<&OsStr>,
+    env: &HashMap<String, String>,
+) -> Result<Option<String>> {
+    let Some(path_env) = path_env else {
+        return Ok(None);
+    };
+
+    let original_entries: Vec<PathBuf> = std::env::split_paths(path_env).collect();
+    let mut pinned_dirs = Vec::new();
+    for binary in GEMINI_RUNTIME_PINNED_PATH_BINARIES {
+        if let Some(dir) = find_direct_tool_dir(binary, Some(path_env), env)?
+            && !pinned_dirs.contains(&dir)
+        {
+            pinned_dirs.push(dir);
+        }
+    }
+
+    if pinned_dirs.is_empty() {
+        return Ok(None);
+    }
+
+    let mut merged_entries = pinned_dirs;
+    for entry in original_entries {
+        if !merged_entries.contains(&entry) {
+            merged_entries.push(entry);
+        }
+    }
+
+    let joined = std::env::join_paths(merged_entries)
+        .context("failed to join pinned Gemini runtime PATH")?;
+    Ok(Some(joined.to_string_lossy().into_owned()))
+}
+
+fn find_direct_tool_dir(
+    name: &str,
+    path_env: Option<&OsStr>,
+    env: &HashMap<String, String>,
+) -> Result<Option<PathBuf>> {
+    Ok(find_direct_tool_path(name, path_env, env)?
+        .and_then(|path| path.parent().map(PathBuf::from)))
+}
+
+fn find_path_entry(name: &str, path_env: Option<&OsStr>) -> Option<PathBuf> {
+    let path_env = path_env?;
+
+    for directory in std::env::split_paths(path_env) {
+        let candidate = directory.join(name);
+        if !candidate.is_file() {
+            continue;
+        }
+
+        return Some(candidate.canonicalize().unwrap_or(candidate));
+    }
+
+    None
+}
+
+fn find_direct_tool_path(
+    name: &str,
+    path_env: Option<&OsStr>,
+    env: &HashMap<String, String>,
+) -> Result<Option<PathBuf>> {
+    if let Some(candidate) = find_non_mise_path_entry(name, path_env) {
+        return Ok(Some(candidate));
+    }
+
+    resolve_mise_which_path(name, path_env, env)
+}
+
+fn find_non_mise_path_entry(name: &str, path_env: Option<&OsStr>) -> Option<PathBuf> {
+    let path_env = path_env?;
+
+    for directory in std::env::split_paths(path_env) {
+        let candidate = directory.join(name);
+        if !candidate.is_file() {
+            continue;
+        }
+
+        let canonical = candidate.canonicalize().unwrap_or(candidate);
+        if canonical
+            .file_name()
+            .is_some_and(|file_name| file_name == OsStr::new("mise"))
+        {
+            continue;
+        }
+
+        return Some(canonical);
+    }
+
+    None
+}
+
+fn resolve_mise_which_path(
+    name: &str,
+    path_env: Option<&OsStr>,
+    env: &HashMap<String, String>,
+) -> Result<Option<PathBuf>> {
+    let Some(mise_path) = find_path_entry("mise", path_env) else {
+        return Ok(None);
+    };
+
+    let mut command = Command::new(&mise_path);
+    command
+        .arg("-C")
+        .arg(std::env::temp_dir())
+        .arg("which")
+        .arg(name);
+    for key in [
+        "HOME",
+        "PATH",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_STATE_HOME",
+        "MISE_CACHE_DIR",
+        "MISE_STATE_DIR",
+    ] {
+        if let Some(value) = env.get(key) {
+            command.env(key, value);
+        }
+    }
+
+    let output = command.output().with_context(|| {
+        format!("failed to resolve Gemini runtime binary `{name}` via mise which")
+    })?;
+    if !output.status.success() {
+        debug!(
+            binary = name,
+            status = ?output.status.code(),
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "mise which did not resolve a direct Gemini runtime binary"
+        );
+        return Ok(None);
+    }
+
+    let resolved = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if resolved.is_empty() {
+        return Ok(None);
+    }
+
+    let resolved_path = PathBuf::from(resolved);
+    if !resolved_path.exists() {
+        return Ok(None);
+    }
+
+    Ok(Some(resolved_path.canonicalize().unwrap_or(resolved_path)))
+}
+
+fn resolve_non_shim_gemini_launch(
+    path_env: Option<&OsStr>,
+    env: &HashMap<String, String>,
+    base_args: &[String],
+) -> Result<Option<GeminiAcpLaunch>> {
+    let Some(gemini_candidate) = find_direct_tool_path("gemini", path_env, env)? else {
+        return Ok(None);
+    };
+
+    if gemini_candidate
+        .extension()
+        .is_some_and(|extension| extension == "js")
+        || is_node_script(&gemini_candidate)
+    {
+        let Some(node_candidate) = find_direct_tool_path("node", path_env, env)? else {
+            return Ok(None);
+        };
+
+        let mut args = vec![
+            "--no-warnings=DEP0040".to_string(),
+            gemini_candidate.to_string_lossy().into_owned(),
+        ];
+        args.extend(base_args.iter().cloned());
+        return Ok(Some(GeminiAcpLaunch {
+            command: node_candidate.to_string_lossy().into_owned(),
+            args,
+        }));
+    }
+
+    Ok(Some(GeminiAcpLaunch {
+        command: gemini_candidate.to_string_lossy().into_owned(),
+        args: base_args.to_vec(),
+    }))
+}
+
+fn is_node_script(path: &Path) -> bool {
+    let Ok(contents) = fs::read(path) else {
+        return false;
+    };
+
+    let Some(first_line) = contents.split(|byte| *byte == b'\n').next() else {
+        return false;
+    };
+    let Ok(first_line) = std::str::from_utf8(first_line) else {
+        return false;
+    };
+    first_line.contains("node")
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    include!("transport_gemini_acp_runtime_tests_tail.rs");
+}

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -1,0 +1,426 @@
+use super::*;
+
+use std::os::unix::fs::PermissionsExt;
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("write executable");
+    let mut perms = fs::metadata(path).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod");
+}
+
+#[test]
+fn prepare_gemini_acp_runtime_sets_runtime_home_and_resolves_direct_launch() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = format!(
+        "01TESTGEMINI{:x}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos()
+    );
+    let source_home = temp.path().join("source-home");
+    let source_gemini = source_home.join(".gemini");
+    fs::create_dir_all(&source_gemini).expect("create source gemini dir");
+    fs::create_dir_all(source_gemini.join("extensions")).expect("create source extensions");
+    fs::create_dir_all(source_home.join(".config").join("gemini-cli"))
+        .expect("create source config dir");
+    fs::create_dir_all(source_home.join(".agents")).expect("create source agents dir");
+    fs::write(source_gemini.join("oauth_creds.json"), "oauth").expect("write oauth");
+    fs::write(source_gemini.join("settings.json"), "{\"theme\":\"test\"}").expect("write settings");
+    fs::write(
+        source_home
+            .join(".config")
+            .join("gemini-cli")
+            .join("settings.json"),
+        "{\"acp\":true}",
+    )
+    .expect("write xdg settings");
+
+    let shims_dir = temp.path().join("shims");
+    let real_dir = temp.path().join("real");
+    let node_dir = temp.path().join("node");
+    fs::create_dir_all(&shims_dir).expect("create shims dir");
+    fs::create_dir_all(real_dir.join("dist")).expect("create real dist dir");
+    fs::create_dir_all(&node_dir).expect("create node dir");
+
+    let mise_path = shims_dir.join("mise");
+    write_executable(&mise_path, "#!/bin/sh\nexit 1\n");
+    std::os::unix::fs::symlink(&mise_path, shims_dir.join("gemini")).expect("symlink shim");
+
+    let real_script = real_dir.join("dist").join("index.js");
+    fs::write(
+        &real_script,
+        "#!/usr/bin/env -S node --no-warnings=DEP0040\nconsole.log('gemini');\n",
+    )
+    .expect("write real script");
+    std::os::unix::fs::symlink(&real_script, real_dir.join("gemini"))
+        .expect("symlink real gemini");
+
+    let node_path = node_dir.join("node");
+    write_executable(&node_path, "#!/bin/sh\nexit 0\n");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "PATH".to_string(),
+        std::env::join_paths([&shims_dir, &real_dir, &node_dir])
+            .expect("join paths")
+            .to_string_lossy()
+            .into_owned(),
+    );
+    env.insert(
+        csa_core::gemini::AUTH_MODE_ENV_KEY.to_string(),
+        csa_core::gemini::AUTH_MODE_OAUTH.to_string(),
+    );
+
+    let launch =
+        prepare_gemini_acp_runtime(&mut env, &session_id, &["--acp".to_string()]).expect("prepare runtime");
+
+    assert_eq!(launch.command, node_path.to_string_lossy());
+    assert_eq!(launch.args[0], "--no-warnings=DEP0040");
+    assert_eq!(launch.args[1], real_script.to_string_lossy());
+    assert_eq!(launch.args[2], "--acp");
+
+    let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
+    assert_eq!(
+        env.get("GEMINI_CLI_HOME"),
+        Some(&runtime_home.to_string_lossy().into_owned())
+    );
+    assert_eq!(
+        env.get("XDG_STATE_HOME"),
+        Some(
+            &runtime_home
+                .join(".local")
+                .join("state")
+                .to_string_lossy()
+                .into_owned()
+        ),
+        "runtime home should redirect XDG state for nested CSA commands"
+    );
+    assert_eq!(
+        env.get("MISE_CACHE_DIR"),
+        Some(
+            &runtime_home
+                .join(GEMINI_RUNTIME_MISE_CACHE_RELATIVE_PATH)
+                .to_string_lossy()
+                .into_owned()
+        ),
+        "runtime home should pin mise cache inside the writable Gemini runtime"
+    );
+    assert_eq!(
+        env.get("MISE_STATE_DIR"),
+        Some(
+            &runtime_home
+                .join(GEMINI_RUNTIME_MISE_STATE_RELATIVE_PATH)
+                .to_string_lossy()
+                .into_owned()
+        ),
+        "runtime home should pin mise state inside the writable Gemini runtime"
+    );
+    assert!(
+        runtime_home.join(".gemini/oauth_creds.json").exists(),
+        "runtime home should mirror oauth creds"
+    );
+    assert!(
+        runtime_home.join(".config/gemini-cli/settings.json").exists(),
+        "runtime home should mirror XDG config"
+    );
+    assert!(
+        runtime_home.join(".gemini/extensions").exists(),
+        "runtime home should preserve extension access"
+    );
+    assert!(
+        runtime_home.join(".agents").exists(),
+        "runtime home should preserve global agent skill access"
+    );
+    assert_eq!(
+        read_selected_auth_type(&runtime_home.join(".gemini/settings.json")),
+        Some(GEMINI_SELECTED_TYPE_OAUTH.to_string()),
+        "phase 1 runtime must stay OAuth-first even when settings are mirrored"
+    );
+}
+
+#[test]
+fn prepare_gemini_acp_runtime_pins_mise_dirs_under_runtime_home() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = "01TESTGEMINIMISEENV0000000000001";
+    let source_home = temp.path().join("source-home");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+
+    prepare_gemini_acp_runtime(&mut env, session_id, &["--acp".to_string()])
+        .expect("prepare runtime");
+
+    let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
+    assert_eq!(
+        env.get("MISE_CACHE_DIR"),
+        Some(
+            &runtime_home
+                .join(GEMINI_RUNTIME_MISE_CACHE_RELATIVE_PATH)
+                .to_string_lossy()
+                .into_owned()
+        )
+    );
+    assert_eq!(
+        env.get("MISE_STATE_DIR"),
+        Some(
+            &runtime_home
+                .join(GEMINI_RUNTIME_MISE_STATE_RELATIVE_PATH)
+                .to_string_lossy()
+                .into_owned()
+        )
+    );
+    assert!(
+        runtime_home
+            .join(GEMINI_RUNTIME_MISE_CACHE_RELATIVE_PATH)
+            .is_dir(),
+        "runtime should create a dedicated mise cache dir to avoid host ~/.cache/mise writes"
+    );
+    assert!(
+        runtime_home
+            .join(GEMINI_RUNTIME_MISE_STATE_RELATIVE_PATH)
+            .is_dir(),
+        "runtime should create a dedicated mise state dir for Gemini ACP startup"
+    );
+}
+
+#[test]
+fn prepare_gemini_acp_runtime_pins_non_shim_runtime_bins_on_path() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = "01TESTGEMINIPATHPINNING0000000001";
+    let source_home = temp.path().join("source-home");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+
+    let shims_dir = temp.path().join("shims");
+    let real_dir = temp.path().join("real");
+    let node_dir = temp.path().join("node");
+    let yarn_dir = temp.path().join("yarn");
+    fs::create_dir_all(&shims_dir).expect("create shims dir");
+    fs::create_dir_all(real_dir.join("dist")).expect("create real dist dir");
+    fs::create_dir_all(&node_dir).expect("create node dir");
+    fs::create_dir_all(&yarn_dir).expect("create yarn dir");
+
+    let mise_path = shims_dir.join("mise");
+    write_executable(&mise_path, "#!/bin/sh\nexit 1\n");
+    std::os::unix::fs::symlink(&mise_path, shims_dir.join("gemini")).expect("symlink gemini");
+    std::os::unix::fs::symlink(&mise_path, shims_dir.join("node")).expect("symlink node");
+
+    let real_script = real_dir.join("dist").join("index.js");
+    fs::write(
+        &real_script,
+        "#!/usr/bin/env -S node --no-warnings=DEP0040\nconsole.log('gemini');\n",
+    )
+    .expect("write real script");
+    std::os::unix::fs::symlink(&real_script, real_dir.join("gemini"))
+        .expect("symlink real gemini");
+    write_executable(&node_dir.join("node"), "#!/bin/sh\nexit 0\n");
+    write_executable(&yarn_dir.join("yarn"), "#!/bin/sh\nexit 0\n");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "PATH".to_string(),
+        std::env::join_paths([&shims_dir, &real_dir, &yarn_dir, &node_dir])
+            .expect("join paths")
+            .to_string_lossy()
+            .into_owned(),
+    );
+    env.insert("MISE_SHIM".to_string(), shims_dir.display().to_string());
+    env.insert(
+        "MISE_SHIMS_DIR".to_string(),
+        shims_dir.display().to_string(),
+    );
+
+    prepare_gemini_acp_runtime(&mut env, session_id, &["--acp".to_string()])
+        .expect("prepare runtime");
+
+    let prepared_path = env.get("PATH").expect("prepared path");
+    assert_eq!(
+        resolve_first_path_entry("node", prepared_path),
+        Some(node_dir.join("node")),
+        "nested yarn/node launches must hit the real node binary before any shim"
+    );
+    assert_eq!(
+        resolve_first_path_entry("yarn", prepared_path),
+        Some(yarn_dir.join("yarn")),
+        "runtime PATH should preserve direct yarn binaries ahead of shim-only entries"
+    );
+    assert_eq!(env.get("MISE_SHIM"), Some(&String::new()));
+    assert_eq!(env.get("MISE_SHIMS_DIR"), Some(&String::new()));
+}
+
+#[test]
+fn prepare_gemini_acp_runtime_resolves_mise_shims_via_mise_which() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = "01TESTGEMINIMISEWHICH0000000001";
+    let source_home = temp.path().join("source-home");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+
+    let shims_dir = temp.path().join("shims");
+    let real_dir = temp.path().join("real");
+    let node_dir = temp.path().join("node");
+    let yarn_dir = temp.path().join("yarn");
+    fs::create_dir_all(&shims_dir).expect("create shims dir");
+    fs::create_dir_all(real_dir.join("dist")).expect("create real dist dir");
+    fs::create_dir_all(&node_dir).expect("create node dir");
+    fs::create_dir_all(&yarn_dir).expect("create yarn dir");
+
+    let real_script = real_dir.join("dist").join("index.js");
+    fs::write(
+        &real_script,
+        "#!/usr/bin/env -S node --no-warnings=DEP0040\nconsole.log('gemini');\n",
+    )
+    .expect("write real script");
+    std::os::unix::fs::symlink(&real_script, real_dir.join("gemini"))
+        .expect("symlink real gemini");
+    write_executable(&node_dir.join("node"), "#!/bin/sh\nexit 0\n");
+    write_executable(&yarn_dir.join("yarn"), "#!/bin/sh\nexit 0\n");
+
+    let mise_path = shims_dir.join("mise");
+    write_executable(
+        &mise_path,
+        &format!(
+            "#!/bin/sh\nif [ \"$1\" = \"-C\" ]; then shift 2; fi\nif [ \"$1\" = \"which\" ]; then\n  case \"$2\" in\n    gemini) printf '%s\\n' '{}' ;;\n    node) printf '%s\\n' '{}' ;;\n    yarn) printf '%s\\n' '{}' ;;\n    *) exit 1 ;;\n  esac\n  exit 0\nfi\nexit 1\n",
+            real_dir.join("gemini").display(),
+            node_dir.join("node").display(),
+            yarn_dir.join("yarn").display(),
+        ),
+    );
+    std::os::unix::fs::symlink(&mise_path, shims_dir.join("gemini")).expect("symlink gemini");
+    std::os::unix::fs::symlink(&mise_path, shims_dir.join("node")).expect("symlink node");
+    std::os::unix::fs::symlink(&mise_path, shims_dir.join("yarn")).expect("symlink yarn");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert("PATH".to_string(), shims_dir.to_string_lossy().into_owned());
+    env.insert("MISE_SHIM".to_string(), shims_dir.display().to_string());
+    env.insert(
+        "MISE_SHIMS_DIR".to_string(),
+        shims_dir.display().to_string(),
+    );
+
+    let launch =
+        prepare_gemini_acp_runtime(&mut env, session_id, &["--acp".to_string()]).expect("prepare runtime");
+
+    assert_eq!(launch.command, node_dir.join("node").to_string_lossy());
+    assert_eq!(launch.args[1], real_script.to_string_lossy());
+    let prepared_path = env.get("PATH").expect("prepared path");
+    assert_eq!(
+        resolve_first_path_entry("node", prepared_path),
+        Some(node_dir.join("node")),
+        "mise-which fallback should pin the real node binary ahead of shim-only PATH entries"
+    );
+    assert_eq!(
+        resolve_first_path_entry("yarn", prepared_path),
+        Some(yarn_dir.join("yarn")),
+        "mise-which fallback should pin the real yarn binary ahead of shim-only PATH entries"
+    );
+}
+
+#[test]
+fn prepare_gemini_acp_runtime_rewrites_runtime_auth_selection_for_api_key_phase() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = "01TESTGEMINIAUTHSWITCH0000000001";
+    let source_home = temp.path().join("source-home");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        csa_core::gemini::AUTH_MODE_ENV_KEY.to_string(),
+        csa_core::gemini::AUTH_MODE_OAUTH.to_string(),
+    );
+
+    prepare_gemini_acp_runtime(&mut env, session_id, &["--acp".to_string()])
+        .expect("prepare oauth runtime");
+    let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
+    assert_eq!(
+        read_selected_auth_type(&runtime_home.join(".gemini/settings.json")),
+        Some(GEMINI_SELECTED_TYPE_OAUTH.to_string()),
+        "first attempt should write OAuth auth selection even without source settings"
+    );
+
+    env.insert(
+        csa_core::gemini::AUTH_MODE_ENV_KEY.to_string(),
+        csa_core::gemini::AUTH_MODE_API_KEY.to_string(),
+    );
+    env.insert(
+        csa_core::gemini::API_KEY_ENV.to_string(),
+        "fallback-key".to_string(),
+    );
+
+    prepare_gemini_acp_runtime(&mut env, session_id, &["--acp".to_string()])
+        .expect("prepare api key runtime");
+    assert_eq!(
+        read_selected_auth_type(&runtime_home.join(".gemini/settings.json")),
+        Some(GEMINI_SELECTED_TYPE_API_KEY.to_string()),
+        "phase 2 runtime must override selected auth type to Gemini API key"
+    );
+    assert_eq!(
+        read_selected_auth_type(&runtime_home.join(".config/gemini-cli/settings.json")),
+        Some(GEMINI_SELECTED_TYPE_API_KEY.to_string()),
+        "phase 2 runtime must keep XDG settings aligned with the selected auth type"
+    );
+}
+
+#[test]
+fn gemini_runtime_home_from_env_prefers_seeded_runtime_paths() {
+    let mut env = HashMap::new();
+    let runtime_home = std::env::temp_dir()
+        .join(GEMINI_RUNTIME_ROOT_DIR)
+        .join("01TESTGEMINIRUNTIMEHOME0000000001");
+    env.insert(
+        "GEMINI_CLI_HOME".to_string(),
+        runtime_home.to_string_lossy().into_owned(),
+    );
+    env.insert("HOME".to_string(), "/home/example".to_string());
+
+    assert_eq!(gemini_runtime_home_from_env(&env), Some(runtime_home));
+}
+
+#[test]
+fn gemini_runtime_home_from_env_rejects_regular_home_paths() {
+    let mut env = HashMap::new();
+    env.insert("HOME".to_string(), "/home/example".to_string());
+    env.insert(
+        "XDG_CONFIG_HOME".to_string(),
+        "/home/example/.config".to_string(),
+    );
+
+    assert_eq!(gemini_runtime_home_from_env(&env), None);
+}
+
+fn read_selected_auth_type(settings_path: &Path) -> Option<String> {
+    let raw = fs::read_to_string(settings_path).ok()?;
+    let parsed: Value = serde_json::from_str(&raw).ok()?;
+    parsed
+        .get("security")?
+        .get("auth")?
+        .get("selectedType")?
+        .as_str()
+        .map(ToString::to_string)
+}
+
+fn resolve_first_path_entry(name: &str, path_env: &str) -> Option<PathBuf> {
+    std::env::split_paths(OsStr::new(path_env))
+        .map(|directory| directory.join(name))
+        .find(|candidate| candidate.is_file())
+}

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -1,0 +1,192 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::anyhow;
+
+use csa_process::ExecutionResult;
+use csa_resource::isolation_plan::IsolationPlan;
+
+use crate::transport_gemini_retry::{gemini_retry_model, gemini_should_use_api_key};
+
+#[derive(Debug, Clone)]
+pub(super) struct GeminiRetryPhase {
+    pub(super) attempt: u8,
+    auth_mode: &'static str,
+    model: &'static str,
+}
+
+impl GeminiRetryPhase {
+    pub(super) fn for_attempt(attempt: u8) -> Self {
+        Self {
+            attempt,
+            auth_mode: if gemini_should_use_api_key(attempt) {
+                "api_key"
+            } else {
+                "oauth"
+            },
+            model: gemini_retry_model(attempt).unwrap_or("inherit"),
+        }
+    }
+}
+
+pub(super) fn gemini_phase_desc(attempt: u8) -> &'static str {
+    match attempt {
+        1 => "OAuth->APIKey(same model)",
+        2 => "APIKey(same model)->APIKey(flash)",
+        3 => "APIKey(flash)",
+        _ => "final",
+    }
+}
+
+pub(super) fn append_gemini_retry_report(
+    execution: &mut ExecutionResult,
+    phases: &[GeminiRetryPhase],
+) {
+    if phases.len() <= 1 {
+        return;
+    }
+
+    let report = format!("[gemini-retry] {}", format_gemini_retry_report(phases));
+    if execution.stderr_output.is_empty() {
+        execution.stderr_output = report;
+        return;
+    }
+
+    if !execution.stderr_output.ends_with('\n') {
+        execution.stderr_output.push('\n');
+    }
+    execution.stderr_output.push_str(&report);
+}
+
+pub(super) fn annotate_gemini_retry_error(
+    error: anyhow::Error,
+    phases: &[GeminiRetryPhase],
+) -> anyhow::Error {
+    if phases.len() <= 1 {
+        return error;
+    }
+
+    anyhow!(
+        "Gemini ACP retry chain exhausted. {}. Last error: {error:#}",
+        format_gemini_retry_report(phases)
+    )
+}
+
+pub(super) fn ensure_gemini_runtime_home_writable_path(
+    isolation_plan: &mut IsolationPlan,
+    runtime_home: Option<&Path>,
+) {
+    let Some(runtime_home) = runtime_home else {
+        return;
+    };
+
+    let runtime_home_is_visible = isolation_plan.writable_paths.iter().any(|existing| {
+        existing == runtime_home
+            || (existing != Path::new("/tmp") && runtime_home.starts_with(existing))
+    });
+    if runtime_home_is_visible {
+        return;
+    }
+
+    isolation_plan
+        .writable_paths
+        .push(runtime_home.to_path_buf());
+}
+
+pub(super) fn gemini_sandbox_runtime_env_overrides(
+    env: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut overrides = HashMap::new();
+    for key in [
+        "HOME",
+        "PATH",
+        "GEMINI_CLI_HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_STATE_HOME",
+        "MISE_CACHE_DIR",
+        "MISE_STATE_DIR",
+        "MISE_SHIM",
+        "MISE_SHIMS_DIR",
+    ] {
+        if let Some(value) = env.get(key) {
+            overrides.insert(key.to_string(), value.clone());
+        }
+    }
+
+    if let Some(auth_mode) = env.get(csa_core::gemini::AUTH_MODE_ENV_KEY) {
+        overrides.insert(
+            csa_core::gemini::AUTH_MODE_ENV_KEY.to_string(),
+            auth_mode.clone(),
+        );
+    }
+
+    // Force the sandboxed Gemini child to see exactly the auth-routing env
+    // chosen for this attempt, overriding any systemd user-manager leakage.
+    overrides.insert(
+        csa_core::gemini::API_KEY_ENV.to_string(),
+        env.get(csa_core::gemini::API_KEY_ENV)
+            .cloned()
+            .unwrap_or_default(),
+    );
+    overrides.insert(
+        csa_core::gemini::BASE_URL_ENV.to_string(),
+        env.get(csa_core::gemini::BASE_URL_ENV)
+            .cloned()
+            .unwrap_or_default(),
+    );
+
+    overrides
+}
+
+pub(super) fn apply_gemini_sandbox_runtime_env_overrides(
+    isolation_plan: &mut IsolationPlan,
+    env_overrides: &HashMap<String, String>,
+) {
+    isolation_plan.env_overrides.extend(
+        env_overrides
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
+}
+
+/// Convert a `tokio::task::JoinError` into a descriptive `anyhow::Error`.
+///
+/// Broken-pipe panics (from `eprintln!` after the tool process closes stderr)
+/// are rewritten into a clean message that mentions the tool died, instead of
+/// surfacing the raw tokio panic trace.
+pub(super) fn classify_join_error(e: tokio::task::JoinError) -> anyhow::Error {
+    if e.is_panic() {
+        let msg = match e.into_panic().downcast::<String>() {
+            Ok(s) => *s,
+            Err(any) => match any.downcast::<&str>() {
+                Ok(s) => s.to_string(),
+                Err(_) => "unknown panic".to_string(),
+            },
+        };
+        if msg.contains("Broken pipe") || msg.contains("os error 32") {
+            return anyhow!(
+                "ACP transport: tool process terminated unexpectedly (broken pipe on stderr)"
+            );
+        }
+        anyhow!("ACP transport: task panicked: {msg}")
+    } else {
+        anyhow!("ACP transport: task cancelled: {e}")
+    }
+}
+
+pub(super) fn format_gemini_retry_report(phases: &[GeminiRetryPhase]) -> String {
+    phases
+        .iter()
+        .map(|phase| {
+            format!(
+                "attempt={} phase=\"{}\" auth={} model={}",
+                phase.attempt,
+                gemini_phase_desc(phase.attempt),
+                phase.auth_mode,
+                phase.model
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -326,7 +326,10 @@ fn last_non_empty_line(output: &str) -> &str {
     output
         .lines()
         .rev()
-        .find(|line| !line.trim().is_empty())
+        .find(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !trimmed.starts_with("<!-- CSA:SECTION:")
+        })
         .unwrap_or_default()
 }
 

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -57,6 +57,13 @@ fn test_build_summary_falls_back_to_stderr_on_failure() {
 }
 
 #[test]
+fn test_build_summary_ignores_csa_section_markers() {
+    let stdout = "Valid summary line\n<!-- CSA:SECTION:summary:END -->\n";
+    let summary = super::build_summary(stdout, "", 0);
+    assert_eq!(summary, "Valid summary line");
+}
+
+#[test]
 fn test_build_summary_falls_back_to_exit_code_when_no_output() {
     let summary = super::build_summary("", "   \n", -1);
     assert_eq!(summary, "exit code -1");

--- a/crates/csa-executor/src/transport_tests_gemini_fallback.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_fallback.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 #[test]
 fn test_gemini_should_use_api_key_by_phase() {
     // Phase 1: OAuth auth
@@ -23,7 +25,10 @@ fn test_gemini_rate_limit_backoff_is_exponential() {
 #[test]
 fn test_inject_api_key_fallback_promotes_key_and_removes_internal() {
     let mut env = HashMap::new();
-    env.insert("_CSA_API_KEY_FALLBACK".to_string(), "test-api-key-123".to_string());
+    env.insert(
+        "_CSA_API_KEY_FALLBACK".to_string(),
+        "test-api-key-123".to_string(),
+    );
     env.insert("_CSA_GEMINI_AUTH_MODE".to_string(), "oauth".to_string());
     env.insert("OTHER_VAR".to_string(), "keep".to_string());
     let result = gemini_inject_api_key_fallback(Some(&env)).unwrap();
@@ -43,7 +48,10 @@ fn test_inject_api_key_fallback_returns_none_without_key() {
 #[test]
 fn test_inject_api_key_fallback_returns_none_for_api_key_mode() {
     let mut env = HashMap::new();
-    env.insert("_CSA_API_KEY_FALLBACK".to_string(), "fallback-key".to_string());
+    env.insert(
+        "_CSA_API_KEY_FALLBACK".to_string(),
+        "fallback-key".to_string(),
+    );
     env.insert("_CSA_GEMINI_AUTH_MODE".to_string(), "api_key".to_string());
     assert!(gemini_inject_api_key_fallback(Some(&env)).is_none());
 }
@@ -51,7 +59,10 @@ fn test_inject_api_key_fallback_returns_none_for_api_key_mode() {
 #[tokio::test]
 async fn test_execute_in_falls_back_to_api_key_after_all_retries_exhausted() {
     let (_temp, mut env, _model_log_path) = setup_fake_gemini_environment(99);
-    env.insert("_CSA_API_KEY_FALLBACK".to_string(), "fallback-key".to_string());
+    env.insert(
+        "_CSA_API_KEY_FALLBACK".to_string(),
+        "fallback-key".to_string(),
+    );
     env.insert("_CSA_GEMINI_AUTH_MODE".to_string(), "oauth".to_string());
     let transport = LegacyTransport::new(Executor::GeminiCli {
         model_override: None,
@@ -82,7 +93,10 @@ async fn test_execute_in_falls_back_to_api_key_after_all_retries_exhausted() {
 #[tokio::test]
 async fn test_execute_falls_back_to_api_key_after_all_retries_exhausted() {
     let (temp, mut env, _model_log_path) = setup_fake_gemini_environment(99);
-    env.insert("_CSA_API_KEY_FALLBACK".to_string(), "fallback-key".to_string());
+    env.insert(
+        "_CSA_API_KEY_FALLBACK".to_string(),
+        "fallback-key".to_string(),
+    );
     env.insert("_CSA_GEMINI_AUTH_MODE".to_string(), "oauth".to_string());
     let transport = LegacyTransport::new(Executor::GeminiCli {
         model_override: None,
@@ -113,6 +127,106 @@ async fn test_execute_falls_back_to_api_key_after_all_retries_exhausted() {
     // (3 model retries + 1 fallback) confirms the fallback path was taken.
     assert_ne!(result.execution.exit_code, 0);
     assert!(result.execution.stderr_output.contains("QUOTA_EXHAUSTED"));
+}
+
+#[tokio::test]
+async fn test_execute_in_new_invocation_restarts_with_oauth_before_fallback() {
+    let (_temp, mut env, model_log_path) = setup_fake_gemini_environment(99);
+    env.insert(
+        "_CSA_API_KEY_FALLBACK".to_string(),
+        "fallback-key".to_string(),
+    );
+    env.insert("_CSA_GEMINI_AUTH_MODE".to_string(), "oauth".to_string());
+    env.insert("_CSA_NO_FLASH_FALLBACK".to_string(), "1".to_string());
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+
+    let first = transport
+        .execute_in(
+            "first invocation",
+            std::path::Path::new("/tmp"),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+        )
+        .await
+        .expect("first invocation should return the last failed attempt");
+    assert_ne!(first.execution.exit_code, 0);
+
+    let second = transport
+        .execute_in(
+            "second invocation",
+            std::path::Path::new("/tmp"),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+        )
+        .await
+        .expect("second invocation should return the last failed attempt");
+    assert_ne!(second.execution.exit_code, 0);
+
+    let auths = read_auth_log(&model_log_path);
+    assert_eq!(
+        auths,
+        vec![
+            "oauth".to_string(),
+            "api_key".to_string(),
+            "oauth".to_string(),
+            "api_key".to_string(),
+        ],
+        "each invocation must restart on the quota-backed path before reusing API key fallback"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_in_non_quota_failure_does_not_trigger_api_key_fallback() {
+    let (_temp, mut env, model_log_path) = setup_fake_gemini_environment(99);
+    env.insert(
+        "_CSA_API_KEY_FALLBACK".to_string(),
+        "fallback-key".to_string(),
+    );
+    env.insert("_CSA_GEMINI_AUTH_MODE".to_string(), "oauth".to_string());
+    env.insert(
+        "CSA_FAKE_GEMINI_FAILURE_REASON".to_string(),
+        "internal server error".to_string(),
+    );
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+
+    let result = transport
+        .execute_in(
+            "non quota failure",
+            std::path::Path::new("/tmp"),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+        )
+        .await
+        .expect("non-quota failures should be returned directly");
+
+    assert_ne!(result.execution.exit_code, 0);
+    assert!(
+        result
+            .execution
+            .stderr_output
+            .contains("internal server error"),
+        "unexpected stderr: {}",
+        result.execution.stderr_output
+    );
+    assert_eq!(
+        read_model_log(&model_log_path),
+        vec!["inherit".to_string()],
+        "non-quota failures must not trigger another Gemini attempt"
+    );
+    assert_eq!(
+        read_auth_log(&model_log_path),
+        vec!["oauth".to_string()],
+        "non-quota failures must not switch auth modes"
+    );
 }
 
 #[tokio::test]
@@ -172,7 +286,13 @@ async fn test_execute_best_effort_sandbox_fallback_preserves_attempt_model_overr
     };
 
     let result = transport
-        .execute("test best effort fallback", None, &session, Some(&env), options)
+        .execute(
+            "test best effort fallback",
+            None,
+            &session,
+            Some(&env),
+            options,
+        )
         .await
         .expect("execute should succeed after best-effort fallback and retry");
 
@@ -219,6 +339,26 @@ fn test_is_gemini_rate_limited_error_matches_acp_wrapped_quota_exhausted() {
 }
 
 #[test]
+fn test_is_gemini_rate_limited_error_matches_new_capacity_phrase() {
+    let acp_error_msg = "ACP transport failed: ACP prompt failed: You have exhausted your capacity on this model. Your quota will reset after 13h52m46s.";
+    assert!(
+        is_gemini_rate_limited_error(acp_error_msg),
+        "should detect Gemini's newer exhausted-capacity wording"
+    );
+}
+
+#[test]
+fn test_is_gemini_rate_limited_error_matches_anyhow_context_chain() {
+    let error = anyhow::anyhow!("You have exhausted your capacity on this model.")
+        .context("ACP prompt failed")
+        .context("ACP transport failed");
+    assert!(
+        is_gemini_rate_limited_error(&format!("{error:#}")),
+        "should detect rate limits in anyhow context chains"
+    );
+}
+
+#[test]
 fn test_is_gemini_rate_limited_error_matches_unsandboxed_fallback_error() {
     let acp_error_msg =
         "ACP transport (unsandboxed fallback) failed: ACP prompt failed: resource exhausted";
@@ -230,8 +370,7 @@ fn test_is_gemini_rate_limited_error_matches_unsandboxed_fallback_error() {
 
 #[test]
 fn test_is_gemini_rate_limited_error_matches_plain_acp_error() {
-    let acp_error_msg =
-        "ACP transport failed: ACP prompt failed: No capacity available for model";
+    let acp_error_msg = "ACP transport failed: ACP prompt failed: No capacity available for model";
     assert!(
         is_gemini_rate_limited_error(acp_error_msg),
         "should detect rate limit in non-sandboxed ACP path"
@@ -287,5 +426,279 @@ fn test_is_gemini_rate_limited_result_ignores_success_exit_code() {
     assert!(
         !is_gemini_rate_limited_result(&execution),
         "should not retry when exit code is 0 even if output contains rate limit text"
+    );
+}
+
+#[test]
+fn test_format_gemini_retry_report_lists_attempt_phases() {
+    let phases = vec![
+        GeminiRetryPhase::for_attempt(1),
+        GeminiRetryPhase::for_attempt(2),
+        GeminiRetryPhase::for_attempt(3),
+    ];
+
+    let report = format_gemini_retry_report(&phases);
+
+    assert!(report.contains("attempt=1"));
+    assert!(report.contains("auth=oauth"));
+    assert!(report.contains("attempt=2"));
+    assert!(report.contains("auth=api_key"));
+    assert!(report.contains("model=gemini-3-flash-preview"));
+}
+
+#[test]
+fn test_annotate_gemini_retry_error_includes_phase_history() {
+    let phases = vec![
+        GeminiRetryPhase::for_attempt(1),
+        GeminiRetryPhase::for_attempt(2),
+    ];
+
+    let error = annotate_gemini_retry_error(anyhow::anyhow!("quota exhausted"), &phases);
+    let rendered = format!("{error:#}");
+
+    assert!(rendered.contains("Gemini ACP retry chain exhausted."));
+    assert!(rendered.contains("attempt=1"));
+    assert!(rendered.contains("attempt=2"));
+    assert!(rendered.contains("quota exhausted"));
+}
+
+#[test]
+fn test_ensure_gemini_runtime_home_writable_path_adds_runtime_home_under_tmp() {
+    let runtime_home = PathBuf::from("/tmp/cli-sub-agent-gemini/01TEST/session-home");
+    let mut isolation_plan = IsolationPlan {
+        resource: csa_resource::sandbox::ResourceCapability::None,
+        filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+        writable_paths: vec![PathBuf::from("/tmp")],
+        env_overrides: HashMap::new(),
+        degraded_reasons: Vec::new(),
+        memory_max_mb: None,
+        memory_swap_max_mb: None,
+        pids_max: None,
+        readonly_project_root: false,
+        project_root: None,
+    };
+
+    ensure_gemini_runtime_home_writable_path(&mut isolation_plan, Some(&runtime_home));
+
+    assert!(
+        isolation_plan.writable_paths.contains(&runtime_home),
+        "runtime home under /tmp must be bound explicitly because bwrap skips --bind /tmp"
+    );
+}
+
+#[test]
+fn test_ensure_gemini_runtime_home_writable_path_skips_when_parent_is_bound() {
+    let runtime_root = PathBuf::from("/tmp/cli-sub-agent-gemini");
+    let runtime_home = runtime_root.join("01TEST/session-home");
+    let mut isolation_plan = IsolationPlan {
+        resource: csa_resource::sandbox::ResourceCapability::None,
+        filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+        writable_paths: vec![runtime_root.clone()],
+        env_overrides: HashMap::new(),
+        degraded_reasons: Vec::new(),
+        memory_max_mb: None,
+        memory_swap_max_mb: None,
+        pids_max: None,
+        readonly_project_root: false,
+        project_root: None,
+    };
+
+    ensure_gemini_runtime_home_writable_path(&mut isolation_plan, Some(&runtime_home));
+
+    assert_eq!(
+        isolation_plan
+            .writable_paths
+            .iter()
+            .filter(|path| **path == runtime_root || **path == runtime_home)
+            .count(),
+        1,
+        "an existing non-/tmp parent bind already exposes the runtime home"
+    );
+}
+
+#[test]
+fn test_ensure_gemini_runtime_home_writable_path_is_noop_without_runtime_home() {
+    let mut isolation_plan = IsolationPlan {
+        resource: csa_resource::sandbox::ResourceCapability::None,
+        filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+        writable_paths: vec![PathBuf::from("/project")],
+        env_overrides: HashMap::new(),
+        degraded_reasons: Vec::new(),
+        memory_max_mb: None,
+        memory_swap_max_mb: None,
+        pids_max: None,
+        readonly_project_root: false,
+        project_root: None,
+    };
+
+    ensure_gemini_runtime_home_writable_path(&mut isolation_plan, None);
+
+    assert_eq!(
+        isolation_plan.writable_paths,
+        vec![PathBuf::from("/project")]
+    );
+}
+
+#[test]
+fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears_api_key() {
+    let runtime_home = "/tmp/cli-sub-agent-gemini/01TEST/runtime-home";
+    let mut env = HashMap::new();
+    env.insert("HOME".to_string(), runtime_home.to_string());
+    env.insert(
+        "PATH".to_string(),
+        "/runtime/node/bin:/runtime/yarn/bin:/usr/local/bin".to_string(),
+    );
+    env.insert("GEMINI_CLI_HOME".to_string(), runtime_home.to_string());
+    env.insert(
+        "XDG_CONFIG_HOME".to_string(),
+        format!("{runtime_home}/.config"),
+    );
+    env.insert(
+        "XDG_CACHE_HOME".to_string(),
+        format!("{runtime_home}/.cache"),
+    );
+    env.insert(
+        "XDG_STATE_HOME".to_string(),
+        format!("{runtime_home}/.local/state"),
+    );
+    env.insert(
+        "MISE_CACHE_DIR".to_string(),
+        format!("{runtime_home}/.cache/mise"),
+    );
+    env.insert(
+        "MISE_STATE_DIR".to_string(),
+        format!("{runtime_home}/.local/state/mise"),
+    );
+    env.insert("MISE_SHIM".to_string(), String::new());
+    env.insert("MISE_SHIMS_DIR".to_string(), String::new());
+    env.insert(
+        csa_core::gemini::AUTH_MODE_ENV_KEY.to_string(),
+        csa_core::gemini::AUTH_MODE_OAUTH.to_string(),
+    );
+    let mut isolation_plan = IsolationPlan {
+        resource: csa_resource::sandbox::ResourceCapability::None,
+        filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+        writable_paths: Vec::new(),
+        env_overrides: HashMap::new(),
+        degraded_reasons: Vec::new(),
+        memory_max_mb: None,
+        memory_swap_max_mb: None,
+        pids_max: None,
+        readonly_project_root: false,
+        project_root: None,
+    };
+
+    let env_overrides = gemini_sandbox_runtime_env_overrides(&env);
+    apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, &env_overrides);
+
+    assert_eq!(
+        isolation_plan.env_overrides.get("HOME"),
+        Some(&runtime_home.to_string())
+    );
+    assert_eq!(
+        isolation_plan.env_overrides.get("GEMINI_CLI_HOME"),
+        Some(&runtime_home.to_string())
+    );
+    assert_eq!(
+        isolation_plan.env_overrides.get("PATH"),
+        Some(&"/runtime/node/bin:/runtime/yarn/bin:/usr/local/bin".to_string()),
+        "sandbox should receive the sanitized runtime PATH so nested yarn/node launches avoid mise shims"
+    );
+    assert_eq!(
+        isolation_plan.env_overrides.get("XDG_STATE_HOME"),
+        Some(&format!("{runtime_home}/.local/state"))
+    );
+    assert_eq!(
+        isolation_plan.env_overrides.get("MISE_CACHE_DIR"),
+        Some(&format!("{runtime_home}/.cache/mise")),
+        "sandbox should pin mise cache inside the Gemini runtime home"
+    );
+    assert_eq!(
+        isolation_plan.env_overrides.get("MISE_STATE_DIR"),
+        Some(&format!("{runtime_home}/.local/state/mise")),
+        "sandbox should pin mise state inside the Gemini runtime home"
+    );
+    assert_eq!(
+        isolation_plan.env_overrides.get("MISE_SHIM"),
+        Some(&String::new())
+    );
+    assert_eq!(
+        isolation_plan.env_overrides.get("MISE_SHIMS_DIR"),
+        Some(&String::new())
+    );
+    assert_eq!(
+        isolation_plan
+            .env_overrides
+            .get(csa_core::gemini::AUTH_MODE_ENV_KEY),
+        Some(&csa_core::gemini::AUTH_MODE_OAUTH.to_string())
+    );
+    assert_eq!(
+        isolation_plan
+            .env_overrides
+            .get(csa_core::gemini::API_KEY_ENV),
+        Some(&String::new()),
+        "phase 1 must clear inherited GEMINI_API_KEY inside the sandbox"
+    );
+    assert_eq!(
+        isolation_plan
+            .env_overrides
+            .get(csa_core::gemini::BASE_URL_ENV),
+        Some(&String::new()),
+        "sandbox should also clear inherited Gemini base-url overrides when absent"
+    );
+}
+
+#[test]
+fn test_apply_gemini_sandbox_runtime_env_overrides_preserves_phase2_api_key() {
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        "/tmp/cli-sub-agent-gemini/01TEST".to_string(),
+    );
+    env.insert(
+        csa_core::gemini::AUTH_MODE_ENV_KEY.to_string(),
+        csa_core::gemini::AUTH_MODE_API_KEY.to_string(),
+    );
+    env.insert(
+        csa_core::gemini::API_KEY_ENV.to_string(),
+        "fallback-key".to_string(),
+    );
+    env.insert(
+        csa_core::gemini::BASE_URL_ENV.to_string(),
+        "https://proxy.example.test".to_string(),
+    );
+    let mut isolation_plan = IsolationPlan {
+        resource: csa_resource::sandbox::ResourceCapability::None,
+        filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+        writable_paths: Vec::new(),
+        env_overrides: HashMap::new(),
+        degraded_reasons: Vec::new(),
+        memory_max_mb: None,
+        memory_swap_max_mb: None,
+        pids_max: None,
+        readonly_project_root: false,
+        project_root: None,
+    };
+
+    let env_overrides = gemini_sandbox_runtime_env_overrides(&env);
+    apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, &env_overrides);
+
+    assert_eq!(
+        isolation_plan
+            .env_overrides
+            .get(csa_core::gemini::AUTH_MODE_ENV_KEY),
+        Some(&csa_core::gemini::AUTH_MODE_API_KEY.to_string())
+    );
+    assert_eq!(
+        isolation_plan
+            .env_overrides
+            .get(csa_core::gemini::API_KEY_ENV),
+        Some(&"fallback-key".to_string())
+    );
+    assert_eq!(
+        isolation_plan
+            .env_overrides
+            .get(csa_core::gemini::BASE_URL_ENV),
+        Some(&"https://proxy.example.test".to_string())
     );
 }

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -1,248 +1,244 @@
-    #[test]
-    fn test_transport_factory_create_routes_tools_to_expected_transport() {
-        let legacy_tools = vec![Executor::Opencode {
-            model_override: None,
-            agent: None,
-            thinking_budget: None,
-        }];
-        for executor in legacy_tools {
-            let transport = TransportFactory::create(&executor, None);
-            assert!(
-                transport.as_ref().as_any().is::<LegacyTransport>(),
-                "Expected LegacyTransport for {}",
-                executor.tool_name()
-            );
-        }
-
-        let acp_tools = vec![
-            Executor::Codex {
-                model_override: None,
-                thinking_budget: None,
-            },
-            Executor::ClaudeCode {
-                model_override: None,
-                thinking_budget: None,
-            },
-            Executor::GeminiCli {
-                model_override: None,
-                thinking_budget: None,
-            },
-        ];
-        for executor in acp_tools {
-            let transport = TransportFactory::create(&executor, Some(SessionConfig::default()));
-            assert!(
-                transport.as_ref().as_any().is::<AcpTransport>(),
-                "Expected AcpTransport for {}",
-                executor.tool_name()
-            );
-        }
+#[test]
+fn test_transport_factory_create_routes_tools_to_expected_transport() {
+    let legacy_tools = vec![Executor::Opencode {
+        model_override: None,
+        agent: None,
+        thinking_budget: None,
+    }];
+    for executor in legacy_tools {
+        let transport = TransportFactory::create(&executor, None);
+        assert!(
+            transport.as_ref().as_any().is::<LegacyTransport>(),
+            "Expected LegacyTransport for {}",
+            executor.tool_name()
+        );
     }
 
-    #[test]
-    fn test_transport_factory_create_preserves_session_config_for_acp_transport() {
-        let executor = Executor::Codex {
+    let acp_tools = vec![
+        Executor::Codex {
             model_override: None,
             thinking_budget: None,
-        };
-        let session_config = SessionConfig {
-            no_load: vec!["skills/foo".to_string()],
-            extra_load: vec!["skills/bar".to_string()],
-            tier: Some("tier-2".to_string()),
-            models: vec!["codex/openai/o3/medium".to_string()],
-            mcp_servers: Vec::new(),
-            mcp_proxy_socket: None,
-        };
-
-        let transport = TransportFactory::create(&executor, Some(session_config.clone()));
-        let acp = transport
-            .as_ref()
-            .as_any()
-            .downcast_ref::<AcpTransport>()
-            .expect("expected AcpTransport");
-
-        assert_eq!(acp.session_config, Some(session_config));
-    }
-
-    #[test]
-    fn test_legacy_transport_construction_from_executor() {
-        let executor = Executor::Opencode {
-            model_override: Some("model".to_string()),
-            agent: Some("coder".to_string()),
+        },
+        Executor::ClaudeCode {
+            model_override: None,
             thinking_budget: None,
-        };
-        let transport = LegacyTransport::new(executor.clone());
-
-        assert_eq!(transport.executor.tool_name(), executor.tool_name());
-        assert_eq!(
-            transport.executor.executable_name(),
-            executor.executable_name()
-        );
-    }
-
-    #[test]
-    fn test_acp_command_for_tool_mappings() {
-        assert_eq!(
-            AcpTransport::acp_command_for_tool("claude-code"),
-            ("claude-code-acp".to_string(), vec![])
-        );
-        assert_eq!(
-            AcpTransport::acp_command_for_tool("codex"),
-            ("codex-acp".to_string(), vec![])
-        );
-        // gemini-cli uses native ACP mode via `gemini --acp`
-        assert_eq!(
-            AcpTransport::acp_command_for_tool("gemini-cli"),
-            ("gemini".to_string(), vec!["--acp".to_string()])
-        );
-        // Unknown tools get "{name}-acp" convention
-        assert_eq!(
-            AcpTransport::acp_command_for_tool("opencode"),
-            ("opencode-acp".to_string(), vec![])
-        );
-    }
-
-    // NOTE: CSA_SUPPRESS_NOTIFY is injected by the pipeline layer (not transport)
-    // based on per-tool config via extra_env. See pipeline.rs suppress_notify logic.
-    #[test]
-    fn test_acp_build_env_propagates_extra_env() {
-        let transport = AcpTransport::new("claude-code", None);
-        let now = chrono::Utc::now();
-        let session = csa_session::state::MetaSessionState {
-            meta_session_id: "01HTEST000000000000000000".to_string(),
-            description: Some("test".to_string()),
-            project_path: "/tmp/test".to_string(),
-            branch: None,
-            created_at: now,
-            last_accessed: now,
-            genealogy: csa_session::state::Genealogy {
-                parent_session_id: None,
-                depth: 0,
-                ..Default::default()
-            },
-            tools: HashMap::new(),
-            context_status: csa_session::state::ContextStatus::default(),
-            total_token_usage: None,
-            phase: csa_session::state::SessionPhase::Active,
-            task_context: csa_session::state::TaskContext::default(),
-            turn_count: 0,
-            token_budget: None,
-            sandbox_info: None,
-
-            termination_reason: None,
-            is_seed_candidate: false,
-            git_head_at_creation: None,
-            last_return_packet: None,
-            change_id: None,
-            spec_id: None,
-            fork_call_timestamps: Vec::new(),
-            vcs_identity: None,
-            identity_version: 1,
-        };
-
-        let mut extra = HashMap::new();
-        extra.insert("CSA_SUPPRESS_NOTIFY".to_string(), "1".to_string());
-        let env = transport.build_env(&session, Some(&extra));
-        assert_eq!(
-            env.get("CSA_SUPPRESS_NOTIFY"),
-            Some(&"1".to_string()),
-            "ACP transport should propagate CSA_SUPPRESS_NOTIFY from extra_env"
-        );
-
-        // Without extra_env, suppress_notify should NOT be present.
-        let env_no_extra = transport.build_env(&session, None);
-        assert_eq!(
-            env_no_extra.get("CSA_SUPPRESS_NOTIFY"),
-            None,
-            "ACP transport should not inject CSA_SUPPRESS_NOTIFY on its own"
-        );
-    }
-
-    #[test]
-    fn test_acp_build_env_includes_csa_session_dir() {
-        let transport = AcpTransport::new("claude-code", None);
-        let now = chrono::Utc::now();
-        let session = csa_session::state::MetaSessionState {
-            meta_session_id: "01HTEST000000000000000000".to_string(),
-            description: Some("test".to_string()),
-            project_path: "/tmp/test".to_string(),
-            branch: None,
-            created_at: now,
-            last_accessed: now,
-            genealogy: csa_session::state::Genealogy {
-                parent_session_id: None,
-                depth: 0,
-                ..Default::default()
-            },
-            tools: HashMap::new(),
-            context_status: csa_session::state::ContextStatus::default(),
-            total_token_usage: None,
-            phase: csa_session::state::SessionPhase::Active,
-            task_context: csa_session::state::TaskContext::default(),
-            turn_count: 0,
-            token_budget: None,
-            sandbox_info: None,
-
-            termination_reason: None,
-            is_seed_candidate: false,
-            git_head_at_creation: None,
-            last_return_packet: None,
-            change_id: None,
-            spec_id: None,
-            fork_call_timestamps: Vec::new(),
-            vcs_identity: None,
-            identity_version: 1,
-        };
-
-        let env = transport.build_env(&session, None);
-        let session_dir = env
-            .get("CSA_SESSION_DIR")
-            .expect("CSA_SESSION_DIR should be present in env");
+        },
+        Executor::GeminiCli {
+            model_override: None,
+            thinking_budget: None,
+        },
+    ];
+    for executor in acp_tools {
+        let transport = TransportFactory::create(&executor, Some(SessionConfig::default()));
         assert!(
-            session_dir.contains("/sessions/"),
-            "CSA_SESSION_DIR should contain /sessions/ path segment, got: {session_dir}"
-        );
-        assert!(
-            session_dir.contains("01HTEST000000000000000000"),
-            "CSA_SESSION_DIR should contain the session ID, got: {session_dir}"
+            transport.as_ref().as_any().is::<AcpTransport>(),
+            "Expected AcpTransport for {}",
+            executor.tool_name()
         );
     }
+}
 
-    #[test]
-    fn test_resume_session_id_extraction() {
-        let now = chrono::Utc::now();
-        let tool_state = ToolState {
-            provider_session_id: Some("test-session-123".to_string()),
-            last_action_summary: String::new(),
-            last_exit_code: 0,
-            updated_at: now,
-            token_usage: None,
-        };
-        let resume_id = tool_state.provider_session_id.as_deref();
-        assert_eq!(resume_id, Some("test-session-123"));
-    }
+#[test]
+fn test_transport_factory_create_preserves_session_config_for_acp_transport() {
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+    };
+    let session_config = SessionConfig {
+        no_load: vec!["skills/foo".to_string()],
+        extra_load: vec!["skills/bar".to_string()],
+        tier: Some("tier-2".to_string()),
+        models: vec!["codex/openai/o3/medium".to_string()],
+        mcp_servers: Vec::new(),
+        mcp_proxy_socket: None,
+    };
 
-    #[test]
-    fn test_resume_session_id_none_when_absent() {
-        let now = chrono::Utc::now();
-        let tool_state = ToolState {
-            provider_session_id: None,
-            last_action_summary: String::new(),
-            last_exit_code: 0,
-            updated_at: now,
-            token_usage: None,
-        };
-        let resume_id = tool_state.provider_session_id.as_deref();
-        assert!(resume_id.is_none());
-    }
+    let transport = TransportFactory::create(&executor, Some(session_config.clone()));
+    let acp = transport
+        .as_ref()
+        .as_any()
+        .downcast_ref::<AcpTransport>()
+        .expect("expected AcpTransport");
+
+    assert_eq!(acp.session_config, Some(session_config));
+}
+
+#[test]
+fn test_legacy_transport_construction_from_executor() {
+    let executor = Executor::Opencode {
+        model_override: Some("model".to_string()),
+        agent: Some("coder".to_string()),
+        thinking_budget: None,
+    };
+    let transport = LegacyTransport::new(executor.clone());
+
+    assert_eq!(transport.executor.tool_name(), executor.tool_name());
+    assert_eq!(
+        transport.executor.executable_name(),
+        executor.executable_name()
+    );
+}
+
+#[test]
+fn test_acp_command_for_tool_mappings() {
+    assert_eq!(
+        AcpTransport::acp_command_for_tool("claude-code"),
+        ("claude-code-acp".to_string(), vec![])
+    );
+    assert_eq!(
+        AcpTransport::acp_command_for_tool("codex"),
+        ("codex-acp".to_string(), vec![])
+    );
+    // gemini-cli uses native ACP mode via `gemini --acp`
+    assert_eq!(
+        AcpTransport::acp_command_for_tool("gemini-cli"),
+        ("gemini".to_string(), vec!["--acp".to_string()])
+    );
+    // Unknown tools get "{name}-acp" convention
+    assert_eq!(
+        AcpTransport::acp_command_for_tool("opencode"),
+        ("opencode-acp".to_string(), vec![])
+    );
+}
+
+// NOTE: CSA_SUPPRESS_NOTIFY is injected by the pipeline layer (not transport)
+// based on per-tool config via extra_env. See pipeline.rs suppress_notify logic.
+#[test]
+fn test_acp_build_env_propagates_extra_env() {
+    let transport = AcpTransport::new("claude-code", None);
+    let now = chrono::Utc::now();
+    let session = csa_session::state::MetaSessionState {
+        meta_session_id: "01HTEST000000000000000000".to_string(),
+        description: Some("test".to_string()),
+        project_path: "/tmp/test".to_string(),
+        branch: None,
+        created_at: now,
+        last_accessed: now,
+        genealogy: csa_session::state::Genealogy {
+            parent_session_id: None,
+            depth: 0,
+            ..Default::default()
+        },
+        tools: HashMap::new(),
+        context_status: csa_session::state::ContextStatus::default(),
+        total_token_usage: None,
+        phase: csa_session::state::SessionPhase::Active,
+        task_context: csa_session::state::TaskContext::default(),
+        turn_count: 0,
+        token_budget: None,
+        sandbox_info: None,
+
+        termination_reason: None,
+        is_seed_candidate: false,
+        git_head_at_creation: None,
+        last_return_packet: None,
+        change_id: None,
+        spec_id: None,
+        fork_call_timestamps: Vec::new(),
+        vcs_identity: None,
+        identity_version: 1,
+    };
+
+    let mut extra = HashMap::new();
+    extra.insert("CSA_SUPPRESS_NOTIFY".to_string(), "1".to_string());
+    let env = transport.build_env(&session, Some(&extra));
+    assert_eq!(
+        env.get("CSA_SUPPRESS_NOTIFY"),
+        Some(&"1".to_string()),
+        "ACP transport should propagate CSA_SUPPRESS_NOTIFY from extra_env"
+    );
+
+    // Without extra_env, suppress_notify should NOT be present.
+    let env_no_extra = transport.build_env(&session, None);
+    assert_eq!(
+        env_no_extra.get("CSA_SUPPRESS_NOTIFY"),
+        None,
+        "ACP transport should not inject CSA_SUPPRESS_NOTIFY on its own"
+    );
+}
+
+#[test]
+fn test_acp_build_env_includes_csa_session_dir() {
+    let transport = AcpTransport::new("claude-code", None);
+    let now = chrono::Utc::now();
+    let session = csa_session::state::MetaSessionState {
+        meta_session_id: "01HTEST000000000000000000".to_string(),
+        description: Some("test".to_string()),
+        project_path: "/tmp/test".to_string(),
+        branch: None,
+        created_at: now,
+        last_accessed: now,
+        genealogy: csa_session::state::Genealogy {
+            parent_session_id: None,
+            depth: 0,
+            ..Default::default()
+        },
+        tools: HashMap::new(),
+        context_status: csa_session::state::ContextStatus::default(),
+        total_token_usage: None,
+        phase: csa_session::state::SessionPhase::Active,
+        task_context: csa_session::state::TaskContext::default(),
+        turn_count: 0,
+        token_budget: None,
+        sandbox_info: None,
+
+        termination_reason: None,
+        is_seed_candidate: false,
+        git_head_at_creation: None,
+        last_return_packet: None,
+        change_id: None,
+        spec_id: None,
+        fork_call_timestamps: Vec::new(),
+        vcs_identity: None,
+        identity_version: 1,
+    };
+
+    let env = transport.build_env(&session, None);
+    let session_dir = env
+        .get("CSA_SESSION_DIR")
+        .expect("CSA_SESSION_DIR should be present in env");
+    assert!(
+        session_dir.contains("/sessions/"),
+        "CSA_SESSION_DIR should contain /sessions/ path segment, got: {session_dir}"
+    );
+    assert!(
+        session_dir.contains("01HTEST000000000000000000"),
+        "CSA_SESSION_DIR should contain the session ID, got: {session_dir}"
+    );
+}
+
+#[test]
+fn test_resume_session_id_extraction() {
+    let now = chrono::Utc::now();
+    let tool_state = ToolState {
+        provider_session_id: Some("test-session-123".to_string()),
+        last_action_summary: String::new(),
+        last_exit_code: 0,
+        updated_at: now,
+        token_usage: None,
+    };
+    let resume_id = tool_state.provider_session_id.as_deref();
+    assert_eq!(resume_id, Some("test-session-123"));
+}
+
+#[test]
+fn test_resume_session_id_none_when_absent() {
+    let now = chrono::Utc::now();
+    let tool_state = ToolState {
+        provider_session_id: None,
+        last_action_summary: String::new(),
+        last_exit_code: 0,
+        updated_at: now,
+        token_usage: None,
+    };
+    let resume_id = tool_state.provider_session_id.as_deref();
+    assert!(resume_id.is_none());
+}
 
 #[test]
 fn test_gemini_retry_model_sequence_matches_policy() {
     // Phase 1: original model + OAuth
-    assert_eq!(
-        gemini_retry_model(1),
-        None,
-        "phase 1 keeps original model"
-    );
+    assert_eq!(gemini_retry_model(1), None, "phase 1 keeps original model");
     // Phase 2: original model + API key (no model switch)
     assert_eq!(
         gemini_retry_model(2),
@@ -319,16 +315,20 @@ fn build_test_meta_session(project_path: &str) -> MetaSessionState {
         git_head_at_creation: None,
         last_return_packet: None,
         change_id: None,
-            spec_id: None,
-            fork_call_timestamps: Vec::new(),
-            vcs_identity: None,
-            identity_version: 1,
+        spec_id: None,
+        fork_call_timestamps: Vec::new(),
+        vcs_identity: None,
+        identity_version: 1,
     }
 }
 
 fn setup_fake_gemini_environment(
     success_on: u32,
-) -> (tempfile::TempDir, HashMap<String, String>, std::path::PathBuf) {
+) -> (
+    tempfile::TempDir,
+    HashMap<String, String>,
+    std::path::PathBuf,
+) {
     use std::os::unix::fs::PermissionsExt;
 
     let temp = tempfile::tempdir().expect("tempdir");
@@ -344,6 +344,7 @@ STATE_FILE="${CSA_FAKE_GEMINI_STATE_FILE:?}"
 MODEL_LOG_FILE="${CSA_FAKE_GEMINI_MODEL_LOG_FILE:?}"
 AUTH_LOG_FILE="${CSA_FAKE_GEMINI_AUTH_LOG_FILE:?}"
 SUCCESS_ON="${CSA_FAKE_GEMINI_SUCCESS_ON:-999}"
+FAILURE_REASON="${CSA_FAKE_GEMINI_FAILURE_REASON:-QUOTA_EXHAUSTED}"
 
 count=0
 if [ -f "${STATE_FILE}" ]; then
@@ -373,7 +374,7 @@ else
 fi
 
 if [ "${count}" -lt "${SUCCESS_ON}" ]; then
-  printf "reason: 'QUOTA_EXHAUSTED' (attempt=%s)\n" "${count}" >&2
+  printf "reason: '%s' (attempt=%s)\n" "${FAILURE_REASON}" "${count}" >&2
   exit 1
 fi
 
@@ -533,9 +534,21 @@ fn test_should_retry_gemini_rate_limited_until_final_attempt() {
         exit_code: 1,
     };
 
-    assert!(transport.should_retry_gemini_rate_limited(&execution, 1, None).is_some());
-    assert!(transport.should_retry_gemini_rate_limited(&execution, 2, None).is_some());
-    assert!(transport.should_retry_gemini_rate_limited(&execution, 3, None).is_none());
+    assert!(
+        transport
+            .should_retry_gemini_rate_limited(&execution, 1, None)
+            .is_some()
+    );
+    assert!(
+        transport
+            .should_retry_gemini_rate_limited(&execution, 2, None)
+            .is_some()
+    );
+    assert!(
+        transport
+            .should_retry_gemini_rate_limited(&execution, 3, None)
+            .is_none()
+    );
 }
 
 #[test]
@@ -550,7 +563,11 @@ fn test_should_not_retry_on_success_exit_code() {
         stderr_output: String::new(),
         exit_code: 0,
     };
-    assert!(transport.should_retry_gemini_rate_limited(&execution, 1, None).is_none());
+    assert!(
+        transport
+            .should_retry_gemini_rate_limited(&execution, 1, None)
+            .is_none()
+    );
 }
 
 #[test]
@@ -565,7 +582,11 @@ fn test_should_retry_on_quota_exhausted_marker() {
         stderr_output: "reason: 'QUOTA_EXHAUSTED'".to_string(),
         exit_code: 1,
     };
-    assert!(transport.should_retry_gemini_rate_limited(&execution, 1, None).is_some());
+    assert!(
+        transport
+            .should_retry_gemini_rate_limited(&execution, 1, None)
+            .is_some()
+    );
 }
 
 #[test]
@@ -583,9 +604,21 @@ fn test_no_flash_fallback_stops_retry_after_attempt_2() {
     let mut env = HashMap::new();
     env.insert("_CSA_NO_FLASH_FALLBACK".to_string(), "1".to_string());
     // Attempt 1 retries (advances to phase 2: same model + API key)
-    assert!(transport.should_retry_gemini_rate_limited(&execution, 1, Some(&env)).is_some());
+    assert!(
+        transport
+            .should_retry_gemini_rate_limited(&execution, 1, Some(&env))
+            .is_some()
+    );
     // Attempt 2 does NOT retry (phase 3 = flash, which is forbidden by no_flash)
-    assert!(transport.should_retry_gemini_rate_limited(&execution, 2, Some(&env)).is_none());
+    assert!(
+        transport
+            .should_retry_gemini_rate_limited(&execution, 2, Some(&env))
+            .is_none()
+    );
     // Without the flag, attempt 2 would still retry (advances to phase 3: flash)
-    assert!(transport.should_retry_gemini_rate_limited(&execution, 2, None).is_some());
+    assert!(
+        transport
+            .should_retry_gemini_rate_limited(&execution, 2, None)
+            .is_some()
+    );
 }


### PR DESCRIPTION
## Summary
- Add Gemini ACP runtime transport layer for gemini-cli tool
- Implement OAuth to API key automatic fallback
- Add transport factory for modular transport creation
- Include comprehensive test coverage

Salvaged from codex session 019d493a checkpoint commits.

## Test plan
- [x] cargo check passes
- [x] csa review --range main...HEAD CLEAN
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)