### PR TITLE
fix(todo,slot): make auto weave upgrade non-blocking and improve slot diagnostics (#541, #542)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.206"
+version = "0.1.207"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.206"
+version = "0.1.207"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -171,8 +171,18 @@ fn resolve_effective_min_timeout() -> u64 {
 }
 
 fn should_attempt_auto_weave_upgrade(command: &Commands) -> bool {
-    // TODO lifecycle commands must stay available for recovery even when weave is unhealthy.
-    !matches!(command, Commands::Todo { .. })
+    // Only execution commands need upgraded weave patterns.
+    // All management/read-only commands stay available even when weave is unhealthy.
+    matches!(
+        command,
+        Commands::Run { .. }
+            | Commands::Review(_)
+            | Commands::Debate(_)
+            | Commands::Batch { .. }
+            | Commands::Plan { .. }
+            | Commands::ClaudeSubAgent(_)
+            | Commands::McpServer
+    )
 }
 
 /// Apply SA mode prompt guard and emit caller-side constraint if active.
@@ -321,41 +331,25 @@ async fn run() -> Result<()> {
                     .status()
                     .await;
 
-                match result {
-                    Ok(status) if status.success() => {
-                        success = true;
-                        break;
-                    }
-                    Ok(status) => {
-                        if attempt < 2 {
-                            tracing::debug!(
-                                "weave upgrade failed (exit {}), retrying in {:?}...",
-                                status.code().unwrap_or(-1),
-                                delay
-                            );
-                            tokio::time::sleep(delay).await;
-                            delay *= 2;
-                        }
-                    }
-                    Err(e) => {
-                        if attempt < 2 {
-                            tracing::debug!(
-                                "weave upgrade failed ({}), retrying in {:?}...",
-                                e,
-                                delay
-                            );
-                            tokio::time::sleep(delay).await;
-                            delay *= 2;
-                        }
-                    }
+                let ok = result.as_ref().map(|s| s.success()).unwrap_or(false);
+                if ok {
+                    success = true;
+                    break;
+                }
+                if attempt < 2 {
+                    tracing::debug!(
+                        "weave upgrade attempt {attempt} failed, retrying in {delay:?}"
+                    );
+                    tokio::time::sleep(delay).await;
+                    delay *= 2;
                 }
             }
 
             if !success {
-                anyhow::bail!(
-                    "auto weave upgrade failed after 3 attempts. \
-                     Disable with [execution] auto_weave_upgrade = false"
-                );
+                let msg = "auto weave upgrade failed after 3 attempts (non-fatal). \
+                           Disable with [execution] auto_weave_upgrade = false";
+                tracing::warn!(msg);
+                eprintln!("warning: {msg}");
             }
         }
     }

--- a/crates/cli-sub-agent/src/main_auto_weave_tests.rs
+++ b/crates/cli-sub-agent/src/main_auto_weave_tests.rs
@@ -8,6 +8,30 @@ fn todo_commands_skip_auto_weave_upgrade() {
 }
 
 #[test]
+fn session_commands_skip_auto_weave_upgrade() {
+    let cli = Cli::parse_from(["csa", "session", "list"]);
+    assert!(!should_attempt_auto_weave_upgrade(&cli.command));
+}
+
+#[test]
+fn config_commands_skip_auto_weave_upgrade() {
+    let cli = Cli::parse_from(["csa", "config", "show"]);
+    assert!(!should_attempt_auto_weave_upgrade(&cli.command));
+}
+
+#[test]
+fn doctor_skips_auto_weave_upgrade() {
+    let cli = Cli::parse_from(["csa", "doctor"]);
+    assert!(!should_attempt_auto_weave_upgrade(&cli.command));
+}
+
+#[test]
+fn gc_skips_auto_weave_upgrade() {
+    let cli = Cli::parse_from(["csa", "gc"]);
+    assert!(!should_attempt_auto_weave_upgrade(&cli.command));
+}
+
+#[test]
 fn run_commands_still_attempt_auto_weave_upgrade() {
     let cli = Cli::parse_from(["csa", "run", "--sa-mode", "false", "status"]);
     assert!(should_attempt_auto_weave_upgrade(&cli.command));
@@ -23,5 +47,17 @@ fn plan_run_still_attempt_auto_weave_upgrade() {
         "--sa-mode",
         "false",
     ]);
+    assert!(should_attempt_auto_weave_upgrade(&cli.command));
+}
+
+#[test]
+fn review_still_attempts_auto_weave_upgrade() {
+    let cli = Cli::parse_from(["csa", "review", "--sa-mode", "false", "--diff"]);
+    assert!(should_attempt_auto_weave_upgrade(&cli.command));
+}
+
+#[test]
+fn debate_still_attempts_auto_weave_upgrade() {
+    let cli = Cli::parse_from(["csa", "debate", "--sa-mode", "false", "question"]);
     assert!(should_attempt_auto_weave_upgrade(&cli.command));
 }

--- a/crates/csa-lock/src/slot.rs
+++ b/crates/csa-lock/src/slot.rs
@@ -142,8 +142,31 @@ pub fn try_acquire_slot(
         {
             Ok(file) => file,
             Err(err) => {
-                open_failures.push(format!("{} ({err})", slot_path.display()));
-                continue;
+                // Self-heal: if the slot file is a dangling symlink or other
+                // non-regular entry, remove it and retry once.
+                if slot_path.symlink_metadata().is_ok() && !slot_path.is_file() {
+                    let _ = fs::remove_file(&slot_path);
+                    if let Ok(file) = OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .create(true)
+                        .truncate(false)
+                        .open(&slot_path)
+                    {
+                        // Retry succeeded after cleanup.
+                        file
+                    } else {
+                        open_failures.push(format!(
+                            "{} ({}; retry after cleanup also failed)",
+                            slot_path.display(),
+                            err
+                        ));
+                        continue;
+                    }
+                } else {
+                    open_failures.push(format!("{} ({})", slot_path.display(), err));
+                    continue;
+                }
             }
         };
 
@@ -189,14 +212,32 @@ pub fn try_acquire_slot(
             .take(3)
             .cloned()
             .collect::<Vec<_>>()
-            .join("; ");
+            .join("\n  - ");
+        let hint = if occupied == 0 && open_failures.len() as u32 == max_concurrent {
+            // All slots failed to open and none are locked — likely a filesystem issue.
+            format!(
+                "\nHint: all {} slot files for '{}' could not be opened. \
+                 Check permissions on {}, or run `csa gc` to clean stale state.",
+                max_concurrent,
+                tool_name,
+                tool_dir.display()
+            )
+        } else {
+            format!(
+                "\nHint: {} of {} slots locked by other processes, \
+                 {} slot file(s) could not be opened.",
+                occupied,
+                max_concurrent,
+                open_failures.len()
+            )
+        };
         anyhow::bail!(
-            "Failed to open {} slot file(s) for '{}'. Locked slots: {}/{}. Examples: {}",
-            open_failures.len(),
+            "Slot file open failure for '{}': {}/{} files could not be opened.\n\
+             Errors:\n  - {}{hint}",
             tool_name,
-            occupied,
+            open_failures.len(),
             max_concurrent,
-            sample
+            sample,
         );
     }
 
@@ -620,35 +661,69 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_try_acquire_slot_skips_malformed_slot_file_and_uses_next_slot() {
+    fn test_try_acquire_slot_self_heals_dangling_symlink() {
         let dir = tempdir().unwrap();
         let tool_dir = dir.path().join("codex");
         fs::create_dir_all(&tool_dir).unwrap();
+        // Create a self-referencing (dangling) symlink in slot 0.
         std::os::unix::fs::symlink("slot-00.lock", tool_dir.join("slot-00.lock")).unwrap();
 
+        // Self-heal removes the symlink and creates a regular file — slot 0 acquired.
         let result = try_acquire_slot(dir.path(), "codex", 2, None).unwrap();
         match result {
-            SlotAcquireResult::Acquired(slot) => assert_eq!(slot.slot_index(), 1),
+            SlotAcquireResult::Acquired(slot) => assert_eq!(slot.slot_index(), 0),
             SlotAcquireResult::Exhausted(_) => panic!("expected slot acquisition"),
         }
     }
 
     #[cfg(unix)]
     #[test]
-    fn test_try_acquire_slot_errors_when_all_slot_files_are_malformed() {
+    fn test_try_acquire_slot_self_heals_all_dangling_symlinks() {
         let dir = tempdir().unwrap();
         let tool_dir = dir.path().join("codex");
         fs::create_dir_all(&tool_dir).unwrap();
         std::os::unix::fs::symlink("slot-00.lock", tool_dir.join("slot-00.lock")).unwrap();
         std::os::unix::fs::symlink("slot-01.lock", tool_dir.join("slot-01.lock")).unwrap();
 
-        let err = match try_acquire_slot(dir.path(), "codex", 2, None) {
-            Ok(_) => panic!("expected malformed slot files to fail"),
-            Err(err) => err,
+        // Both dangling symlinks are cleaned up — slot 0 acquired.
+        let result = try_acquire_slot(dir.path(), "codex", 2, None).unwrap();
+        match result {
+            SlotAcquireResult::Acquired(slot) => assert_eq!(slot.slot_index(), 0),
+            SlotAcquireResult::Exhausted(_) => panic!("expected slot acquisition after self-heal"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_try_acquire_slot_errors_with_diagnostic_on_permission_denied() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let tool_dir = dir.path().join("perm-tool");
+        fs::create_dir_all(&tool_dir).unwrap();
+
+        // Create a slot file and make it unreadable/unwritable.
+        let slot_path = tool_dir.join("slot-00.lock");
+        fs::write(&slot_path, "").unwrap();
+        fs::set_permissions(&slot_path, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = try_acquire_slot(dir.path(), "perm-tool", 1, None);
+        // Restore permissions for cleanup.
+        let _ = fs::set_permissions(&slot_path, fs::Permissions::from_mode(0o644));
+
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected error for permission-denied slot file"),
         };
         let msg = err.to_string();
-        assert!(msg.contains("Failed to open 2 slot file(s) for 'codex'"));
-        assert!(msg.contains("slot-00.lock"));
-        assert!(msg.contains("slot-01.lock"));
+        assert!(
+            msg.contains("Slot file open failure for 'perm-tool'"),
+            "error should mention tool name: {msg}"
+        );
+        assert!(
+            msg.contains("slot-00.lock"),
+            "error should include file path: {msg}"
+        );
+        assert!(msg.contains("Hint:"), "error should include hint: {msg}");
     }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.202"
+csa = "0.1.206"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.202"
+weave = "0.1.206"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

Fixes #541 and #542.

- **#541**: Auto weave upgrade changed from hard `bail!` to non-fatal warning. Management/read-only commands (todo, session, config, doctor, gc) now skip upgrade entirely.
- **#542**: Slot file acquisition now self-heals dangling symlinks and provides actionable diagnostics (errno, path, suggested remediation).

## Changes

### Auto weave upgrade (#541)
- `should_attempt_auto_weave_upgrade()` switched from denylist to allowlist (only execution commands trigger)
- Failed upgrade downgrades from fatal error to `tracing::warn!` + `eprintln!`
- 6 new tests for command classification

### Slot file diagnostics (#542)
- Self-healing: dangling symlinks auto-removed and recreated as regular files
- Error messages now include per-file errno, slot directory path, and hints (check permissions, run `csa gc`)
- 3 new tests for self-healing and diagnostic output

## Test plan

- [ ] `csa todo list` works when `auto_weave_upgrade = true` and weave is broken
- [ ] `csa run` shows warning (not error) when auto upgrade fails
- [ ] Slot file dangling symlinks are self-healed on next debate/run
- [ ] Permission denied on slot files produces actionable error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)