### PR TITLE
fix(session): preserve late results over synthetic fallback (#638)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "chrono",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "chrono",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "axum",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "chrono",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "chrono",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.258"
+version = "0.1.259"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.258"
+version = "0.1.259"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -1,12 +1,11 @@
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use std::fs;
 use std::path::Path;
-use tracing::{info, warn};
+use tracing::info;
 
 use csa_core::types::OutputFormat;
 use csa_session::{
-    SessionPhase, SessionResult, delete_session, get_session_dir, list_sessions,
-    list_sessions_tree_filtered, load_result, load_session, save_session_in,
+    SessionResult, delete_session, list_sessions, list_sessions_tree_filtered, load_session,
 };
 
 // Re-export types and functions from session_cmds_result so that
@@ -33,107 +32,16 @@ use list::{
     session_to_json, truncate_with_ellipsis,
 };
 
-pub(crate) fn ensure_terminal_result_for_dead_active_session(
-    project_root: &Path,
-    session_id: &str,
-    trigger: &str,
-) -> Result<bool> {
-    let mut session = load_session(project_root, session_id)?;
-    if !matches!(session.phase, SessionPhase::Active) {
-        return Ok(false);
-    }
-    let session_dir = get_session_dir(project_root, session_id)?;
-    if csa_process::ToolLiveness::has_live_process(&session_dir)
-        || load_result(project_root, session_id)?.is_some()
-    {
-        return Ok(false);
-    }
-    let now = chrono::Utc::now();
-    let tool_name = session
-        .tools
-        .iter()
-        .max_by_key(|(_, state)| state.updated_at)
-        .map(|(tool, _)| tool.clone())
-        .unwrap_or_else(|| "unknown".to_string());
-    let artifacts =
-        crate::pipeline_post_exec::collect_fallback_result_artifacts(project_root, session_id);
-    let summary_prefix =
-        format!("synthetic failure by {trigger}: process dead, result.toml missing");
-    let fallback = SessionResult {
-        status: "failure".to_string(),
-        exit_code: 1,
-        summary: crate::pipeline_post_exec::build_fallback_result_summary(
-            &session_dir,
-            &summary_prefix,
-        ),
-        tool: tool_name,
-        started_at: std::cmp::min(session.last_accessed, now),
-        completed_at: now,
-        events_count: 0,
-        artifacts,
-        peak_memory_mb: None,
-    };
-    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
-    if result_path.exists() {
-        return Ok(false);
-    }
-    let result_contents = toml::to_string_pretty(&fallback)
-        .map_err(|err| anyhow!("Failed to serialize synthetic result for {session_id}: {err}"))?;
-    fs::write(&result_path, result_contents)
-        .map_err(|err| anyhow!("Failed to write synthetic result for {session_id}: {err}"))?;
-    // Best-effort cooldown marker
-    csa_session::write_cooldown_marker_from_session_dir(
-        &session_dir,
-        session_id,
-        fallback.completed_at,
-    );
-    session.termination_reason = Some("orphaned_process".to_string());
-    // Transition to Retired so the session no longer blocks new launches (#540).
-    let _ = session.apply_phase_event(csa_session::PhaseEvent::Retired);
-    let session_root = session_dir
-        .parent()
-        .and_then(Path::parent)
-        .ok_or_else(|| anyhow!("Invalid session dir layout: {}", session_dir.display()))?;
-    save_session_in(session_root, &session)?;
-    warn!(session_id = %session_id, trigger = %trigger, "Recovered orphaned session with synthetic result");
-    Ok(true)
-}
-
-/// Retire an Active session whose tool process is dead and result.toml already
-/// exists. Covers the gap where post-exec wrote result.toml but the session was
-/// never Retired (e.g. process exited before phase transition). See #540.
-pub(crate) fn retire_if_dead_with_result(
-    project_root: &Path,
-    session_id: &str,
-    trigger: &str,
-) -> Result<bool> {
-    let mut session = load_session(project_root, session_id)?;
-    if !matches!(session.phase, SessionPhase::Active) {
-        return Ok(false);
-    }
-    let session_dir = get_session_dir(project_root, session_id)?;
-    if csa_process::ToolLiveness::has_live_process(&session_dir)
-        || load_result(project_root, session_id)?.is_none()
-    {
-        return Ok(false);
-    }
-    if session
-        .apply_phase_event(csa_session::PhaseEvent::Retired)
-        .is_err()
-    {
-        return Ok(false);
-    }
-    session
-        .termination_reason
-        .get_or_insert_with(|| "completed".to_string());
-    let session_root = session_dir
-        .parent()
-        .and_then(Path::parent)
-        .ok_or_else(|| anyhow!("Invalid session dir layout: {}", session_dir.display()))?;
-    save_session_in(session_root, &session)?;
-    info!(session_id = %session_id, trigger = %trigger, "Retired dead Active session with result");
-    Ok(true)
-}
+#[path = "session_cmds_reconcile.rs"]
+mod reconcile;
+#[cfg(test)]
+pub(crate) use reconcile::{
+    DeadActiveSessionReconciliation,
+    ensure_terminal_result_for_dead_active_session_with_before_write,
+};
+pub(crate) use reconcile::{
+    ensure_terminal_result_for_dead_active_session, retire_if_dead_with_result,
+};
 
 pub(crate) fn handle_session_list(
     cd: Option<String>,

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -123,6 +123,42 @@ pub(crate) fn handle_session_wait(
     cd: Option<String>,
     wait_timeout_secs: u64,
 ) -> Result<i32> {
+    handle_session_wait_with_hooks(
+        session,
+        cd,
+        wait_timeout_secs,
+        |project_root, session_id, trigger| {
+            let reconciled = crate::session_cmds::ensure_terminal_result_for_dead_active_session(
+                project_root,
+                session_id,
+                trigger,
+            )?;
+            Ok(WaitReconciliationOutcome {
+                result_became_available: reconciled.result_became_available(),
+                synthetic: reconciled.synthesized_failure(),
+            })
+        },
+        emit_wait_completion_signal,
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WaitReconciliationOutcome {
+    pub(crate) result_became_available: bool,
+    pub(crate) synthetic: bool,
+}
+
+pub(crate) fn handle_session_wait_with_hooks<R, E>(
+    session: String,
+    cd: Option<String>,
+    wait_timeout_secs: u64,
+    mut reconcile_dead_active_session: R,
+    mut emit_completion_signal: E,
+) -> Result<i32>
+where
+    R: FnMut(&Path, &str, &str) -> Result<WaitReconciliationOutcome>,
+    E: FnMut(&str, &str, i32, bool, bool),
+{
     let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
     let resolved = resolve_session_prefix_with_global_fallback(&project_root, &session)?;
     // For cross-project sessions, derive session_dir from the resolved sessions_dir
@@ -150,7 +186,7 @@ pub(crate) fn handle_session_wait(
             );
             let streamed_output = stream_wait_output(&session_dir)?;
             emit_wait_next_step_if_needed(&session_dir)?;
-            emit_wait_completion_signal(
+            emit_completion_signal(
                 &resolved.session_id,
                 &completion.status,
                 completion.exit_code,
@@ -168,7 +204,7 @@ pub(crate) fn handle_session_wait(
         )? {
             let streamed_output = stream_wait_output(&session_dir)?;
             emit_wait_next_step_if_needed(&session_dir)?;
-            emit_wait_completion_signal(
+            emit_completion_signal(
                 &resolved.session_id,
                 &result.status,
                 result.exit_code,
@@ -179,12 +215,9 @@ pub(crate) fn handle_session_wait(
         }
 
         // Synthesize terminal result for dead Active sessions.
-        let synthesized = crate::session_cmds::ensure_terminal_result_for_dead_active_session(
-            effective_root,
-            &resolved.session_id,
-            "session wait",
-        )?;
-        if synthesized.result_became_available()
+        let reconciled =
+            reconcile_dead_active_session(effective_root, &resolved.session_id, "session wait")?;
+        if reconciled.result_became_available
             && let Some(result) = load_completed_daemon_result_adaptive(
                 effective_root,
                 &resolved.session_id,
@@ -194,14 +227,14 @@ pub(crate) fn handle_session_wait(
         {
             let streamed_output = stream_wait_output(&session_dir)?;
             emit_wait_next_step_if_needed(&session_dir)?;
-            emit_wait_completion_signal(
+            emit_completion_signal(
                 &resolved.session_id,
                 &result.status,
                 result.exit_code,
-                true,
+                reconciled.synthetic,
                 !streamed_output,
             );
-            if synthesized.synthesized_failure() && !streamed_output {
+            if reconciled.synthetic && !streamed_output {
                 eprintln!(
                     "Session {} reached a synthesized terminal result because no live daemon process remained.",
                     resolved.session_id,
@@ -219,7 +252,7 @@ pub(crate) fn handle_session_wait(
             )? {
                 let streamed_output = stream_wait_output(&session_dir)?;
                 emit_wait_next_step_if_needed(&session_dir)?;
-                emit_wait_completion_signal(
+                emit_completion_signal(
                     &resolved.session_id,
                     &result.status,
                     result.exit_code,

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -184,7 +184,7 @@ pub(crate) fn handle_session_wait(
             &resolved.session_id,
             "session wait",
         )?;
-        if synthesized
+        if synthesized.result_became_available()
             && let Some(result) = load_completed_daemon_result_adaptive(
                 effective_root,
                 &resolved.session_id,
@@ -201,7 +201,7 @@ pub(crate) fn handle_session_wait(
                 true,
                 !streamed_output,
             );
-            if !streamed_output {
+            if synthesized.synthesized_failure() && !streamed_output {
                 eprintln!(
                     "Session {} reached a synthesized terminal result because no live daemon process remained.",
                     resolved.session_id,

--- a/crates/cli-sub-agent/src/session_cmds_list.rs
+++ b/crates/cli-sub-agent/src/session_cmds_list.rs
@@ -79,7 +79,7 @@ pub(super) fn resolve_session_status(session: &MetaSessionState) -> String {
         Ok(None) => {
             let reconciled =
                 ensure_terminal_result_for_dead_active_session(project_root, sid, "session list");
-            if matches!(reconciled, Ok(true))
+            if matches!(reconciled, Ok(outcome) if outcome.result_became_available())
                 && let Ok(Some(result)) = load_result(project_root, sid)
             {
                 return status_from_phase_and_result(&SessionPhase::Retired, Some(&result))

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -30,7 +30,13 @@ pub(crate) fn ensure_terminal_result_for_dead_active_session(
     session_id: &str,
     trigger: &str,
 ) -> Result<DeadActiveSessionReconciliation> {
-    ensure_terminal_result_for_dead_active_session_impl(project_root, session_id, trigger, |_| {})
+    ensure_terminal_result_for_dead_active_session_impl(
+        project_root,
+        session_id,
+        trigger,
+        |_| {},
+        |_| {},
+    )
 }
 
 #[cfg(test)]
@@ -48,17 +54,20 @@ where
         session_id,
         trigger,
         before_write,
+        |_| {},
     )
 }
 
-fn ensure_terminal_result_for_dead_active_session_impl<F>(
+fn ensure_terminal_result_for_dead_active_session_impl<F, B>(
     project_root: &Path,
     session_id: &str,
     trigger: &str,
     before_write: F,
+    before_retire: B,
 ) -> Result<DeadActiveSessionReconciliation>
 where
     F: FnOnce(&Path),
+    B: FnOnce(&mut csa_session::MetaSessionState),
 {
     let mut session = load_session(project_root, session_id)?;
     if !matches!(session.phase, SessionPhase::Active) {
@@ -141,16 +150,18 @@ where
         session_id,
         fallback.completed_at,
     );
-    session.termination_reason = Some("orphaned_process".to_string());
+    before_retire(&mut session);
     if let Err(err) = session.apply_phase_event(csa_session::PhaseEvent::Retired) {
         warn!(
             session_id = %session_id,
             trigger = %trigger,
             reconciliation_reason = "true_missing_result",
             error = %err,
-            "Failed to transition orphaned session to Retired phase during reconciliation"
+            "Failed to transition orphaned session to Retired phase during reconciliation; leaving session state unchanged"
         );
+        return Ok(DeadActiveSessionReconciliation::NoChange);
     }
+    session.termination_reason = Some("orphaned_process".to_string());
     let session_root = derive_session_root(&session_dir)?;
     save_session_in(session_root, &session)?;
     warn!(
@@ -219,6 +230,22 @@ fn persist_new_result_file<F>(
 where
     F: FnOnce(&Path),
 {
+    persist_new_result_file_with_writer(result_path, contents, before_write, |file, contents| {
+        file.write_all(contents.as_bytes())?;
+        file.sync_all()
+    })
+}
+
+fn persist_new_result_file_with_writer<F, W>(
+    result_path: &Path,
+    contents: &str,
+    before_write: F,
+    write_contents: W,
+) -> Result<SyntheticResultPersistOutcome>
+where
+    F: FnOnce(&Path),
+    W: FnOnce(&mut fs::File, &str) -> std::io::Result<()>,
+{
     before_write(result_path);
     match OpenOptions::new()
         .write(true)
@@ -226,18 +253,13 @@ where
         .open(result_path)
     {
         Ok(mut file) => {
-            file.write_all(contents.as_bytes()).map_err(|err| {
-                anyhow!(
-                    "Failed to write synthetic result for {}: {err}",
+            if let Err(err) = write_contents(&mut file, contents) {
+                fs::remove_file(result_path).ok();
+                return Err(anyhow!(
+                    "Failed to write or sync synthetic result for {}: {err}",
                     result_path.display()
-                )
-            })?;
-            file.sync_all().map_err(|err| {
-                anyhow!(
-                    "Failed to sync synthetic result for {}: {err}",
-                    result_path.display()
-                )
-            })?;
+                ));
+            }
             Ok(SyntheticResultPersistOutcome::Created)
         }
         Err(err) if err.kind() == ErrorKind::AlreadyExists => {
@@ -254,4 +276,176 @@ fn format_optional_file_mtime(path: &Path) -> Option<String> {
     let modified = fs::metadata(path).ok()?.modified().ok()?;
     let modified = chrono::DateTime::<chrono::Utc>::from(modified);
     Some(modified.to_rfc3339())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_cmds_daemon::{WaitReconciliationOutcome, handle_session_wait_with_hooks};
+    use crate::test_env_lock::TEST_ENV_LOCK;
+    use chrono::Utc;
+    use csa_session::{
+        SessionPhase, SessionResult, create_session, get_session_dir, load_result, load_session,
+        save_result,
+    };
+    use tempfile::tempdir;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe {
+                match self.original.as_deref() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    fn make_result(status: &str, exit_code: i32) -> SessionResult {
+        let now = Utc::now();
+        SessionResult {
+            status: status.to_string(),
+            exit_code,
+            summary: "summary".to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: Vec::new(),
+            peak_memory_mb: None,
+        }
+    }
+
+    #[test]
+    fn ensure_terminal_result_for_dead_active_session_leaves_state_unchanged_on_transition_failure()
+    {
+        let td = tempdir().expect("tempdir");
+        let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+        let state_home = td.path().join("xdg-state");
+        std::fs::create_dir_all(&state_home).expect("create state home");
+        let _home_guard = EnvVarGuard::set("HOME", td.path());
+        let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+        let project = td.path();
+
+        let session = create_session(project, Some("transition-failure"), None, None).unwrap();
+        let session_id = session.meta_session_id;
+        let session_dir = get_session_dir(project, &session_id).unwrap();
+        let state_path = session_dir.join("state.toml");
+        let original_state = fs::read_to_string(&state_path).unwrap();
+
+        let reconciled = ensure_terminal_result_for_dead_active_session_impl(
+            project,
+            &session_id,
+            "session list",
+            |_| {},
+            |session| {
+                session.phase = SessionPhase::Retired;
+            },
+        )
+        .unwrap();
+
+        assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
+        let persisted = load_session(project, &session_id).unwrap();
+        assert_eq!(persisted.phase, SessionPhase::Active);
+        assert_eq!(persisted.termination_reason, None);
+        assert_eq!(fs::read_to_string(&state_path).unwrap(), original_state);
+        assert!(
+            load_result(project, &session_id).unwrap().is_some(),
+            "synthetic result should remain available for later reconciliation"
+        );
+    }
+
+    #[test]
+    fn persist_new_result_file_removes_partial_file_when_write_fails() {
+        let td = tempdir().expect("tempdir");
+        let result_path = td.path().join("result.toml");
+
+        let err = persist_new_result_file_with_writer(
+            &result_path,
+            "status = \"failure\"\n",
+            |_| {},
+            |file, _contents| {
+                file.write_all(b"partial")?;
+                Err(std::io::Error::other("boom"))
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Failed to write or sync synthetic result"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            !result_path.exists(),
+            "partial synthetic result should be removed after write failure"
+        );
+    }
+
+    #[test]
+    fn handle_session_wait_marks_late_real_result_completion_as_non_synthetic() {
+        let td = tempdir().expect("tempdir");
+        let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+        let state_home = td.path().join("xdg-state");
+        std::fs::create_dir_all(&state_home).expect("create state home");
+        let _home_guard = EnvVarGuard::set("HOME", td.path());
+        let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+        let project = td.path();
+
+        let session =
+            create_session(project, Some("wait-late-real-result"), None, Some("codex")).unwrap();
+        let session_id = session.meta_session_id;
+        let late_result = SessionResult {
+            summary: "real terminal result".to_string(),
+            ..make_result("success", 0)
+        };
+        let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+
+        let exit_code = handle_session_wait_with_hooks(
+            session_id.clone(),
+            Some(project.to_string_lossy().into_owned()),
+            5,
+            |project_root, current_session_id, trigger| {
+                let reconciled = ensure_terminal_result_for_dead_active_session_with_before_write(
+                    project_root,
+                    current_session_id,
+                    trigger,
+                    |_| {
+                        save_result(project_root, current_session_id, &late_result)
+                            .expect("persist late real result");
+                    },
+                )?;
+                Ok(WaitReconciliationOutcome {
+                    result_became_available: reconciled.result_became_available(),
+                    synthetic: reconciled.synthesized_failure(),
+                })
+            },
+            |sid, status, exit_code, synthetic, _mirror_to_stdout| {
+                emitted_completion =
+                    Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+            },
+        )
+        .unwrap();
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            emitted_completion,
+            Some((session_id, "success".to_string(), 0, false))
+        );
+    }
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -1,0 +1,248 @@
+use anyhow::{Result, anyhow};
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::Path;
+use tracing::{info, warn};
+
+use csa_session::{
+    SessionPhase, SessionResult, get_session_dir, load_result, load_session, save_session_in,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeadActiveSessionReconciliation {
+    NoChange,
+    SynthesizedFailure,
+    LateResultRetired,
+}
+
+impl DeadActiveSessionReconciliation {
+    pub(crate) fn result_became_available(self) -> bool {
+        matches!(self, Self::SynthesizedFailure | Self::LateResultRetired)
+    }
+
+    pub(crate) fn synthesized_failure(self) -> bool {
+        matches!(self, Self::SynthesizedFailure)
+    }
+}
+
+pub(crate) fn ensure_terminal_result_for_dead_active_session(
+    project_root: &Path,
+    session_id: &str,
+    trigger: &str,
+) -> Result<DeadActiveSessionReconciliation> {
+    ensure_terminal_result_for_dead_active_session_impl(project_root, session_id, trigger, |_| {})
+}
+
+#[cfg(test)]
+pub(crate) fn ensure_terminal_result_for_dead_active_session_with_before_write<F>(
+    project_root: &Path,
+    session_id: &str,
+    trigger: &str,
+    before_write: F,
+) -> Result<DeadActiveSessionReconciliation>
+where
+    F: FnOnce(&Path),
+{
+    ensure_terminal_result_for_dead_active_session_impl(
+        project_root,
+        session_id,
+        trigger,
+        before_write,
+    )
+}
+
+fn ensure_terminal_result_for_dead_active_session_impl<F>(
+    project_root: &Path,
+    session_id: &str,
+    trigger: &str,
+    before_write: F,
+) -> Result<DeadActiveSessionReconciliation>
+where
+    F: FnOnce(&Path),
+{
+    let mut session = load_session(project_root, session_id)?;
+    if !matches!(session.phase, SessionPhase::Active) {
+        return Ok(DeadActiveSessionReconciliation::NoChange);
+    }
+    let session_dir = get_session_dir(project_root, session_id)?;
+    if csa_process::ToolLiveness::has_live_process(&session_dir) {
+        return Ok(DeadActiveSessionReconciliation::NoChange);
+    }
+    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
+    match load_result(project_root, session_id) {
+        Ok(Some(_)) => return Ok(DeadActiveSessionReconciliation::NoChange),
+        Ok(None) => {}
+        Err(err) if result_path.is_file() => {
+            warn!(
+                session_id = %session_id,
+                trigger = %trigger,
+                reconciliation_reason = "late_result_write_unreadable",
+                result_path = %result_path.display(),
+                error = %err,
+                "Result file appeared during dead-session reconciliation; preserving late writer and skipping synthetic fallback"
+            );
+            return Ok(DeadActiveSessionReconciliation::NoChange);
+        }
+        Err(err) => return Err(err),
+    }
+
+    let now = chrono::Utc::now();
+    let tool_name = session
+        .tools
+        .iter()
+        .max_by_key(|(_, state)| state.updated_at)
+        .map(|(tool, _)| tool.clone())
+        .unwrap_or_else(|| "unknown".to_string());
+    let artifacts =
+        crate::pipeline_post_exec::collect_fallback_result_artifacts(project_root, session_id);
+    let output_log_mtime = format_optional_file_mtime(&session_dir.join("output.log"));
+    let summary_prefix = format!(
+        "synthetic failure by {trigger}: process dead, result.toml missing (reconciliation_reason=true_missing_result, output_log_mtime={})",
+        output_log_mtime.as_deref().unwrap_or("missing")
+    );
+    let fallback = SessionResult {
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: crate::pipeline_post_exec::build_fallback_result_summary(
+            &session_dir,
+            &summary_prefix,
+        ),
+        tool: tool_name,
+        started_at: std::cmp::min(session.last_accessed, now),
+        completed_at: now,
+        events_count: 0,
+        artifacts,
+        peak_memory_mb: None,
+    };
+    let result_contents = toml::to_string_pretty(&fallback)
+        .map_err(|err| anyhow!("Failed to serialize synthetic result for {session_id}: {err}"))?;
+    match persist_new_result_file(&result_path, &result_contents, before_write)? {
+        SyntheticResultPersistOutcome::AlreadyExists => {
+            let retired = retire_if_dead_with_result(project_root, session_id, trigger)?;
+            info!(
+                session_id = %session_id,
+                trigger = %trigger,
+                reconciliation_reason = "late_result_write",
+                result_path = %result_path.display(),
+                result_mtime = %format_optional_file_mtime(&result_path).unwrap_or_else(|| "unknown".to_string()),
+                "Late result.toml write won during dead-session reconciliation"
+            );
+            return Ok(if retired {
+                DeadActiveSessionReconciliation::LateResultRetired
+            } else {
+                DeadActiveSessionReconciliation::NoChange
+            });
+        }
+        SyntheticResultPersistOutcome::Created => {}
+    }
+
+    csa_session::write_cooldown_marker_from_session_dir(
+        &session_dir,
+        session_id,
+        fallback.completed_at,
+    );
+    session.termination_reason = Some("orphaned_process".to_string());
+    let _ = session.apply_phase_event(csa_session::PhaseEvent::Retired);
+    let session_root = session_dir
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| anyhow!("Invalid session dir layout: {}", session_dir.display()))?;
+    save_session_in(session_root, &session)?;
+    warn!(
+        session_id = %session_id,
+        trigger = %trigger,
+        reconciliation_reason = "true_missing_result",
+        result_path = %result_path.display(),
+        output_log_mtime = %output_log_mtime.unwrap_or_else(|| "missing".to_string()),
+        "Recovered orphaned session with synthetic result"
+    );
+    Ok(DeadActiveSessionReconciliation::SynthesizedFailure)
+}
+
+pub(crate) fn retire_if_dead_with_result(
+    project_root: &Path,
+    session_id: &str,
+    trigger: &str,
+) -> Result<bool> {
+    let mut session = load_session(project_root, session_id)?;
+    if !matches!(session.phase, SessionPhase::Active) {
+        return Ok(false);
+    }
+    let session_dir = get_session_dir(project_root, session_id)?;
+    if csa_process::ToolLiveness::has_live_process(&session_dir)
+        || load_result(project_root, session_id)?.is_none()
+    {
+        return Ok(false);
+    }
+    if session
+        .apply_phase_event(csa_session::PhaseEvent::Retired)
+        .is_err()
+    {
+        return Ok(false);
+    }
+    session
+        .termination_reason
+        .get_or_insert_with(|| "completed".to_string());
+    let session_root = session_dir
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| anyhow!("Invalid session dir layout: {}", session_dir.display()))?;
+    save_session_in(session_root, &session)?;
+    info!(
+        session_id = %session_id,
+        trigger = %trigger,
+        "Retired dead Active session with result"
+    );
+    Ok(true)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SyntheticResultPersistOutcome {
+    Created,
+    AlreadyExists,
+}
+
+fn persist_new_result_file<F>(
+    result_path: &Path,
+    contents: &str,
+    before_write: F,
+) -> Result<SyntheticResultPersistOutcome>
+where
+    F: FnOnce(&Path),
+{
+    before_write(result_path);
+    match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(result_path)
+    {
+        Ok(mut file) => {
+            file.write_all(contents.as_bytes()).map_err(|err| {
+                anyhow!(
+                    "Failed to write synthetic result for {}: {err}",
+                    result_path.display()
+                )
+            })?;
+            file.sync_all().map_err(|err| {
+                anyhow!(
+                    "Failed to sync synthetic result for {}: {err}",
+                    result_path.display()
+                )
+            })?;
+            Ok(SyntheticResultPersistOutcome::Created)
+        }
+        Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+            Ok(SyntheticResultPersistOutcome::AlreadyExists)
+        }
+        Err(err) => Err(anyhow!(
+            "Failed to create synthetic result for {}: {err}",
+            result_path.display()
+        )),
+    }
+}
+
+fn format_optional_file_mtime(path: &Path) -> Option<String> {
+    let modified = fs::metadata(path).ok()?.modified().ok()?;
+    let modified = chrono::DateTime::<chrono::Utc>::from(modified);
+    Some(modified.to_rfc3339())
+}

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -142,11 +142,16 @@ where
         fallback.completed_at,
     );
     session.termination_reason = Some("orphaned_process".to_string());
-    let _ = session.apply_phase_event(csa_session::PhaseEvent::Retired);
-    let session_root = session_dir
-        .parent()
-        .and_then(Path::parent)
-        .ok_or_else(|| anyhow!("Invalid session dir layout: {}", session_dir.display()))?;
+    if let Err(err) = session.apply_phase_event(csa_session::PhaseEvent::Retired) {
+        warn!(
+            session_id = %session_id,
+            trigger = %trigger,
+            reconciliation_reason = "true_missing_result",
+            error = %err,
+            "Failed to transition orphaned session to Retired phase during reconciliation"
+        );
+    }
+    let session_root = derive_session_root(&session_dir)?;
     save_session_in(session_root, &session)?;
     warn!(
         session_id = %session_id,
@@ -183,10 +188,7 @@ pub(crate) fn retire_if_dead_with_result(
     session
         .termination_reason
         .get_or_insert_with(|| "completed".to_string());
-    let session_root = session_dir
-        .parent()
-        .and_then(Path::parent)
-        .ok_or_else(|| anyhow!("Invalid session dir layout: {}", session_dir.display()))?;
+    let session_root = derive_session_root(&session_dir)?;
     save_session_in(session_root, &session)?;
     info!(
         session_id = %session_id,
@@ -200,6 +202,13 @@ pub(crate) fn retire_if_dead_with_result(
 enum SyntheticResultPersistOutcome {
     Created,
     AlreadyExists,
+}
+
+fn derive_session_root(session_dir: &Path) -> Result<&Path> {
+    session_dir
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| anyhow!("Invalid session dir layout: {}", session_dir.display()))
 }
 
 fn persist_new_result_file<F>(

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -1,8 +1,9 @@
 use super::resolve::resolve_session_prefix_from_dirs;
 use super::{
-    display_acp_events, display_daemon_spool_logs, display_log_files,
-    ensure_terminal_result_for_dead_active_session, handle_session_is_alive, handle_session_wait,
-    print_content_with_tail, select_sessions_for_list, session_to_json,
+    DeadActiveSessionReconciliation, display_acp_events, display_daemon_spool_logs,
+    display_log_files, ensure_terminal_result_for_dead_active_session,
+    ensure_terminal_result_for_dead_active_session_with_before_write, handle_session_is_alive,
+    handle_session_wait, print_content_with_tail, select_sessions_for_list, session_to_json,
     status_from_phase_and_result, truncate_with_ellipsis,
 };
 use crate::cli::{Cli, Commands, SessionCommands};

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -64,7 +64,7 @@ fn ensure_terminal_result_for_dead_active_session_is_noop_when_result_exists() {
     let reconciled =
         ensure_terminal_result_for_dead_active_session(project, &session_id, "session is-alive")
             .unwrap();
-    assert!(!reconciled);
+    assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
 
     let result = load_result(project, &session_id).unwrap().unwrap();
     assert_eq!(result.summary, "existing result");
@@ -124,7 +124,7 @@ fn ensure_terminal_result_for_dead_active_session_is_noop_for_non_active_phase()
     let reconciled =
         ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
             .unwrap();
-    assert!(!reconciled);
+    assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
     assert!(load_result(project, &session_id).unwrap().is_none());
 }
 
@@ -153,7 +153,7 @@ fn ensure_terminal_result_for_dead_active_session_is_noop_when_alive() {
     let reconciled =
         ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
             .unwrap();
-    assert!(!reconciled);
+    assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
     assert!(load_result(project, &session_id).unwrap().is_none());
 }
 
@@ -183,7 +183,10 @@ fn ensure_terminal_result_for_dead_active_session_persists_into_legacy_session_d
     let reconciled =
         ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
             .unwrap();
-    assert!(reconciled);
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
     assert!(
         legacy_session_dir
             .join(csa_session::result::RESULT_FILE_NAME)
@@ -332,12 +335,20 @@ fn ensure_terminal_result_for_dead_active_session_persists_synthetic_failure() {
     let reconciled =
         ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
             .unwrap();
-    assert!(reconciled);
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
 
     let result = load_result(project, &session_id).unwrap().unwrap();
     assert_eq!(result.status, "failure");
     assert_eq!(result.exit_code, 1);
     assert!(result.summary.contains("session list"));
+    assert!(
+        result
+            .summary
+            .contains("reconciliation_reason=true_missing_result")
+    );
     assert!(
         result
             .artifacts
@@ -350,6 +361,51 @@ fn ensure_terminal_result_for_dead_active_session_persists_synthetic_failure() {
     assert_eq!(
         persisted.termination_reason.as_deref(),
         Some("orphaned_process")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_terminal_result_for_dead_active_session_preserves_late_real_result() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(project, Some("late-result"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let late_result = SessionResult {
+        summary: "real terminal result".to_string(),
+        ..make_result("success", 0)
+    };
+
+    let reconciled = ensure_terminal_result_for_dead_active_session_with_before_write(
+        project,
+        &session_id,
+        "session list",
+        |_| {
+            save_result(project, &session_id, &late_result).unwrap();
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::LateResultRetired
+    );
+
+    let persisted = load_result(project, &session_id).unwrap().unwrap();
+    assert_eq!(persisted.status, "success");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.summary, "real terminal result");
+
+    let saved_session = load_session(project, &session_id).unwrap();
+    assert_eq!(saved_session.phase, SessionPhase::Retired);
+    assert_eq!(
+        saved_session.termination_reason.as_deref(),
+        Some("completed")
     );
 }
 
@@ -375,8 +431,9 @@ fn ensure_terminal_result_for_dead_active_session_reconciles_fresh_output_withou
     let reconciled =
         ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
             .unwrap();
-    assert!(
+    assert_eq!(
         reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure,
         "fresh file writes without a live process should still synthesize a terminal result"
     );
     assert!(load_result(project, &session_id).unwrap().is_some());

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.249"
-weave = "0.1.249"
+csa = "0.1.258"
+weave = "0.1.258"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Fix #638. Dead-session reconciliation now yields to a late-arriving real `result.toml` instead of overwriting it with a synthetic failure. Adds deterministic regression coverage for the child-completed / parent-sees-no-result-yet race, and improves diagnostics so true-missing results are distinguishable from late-write races.

## What changed

- Extracted dead Active-session reconciliation into a focused module.
- Made synthetic fallback writes atomic with `create_new` semantics so reconciliation can never overwrite a real `result.toml`.
- Return explicit reconciliation outcomes so `csa session list` and `csa session wait` can distinguish synthesized failures from late real-result retirement.
- Added diagnostics (reconciliation_reason + output log mtime) for future observability.
- Added a deterministic regression test.

## Test plan

- [x] `just fmt`
- [x] `just clippy`
- [x] Targeted session reconciliation tests
- [x] Full `just test` via pre-commit
- [x] `csa review --branch main --tier tier-4-critical` → PASS (gemini-cli)

Closes #638