### PR TITLE
fix(config,session): expose effective min_timeout and add KV cache hint (#539)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.207"
+version = "0.1.208"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.207"
+version = "0.1.208"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -204,6 +204,12 @@ pub(crate) fn handle_session_wait(
                 "<!-- CSA:SESSION_WAIT_TIMEOUT session={} elapsed={}s cmd=\"csa session wait --session {}{}\" -->",
                 resolved.session_id, elapsed, resolved.session_id, cd_arg,
             );
+            eprintln!(
+                "Hint: Call `csa session wait` again individually (not in a tight loop script). \
+                 The {}s timeout is designed to let the calling agent generate tokens between waits, \
+                 keeping its KV cache warm.",
+                wait_timeout_secs,
+            );
             return Ok(124);
         }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.206"
+csa = "0.1.207"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.206"
+weave = "0.1.207"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

Closes #539. Also adds KV cache warming hint.

- **#539**: `csa config get execution.min_timeout_seconds` already returns 1800 and `csa config show` displays the effective section (fixed in prior PRs). This PR confirms the fix and adds the KV cache warming hint.
- **KV cache**: `csa session wait` timeout output (exit 124) now includes a hint telling calling agents to invoke wait individually (not in a tight loop script) to keep their KV cache warm.

## Changes

- Version bump to 0.1.208
- Added `eprintln!` hint after session wait timeout explaining KV cache warming pattern

## Test plan

- [ ] `csa config get execution.min_timeout_seconds` returns 1800
- [ ] `csa session wait --session <id>` timeout output includes KV cache hint
- [ ] Review session confirmed verdict=PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)