### PR TITLE
fix(acp): stabilize long-output daemon sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.253"
+version = "0.1.254"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.253"
+version = "0.1.254"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -218,7 +218,7 @@ pub enum SessionCommands {
         cd: Option<String>,
     },
 
-    /// Attach to a running daemon session (tail stdout/stderr until the daemon exits)
+    /// Attach to a running daemon session (tail live output/stderr until the daemon exits)
     Attach {
         /// Session ID to attach to
         #[arg(long)]

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -359,8 +359,9 @@ async fn run() -> Result<()> {
             )?;
 
             // Daemon child path: continue with normal run logic.
-            // --stream-stdout forces streaming; --no-stream-stdout forces buffering;
-            // default: stream for Text output in all contexts.
+            // --stream-stdout forces streaming intent; --no-stream-stdout forces buffering.
+            // The ACP transport may still suppress stderr mirroring in daemon mode because
+            // output.log is the canonical progressive output channel there.
             let stream_mode = if no_stream_stdout {
                 csa_process::StreamMode::BufferOnly
             } else if stream_stdout || matches!(output_format, OutputFormat::Text) {

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -7,6 +7,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use csa_executor::{TransportFactory, TransportMode};
 use csa_session::get_session_dir;
 use csa_session::state::ReviewSessionMeta;
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,12 @@ const DAEMON_SESSION_DIR_ENV: &str = "CSA_DAEMON_SESSION_DIR";
 const DAEMON_PROJECT_ROOT_ENV: &str = "CSA_DAEMON_PROJECT_ROOT";
 const DAEMON_COMPLETION_FILE: &str = "daemon-completion.toml";
 const POST_REVIEW_PR_BOT_CMD: &str = "csa plan run --sa-mode true --pattern pr-bot";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttachPrimaryOutput {
+    StdoutLog,
+    OutputLog,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct DaemonCompletionPacket {
@@ -37,6 +44,24 @@ impl DaemonCompletionPacket {
 fn is_pid_alive(pid: u32) -> bool {
     // SAFETY: kill(pid, 0) is a standard POSIX liveness probe.
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+fn attach_primary_output_for_session(session_dir: &Path) -> AttachPrimaryOutput {
+    let metadata_path = session_dir.join(csa_session::metadata::METADATA_FILE_NAME);
+    let Ok(contents) = fs::read_to_string(metadata_path) else {
+        return AttachPrimaryOutput::StdoutLog;
+    };
+    let Ok(metadata) = toml::from_str::<csa_session::metadata::SessionMetadata>(&contents) else {
+        return AttachPrimaryOutput::StdoutLog;
+    };
+    if matches!(
+        TransportFactory::mode_for_tool(&metadata.tool),
+        TransportMode::Acp
+    ) {
+        AttachPrimaryOutput::OutputLog
+    } else {
+        AttachPrimaryOutput::StdoutLog
+    }
 }
 
 /// Read the daemon PID from the session directory.
@@ -433,8 +458,9 @@ fn emit_wait_completion_signal(
     );
 }
 
-/// Attach to a running daemon session: tail stdout.log (and optionally
-/// stderr.log) in real time until the daemon fully completes.
+/// Attach to a running daemon session: tail the primary live output channel
+/// (output.log for ACP sessions, stdout.log otherwise) and optionally stderr.log
+/// until the daemon fully completes.
 pub(crate) fn handle_session_attach(
     session: String,
     show_stderr: bool,
@@ -447,21 +473,46 @@ pub(crate) fn handle_session_attach(
 
     let stdout_path = session_dir.join("stdout.log");
     let stderr_path = session_dir.join("stderr.log");
+    let output_path = session_dir.join("output.log");
+    let primary_output = attach_primary_output_for_session(&session_dir);
+    let live_stdout_path = match primary_output {
+        AttachPrimaryOutput::StdoutLog => &stdout_path,
+        AttachPrimaryOutput::OutputLog => &output_path,
+    };
 
     // Wait for the spool file to appear (daemon may still be starting).
     let start = std::time::Instant::now();
-    while !stdout_path.exists() {
+    while !live_stdout_path.exists() {
         if start.elapsed().as_secs() > 30 {
+            if primary_output == AttachPrimaryOutput::OutputLog && stdout_path.exists() {
+                break;
+            }
+            let missing_name = live_stdout_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("session output");
             anyhow::bail!(
-                "stdout.log not found after 30s — session {} may not be a daemon session",
-                resolved.session_id,
+                "{missing_name} not found after 30s — session {} may not be a daemon session",
+                resolved.session_id
             );
         }
         std::thread::sleep(std::time::Duration::from_millis(200));
     }
 
     let daemon_pid = read_daemon_pid(&session_dir);
-    let mut stdout_file = std::fs::File::open(&stdout_path)?;
+    let live_stdout_path = if live_stdout_path.exists() {
+        live_stdout_path
+    } else {
+        &stdout_path
+    };
+    let live_streams_output_log = live_stdout_path == output_path.as_path();
+    let mut live_stdout_file = std::fs::File::open(live_stdout_path)?;
+    let mut completion_stdout_file: Option<std::fs::File> =
+        if live_streams_output_log && stdout_path.exists() {
+            Some(std::fs::File::open(&stdout_path)?)
+        } else {
+            None
+        };
     // Lazy-open stderr: retry on each poll iteration if not yet available.
     let mut stderr_file: Option<std::fs::File> = if show_stderr && stderr_path.exists() {
         Some(std::fs::File::open(&stderr_path)?)
@@ -475,7 +526,7 @@ pub(crate) fn handle_session_attach(
     loop {
         let mut any_output = false;
 
-        let n = stdout_file.read(&mut buf)?;
+        let n = live_stdout_file.read(&mut buf)?;
         if n > 0 {
             std::io::stdout().write_all(&buf[..n])?;
             std::io::stdout().flush()?;
@@ -498,11 +549,25 @@ pub(crate) fn handle_session_attach(
         if let Some(completion) = load_daemon_completion_packet(&session_dir)? {
             // Drain remaining stdout.
             loop {
-                let n = stdout_file.read(&mut buf)?;
+                let n = live_stdout_file.read(&mut buf)?;
                 if n == 0 {
                     break;
                 }
                 std::io::stdout().write_all(&buf[..n])?;
+            }
+            if live_streams_output_log {
+                if completion_stdout_file.is_none() && stdout_path.exists() {
+                    completion_stdout_file = Some(std::fs::File::open(&stdout_path)?);
+                }
+                if let Some(ref mut f) = completion_stdout_file {
+                    loop {
+                        let n = f.read(&mut buf)?;
+                        if n == 0 {
+                            break;
+                        }
+                        std::io::stdout().write_all(&buf[..n])?;
+                    }
+                }
             }
             std::io::stdout().flush()?;
             // Drain remaining stderr.
@@ -640,4 +705,49 @@ pub(crate) fn handle_session_kill(session: String, cd: Option<String>) -> Result
 
     eprintln!("Session {} killed", resolved.session_id);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attach_primary_output_prefers_output_log_for_acp_tools() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let metadata = csa_session::metadata::SessionMetadata {
+            tool: "codex".to_string(),
+            tool_locked: true,
+        };
+        let metadata_toml = toml::to_string_pretty(&metadata).expect("metadata toml");
+        std::fs::write(
+            td.path().join(csa_session::metadata::METADATA_FILE_NAME),
+            metadata_toml,
+        )
+        .expect("write metadata");
+
+        assert_eq!(
+            attach_primary_output_for_session(td.path()),
+            AttachPrimaryOutput::OutputLog
+        );
+    }
+
+    #[test]
+    fn attach_primary_output_keeps_stdout_for_legacy_tools() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let metadata = csa_session::metadata::SessionMetadata {
+            tool: "opencode".to_string(),
+            tool_locked: true,
+        };
+        let metadata_toml = toml::to_string_pretty(&metadata).expect("metadata toml");
+        std::fs::write(
+            td.path().join(csa_session::metadata::METADATA_FILE_NAME),
+            metadata_toml,
+        )
+        .expect("write metadata");
+
+        assert_eq!(
+            attach_primary_output_for_session(td.path()),
+            AttachPrimaryOutput::StdoutLog
+        );
+    }
 }

--- a/crates/csa-acp/src/client.rs
+++ b/crates/csa-acp/src/client.rs
@@ -96,7 +96,7 @@ impl StreamingMetadata {
 
 /// Trim a tail buffer back to [`TAIL_BUFFER_MAX_BYTES`] when it exceeds
 /// [`TAIL_BUFFER_HIGH_WATER`], respecting UTF-8 char boundaries.
-fn trim_tail_buffer(buf: &mut String) {
+pub(crate) fn trim_tail_buffer(buf: &mut String) {
     if buf.len() > TAIL_BUFFER_HIGH_WATER {
         let excess = buf.len() - TAIL_BUFFER_MAX_BYTES;
         let mut trim_at = excess;

--- a/crates/csa-acp/src/connection_spawn.rs
+++ b/crates/csa-acp/src/connection_spawn.rs
@@ -22,11 +22,16 @@ use csa_resource::isolation_plan::IsolationPlan;
 use csa_resource::sandbox::ResourceCapability;
 
 use crate::{
-    client::{AcpClient, SessionEventStore},
+    client::{AcpClient, SessionEventStore, trim_tail_buffer},
     error::{AcpError, AcpResult},
 };
 
 use super::AcpConnection;
+
+fn append_stderr_tail(stderr_buf: &mut String, chunk: &str) {
+    stderr_buf.push_str(chunk);
+    trim_tail_buffer(stderr_buf);
+}
 
 /// Holds sandbox resources that must live as long as the ACP child process.
 ///
@@ -616,7 +621,7 @@ impl AcpConnection {
                             Ok(n) => {
                                 *activity_clone.borrow_mut() = Instant::now();
                                 let text = String::from_utf8_lossy(&buf[..n]);
-                                stderr_buf_clone.borrow_mut().push_str(&text);
+                                append_stderr_tail(&mut stderr_buf_clone.borrow_mut(), &text);
                             }
                             Err(err) => {
                                 warn!(error = %err, "failed to read ACP stderr stream");
@@ -646,6 +651,22 @@ impl AcpConnection {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn append_stderr_tail_bounds_retained_memory_to_tail_window() {
+        let mut stderr = "a".repeat(1024 * 1024);
+        append_stderr_tail(&mut stderr, &"b".repeat(1024 * 1024 + 64));
+
+        assert_eq!(
+            stderr.len(),
+            1024 * 1024,
+            "stderr retention should trim back to the 1 MiB tail window"
+        );
+        assert!(
+            stderr.ends_with(&"b".repeat(4096)),
+            "stderr tail should retain the most recent bytes after trimming"
+        );
+    }
 
     fn has_setenv(args: &[String], key: &str, value: &str) -> bool {
         args.windows(3)

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -97,6 +97,14 @@ pub struct TransportResult {
     pub metadata: csa_acp::StreamingMetadata,
 }
 
+fn should_stream_acp_stdout_to_stderr(
+    stream_mode: StreamMode,
+    output_spool: Option<&Path>,
+) -> bool {
+    !(matches!(stream_mode, StreamMode::BufferOnly)
+        || output_spool.is_some() && std::env::var_os("CSA_DAEMON_SESSION_ID").is_some())
+}
+
 #[derive(Debug, Clone)]
 pub struct LegacyTransport {
     executor: Executor,
@@ -498,10 +506,8 @@ impl AcpTransport {
         let sandbox_session_id = options.sandbox.map(|s| s.session_id.clone());
         let sandbox_best_effort = options.sandbox.is_some_and(|s| s.best_effort);
         let idle_timeout_seconds = options.idle_timeout_seconds;
-        // ACP transport: skip initial_response_timeout. ACP init_timeout
-        // already catches startup failures, and idle_timeout handles
-        // post-start hangs. IRT causes false positives with tools that
-        // do heavy post-initialization (gemini-cli loading extensions/MCP).
+        // ACP transport: skip initial_response_timeout; ACP init_timeout already catches
+        // startup failures, and idle_timeout handles post-start hangs for heavy post-init tools.
         let initial_response_timeout_seconds: Option<u64> = None;
         let acp_init_timeout_seconds = options.acp_init_timeout_seconds;
         let termination_grace_period_seconds = options.termination_grace_period_seconds;
@@ -509,11 +515,11 @@ impl AcpTransport {
             options.setting_sources.as_deref(),
             self.session_config.as_ref(),
         );
-        let stream_stdout_to_stderr = options.stream_mode != StreamMode::BufferOnly;
+        let stream_stdout_to_stderr =
+            should_stream_acp_stdout_to_stderr(options.stream_mode, options.output_spool);
         let output_spool = options.output_spool.map(std::path::Path::to_path_buf);
         let output_spool_max_bytes = options.output_spool_max_bytes;
         let output_spool_keep_rotated = options.output_spool_keep_rotated;
-
         let output =
             tokio::task::spawn_blocking(move || -> Result<csa_acp::transport::AcpOutput> {
                 let rt = tokio::runtime::Builder::new_current_thread()

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -1,3 +1,18 @@
+use std::sync::{LazyLock, Mutex};
+
+const DAEMON_SESSION_ID_ENV: &str = "CSA_DAEMON_SESSION_ID";
+static DAEMON_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn restore_env_var(key: &str, original: Option<String>) {
+    // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+    unsafe {
+        match original {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+}
+
 // --- classify_join_error tests ---
 
 #[tokio::test]
@@ -67,6 +82,53 @@ fn test_build_summary_ignores_csa_section_markers() {
 fn test_build_summary_falls_back_to_exit_code_when_no_output() {
     let summary = super::build_summary("", "   \n", -1);
     assert_eq!(summary, "exit code -1");
+}
+
+#[test]
+fn test_daemon_mode_disables_acp_stderr_streaming_when_output_spool_exists() {
+    let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
+    let original = std::env::var(DAEMON_SESSION_ID_ENV).ok();
+    // SAFETY: guarded by DAEMON_ENV_LOCK for this test.
+    unsafe { std::env::set_var(DAEMON_SESSION_ID_ENV, "01KTESTSESSION") };
+
+    let spool_path = std::path::Path::new("/tmp/output.log");
+    assert!(!super::should_stream_acp_stdout_to_stderr(
+        StreamMode::TeeToStderr,
+        Some(spool_path)
+    ));
+
+    restore_env_var(DAEMON_SESSION_ID_ENV, original);
+}
+
+#[test]
+fn test_foreground_mode_keeps_acp_stderr_streaming_even_with_output_spool() {
+    let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
+    let original = std::env::var(DAEMON_SESSION_ID_ENV).ok();
+    // SAFETY: guarded by DAEMON_ENV_LOCK for this test.
+    unsafe { std::env::remove_var(DAEMON_SESSION_ID_ENV) };
+
+    let spool_path = std::path::Path::new("/tmp/output.log");
+    assert!(super::should_stream_acp_stdout_to_stderr(
+        StreamMode::TeeToStderr,
+        Some(spool_path)
+    ));
+
+    restore_env_var(DAEMON_SESSION_ID_ENV, original);
+}
+
+#[test]
+fn test_daemon_mode_without_output_spool_keeps_acp_stderr_streaming() {
+    let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
+    let original = std::env::var(DAEMON_SESSION_ID_ENV).ok();
+    // SAFETY: guarded by DAEMON_ENV_LOCK for this test.
+    unsafe { std::env::set_var(DAEMON_SESSION_ID_ENV, "01KTESTSESSION") };
+
+    assert!(super::should_stream_acp_stdout_to_stderr(
+        StreamMode::TeeToStderr,
+        None
+    ));
+
+    restore_env_var(DAEMON_SESSION_ID_ENV, original);
 }
 
 // --- 3-phase Gemini fallback chain integration tests ---


### PR DESCRIPTION
## Summary
- suppress ACP stdout/thought mirroring to stderr for daemon-spooled sessions so long output is not double-written through stderr.log
- bound ACP child stderr tail retention to the existing 1 MiB tail window
- restore `csa session attach` progressive visibility for ACP daemon sessions by tailing `output.log` while still draining `stdout.log` at completion

## Validation
- cargo test -p csa-executor acp_stderr_streaming -- --nocapture
- cargo test -p csa-acp append_stderr_tail_bounds_retained_memory_to_tail_window -- --nocapture
- cargo test -p cli-sub-agent attach_primary_output_ -- --nocapture
- cargo clippy -p csa-acp -p csa-executor --tests -- -D warnings
- cargo clippy -p cli-sub-agent --tests -- -D warnings
- pre-commit / pre-push quality gates

Closes #623.