### PR TITLE
fix: surface actionable causes for failed runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.254"
+version = "0.1.255"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/error_report.rs
+++ b/crates/cli-sub-agent/src/error_report.rs
@@ -1,0 +1,92 @@
+use anyhow::Error;
+
+const META_SESSION_MARKER: &str = "meta_session_id=";
+
+pub(crate) fn render_user_facing_error(err: &Error) -> String {
+    let mut session_id = None;
+    let mut messages = Vec::new();
+
+    for cause in err.chain() {
+        let message = cause.to_string();
+        if let Some(extracted) = parse_meta_session_id(&message) {
+            session_id.get_or_insert(extracted.to_string());
+            continue;
+        }
+        if messages.last() != Some(&message) {
+            messages.push(message);
+        }
+    }
+
+    let primary = messages.first().cloned().unwrap_or_else(|| err.to_string());
+    let mut rendered = format!("Error: {primary}");
+
+    if messages.len() > 1 {
+        rendered.push_str("\n\nCaused by:");
+        for cause in messages.iter().skip(1) {
+            rendered.push_str(&format!("\n  - {cause}"));
+        }
+    }
+
+    if let Some(session_id) = session_id {
+        rendered.push_str(&format!("\n\nSession ID: {session_id}"));
+    }
+
+    rendered
+}
+
+fn parse_meta_session_id(message: &str) -> Option<&str> {
+    let suffix = message.trim().strip_prefix(META_SESSION_MARKER)?;
+    let end = suffix
+        .find(|ch: char| !ch.is_ascii_alphanumeric())
+        .unwrap_or(suffix.len());
+    let session_id = &suffix[..end];
+    (!session_id.is_empty()).then_some(session_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_user_facing_error_skips_meta_wrapper_and_keeps_session_id() {
+        let err = anyhow::anyhow!("ACP subprocess spawn failed: No such file or directory")
+            .context("meta_session_id=01KTESTSESSIONABCDE123456");
+
+        let rendered = render_user_facing_error(&err);
+
+        assert!(
+            rendered.starts_with("Error: ACP subprocess spawn failed"),
+            "unexpected rendered error: {rendered}"
+        );
+        assert!(
+            rendered.contains("Session ID: 01KTESTSESSIONABCDE123456"),
+            "session id should be preserved: {rendered}"
+        );
+        assert!(
+            !rendered
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .contains("meta_session_id="),
+            "first line should not be opaque metadata: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_user_facing_error_includes_non_meta_cause_chain() {
+        let err = anyhow::anyhow!("No such file or directory")
+            .context("Failed to load transcript")
+            .context("meta_session_id=01KTESTSESSIONABCDE123456");
+
+        let rendered = render_user_facing_error(&err);
+
+        assert!(
+            rendered.contains("Error: Failed to load transcript"),
+            "top-level actionable context should be surfaced: {rendered}"
+        );
+        assert!(
+            rendered.contains("Caused by:\n  - No such file or directory"),
+            "root cause should remain visible: {rendered}"
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -16,6 +16,7 @@ mod debate_errors;
 mod doctor;
 mod edit_restriction_guard;
 mod error_hints;
+mod error_report;
 mod eval_cmd;
 mod gc;
 mod hooks_cmd;
@@ -101,7 +102,7 @@ fn report_daemon_error_or_exit_code(
         Ok(code) => code,
         Err(err) => {
             // fd 2 is still the pipe write-end (guard is alive), so eprintln! works.
-            eprintln!("Error: {err}");
+            eprintln!("{}", error_report::render_user_facing_error(&err));
             if let Some(hint) = error_hints::suggest_fix(&err) {
                 eprintln!();
                 eprintln!("{hint}");
@@ -166,7 +167,7 @@ fn should_attempt_auto_weave_upgrade(command: &Commands) -> bool {
 
 async fn main() {
     if let Err(err) = run().await {
-        eprintln!("Error: {err}");
+        eprintln!("{}", error_report::render_user_facing_error(&err));
         if let Some(hint) = error_hints::suggest_fix(&err) {
             eprintln!();
             eprintln!("{hint}");

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -7,6 +7,8 @@ mod cli_defs;
 use clap::Parser;
 use cli_defs::{AuditCommands, Cli, Commands, McpHubCommands, validate_command_args};
 use csa_core::types::OutputFormat;
+use std::collections::HashMap;
+use std::path::Path;
 use std::process::Command;
 
 /// Create a [`Command`] pointing at the built `csa` binary with HOME, XDG_STATE_HOME,
@@ -38,6 +40,51 @@ fn init_project_full(tmp: &std::path::Path) {
         .status()
         .expect("failed to run csa init --full");
     assert!(status.success(), "csa init --full should succeed");
+}
+
+fn write_project_config_with_tier(project_root: &Path) {
+    let mut config = csa_config::ProjectConfig {
+        schema_version: csa_config::config::CURRENT_SCHEMA_VERSION,
+        project: csa_config::ProjectMeta {
+            name: "test".to_string(),
+            created_at: chrono::Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: csa_config::ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+    config.tiers.insert(
+        "default".to_string(),
+        csa_config::config::TierConfig {
+            description: "Test tier".to_string(),
+            models: vec!["codex/gpt-5-codex/medium".to_string()],
+            strategy: csa_config::TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+
+    let config_path = csa_config::ProjectConfig::config_path(project_root);
+    std::fs::create_dir_all(config_path.parent().expect("config dir")).expect("create config dir");
+    std::fs::write(
+        config_path,
+        toml::to_string_pretty(&config).expect("serialize config"),
+    )
+    .expect("write config");
 }
 
 #[test]
@@ -308,6 +355,60 @@ fn session_list_exits_zero() {
     assert!(
         combined.contains("No sessions found"),
         "empty state should report no sessions"
+    );
+}
+
+#[test]
+fn run_direct_tool_tier_rejection_surfaces_cause_and_session_id() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_project_config_with_tier(tmp.path());
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "run",
+            "--sa-mode",
+            "true",
+            "--no-daemon",
+            "--tool",
+            "codex",
+            "--no-idle-timeout",
+            "--timeout",
+            "1800",
+            "inspect the repository",
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit code 1, got {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Direct --tool is blocked when tiers are configured"),
+        "user-facing cause should be shown, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("--auto-route <intent>"),
+        "actionable guidance should remain visible, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Session ID:"),
+        "session id should be preserved for diagnostics, stderr: {stderr}"
+    );
+    assert!(
+        !stderr
+            .lines()
+            .find(|line| line.starts_with("Error:"))
+            .unwrap_or_default()
+            .contains("meta_session_id="),
+        "top-level error line should not be opaque metadata, stderr: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary
- surface the real failure cause instead of only showing meta_session_id
- preserve session id as a separate diagnostic line in CLI error output
- add unit and e2e regression coverage for the user-facing output

Closes #626