### PR TITLE
fix(pr-bot): forbid squash merge to preserve per-commit audit trail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,85 @@
-drafts/CLAUDE.md
+# CLAUDE.md - csa (cli-sub-agent)
+
+Recursive Agent Container: Standardized, composable Unix processes for LLM CLI tools.
+CSA wraps four heterogeneous AI coding tools (claude-code, codex, gemini-cli, opencode)
+behind a unified CLI, providing session management, resource sandboxing, consensus-based
+review, and fractal sub-agent spawning. Each `csa` invocation is an isolated Unix process
+with its own ULID-identified session, lock files, and lifecycle tracking.
+
+## Commands
+
+Most commands are documented in `csa --help` and subcommand help (`csa <subcommand> --help`).
+
+High-frequency command groups:
+
+- Development: `just pre-commit`, `just clippy`, `just test`, `just fmt`.
+- Execution: `csa run`, `csa review`, `csa debate`.
+- Session management: `csa session list|result|logs|fork|checkpoint`.
+- Planning: `csa todo ...` and `csa plan run workflow.toml` (`csa todo show --spec` renders persisted
+  spec criteria from `spec.toml` when present). `csa todo ref list|show|add|import-transcript`
+  for progressive disclosure references.
+- Token estimation: `csa tokuin estimate [files...]`.
+- Transcript reading: `csa xurl threads`.
+- MCP hub: `csa mcp-hub serve|status|stop|gen-skill`.
+- Ops: `csa doctor`, `csa gc`, `csa migrate`, `csa self-update`.
+
+### Timeout Policy
+
+- **Minimum Timeout**: The absolute wall-clock timeout (`--timeout`) MUST be at least 1800 seconds (30 minutes). Short timeouts waste tokens because the agent starts working but gets killed before producing output. This is enforced at the CLI level.
+
+### CSA Run
+
+```bash
+csa run --fork-call "prompt"                     # fork-call mode (child returns to parent)
+csa run --fork-call --return-to last "prompt"   # return to most recent session
+csa run --fork-call --return-to <ULID> "prompt" # return to specific session
+```
+
+## Git Workflow
+
+Feature branches ONLY (`feat/`/`fix/`/`refactor/`/`docs/`/`test/`/`chore/`), NEVER push to `dev`/`main` directly. Full pipeline (branch→plan→implement→review→PR→merge) is enforced by `dev2merge` pattern via `csa plan run`. Do NOT rely on LLM instruction-following for pipeline steps — use deterministic weave workflows. CSA tasks MUST NOT include PR creation. Conventional Commits with crate scope. `just pre-commit` before every commit.
+PRs MUST be merged with merge commits (`gh pr merge --merge`), NEVER squash (`--squash`). Each commit contains AI Reviewer Metadata for audit trails; squash merge destroys this per-commit history.
+→ `.agents/project-rules-ref/git-workflow.md`
+
+## Planning (MANDATORY)
+
+NEVER use Claude Code's native `EnterPlanMode`. Always use `/mktd` skill instead,
+which provides debate-enhanced planning with CSA reconnaissance and adversarial review.
+
+## Task Tracking (MANDATORY)
+
+Any insight, requirement, or issue discovered mid-work MUST be immediately
+recorded via `TaskCreate` before continuing. This includes:
+
+- CSA failures (timeout, quota, unexpected kill)
+- Mid-task requirement changes from user
+- Bugs or design issues discovered during implementation
+- CLI syntax errors found in skills/patterns
+- Configuration gaps (missing timeout, wrong defaults)
+
+**Why**: Context compaction and CSA session kills lose unrecorded information.
+TaskCreate persists across compaction and session boundaries.
+
+## Verification
+
+- Commit: `just pre-commit` exit 0
+- Feature complete: `cargo test` exit 0 + `git status` clean + branch is not main/dev
+- CSA run: session result written to `~/.local/state/cli-sub-agent/`
+- PR ready: `csa review --diff` verdict is Pass
+
+## Compact Instructions
+
+After `/compact`, restore context:
+1. Read `CLAUDE.md` and `.claude/rules/csa-architecture-ref.md`
+2. Run `csa todo show` for current task state
+3. Check `git log --oneline -5` and `git status` for working state
+4. Check TaskList for in-progress items
+
+## Memory
+
+Architecture decisions and user preferences in auto-memory system.
+Check MEMORY.md for: timeout policy, config state, tool preferences, feedback history.
+
+### Process Issues
+
+When discovering workflow/process issues, fix them in the relevant skill/pattern/workflow/CSA hook files so ALL CSA users benefit. Agent memory is for user preferences and project context only — never use it as a substitute for fixing the actual skill/pattern code.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.234"
+version = "0.1.235"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -250,7 +250,7 @@ max_recursion_depth = 5
 #                                            #          "@<name> review" for others
 # cloud_bot_wait_seconds = 250               # Quiet wait before polling (default: 250)
 # cloud_bot_poll_max_seconds = 250           # Max poll duration after quiet wait (default: 250)
-# merge_strategy = "merge"                   # "merge" | "rebase" | "squash" (default: "merge")
+# merge_strategy = "merge"                   # "merge" | "rebase" (squash is forbidden, default: "merge")
 # delete_branch = false                      # Delete remote branch after merge (default: false)
 
 # ─── Aliases ────────────────────────────────────────────────────

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -1210,8 +1210,8 @@ No issues found by bot. Proceed to merge.
 
 > **Layer**: 0 (Orchestrator) -- git history cleanup before merge.
 > **Status**: Disabled. With `--merge` (not `--squash`), rebase destroys the
-> per-commit audit trail instead of cleaning it up. Set `REBASE_ENABLED=true`
-> to re-enable for squash-merge workflows.
+> per-commit audit trail instead of cleaning it up.
+> Squash merges are forbidden for audit reasons.
 
 Tool: bash
 

--- a/patterns/pr-bot/skills/pr-bot/SKILL.md
+++ b/patterns/pr-bot/skills/pr-bot/SKILL.md
@@ -131,7 +131,7 @@ cloud_bot_name = "gemini-code-assist"      # bot name (for @mention and display)
 cloud_bot_trigger = "auto"                 # "auto" (bot auto-reviews) | "comment" (@bot review)
 cloud_bot_login = ""                       # bot GitHub login override (default: "${cloud_bot_name}[bot]")
 cloud_bot_retrigger_command = ""           # command to re-trigger after fix push (default: derived from name)
-merge_strategy = "merge"                   # "merge" | "rebase" | "squash"
+merge_strategy = "merge"                   # "merge" | "rebase" (squash is forbidden for audit)
 delete_branch = false                      # delete remote branch after merge
 ```
 
@@ -198,7 +198,7 @@ breaks prompt-guard propagation.
 8. **Fix non-stale real issues**: For surviving Category C comments, fix using `csa review --fix` to resume the reviewer session (preserves review context, avoids 50K+ token waste of spawning fresh). Commit fixes, then run `csa review --range main...HEAD` (review gate) BEFORE pushing — unreviewed fix code must not reach the remote.
 9. **Continue loop**: Push fixes and loop back (next trigger is issued in Step 4). Track iteration count via `REVIEW_ROUND`. When `REVIEW_ROUND` reaches `MAX_REVIEW_ROUNDS` (default: 10), STOP and present options to the user: (A) Merge now, (B) Continue for more rounds, (C) Abort and investigate manually. The workflow MUST NOT auto-merge or auto-abort at the round limit.
 10. **Clean resubmission** (if fixes accumulated): Create clean branch for final review.
-10.5. ~~**Rebase for clean history**~~: DISABLED. With merge commits (not squash), rebase destroys per-commit audit trail. Set `REBASE_ENABLED=true` to re-enable for squash-merge workflows.
+10.5. ~~**Rebase for clean history**~~: DISABLED. With merge commits (not squash), rebase destroys per-commit audit trail. Squash merges are forbidden for audit reasons.
 11. **Merge**: When `cloud_bot=false`, leave audit trail comment explaining merge rationale (bot disabled + local review CLEAN). When `cloud_bot=true`, bot must have confirmed no issues before reaching this step (timeout aborts the workflow, never falls through to merge). Read merge strategy from `csa config get pr_review.merge_strategy --default merge` and branch deletion from `csa config get pr_review.delete_branch --default false`. Then `gh pr merge --${MERGE_STRATEGY} [--delete-branch]`, then `git fetch origin && git checkout main && git merge origin/main --ff-only`.
 
 ## Example Usage

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -1505,8 +1505,8 @@ tool = "bash"
 prompt = '''
 > **Layer**: 0 (Orchestrator) -- git history cleanup before merge.
 > **Status**: Disabled. With `--merge` (not `--squash`), rebase destroys the
-> per-commit audit trail instead of cleaning it up. Set `REBASE_ENABLED=true`
-> to re-enable for squash-merge workflows.
+> per-commit audit trail instead of cleaning it up.
+> Squash merges are forbidden for audit reasons.
 
 Tool: bash
 


### PR DESCRIPTION
## Summary
- Replace all --squash with --merge across 9 files (skills, patterns, workflows, hooks, test plans)
- Update CLAUDE.md: no-squash rule + fix-in-skills-not-memory rule
- Hooks that were symlinks to read-only FS replaced with standalone files

## Test plan
- [x] just pre-commit passes (3176 unit + 18 e2e)
- [x] CSA cumulative review PASS
- [x] grep -ri squash shows no valid merge strategy hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)