### PR TITLE
fix(weave): use literal strings for bash prompts in plan_to_toml (#580)

### DIFF
--- a/.claude/rules/csa-architecture-ref.md
+++ b/.claude/rules/csa-architecture-ref.md
@@ -20,7 +20,7 @@ Dual-axis isolation model: `ResourceCapability` (CgroupV2/Setrlimit/None) for me
 
 ## Session Management
 
-`Genealogy` parent-child tracking. Two fork methods: `Native` (ACP session reload, saves 30-60K tokens) and `Soft` (context summary injection). `ReturnPacket` protocol for fork-call return. Fork rate limit: 10/minute per parent. `SessionPhase` state machine: Active↔Available↔Retired. Seed sessions for warm fork. Idle timeout → liveness poll → two-phase kill. Defaults: idle 250s, dead 600s, grace 5s. **Process lifetime**: ALL child processes (including `nohup`/`disown`) are killed on session end via process group kill + cgroup scope cleanup. To outlive CSA, start processes from the caller (`systemd-run --user --scope`).
+`Genealogy` parent-child tracking. Two fork methods: `Native` (ACP session reload, saves 30-60K tokens) and `Soft` (context summary injection). `ReturnPacket` protocol for fork-call return. Fork rate limit: 10/minute per parent. `SessionPhase` state machine: Active↔Available↔Retired. Seed sessions for warm fork. Idle timeout → liveness poll → two-phase kill. Defaults: idle 250s, dead 600s, grace 5s. **Process lifetime**: ALL child processes (including `nohup`/`disown`) are killed on session end via process group kill + cgroup scope cleanup. To outlive CSA, start processes from the caller (`systemd-run --user --scope`). `csa session wait` calls MUST be sequential (never parallel). Claude Code's parallel tool cancellation + 250s KV timeout causes token waste and context rot when parallel waits are used.
 → `.agents/project-rules-ref/session-management.md`
 
 ## Debate & Review

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ High-frequency command groups:
 
 - **Minimum Timeout**: The absolute wall-clock timeout (`--timeout`) MUST be at least 1800 seconds (30 minutes). Short timeouts waste tokens because the agent starts working but gets killed before producing output. This is enforced at the CLI level.
 
+### Session Wait
+
+- **NEVER** call multiple `csa session wait` in parallel Bash tool calls. Claude Code cancels sibling parallel calls when one times out (250s KV cache warming), wasting tokens and aggravating context rot. Always wait for sessions **sequentially**, generating tokens between each wait to keep the KV cache warm.
+
 ### CSA Run
 
 ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3894,7 +3894,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3966,6 +3966,19 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -4367,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "clap",
@@ -4379,6 +4392,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml 1.0.7+spec-1.1.0",
+ "toml_edit 0.25.5+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "which 8.0.2",
@@ -4915,6 +4929,9 @@ name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.236"
+version = "0.1.237"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -35,6 +35,7 @@ reqwest = { version = "0.13", features = ["json", "rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.0"
+toml_edit = "0.25"
 chrono = { version = "0.4", features = ["serde"] }
 ulid = { version = "1.1", features = ["serde"] }
 

--- a/crates/weave/Cargo.toml
+++ b/crates/weave/Cargo.toml
@@ -19,6 +19,7 @@ csa-config.workspace = true
 clap.workspace = true
 serde.workspace = true
 toml.workspace = true
+toml_edit.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/weave/src/compiler.rs
+++ b/crates/weave/src/compiler.rs
@@ -494,11 +494,55 @@ struct WorkflowWrapper {
 }
 
 /// Serialize an execution plan to TOML (uses `[workflow]` key).
+///
+/// Prompts for bash steps (or prompts containing backslashes) are emitted as
+/// TOML literal strings (`'''…'''`) so that backslash-heavy content is not
+/// mangled by escape processing.  If a prompt contains the literal-string
+/// delimiter `'''` or a carriage return (`\r`), we fall back to the default
+/// escaped basic string because TOML literal strings cannot represent those.
 pub fn plan_to_toml(plan: &ExecutionPlan) -> Result<String> {
     let wrapper = WorkflowWrapper {
         workflow: plan.clone(),
     };
-    toml::to_string_pretty(&wrapper).map_err(|e| anyhow::anyhow!("TOML serialization failed: {e}"))
+    let pretty = toml::to_string_pretty(&wrapper)
+        .map_err(|e| anyhow::anyhow!("TOML serialization failed: {e}"))?;
+
+    // Post-process: convert prompts that benefit from literal strings.
+    let mut doc: toml_edit::DocumentMut = pretty
+        .parse()
+        .map_err(|e| anyhow::anyhow!("toml_edit parse failed: {e}"))?;
+
+    if let Some(workflow) = doc.get_mut("workflow")
+        && let Some(steps) = workflow.get_mut("steps")
+        && let Some(arr) = steps.as_array_of_tables_mut()
+    {
+        for (i, step) in arr.iter_mut().enumerate() {
+            let needs_literal = plan
+                .steps
+                .get(i)
+                .is_some_and(|s| s.tool.as_deref() == Some("bash") || s.prompt.contains('\\'));
+            if !needs_literal {
+                continue;
+            }
+            let text = &plan.steps[i].prompt;
+            // Literal strings cannot contain ''' or \r.
+            if text.contains("'''") || text.contains('\r') {
+                continue;
+            }
+            // Build a literal-string Value by parsing a tiny TOML snippet.
+            // toml_edit preserves the repr through parse, so the resulting
+            // Value carries the literal-string encoding.
+            let snippet = format!("v = '''\n{}'''", text);
+            if let Ok(tiny) = snippet.parse::<toml_edit::DocumentMut>()
+                && let Some(val) = tiny.get("v").and_then(|i| i.as_value()).cloned()
+                && let Some(prompt_item) = step.get_mut("prompt")
+            {
+                *prompt_item = toml_edit::Item::Value(val);
+            }
+        }
+    }
+
+    Ok(doc.to_string())
 }
 
 /// Deserialize an execution plan from TOML.
@@ -512,3 +556,7 @@ pub fn plan_from_toml(toml_str: &str) -> Result<ExecutionPlan> {
 #[cfg(test)]
 #[path = "compiler_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "compiler_literal_tests.rs"]
+mod literal_tests;

--- a/crates/weave/src/compiler_literal_tests.rs
+++ b/crates/weave/src/compiler_literal_tests.rs
@@ -1,0 +1,113 @@
+use super::*;
+use crate::parser::parse_skill;
+
+// ---------------------------------------------------------------------------
+// Literal strings for bash prompts (regression: backslashes)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_bash_prompt_uses_literal_string() {
+    let input = r#"---
+name = "literal-test"
+---
+## Run Build
+Tool: bash
+cargo build --release 2>&1 | grep -E "error\[E"
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    let toml_str = plan_to_toml(&plan).unwrap();
+
+    // The serialized TOML must use literal strings (''') for the bash prompt
+    // so that backslashes are not interpreted as escape sequences.
+    assert!(
+        toml_str.contains("'''"),
+        "bash prompt should use literal strings, got:\n{toml_str}"
+    );
+    // Must NOT contain escaped backslash sequences like \\[
+    assert!(
+        !toml_str.contains(r#"\\["#),
+        "bash prompt should not double-escape backslashes, got:\n{toml_str}"
+    );
+
+    // Round-trip: the deserialized prompt must match the original.
+    let restored = plan_from_toml(&toml_str).unwrap();
+    assert_eq!(plan.steps[0].prompt, restored.steps[0].prompt);
+}
+
+#[test]
+fn test_non_bash_prompt_without_backslash_unchanged() {
+    let input = r#"---
+name = "no-literal"
+---
+## Review Code
+Tool: claude-code
+Review the code for issues.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    let toml_str = plan_to_toml(&plan).unwrap();
+
+    // Non-bash prompts without backslashes should NOT use literal strings.
+    assert!(
+        !toml_str.contains("'''"),
+        "non-bash prompt without backslash should use basic string, got:\n{toml_str}"
+    );
+
+    let restored = plan_from_toml(&toml_str).unwrap();
+    assert_eq!(plan.steps[0].prompt, restored.steps[0].prompt);
+}
+
+#[test]
+fn test_prompt_with_triple_quote_fallback() {
+    // If a prompt contains ''', it cannot be a literal string.
+    let plan = ExecutionPlan {
+        name: "fallback-test".into(),
+        description: String::new(),
+        variables: vec![],
+        steps: vec![PlanStep {
+            id: 1,
+            title: "Tricky".into(),
+            tool: Some("bash".into()),
+            prompt: "echo '''hello'''".into(),
+            tier: None,
+            depends_on: vec![],
+            on_fail: FailAction::Abort,
+            condition: None,
+            loop_var: None,
+            session: None,
+        }],
+    };
+
+    let toml_str = plan_to_toml(&plan).unwrap();
+    // Should fall back to basic string (no literal ''').
+    // The prompt should still round-trip correctly.
+    let restored = plan_from_toml(&toml_str).unwrap();
+    assert_eq!(plan.steps[0].prompt, restored.steps[0].prompt);
+}
+
+#[test]
+fn test_backslash_in_non_bash_prompt_uses_literal() {
+    let input = r#"---
+name = "backslash-nonbash"
+---
+## Analyze
+Tool: claude-code
+Find files matching pattern: src\main\java
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    let toml_str = plan_to_toml(&plan).unwrap();
+
+    // Even non-bash prompts with backslashes should get literal strings.
+    assert!(
+        toml_str.contains("'''"),
+        "prompt with backslash should use literal string, got:\n{toml_str}"
+    );
+
+    let restored = plan_from_toml(&toml_str).unwrap();
+    assert_eq!(plan.steps[0].prompt, restored.steps[0].prompt);
+}


### PR DESCRIPTION
## Summary
- Post-process `plan_to_toml()` output with `toml_edit` to convert bash step prompts to TOML literal strings (`'''`)
- Prevents TOML parse errors from unescaped backslashes in sed/shell patterns
- Falls back to escaped string for prompts containing `'''` or `\r`
- Adds sequential session-wait rule to CLAUDE.md and architecture ref

## Changes
- Added `toml_edit` as workspace dependency
- Modified `plan_to_toml()` in `compiler.rs` with post-processing pass
- 4 new regression tests in `compiler_literal_tests.rs`
- Documentation updates for session wait rules

Fixes #580

## Test plan
- [x] `cargo test -p weave` — 204 tests pass
- [x] `cargo clippy -p weave` — clean
- [x] `just pre-commit` — all hooks pass
- [x] Cumulative review — PASS

Generated with [Claude Code](https://claude.com/claude-code)