### PR TITLE
fix(daemon): resolve silent failure in stderr capture (fixes #571, #573, #574)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.226"
+version = "0.1.227"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -78,73 +78,46 @@ use cli::{
     validate_command_args,
 };
 use csa_core::types::OutputFormat;
+use sa_mode::apply_sa_mode_prompt_guard;
 
 mod migrate_cmd;
+mod sa_mode;
 
-const SA_MODE_REQUIRED_ERROR_PREFIX: &str = "--sa-mode true|false is required for root callers on execution commands.\n\
-     Hint: add --sa-mode false for interactive use, or --sa-mode true for autonomous workflows";
-const CSA_INTERNAL_INVOCATION_ENV: &str = "CSA_INTERNAL_INVOCATION";
+// Re-export for tests that reference `crate::validate_sa_mode`.
+#[cfg(test)]
+pub(crate) use sa_mode::validate_sa_mode;
+
+/// Report a daemon command error to stderr while the daemon guard still holds
+/// fd 2 open, then return an exit code.
+///
+/// Without this, `?`-propagated errors would drop the guard (closing fd 2)
+/// *before* `main()` could print the error via `eprintln!`, causing EBADF →
+/// double-panic → process abort (issue #574).
+fn report_daemon_error_or_exit_code(
+    result: Result<i32>,
+    daemon_guard: &mut run_cmd_daemon::DaemonChildGuard,
+) -> i32 {
+    match result {
+        Ok(code) => code,
+        Err(err) => {
+            // fd 2 is still the pipe write-end (guard is alive), so eprintln! works.
+            eprintln!("Error: {err}");
+            if let Some(hint) = error_hints::suggest_fix(&err) {
+                eprintln!();
+                eprintln!("{hint}");
+            }
+            // Finalize the guard explicitly so stderr.log captures the error above.
+            daemon_guard.finalize();
+            exit_current_process(1);
+        }
+    }
+}
 
 fn exit_current_process(exit_code: i32) -> ! {
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
     crate::session_cmds_daemon::persist_daemon_completion_from_env(exit_code);
     std::process::exit(exit_code);
-}
-
-fn command_name_for_sa_mode(command: &Commands) -> Option<&'static str> {
-    match command {
-        Commands::Run { .. } => Some("run"),
-        Commands::Review(_) => Some("review"),
-        Commands::Debate(_) => Some("debate"),
-        Commands::Batch { .. } => Some("batch"),
-        Commands::Plan {
-            cmd: PlanCommands::Run { .. },
-        } => Some("plan run"),
-        Commands::ClaudeSubAgent(_) => Some("claude-sub-agent"),
-        _ => None,
-    }
-}
-
-fn command_sa_mode_arg(command: &Commands) -> Option<Option<bool>> {
-    match command {
-        Commands::Run { sa_mode, .. } => Some(*sa_mode),
-        Commands::Review(args) => Some(args.sa_mode),
-        Commands::Debate(args) => Some(args.sa_mode),
-        Commands::Batch { sa_mode, .. } => Some(*sa_mode),
-        Commands::Plan {
-            cmd: PlanCommands::Run { sa_mode, .. },
-        } => Some(*sa_mode),
-        Commands::ClaudeSubAgent(args) => Some(args.sa_mode),
-        _ => None,
-    }
-}
-
-fn is_internal_sa_invocation(current_depth: u32) -> bool {
-    if current_depth == 0 {
-        return false;
-    }
-
-    std::env::var(CSA_INTERNAL_INVOCATION_ENV)
-        .ok()
-        .map(|raw| {
-            let normalized = raw.trim().to_ascii_lowercase();
-            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
-        })
-        .unwrap_or(false)
-}
-
-pub(crate) fn validate_sa_mode(command: &Commands, current_depth: u32) -> anyhow::Result<bool> {
-    let Some(sa_mode_arg) = command_sa_mode_arg(command) else {
-        return Ok(false);
-    };
-
-    if sa_mode_arg.is_none() && !is_internal_sa_invocation(current_depth) {
-        let command_name = command_name_for_sa_mode(command).unwrap_or("execution command");
-        anyhow::bail!("{SA_MODE_REQUIRED_ERROR_PREFIX}: command `{command_name}`");
-    }
-
-    Ok(sa_mode_arg.unwrap_or(false))
 }
 
 /// Resolve the effective minimum timeout from project and global configs.
@@ -187,43 +160,6 @@ fn should_attempt_auto_weave_upgrade(command: &Commands) -> bool {
             | Commands::ClaudeSubAgent(_)
             | Commands::McpServer
     )
-}
-
-/// Apply SA mode prompt guard and emit caller-side constraint if active.
-///
-/// Returns `true` when SA mode is effectively enabled for this invocation.
-/// When SA mode is active at root depth, a structured guard block is emitted
-/// to stdout so the calling agent sees the Layer 0 Manager constraints.
-fn apply_sa_mode_prompt_guard(
-    command: &Commands,
-    current_depth: u32,
-    output_format: OutputFormat,
-) -> anyhow::Result<bool> {
-    if command_sa_mode_arg(command).is_none() {
-        return Ok(false);
-    }
-
-    let sa_mode_enabled = validate_sa_mode(command, current_depth)?;
-    let value = if sa_mode_enabled { "true" } else { "false" };
-
-    // SAFETY: process-level env updated once during startup before async work begins.
-    unsafe {
-        std::env::set_var(
-            crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV,
-            value,
-        )
-    };
-
-    // Emit SA mode caller guard to stdout (pre-session constraint).
-    // Only for Text output — JSON mode must not be corrupted by guard XML.
-    let text_mode = matches!(output_format, OutputFormat::Text);
-    crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
-        sa_mode_enabled,
-        current_depth,
-        text_mode,
-    );
-
-    Ok(sa_mode_enabled)
 }
 
 #[tokio::main]
@@ -444,7 +380,7 @@ async fn run() -> Result<()> {
                 csa_process::StreamMode::BufferOnly
             };
 
-            let exit_code = run_cmd::handle_run(
+            let result = run_cmd::handle_run(
                 tool,
                 skill,
                 prompt,
@@ -480,14 +416,16 @@ async fn run() -> Result<()> {
                 no_fs_sandbox,
                 extra_writable,
             )
-            .await?;
+            .await;
+            // Report errors while fd 2 is still open (guard holds stderr rotation).
+            // Dropping the guard closes fd 2, so eprintln! must happen first.
+            let exit_code = report_daemon_error_or_exit_code(result, &mut daemon_guard);
             // Post-session SA mode reminder so caller sees constraint before next action.
             crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
                 sa_mode_active,
                 current_depth,
                 matches!(output_format, OutputFormat::Text),
             );
-            // Finalize stderr rotation before process::exit() which skips Drop.
             daemon_guard.finalize();
             exit_current_process(exit_code);
         }
@@ -546,7 +484,8 @@ async fn run() -> Result<()> {
                 &args.session_id,
                 args.cd.as_deref(),
             )?;
-            let exit_code = review_cmd::handle_review(args, current_depth).await?;
+            let result = review_cmd::handle_review(args, current_depth).await;
+            let exit_code = report_daemon_error_or_exit_code(result, &mut daemon_guard);
             crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
                 sa_mode_active,
                 current_depth,
@@ -563,7 +502,8 @@ async fn run() -> Result<()> {
                 &args.session_id,
                 args.cd.as_deref(),
             )?;
-            let exit_code = debate_cmd::handle_debate(args, current_depth, output_format).await?;
+            let result = debate_cmd::handle_debate(args, current_depth, output_format).await;
+            let exit_code = report_daemon_error_or_exit_code(result, &mut daemon_guard);
             crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
                 sa_mode_active,
                 current_depth,

--- a/crates/cli-sub-agent/src/sa_mode.rs
+++ b/crates/cli-sub-agent/src/sa_mode.rs
@@ -1,0 +1,98 @@
+use crate::cli::{Commands, PlanCommands};
+use csa_core::types::OutputFormat;
+
+const SA_MODE_REQUIRED_ERROR_PREFIX: &str = "--sa-mode true|false is required for root callers on execution commands.\n\
+     Hint: add --sa-mode false for interactive use, or --sa-mode true for autonomous workflows";
+const CSA_INTERNAL_INVOCATION_ENV: &str = "CSA_INTERNAL_INVOCATION";
+
+fn command_name_for_sa_mode(command: &Commands) -> Option<&'static str> {
+    match command {
+        Commands::Run { .. } => Some("run"),
+        Commands::Review(_) => Some("review"),
+        Commands::Debate(_) => Some("debate"),
+        Commands::Batch { .. } => Some("batch"),
+        Commands::Plan {
+            cmd: PlanCommands::Run { .. },
+        } => Some("plan run"),
+        Commands::ClaudeSubAgent(_) => Some("claude-sub-agent"),
+        _ => None,
+    }
+}
+
+pub(crate) fn command_sa_mode_arg(command: &Commands) -> Option<Option<bool>> {
+    match command {
+        Commands::Run { sa_mode, .. } => Some(*sa_mode),
+        Commands::Review(args) => Some(args.sa_mode),
+        Commands::Debate(args) => Some(args.sa_mode),
+        Commands::Batch { sa_mode, .. } => Some(*sa_mode),
+        Commands::Plan {
+            cmd: PlanCommands::Run { sa_mode, .. },
+        } => Some(*sa_mode),
+        Commands::ClaudeSubAgent(args) => Some(args.sa_mode),
+        _ => None,
+    }
+}
+
+fn is_internal_sa_invocation(current_depth: u32) -> bool {
+    if current_depth == 0 {
+        return false;
+    }
+
+    std::env::var(CSA_INTERNAL_INVOCATION_ENV)
+        .ok()
+        .map(|raw| {
+            let normalized = raw.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
+}
+
+pub(crate) fn validate_sa_mode(command: &Commands, current_depth: u32) -> anyhow::Result<bool> {
+    let Some(sa_mode_arg) = command_sa_mode_arg(command) else {
+        return Ok(false);
+    };
+
+    if sa_mode_arg.is_none() && !is_internal_sa_invocation(current_depth) {
+        let command_name = command_name_for_sa_mode(command).unwrap_or("execution command");
+        anyhow::bail!("{SA_MODE_REQUIRED_ERROR_PREFIX}: command `{command_name}`");
+    }
+
+    Ok(sa_mode_arg.unwrap_or(false))
+}
+
+/// Apply SA mode prompt guard and emit caller-side constraint if active.
+///
+/// Returns `true` when SA mode is effectively enabled for this invocation.
+/// When SA mode is active at root depth, a structured guard block is emitted
+/// to stdout so the calling agent sees the Layer 0 Manager constraints.
+pub(crate) fn apply_sa_mode_prompt_guard(
+    command: &Commands,
+    current_depth: u32,
+    output_format: OutputFormat,
+) -> anyhow::Result<bool> {
+    if command_sa_mode_arg(command).is_none() {
+        return Ok(false);
+    }
+
+    let sa_mode_enabled = validate_sa_mode(command, current_depth)?;
+    let value = if sa_mode_enabled { "true" } else { "false" };
+
+    // SAFETY: process-level env updated once during startup before async work begins.
+    unsafe {
+        std::env::set_var(
+            crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV,
+            value,
+        )
+    };
+
+    // Emit SA mode caller guard to stdout (pre-session constraint).
+    // Only for Text output — JSON mode must not be corrupted by guard XML.
+    let text_mode = matches!(output_format, OutputFormat::Text);
+    crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
+        sa_mode_enabled,
+        current_depth,
+        text_mode,
+    );
+
+    Ok(sa_mode_enabled)
+}

--- a/crates/cli-sub-agent/tests/daemon_stderr_e2e.rs
+++ b/crates/cli-sub-agent/tests/daemon_stderr_e2e.rs
@@ -1,0 +1,364 @@
+// End-to-end tests for daemon stderr capture and daemon-completion.toml
+// writing on error paths (issues #571, #573, #574).
+//
+// These tests exercise the *user-observable* behavior: when a daemon child
+// process exits with an error, the diagnostic message MUST appear in
+// stderr.log and daemon-completion.toml MUST be written even on error paths.
+//
+// Two scenarios:
+//   A. Ok(non-zero) — handle_run returns Ok(1) without Err propagation.
+//      daemon-completion.toml must still be written with exit_code=1.
+//   B. Err() propagation — handle_run returns Err(e) which is caught by
+//      report_daemon_error_or_exit_code (issue #574 fix).
+//      stderr.log must contain the error message and daemon-completion.toml
+//      must be written.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Create a [`Command`] for the built `csa` binary with HOME, XDG_STATE_HOME,
+/// and XDG_CONFIG_HOME redirected to the given temp directory.
+fn csa_cmd(tmp: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"));
+    cmd
+}
+
+/// Compute the session directory path that CSA will use for a given project
+/// root and session ID when `XDG_STATE_HOME` is set.
+///
+/// This mirrors `csa_session::get_session_dir` logic:
+///   `$XDG_STATE_HOME/cli-sub-agent/{normalized_project_path}/sessions/{session_id}/`
+fn compute_session_dir(xdg_state_home: &Path, project_root: &Path, session_id: &str) -> PathBuf {
+    // Canonicalize to resolve symlinks (tempdir may go through /tmp -> real path).
+    let canonical = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    let normalized = canonical
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .replace('/', std::path::MAIN_SEPARATOR_STR);
+    xdg_state_home
+        .join("cli-sub-agent")
+        .join(normalized)
+        .join("sessions")
+        .join(session_id)
+}
+
+/// Parse daemon-completion.toml and return (exit_code, status).
+fn read_daemon_completion(session_dir: &Path) -> (i32, String) {
+    let path = session_dir.join("daemon-completion.toml");
+    let content = fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "daemon-completion.toml not found at {}: {e}",
+            path.display()
+        )
+    });
+    let table: toml::Table =
+        toml::from_str(&content).expect("daemon-completion.toml should be valid TOML");
+    let exit_code = table["exit_code"]
+        .as_integer()
+        .expect("exit_code should be integer") as i32;
+    let status = table["status"]
+        .as_str()
+        .expect("status should be string")
+        .to_string();
+    (exit_code, status)
+}
+
+/// Generate a ULID-like session ID for testing (not a real ULID, but formatted
+/// similarly — 26 uppercase alphanumeric chars).
+fn test_session_id(suffix: &str) -> String {
+    // Use a fixed prefix + suffix so test output is recognizable.
+    format!("01TEST{:0>20}", suffix)
+}
+
+// ---------------------------------------------------------------------------
+// Scenario A: Ok(non-zero) return path
+//
+// When CSA_DEPTH exceeds max_depth, load_and_validate returns Ok(None) and
+// handle_run returns Ok(1). This tests that daemon-completion.toml is written
+// even on the non-error exit path with a non-zero exit code.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn daemon_child_ok_nonzero_writes_completion_toml() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path().join("project");
+    fs::create_dir_all(&project_root).expect("create project dir");
+
+    let xdg_state_home = tmp.path().join(".local/state");
+    let session_id = test_session_id("OKPATH00000000000001");
+
+    let session_dir = compute_session_dir(&xdg_state_home, &project_root, &session_id);
+    fs::create_dir_all(&session_dir).expect("create session dir");
+
+    // Run as daemon-child with CSA_DEPTH=100 (exceeds default max_depth=5).
+    // handle_run will call load_and_validate → None → return Ok(1).
+    let output = csa_cmd(tmp.path())
+        .args([
+            "run",
+            "--daemon-child",
+            "--session-id",
+            &session_id,
+            "--sa-mode",
+            "false",
+            "--no-idle-timeout",
+            "--timeout",
+            "1800",
+            "test prompt for scenario A",
+        ])
+        .env("CSA_DEPTH", "100")
+        .env("CSA_DAEMON_SESSION_DIR", &session_dir)
+        .env("CSA_DAEMON_PROJECT_ROOT", &project_root)
+        .current_dir(&project_root)
+        .output()
+        .expect("failed to run csa");
+
+    // Process should exit with code 1 (not hang or crash).
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit code 1, got {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // daemon-completion.toml MUST exist.
+    let completion_path = session_dir.join("daemon-completion.toml");
+    assert!(
+        completion_path.exists(),
+        "daemon-completion.toml should exist at {}",
+        completion_path.display()
+    );
+
+    let (exit_code, status) = read_daemon_completion(&session_dir);
+    assert_eq!(exit_code, 1, "exit_code should be 1");
+    // status_from_exit_code(1) = "failure" (0 = "success", 137/143 = "signal", else = "failure").
+    assert_eq!(
+        status, "failure",
+        "status should be 'failure' for exit code 1"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario B: Err() propagation path
+//
+// Using --tool with an unknown name triggers resolve_alias failure inside
+// handle_run (after daemon guard is established), which returns Err.
+// report_daemon_error_or_exit_code catches this, writes to stderr via
+// eprintln!, then finalizes the daemon guard.
+//
+// This is the exact path that caused double-panic → orphaned process
+// before the issue #574 fix.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn daemon_child_err_path_captures_stderr_and_writes_completion() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path().join("project");
+    fs::create_dir_all(&project_root).expect("create project dir");
+
+    let xdg_state_home = tmp.path().join(".local/state");
+    let session_id = test_session_id("ERRPATH0000000000001");
+
+    let session_dir = compute_session_dir(&xdg_state_home, &project_root, &session_id);
+    fs::create_dir_all(&session_dir).expect("create session dir");
+
+    // Use --tool bogus-tool-xyz which passes clap parsing as ToolArg::Alias
+    // but fails during resolve_alias in handle_run → Err.
+    // --force-ignore-tier-setting bypasses tier enforcement so the alias
+    // resolution actually runs (not blocked by tier check).
+    let child = Command::new(env!("CARGO_BIN_EXE_csa"))
+        .args([
+            "run",
+            "--daemon-child",
+            "--session-id",
+            &session_id,
+            "--sa-mode",
+            "false",
+            "--force-ignore-tier-setting",
+            "--tool",
+            "bogus-tool-xyz",
+            "--no-idle-timeout",
+            "--timeout",
+            "1800",
+            "test prompt for scenario B",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_STATE_HOME", &xdg_state_home)
+        .env("XDG_CONFIG_HOME", tmp.path().join(".config"))
+        .env("CSA_DAEMON_SESSION_DIR", &session_dir)
+        .env("CSA_DAEMON_PROJECT_ROOT", &project_root)
+        .current_dir(&project_root)
+        .output()
+        .expect("failed to spawn csa");
+
+    // Must exit with code 1 (not hang, not crash with signal).
+    assert_eq!(
+        child.status.code(),
+        Some(1),
+        "expected exit code 1, got {:?}\nstdout: {}\nstderr: {}",
+        child.status.code(),
+        String::from_utf8_lossy(&child.stdout),
+        String::from_utf8_lossy(&child.stderr),
+    );
+
+    // --- Check daemon-completion.toml ---
+    let completion_path = session_dir.join("daemon-completion.toml");
+    assert!(
+        completion_path.exists(),
+        "daemon-completion.toml should exist at {}",
+        completion_path.display()
+    );
+
+    let (exit_code, status) = read_daemon_completion(&session_dir);
+    assert_eq!(exit_code, 1, "exit_code should be 1");
+    assert_eq!(
+        status, "failure",
+        "status should be 'failure' for exit code 1"
+    );
+
+    // --- Check stderr.log ---
+    // When stderr rotation installs successfully, stderr is redirected to
+    // stderr.log in the session dir. The error message from
+    // report_daemon_error_or_exit_code ("Error: <msg>") should be captured.
+    let stderr_log_path = session_dir.join("stderr.log");
+    if stderr_log_path.exists() {
+        let stderr_content = fs::read_to_string(&stderr_log_path).expect("should read stderr.log");
+        // The error message should contain the tool name that failed.
+        assert!(
+            stderr_content.contains("bogus-tool-xyz"),
+            "stderr.log should contain the unknown tool name 'bogus-tool-xyz', \
+             got: {stderr_content}"
+        );
+        assert!(
+            stderr_content.contains("Error:") || stderr_content.contains("unknown tool"),
+            "stderr.log should contain error indicator, got: {stderr_content}"
+        );
+    } else {
+        // If stderr rotation did not install (e.g. session dir resolution
+        // differs from expected), the error should still be on process stderr.
+        let process_stderr = String::from_utf8_lossy(&child.stderr);
+        assert!(
+            process_stderr.contains("bogus-tool-xyz"),
+            "process stderr should contain 'bogus-tool-xyz' when stderr.log \
+             is not available. stderr: {process_stderr}"
+        );
+    }
+
+    // --- No double-panic backtrace ---
+    // Before the fix, the process would abort with a double-panic. Verify no
+    // panic backtrace appears in any output.
+    let all_output = format!(
+        "{}{}{}",
+        String::from_utf8_lossy(&child.stdout),
+        String::from_utf8_lossy(&child.stderr),
+        fs::read_to_string(session_dir.join("stderr.log")).unwrap_or_default(),
+    );
+    assert!(
+        !all_output.contains("panicked at"),
+        "should not contain panic backtrace, got: {all_output}"
+    );
+    assert!(
+        !all_output.contains("thread 'main' panicked"),
+        "should not contain main thread panic, got: {all_output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario B variant: Err() on review command
+//
+// Exercises the same report_daemon_error_or_exit_code path on `csa review`
+// to ensure all three execution commands (run/review/debate) are covered.
+// Uses --cd with a nonexistent path to trigger determine_project_root error.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn daemon_child_review_err_writes_completion() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path().join("project");
+    fs::create_dir_all(&project_root).expect("create project dir");
+
+    let xdg_state_home = tmp.path().join(".local/state");
+    let session_id = test_session_id("REVIEW0000000000001");
+
+    // Pre-create session dir so the env-var based completion writer can find it.
+    let session_dir = compute_session_dir(&xdg_state_home, &project_root, &session_id);
+    fs::create_dir_all(&session_dir).expect("create session dir");
+
+    // `csa review --daemon-child --session-id <ID> --sa-mode false --diff --cd /nonexistent`
+    // check_daemon_flags succeeds (daemon_child=true, session_id present).
+    // install_daemon_stderr_rotation may fail (cd=/nonexistent), which is best-effort.
+    // handle_review calls determine_project_root(Some("/nonexistent")) → Err.
+    // report_daemon_error_or_exit_code catches Err → eprintln! → finalize → exit(1).
+    let output = Command::new(env!("CARGO_BIN_EXE_csa"))
+        .args([
+            "review",
+            "--daemon-child",
+            "--session-id",
+            &session_id,
+            "--sa-mode",
+            "false",
+            "--diff",
+            "--cd",
+            "/nonexistent/path/for/daemon/stderr/e2e/test",
+        ])
+        .env("HOME", tmp.path())
+        .env("XDG_STATE_HOME", &xdg_state_home)
+        .env("XDG_CONFIG_HOME", tmp.path().join(".config"))
+        .env("CSA_DAEMON_SESSION_DIR", &session_dir)
+        .env("CSA_DAEMON_PROJECT_ROOT", &project_root)
+        .current_dir(&project_root)
+        .output()
+        .expect("failed to run csa review");
+
+    // Must exit cleanly with code 1.
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit code 1, got {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // daemon-completion.toml MUST exist even when the error occurred early.
+    let completion_path = session_dir.join("daemon-completion.toml");
+    assert!(
+        completion_path.exists(),
+        "daemon-completion.toml should exist at {}",
+        completion_path.display()
+    );
+
+    let (exit_code, status) = read_daemon_completion(&session_dir);
+    assert_eq!(exit_code, 1, "exit_code should be 1");
+    assert_eq!(
+        status, "failure",
+        "status should be 'failure' for exit code 1"
+    );
+
+    // The error message should mention the nonexistent path.
+    // It may be in stderr.log (if rotation installed before --cd resolution)
+    // or in process stderr (if rotation didn't install).
+    let process_stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr_log = fs::read_to_string(session_dir.join("stderr.log")).unwrap_or_default();
+    let combined_stderr = format!("{process_stderr}{stderr_log}");
+
+    assert!(
+        combined_stderr.contains("nonexistent") || combined_stderr.contains("No such file"),
+        "stderr should mention the nonexistent path. \
+         process stderr: {process_stderr}\n\
+         stderr.log: {stderr_log}"
+    );
+
+    // No panic backtrace.
+    assert!(
+        !combined_stderr.contains("panicked at"),
+        "should not contain panic backtrace"
+    );
+}

--- a/crates/csa-process/src/daemon_stderr.rs
+++ b/crates/csa-process/src/daemon_stderr.rs
@@ -148,18 +148,11 @@ pub fn install_stderr_rotation(
 
     let stderr_path = stderr_path.to_path_buf();
     let shutdown = Arc::new(AtomicBool::new(false));
-    let shutdown_clone = shutdown.clone();
 
     let thread = match std::thread::Builder::new()
         .name("csa-stderr-rotation".to_string())
         .spawn(move || {
-            run_stderr_drain(
-                read_file,
-                &stderr_path,
-                max_bytes,
-                keep_rotated,
-                shutdown_clone,
-            );
+            run_stderr_drain(read_file, &stderr_path, max_bytes, keep_rotated);
         }) {
         Ok(handle) => handle,
         Err(e) => {
@@ -193,7 +186,6 @@ fn run_stderr_drain(
     stderr_path: &Path,
     max_bytes: u64,
     keep_rotated: bool,
-    shutdown: Arc<AtomicBool>,
 ) {
     let mut rotator = match SpoolRotator::open(stderr_path, max_bytes, keep_rotated) {
         Ok(r) => r,
@@ -210,10 +202,11 @@ fn run_stderr_drain(
 
     let mut buf = [0u8; 8192];
     loop {
-        if shutdown.load(Ordering::Acquire) {
-            break;
-        }
-
+        // NOTE: No shutdown atomic check here — we rely on EOF from the closed
+        // write-end as the sole termination signal.  Checking `shutdown` before
+        // `read()` caused a race where finalize() set the flag AND closed the
+        // write-end, but the reader saw the flag first and exited *before*
+        // draining remaining bytes from the pipe buffer.  See issue #571.
         match pipe.read(&mut buf) {
             Ok(0) => break, // EOF — write-end closed (process exiting)
             Ok(n) => {
@@ -273,12 +266,10 @@ mod tests {
         let stderr_path = tmp.path().join("stderr.log");
 
         let (read_file, mut write_file) = make_pipe();
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let shutdown_clone = shutdown.clone();
 
         let path_clone = stderr_path.clone();
         let handle = std::thread::spawn(move || {
-            run_stderr_drain(read_file, &path_clone, 1024 * 1024, true, shutdown_clone);
+            run_stderr_drain(read_file, &path_clone, 1024 * 1024, true);
         });
 
         // Write data to the pipe write-end.
@@ -320,13 +311,11 @@ mod tests {
         let rotated_path = tmp.path().join("stderr.log.rotated");
 
         let (read_file, mut write_file) = make_pipe();
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let shutdown_clone = shutdown.clone();
 
         let max_bytes = 256u64;
         let path_clone = stderr_path.clone();
         let handle = std::thread::spawn(move || {
-            run_stderr_drain(read_file, &path_clone, max_bytes, true, shutdown_clone);
+            run_stderr_drain(read_file, &path_clone, max_bytes, true);
         });
 
         // Write in separate batches with pauses so the drain thread processes
@@ -378,13 +367,11 @@ mod tests {
         let rotated_path = tmp.path().join("stderr.log.rotated");
 
         let (read_file, mut write_file) = make_pipe();
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let shutdown_clone = shutdown.clone();
 
         let max_bytes = 128u64;
         let path_clone = stderr_path.clone();
         let handle = std::thread::spawn(move || {
-            run_stderr_drain(read_file, &path_clone, max_bytes, false, shutdown_clone);
+            run_stderr_drain(read_file, &path_clone, max_bytes, false);
         });
 
         // Write in batches to ensure multiple read() calls in drain thread.
@@ -404,6 +391,54 @@ mod tests {
         assert!(
             !rotated_path.exists(),
             "stderr.log.rotated should be removed when keep_rotated=false"
+        );
+    }
+
+    /// Regression test for issue #571: pipe data must be fully drained even
+    /// when `StderrRotationGuard::finalize()` is called before the reader
+    /// thread has consumed all buffered data.
+    ///
+    /// Before the fix, the reader loop checked `shutdown.load()` *before*
+    /// `pipe.read()`, so it could exit the loop with unread data in the pipe
+    /// buffer.  After the fix, EOF from the closed write-end is the only
+    /// termination condition, guaranteeing full drainage.
+    #[test]
+    fn test_drain_after_finalize() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let stderr_path = tmp.path().join("stderr.log");
+
+        // We test via the public install API by creating a *separate* pipe
+        // pair (not modifying fd 2 of this test process) and driving the
+        // drain function directly.
+        let (read_file, mut write_file) = make_pipe();
+
+        let path_clone = stderr_path.clone();
+        let handle = std::thread::spawn(move || {
+            run_stderr_drain(read_file, &path_clone, 1024 * 1024, true);
+        });
+
+        // Write a moderate amount of data — enough to sit in the pipe buffer.
+        let payload = "drain-test-line\n".repeat(200);
+        write_file
+            .write_all(payload.as_bytes())
+            .expect("write to pipe");
+
+        // Simulate what finalize() does: close the write-end while there may
+        // still be unread data in the pipe buffer.  The reader should drain
+        // everything before exiting.
+        drop(write_file);
+
+        handle.join().expect("drain thread panicked");
+
+        let content = std::fs::read_to_string(&stderr_path).expect("read stderr.log");
+        let line_count = content.lines().count();
+        assert_eq!(
+            line_count, 200,
+            "all 200 lines must be drained to stderr.log after write-end close, got {line_count}"
+        );
+        assert!(
+            content.contains("drain-test-line"),
+            "stderr.log must contain the test payload, got: {content:?}"
         );
     }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.225"
+csa = "0.1.226"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.225"
+weave = "0.1.226"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

Fixes three related daemon failure modes where error diagnostics were silently lost:

- **Bug A — Pipe drainage race (#571, #573)**: `DaemonStderr` reader thread checked `shutdown` atomic BEFORE `pipe.read()`, discarding buffer bytes when `finalize()` closed the write-end. Fix removes the shutdown check; EOF (`Ok(0)`) is now the sole termination condition, guaranteeing complete drainage.
- **Bug B — Guard lifetime (#574)**: `DaemonChildGuard` was dropped via early `?` before `main()` could `eprintln!` the error, causing EBADF panic storm (fd 2 already closed). Fix introduces `report_daemon_error_or_exit_code()` helper that takes `&mut DaemonChildGuard`, ensuring the guard (and its stderr pipe dup) stays alive through error reporting and `finalize()`.
- **Refactor**: Extracts `sa_mode.rs` module from `main.rs` (requested by `/commit` skill Step 6 review).

## Changes

- `crates/cli-sub-agent/src/daemon_stderr.rs`: Remove preemptive `shutdown.load()` check; EOF is sole exit
- `crates/cli-sub-agent/src/main.rs`: Add `report_daemon_error_or_exit_code()` helper, refactor daemon error paths
- `crates/cli-sub-agent/src/sa_mode.rs`: New module extracted from `main.rs`
- `crates/cli-sub-agent/tests/daemon_stderr_e2e.rs`: 3 E2E tests covering both failure paths

## Test plan

- [x] All 3169 tests pass (`cargo test`)
- [x] `just clippy` — 0 warnings
- [x] `just pre-commit` — exit 0
- [x] `csa review --branch main` — verdict: PASS (gemini-cli, all spec criteria c1–c6 verified)

Closes #571
Closes #573
Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)