### PR TITLE
feat(pipeline): enforce progression via output chaining and hooks (#524)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.208"
+version = "0.1.209"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.208"
+version = "0.1.209"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -326,6 +326,7 @@ fi
 
 trap 'rm -f "${COMMIT_MESSAGE_FILE_LOCAL}"' EXIT
 git commit -F "${COMMIT_MESSAGE_FILE_LOCAL}"
+echo '<!-- CSA:NEXT_STEP cmd="cumulative branch review (Step 18) or publish" required=true -->'
 ```
 
 ## IF NOT ${SKIP_PUBLISH} (Auto-Publish — standalone by default)
@@ -342,6 +343,7 @@ This catches cross-commit issues that per-commit reviews might miss.
 ```bash
 SID=$(csa review --range main...HEAD)
 bash scripts/csa/session-wait-until-done.sh "$SID"
+echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 19)" required=true -->'
 ```
 
 ## Step 19: Auto PR Transaction
@@ -377,6 +379,7 @@ if [ "${CREATE_RC}" -ne 0 ]; then
   echo "INFO: PR already exists for ${BRANCH}; continuing with post-create helper."
 fi
 scripts/hooks/post-pr-create.sh --base main
+echo '<!-- CSA:NEXT_STEP cmd="csa plan run --sa-mode true patterns/pr-bot/workflow.toml" required=true -->'
 ```
 
 ## ENDIF

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -412,6 +412,7 @@ fi
 
 trap 'rm -f "${COMMIT_MESSAGE_FILE_LOCAL}"' EXIT
 git commit -F "${COMMIT_MESSAGE_FILE_LOCAL}"
+echo '<!-- CSA:NEXT_STEP cmd="cumulative branch review (Step 18) or publish" required=true -->'
 ```"""
 on_fail = "abort"
 
@@ -426,6 +427,7 @@ This catches cross-commit issues that per-commit reviews might miss.
 ```bash
 SID=$(csa review --range main...HEAD)
 bash scripts/csa/session-wait-until-done.sh "$SID"
+echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 19)" required=true -->'
 ```"""
 tier = "tier-2-standard"
 on_fail = "abort"
@@ -469,6 +471,7 @@ if [ "${CREATE_RC}" -ne 0 ]; then
   echo "INFO: PR already exists for ${BRANCH}; continuing with post-create helper."
 fi
 scripts/hooks/post-pr-create.sh --base main
+echo '<!-- CSA:NEXT_STEP cmd="csa plan run --sa-mode true patterns/pr-bot/workflow.toml" required=true -->'
 ```'''
 on_fail = "abort"
 condition = "!(${SKIP_PUBLISH})"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -125,6 +125,7 @@ SID=$(csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD")
 REVIEW_OUTPUT="$(bash scripts/csa/session-wait-until-done.sh "$SID" 2>&1)"
 printf '%s\n' "${REVIEW_OUTPUT}"
 echo "CSA_VAR:REVIEW_COMPLETED=true"
+echo '<!-- CSA:NEXT_STEP cmd="push to origin (Step 11)" required=true -->'
 ```
 
 ## ELSE
@@ -221,6 +222,7 @@ if [ "${VERDICT_LINE}" = "final_decision: HAS_ISSUES" ]; then
   exit 1
 fi
 echo "CSA_VAR:REVIEW_COMPLETED=true"
+echo '<!-- CSA:NEXT_STEP cmd="push to origin (Step 11)" required=true -->'
 ```
 
 ## ENDIF
@@ -241,6 +243,7 @@ fi
 BRANCH="$(git branch --show-current)"
 git push -u origin "${BRANCH}" --force-with-lease
 echo "CSA_VAR:PUSHED=true"
+echo '<!-- CSA:NEXT_STEP cmd="create or reuse PR (Step 12)" required=true -->'
 ```
 
 ## Step 12: Create or Reuse Pull Request
@@ -301,6 +304,7 @@ fi
 echo "PR #${PR_NUMBER} resolved: ${PR_URL}"
 echo "CSA_VAR:PR_NUMBER=${PR_NUMBER}"
 echo "CSA_VAR:PR_URL=${PR_URL}"
+echo '<!-- CSA:NEXT_STEP cmd="csa plan run --sa-mode true patterns/pr-bot/workflow.toml" required=true -->'
 ```
 
 ## Step 13: pr-bot Review & Merge Gate (HARD GATE)
@@ -346,6 +350,7 @@ trap cleanup_lock EXIT
 if [ -f "${DONE_MARKER}" ]; then
   echo "pr-bot already completed for PR #${PR_NUMBER} at HEAD ${HEAD_SHA:0:11}; skipping."
   echo "CSA_VAR:PR_BOT_DONE_MARKER=${DONE_MARKER}"
+  echo '<!-- CSA:NEXT_STEP cmd="post-merge local sync (Step 14)" required=true -->'
 elif ! mkdir "${LOCK_DIR}" 2>/dev/null; then
   echo "ERROR: pr-bot already running for PR #${PR_NUMBER} at HEAD ${HEAD_SHA:0:11}." >&2
   echo "Wait for the other run to finish, or remove the lock: ${LOCK_DIR}" >&2
@@ -357,6 +362,7 @@ else
   if csa plan run --sa-mode true patterns/pr-bot/workflow.toml; then
     touch "${DONE_MARKER}"
     echo "CSA_VAR:PR_BOT_DONE_MARKER=${DONE_MARKER}"
+    echo '<!-- CSA:NEXT_STEP cmd="post-merge local sync (Step 14)" required=true -->'
     LOCK_HELD=0
     rmdir "${LOCK_DIR}" 2>/dev/null || true
   else

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -205,6 +205,7 @@ SID=$(csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD")
 REVIEW_OUTPUT="$(bash scripts/csa/session-wait-until-done.sh "$SID" 2>&1)"
 printf '%s\n' "${REVIEW_OUTPUT}"
 echo "CSA_VAR:REVIEW_COMPLETED=true"
+echo '<!-- CSA:NEXT_STEP cmd="push to origin (Step 11)" required=true -->'
 ```'''
 on_fail = "abort"
 condition = "${FAST_PATH}"
@@ -308,6 +309,7 @@ if [ "${VERDICT_LINE}" = "final_decision: HAS_ISSUES" ]; then
   exit 1
 fi
 echo "CSA_VAR:REVIEW_COMPLETED=true"
+echo '<!-- CSA:NEXT_STEP cmd="push to origin (Step 11)" required=true -->'
 ```'''
 on_fail = "abort"
 condition = "!(${FAST_PATH})"
@@ -328,6 +330,7 @@ fi
 BRANCH="$(git branch --show-current)"
 git push -u origin "${BRANCH}" --force-with-lease
 echo "CSA_VAR:PUSHED=true"
+echo '<!-- CSA:NEXT_STEP cmd="create or reuse PR (Step 12)" required=true -->'
 ```"""
 on_fail = "abort"
 
@@ -389,6 +392,7 @@ fi
 echo "PR #${PR_NUMBER} resolved: ${PR_URL}"
 echo "CSA_VAR:PR_NUMBER=${PR_NUMBER}"
 echo "CSA_VAR:PR_URL=${PR_URL}"
+echo '<!-- CSA:NEXT_STEP cmd="csa plan run --sa-mode true patterns/pr-bot/workflow.toml" required=true -->'
 ```'''
 on_fail = "abort"
 
@@ -436,6 +440,7 @@ trap cleanup_lock EXIT
 if [ -f "${DONE_MARKER}" ]; then
   echo "pr-bot already completed for PR #${PR_NUMBER} at HEAD ${HEAD_SHA:0:11}; skipping."
   echo "CSA_VAR:PR_BOT_DONE_MARKER=${DONE_MARKER}"
+  echo '<!-- CSA:NEXT_STEP cmd="post-merge local sync (Step 14)" required=true -->'
 elif ! mkdir "${LOCK_DIR}" 2>/dev/null; then
   echo "ERROR: pr-bot already running for PR #${PR_NUMBER} at HEAD ${HEAD_SHA:0:11}." >&2
   echo "Wait for the other run to finish, or remove the lock: ${LOCK_DIR}" >&2
@@ -447,6 +452,7 @@ else
   if csa plan run --sa-mode true patterns/pr-bot/workflow.toml; then
     touch "${DONE_MARKER}"
     echo "CSA_VAR:PR_BOT_DONE_MARKER=${DONE_MARKER}"
+    echo '<!-- CSA:NEXT_STEP cmd="post-merge local sync (Step 14)" required=true -->'
     LOCK_HELD=0
     rmdir "${LOCK_DIR}" 2>/dev/null || true
   else

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -85,6 +85,7 @@ else
 fi
 REVIEW_COMPLETED=true
 echo "CSA_VAR:REVIEW_COMPLETED=$REVIEW_COMPLETED"
+echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 4)" required=true -->'
 ```
 
 ## IF ${LOCAL_REVIEW_HAS_ISSUES}
@@ -223,6 +224,7 @@ fi
 REPO="$(gh repo view --json nameWithOwner -q '.nameWithOwner')"
 echo "CSA_VAR:PR_NUM=$PR_NUM"
 echo "CSA_VAR:REPO=$REPO"
+echo '<!-- CSA:NEXT_STEP cmd="trigger cloud bot review or merge (Step 4a/5)" required=true -->'
 ```
 
 ## Step 4a: Check Cloud Bot Configuration
@@ -637,6 +639,7 @@ git fetch origin
 git checkout main
 git merge origin/main --ff-only
 git log --oneline -1  # verify local matches remote
+echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged without bot" required=false -->'
 ```
 
 ## ELSE
@@ -1234,6 +1237,7 @@ git fetch origin
 git checkout main
 git merge origin/main --ff-only
 git log --oneline -1  # verify local matches remote
+echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
 ```
 
 ## ELSE
@@ -1280,6 +1284,7 @@ git fetch origin
 git checkout main
 git merge origin/main --ff-only
 git log --oneline -1  # verify local matches remote
+echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
 ```
 
 ## ENDIF

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -135,6 +135,7 @@ else
 fi
 REVIEW_COMPLETED=true
 echo "CSA_VAR:REVIEW_COMPLETED=$REVIEW_COMPLETED"
+echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 4)" required=true -->'
 ```"""
 on_fail = "abort"
 
@@ -257,6 +258,7 @@ fi
 REPO="$(gh repo view --json nameWithOwner -q '.nameWithOwner')"
 echo "CSA_VAR:PR_NUM=$PR_NUM"
 echo "CSA_VAR:REPO=$REPO"
+echo '<!-- CSA:NEXT_STEP cmd="trigger cloud bot review or merge (Step 4a/5)" required=true -->'
 ```"""
 on_fail = "abort"
 
@@ -645,6 +647,7 @@ git fetch origin
 git checkout main
 git merge origin/main --ff-only
 git log --oneline -1  # verify local matches remote
+echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged without bot" required=false -->'
 ```"""
 on_fail = "abort"
 condition = "(${BOT_UNAVAILABLE}) && (!(${FALLBACK_REVIEW_HAS_ISSUES})) && (!(${ROUND_LIMIT_REACHED}))"
@@ -1423,6 +1426,7 @@ git fetch origin
 git checkout main
 git merge origin/main --ff-only
 git log --oneline -1  # verify local matches remote
+echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
 ```"""
 on_fail = "abort"
 condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED}) && (!(${ROUND_LIMIT_REACHED}))"
@@ -1466,6 +1470,7 @@ git fetch origin
 git checkout main
 git merge origin/main --ff-only
 git log --oneline -1  # verify local matches remote
+echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
 ```"""
 on_fail = "abort"
 condition = "(!(${BOT_UNAVAILABLE})) && (!(${FIXES_ACCUMULATED})) && (!(${ROUND_LIMIT_REACHED}))"

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.207"
+csa = "0.1.209"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.207"
+weave = "0.1.209"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

- Add `<!-- CSA:NEXT_STEP cmd="..." required=true -->` directives to all pipeline transition points across dev2merge (6), pr-bot (5), and commit (3) patterns
- Prevents agents from skipping pipeline steps (especially pr-bot after PR creation) by emitting machine-readable output chaining directives
- PATTERN.md and workflow.toml kept in sync per rule 027 (pattern-workflow-sync)
- PostReview hook secondary enforcement mechanism was already pre-existing in csa-hooks

## Changes

| Pattern | Directives Added | Key Transitions |
|---------|-----------------|-----------------|
| dev2merge | 6 | FAST_PATH→push, review→push, push→PR, PR→pr-bot, pr-bot→sync |
| pr-bot | 5 | review→push, push→bot, merge variants→complete |
| commit | 3 | commit→review, review→PR, PR→pr-bot |

## Test plan

- [x] `weave compile` passes for all three patterns
- [x] PATTERN.md and workflow.toml 1:1 step correspondence verified
- [x] `csa review --range main...HEAD` verdict: PASS
- [ ] End-to-end: run `/commit` standalone and verify NEXT_STEP directives appear in output
- [ ] End-to-end: run `dev2merge` and verify pipeline steps chain correctly

Closes #524