### PR TITLE
fix(patterns): enforce pr-bot as separate task in mktsk and dev2merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.209"
+version = "0.1.210"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.209"
+version = "0.1.210"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -13,7 +13,14 @@ hard gates (`on_fail = "abort"`). No step can be skipped by the LLM.
 
 Pipeline: Branch Validation → FAST_PATH Detection → mktd (planning) →
 mktsk N*(implement → commit) → Pre-PR Cumulative Review → Push →
-PR Creation → pr-bot Hard Gate → Post-Merge Sync.
+PR Creation → **pr-bot Hard Gate** → Post-Merge Sync.
+
+**CRITICAL PIPELINE INVARIANT**: PR creation (Step 12) and pr-bot (Step 13) are
+**two separate hard gates**. Creating a PR does NOT complete the pipeline. You
+MUST run pr-bot (Step 13) after PR creation. NEVER skip Step 13. NEVER merge
+the PR manually or via `gh pr merge`. The pr-bot workflow handles the merge.
+Agents that stop after Step 12 leave the PR unmerged — this is a known failure
+mode that this invariant exists to prevent.
 
 Sub-workflows are included via `## INCLUDE`, not inlined.
 

--- a/patterns/mktsk/PATTERN.md
+++ b/patterns/mktsk/PATTERN.md
@@ -34,6 +34,16 @@ Register each parsed TODO item via TaskCreate. Each task MUST include:
 
 Do NOT modify TODO.md checkboxes — task progress is tracked via TaskUpdate status.
 
+**MANDATORY publish-phase task decomposition** (when Step 6 applies):
+The publish pipeline MUST be registered as **separate, individually tracked tasks**:
+1. Push to remote
+2. Create or reuse PR
+3. **Run pr-bot** — SEPARATE task from PR creation. NEVER combine with step 2.
+4. Post-merge local sync
+
+pr-bot is the step that performs cloud review and the actual merge. Without a
+dedicated task for it, agents consistently skip it after PR creation.
+
 ## Step 3: Execute Tasks Serially
 
 Execute tasks strictly in order. Do not parallelize implementation work.
@@ -94,7 +104,13 @@ parent), complete the full pipeline:
 2. Run cumulative review (`csa review --range main...HEAD`).
 3. Push to remote (`--force-with-lease`).
 4. Create or reuse PR (`gh pr create`).
-5. Run pr-bot workflow for review + merge.
+5. **Run pr-bot** (`csa plan run --sa-mode true patterns/pr-bot/workflow.toml`).
+
+**CRITICAL — pr-bot is a SEPARATE step from PR creation:**
+- NEVER skip pr-bot after creating a PR.
+- NEVER merge the PR manually or via `gh pr merge`.
+- NEVER consider the pipeline "done" after PR creation.
+- pr-bot performs cloud review and the actual merge. It is the final gate.
 
 **Skipped when**: `CSA_SKIP_PUBLISH=true` is set by the parent workflow.
 dev2merge sets this before calling mktsk, since it handles publish in its

--- a/patterns/mktsk/skills/mktsk/SKILL.md
+++ b/patterns/mktsk/skills/mktsk/SKILL.md
@@ -48,4 +48,9 @@ For `csa` commands within pattern steps (e.g., `csa review --diff`), add
 
 1. All TODO items executed and verified via `DONE WHEN` conditions.
 2. All tasks marked complete via TaskUpdate.
-3. Branch pushed, PR created, pr-bot completed (or skipped when `CSA_SKIP_PUBLISH=true`).
+3. Branch pushed to remote.
+4. PR created (or reused).
+5. **pr-bot completed** — this is a SEPARATE gate from PR creation. NEVER mark
+   pipeline as done after PR creation without running pr-bot. pr-bot performs
+   cloud review and the actual merge.
+   (Steps 3-5 skipped when `CSA_SKIP_PUBLISH=true`.)

--- a/patterns/mktsk/workflow.toml
+++ b/patterns/mktsk/workflow.toml
@@ -31,6 +31,14 @@ Register each parsed TODO item via TaskCreate. Each task must include:
 
 Do NOT modify TODO.md checkboxes — task progress is tracked via TaskUpdate.
 
+MANDATORY publish-phase task decomposition (when publish is not skipped):
+The publish pipeline MUST be registered as SEPARATE tasks:
+1. Push to remote
+2. Create or reuse PR
+3. Run pr-bot — SEPARATE task from PR creation. NEVER combine with step 2.
+   NEVER skip pr-bot. NEVER merge the PR manually.
+4. Post-merge local sync
+
 ## Parsed Items
 ${STEP_1_OUTPUT}"""
 on_fail = "abort"


### PR DESCRIPTION
Reinforces pr-bot as a mandatory separate step after PR creation across mktsk and dev2merge patterns.

Changes:
- mktsk PATTERN.md Step 2: mandatory publish-phase task decomposition
- mktsk PATTERN.md Step 6: CRITICAL warning for pr-bot independence
- mktsk workflow.toml Step 2: sync pr-bot task requirement
- dev2merge PATTERN.md: PIPELINE INVARIANT warning at top
- mktsk SKILL.md: Done Criteria split into 5 verifiable gates
- Version bump to 0.1.210