### PR TITLE
feat(tier): add tier-aware tool override and fix #584

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.231"
+version = "0.1.232"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -173,11 +173,15 @@ pub(crate) async fn handle_debate(
 
     // 4. Build debate instruction (parameter passing — tool loads debate skill)
     let prompt = build_debate_instruction(&question, args.session.is_some(), args.rounds);
+    let debate_description = format!(
+        "debate: {}",
+        crate::run_helpers::truncate_prompt(&question, 80)
+    );
 
     // 5. Determine tool (with tier-based resolution)
     let detected_parent_tool = crate::run_helpers::detect_parent_tool();
     let parent_tool = crate::run_helpers::resolve_tool(detected_parent_tool, &global_config);
-    let (tool, debate_mode, tier_model_spec) = resolve_debate_tool(
+    let (tool, debate_mode, tier_model_spec) = match resolve_debate_tool(
         args.tool,
         config.as_ref(),
         &global_config,
@@ -186,7 +190,23 @@ pub(crate) async fn handle_debate(
         args.force_override_user_config,
         args.tier.as_deref(),
         args.force_ignore_tier_setting,
-    )?;
+    ) {
+        Ok(resolved) => resolved,
+        Err(err) => {
+            return Err(crate::session_guard::persist_pre_exec_error_result(
+                crate::session_guard::PreExecErrorCtx {
+                    project_root: &project_root,
+                    session_id: args.session.as_deref(),
+                    description: Some(debate_description.as_str()),
+                    parent: None,
+                    tool_name: args.tool.map(|tool| tool.as_str()),
+                    task_type: Some("debate"),
+                    tier_name: args.tier.as_deref(),
+                    error: err,
+                },
+            ));
+        }
+    };
     let resolved_tier_name = if tier_model_spec.is_some() {
         resolve_debate_tier_name(
             config.as_ref(),
@@ -263,10 +283,6 @@ pub(crate) async fn handle_debate(
     let _slot_guard = crate::pipeline::acquire_slot(&executor, &global_config)?;
 
     // 9. Execute with session (with optional absolute timeout + transient retry)
-    let description = format!(
-        "debate: {}",
-        crate::run_helpers::truncate_prompt(&question, 80)
-    );
     let timeout_seconds =
         resolve_debate_timeout_seconds(args.timeout, Some(global_config.debate.timeout_seconds));
     let wall_clock_start = Instant::now();
@@ -284,7 +300,7 @@ pub(crate) async fn handle_debate(
             &prompt,
             output_format,
             resume_session.clone(),
-            Some(description.clone()),
+            Some(debate_description.clone()),
             None,
             &project_root,
             config.as_ref(),

--- a/crates/cli-sub-agent/src/debate_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_resolve.rs
@@ -35,18 +35,11 @@ pub(crate) fn resolve_debate_tool(
         let alias_hint = cfg.format_tier_aliases();
         anyhow::bail!(
             "Direct --tool is restricted when tiers are configured. \
-             Use --tier <name> or add --force-ignore-tier-setting to override. \
+             Use --tier <name> to specify which tier's model/thinking config to use, \
+             or add --force-ignore-tier-setting to override. \
              Available tiers: [{}]{alias_hint}",
             available.join(", ")
         );
-    }
-
-    // CLI --tool override wins (when not blocked by tier enforcement above)
-    if let Some(tool) = arg_tool {
-        if let Some(cfg) = project_config {
-            cfg.enforce_tool_enabled(tool.as_str(), force_override_user_config)?;
-        }
-        return Ok((tool, DebateMode::Heterogeneous, None));
     }
 
     let tier_name = resolve_debate_tier_name(
@@ -56,6 +49,31 @@ pub(crate) fn resolve_debate_tool(
         force_override_user_config,
         force_ignore_tier_setting,
     )?;
+
+    if let Some(tool) = arg_tool {
+        if let Some(ref tier) = tier_name
+            && let Some(cfg) = project_config
+        {
+            let resolution = crate::run_helpers::resolve_requested_tool_from_tier(
+                tier,
+                cfg,
+                parent_tool,
+                tool,
+                force_override_user_config,
+                &[],
+            )?;
+            return Ok((
+                resolution.tool,
+                DebateMode::Heterogeneous,
+                Some(resolution.model_spec),
+            ));
+        }
+
+        if let Some(cfg) = project_config {
+            cfg.enforce_tool_enabled(tool.as_str(), force_override_user_config)?;
+        }
+        return Ok((tool, DebateMode::Heterogeneous, None));
+    }
 
     // Compute effective whitelist from tool selection (project > global)
     let effective_whitelist = project_config

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -1,4 +1,24 @@
 use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn write_debate_project_config(project_root: &Path, config: &ProjectConfig) {
+    let config_path = ProjectConfig::config_path(project_root);
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(config_path, toml::to_string_pretty(config).unwrap()).unwrap();
+}
+
+fn install_pattern(project_root: &Path, name: &str) {
+    let skill_dir = project_root
+        .join(".csa")
+        .join("patterns")
+        .join(name)
+        .join("skills")
+        .join(name);
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(skill_dir.join("SKILL.md"), "# test pattern\n").unwrap();
+}
 
 // --- resolve_debate_thinking tests ---
 
@@ -132,6 +152,61 @@ fn verify_debate_skill_no_fallback_without_skill() {
     assert!(
         result.is_err(),
         "missing skill must be a hard error, not a warning"
+    );
+}
+
+#[tokio::test]
+async fn handle_debate_persists_result_for_direct_tool_tier_rejection() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    config.tiers.insert(
+        "default".to_string(),
+        csa_config::config::TierConfig {
+            description: "Test tier".to_string(),
+            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            strategy: csa_config::TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    write_debate_project_config(project_dir.path(), &config);
+    install_pattern(project_dir.path(), "debate");
+
+    let cd = project_dir.path().display().to_string();
+    let args = parse_debate_args(&[
+        "csa",
+        "debate",
+        "--cd",
+        &cd,
+        "--tool",
+        "codex",
+        "Should we refactor the API?",
+    ]);
+
+    let err = handle_debate(args, 0, csa_core::types::OutputFormat::Text)
+        .await
+        .expect_err("direct --tool tier rejection must fail");
+    assert!(
+        err.chain().any(|cause| cause
+            .to_string()
+            .contains("restricted when tiers are configured")),
+        "unexpected error chain: {err:#}"
+    );
+
+    let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
+    assert_eq!(sessions.len(), 1, "expected one failed debate session");
+
+    let result = csa_session::load_result(project_dir.path(), &sessions[0].meta_session_id)
+        .unwrap()
+        .expect("result.toml must be written for debate tier rejection");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(result.summary.contains("pre-exec:"));
+    assert!(
+        result
+            .summary
+            .contains("restricted when tiers are configured")
     );
 }
 

--- a/crates/cli-sub-agent/src/debate_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tier_tests.rs
@@ -124,6 +124,67 @@ fn test_debate_allows_tier_flag() {
 }
 
 #[test]
+fn test_debate_tool_plus_tier_resolves_requested_tool_from_tier() {
+    let global = GlobalConfig::default();
+    let cfg = debate_config_with_tier(
+        "quality",
+        vec![
+            "gemini-cli/google/default/xhigh",
+            "codex/openai/gpt-5.4/high",
+            "claude-code/anthropic/sonnet-4.6/xhigh",
+        ],
+        &["gemini-cli", "codex", "claude-code"],
+    );
+    let result = resolve_debate_tool(
+        Some(ToolName::Codex),
+        Some(&cfg),
+        &global,
+        Some("claude-code"),
+        std::path::Path::new("/tmp/test-project"),
+        false,
+        Some("quality"),
+        false,
+    );
+
+    assert!(
+        result.is_ok(),
+        "tool+tier should resolve requested debate tool: {}",
+        result.unwrap_err()
+    );
+    let (tool, mode, model_spec) = result.unwrap();
+    assert_eq!(tool, ToolName::Codex);
+    assert_eq!(mode, DebateMode::Heterogeneous);
+    assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/high"));
+}
+
+#[test]
+fn test_debate_tool_plus_tier_errors_when_tool_missing_from_tier() {
+    let global = GlobalConfig::default();
+    let cfg = debate_config_with_tier(
+        "quality",
+        vec!["gemini-cli/google/default/xhigh"],
+        &["gemini-cli", "codex"],
+    );
+    let result = resolve_debate_tool(
+        Some(ToolName::Codex),
+        Some(&cfg),
+        &global,
+        Some("claude-code"),
+        std::path::Path::new("/tmp/test-project"),
+        false,
+        Some("quality"),
+        false,
+    );
+
+    let err = result.expect_err("missing tool in debate tier must error");
+    assert!(
+        err.to_string()
+            .contains("Requested tool 'codex' is not available in tier 'quality'"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn test_debate_force_ignore_tier_allows_direct_tool() {
     let global = GlobalConfig::default();
     let cfg = debate_config_with_tier(

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -1,8 +1,6 @@
-use std::path::{Path, PathBuf};
-
 use anyhow::{Context, Result};
 use tokio::task::JoinSet;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use crate::cli::ReviewArgs;
 use crate::review_consensus::{
@@ -15,10 +13,14 @@ use crate::review_context::discover_review_context_for_branch;
 use crate::review_context::resolve_review_context;
 #[cfg(test)]
 use crate::review_context::{ResolvedReviewContext, ResolvedReviewContextKind};
-use crate::review_routing::{ReviewRoutingMetadata, persist_review_routing_artifact};
-use csa_config::{ExecutionEnvOptions, GlobalConfig, ProjectConfig};
+#[cfg(test)]
+use crate::review_routing::ReviewRoutingMetadata;
+#[cfg(test)]
+use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::consensus::AgentResponse;
-use csa_core::types::{OutputFormat, ReviewDecision, ToolName};
+use csa_core::types::ReviewDecision;
+#[cfg(test)]
+use csa_core::types::ToolName;
 use csa_session::state::ReviewSessionMeta;
 
 #[path = "review_cmd_output.rs"]
@@ -37,8 +39,12 @@ mod post_review;
 #[path = "review_cmd_reviewers.rs"]
 mod reviewers;
 
+#[path = "review_cmd_execute.rs"]
+mod execute;
+
 #[path = "review_cmd_resolve.rs"]
 mod resolve;
+use execute::{compute_diff_fingerprint, execute_review};
 use post_review::{build_post_review_output, emit_post_review_output, review_scope_is_cumulative};
 #[cfg(test)]
 use resolve::build_review_instruction;
@@ -203,6 +209,10 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         has_context = context.is_some(),
         "Review parameters"
     );
+    let review_description = format!(
+        "review: {}",
+        crate::run_helpers::truncate_prompt(&scope, 80)
+    );
 
     // 4. Build review instruction (no diff content — tool loads skill and fetches diff itself)
     let (mut prompt, review_routing) = build_review_instruction_for_project(
@@ -224,7 +234,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
     // 5. Determine tool (with tier-based resolution)
     let detected_parent_tool = crate::run_helpers::detect_parent_tool();
     let parent_tool = crate::run_helpers::resolve_tool(detected_parent_tool, &global_config);
-    let (tool, tier_model_spec) = resolve_review_tool(
+    let (tool, tier_model_spec) = match resolve_review_tool(
         args.tool,
         config.as_ref(),
         &global_config,
@@ -233,7 +243,23 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         args.force_override_user_config,
         args.tier.as_deref(),
         args.force_ignore_tier_setting,
-    )?;
+    ) {
+        Ok(resolved) => resolved,
+        Err(err) => {
+            return Err(crate::session_guard::persist_pre_exec_error_result(
+                crate::session_guard::PreExecErrorCtx {
+                    project_root: &project_root,
+                    session_id: args.session.as_deref(),
+                    description: Some(review_description.as_str()),
+                    parent: None,
+                    tool_name: args.tool.map(|tool| tool.as_str()),
+                    task_type: Some("review"),
+                    tier_name: args.tier.as_deref(),
+                    error: err,
+                },
+            ));
+        }
+    };
     let resolved_tier_name = if tier_model_spec.is_some() {
         resolve_review_tier_name(
             config.as_ref(),
@@ -290,10 +316,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             tier_model_spec.clone(),
             resolved_tier_name.clone(),
             review_thinking.clone(),
-            format!(
-                "review: {}",
-                crate::run_helpers::truncate_prompt(&scope, 80)
-            ),
+            review_description.clone(),
             &project_root,
             config.as_ref(),
             &global_config,
@@ -655,140 +678,6 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
     }
 
     Ok(if final_verdict == CLEAN { 0 } else { 1 })
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn execute_review(
-    tool: ToolName,
-    prompt: String,
-    session: Option<String>,
-    model: Option<String>,
-    tier_model_spec: Option<String>,
-    tier_name: Option<String>,
-    thinking: Option<String>,
-    description: String,
-    project_root: &Path,
-    project_config: Option<&ProjectConfig>,
-    global_config: &GlobalConfig,
-    review_routing: ReviewRoutingMetadata,
-    stream_mode: csa_process::StreamMode,
-    idle_timeout_seconds: u64,
-    initial_response_timeout_seconds: Option<u64>,
-    force_override_user_config: bool,
-    no_fs_sandbox: bool,
-    readonly_project_root: bool,
-    extra_writable: &[PathBuf],
-) -> Result<crate::pipeline::SessionExecutionResult> {
-    let enforce_tier = tier_model_spec.is_some();
-    let executor = crate::pipeline::build_and_validate_executor(
-        &tool,
-        tier_model_spec.as_deref(),
-        model.as_deref(),
-        thinking.as_deref(),
-        crate::pipeline::ConfigRefs {
-            project: project_config,
-            global: Some(global_config),
-        },
-        enforce_tier,
-        force_override_user_config,
-        false, // review must not inherit `csa run` per-tool defaults
-    )
-    .await?;
-
-    let can_edit =
-        project_config.is_none_or(|cfg| cfg.can_tool_edit_existing(executor.tool_name()));
-    let can_write_new =
-        project_config.is_none_or(|cfg| cfg.can_tool_write_new(executor.tool_name()));
-    let effective_prompt = if !can_edit || !can_write_new {
-        info!(
-            tool = %executor.tool_name(),
-            can_edit,
-            can_write_new,
-            "Applying filesystem restrictions via prompt injection"
-        );
-        executor.apply_restrictions(&prompt, can_edit, can_write_new)
-    } else {
-        prompt
-    };
-
-    let extra_env_owned = global_config.build_execution_env(
-        executor.tool_name(),
-        ExecutionEnvOptions::with_no_flash_fallback(),
-    );
-    let extra_env = extra_env_owned.as_ref();
-    let _slot_guard = crate::pipeline::acquire_slot(&executor, global_config)?;
-
-    if session.is_none()
-        && let Ok(inherited_session_id) = std::env::var("CSA_SESSION_ID")
-    {
-        warn!(
-            inherited_session_id = %inherited_session_id,
-            "Ignoring inherited CSA_SESSION_ID for `csa review`; pass --session to resume explicitly"
-        );
-    }
-
-    let execution = crate::pipeline::execute_with_session_and_meta_with_parent_source(
-        &executor,
-        &tool,
-        &effective_prompt,
-        OutputFormat::Json,
-        session,
-        Some(description),
-        None,
-        project_root,
-        project_config,
-        extra_env,
-        Some("review"),
-        tier_name.as_deref(),
-        None,
-        stream_mode,
-        idle_timeout_seconds,
-        initial_response_timeout_seconds,
-        None,
-        None,
-        Some(global_config),
-        crate::pipeline::ParentSessionSource::ExplicitOnly,
-        no_fs_sandbox,
-        readonly_project_root,
-        extra_writable,
-    )
-    .await?;
-
-    persist_review_routing_artifact(project_root, &execution.meta_session_id, &review_routing);
-
-    Ok(execution)
-}
-
-/// Compute a SHA-256 content hash of the diff being reviewed.
-///
-/// The fingerprint enables diff-level deduplication: if two review
-/// invocations produce the same diff content (e.g., revert-then-revert),
-/// the second can reuse the first review's result.
-fn compute_diff_fingerprint(project_root: &Path, scope: &str) -> Option<String> {
-    use sha2::{Digest, Sha256};
-
-    let diff_args: Vec<&str> = if scope == "uncommitted" {
-        vec!["diff", "HEAD"]
-    } else if let Some(range) = scope.strip_prefix("range:") {
-        vec!["diff", range]
-    } else if let Some(base) = scope.strip_prefix("base:") {
-        vec!["diff", base]
-    } else {
-        return None;
-    };
-
-    let output = std::process::Command::new("git")
-        .args(&diff_args)
-        .current_dir(project_root)
-        .output()
-        .ok()?;
-
-    if !output.status.success() || output.stdout.is_empty() {
-        return None;
-    }
-
-    let digest = Sha256::digest(&output.stdout);
-    Some(format!("sha256:{digest:x}"))
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -1,0 +1,144 @@
+//! Review execution helpers extracted from `review_cmd.rs`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use csa_config::{ExecutionEnvOptions, GlobalConfig, ProjectConfig};
+use csa_core::types::{OutputFormat, ToolName};
+use tracing::{info, warn};
+
+use crate::review_routing::{ReviewRoutingMetadata, persist_review_routing_artifact};
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn execute_review(
+    tool: ToolName,
+    prompt: String,
+    session: Option<String>,
+    model: Option<String>,
+    tier_model_spec: Option<String>,
+    tier_name: Option<String>,
+    thinking: Option<String>,
+    description: String,
+    project_root: &Path,
+    project_config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+    review_routing: ReviewRoutingMetadata,
+    stream_mode: csa_process::StreamMode,
+    idle_timeout_seconds: u64,
+    initial_response_timeout_seconds: Option<u64>,
+    force_override_user_config: bool,
+    no_fs_sandbox: bool,
+    readonly_project_root: bool,
+    extra_writable: &[PathBuf],
+) -> Result<crate::pipeline::SessionExecutionResult> {
+    let enforce_tier = tier_model_spec.is_some();
+    let executor = crate::pipeline::build_and_validate_executor(
+        &tool,
+        tier_model_spec.as_deref(),
+        model.as_deref(),
+        thinking.as_deref(),
+        crate::pipeline::ConfigRefs {
+            project: project_config,
+            global: Some(global_config),
+        },
+        enforce_tier,
+        force_override_user_config,
+        false, // review must not inherit `csa run` per-tool defaults
+    )
+    .await?;
+
+    let can_edit =
+        project_config.is_none_or(|cfg| cfg.can_tool_edit_existing(executor.tool_name()));
+    let can_write_new =
+        project_config.is_none_or(|cfg| cfg.can_tool_write_new(executor.tool_name()));
+    let effective_prompt = if !can_edit || !can_write_new {
+        info!(
+            tool = %executor.tool_name(),
+            can_edit,
+            can_write_new,
+            "Applying filesystem restrictions via prompt injection"
+        );
+        executor.apply_restrictions(&prompt, can_edit, can_write_new)
+    } else {
+        prompt
+    };
+
+    let extra_env_owned = global_config.build_execution_env(
+        executor.tool_name(),
+        ExecutionEnvOptions::with_no_flash_fallback(),
+    );
+    let extra_env = extra_env_owned.as_ref();
+    let _slot_guard = crate::pipeline::acquire_slot(&executor, global_config)?;
+
+    if session.is_none()
+        && let Ok(inherited_session_id) = std::env::var("CSA_SESSION_ID")
+    {
+        warn!(
+            inherited_session_id = %inherited_session_id,
+            "Ignoring inherited CSA_SESSION_ID for `csa review`; pass --session to resume explicitly"
+        );
+    }
+
+    let execution = crate::pipeline::execute_with_session_and_meta_with_parent_source(
+        &executor,
+        &tool,
+        &effective_prompt,
+        OutputFormat::Json,
+        session,
+        Some(description),
+        None,
+        project_root,
+        project_config,
+        extra_env,
+        Some("review"),
+        tier_name.as_deref(),
+        None,
+        stream_mode,
+        idle_timeout_seconds,
+        initial_response_timeout_seconds,
+        None,
+        None,
+        Some(global_config),
+        crate::pipeline::ParentSessionSource::ExplicitOnly,
+        no_fs_sandbox,
+        readonly_project_root,
+        extra_writable,
+    )
+    .await?;
+
+    persist_review_routing_artifact(project_root, &execution.meta_session_id, &review_routing);
+
+    Ok(execution)
+}
+
+/// Compute a SHA-256 content hash of the diff being reviewed.
+///
+/// The fingerprint enables diff-level deduplication: if two review
+/// invocations produce the same diff content (e.g., revert-then-revert),
+/// the second can reuse the first review's result.
+pub(super) fn compute_diff_fingerprint(project_root: &Path, scope: &str) -> Option<String> {
+    use sha2::{Digest, Sha256};
+
+    let diff_args: Vec<&str> = if scope == "uncommitted" {
+        vec!["diff", "HEAD"]
+    } else if let Some(range) = scope.strip_prefix("range:") {
+        vec!["diff", range]
+    } else if let Some(base) = scope.strip_prefix("base:") {
+        vec!["diff", base]
+    } else {
+        return None;
+    };
+
+    let output = std::process::Command::new("git")
+        .args(&diff_args)
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+
+    if !output.status.success() || output.stdout.is_empty() {
+        return None;
+    }
+
+    let digest = Sha256::digest(&output.stdout);
+    Some(format!("sha256:{digest:x}"))
+}

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -99,18 +99,11 @@ pub(crate) fn resolve_review_tool(
         let alias_hint = cfg.format_tier_aliases();
         anyhow::bail!(
             "Direct --tool is restricted when tiers are configured. \
-             Use --tier <name> or add --force-ignore-tier-setting to override. \
+             Use --tier <name> to specify which tier's model/thinking config to use, \
+             or add --force-ignore-tier-setting to override. \
              Available tiers: [{}]{alias_hint}",
             available.join(", ")
         );
-    }
-
-    // CLI --tool override wins (when not blocked by tier enforcement above)
-    if let Some(tool) = arg_tool {
-        if let Some(cfg) = project_config {
-            cfg.enforce_tool_enabled(tool.as_str(), force_override_user_config)?;
-        }
-        return Ok((tool, None));
     }
 
     let tier_name = resolve_review_tier_name(
@@ -120,6 +113,27 @@ pub(crate) fn resolve_review_tool(
         force_override_user_config,
         force_ignore_tier_setting,
     )?;
+
+    if let Some(tool) = arg_tool {
+        if let Some(ref tier) = tier_name
+            && let Some(cfg) = project_config
+        {
+            let resolution = crate::run_helpers::resolve_requested_tool_from_tier(
+                tier,
+                cfg,
+                parent_tool,
+                tool,
+                force_override_user_config,
+                &[],
+            )?;
+            return Ok((resolution.tool, Some(resolution.model_spec)));
+        }
+
+        if let Some(cfg) = project_config {
+            cfg.enforce_tool_enabled(tool.as_str(), force_override_user_config)?;
+        }
+        return Ok((tool, None));
+    }
 
     // Compute effective whitelist from tool selection (project > global)
     let effective_whitelist = project_config

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_config::{ProjectProfile, ToolRestrictions};
+use std::path::Path;
 use tempfile::tempdir;
 
 // --- is_worktree_submodule tests ---
@@ -495,7 +497,6 @@ fn verify_review_skill_allow_fallback_without_skill() {
 #[cfg(unix)]
 #[tokio::test]
 async fn execute_review_ignores_inherited_csa_session_id_without_explicit_session() {
-    use crate::test_session_sandbox::ScopedSessionSandbox;
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = tempdir().unwrap();
@@ -542,6 +543,79 @@ async fn execute_review_ignores_inherited_csa_session_id_without_explicit_sessio
 
     let execution = result.expect("review should ignore inherited stale CSA_SESSION_ID");
     assert_eq!(execution.execution.exit_code, 0);
+}
+
+fn write_review_project_config(project_root: &Path, config: &ProjectConfig) {
+    let config_path = ProjectConfig::config_path(project_root);
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(config_path, toml::to_string_pretty(config).unwrap()).unwrap();
+}
+
+fn install_pattern(project_root: &Path, name: &str) {
+    let skill_dir = project_root
+        .join(".csa")
+        .join("patterns")
+        .join(name)
+        .join("skills")
+        .join(name);
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(skill_dir.join("SKILL.md"), "# test pattern\n").unwrap();
+}
+
+#[tokio::test]
+async fn handle_review_persists_result_for_direct_tool_tier_rejection() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    config.tiers.insert(
+        "default".to_string(),
+        csa_config::config::TierConfig {
+            description: "Test tier".to_string(),
+            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            strategy: csa_config::TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    write_review_project_config(project_dir.path(), &config);
+    install_pattern(project_dir.path(), "csa-review");
+
+    let cd = project_dir.path().display().to_string();
+    let args = parse_review_args(&[
+        "csa",
+        "review",
+        "--cd",
+        &cd,
+        "--files",
+        "src/lib.rs",
+        "--tool",
+        "codex",
+    ]);
+
+    let err = handle_review(args, 0)
+        .await
+        .expect_err("direct --tool tier rejection must fail");
+    assert!(
+        err.chain().any(|cause| cause
+            .to_string()
+            .contains("restricted when tiers are configured")),
+        "unexpected error chain: {err:#}"
+    );
+
+    let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
+    assert_eq!(sessions.len(), 1, "expected one failed review session");
+
+    let result = csa_session::load_result(project_dir.path(), &sessions[0].meta_session_id)
+        .unwrap()
+        .expect("result.toml must be written for review tier rejection");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(result.summary.contains("pre-exec:"));
+    assert!(
+        result
+            .summary
+            .contains("restricted when tiers are configured")
+    );
 }
 
 // --- fix loop restriction gate tests ---

--- a/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
@@ -121,6 +121,66 @@ fn test_review_allows_tier_flag() {
 }
 
 #[test]
+fn test_review_tool_plus_tier_resolves_requested_tool_from_tier() {
+    let global = GlobalConfig::default();
+    let cfg = review_config_with_tier(
+        "quality",
+        vec![
+            "gemini-cli/google/default/xhigh",
+            "codex/openai/gpt-5.4/high",
+            "claude-code/anthropic/sonnet-4.6/xhigh",
+        ],
+        &["gemini-cli", "codex", "claude-code"],
+    );
+    let result = resolve_review_tool(
+        Some(ToolName::Codex),
+        Some(&cfg),
+        &global,
+        Some("claude-code"),
+        std::path::Path::new("/tmp/test-project"),
+        false,
+        Some("quality"),
+        false,
+    );
+
+    assert!(
+        result.is_ok(),
+        "tool+tier should resolve requested review tool: {}",
+        result.unwrap_err()
+    );
+    let (tool, model_spec) = result.unwrap();
+    assert_eq!(tool, ToolName::Codex);
+    assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/high"));
+}
+
+#[test]
+fn test_review_tool_plus_tier_errors_when_tool_missing_from_tier() {
+    let global = GlobalConfig::default();
+    let cfg = review_config_with_tier(
+        "quality",
+        vec!["gemini-cli/google/default/xhigh"],
+        &["gemini-cli", "codex"],
+    );
+    let result = resolve_review_tool(
+        Some(ToolName::Codex),
+        Some(&cfg),
+        &global,
+        Some("claude-code"),
+        std::path::Path::new("/tmp/test-project"),
+        false,
+        Some("quality"),
+        false,
+    );
+
+    let err = result.expect_err("missing tool in review tier must error");
+    assert!(
+        err.to_string()
+            .contains("Requested tool 'codex' is not available in tier 'quality'"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn test_review_force_ignore_tier_allows_direct_tool() {
     let global = GlobalConfig::default();
     let cfg = review_config_with_tier(

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -180,6 +180,10 @@ pub(crate) async fn handle_run(
     if let Some(c) = config.as_ref() {
         merged_aliases.extend(c.tool_aliases.iter().map(|(k, v)| (k.clone(), v.clone())));
     }
+    let explicit_tool_name = match skill_res.tool.as_ref() {
+        Some(ToolArg::Specific(tool)) => Some(tool.as_str()),
+        _ => None,
+    };
 
     // Enforce tier routing: when tiers are configured, explicit --tool (any
     // value, including "auto") is blocked unless --tier is also specified or
@@ -193,12 +197,39 @@ pub(crate) async fn handle_run(
     {
         let cfg = config.as_ref().unwrap();
         let tier_list: Vec<&str> = cfg.tiers.keys().map(|s| s.as_str()).collect();
-        anyhow::bail!(
+        let err = anyhow::anyhow!(
             "Direct --tool is blocked when tiers are configured.\n\
-             Use --tier <name> to select a tier, or --force-ignore-tier-setting to bypass.\n\
+             Use --tier <name> to specify which tier's model/thinking config to use, or \
+             --force-ignore-tier-setting to bypass.\n\
              Available tiers: {}",
             tier_list.join(", ")
         );
+        let fallback_description = crate::run_helpers::truncate_prompt(&prompt_text, 80);
+        let pre_exec_description = description
+            .as_deref()
+            .or(skill_session_tag.as_deref())
+            .or(Some(fallback_description.as_str()));
+        let pre_exec_parent = if is_fork {
+            session_arg.as_deref().or(parent.as_deref())
+        } else {
+            parent.as_deref()
+        };
+        return Err(crate::session_guard::persist_pre_exec_error_result(
+            crate::session_guard::PreExecErrorCtx {
+                project_root: &project_root,
+                session_id: if is_fork {
+                    None
+                } else {
+                    session_arg.as_deref()
+                },
+                description: pre_exec_description,
+                parent: pre_exec_parent,
+                tool_name: explicit_tool_name,
+                task_type: Some("run"),
+                tier_name: tier.as_deref(),
+                error: err,
+            },
+        ));
     }
 
     let strategy = skill_res

--- a/crates/cli-sub-agent/src/run_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests.rs
@@ -783,6 +783,9 @@ fn apply_no_verify_commit_policy_sets_failure_when_forbidden_flag_detected() {
     assert!(result.stderr_output.contains("git commit --no-verify"));
 }
 
+#[path = "run_cmd_tier_tests.rs"]
+mod tier_tests;
+
 #[path = "run_cmd_tests_tail.rs"]
 mod tail_tests;
 

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -1,0 +1,135 @@
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_core::types::{OutputFormat, ToolArg};
+use std::collections::HashMap;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn run_config_with_tier(
+    tier_name: &str,
+    models: Vec<&str>,
+    enabled_tools: &[&str],
+) -> csa_config::ProjectConfig {
+    let mut tool_map = HashMap::new();
+    for tool in csa_config::global::all_known_tools() {
+        let name = tool.as_str();
+        tool_map.insert(
+            name.to_string(),
+            csa_config::ToolConfig {
+                enabled: enabled_tools.contains(&name),
+                ..Default::default()
+            },
+        );
+    }
+
+    let mut config = csa_config::ProjectConfig {
+        schema_version: csa_config::config::CURRENT_SCHEMA_VERSION,
+        project: csa_config::ProjectMeta {
+            name: "test".to_string(),
+            created_at: chrono::Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: csa_config::ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: tool_map,
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+    config.tiers.insert(
+        tier_name.to_string(),
+        csa_config::config::TierConfig {
+            description: "Test tier".to_string(),
+            models: models.into_iter().map(String::from).collect(),
+            strategy: csa_config::TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    config
+}
+
+fn write_project_config(project_root: &Path, config: &csa_config::ProjectConfig) {
+    let config_path = csa_config::ProjectConfig::config_path(project_root);
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(config_path, toml::to_string_pretty(config).unwrap()).unwrap();
+}
+
+#[tokio::test]
+async fn handle_run_persists_result_for_direct_tool_tier_rejection() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let config = run_config_with_tier(
+        "default",
+        vec!["gemini-cli/google/default/xhigh"],
+        &["gemini-cli", "codex"],
+    );
+    write_project_config(project_dir.path(), &config);
+
+    let err = handle_run(
+        Some(ToolArg::Specific(ToolName::Codex)),
+        None,
+        Some("inspect the repository".to_string()),
+        None,
+        None,
+        false,
+        None,
+        false,
+        None,
+        false,
+        None,
+        None,
+        false,
+        Some(project_dir.path().display().to_string()),
+        None,
+        None,
+        None,
+        false,
+        false,
+        false,
+        false,
+        None,
+        None,
+        None,
+        false,
+        false,
+        None,
+        0,
+        OutputFormat::Text,
+        csa_process::StreamMode::BufferOnly,
+        None,
+        false,
+        false,
+        Vec::new(),
+    )
+    .await
+    .expect_err("direct --tool tier rejection must return an error");
+
+    assert!(
+        err.chain().any(|cause| cause
+            .to_string()
+            .contains("Direct --tool is blocked when tiers are configured")),
+        "unexpected error chain: {err:#}"
+    );
+
+    let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
+    assert_eq!(sessions.len(), 1, "expected one failed run session");
+
+    let result = csa_session::load_result(project_dir.path(), &sessions[0].meta_session_id)
+        .unwrap()
+        .expect("result.toml must be written for pre-exec tier rejection");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(result.summary.contains("pre-exec:"));
+    assert!(result.summary.contains("Direct --tool is blocked"));
+}

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -57,7 +57,8 @@ pub(crate) fn resolve_tool_and_model(
         let alias_hint = cfg.format_tier_aliases();
         anyhow::bail!(
             "Direct --tool/--model/--model-spec/--thinking is restricted when tiers are configured.\n\
-             Use --tier <name> or add --force-ignore-tier-setting to override.\n\
+             Use --tier <name> to specify which tier's model/thinking config to use, \
+             or add --force-ignore-tier-setting to override.\n\
              Available tiers: [{tier_list}]{alias_hint}\n\
              Hint: omit --tool entirely to use auto-selection, or use --tool auto"
         );
@@ -106,28 +107,43 @@ pub(crate) fn resolve_tool_and_model(
         );
     }
 
-    // Case 0: --tier provided → resolve tool/model from tier definition
+    // Case 0: --tier provided → resolve tool/model from tier definition.
+    // A user-explicit `--tool` acts as a filter inside the selected tier.
     if let Some(ref canonical_name) = canonical_tier
         && let Some(cfg) = config
     {
-        if let Some(resolution) = resolve_tool_from_tier(canonical_name, cfg, None, None, &[]) {
-            // Flow resolved tool through existing enforcement checks
-            cfg.enforce_tool_enabled(resolution.tool.as_str(), force_override_user_config)?;
-            if !force {
-                cfg.enforce_tier_whitelist(resolution.tool.as_str(), Some(&resolution.model_spec))?;
-            }
-            let resolved_model = model.map(|m| {
-                config
-                    .map(|cfg| cfg.resolve_alias(m))
-                    .unwrap_or_else(|| m.to_string())
-            });
-            return Ok((resolution.tool, Some(resolution.model_spec), resolved_model));
+        let resolution = if let Some(requested_tool) = tool.filter(|_| !tool_is_auto_resolved) {
+            resolve_requested_tool_from_tier(
+                canonical_name,
+                cfg,
+                None,
+                requested_tool,
+                force_override_user_config,
+                &[],
+            )?
+        } else if let Some(resolution) =
+            resolve_tool_from_tier(canonical_name, cfg, None, None, &[])
+        {
+            resolution
+        } else {
+            anyhow::bail!(
+                "No available tool found in tier '{}'. Check that at least one tool \
+                     in the tier is enabled and installed.",
+                canonical_name
+            );
+        };
+
+        // Flow resolved tool through existing enforcement checks.
+        cfg.enforce_tool_enabled(resolution.tool.as_str(), force_override_user_config)?;
+        if !force {
+            cfg.enforce_tier_whitelist(resolution.tool.as_str(), Some(&resolution.model_spec))?;
         }
-        anyhow::bail!(
-            "No available tool found in tier '{}'. Check that at least one tool \
-                 in the tier is enabled and installed.",
-            canonical_name
-        );
+        let resolved_model = model.map(|m| {
+            config
+                .map(|cfg| cfg.resolve_alias(m))
+                .unwrap_or_else(|| m.to_string())
+        });
+        return Ok((resolution.tool, Some(resolution.model_spec), resolved_model));
     }
 
     // Case 1: model_spec provided → parse it to get tool
@@ -514,6 +530,53 @@ pub(crate) fn collect_available_tier_models(
             })
         })
         .collect()
+}
+
+/// Resolve a user-requested tool from a tier, preserving tier ordering while
+/// failing clearly when the tool is absent from that tier.
+pub(crate) fn resolve_requested_tool_from_tier(
+    tier_name: &str,
+    config: &ProjectConfig,
+    parent_tool: Option<&str>,
+    requested_tool: ToolName,
+    force_override_user_config: bool,
+    skip_specs: &[String],
+) -> Result<TierToolResolution> {
+    let requested_tool_name = requested_tool.as_str();
+    let Some(tier) = config.tiers.get(tier_name) else {
+        anyhow::bail!("Tier '{}' not found.", tier_name);
+    };
+
+    let tool_in_tier = tier.models.iter().any(|spec| {
+        !skip_specs.iter().any(|skip| skip == spec)
+            && spec
+                .split('/')
+                .next()
+                .is_some_and(|tool_name| tool_name == requested_tool_name)
+    });
+    if !tool_in_tier {
+        anyhow::bail!(
+            "Requested tool '{}' is not available in tier '{}'.",
+            requested_tool_name,
+            tier_name
+        );
+    }
+
+    config.enforce_tool_enabled(requested_tool_name, force_override_user_config)?;
+
+    let whitelist = [requested_tool_name.to_string()];
+    if let Some(resolution) =
+        resolve_tool_from_tier(tier_name, config, parent_tool, Some(&whitelist), skip_specs)
+    {
+        return Ok(resolution);
+    }
+
+    anyhow::bail!(
+        "Requested tool '{}' is configured in tier '{}' but is not currently available. \
+         Ensure it is installed and enabled.",
+        requested_tool_name,
+        tier_name
+    );
 }
 
 /// Resolve a tool from a named tier's models list with heterogeneous preference.

--- a/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
@@ -529,19 +529,17 @@ fn resolve_tool_and_model_tier_flag_resolves_from_tier() {
     );
 }
 
-/// --tier with --tool simultaneously: --tier takes precedence when tiers are configured
-/// (direct tool is blocked), but both --tier and --tool together where --tier resolves first.
 #[test]
-fn resolve_tool_and_model_tier_with_tool_blocked_without_force() {
+fn resolve_tool_and_model_tier_with_tool_resolves_requested_tool_from_tier() {
     let cfg = config_with_tier(
         "quality",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec![
+            "gemini-cli/google/default/xhigh",
+            "codex/openai/gpt-5.4/high",
+            "claude-code/anthropic/sonnet-4.6/xhigh",
+        ],
+        &["gemini-cli", "codex", "claude-code"],
     );
-    // --tier quality --tool codex (without --force-ignore-tier-setting)
-    // Since tiers are configured and tool is Some, the enforcement blocks it.
-    // But --tier is also provided... The enforcement check uses tier.is_none(),
-    // so when --tier IS provided, the direct-tool block does NOT trigger.
     let result = super::resolve_tool_and_model(
         Some(ToolName::Codex),
         None,
@@ -555,15 +553,79 @@ fn resolve_tool_and_model_tier_with_tool_blocked_without_force() {
         false,
         false, // tool_is_auto_resolved
     );
-    // --tier is present, so enforcement skips (tier.is_none() == false).
-    // The --tier branch resolves tool from tier, ignoring the --tool arg.
     assert!(
         result.is_ok(),
-        "tier+tool should resolve via tier: {}",
+        "tier+tool should resolve requested tool from tier: {}",
         result.unwrap_err()
     );
-    let (tool, _, _) = result.unwrap();
-    assert_eq!(tool, ToolName::GeminiCli, "tier should win over --tool");
+    let (tool, model_spec, _) = result.unwrap();
+    assert_eq!(tool, ToolName::Codex);
+    assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/high"));
+}
+
+#[test]
+fn resolve_tool_and_model_tier_with_tool_errors_when_tool_missing_from_tier() {
+    let cfg = config_with_tier(
+        "quality",
+        vec!["gemini-cli/google/default/xhigh"],
+        &["gemini-cli", "codex"],
+    );
+
+    let result = super::resolve_tool_and_model(
+        Some(ToolName::Codex),
+        None,
+        None,
+        Some(&cfg),
+        std::path::Path::new("/tmp"),
+        false,
+        false,
+        false,
+        Some("quality"),
+        false,
+        false,
+    );
+
+    let err = result.expect_err("missing tool in tier must error");
+    assert!(
+        err.to_string()
+            .contains("Requested tool 'codex' is not available in tier 'quality'"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn resolve_tool_and_model_tier_ignores_auto_resolved_tool_hint() {
+    let cfg = config_with_tier(
+        "quality",
+        vec!["gemini-cli/google/default/xhigh"],
+        &["gemini-cli", "codex"],
+    );
+
+    let result = super::resolve_tool_and_model(
+        Some(ToolName::Codex),
+        None,
+        None,
+        Some(&cfg),
+        std::path::Path::new("/tmp"),
+        false,
+        false,
+        false,
+        Some("quality"),
+        false,
+        true, // tool_is_auto_resolved
+    );
+
+    assert!(
+        result.is_ok(),
+        "auto-resolved tool hint should not constrain tier: {}",
+        result.unwrap_err()
+    );
+    let (tool, model_spec, _) = result.unwrap();
+    assert_eq!(tool, ToolName::GeminiCli);
+    assert_eq!(
+        model_spec.as_deref(),
+        Some("gemini-cli/google/default/xhigh")
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_guard.rs
+++ b/crates/cli-sub-agent/src/session_guard.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 
-use csa_session::{SessionResult, save_result};
+use csa_session::{SessionResult, create_session, save_result, save_session};
 
 /// RAII guard that cleans up a newly created session directory on failure.
 ///
@@ -95,4 +95,82 @@ pub(crate) fn write_pre_exec_error_result(
     }
     // Best-effort cooldown marker
     csa_session::write_cooldown_marker_for_project(project_root, session_id, now);
+}
+
+fn create_pre_exec_failure_session(
+    project_root: &Path,
+    description: Option<&str>,
+    parent: Option<&str>,
+    tool_name: Option<&str>,
+    task_type: Option<&str>,
+    tier_name: Option<&str>,
+) -> anyhow::Result<String> {
+    let mut session = create_session(project_root, description, parent, tool_name)?;
+    session.task_context.task_type = task_type.map(str::to_string);
+    session.task_context.tier_name = tier_name.map(str::to_string);
+    let session_id = session.meta_session_id.clone();
+    if let Err(err) = save_session(&session) {
+        warn!(
+            session_id = %session_id,
+            error = %err,
+            "Failed to persist task context for pre-exec failure session"
+        );
+    }
+    Ok(session_id)
+}
+
+pub(crate) struct PreExecErrorCtx<'ctx> {
+    pub(crate) project_root: &'ctx Path,
+    pub(crate) session_id: Option<&'ctx str>,
+    pub(crate) description: Option<&'ctx str>,
+    pub(crate) parent: Option<&'ctx str>,
+    pub(crate) tool_name: Option<&'ctx str>,
+    pub(crate) task_type: Option<&'ctx str>,
+    pub(crate) tier_name: Option<&'ctx str>,
+    pub(crate) error: anyhow::Error,
+}
+
+/// Persist a structured pre-exec failure result, creating a session when needed.
+///
+/// Returns the original error annotated with `meta_session_id=...` when a session
+/// is available so downstream error handlers can still recover the session ID.
+pub(crate) fn persist_pre_exec_error_result(ctx: PreExecErrorCtx<'_>) -> anyhow::Error {
+    let PreExecErrorCtx {
+        project_root,
+        session_id,
+        description,
+        parent,
+        tool_name,
+        task_type,
+        tier_name,
+        error,
+    } = ctx;
+    let recorded_session_id = match session_id {
+        Some(existing) => Some(existing.to_string()),
+        None => match create_pre_exec_failure_session(
+            project_root,
+            description,
+            parent,
+            tool_name,
+            task_type,
+            tier_name,
+        ) {
+            Ok(created) => Some(created),
+            Err(create_err) => {
+                warn!(
+                    error = %create_err,
+                    task_type = task_type.unwrap_or("unknown"),
+                    "Failed to create session for pre-exec error result"
+                );
+                None
+            }
+        },
+    };
+
+    if let Some(ref sid) = recorded_session_id {
+        write_pre_exec_error_result(project_root, sid, tool_name.unwrap_or("unknown"), &error);
+        error.context(format!("meta_session_id={sid}"))
+    } else {
+        error
+    }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,9 @@
 package = []
 
 [versions]
-csa = "0.1.230"
+csa = "0.1.231"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.230"
+weave = "0.1.231"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

- **Tier-aware tool override**: `--tool codex --tier tier-2-standard` now works — forces a specific tool while resolving model/thinking from the tier's entry. Previously `--tool` was rejected when tiers were configured unless `--force-ignore-tier-setting` was used.
- **Fix #584**: Tier validation failures now write `result.toml` via `persist_pre_exec_error_result` helper, so orchestrators see structured errors instead of empty session dirs with exit=1.
- **Monolith splits**: `review_cmd.rs` → `review_cmd_execute.rs`, `run_cmd_tests_tail.rs` → `run_cmd_tier_tests.rs`

## Changes

- `session_guard.rs`: New `PreExecErrorCtx` struct + `persist_pre_exec_error_result` helper
- `run_helpers.rs`: `resolve_tool_and_model` passes `--tool` as whitelist to tier resolver; new `resolve_requested_tool_from_tier`
- `debate_cmd_resolve.rs`, `review_cmd_resolve.rs`: Use tier resolution with tool whitelist instead of early-exit
- `run_cmd_execute.rs`, `review_cmd.rs`, `debate_cmd.rs`: Updated conflict checks, persist result.toml on tier errors
- 10 new tests across run/review/debate tier resolution paths

## Test plan

- [x] `just pre-commit` exits 0 (3167 tests + 18 E2E)
- [x] Tier-aware tool override resolves correct model/thinking
- [x] Missing tool in tier gives clear error message
- [x] `--force-ignore-tier-setting` backward compatible
- [x] Tier validation failure writes result.toml
- [x] Monolith files under 800 lines

Fixes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)