### PR TITLE
fix(plan): preserve manual and await-user workflow stops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.252"
+version = "0.1.253"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -35,6 +35,9 @@ mod plan_cmd_exec;
 #[cfg(test)]
 use plan_cmd_exec::{extract_bash_code_block, truncate};
 
+#[path = "plan_cmd_flow.rs"]
+mod plan_cmd_flow;
+
 #[path = "plan_cmd_steps.rs"]
 mod plan_cmd_steps;
 use plan_cmd_steps::{PlanRunContext, execute_plan_with_journal};
@@ -214,7 +217,13 @@ fn load_plan_resume_context(
 
     let same_workflow = journal.workflow_name == plan.name
         && journal.workflow_path == normalize_path(workflow_path);
-    if !same_workflow || journal.status == "completed" {
+    let status_prevents_resume = matches!(
+        journal.status.as_str(),
+        "completed" | "awaiting-user" | "manual-handoff"
+    );
+    if !same_workflow
+        || status_prevents_resume && !(explicit_resume && journal.status == "manual-handoff")
+    {
         return Ok(PlanResumeContext {
             initial_vars,
             completed_steps: HashSet::new(),
@@ -543,6 +552,27 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
 
     // 8. Print summary
     print_summary(&results, total_start.elapsed().as_secs_f64());
+
+    if journal.status == "manual-handoff" {
+        apply_repo_fingerprint(&mut journal, &detect_repo_fingerprint(&project_root));
+        persist_plan_journal(&journal_path, &journal)?;
+        eprintln!(
+            "Workflow '{}' paused for manual handoff. Complete the requested main-agent action, then resume with `csa plan run --sa-mode true --resume {}`.",
+            plan.name,
+            journal_path.display()
+        );
+        return Ok(());
+    }
+
+    if journal.status == "awaiting-user" {
+        apply_repo_fingerprint(&mut journal, &detect_repo_fingerprint(&project_root));
+        persist_plan_journal(&journal_path, &journal)?;
+        eprintln!(
+            "Workflow '{}' is awaiting user action. Re-run the workflow from the beginning after the requested remediation is complete.",
+            plan.name
+        );
+        return Ok(());
+    }
 
     // 9. Warn about unsupported skips (loop_var)
     let unsupported_skips = results

--- a/crates/cli-sub-agent/src/plan_cmd_flow.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_flow.rs
@@ -1,0 +1,123 @@
+use std::path::Path;
+
+use weave::compiler::PlanStep;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum OrchestratorHandoff {
+    ManualResume,
+    AwaitUser,
+}
+
+fn shell_escape_for_command(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub(super) fn format_plan_resume_command(
+    project_root: &Path,
+    workflow_path: &Path,
+    journal_path: Option<&Path>,
+) -> String {
+    if let Some(jp) = journal_path {
+        let display = jp.to_string_lossy();
+        format!(
+            "csa plan run --sa-mode true --resume {}",
+            shell_escape_for_command(&display)
+        )
+    } else {
+        let display_path = workflow_path
+            .strip_prefix(project_root)
+            .unwrap_or(workflow_path);
+        let display = display_path.to_string_lossy();
+        format!(
+            "csa plan run --sa-mode true {}",
+            shell_escape_for_command(&display)
+        )
+    }
+}
+
+pub(super) fn orchestrator_handoff_mode(step: &PlanStep) -> Option<OrchestratorHandoff> {
+    match step.tool.as_deref().map(str::trim) {
+        Some(tool) if tool.eq_ignore_ascii_case("manual") => {
+            Some(OrchestratorHandoff::ManualResume)
+        }
+        Some(tool) if tool.eq_ignore_ascii_case("await-user") => {
+            Some(OrchestratorHandoff::AwaitUser)
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn format_orchestrator_message(step: &PlanStep, mode: OrchestratorHandoff) -> String {
+    let marker = match mode {
+        OrchestratorHandoff::ManualResume => format!("MANUAL_STEP: {}", step.title),
+        OrchestratorHandoff::AwaitUser => format!("AWAIT_USER: {}", step.title),
+    };
+    let guidance = step.prompt.trim();
+    if guidance.is_empty() {
+        marker
+    } else {
+        format!("{marker}\n{guidance}")
+    }
+}
+
+/// Find the next step in the plan after the current step.
+///
+/// Returns the first step with an ID greater than the current step's ID,
+/// which is the sequential successor in a linear workflow.
+pub(super) fn find_next_step<'a>(
+    current: &PlanStep,
+    steps: &'a [PlanStep],
+) -> Option<&'a PlanStep> {
+    steps.iter().find(|s| s.id > current.id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_plan_resume_command_uses_journal_path_when_available() {
+        let project_root = Path::new("/tmp/workspace");
+        let workflow_path = Path::new("/tmp/workspace/patterns/dev2merge/workflow.toml");
+        let journal_path = Path::new("/tmp/workspace/.csa/state/plan/dev2merge.journal.json");
+
+        assert_eq!(
+            format_plan_resume_command(project_root, workflow_path, Some(journal_path)),
+            "csa plan run --sa-mode true --resume '/tmp/workspace/.csa/state/plan/dev2merge.journal.json'"
+        );
+    }
+
+    #[test]
+    fn format_plan_resume_command_falls_back_to_workflow_path() {
+        let project_root = Path::new("/tmp/workspace");
+        let workflow_path = Path::new("/tmp/workspace/patterns/dev2merge/workflow.toml");
+
+        assert_eq!(
+            format_plan_resume_command(project_root, workflow_path, None),
+            "csa plan run --sa-mode true 'patterns/dev2merge/workflow.toml'"
+        );
+    }
+
+    #[test]
+    fn format_plan_resume_command_escapes_special_characters() {
+        let project_root = Path::new("/tmp/workspace");
+        let workflow_path = Path::new("/tmp/workspace/patterns/weird name's/workflow.toml");
+
+        assert_eq!(
+            format_plan_resume_command(project_root, workflow_path, None),
+            "csa plan run --sa-mode true 'patterns/weird name'\\''s/workflow.toml'"
+        );
+    }
+
+    #[test]
+    fn format_plan_resume_command_escapes_journal_path_special_characters() {
+        let project_root = Path::new("/tmp/workspace");
+        let workflow_path = Path::new("/tmp/workspace/workflow.toml");
+        let journal_path = Path::new("/tmp/workspace/.csa/state/plan/weird name's.journal.json");
+
+        assert_eq!(
+            format_plan_resume_command(project_root, workflow_path, Some(journal_path)),
+            "csa plan run --sa-mode true --resume '/tmp/workspace/.csa/state/plan/weird name'\\''s.journal.json'"
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/plan_cmd_override_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_override_tests.rs
@@ -10,6 +10,7 @@ fn resolve_step_tool_all_explicit_tools() {
         ("bash", true),         // DirectBash
         ("note", false),        // Note
         ("manual", false),      // Manual
+        ("await-user", false),  // AwaitUser
         ("claude-code", false), // CsaTool
         ("codex", false),       // CsaTool
         ("gemini-cli", false),  // CsaTool
@@ -44,6 +45,11 @@ fn resolve_step_tool_all_explicit_tools() {
             assert!(
                 matches!(target, StepTarget::Manual),
                 "tool=manual must resolve to Manual"
+            );
+        } else if tool_str == "await-user" {
+            assert!(
+                matches!(target, StepTarget::AwaitUser),
+                "tool=await-user must resolve to AwaitUser"
             );
         } else if tool_str == "weave" {
             assert!(
@@ -120,7 +126,7 @@ async fn execute_step_note_skips_without_dispatch() {
 }
 
 #[tokio::test]
-async fn execute_step_manual_fails_closed() {
+async fn execute_step_manual_returns_resumable_handoff() {
     let tmp = tempfile::tempdir().unwrap();
     let step = PlanStep {
         id: 1,
@@ -138,14 +144,58 @@ async fn execute_step_manual_fails_closed() {
 
     let result = execute_step(&step, &vars, tmp.path(), None, None).await;
 
-    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.exit_code, 0);
     assert!(!result.skipped);
     assert!(
         result
             .error
             .as_deref()
             .unwrap_or("")
-            .contains("requires orchestrator handling")
+            .contains("resume the workflow explicitly")
+    );
+    assert!(
+        result
+            .output
+            .as_deref()
+            .unwrap_or("")
+            .contains("MANUAL_STEP: manual-step")
+    );
+}
+
+#[tokio::test]
+async fn execute_step_await_user_returns_instructions() {
+    let tmp = tempfile::tempdir().unwrap();
+    let step = PlanStep {
+        id: 1,
+        title: "await-user-step".into(),
+        tool: Some("await-user".into()),
+        prompt: "User must fix external configuration.".into(),
+        tier: None,
+        depends_on: vec![],
+        on_fail: FailAction::Abort,
+        condition: None,
+        loop_var: None,
+        session: None,
+    };
+    let vars = HashMap::new();
+
+    let result = execute_step(&step, &vars, tmp.path(), None, None).await;
+
+    assert_eq!(result.exit_code, 0);
+    assert!(!result.skipped);
+    assert!(
+        result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("Awaiting user action")
+    );
+    assert!(
+        result
+            .output
+            .as_deref()
+            .unwrap_or("")
+            .contains("AWAIT_USER: await-user-step")
     );
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_override_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_override_tests.rs
@@ -8,6 +8,8 @@ fn resolve_step_tool_all_explicit_tools() {
     // Verify all explicit tool names resolve to the correct StepTarget variant.
     let cases = [
         ("bash", true),         // DirectBash
+        ("note", false),        // Note
+        ("manual", false),      // Manual
         ("claude-code", false), // CsaTool
         ("codex", false),       // CsaTool
         ("gemini-cli", false),  // CsaTool
@@ -32,6 +34,16 @@ fn resolve_step_tool_all_explicit_tools() {
             assert!(
                 matches!(target, StepTarget::DirectBash),
                 "tool={tool_str} must resolve to DirectBash"
+            );
+        } else if tool_str == "note" {
+            assert!(
+                matches!(target, StepTarget::Note),
+                "tool=note must resolve to Note"
+            );
+        } else if tool_str == "manual" {
+            assert!(
+                matches!(target, StepTarget::Manual),
+                "tool=manual must resolve to Manual"
             );
         } else if tool_str == "weave" {
             assert!(
@@ -81,6 +93,60 @@ async fn execute_step_tool_override_replaces_csa_tool() {
         "bash step must not be affected by --tool override"
     );
     assert!(!result.skipped);
+}
+
+#[tokio::test]
+async fn execute_step_note_skips_without_dispatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let step = PlanStep {
+        id: 1,
+        title: "note-step".into(),
+        tool: Some("note".into()),
+        prompt: "This is informational only.".into(),
+        tier: None,
+        depends_on: vec![],
+        on_fail: FailAction::Abort,
+        condition: None,
+        loop_var: None,
+        session: None,
+    };
+    let vars = HashMap::new();
+
+    let result = execute_step(&step, &vars, tmp.path(), None, None).await;
+
+    assert_eq!(result.exit_code, 0);
+    assert!(result.skipped, "note steps must not dispatch to AI tools");
+    assert!(result.error.is_none());
+}
+
+#[tokio::test]
+async fn execute_step_manual_fails_closed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let step = PlanStep {
+        id: 1,
+        title: "manual-step".into(),
+        tool: Some("manual".into()),
+        prompt: "Main agent must handle this.".into(),
+        tier: None,
+        depends_on: vec![],
+        on_fail: FailAction::Abort,
+        condition: None,
+        loop_var: None,
+        session: None,
+    };
+    let vars = HashMap::new();
+
+    let result = execute_step(&step, &vars, tmp.path(), None, None).await;
+
+    assert_eq!(result.exit_code, 1);
+    assert!(!result.skipped);
+    assert!(
+        result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("requires orchestrator handling")
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -15,6 +15,10 @@ use weave::compiler::{ExecutionPlan, FailAction, PlanStep};
 use super::plan_cmd_exec::{
     StepExecutionOutcome, execute_bash_step, execute_csa_step, run_with_heartbeat,
 };
+use super::plan_cmd_flow::{
+    OrchestratorHandoff, find_next_step, format_orchestrator_message, format_plan_resume_command,
+    orchestrator_handoff_mode,
+};
 use super::{
     PlanRunJournal, apply_repo_fingerprint, detect_repo_fingerprint, persist_plan_journal,
     substitute_vars, validate_variable_name,
@@ -36,6 +40,8 @@ pub(crate) enum StepTarget {
     Note,
     /// Manual action that must be handled by the orchestrator, not CSA.
     Manual,
+    /// Stop the workflow and wait for explicit user action before any rerun.
+    AwaitUser,
     /// Dispatch to an AI tool via CSA infrastructure.
     CsaTool {
         tool_name: ToolName,
@@ -80,33 +86,6 @@ pub(super) struct PlanRunContext<'a> {
     pub(super) chunked: bool,
 }
 
-fn shell_escape_for_command(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
-}
-
-fn format_plan_resume_command(
-    project_root: &Path,
-    workflow_path: &Path,
-    journal_path: Option<&Path>,
-) -> String {
-    if let Some(jp) = journal_path {
-        let display = jp.to_string_lossy();
-        format!(
-            "csa plan run --sa-mode true --resume {}",
-            shell_escape_for_command(&display)
-        )
-    } else {
-        let display_path = workflow_path
-            .strip_prefix(project_root)
-            .unwrap_or(workflow_path);
-        let display = display_path.to_string_lossy();
-        format!(
-            "csa plan run --sa-mode true {}",
-            shell_escape_for_command(&display)
-        )
-    }
-}
-
 /// Resolve a step's execution target from its annotations and config.
 ///
 /// Resolution order:
@@ -124,6 +103,7 @@ pub(crate) fn resolve_step_tool(
             "bash" => return Ok(StepTarget::DirectBash),
             "note" => return Ok(StepTarget::Note),
             "manual" => return Ok(StepTarget::Manual),
+            "await-user" => return Ok(StepTarget::AwaitUser),
             "gemini-cli" => return Ok(StepTarget::csa(ToolName::GeminiCli, None)),
             "opencode" => return Ok(StepTarget::csa(ToolName::Opencode, None)),
             "codex" => return Ok(StepTarget::csa(ToolName::Codex, None)),
@@ -156,7 +136,7 @@ pub(crate) fn resolve_step_tool(
             // "weave" = compile-time INCLUDE directive, skip at runtime
             "weave" => return Ok(StepTarget::WeaveInclude),
             other => bail!(
-                "Unknown tool '{}' in step {} ('{}'). Known: bash, note, manual, gemini-cli, opencode, codex, claude-code, csa, weave",
+                "Unknown tool '{}' in step {} ('{}'). Known: bash, note, manual, await-user, gemini-cli, opencode, codex, claude-code, csa, weave",
                 other,
                 step.id,
                 step.title
@@ -278,6 +258,7 @@ pub(super) async fn execute_plan_with_journal(
             run_ctx.tool_override,
         )
         .await;
+        let orchestrator_handoff = orchestrator_handoff_mode(step);
         let is_failure = !result.skipped && result.exit_code != 0;
 
         // Inject step output for subsequent steps (successful steps only).
@@ -312,6 +293,45 @@ pub(super) async fn execute_plan_with_journal(
         );
         if let Some(path) = run_ctx.journal_path {
             persist_plan_journal(path, run_ctx.journal)?;
+        }
+
+        if let Some(handoff_mode) = orchestrator_handoff {
+            run_ctx.journal.status = match handoff_mode {
+                OrchestratorHandoff::ManualResume => "manual-handoff".to_string(),
+                OrchestratorHandoff::AwaitUser => "awaiting-user".to_string(),
+            };
+            run_ctx.journal.last_error = result.error.clone();
+            apply_repo_fingerprint(
+                run_ctx.journal,
+                &detect_repo_fingerprint(run_ctx.project_root),
+            );
+            if let Some(path) = run_ctx.journal_path {
+                persist_plan_journal(path, run_ctx.journal)?;
+            }
+            if run_ctx.chunked {
+                let json = serde_json::to_string(&result)
+                    .expect("StepResult serialization should never fail");
+                println!("{json}");
+                results.push(result);
+                break;
+            }
+            if let Some(output) = result.output.as_deref() {
+                println!("{output}");
+            }
+            if matches!(handoff_mode, OrchestratorHandoff::ManualResume)
+                && let Some(next_step) = find_next_step(step, &plan.steps)
+            {
+                let cmd = format_plan_resume_command(
+                    run_ctx.project_root,
+                    run_ctx.workflow_path,
+                    run_ctx.journal_path,
+                );
+                let required = matches!(next_step.on_fail, FailAction::Abort);
+                println!("MANUAL_STEP_RESUME: {cmd}");
+                eprintln!("{}", format_next_step_directive(&cmd, required));
+            }
+            results.push(result);
+            break;
         }
 
         // Chunked mode: emit the single StepResult as JSON to stdout and stop.
@@ -493,20 +513,40 @@ pub(crate) async fn execute_step(
             };
         }
         StepTarget::Manual => {
-            let error = format!(
-                "Manual step '{}' requires orchestrator handling; csa plan run cannot execute it directly.",
+            let message = format_orchestrator_message(step, OrchestratorHandoff::ManualResume);
+            let status = format!(
+                "Manual handoff required for step '{}'; execute the documented main-agent action, then resume the workflow explicitly.",
                 step.title
             );
-            warn!("{} - {}", label, error);
+            warn!("{} - {}", label, status);
             eprintln!("{label} - MANUAL ACTION REQUIRED");
             return StepResult {
                 step_id: step.id,
                 title: step.title.clone(),
-                exit_code: 1,
+                exit_code: 0,
                 duration_secs: start.elapsed().as_secs_f64(),
                 skipped: false,
-                error: Some(error),
-                output: None,
+                error: Some(status),
+                output: Some(message),
+                session_id: None,
+            };
+        }
+        StepTarget::AwaitUser => {
+            let message = format_orchestrator_message(step, OrchestratorHandoff::AwaitUser);
+            let status = format!(
+                "Awaiting user action for step '{}'; rerun the workflow from the beginning after the remediation is complete.",
+                step.title
+            );
+            warn!("{} - {}", label, status);
+            eprintln!("{label} - AWAITING USER ACTION");
+            return StepResult {
+                step_id: step.id,
+                title: step.title.clone(),
+                exit_code: 0,
+                duration_secs: start.elapsed().as_secs_f64(),
+                skipped: false,
+                error: Some(status),
+                output: Some(message),
                 session_id: None,
             };
         }
@@ -590,7 +630,9 @@ pub(crate) async fn execute_step(
                 )
                 .await
             }
-            StepTarget::Note | StepTarget::Manual => unreachable!("handled above"),
+            StepTarget::Note | StepTarget::Manual | StepTarget::AwaitUser => {
+                unreachable!("handled above")
+            }
             StepTarget::WeaveInclude => unreachable!("handled above"),
         };
         let outcome = match execution_result {
@@ -733,63 +775,4 @@ pub(crate) fn should_inject_assignment_markers(step: &PlanStep) -> bool {
 
 pub(crate) fn is_assignment_marker_key(key: &str) -> bool {
     validate_variable_name(key).is_ok()
-}
-
-/// Find the next step in the plan after the current step.
-///
-/// Returns the first step with an ID greater than the current step's ID,
-/// which is the sequential successor in a linear workflow.
-fn find_next_step<'a>(current: &PlanStep, steps: &'a [PlanStep]) -> Option<&'a PlanStep> {
-    steps.iter().find(|s| s.id > current.id)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn format_plan_resume_command_uses_journal_path_when_available() {
-        let project_root = Path::new("/tmp/workspace");
-        let workflow_path = Path::new("/tmp/workspace/patterns/dev2merge/workflow.toml");
-        let journal_path = Path::new("/tmp/workspace/.csa/state/plan/dev2merge.journal.json");
-
-        assert_eq!(
-            format_plan_resume_command(project_root, workflow_path, Some(journal_path)),
-            "csa plan run --sa-mode true --resume '/tmp/workspace/.csa/state/plan/dev2merge.journal.json'"
-        );
-    }
-
-    #[test]
-    fn format_plan_resume_command_falls_back_to_workflow_path() {
-        let project_root = Path::new("/tmp/workspace");
-        let workflow_path = Path::new("/tmp/workspace/patterns/dev2merge/workflow.toml");
-
-        assert_eq!(
-            format_plan_resume_command(project_root, workflow_path, None),
-            "csa plan run --sa-mode true 'patterns/dev2merge/workflow.toml'"
-        );
-    }
-
-    #[test]
-    fn format_plan_resume_command_escapes_special_characters() {
-        let project_root = Path::new("/tmp/workspace");
-        let workflow_path = Path::new("/tmp/workspace/patterns/weird name's/workflow.toml");
-
-        assert_eq!(
-            format_plan_resume_command(project_root, workflow_path, None),
-            "csa plan run --sa-mode true 'patterns/weird name'\\''s/workflow.toml'"
-        );
-    }
-
-    #[test]
-    fn format_plan_resume_command_escapes_journal_path_special_characters() {
-        let project_root = Path::new("/tmp/workspace");
-        let workflow_path = Path::new("/tmp/workspace/workflow.toml");
-        let journal_path = Path::new("/tmp/workspace/.csa/state/plan/weird name's.journal.json");
-
-        assert_eq!(
-            format_plan_resume_command(project_root, workflow_path, Some(journal_path)),
-            "csa plan run --sa-mode true --resume '/tmp/workspace/.csa/state/plan/weird name'\\''s.journal.json'"
-        );
-    }
 }

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -32,6 +32,10 @@ pub(crate) enum StepTarget {
     DirectBash,
     /// Skip this step (compile-time INCLUDE directive from weave).
     WeaveInclude,
+    /// Non-executable note for human-facing workflow context.
+    Note,
+    /// Manual action that must be handled by the orchestrator, not CSA.
+    Manual,
     /// Dispatch to an AI tool via CSA infrastructure.
     CsaTool {
         tool_name: ToolName,
@@ -108,7 +112,7 @@ fn format_plan_resume_command(
 /// Resolution order:
 /// 1. `step.tool` — explicit tool name (e.g. "bash", "claude-code", "codex")
 /// 2. `step.tier` — tier name looked up in config's `tiers` map
-/// 3. Fallback: "bash" (safest default for v1)
+/// 3. Fallback: default configured AI tool, or codex if no config is present
 pub(crate) fn resolve_step_tool(
     step: &PlanStep,
     config: Option<&ProjectConfig>,
@@ -118,6 +122,8 @@ pub(crate) fn resolve_step_tool(
         let tool_lower = tool_str.to_lowercase();
         match tool_lower.as_str() {
             "bash" => return Ok(StepTarget::DirectBash),
+            "note" => return Ok(StepTarget::Note),
+            "manual" => return Ok(StepTarget::Manual),
             "gemini-cli" => return Ok(StepTarget::csa(ToolName::GeminiCli, None)),
             "opencode" => return Ok(StepTarget::csa(ToolName::Opencode, None)),
             "codex" => return Ok(StepTarget::csa(ToolName::Codex, None)),
@@ -150,7 +156,7 @@ pub(crate) fn resolve_step_tool(
             // "weave" = compile-time INCLUDE directive, skip at runtime
             "weave" => return Ok(StepTarget::WeaveInclude),
             other => bail!(
-                "Unknown tool '{}' in step {} ('{}'). Known: bash, gemini-cli, opencode, codex, claude-code, csa, weave",
+                "Unknown tool '{}' in step {} ('{}'). Known: bash, note, manual, gemini-cli, opencode, codex, claude-code, csa, weave",
                 other,
                 step.id,
                 step.title
@@ -458,19 +464,53 @@ pub(crate) async fn execute_step(
         target
     };
 
-    // Skip weave INCLUDE steps (compile-time directive, not executable at runtime)
-    if matches!(target, StepTarget::WeaveInclude) {
-        info!("{} - Skipping INCLUDE step (compile-time directive)", label);
-        return StepResult {
-            step_id: step.id,
-            title: step.title.clone(),
-            exit_code: 0,
-            duration_secs: 0.0,
-            skipped: true,
-            error: None,
-            output: None,
-            session_id: None,
-        };
+    match target {
+        StepTarget::WeaveInclude => {
+            info!("{} - Skipping INCLUDE step (compile-time directive)", label);
+            return StepResult {
+                step_id: step.id,
+                title: step.title.clone(),
+                exit_code: 0,
+                duration_secs: 0.0,
+                skipped: true,
+                error: None,
+                output: None,
+                session_id: None,
+            };
+        }
+        StepTarget::Note => {
+            info!("{} - NOTE step (non-executable)", label);
+            eprintln!("{label} - NOTE");
+            return StepResult {
+                step_id: step.id,
+                title: step.title.clone(),
+                exit_code: 0,
+                duration_secs: 0.0,
+                skipped: true,
+                error: None,
+                output: None,
+                session_id: None,
+            };
+        }
+        StepTarget::Manual => {
+            let error = format!(
+                "Manual step '{}' requires orchestrator handling; csa plan run cannot execute it directly.",
+                step.title
+            );
+            warn!("{} - {}", label, error);
+            eprintln!("{label} - MANUAL ACTION REQUIRED");
+            return StepResult {
+                step_id: step.id,
+                title: step.title.clone(),
+                exit_code: 1,
+                duration_secs: start.elapsed().as_secs_f64(),
+                skipped: false,
+                error: Some(error),
+                output: None,
+                session_id: None,
+            };
+        }
+        StepTarget::DirectBash | StepTarget::CsaTool { .. } => {}
     }
 
     // CSA prompts use template substitution. Bash steps receive variables via env vars.
@@ -550,6 +590,7 @@ pub(crate) async fn execute_step(
                 )
                 .await
             }
+            StepTarget::Note | StepTarget::Manual => unreachable!("handled above"),
             StepTarget::WeaveInclude => unreachable!("handled above"),
         };
         let outcome = match execution_result {

--- a/crates/cli-sub-agent/src/plan_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests.rs
@@ -117,6 +117,112 @@ fn load_plan_resume_context_rejects_journal_when_repo_fingerprint_changed() {
 }
 
 #[test]
+fn load_plan_resume_context_requires_explicit_resume_for_manual_handoff() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workflow_path = tmp.path().join("workflow.toml");
+    std::fs::write(&workflow_path, "[workflow]\nname='test'\n").unwrap();
+
+    let plan = ExecutionPlan {
+        name: "test".into(),
+        description: String::new(),
+        variables: vec![],
+        steps: vec![],
+    };
+
+    let journal_path = tmp.path().join("test.journal.json");
+    let journal = PlanRunJournal {
+        schema_version: PLAN_JOURNAL_SCHEMA_VERSION,
+        workflow_name: "test".into(),
+        workflow_path: normalize_path(&workflow_path),
+        status: "manual-handoff".into(),
+        vars: HashMap::from([("STEP_1_OUTPUT".to_string(), "cached".to_string())]),
+        completed_steps: vec![1],
+        last_error: Some("manual handoff required".to_string()),
+        repo_head: Some("abc123".to_string()),
+        repo_dirty: Some(false),
+    };
+    persist_plan_journal(&journal_path, &journal).unwrap();
+
+    let repo_fingerprint = RepoFingerprint {
+        head: Some("abc123".to_string()),
+        dirty: Some(false),
+    };
+    let implicit = load_plan_resume_context(
+        &plan,
+        &workflow_path,
+        &journal_path,
+        &HashMap::new(),
+        &repo_fingerprint,
+        false,
+    )
+    .unwrap();
+    assert!(
+        !implicit.resumed,
+        "manual handoff must not auto-resume without explicit --resume"
+    );
+
+    let explicit = load_plan_resume_context(
+        &plan,
+        &workflow_path,
+        &journal_path,
+        &HashMap::new(),
+        &repo_fingerprint,
+        true,
+    )
+    .unwrap();
+    assert!(
+        explicit.resumed,
+        "manual handoff should resume when explicitly requested"
+    );
+}
+
+#[test]
+fn load_plan_resume_context_rejects_awaiting_user_journal_even_with_explicit_resume() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workflow_path = tmp.path().join("workflow.toml");
+    std::fs::write(&workflow_path, "[workflow]\nname='test'\n").unwrap();
+
+    let plan = ExecutionPlan {
+        name: "test".into(),
+        description: String::new(),
+        variables: vec![],
+        steps: vec![],
+    };
+
+    let journal_path = tmp.path().join("test.journal.json");
+    let journal = PlanRunJournal {
+        schema_version: PLAN_JOURNAL_SCHEMA_VERSION,
+        workflow_name: "test".into(),
+        workflow_path: normalize_path(&workflow_path),
+        status: "awaiting-user".into(),
+        vars: HashMap::from([("STEP_1_OUTPUT".to_string(), "cached".to_string())]),
+        completed_steps: vec![1],
+        last_error: Some("awaiting user action".to_string()),
+        repo_head: Some("abc123".to_string()),
+        repo_dirty: Some(false),
+    };
+    persist_plan_journal(&journal_path, &journal).unwrap();
+
+    let repo_fingerprint = RepoFingerprint {
+        head: Some("abc123".to_string()),
+        dirty: Some(false),
+    };
+    let ctx = load_plan_resume_context(
+        &plan,
+        &workflow_path,
+        &journal_path,
+        &HashMap::new(),
+        &repo_fingerprint,
+        true,
+    )
+    .unwrap();
+    assert!(
+        !ctx.resumed,
+        "awaiting-user journals must force a fresh rerun after remediation"
+    );
+}
+
+#[test]
 fn detect_effective_repo_strips_credentials_from_https_origin() {
     let tmp = tempfile::tempdir().unwrap();
     let git_dir = tmp.path();

--- a/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
@@ -176,7 +176,7 @@ fn pr_bot_workflow_marks_non_ai_steps_explicitly() {
         .iter()
         .find(|step| step.title == "Step 5a: Abort — Bot Needs Environment Configuration")
         .expect("missing bot setup abort step");
-    assert_eq!(setup_abort.tool.as_deref(), Some("manual"));
+    assert_eq!(setup_abort.tool.as_deref(), Some("await-user"));
 
     let clean_note = plan
         .steps
@@ -198,6 +198,128 @@ fn dev2merge_workflow_marks_mktsk_step_manual() {
         .find(|step| step.title == "Execute Plan with mktsk")
         .expect("missing dev2merge mktsk step");
     assert_eq!(mktsk_step.tool.as_deref(), Some("manual"));
+}
+
+#[tokio::test]
+async fn execute_plan_stops_after_manual_handoff() {
+    let plan = ExecutionPlan {
+        name: "manual-handoff".into(),
+        description: String::new(),
+        variables: vec![],
+        steps: vec![
+            PlanStep {
+                id: 1,
+                title: "manual-step".into(),
+                tool: Some("manual".into()),
+                prompt: "Use mktsk in the main agent, then resume.".into(),
+                tier: None,
+                depends_on: vec![],
+                on_fail: FailAction::Abort,
+                condition: None,
+                loop_var: None,
+                session: None,
+            },
+            PlanStep {
+                id: 2,
+                title: "should-not-run".into(),
+                tool: Some("bash".into()),
+                prompt: "```bash\ntouch should-not-run\n```".into(),
+                tier: None,
+                depends_on: vec![],
+                on_fail: FailAction::Abort,
+                condition: None,
+                loop_var: None,
+                session: None,
+            },
+        ],
+    };
+    let vars = HashMap::new();
+    let tmp = tempfile::tempdir().unwrap();
+    let workflow_path = tmp.path().join("workflow.toml");
+    let journal_path = tmp.path().join("manual-handoff.journal.json");
+    std::fs::write(&workflow_path, "[workflow]\nname='manual-handoff'\n").unwrap();
+    let completed = std::collections::HashSet::new();
+    let mut journal = PlanRunJournal::new("manual-handoff", &workflow_path, vars.clone());
+    let mut run_ctx = PlanRunContext {
+        project_root: tmp.path(),
+        workflow_path: &workflow_path,
+        config: None,
+        tool_override: None,
+        journal: &mut journal,
+        journal_path: Some(&journal_path),
+        resume_completed_steps: &completed,
+        chunked: false,
+    };
+
+    let results = execute_plan_with_journal(&plan, &vars, &mut run_ctx)
+        .await
+        .expect("manual handoff plan should execute");
+
+    assert_eq!(results.len(), 1, "manual handoff must pause the workflow");
+    assert_eq!(journal.status, "manual-handoff");
+    assert!(journal.completed_steps.contains(&1));
+    assert!(!tmp.path().join("should-not-run").exists());
+}
+
+#[tokio::test]
+async fn execute_plan_stops_for_await_user() {
+    let plan = ExecutionPlan {
+        name: "await-user".into(),
+        description: String::new(),
+        variables: vec![],
+        steps: vec![
+            PlanStep {
+                id: 1,
+                title: "setup-step".into(),
+                tool: Some("await-user".into()),
+                prompt: "Fix the bot configuration before retrying.".into(),
+                tier: None,
+                depends_on: vec![],
+                on_fail: FailAction::Abort,
+                condition: None,
+                loop_var: None,
+                session: None,
+            },
+            PlanStep {
+                id: 2,
+                title: "should-not-run".into(),
+                tool: Some("bash".into()),
+                prompt: "```bash\ntouch should-not-run\n```".into(),
+                tier: None,
+                depends_on: vec![],
+                on_fail: FailAction::Abort,
+                condition: None,
+                loop_var: None,
+                session: None,
+            },
+        ],
+    };
+    let vars = HashMap::new();
+    let tmp = tempfile::tempdir().unwrap();
+    let workflow_path = tmp.path().join("workflow.toml");
+    let journal_path = tmp.path().join("await-user.journal.json");
+    std::fs::write(&workflow_path, "[workflow]\nname='await-user'\n").unwrap();
+    let completed = std::collections::HashSet::new();
+    let mut journal = PlanRunJournal::new("await-user", &workflow_path, vars.clone());
+    let mut run_ctx = PlanRunContext {
+        project_root: tmp.path(),
+        workflow_path: &workflow_path,
+        config: None,
+        tool_override: None,
+        journal: &mut journal,
+        journal_path: Some(&journal_path),
+        resume_completed_steps: &completed,
+        chunked: false,
+    };
+
+    let results = execute_plan_with_journal(&plan, &vars, &mut run_ctx)
+        .await
+        .expect("await-user plan should stop cleanly");
+
+    assert_eq!(results.len(), 1, "await-user must stop the workflow");
+    assert_eq!(journal.status, "awaiting-user");
+    assert!(journal.completed_steps.contains(&1));
+    assert!(!tmp.path().join("should-not-run").exists());
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
@@ -142,20 +142,62 @@ fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
 }
 
-fn load_pr_bot_step(step_id: usize) -> PlanStep {
+fn load_pr_bot_step_by_title(title: &str) -> PlanStep {
     let workflow_path = workspace_root().join("patterns/pr-bot/workflow.toml");
     let workflow = std::fs::read_to_string(&workflow_path).unwrap();
     let plan = plan_from_toml(&workflow).unwrap();
     let step = plan
         .steps
         .into_iter()
-        .find(|step| step.id == step_id)
-        .unwrap_or_else(|| panic!("missing pr-bot step {step_id}"));
+        .find(|step| step.title == title)
+        .unwrap_or_else(|| panic!("missing pr-bot step '{title}'"));
     PlanStep {
         condition: None,
         loop_var: None,
         ..step
     }
+}
+
+#[test]
+fn pr_bot_workflow_marks_non_ai_steps_explicitly() {
+    let workflow_path = workspace_root().join("patterns/pr-bot/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+
+    assert!(
+        plan.steps
+            .iter()
+            .all(|step| step.title != "Dispatcher Model Note"),
+        "dispatcher note must remain informational markdown, not an executable step"
+    );
+
+    let setup_abort = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Step 5a: Abort — Bot Needs Environment Configuration")
+        .expect("missing bot setup abort step");
+    assert_eq!(setup_abort.tool.as_deref(), Some("manual"));
+
+    let clean_note = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Step 10a: Bot Review Clean")
+        .expect("missing bot review clean step");
+    assert_eq!(clean_note.tool.as_deref(), Some("note"));
+}
+
+#[test]
+fn dev2merge_workflow_marks_mktsk_step_manual() {
+    let workflow_path = workspace_root().join("patterns/dev2merge/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+
+    let mktsk_step = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Execute Plan with mktsk")
+        .expect("missing dev2merge mktsk step");
+    assert_eq!(mktsk_step.tool.as_deref(), Some("manual"));
 }
 
 #[test]
@@ -272,7 +314,7 @@ PR_COMMENT_END
 
 #[tokio::test]
 async fn execute_step_bash_posts_pr_audit_trail_for_dismissed_verdict() {
-    let step = load_pr_bot_step(15);
+    let step = load_pr_bot_step_by_title("Step 8a: Post Debate Audit Trail Comment");
     let tmp = tempfile::tempdir().unwrap();
     let capture_path = install_fake_gh(tmp.path());
     let vars = step_15_env(tmp.path(), &capture_path, dismissed_debate_output());
@@ -302,7 +344,7 @@ async fn execute_step_bash_posts_pr_audit_trail_for_dismissed_verdict() {
 
 #[tokio::test]
 async fn execute_step_bash_reroutes_confirmed_verdict_without_posting_comment() {
-    let step = load_pr_bot_step(15);
+    let step = load_pr_bot_step_by_title("Step 8a: Post Debate Audit Trail Comment");
     let tmp = tempfile::tempdir().unwrap();
     let capture_path = install_fake_gh(tmp.path());
     let vars = step_15_env(tmp.path(), &capture_path, confirmed_debate_output());
@@ -336,7 +378,7 @@ async fn execute_step_bash_reroutes_confirmed_verdict_without_posting_comment() 
 
 #[tokio::test]
 async fn execute_step_bash_fails_closed_on_malformed_dismissed_output() {
-    let step = load_pr_bot_step(15);
+    let step = load_pr_bot_step_by_title("Step 8a: Post Debate Audit Trail Comment");
     let tmp = tempfile::tempdir().unwrap();
     let capture_path = install_fake_gh(tmp.path());
     let malformed_output = r#"VERDICT: DISMISSED
@@ -374,7 +416,7 @@ CSA session ID: 01TESTDEBATESESSIONID
 
 #[tokio::test]
 async fn execute_step_bash_fails_closed_on_duplicate_verdict_markers() {
-    let step = load_pr_bot_step(15);
+    let step = load_pr_bot_step_by_title("Step 8a: Post Debate Audit Trail Comment");
     let tmp = tempfile::tempdir().unwrap();
     let capture_path = install_fake_gh(tmp.path());
     let duplicate_verdict_output = r#"VERDICT: DISMISSED

--- a/crates/cli-sub-agent/src/plan_display.rs
+++ b/crates/cli-sub-agent/src/plan_display.rs
@@ -34,6 +34,7 @@ pub(crate) fn print_plan(
             Ok(StepTarget::WeaveInclude) => "weave (include)".into(),
             Ok(StepTarget::Note) => "note (non-executable)".into(),
             Ok(StepTarget::Manual) => "manual (orchestrator-required)".into(),
+            Ok(StepTarget::AwaitUser) => "await-user (user-action required)".into(),
             Ok(StepTarget::CsaTool {
                 tool_name,
                 model_spec,

--- a/crates/cli-sub-agent/src/plan_display.rs
+++ b/crates/cli-sub-agent/src/plan_display.rs
@@ -32,6 +32,8 @@ pub(crate) fn print_plan(
         let tool_info = match resolve_step_tool(step, config) {
             Ok(StepTarget::DirectBash) => "bash (direct)".into(),
             Ok(StepTarget::WeaveInclude) => "weave (include)".into(),
+            Ok(StepTarget::Note) => "note (non-executable)".into(),
+            Ok(StepTarget::Manual) => "manual (orchestrator-required)".into(),
             Ok(StepTarget::CsaTool {
                 tool_name,
                 model_spec,

--- a/crates/weave/src/compiler.rs
+++ b/crates/weave/src/compiler.rs
@@ -101,8 +101,11 @@ const MAX_ITERATIONS_WARN_THRESHOLD: u32 = 50;
 // ---------------------------------------------------------------------------
 
 /// Matches a `Tool: <name>` line at the start of a step body.
+///
+/// Optional trailing prose is allowed so authors can annotate manual/note
+/// steps inline, for example `Tool: manual (main agent action)`.
 static TOOL_HINT_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)^Tool:\s*(\S+)\s*$").expect("valid regex"));
+    LazyLock::new(|| Regex::new(r"(?i)^Tool:\s*(\S+)(?:\s+.*)?$").expect("valid regex"));
 
 /// Matches a `Tier: <name>` line at the start of a step body.
 static TIER_HINT_RE: LazyLock<Regex> =
@@ -249,6 +252,11 @@ struct StepHints {
     prompt: String,
 }
 
+fn is_hint_preamble_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.is_empty() || trimmed.starts_with('>')
+}
+
 /// Extract metadata hints (Tool, Tier, OnFail, MaxIterations) from the first
 /// lines of a step body and return the remaining prompt text.
 fn extract_hints(body: &str) -> StepHints {
@@ -282,10 +290,12 @@ fn extract_hints(body: &str) -> StepHints {
                 max_iterations = caps[1].parse().ok();
                 continue;
             }
-            // First non-hint line ends hint extraction.
-            if !line.trim().is_empty() {
-                in_hints = false;
+            if is_hint_preamble_line(line) {
+                prompt_lines.push(line);
+                continue;
             }
+            // First non-hint line ends hint extraction.
+            in_hints = false;
         }
         prompt_lines.push(line);
     }

--- a/crates/weave/src/compiler_tests.rs
+++ b/crates/weave/src/compiler_tests.rs
@@ -69,6 +69,50 @@ Build the project with cargo.
 }
 
 #[test]
+fn test_compile_step_with_annotated_tool_hint() {
+    let input = r#"---
+name = "annotated-tool"
+---
+## Coordinate Main Agent
+Tool: manual (main agent action)
+Explain what the orchestrator must do next.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(plan.steps.len(), 1);
+    let step = &plan.steps[0];
+    assert_eq!(step.tool.as_deref(), Some("manual"));
+    assert_eq!(step.prompt, "Explain what the orchestrator must do next.");
+}
+
+#[test]
+fn test_compile_step_with_blockquote_preamble_before_hints() {
+    let input = r#"---
+name = "blockquote-preamble"
+---
+## Run Bash
+> **Layer**: 0 (Orchestrator)
+> Shell only.
+
+Tool: bash
+OnFail: abort
+
+```bash
+echo ok
+```
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    let step = &plan.steps[0];
+    assert_eq!(step.tool.as_deref(), Some("bash"));
+    assert_eq!(step.on_fail, FailAction::Abort);
+    assert!(step.prompt.contains("> **Layer**: 0 (Orchestrator)"));
+    assert!(step.prompt.contains("```bash"));
+}
+
+#[test]
 fn test_compile_step_with_tier_hint() {
     let input = r#"---
 name = "tiered"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -190,6 +190,7 @@ echo "CSA_VAR:MKTD_TODO_PATH=${TODO_PATH}"
 ## Step 8: Execute Plan with mktsk
 
 OnFail: abort
+Tool: manual (main agent action)
 
 Invoke the mktsk skill directly (NOT via `csa run`). mktsk MUST run in the
 main agent context so it can use TaskCreate/TaskUpdate for progress tracking.

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -51,10 +51,10 @@ name = "LOCAL_SHA"
 name = "MKTD_TODO_PATH"
 
 [[workflow.variables]]
-name = "MKTD_TODO_TIMESTAMP"
+name = "MKTD_INTENSITY"
 
 [[workflow.variables]]
-name = "MKTD_INTENSITY"
+name = "MKTD_TODO_TIMESTAMP"
 
 [[workflow.variables]]
 name = "MKTD_TOOL_EFFECTIVE"
@@ -117,7 +117,7 @@ name = "VERSION"
 id = 1
 title = "Validate Branch"
 tool = "bash"
-prompt = """
+prompt = '''
 Verify the current branch is a feature branch, not protected.
 
 ```bash
@@ -134,7 +134,7 @@ if [ "$BRANCH" = "$DEFAULT_BRANCH" ] || [ "$BRANCH" = "dev" ]; then
 fi
 echo "CSA_VAR:WORKFLOW_BRANCH=$BRANCH"
 echo "CSA_VAR:DEFAULT_BRANCH=$DEFAULT_BRANCH"
-```"""
+```'''
 on_fail = "abort"
 
 [[workflow.steps]]
@@ -163,20 +163,20 @@ on_fail = "abort"
 id = 3
 title = "L1/L2 Quality Gates (Always Run)"
 tool = "bash"
-prompt = """
+prompt = '''
 Formatters and linters run regardless of FAST_PATH.
 
 ```bash
 just fmt
 just clippy
-```"""
+```'''
 on_fail = "abort"
 
 [[workflow.steps]]
 id = 4
 title = "FAST_PATH Commit"
 tool = "bash"
-prompt = """
+prompt = '''
 For docs/config-only changes, run a simplified commit flow:
 stage, generate message, commit. No mktd/mktsk/security-audit overhead.
 
@@ -191,7 +191,7 @@ fi
 COMMIT_MSG="$(scripts/gen_commit_msg.sh "${SCOPE:-}" 2>/dev/null || echo "docs: update documentation")"
 git commit -m "${COMMIT_MSG}"
 echo "CSA_VAR:FAST_PATH_COMMITTED=true"
-```"""
+```'''
 on_fail = "abort"
 condition = "${FAST_PATH}"
 
@@ -199,7 +199,7 @@ condition = "${FAST_PATH}"
 id = 5
 title = "FAST_PATH Version Bump"
 tool = "bash"
-prompt = """
+prompt = '''
 ```bash
 set -euo pipefail
 if ! just check-version-bumped 2>/dev/null; then
@@ -209,7 +209,7 @@ if ! just check-version-bumped 2>/dev/null; then
   VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')"
   git commit -m "chore(release): bump workspace version to ${VERSION}"
 fi
-```"""
+```'''
 on_fail = "abort"
 condition = "${FAST_PATH}"
 
@@ -284,6 +284,7 @@ condition = "!(${FAST_PATH})"
 [[workflow.steps]]
 id = 8
 title = "Execute Plan with mktsk"
+tool = "manual"
 prompt = """
 Invoke the mktsk skill directly (NOT via csa run). mktsk MUST run in the
 main agent context so it can use TaskCreate/TaskUpdate for progress tracking.
@@ -301,7 +302,7 @@ condition = "!(${FAST_PATH})"
 id = 9
 title = "Ensure Version Bumped"
 tool = "bash"
-prompt = """
+prompt = '''
 ```bash
 set -euo pipefail
 if ! just check-version-bumped 2>/dev/null; then
@@ -311,7 +312,7 @@ if ! just check-version-bumped 2>/dev/null; then
   VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')"
   git commit -m "chore(release): bump workspace version to ${VERSION}"
 fi
-```"""
+```'''
 on_fail = "abort"
 condition = "!(${FAST_PATH})"
 
@@ -352,7 +353,7 @@ condition = "!(${FAST_PATH})"
 id = 11
 title = "Push Gate"
 tool = "bash"
-prompt = """
+prompt = '''
 Hard gate: REVIEW_COMPLETED must be true before any push.
 
 ```bash
@@ -365,7 +366,7 @@ BRANCH="$(git branch --show-current)"
 git push -u origin "${BRANCH}" --force-with-lease
 echo "CSA_VAR:PUSHED=true"
 echo '<!-- CSA:NEXT_STEP cmd="create or reuse PR (Step 12)" required=true -->'
-```"""
+```'''
 on_fail = "abort"
 
 [[workflow.steps]]

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -542,7 +542,7 @@ echo "CSA_VAR:BOT_HAS_ISSUES=$BOT_HAS_ISSUES"
 
 ## Step 5a: Abort — Bot Needs Environment Configuration
 
-Tool: manual (orchestrator action)
+Tool: await-user (orchestrator action)
 OnFail: abort
 
 The Cloud bot responded but did not perform an actual code review — it sent a

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -33,7 +33,7 @@ without SHA verification, auto-merging or auto-aborting at round limit,
 proceeding when bot responds with environment/configuration setup message
 instead of an actual code review (MUST stop and ask user to configure).
 
-## Dispatcher Model Note
+### Dispatcher Model Note
 
 This pattern follows a 3-layer dispatcher architecture:
 - **Layer 0 (Orchestrator)**: The main agent dispatches steps -- never touches code directly.
@@ -542,7 +542,7 @@ echo "CSA_VAR:BOT_HAS_ISSUES=$BOT_HAS_ISSUES"
 
 ## Step 5a: Abort — Bot Needs Environment Configuration
 
-Tool: none (orchestrator action)
+Tool: manual (orchestrator action)
 OnFail: abort
 
 The Cloud bot responded but did not perform an actual code review — it sent a
@@ -1020,6 +1020,9 @@ Loop back to Step 5 (delegated wait gate).
 
 ## Step 10b: Post-Fix Re-Review Gate (HARD GATE)
 
+Tool: bash
+OnFail: abort
+
 After fixing bot findings, verify the bot has actually re-reviewed the current
 HEAD and found zero actionable findings before any merge path can execute.
 
@@ -1040,10 +1043,7 @@ The gate:
 4. If review event found AND clean → clears `BOT_HAS_ISSUES=false` so merge steps can proceed
 5. If no review event within timeout → falls back to local `csa review --range main...HEAD`
 
-Tool: bash
-OnFail: abort
 Condition: !(${BOT_UNAVAILABLE}) && (${BOT_HAS_ISSUES}) && !(${ROUND_LIMIT_REACHED})
-
 Apply the same wait policy as Step 5: `cloud_bot_wait_seconds` quiet wait,
 then up to `cloud_bot_poll_max_seconds` of polling.
 
@@ -1203,6 +1203,8 @@ echo "Post-fix re-review gate PASSED. Merge is now allowed."
 ## ELSE
 
 ## Step 10a: Bot Review Clean
+
+Tool: note
 
 No issues found by bot. Proceed to merge.
 

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -809,7 +809,7 @@ condition = "${CLOUD_BOT}"
 [[workflow.steps]]
 id = 7
 title = "Step 5a: Abort — Bot Needs Environment Configuration"
-tool = "manual"
+tool = "await-user"
 prompt = """
 The Cloud bot responded but did not perform an actual code review — it sent a
 message indicating environment configuration is needed. The workflow MUST stop

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -301,24 +301,11 @@ name = "setup_body"
 
 [[workflow.steps]]
 id = 1
-title = "Dispatcher Model Note"
-prompt = """
-This pattern follows a 3-layer dispatcher architecture:
-- **Layer 0 (Orchestrator)**: The main agent dispatches steps -- never touches code directly.
-- **Layer 1 (Executors)**: CSA sub-agents and Task tool agents perform actual work.
-- **Layer 2 (Sub-sub-agents)**: Spawned by Layer 1 for specific sub-tasks (invisible to Layer 0).
-
-Each step below is annotated with its execution layer."""
-on_fail = "abort"
-
-[[workflow.steps]]
-id = 2
 title = "Commit Changes"
 tool = "bash"
-prompt = """
+prompt = '''
 > **Layer**: 0 (Orchestrator) -- lightweight shell command, no code reading.
 
-Tool: bash
 
 Ensure all changes committed. Set WORKFLOW_BRANCH once (persists through
 clean branch switches in Step 11).
@@ -326,19 +313,17 @@ clean branch switches in Step 11).
 ```bash
 WORKFLOW_BRANCH="$(git branch --show-current)"
 echo "CSA_VAR:WORKFLOW_BRANCH=$WORKFLOW_BRANCH"
-```"""
+```'''
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 3
+id = 2
 title = "Local Pre-PR Review (SYNCHRONOUS — MUST NOT background)"
 tool = "bash"
-prompt = """
+prompt = '''
 > **Layer**: 1 (CSA executor) -- Layer 0 dispatches `csa review`, which spawns
 > Layer 2 reviewer model(s) internally. Orchestrator waits for result.
 
-Tool: bash
-OnFail: abort
 
 Run cumulative local review covering all commits since main.
 This is the FOUNDATION — without it, bot unavailability cannot safely merge.
@@ -362,34 +347,32 @@ fi
 REVIEW_COMPLETED=true
 echo "CSA_VAR:REVIEW_COMPLETED=$REVIEW_COMPLETED"
 echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 4)" required=true -->'
-```"""
+```'''
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 4
+id = 3
 title = "Fix Local Review Issues"
 tool = "csa"
 prompt = """
 > **Layer**: 1 (CSA executor) -- Layer 0 dispatches fix task to CSA. CSA reads
 > code, applies fixes, and returns results. Orchestrator reviews outcome.
 
-Tool: csa
-Tier: tier-4-critical
-OnFail: retry 3
 
 Fix issues found by local review. Loop until clean (max 3 rounds)."""
-on_fail = "abort"
+tier = "tier-4-critical"
 condition = "${LOCAL_REVIEW_HAS_ISSUES}"
 
+[workflow.steps.on_fail]
+retry = 3
+
 [[workflow.steps]]
-id = 5
+id = 4
 title = "Push and Ensure PR"
 tool = "bash"
 prompt = '''
 > **Layer**: 0 (Orchestrator) -- shell commands only, no code reading/writing.
 
-Tool: bash
-OnFail: abort
 
 **PRECONDITION (MANDATORY)**: Step 2 local review MUST have completed successfully.
 - If `REVIEW_COMPLETED` is not `true`, STOP and report:
@@ -510,14 +493,12 @@ echo '<!-- CSA:NEXT_STEP cmd="trigger cloud bot review or merge (Step 4a/5)" req
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 6
+id = 5
 title = "Step 4a: Check Cloud Bot Configuration"
 tool = "bash"
-prompt = """
+prompt = '''
 > **Layer**: 0 (Orchestrator) -- config check, lightweight.
 
-Tool: bash
-OnFail: abort
 
 Check whether cloud bot review is enabled for this project.
 
@@ -599,11 +580,11 @@ If `CLOUD_BOT` is `false`:
 - Reuse the same SHA-verified fast-path before supplementary review:
   - If current `HEAD` matches latest reviewed session HEAD SHA → skip review.
   - Otherwise run full `csa review --branch main`.
-- Route to Step 6a (Merge Without Bot) after supplementary local review gate passes."""
+- Route to Step 6a (Merge Without Bot) after supplementary local review gate passes.'''
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 7
+id = 6
 title = "Trigger Cloud Bot Review and Delegate Waiting"
 tool = "bash"
 prompt = '''
@@ -612,8 +593,6 @@ prompt = '''
 > `cloud_bot_trigger` config and review round) and delegates the long wait to a
 > single CSA-managed step. No explicit caller-side polling loop.
 
-Tool: bash
-OnFail: abort
 Condition: !(${BOT_UNAVAILABLE})
 
 Trigger cloud bot review for current HEAD. Trigger method is **round-aware**:
@@ -825,15 +804,13 @@ echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
 echo "CSA_VAR:BOT_HAS_ISSUES=$BOT_HAS_ISSUES"
 ```'''
 on_fail = "abort"
-condition = '${CLOUD_BOT}'
+condition = "${CLOUD_BOT}"
 
 [[workflow.steps]]
-id = 8
+id = 7
 title = "Step 5a: Abort — Bot Needs Environment Configuration"
+tool = "manual"
 prompt = """
-Tool: none (orchestrator action)
-OnFail: abort
-
 The Cloud bot responded but did not perform an actual code review — it sent a
 message indicating environment configuration is needed. The workflow MUST stop
 here and report to the user. FORBIDDEN: falling back to local review, skipping
@@ -844,18 +821,16 @@ user must:
 1. Configure the cloud bot (follow the bot's instructions)
 2. Re-run `pr-bot` after configuration is complete"""
 on_fail = "abort"
-condition = '(${CLOUD_BOT}) && (${BOT_NEEDS_SETUP})'
+condition = "(${CLOUD_BOT}) && (${BOT_NEEDS_SETUP})"
 
 [[workflow.steps]]
-id = 9
+id = 8
 title = "Step 6-fix: Fallback Review Fix Cycle (Bot Timeout Path)"
 tool = "bash"
 prompt = '''
 > **Layer**: 0 + 1 (Orchestrator + CSA executor) -- wrapper step enforces
 > timeout/return-code/marker contracts, while CSA performs the fix cycle.
 
-Tool: bash
-OnFail: abort
 
 When `FALLBACK_REVIEW_HAS_ISSUES=true` (set in Step 5 when `csa review`
 found issues during bot timeout), this dedicated fix cycle runs WITHIN the
@@ -903,16 +878,15 @@ FALLBACK_REVIEW_HAS_ISSUES=false
 echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
 ```'''
 on_fail = "abort"
-condition = '(${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && (${FALLBACK_REVIEW_HAS_ISSUES})'
+condition = "(${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && (${FALLBACK_REVIEW_HAS_ISSUES})"
 
 [[workflow.steps]]
-id = 10
+id = 9
 title = "Step 6a: Merge Without Bot"
 tool = "bash"
 prompt = '''
 > **Layer**: 0 (Orchestrator) -- merge command, no code analysis.
 
-Tool: bash
 
 Cloud bot explicitly disabled (cloud_bot=false). Local fallback review passed
 (either initially in Step 4a, or after fix cycle in Step 6-fix). Step 6-fix
@@ -965,10 +939,10 @@ git log --oneline -1  # verify local matches remote
 echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged without bot" required=false -->'
 ```'''
 on_fail = "abort"
-condition = '(${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && (!(${FALLBACK_REVIEW_HAS_ISSUES}))'
+condition = "(${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && (!(${FALLBACK_REVIEW_HAS_ISSUES}))"
 
 [[workflow.steps]]
-id = 11
+id = 10
 title = "Select Current Bot Comment"
 tool = "bash"
 prompt = '''
@@ -977,8 +951,6 @@ prompt = '''
 > comment per loop iteration; after Step 10 pushes, the next bot review
 > trigger picks up any remaining findings.
 
-Tool: bash
-OnFail: abort
 
 Select one actionable bot review comment from the current review window and
 export its metadata as `CURRENT_COMMENT_ID`, `COMMENT_PATH`, and
@@ -1014,13 +986,13 @@ echo "CSA_VAR:COMMENT_IS_FALSE_POSITIVE=true"
 echo "CSA_VAR:COMMENT_IS_STALE=false"
 ```'''
 on_fail = "abort"
-condition = '(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (${BOT_HAS_ISSUES}))'
+condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (${BOT_HAS_ISSUES}))"
 
 [[workflow.steps]]
-id = 12
+id = 11
 title = "Step 7a: Staleness Filter"
 tool = "bash"
-prompt = """
+prompt = '''
 For the current bot comment selected in Step 7, run a conservative file-level
 staleness check. When the referenced file changed on this branch after the
 comment timestamp, set `COMMENT_IS_STALE=true` and skip arbitration/fix for
@@ -1039,42 +1011,38 @@ if [ -n "${COMMENT_PATH:-}" ] && [ -n "${COMMENT_TIMESTAMP:-}" ]; then
 fi
 
 echo "CSA_VAR:COMMENT_IS_STALE=$COMMENT_IS_STALE"
-```"""
+```'''
 on_fail = "skip"
-condition = '(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (${BOT_HAS_ISSUES}))'
+condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (${BOT_HAS_ISSUES}))"
 
 [[workflow.steps]]
-id = 13
+id = 12
 title = "Arbitrate via Debate"
 tool = "csa"
 prompt = """
 > **Layer**: 1 (CSA debate) -- Layer 0 dispatches to `csa debate`, which
 > internally spawns Layer 2 independent models for adversarial evaluation.
-> Orchestrator receives the verdict and posts audit trail to PR.
-
-Tool: csa
-Tier: tier-4-critical"""
+> Orchestrator receives the verdict and posts audit trail to PR."""
+tier = "tier-4-critical"
 on_fail = "abort"
-condition = '(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && ((${BOT_HAS_ISSUES}) && (${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE}))))'
+condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && ((${BOT_HAS_ISSUES}) && (${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE}))))"
 
 [[workflow.steps]]
-id = 14
+id = 13
 title = "Include debate"
 tool = "weave"
 prompt = "debate"
 on_fail = "abort"
-condition = '(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && ((${BOT_HAS_ISSUES}) && (${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE}))))'
+condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && ((${BOT_HAS_ISSUES}) && (${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE}))))"
 
 [[workflow.steps]]
-id = 15
+id = 14
 title = "Step 8a: Post Debate Audit Trail Comment"
 tool = "bash"
 prompt = '''
 > **Layer**: 0 (Orchestrator) -- explicit bash step that posts the PR comment
 > or reroutes to the fix path based on the debate verdict.
 
-Tool: bash
-OnFail: abort
 
 Parse the structured debate result from Step 8.
 - If `VERDICT=DISMISSED`: post the explanatory PR comment explicitly via
@@ -1155,35 +1123,34 @@ case "${VERDICT}" in
 esac
 ```'''
 on_fail = "abort"
-condition = '(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && ((${BOT_HAS_ISSUES}) && (${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE}))))'
+condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && ((${BOT_HAS_ISSUES}) && (${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE}))))"
 
 [[workflow.steps]]
-id = 16
+id = 15
 title = "Fix Real Issue"
 tool = "csa"
 prompt = """
 > **Layer**: 1 (CSA executor) -- Layer 0 dispatches fix to CSA sub-agent.
 > CSA reads code, applies fix, commits. Orchestrator verifies result.
 
-Tool: csa
-Tier: tier-4-critical
-OnFail: retry 2
 
 Fix the real issue for the current bot review comment (non-stale,
 non-false-positive). Fetch the comment body via
 `gh api repos/${REPO}/pulls/comments/${CURRENT_COMMENT_ID}`, apply the fix,
 and commit it."""
-on_fail = "abort"
-condition = '(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && ((${BOT_HAS_ISSUES}) && (!(${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE})))))'
+tier = "tier-4-critical"
+condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && ((${BOT_HAS_ISSUES}) && (!(${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE})))))"
+
+[workflow.steps.on_fail]
+retry = 2
 
 [[workflow.steps]]
-id = 17
+id = 16
 title = "Push Fixes and Continue Loop"
 tool = "bash"
-prompt = """
+prompt = '''
 > **Layer**: 0 (Orchestrator) -- shell commands to push fixes and continue loop.
 
-Tool: bash
 
 Track iteration count via `REVIEW_ROUND`. Check the round cap BEFORE
 pushing fixes and continuing to the next review loop iteration. When `REVIEW_ROUND`
@@ -1300,12 +1267,12 @@ echo "CSA_VAR:REVIEW_ROUND=$REVIEW_ROUND"
 echo "CSA_VAR:MAX_REVIEW_ROUNDS=$MAX_REVIEW_ROUNDS"
 ```
 
-Loop back to Step 5 (delegated wait gate)."""
+Loop back to Step 5 (delegated wait gate).'''
 on_fail = "abort"
-condition = '(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (${BOT_HAS_ISSUES}))'
+condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (${BOT_HAS_ISSUES}))"
 
 [[workflow.steps]]
-id = 18
+id = 17
 title = "Step 10b: Post-Fix Re-Review Gate (HARD GATE)"
 tool = "bash"
 prompt = '''
@@ -1329,10 +1296,7 @@ The gate:
 4. If review event found AND clean → clears `BOT_HAS_ISSUES=false` so merge steps can proceed
 5. If no review event within timeout → falls back to local `csa review --range main...HEAD`
 
-Tool: bash
-OnFail: abort
 Condition: !(${BOT_UNAVAILABLE}) && (${BOT_HAS_ISSUES}) && !(${ROUND_LIMIT_REACHED})
-
 Apply the same wait policy as Step 5: `cloud_bot_wait_seconds` quiet wait,
 then up to `cloud_bot_poll_max_seconds` of polling.
 
@@ -1489,17 +1453,18 @@ echo "CSA_VAR:BOT_HAS_ISSUES=$BOT_HAS_ISSUES"
 echo "Post-fix re-review gate PASSED. Merge is now allowed."
 ```'''
 on_fail = "abort"
-condition = '(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (${BOT_HAS_ISSUES}))'
+condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (${BOT_HAS_ISSUES}))"
+
+[[workflow.steps]]
+id = 18
+title = "Step 10a: Bot Review Clean"
+tool = "note"
+prompt = "No issues found by bot. Proceed to merge."
+on_fail = "abort"
+condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (!(${BOT_HAS_ISSUES})))"
 
 [[workflow.steps]]
 id = 19
-title = "Step 10a: Bot Review Clean"
-prompt = "No issues found by bot. Proceed to merge."
-on_fail = "abort"
-condition = '(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (!(${BOT_HAS_ISSUES})))'
-
-[[workflow.steps]]
-id = 20
 title = "Step 10.5: Rebase for Clean History (DISABLED)"
 tool = "bash"
 prompt = '''
@@ -1508,7 +1473,6 @@ prompt = '''
 > per-commit audit trail instead of cleaning it up.
 > Squash merges are forbidden for audit reasons.
 
-Tool: bash
 
 Reorganize accumulated fix commits into logical groups (source, patterns, other)
 before merging. Skip if <= 3 commits.
@@ -1656,16 +1620,15 @@ if [ "${COMMIT_COUNT}" -gt 3 ]; then
 fi
 ```'''
 on_fail = "abort"
-condition = '(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (!(${BOT_HAS_ISSUES}))) && (${REBASE_ENABLED})'
+condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE})) && (!(${BOT_HAS_ISSUES}))) && (${REBASE_ENABLED})"
 
 [[workflow.steps]]
-id = 21
+id = 20
 title = "Clean Resubmission (if needed)"
 tool = "bash"
-prompt = """
+prompt = '''
 > **Layer**: 0 (Orchestrator) -- git branch management, no code reading.
 
-Tool: bash
 
 If fixes accumulated, create clean branch for final review.
 
@@ -1674,19 +1637,17 @@ CLEAN_BRANCH="${WORKFLOW_BRANCH}-clean"
 git checkout -b "${CLEAN_BRANCH}"
 git push -u origin "${CLEAN_BRANCH}"
 gh pr create --base main --head "${CLEAN_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}"
-```"""
+```'''
 on_fail = "abort"
 condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED})"
 
 [[workflow.steps]]
-id = 22
+id = 21
 title = "Final Merge"
 tool = "bash"
-prompt = """
+prompt = '''
 > **Layer**: 0 (Orchestrator) -- final merge command, no code analysis.
 
-Tool: bash
-OnFail: abort
 
 Merge and update local main.
 
@@ -1724,19 +1685,17 @@ git checkout main
 git merge origin/main --ff-only
 git log --oneline -1  # verify local matches remote
 echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
-```"""
+```'''
 on_fail = "abort"
 condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED})"
 
 [[workflow.steps]]
-id = 23
+id = 22
 title = "Step 12b: Final Merge (Direct)"
 tool = "bash"
-prompt = """
+prompt = '''
 > **Layer**: 0 (Orchestrator) -- direct merge, no code analysis needed.
 
-Tool: bash
-OnFail: abort
 
 First-pass clean review: merge the existing PR directly.
 
@@ -1774,6 +1733,6 @@ git checkout main
 git merge origin/main --ff-only
 git log --oneline -1  # verify local matches remote
 echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
-```"""
+```'''
 on_fail = "abort"
 condition = "(!(${BOT_UNAVAILABLE})) && (!(${FIXES_ACCUMULATED}))"

--- a/scripts/hooks/post-pr-create.sh
+++ b/scripts/hooks/post-pr-create.sh
@@ -240,12 +240,12 @@ csa plan run --sa-mode true patterns/pr-bot/workflow.toml | tee "${PLAN_RESULT_F
 PLAN_RC=${PIPESTATUS[0]}
 set -e
 
-if grep -Eq '^[[:space:]]*ROUND_LIMIT_HALT:' "${PLAN_RESULT_FILE}"; then
+if grep -Eq '^[[:space:]]*(ROUND_LIMIT_HALT|AWAIT_USER):' "${PLAN_RESULT_FILE}"; then
   rm -f "${PLAN_RESULT_FILE}"
   touch "${PR_BOT_AWAITING_USER_MARKER}"
   rmdir "${PR_BOT_LOCK_DIR}" 2>/dev/null || true
   PR_BOT_LOCK_HELD=0
-  echo "WARN: pr-bot reached REVIEW_ROUND limit and is awaiting manual follow-up; done marker was not written." >&2
+  echo "WARN: pr-bot is awaiting manual follow-up; done marker was not written." >&2
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- stop treating dispatcher or prompt-only workflow steps as executable AI work
- preserve resumable main-agent handoff for `dev2merge` mktsk execution
- preserve actionable awaiting-user behavior for `pr-bot` bot-setup stops

## Testing
- `cargo test -p cli-sub-agent manual_handoff -- --nocapture`
- `cargo test -p cli-sub-agent await_user -- --nocapture`
- `cargo test -p cli-sub-agent load_plan_resume_context_ -- --nocapture`
- `cargo test -p cli-sub-agent pr_bot_workflow_marks_non_ai_steps_explicitly -- --nocapture`
- `cargo test -p cli-sub-agent resolve_step_tool_all_explicit_tools -- --nocapture`
- `cargo clippy -p cli-sub-agent --tests -- -D warnings`
- `cargo fmt --all --check`
- `bash -n scripts/hooks/post-pr-create.sh`

Closes #622.