### PR TITLE
fix: wait for live daemon before honoring completion packet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.255"
+version = "0.1.256"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.255"
+version = "0.1.256"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -139,7 +139,9 @@ pub(crate) fn handle_session_wait(
     let poll_interval = std::time::Duration::from_secs(1);
 
     loop {
-        if let Some(completion) = load_daemon_completion_packet(&session_dir)? {
+        if let Some(completion) = load_daemon_completion_packet(&session_dir)?
+            && !csa_process::ToolLiveness::has_live_process(&session_dir)
+        {
             let _ = refresh_result_for_wait(
                 effective_root,
                 &resolved.session_id,

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -517,6 +517,59 @@ fn handle_session_wait_prefers_daemon_completion_exit_code() {
 
 #[cfg(unix)]
 #[test]
+fn handle_session_wait_ignores_completion_packet_while_daemon_alive() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-live-completion-packet"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+
+    let script_path = td.path().join("live-completion-packet.sh");
+    let script =
+        "#!/bin/sh\nset -eu\nsession_id=\"$1\"\nsleep 2\nprintf '%s' \"$session_id\" >/dev/null\n";
+    std::fs::write(&script_path, script).unwrap();
+    let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script_path, perms).unwrap();
+
+    let mut child = Command::new(&script_path).arg(&session_id).spawn().unwrap();
+    std::fs::write(session_dir.join("daemon.pid"), child.id().to_string()).unwrap();
+    wait_for_spawned_daemon_visibility(&session_dir, &mut child);
+
+    let exit_code =
+        handle_session_wait(session_id, Some(project.to_string_lossy().into_owned()), 1).unwrap();
+
+    assert_eq!(
+        exit_code, 124,
+        "wait should time out instead of reporting completion while the daemon is still alive"
+    );
+
+    child.kill().ok();
+    let _ = child.wait();
+}
+
+#[cfg(unix)]
+#[test]
 fn handle_session_wait_returns_pre_exec_failure_without_timeout_packet() {
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");


### PR DESCRIPTION
## Summary
- ignore daemon-completion packets while the session still has a live process
- keep honoring the completion packet exit code once the daemon is actually finished
- add a regression test for the false completion case

Closes #627