### PR TITLE
fix(session): harden sandbox root and startup resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "axum",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.256"
+version = "0.1.257"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.256"
+version = "0.1.257"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -4,7 +4,7 @@
 //! Handles enforcement mode checking, capability detection, config resolution,
 //! and first-turn telemetry recording.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use csa_config::ProjectConfig;
 use csa_executor::{ExecuteOptions, SandboxContext};
@@ -41,6 +41,7 @@ pub(crate) fn resolve_sandbox_options(
     config: Option<&ProjectConfig>,
     tool_name: &str,
     session_id: &str,
+    project_root: &Path,
     stream_mode: StreamMode,
     idle_timeout_seconds: u64,
     liveness_dead_seconds: u64,
@@ -94,7 +95,6 @@ pub(crate) fn resolve_sandbox_options(
         }
 
         // Build IsolationPlan via builder (BestEffort for profile defaults).
-        let cwd = std::env::current_dir().unwrap_or_default();
         let mut builder = IsolationPlanBuilder::new(ResourceEnforcementMode::BestEffort)
             .with_resource_capability(resource_cap)
             .with_filesystem_capability(fs_cap)
@@ -105,8 +105,7 @@ pub(crate) fn resolve_sandbox_options(
             )
             .with_tool_defaults(
                 tool_name,
-                // No project root available from profile defaults; use cwd.
-                &cwd,
+                project_root,
                 // No session dir available; use a temporary placeholder.
                 &std::env::temp_dir(),
             )
@@ -114,7 +113,7 @@ pub(crate) fn resolve_sandbox_options(
 
         // CSA runtime writable paths (best-effort for profile defaults).
         if !no_fs_sandbox {
-            if let Ok(project_state_root) = csa_session::manager::get_session_root(&cwd) {
+            if let Ok(project_state_root) = csa_session::manager::get_session_root(project_root) {
                 builder = builder.with_writable_path(project_state_root);
             }
             if let Ok(slots) = csa_config::GlobalConfig::slots_dir() {
@@ -122,9 +121,10 @@ pub(crate) fn resolve_sandbox_options(
             }
             // CLI --extra-writable (no-config path).
             if !extra_writable.is_empty() {
-                if let Err(e) =
-                    csa_resource::isolation_plan::validate_writable_paths(extra_writable, &cwd)
-                {
+                if let Err(e) = csa_resource::isolation_plan::validate_writable_paths(
+                    extra_writable,
+                    project_root,
+                ) {
                     return SandboxResolution::RequiredButUnavailable(format!(
                         "--extra-writable validation failed: {e}"
                     ));
@@ -226,8 +226,7 @@ pub(crate) fn resolve_sandbox_options(
     }
 
     // Resolve project root and session dir for tool-specific writable paths.
-    let project_root = std::env::current_dir().unwrap_or_default();
-    let session_dir = csa_session::manager::get_session_dir(&project_root, session_id)
+    let session_dir = csa_session::manager::get_session_dir(project_root, session_id)
         .unwrap_or_else(|_| std::env::temp_dir());
 
     let memory_swap_max_mb = cfg.sandbox_memory_swap_max_mb(tool_name);
@@ -249,7 +248,7 @@ pub(crate) fn resolve_sandbox_options(
         .with_resource_capability(resource_cap)
         .with_filesystem_capability(fs_cap)
         .with_resource_limits(Some(memory_max_mb), memory_swap_max_mb, pids_max)
-        .with_tool_defaults(tool_name, &project_root, &session_dir)
+        .with_tool_defaults(tool_name, project_root, &session_dir)
         .with_readonly_project_root(effective_readonly)
         .with_soft_limit_percent(cfg.resources.soft_limit_percent)
         .with_memory_monitor_interval(cfg.resources.memory_monitor_interval_seconds);
@@ -259,7 +258,7 @@ pub(crate) fn resolve_sandbox_options(
     // regardless of per-tool REPLACE semantics because CSA needs them to
     // function even when the tool's project-root access is restricted.
     if !no_fs_sandbox {
-        if let Ok(project_state_root) = csa_session::manager::get_session_root(&project_root) {
+        if let Ok(project_state_root) = csa_session::manager::get_session_root(project_root) {
             builder = builder.with_writable_path(project_state_root);
         }
         if let Ok(slots) = csa_config::GlobalConfig::slots_dir() {
@@ -271,7 +270,7 @@ pub(crate) fn resolve_sandbox_options(
         if let Some(ref paths) = per_tool_writable {
             // Validate user-provided writable paths before applying.
             if let Err(e) =
-                csa_resource::isolation_plan::validate_writable_paths(paths, &project_root)
+                csa_resource::isolation_plan::validate_writable_paths(paths, project_root)
             {
                 return SandboxResolution::RequiredButUnavailable(format!(
                     "Per-tool writable_paths validation failed for '{tool_name}': {e}"
@@ -292,7 +291,7 @@ pub(crate) fn resolve_sandbox_options(
     // CLI --extra-writable paths: always appended (APPEND semantics, not REPLACE).
     if !no_fs_sandbox && !extra_writable.is_empty() {
         if let Err(e) =
-            csa_resource::isolation_plan::validate_writable_paths(extra_writable, &project_root)
+            csa_resource::isolation_plan::validate_writable_paths(extra_writable, project_root)
         {
             return SandboxResolution::RequiredButUnavailable(format!(
                 "--extra-writable validation failed: {e}"

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -1,10 +1,33 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::*;
+use crate::test_env_lock::TEST_ENV_LOCK;
 
 /// Helper: parse a TOML string into a ProjectConfig for test setup.
 fn parse_project_config(toml_str: &str) -> csa_config::ProjectConfig {
     toml::from_str(toml_str).expect("test TOML should parse")
+}
+
+fn current_project_root() -> PathBuf {
+    std::env::current_dir().unwrap_or_default()
+}
+
+struct CurrentDirGuard {
+    original: PathBuf,
+}
+
+impl CurrentDirGuard {
+    fn change_to(path: &Path) -> Self {
+        let original = std::env::current_dir().expect("current dir");
+        std::env::set_current_dir(path).expect("set current dir");
+        Self { original }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.original);
+    }
 }
 
 /// Heavyweight tools (claude-code) with no project config should get setting_sources=Some(vec![]).
@@ -14,6 +37,7 @@ fn test_none_config_sets_setting_sources_for_heavyweight() {
         None,
         "claude-code",
         "test-session",
+        &current_project_root(),
         StreamMode::BufferOnly,
         120,
         600,
@@ -41,6 +65,7 @@ fn test_none_config_lightweight_skips_sandbox() {
         None,
         "opencode",
         "test-session",
+        &current_project_root(),
         StreamMode::BufferOnly,
         120,
         600,
@@ -72,6 +97,7 @@ fn test_none_config_heavyweight_gets_sandbox() {
         None,
         "claude-code",
         "test-session",
+        &current_project_root(),
         StreamMode::BufferOnly,
         120,
         600,
@@ -140,6 +166,7 @@ writable_paths = ["/tmp"]
         Some(&cfg),
         "gemini-cli",
         "test-session",
+        &current_project_root(),
         StreamMode::BufferOnly,
         120,
         600,
@@ -195,6 +222,7 @@ memory_max_mb = 2048
         Some(&cfg),
         "claude-code",
         "test-session",
+        &current_project_root(),
         StreamMode::BufferOnly,
         120,
         600,
@@ -243,6 +271,7 @@ writable_paths = ["/"]
         Some(&cfg),
         "gemini-cli",
         "test-session",
+        &current_project_root(),
         StreamMode::BufferOnly,
         120,
         600,
@@ -288,10 +317,72 @@ enforcement_mode = "best-effort"
     );
 }
 
+#[test]
+fn test_cross_repo_cd_uses_explicit_project_root_for_sandbox_plan() {
+    let _env_lock = TEST_ENV_LOCK
+        .lock()
+        .expect("pipeline sandbox env lock poisoned");
+    let invocation_cwd = tempfile::tempdir().expect("invocation cwd tempdir");
+    let target_project = tempfile::tempdir().expect("target project tempdir");
+    let _cwd_guard = CurrentDirGuard::change_to(invocation_cwd.path());
+
+    let cfg = parse_project_config(
+        r#"
+[resources]
+memory_max_mb = 2048
+enforcement_mode = "best-effort"
+"#,
+    );
+
+    let result = resolve_sandbox_options(
+        Some(&cfg),
+        "gemini-cli",
+        "test-session",
+        target_project.path(),
+        StreamMode::BufferOnly,
+        120,
+        600,
+        Some(120),
+        false,
+        false,
+        &[],
+    );
+
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("Expected SandboxResolution::Ok");
+    };
+
+    let sandbox = opts
+        .sandbox
+        .as_ref()
+        .expect("Expected SandboxContext for heavyweight tool");
+
+    assert_eq!(
+        sandbox.isolation_plan.project_root,
+        Some(target_project.path().to_path_buf()),
+        "sandbox must target the explicit --cd project root, not process cwd"
+    );
+    assert!(
+        sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&target_project.path().to_path_buf()),
+        "target project root should be writable in the sandbox plan"
+    );
+    assert!(
+        !sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&invocation_cwd.path().to_path_buf()),
+        "invocation cwd must not leak into cross-repo sandbox writable paths"
+    );
+}
+
 /// Verify that resolve_sandbox_options injects CSA state paths (project state
 /// root and global slots) into the isolation plan's writable_paths.
 #[test]
 fn test_csa_state_paths_in_writable_paths() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
     let cfg = parse_project_config(
         r#"
 [resources]
@@ -304,6 +395,7 @@ enforcement_mode = "best-effort"
         Some(&cfg),
         "claude-code",
         "test-session",
+        project_root.path(),
         StreamMode::BufferOnly,
         120,
         600,
@@ -325,8 +417,7 @@ enforcement_mode = "best-effort"
     let writable = &sandbox.isolation_plan.writable_paths;
 
     // Project state root should be present (allows fork-call session creation).
-    let cwd = std::env::current_dir().unwrap_or_default();
-    if let Ok(project_state_root) = csa_session::manager::get_session_root(&cwd) {
+    if let Ok(project_state_root) = csa_session::manager::get_session_root(project_root.path()) {
         assert!(
             writable.contains(&project_state_root),
             "writable_paths should include project state root: {project_state_root:?}\n  actual: {writable:?}"
@@ -346,6 +437,7 @@ enforcement_mode = "best-effort"
 /// semantics restrict project-root writability.
 #[test]
 fn test_csa_state_paths_survive_replace_semantics() {
+    let project_root = current_project_root();
     let cfg = parse_project_config(
         r#"
 [resources]
@@ -361,6 +453,7 @@ writable_paths = ["/tmp/restricted-only"]
         Some(&cfg),
         "claude-code",
         "test-session",
+        &project_root,
         StreamMode::BufferOnly,
         120,
         600,
@@ -387,8 +480,7 @@ writable_paths = ["/tmp/restricted-only"]
     );
 
     // But CSA state paths should still be present.
-    let cwd = std::env::current_dir().unwrap_or_default();
-    if let Ok(project_state_root) = csa_session::manager::get_session_root(&cwd) {
+    if let Ok(project_state_root) = csa_session::manager::get_session_root(&project_root) {
         assert!(
             writable.contains(&project_state_root),
             "CSA state root must survive REPLACE semantics"
@@ -424,6 +516,7 @@ enforcement_mode = "best-effort"
         Some(&cfg),
         "claude-code",
         "test-session",
+        &current_project_root(),
         StreamMode::BufferOnly,
         120,
         600,
@@ -472,6 +565,7 @@ enforcement_mode = "best-effort"
         Some(&cfg),
         "claude-code",
         "test-session",
+        &current_project_root(),
         StreamMode::BufferOnly,
         120,
         600,

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -537,6 +537,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         config,
         executor.tool_name(),
         &session.meta_session_id,
+        project_root,
         stream_mode,
         idle_timeout_seconds,
         liveness_dead_seconds,

--- a/crates/cli-sub-agent/src/session_cmds_resolve.rs
+++ b/crates/cli-sub-agent/src/session_cmds_resolve.rs
@@ -115,6 +115,10 @@ pub(crate) fn resolve_session_prefix_with_global_fallback(
             if csa_session::validate_session_id(prefix).is_err() {
                 return Err(project_err);
             }
+            if let Some(resolution) = resolve_exact_initializing_session_dir(project_root, prefix)?
+            {
+                return Ok(resolution);
+            }
             // Try global exact lookup
             if let Some(session_dir) = csa_session::get_session_dir_global(prefix)? {
                 let sessions_dir = session_dir
@@ -137,6 +141,33 @@ pub(crate) fn resolve_session_prefix_with_global_fallback(
             Err(project_err)
         }
     }
+}
+
+fn resolve_exact_initializing_session_dir(
+    project_root: &Path,
+    session_id: &str,
+) -> Result<Option<SessionPrefixResolution>> {
+    let primary_root = csa_session::get_session_root(project_root)?;
+    let primary_sessions_dir = primary_root.join("sessions");
+    if primary_sessions_dir.join(session_id).is_dir() {
+        return Ok(Some(SessionPrefixResolution {
+            session_id: session_id.to_string(),
+            sessions_dir: primary_sessions_dir,
+            foreign_project_root: None,
+        }));
+    }
+
+    if let Some(legacy_sessions_dir) = legacy_sessions_dir_from_primary_root(&primary_root)
+        && legacy_sessions_dir.join(session_id).is_dir()
+    {
+        return Ok(Some(SessionPrefixResolution {
+            session_id: session_id.to_string(),
+            sessions_dir: legacy_sessions_dir,
+            foreign_project_root: None,
+        }));
+    }
+
+    Ok(None)
 }
 
 /// Read `state.toml` from a session directory and extract the `project_path`

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::session_cmds::resolve_session_prefix_with_global_fallback;
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 
@@ -18,6 +19,24 @@ fn wait_for_spawned_daemon_visibility(
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
     panic!("daemon child never became visible to ToolLiveness");
+}
+
+#[test]
+fn resolve_session_prefix_with_global_fallback_accepts_initializing_exact_session_dir() {
+    let td = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&td);
+    let project = td.path();
+    let session_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+
+    let session_root = get_session_root(project).unwrap();
+    let session_dir = session_root.join("sessions").join(session_id);
+    std::fs::create_dir_all(&session_dir).unwrap();
+    std::fs::write(session_dir.join("daemon.pid"), "12345\n").unwrap();
+
+    let resolved = resolve_session_prefix_with_global_fallback(project, session_id).unwrap();
+    assert_eq!(resolved.session_id, session_id);
+    assert_eq!(resolved.sessions_dir, session_root.join("sessions"));
+    assert_eq!(resolved.foreign_project_root, None);
 }
 
 #[cfg(unix)]

--- a/crates/csa-executor/src/transport_acp_crash_retry.rs
+++ b/crates/csa-executor/src/transport_acp_crash_retry.rs
@@ -47,6 +47,12 @@ pub(crate) fn is_oom_error(error_display: &str) -> bool {
     is_oom_lowered(&lowered)
 }
 
+/// Check if the error indicates a deterministic auth or permission failure.
+pub(crate) fn is_auth_error(error_display: &str) -> bool {
+    let lowered = error_display.to_lowercase();
+    is_auth_lowered(&lowered)
+}
+
 // ---------------------------------------------------------------------------
 // Internal classifiers operating on pre-lowered strings.
 // ---------------------------------------------------------------------------
@@ -55,6 +61,11 @@ pub(crate) fn is_oom_error(error_display: &str) -> bool {
 fn is_retryable_crash_lowered(lowered: &str) -> bool {
     // Never retry OOM / resource limit kills — the same limit will be hit again.
     if is_oom_lowered(lowered) {
+        return false;
+    }
+
+    // Never retry auth/permission failures — the same credentials will fail again.
+    if is_auth_lowered(lowered) {
         return false;
     }
 
@@ -92,6 +103,16 @@ fn is_oom_lowered(lowered: &str) -> bool {
         || lowered.contains("out of memory")
         || lowered.contains("memory.max")
         || lowered.contains("memorymax")
+}
+
+/// Authentication or authorization failures (deterministic, never retry).
+fn is_auth_lowered(lowered: &str) -> bool {
+    lowered.contains("401 unauthorized")
+        || lowered.contains("403 forbidden")
+        || lowered.contains("insufficient permissions")
+        || lowered.contains("missing scopes")
+        || lowered.contains("missing_scope")
+        || lowered.contains("unauthorized")
 }
 
 /// Configuration or spawn failure (deterministic, never retry).
@@ -147,6 +168,18 @@ pub(crate) fn format_oom_crash(error: anyhow::Error, tool_name: &str) -> anyhow:
          Consider: (1) increasing memory limits in .csa/config.toml [resources], \
          (2) reducing diff/context size, \
          (3) switching to a different tool via --tier. \
+         Error: {error:#}"
+    )
+}
+
+/// Format a user-facing error message for a non-retryable auth/config failure.
+pub(crate) fn format_auth_failure(error: anyhow::Error, tool_name: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "ACP transport for {tool_name} failed due to authentication or permission error. \
+         This is not retryable with the current credentials. \
+         Consider: (1) verifying the tool's auth/session setup, \
+         (2) checking required API scopes/roles, \
+         (3) switching to a different tool via --tier if available. \
          Error: {error:#}"
     )
 }
@@ -207,6 +240,9 @@ pub(super) async fn execute_with_crash_retry(
 
                 if is_oom_error(&error_display) {
                     return Err(format_oom_crash(error, &transport.tool_name));
+                }
+                if is_auth_error(&error_display) {
+                    return Err(format_auth_failure(error, &transport.tool_name));
                 }
                 if attempt > 1 {
                     return Err(format_crash_retry_exhausted(
@@ -321,6 +357,22 @@ mod tests {
         assert!(!is_retryable_acp_crash(err));
     }
 
+    #[test]
+    fn test_unauthorized_missing_scope_is_not_retryable() {
+        let err = "ACP prompt failed: Internal error: unexpected status 401 Unauthorized: \
+                   You have insufficient permissions for this operation. \
+                   Missing scopes: api.responses.write";
+        assert!(is_auth_error(err));
+        assert!(!is_retryable_acp_crash(err));
+    }
+
+    #[test]
+    fn test_missing_scope_marker_is_not_retryable() {
+        let err = "codex responses error: code=missing_scope";
+        assert!(is_auth_error(err));
+        assert!(!is_retryable_acp_crash(err));
+    }
+
     // --- Non-retryable: Timeout ---
 
     #[test]
@@ -369,6 +421,17 @@ mod tests {
         let msg = formatted.to_string();
         assert!(msg.contains("codex"));
         assert!(msg.contains("memory limits"));
+        assert!(msg.contains("--tier"));
+    }
+
+    #[test]
+    fn test_format_auth_failure_contains_key_info() {
+        let err = anyhow::anyhow!("401 Unauthorized: Missing scopes: api.responses.write");
+        let formatted = format_auth_failure(err, "codex");
+        let msg = formatted.to_string();
+        assert!(msg.contains("codex"));
+        assert!(msg.contains("authentication or permission error"));
+        assert!(msg.contains("scopes"));
         assert!(msg.contains("--tier"));
     }
 }


### PR DESCRIPTION
Fixes #630
Fixes #631
Fixes #632

## Summary
- respect the explicit project root when building sandbox plans for cross-repo `--cd` runs
- classify deterministic Codex auth failures as non-retryable auth/config failures instead of ACP crash retries
- allow exact session resolution for initializing daemon session directories so immediate `session wait/result` can attach during startup

## Validation
- `just fmt`
- `just clippy`
- `cargo test -p cli-sub-agent pipeline_sandbox::tests::test_cross_repo_cd_uses_explicit_project_root_for_sandbox_plan -- --exact`
- `cargo test -p cli-sub-agent session_cmds::tests::tail_tests::resolve_session_prefix_with_global_fallback_accepts_initializing_exact_session_dir -- --exact`
- `cargo test -p csa-executor test_unauthorized_missing_scope_is_not_retryable -- --exact`
- `lefthook run pre-commit`
- `csa review --sa-mode true --tier tier-review --diff`
- `csa review --sa-mode true --tier tier-review --range main...HEAD`
