### PR TITLE
fix: guard false-dead daemon reconciliation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "axum",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.261"
+version = "0.1.262"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.261"
+version = "0.1.262"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -46,6 +46,11 @@ fn is_pid_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
 }
 
+fn session_has_terminal_process(session_dir: &Path) -> bool {
+    csa_process::ToolLiveness::has_live_process(session_dir)
+        || csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
+}
+
 fn attach_primary_output_for_session(session_dir: &Path) -> AttachPrimaryOutput {
     let metadata_path = session_dir.join(csa_session::metadata::METADATA_FILE_NAME);
     let Ok(contents) = fs::read_to_string(metadata_path) else {
@@ -71,7 +76,8 @@ fn read_daemon_pid(session_dir: &std::path::Path) -> Option<u32> {
     // Primary: daemon.pid file (written by spawn_daemon since v0.1.198).
     let pid_path = session_dir.join("daemon.pid");
     if let Ok(content) = fs::read_to_string(&pid_path)
-        && let Ok(pid) = content.trim().parse()
+        && let Some(pid_str) = content.split_whitespace().next()
+        && let Ok(pid) = pid_str.parse()
     {
         return Some(pid);
     }
@@ -176,7 +182,7 @@ where
 
     loop {
         if let Some(completion) = load_daemon_completion_packet(&session_dir)?
-            && !csa_process::ToolLiveness::has_live_process(&session_dir)
+            && !session_has_terminal_process(&session_dir)
         {
             let _ = refresh_result_for_wait(
                 effective_root,
@@ -243,7 +249,7 @@ where
             return Ok(result.exit_code);
         }
 
-        if !csa_process::ToolLiveness::has_live_process(&session_dir) {
+        if !session_has_terminal_process(&session_dir) {
             if let Some(result) = load_completed_daemon_result_adaptive(
                 effective_root,
                 &resolved.session_id,
@@ -364,7 +370,7 @@ fn load_completed_daemon_result(
     session_id: &str,
     session_dir: &std::path::Path,
 ) -> Result<Option<csa_session::SessionResult>> {
-    let daemon_alive_at_refresh_start = csa_process::ToolLiveness::has_live_process(session_dir);
+    let daemon_alive_at_refresh_start = session_has_terminal_process(session_dir);
     let result =
         match crate::session_observability::refresh_and_repair_result(project_root, session_id) {
             Ok(Some(result)) => result,
@@ -380,7 +386,7 @@ fn load_completed_daemon_result(
             Err(err) => return Err(err),
         };
 
-    if csa_process::ToolLiveness::has_live_process(session_dir) {
+    if session_has_terminal_process(session_dir) {
         return Ok(None);
     }
 
@@ -410,8 +416,7 @@ fn load_completed_daemon_result_adaptive(
     is_cross_project: bool,
 ) -> Result<Option<csa_session::SessionResult>> {
     if is_cross_project {
-        let daemon_alive_at_refresh_start =
-            csa_process::ToolLiveness::has_live_process(session_dir);
+        let daemon_alive_at_refresh_start = session_has_terminal_process(session_dir);
         let result = match crate::session_observability::refresh_and_repair_result_from_dir(
             session_dir,
         ) {
@@ -427,7 +432,7 @@ fn load_completed_daemon_result_adaptive(
             }
             Err(err) => return Err(err),
         };
-        if csa_process::ToolLiveness::has_live_process(session_dir) {
+        if session_has_terminal_process(session_dir) {
             return Ok(None);
         }
         Ok(Some(result))
@@ -620,7 +625,7 @@ pub(crate) fn handle_session_attach(
             return Ok(completion.exit_code);
         }
 
-        if result_path.exists() && !csa_process::ToolLiveness::has_live_process(&session_dir) {
+        if result_path.exists() && !session_has_terminal_process(&session_dir) {
             let exit_code = fs::read_to_string(&result_path)
                 .ok()
                 .and_then(|s| toml::from_str::<csa_session::result::SessionResult>(&s).ok())
@@ -672,12 +677,20 @@ pub(crate) fn handle_session_kill(session: String, cd: Option<String>) -> Result
     let resolved = resolve_session_prefix_with_global_fallback(&project_root, &session)?;
     let session_dir = resolved.sessions_dir.join(&resolved.session_id);
 
-    let pid = read_daemon_pid(&session_dir).ok_or_else(|| {
-        anyhow::anyhow!(
+    let pid = if let Some(pid) = csa_process::ToolLiveness::daemon_pid_for_signal(&session_dir) {
+        pid
+    } else if let Some(stale_pid) = read_daemon_pid(&session_dir) {
+        anyhow::bail!(
+            "Stored daemon PID {} for session {} no longer matches a live session process; refusing to signal a potentially reused PID",
+            stale_pid,
+            resolved.session_id,
+        );
+    } else {
+        anyhow::bail!(
             "No daemon PID found for session {} — may not be a daemon session",
             resolved.session_id,
-        )
-    })?;
+        );
+    };
 
     if pid <= 1 {
         anyhow::bail!(
@@ -743,46 +756,5 @@ pub(crate) fn handle_session_kill(session: String, cd: Option<String>) -> Result
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn attach_primary_output_prefers_output_log_for_acp_tools() {
-        let td = tempfile::tempdir().expect("tempdir");
-        let metadata = csa_session::metadata::SessionMetadata {
-            tool: "codex".to_string(),
-            tool_locked: true,
-        };
-        let metadata_toml = toml::to_string_pretty(&metadata).expect("metadata toml");
-        std::fs::write(
-            td.path().join(csa_session::metadata::METADATA_FILE_NAME),
-            metadata_toml,
-        )
-        .expect("write metadata");
-
-        assert_eq!(
-            attach_primary_output_for_session(td.path()),
-            AttachPrimaryOutput::OutputLog
-        );
-    }
-
-    #[test]
-    fn attach_primary_output_keeps_stdout_for_legacy_tools() {
-        let td = tempfile::tempdir().expect("tempdir");
-        let metadata = csa_session::metadata::SessionMetadata {
-            tool: "opencode".to_string(),
-            tool_locked: true,
-        };
-        let metadata_toml = toml::to_string_pretty(&metadata).expect("metadata toml");
-        std::fs::write(
-            td.path().join(csa_session::metadata::METADATA_FILE_NAME),
-            metadata_toml,
-        )
-        .expect("write metadata");
-
-        assert_eq!(
-            attach_primary_output_for_session(td.path()),
-            AttachPrimaryOutput::StdoutLog
-        );
-    }
-}
+#[path = "session_cmds_daemon_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -539,7 +539,6 @@ pub(crate) fn handle_session_attach(
         std::thread::sleep(std::time::Duration::from_millis(200));
     }
 
-    let daemon_pid = read_daemon_pid(&session_dir);
     let live_stdout_path = if live_stdout_path.exists() {
         live_stdout_path
     } else {
@@ -634,15 +633,21 @@ pub(crate) fn handle_session_attach(
             return Ok(exit_code);
         }
 
-        // Detect dead daemon: PID gone but no result.toml.
-        // Synthesize a terminal result so callers always observe result.toml (#543).
-        if let Some(pid) = daemon_pid
-            && !is_pid_alive(pid)
-        {
-            eprintln!(
-                "Daemon process {} exited without producing result.toml; synthesizing fallback",
-                pid,
-            );
+        // Detect dead daemon: no live session-relevant process remains and no
+        // terminal result exists yet. This shares the same PID-reuse guard as
+        // wait/reconcile/kill instead of trusting the raw daemon.pid value.
+        if !session_has_terminal_process(&session_dir) {
+            if let Some(pid) = read_daemon_pid(&session_dir) {
+                eprintln!(
+                    "Daemon process {} exited without producing result.toml; synthesizing fallback",
+                    pid,
+                );
+            } else {
+                eprintln!(
+                    "Session {} has no live daemon process and no result.toml; synthesizing fallback",
+                    resolved.session_id,
+                );
+            }
             // For cross-project sessions, skip synthesis (requires project_root write access).
             let is_cross_project =
                 csa_session::get_session_dir(&project_root, &resolved.session_id).is_err();

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -585,7 +585,9 @@ pub(crate) fn handle_session_attach(
             }
         }
 
-        if let Some(completion) = load_daemon_completion_packet(&session_dir)? {
+        if let Some(completion) = load_daemon_completion_packet(&session_dir)?
+            && !session_has_terminal_process(&session_dir)
+        {
             // Drain remaining stdout.
             loop {
                 let n = live_stdout_file.read(&mut buf)?;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+#[test]
+fn attach_primary_output_prefers_output_log_for_acp_tools() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let metadata = csa_session::metadata::SessionMetadata {
+        tool: "codex".to_string(),
+        tool_locked: true,
+    };
+    let metadata_toml = toml::to_string_pretty(&metadata).expect("metadata toml");
+    std::fs::write(
+        td.path().join(csa_session::metadata::METADATA_FILE_NAME),
+        metadata_toml,
+    )
+    .expect("write metadata");
+
+    assert_eq!(
+        attach_primary_output_for_session(td.path()),
+        AttachPrimaryOutput::OutputLog
+    );
+}
+
+#[test]
+fn attach_primary_output_keeps_stdout_for_legacy_tools() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let metadata = csa_session::metadata::SessionMetadata {
+        tool: "opencode".to_string(),
+        tool_locked: true,
+    };
+    let metadata_toml = toml::to_string_pretty(&metadata).expect("metadata toml");
+    std::fs::write(
+        td.path().join(csa_session::metadata::METADATA_FILE_NAME),
+        metadata_toml,
+    )
+    .expect("write metadata");
+
+    assert_eq!(
+        attach_primary_output_for_session(td.path()),
+        AttachPrimaryOutput::StdoutLog
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
@@ -1,5 +1,37 @@
 use super::*;
 
+#[cfg(target_os = "linux")]
+use crate::test_env_lock::TEST_ENV_LOCK;
+
+#[cfg(target_os = "linux")]
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+#[cfg(target_os = "linux")]
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 #[test]
 fn attach_primary_output_prefers_output_log_for_acp_tools() {
     let td = tempfile::tempdir().expect("tempdir");
@@ -38,4 +70,65 @@ fn attach_primary_output_keeps_stdout_for_legacy_tools() {
         attach_primary_output_for_session(td.path()),
         AttachPrimaryOutput::StdoutLog
     );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn handle_session_attach_treats_stale_daemon_pid_as_dead() {
+    use std::process::Command;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = csa_session::create_session(
+        project,
+        Some("attach-stale-daemon-pid"),
+        None,
+        Some("opencode"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = csa_session::get_session_dir(project, &session_id).expect("session dir");
+    std::fs::write(session_dir.join("stdout.log"), "").expect("write stdout log");
+
+    let mut child = Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .expect("spawn child");
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        format!("{} 0\n", child.id()),
+    )
+    .expect("write daemon pid");
+
+    let (tx, rx) = mpsc::channel();
+    let attach_session = session_id.clone();
+    let attach_project = project.to_string_lossy().into_owned();
+    let handle = std::thread::spawn(move || {
+        let result = handle_session_attach(attach_session, false, Some(attach_project))
+            .map_err(|err| err.to_string());
+        let _ = tx.send(result);
+    });
+
+    let attach_result = rx.recv_timeout(Duration::from_secs(2));
+
+    child.kill().ok();
+    child.wait().ok();
+    handle.join().expect("attach thread join");
+
+    let exit_code = attach_result
+        .expect("attach should converge instead of waiting on a reused PID")
+        .expect("attach result");
+    assert_eq!(exit_code, 1);
+    let result = csa_session::load_result(project, &session_id)
+        .expect("load result")
+        .expect("synthetic result");
+    assert_eq!(result.status, "failure");
 }

--- a/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
@@ -1,15 +1,15 @@
 use super::*;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use crate::test_env_lock::TEST_ENV_LOCK;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 struct EnvVarGuard {
     key: &'static str,
     original: Option<String>,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 impl EnvVarGuard {
     fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
         let original = std::env::var(key).ok();
@@ -19,7 +19,7 @@ impl EnvVarGuard {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
@@ -72,10 +72,90 @@ fn attach_primary_output_keeps_stdout_for_legacy_tools() {
     );
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn spawn_daemon_like_process(session_id: &str) -> std::process::Child {
+    use std::os::unix::process::CommandExt;
+    use std::process::Command;
+
+    let mut cmd = Command::new("sh");
+    cmd.args(["-c", "sleep 60", "csa-daemon", session_id]);
+    // SAFETY: test fixture only; makes the child its own session leader like a daemon.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    cmd.spawn().expect("spawn daemon-like child")
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn handle_session_attach_waits_for_live_daemon_before_consuming_completion_packet() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = csa_session::create_session(
+        project,
+        Some("attach-completion-gate"),
+        None,
+        Some("opencode"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = csa_session::get_session_dir(project, &session_id).expect("session dir");
+    std::fs::write(session_dir.join("stdout.log"), "").expect("write stdout log");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .expect("write completion packet");
+
+    let mut child = spawn_daemon_like_process(&session_id);
+    std::fs::write(session_dir.join("daemon.pid"), format!("{}\n", child.id()))
+        .expect("write daemon pid");
+
+    let (tx, rx) = mpsc::channel();
+    let attach_session = session_id.clone();
+    let attach_project = project.to_string_lossy().into_owned();
+    let handle = std::thread::spawn(move || {
+        let result = handle_session_attach(attach_session, false, Some(attach_project))
+            .map_err(|err| err.to_string());
+        let _ = tx.send(result);
+    });
+
+    assert!(
+        matches!(
+            rx.recv_timeout(Duration::from_millis(500)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ),
+        "attach must keep tailing while the daemon process is still alive"
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+
+    let exit_code = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("attach should finish after the daemon exits")
+        .expect("attach result");
+    handle.join().expect("attach thread join");
+    assert_eq!(exit_code, 1);
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn handle_session_attach_treats_stale_daemon_pid_as_dead() {
-    use std::process::Command;
     use std::sync::mpsc;
     use std::time::Duration;
 
@@ -98,7 +178,7 @@ fn handle_session_attach_treats_stale_daemon_pid_as_dead() {
     let session_dir = csa_session::get_session_dir(project, &session_id).expect("session dir");
     std::fs::write(session_dir.join("stdout.log"), "").expect("write stdout log");
 
-    let mut child = Command::new("sleep")
+    let mut child = std::process::Command::new("sleep")
         .arg("60")
         .spawn()
         .expect("spawn child");
@@ -131,4 +211,49 @@ fn handle_session_attach_treats_stale_daemon_pid_as_dead() {
         .expect("load result")
         .expect("synthetic result");
     assert_eq!(result.status, "failure");
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn handle_session_kill_accepts_legacy_stderr_pid() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session =
+        csa_session::create_session(project, Some("kill-legacy-stderr"), None, Some("opencode"))
+            .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = csa_session::get_session_dir(project, &session_id).expect("session dir");
+
+    let mut child = spawn_daemon_like_process(&session_id);
+    let child_pid = child.id();
+    std::fs::write(
+        session_dir.join("stderr.log"),
+        format!(
+            "<!-- CSA:SESSION_STARTED id={} pid={} dir=\"{}\" wait_cmd=\"\" attach_cmd=\"\" -->\n",
+            session_id,
+            child_pid,
+            session_dir.display()
+        ),
+    )
+    .expect("write legacy stderr pid");
+
+    let reaper = std::thread::spawn(move || child.wait().expect("wait child"));
+
+    handle_session_kill(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+    )
+    .expect("legacy kill should succeed");
+
+    let status = reaper.join().expect("reaper join");
+    assert!(
+        !status.success(),
+        "legacy daemon process should be terminated by session kill"
+    );
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -57,6 +57,10 @@ fn with_reconcile_lock<R>(
 
 fn noop_path(_: &Path) {}
 
+fn session_has_terminal_process(session_dir: &Path) -> bool {
+    ToolLiveness::has_live_process(session_dir) || ToolLiveness::daemon_pid_is_alive(session_dir)
+}
+
 pub(crate) fn ensure_terminal_result_for_dead_active_session(
     project_root: &Path,
     session_id: &str,
@@ -127,7 +131,7 @@ fn dead_active_session_needs_terminal_result(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    if ToolLiveness::has_live_process(session_dir) {
+    if session_has_terminal_process(session_dir) {
         return Ok(false);
     }
     let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
@@ -169,7 +173,7 @@ where
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(DeadActiveSessionReconciliation::NoChange);
     }
-    if ToolLiveness::has_live_process(session_dir) {
+    if session_has_terminal_process(session_dir) {
         return Ok(DeadActiveSessionReconciliation::NoChange);
     }
     let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
@@ -335,7 +339,7 @@ fn dead_session_with_result_needs_retire(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    if ToolLiveness::has_live_process(session_dir) {
+    if session_has_terminal_process(session_dir) {
         return Ok(false);
     }
     Ok(load_result(project_root, session_id)?.is_some())
@@ -352,8 +356,7 @@ fn retire_if_dead_with_result_impl(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    if ToolLiveness::has_live_process(session_dir)
-        || load_result(project_root, session_id)?.is_none()
+    if session_has_terminal_process(session_dir) || load_result(project_root, session_id)?.is_none()
     {
         return Ok(false);
     }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
@@ -139,6 +139,31 @@ fn backdate_tree(path: &std::path::Path, seconds_ago: u64) {
     set_file_mtime_seconds_ago(path, seconds_ago);
 }
 
+#[cfg(unix)]
+fn read_process_start_time_ticks(pid: u32) -> u64 {
+    let stat_path = format!("/proc/{pid}/stat");
+    let content = fs::read_to_string(stat_path).expect("read /proc stat");
+    let close_paren = content.rfind(')').expect("stat comm terminator");
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    parts.next().expect("state");
+    parts.next().expect("ppid");
+    parts.next().expect("pgrp");
+    for _ in 0..16 {
+        parts.next().expect("intermediate stat field");
+    }
+    parts
+        .next()
+        .expect("starttime")
+        .parse::<u64>()
+        .expect("starttime parse")
+}
+
+#[cfg(unix)]
+fn daemon_pid_record(pid: u32) -> String {
+    format!("{pid} {}\n", read_process_start_time_ticks(pid))
+}
+
 #[test]
 fn ensure_terminal_result_for_dead_active_session_leaves_state_unchanged_on_transition_failure() {
     let td = tempdir().expect("tempdir");
@@ -549,7 +574,7 @@ fn handle_session_wait_marks_late_real_result_completion_as_non_synthetic() {
 
 #[cfg(unix)]
 #[test]
-fn ensure_terminal_result_for_dead_active_session_reconciles_even_with_reused_pid_in_daemon_pid() {
+fn ensure_terminal_result_for_dead_active_session_skips_synthesis_while_daemon_pid_is_alive() {
     let td = tempdir().expect("tempdir");
     let _env = SessionTestEnv::new(&td);
     let project = td.path();
@@ -564,7 +589,86 @@ fn ensure_terminal_result_for_dead_active_session_reconciles_even_with_reused_pi
         .spawn()
         .unwrap();
     let pid = child.id();
-    fs::write(session_dir.join("daemon.pid"), format!("{pid}\n")).unwrap();
+    fs::write(session_dir.join("daemon.pid"), daemon_pid_record(pid)).unwrap();
+    assert!(
+        !csa_process::ToolLiveness::has_live_process(&session_dir),
+        "fixture should exercise raw daemon.pid fallback, not context-matched liveness"
+    );
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
+            .unwrap();
+
+    child.kill().ok();
+    child.wait().ok();
+
+    assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
+    assert!(
+        load_result(project, &session_id).unwrap().is_none(),
+        "live daemon.pid must block synthetic failure"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_terminal_result_for_dead_active_session_reconciles_when_daemon_pid_is_dead() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(project, Some("dead-daemon-pid"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .unwrap();
+    let pid = child.id();
+    fs::write(session_dir.join("daemon.pid"), daemon_pid_record(pid)).unwrap();
+    child.kill().ok();
+    child.wait().ok();
+    assert!(!csa_process::ToolLiveness::daemon_pid_is_alive(
+        &session_dir
+    ));
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
+            .unwrap();
+
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("result should be synthesized");
+    assert_eq!(result.status, "failure");
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_terminal_result_for_dead_active_session_ignores_reused_daemon_pid_with_start_time_mismatch()
+ {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(project, Some("daemon-pid-reuse-guard"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .unwrap();
+    let pid = child.id();
+    fs::write(session_dir.join("daemon.pid"), format!("{pid} 0\n")).unwrap();
+    assert!(
+        !csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir),
+        "start time mismatch must prevent unrelated PID reuse from blocking reconciliation"
+    );
 
     let reconciled =
         ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
@@ -577,10 +681,6 @@ fn ensure_terminal_result_for_dead_active_session_reconciles_even_with_reused_pi
         reconciled,
         DeadActiveSessionReconciliation::SynthesizedFailure
     );
-    let result = load_result(project, &session_id)
-        .unwrap()
-        .expect("result should be synthesized");
-    assert_eq!(result.status, "failure");
 }
 
 #[cfg(unix)]

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
@@ -139,7 +139,7 @@ fn backdate_tree(path: &std::path::Path, seconds_ago: u64) {
     set_file_mtime_seconds_ago(path, seconds_ago);
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn read_process_start_time_ticks(pid: u32) -> u64 {
     let stat_path = format!("/proc/{pid}/stat");
     let content = fs::read_to_string(stat_path).expect("read /proc stat");
@@ -159,7 +159,7 @@ fn read_process_start_time_ticks(pid: u32) -> u64 {
         .expect("starttime parse")
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn daemon_pid_record(pid: u32) -> String {
     format!("{pid} {}\n", read_process_start_time_ticks(pid))
 }
@@ -572,7 +572,7 @@ fn handle_session_wait_marks_late_real_result_completion_as_non_synthetic() {
     );
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn ensure_terminal_result_for_dead_active_session_skips_synthesis_while_daemon_pid_is_alive() {
     let td = tempdir().expect("tempdir");
@@ -610,7 +610,7 @@ fn ensure_terminal_result_for_dead_active_session_skips_synthesis_while_daemon_p
     );
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn ensure_terminal_result_for_dead_active_session_reconciles_when_daemon_pid_is_dead() {
     let td = tempdir().expect("tempdir");
@@ -647,7 +647,7 @@ fn ensure_terminal_result_for_dead_active_session_reconciles_when_daemon_pid_is_
     assert_eq!(result.status, "failure");
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn ensure_terminal_result_for_dead_active_session_ignores_reused_daemon_pid_with_start_time_mismatch()
  {

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -3,8 +3,8 @@ use super::{
     DeadActiveSessionReconciliation, display_acp_events, display_daemon_spool_logs,
     display_log_files, ensure_terminal_result_for_dead_active_session,
     ensure_terminal_result_for_dead_active_session_with_before_write, handle_session_is_alive,
-    handle_session_wait, print_content_with_tail, select_sessions_for_list, session_to_json,
-    status_from_phase_and_result, truncate_with_ellipsis,
+    handle_session_kill, handle_session_wait, print_content_with_tail, select_sessions_for_list,
+    session_to_json, status_from_phase_and_result, truncate_with_ellipsis,
 };
 use crate::cli::{Cli, Commands, SessionCommands};
 use crate::session_cmds_daemon::{
@@ -791,3 +791,6 @@ fn session_to_json_includes_depth_and_parent() {
 
 #[path = "session_cmds_tests_tail.rs"]
 mod tail_tests;
+
+#[path = "session_cmds_tests_daemon_pid_tail.rs"]
+mod daemon_pid_tail_tests;

--- a/crates/cli-sub-agent/src/session_cmds_tests_daemon_pid_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_daemon_pid_tail.rs
@@ -1,0 +1,124 @@
+use super::*;
+
+#[cfg(unix)]
+fn read_process_start_time_ticks(pid: u32) -> u64 {
+    let stat_path = format!("/proc/{pid}/stat");
+    let content = std::fs::read_to_string(stat_path).expect("read /proc stat");
+    let close_paren = content.rfind(')').expect("stat comm terminator");
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    parts.next().expect("state");
+    parts.next().expect("ppid");
+    parts.next().expect("pgrp");
+    for _ in 0..16 {
+        parts.next().expect("intermediate stat field");
+    }
+    parts
+        .next()
+        .expect("starttime")
+        .parse::<u64>()
+        .expect("starttime parse")
+}
+
+#[cfg(unix)]
+fn daemon_pid_record(pid: u32) -> String {
+    format!("{pid} {}\n", read_process_start_time_ticks(pid))
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_wait_ignores_completion_packet_while_raw_daemon_pid_is_alive() {
+    use std::process::Command;
+
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-raw-daemon-pid-completion-packet"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+
+    let mut child = Command::new("sleep").arg("5").spawn().unwrap();
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .unwrap();
+    assert!(
+        !csa_process::ToolLiveness::has_live_process(&session_dir),
+        "fixture should rely on raw daemon.pid liveness, not context-matched process detection"
+    );
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    let exit_code =
+        handle_session_wait(session_id, Some(project.to_string_lossy().into_owned()), 1).unwrap();
+
+    assert_eq!(
+        exit_code, 124,
+        "wait should time out instead of trusting daemon-completion while daemon.pid is still alive"
+    );
+
+    child.kill().ok();
+    let _ = child.wait();
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_kill_rejects_daemon_pid_start_time_mismatch() {
+    use std::process::Command;
+
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("kill-raw-daemon-pid-mismatch"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    let mut child = Command::new("sleep").arg("60").spawn().unwrap();
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        format!("{} 0\n", child.id()),
+    )
+    .unwrap();
+
+    let err =
+        handle_session_kill(session_id, Some(project.to_string_lossy().into_owned())).unwrap_err();
+
+    assert!(
+        err.to_string().contains("potentially reused PID"),
+        "unexpected error: {err:#}"
+    );
+    assert!(
+        child.try_wait().unwrap().is_none(),
+        "mismatched daemon pid record must not kill an unrelated process"
+    );
+
+    child.kill().ok();
+    let _ = child.wait();
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_daemon_pid_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_daemon_pid_tail.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn read_process_start_time_ticks(pid: u32) -> u64 {
     let stat_path = format!("/proc/{pid}/stat");
     let content = std::fs::read_to_string(stat_path).expect("read /proc stat");
@@ -20,12 +20,12 @@ fn read_process_start_time_ticks(pid: u32) -> u64 {
         .expect("starttime parse")
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn daemon_pid_record(pid: u32) -> String {
     format!("{pid} {}\n", read_process_start_time_ticks(pid))
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn handle_session_wait_ignores_completion_packet_while_raw_daemon_pid_is_alive() {
     use std::process::Command;
@@ -77,7 +77,7 @@ fn handle_session_wait_ignores_completion_packet_while_raw_daemon_pid_is_alive()
     let _ = child.wait();
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn handle_session_kill_rejects_daemon_pid_start_time_mismatch() {
     use std::process::Command;

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -647,7 +647,6 @@ fn handle_session_wait_ignores_completion_packet_while_daemon_alive() {
     let _ = child.wait();
 }
 
-#[cfg(unix)]
 #[test]
 fn handle_session_wait_returns_pre_exec_failure_without_timeout_packet() {
     let td = tempdir().unwrap();

--- a/crates/csa-process/src/daemon.rs
+++ b/crates/csa-process/src/daemon.rs
@@ -40,6 +40,34 @@ fn open_log_file(dir: &std::path::Path, name: &str) -> Result<File> {
         .with_context(|| format!("failed to create {name} in {}", dir.display()))
 }
 
+fn daemon_pid_record(pid: u32) -> String {
+    match read_process_start_time_ticks(pid) {
+        Some(start_time_ticks) => format!("{pid} {start_time_ticks}\n"),
+        None => format!("{pid}\n"),
+    }
+}
+
+#[cfg(unix)]
+fn read_process_start_time_ticks(pid: u32) -> Option<u64> {
+    let stat_path = format!("/proc/{pid}/stat");
+    let content = std::fs::read_to_string(stat_path).ok()?;
+    let close_paren = content.rfind(')')?;
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    parts.next()?;
+    parts.next()?;
+    parts.next()?;
+    for _ in 0..16 {
+        parts.next()?;
+    }
+    parts.next()?.parse::<u64>().ok()
+}
+
+#[cfg(not(unix))]
+fn read_process_start_time_ticks(_pid: u32) -> Option<u64> {
+    None
+}
+
 /// Spawn a detached daemon process with setsid, stdin=/dev/null,
 /// stdout/stderr redirected to spool files in the session directory.
 pub fn spawn_daemon(config: DaemonSpawnConfig) -> Result<DaemonSpawnResult> {
@@ -89,7 +117,7 @@ pub fn spawn_daemon(config: DaemonSpawnConfig) -> Result<DaemonSpawnResult> {
 
     // Write daemon PID file for `csa session kill` and `wait` liveness checks.
     let pid_path = config.session_dir.join("daemon.pid");
-    std::fs::write(&pid_path, pid.to_string())
+    std::fs::write(&pid_path, daemon_pid_record(pid))
         .with_context(|| format!("failed to write {}", pid_path.display()))?;
 
     // Detach: the daemon child will outlive us. We must not leave a

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -127,6 +127,7 @@ impl ToolLiveness {
                 {
                     Some(record.pid)
                 }
+                (Some(_), Some(ProcessMetadata { state: 'Z', .. })) => None,
                 (Some(_), Some(_)) => Some(record.pid),
                 (Some(_), None) if is_process_alive(record.pid) => Some(record.pid),
                 (None, Some(ProcessMetadata { state: 'Z', .. }))
@@ -134,6 +135,7 @@ impl ToolLiveness {
                 {
                     Some(record.pid)
                 }
+                (None, Some(ProcessMetadata { state: 'Z', .. })) => None,
                 (None, _) if find_session_pid(session_dir) == Some(record.pid) => Some(record.pid),
                 _ => None,
             }
@@ -493,7 +495,7 @@ fn is_process_alive(pid: u32) -> bool {
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn daemon_pid_record(pid: u32) -> String {
         let metadata = read_process_metadata(pid).expect("process metadata");
         format!("{pid} {}\n", metadata.start_time_ticks)
@@ -577,7 +579,7 @@ mod tests {
         assert_eq!(found_pid, Some(pid));
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     #[test]
     fn daemon_pid_is_alive_detects_live_pid_without_context_match() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -606,7 +608,7 @@ mod tests {
         child.wait().ok();
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     #[test]
     fn daemon_pid_is_alive_rejects_start_time_mismatch() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -624,6 +626,37 @@ mod tests {
         );
 
         child.kill().ok();
+        child.wait().ok();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn daemon_pid_is_alive_rejects_zombie_without_live_process_group() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        fs::write(tmp.path().join(DAEMON_PID_FILE), daemon_pid_record(pid))
+            .expect("write daemon pid");
+
+        child.kill().expect("kill child");
+        for _ in 0..20 {
+            if matches!(
+                read_process_metadata(pid),
+                Some(ProcessMetadata { state: 'Z', .. })
+            ) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(
+            !ToolLiveness::daemon_pid_is_alive(tmp.path()),
+            "zombie daemon without live process-group members must not block finalization"
+        );
+
         child.wait().ok();
     }
 

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -308,7 +308,7 @@ fn read_process_command_line(pid: u32) -> Option<String> {
 #[cfg(target_os = "macos")]
 fn read_process_command_line(pid: u32) -> Option<String> {
     let output = std::process::Command::new("/bin/ps")
-        .args(["-o", "command=", "-p", &pid.to_string()])
+        .args(["-ww", "-o", "command=", "-p", &pid.to_string()])
         .output()
         .ok()?;
     if !output.status.success() {

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -1,16 +1,13 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
-
 const LIVENESS_RECENT_WINDOW_SECS: u64 = 30;
 const LOCK_FILE_STALE_SECS: u64 = 60;
 const DAEMON_PID_FILE: &str = "daemon.pid";
 const ACP_EVENTS_LOG_FILE: &str = "output/acp-events.jsonl";
 const STDERR_LOG_FILE: &str = "stderr.log";
 const SNAPSHOT_FILE: &str = ".liveness.snapshot";
-
 pub const DEFAULT_LIVENESS_DEAD_SECS: u64 = 600;
-
 #[derive(Debug, Clone, Copy)]
 struct DaemonPidRecord {
     pid: u32,
@@ -348,7 +345,20 @@ fn read_daemon_pid(session_dir: &Path) -> Option<u32> {
 
 fn read_daemon_pid_record(session_dir: &Path) -> Option<DaemonPidRecord> {
     let pid_path = session_dir.join(DAEMON_PID_FILE);
-    let content = fs::read_to_string(&pid_path).ok()?;
+    if let Ok(content) = fs::read_to_string(&pid_path)
+        && let Some(record) = parse_daemon_pid_record(&content)
+    {
+        return Some(record);
+    }
+
+    let pid = read_legacy_daemon_pid_from_stderr(session_dir)?;
+    Some(DaemonPidRecord {
+        pid,
+        start_time_ticks: None,
+    })
+}
+
+fn parse_daemon_pid_record(content: &str) -> Option<DaemonPidRecord> {
     let mut parts = content.split_whitespace();
     let pid = parts.next()?.parse::<u32>().ok()?;
     let start_time_ticks = parts.next().and_then(|value| value.parse::<u64>().ok());
@@ -356,6 +366,15 @@ fn read_daemon_pid_record(session_dir: &Path) -> Option<DaemonPidRecord> {
         pid,
         start_time_ticks,
     })
+}
+
+fn read_legacy_daemon_pid_from_stderr(session_dir: &Path) -> Option<u32> {
+    let stderr_path = session_dir.join(STDERR_LOG_FILE);
+    let content = fs::read_to_string(stderr_path).ok()?;
+    let pid_start = content.find("pid=")?;
+    let rest = &content[pid_start + 4..];
+    let pid_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    pid_str.parse::<u32>().ok()
 }
 
 fn has_output_growth_signal(session_dir: &Path, snapshot: &mut LivenessSnapshot) -> bool {

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -292,23 +292,41 @@ fn lock_file_is_recent(lock_path: &Path, now: SystemTime) -> bool {
 }
 
 fn process_matches_session_context(pid: u32, tool_name: Option<&str>, session_dir: &Path) -> bool {
-    #[cfg(unix)]
-    {
-        let cmdline_path = PathBuf::from(format!("/proc/{pid}/cmdline"));
-        let Ok(raw_cmdline) = fs::read(cmdline_path) else {
-            return false;
-        };
-        let cmdline = String::from_utf8_lossy(&raw_cmdline).replace('\0', " ");
-        let session_id = session_dir.file_name().and_then(|name| name.to_str());
+    let Some(cmdline) = read_process_command_line(pid) else {
+        return false;
+    };
+    let session_id = session_dir.file_name().and_then(|name| name.to_str());
 
-        tool_name.is_some_and(|tool| cmdline.contains(tool))
-            || session_id.is_some_and(|id| cmdline.contains(id))
+    tool_name.is_some_and(|tool| cmdline.contains(tool))
+        || session_id.is_some_and(|id| cmdline.contains(id))
+}
+
+#[cfg(target_os = "linux")]
+fn read_process_command_line(pid: u32) -> Option<String> {
+    let cmdline_path = PathBuf::from(format!("/proc/{pid}/cmdline"));
+    let raw_cmdline = fs::read(cmdline_path).ok()?;
+    Some(String::from_utf8_lossy(&raw_cmdline).replace('\0', " "))
+}
+
+#[cfg(target_os = "macos")]
+fn read_process_command_line(pid: u32) -> Option<String> {
+    let output = std::process::Command::new("/bin/ps")
+        .args(["-o", "command=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
     }
-    #[cfg(not(unix))]
-    {
-        let _ = (pid, lock_path, session_dir);
-        false
+    let command = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if command.is_empty() {
+        return None;
     }
+    Some(command)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn read_process_command_line(_pid: u32) -> Option<String> {
+    None
 }
 
 fn pid_matches_session_context(
@@ -602,6 +620,33 @@ mod tests {
         assert!(
             !ToolLiveness::has_live_process(tmp.path()),
             "context-matched process detection should remain false for this fixture"
+        );
+
+        child.kill().ok();
+        child.wait().ok();
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn daemon_pid_is_alive_accepts_legacy_pid_with_session_id_context() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session_dir = tmp.path().join("01TESTSESSIONCONTEXT0000000001");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        let mut child = std::process::Command::new("sh")
+            .args([
+                "-c",
+                "sleep 60",
+                "csa-daemon",
+                "01TESTSESSIONCONTEXT0000000001",
+            ])
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        fs::write(session_dir.join(DAEMON_PID_FILE), format!("{pid}\n")).expect("write daemon pid");
+
+        assert!(
+            ToolLiveness::daemon_pid_is_alive(&session_dir),
+            "legacy bare daemon.pid should stay alive when the process command still carries the session context"
         );
 
         child.kill().ok();

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -11,6 +11,20 @@ const SNAPSHOT_FILE: &str = ".liveness.snapshot";
 
 pub const DEFAULT_LIVENESS_DEAD_SECS: u64 = 600;
 
+#[derive(Debug, Clone, Copy)]
+struct DaemonPidRecord {
+    pid: u32,
+    start_time_ticks: Option<u64>,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy)]
+struct ProcessMetadata {
+    state: char,
+    pgrp: i32,
+    start_time_ticks: u64,
+}
+
 /// Fine-grained liveness signals used by idle-timeout watchdog logic.
 ///
 /// `pid_alive`/`session_write` indicate coarse liveness, while
@@ -57,9 +71,10 @@ impl ToolLiveness {
     pub(crate) fn probe(session_dir: &Path) -> LivenessSignals {
         let now = SystemTime::now();
         let mut snapshot = load_snapshot(session_dir);
+        let daemon_pid_alive = Self::daemon_pid_is_alive(session_dir);
 
         let signals = LivenessSignals {
-            pid_alive: has_live_pid_signal(session_dir),
+            pid_alive: has_live_pid_signal(session_dir) || daemon_pid_alive,
             output_growth: has_output_growth_signal(session_dir, &mut snapshot),
             session_write: has_recent_session_write_signal(session_dir, now),
             stderr_activity: has_stderr_activity_signal(session_dir, &mut snapshot),
@@ -85,6 +100,49 @@ impl ToolLiveness {
     /// Whether a session still has a live process associated with it.
     pub fn has_live_process(session_dir: &Path) -> bool {
         Self::live_process_pid(session_dir).is_some()
+    }
+
+    /// Whether the recorded daemon PID still blocks session finalization.
+    ///
+    /// For modern `daemon.pid` records this verifies the same process instance
+    /// via PID + start-time; for legacy single-field records it only falls back
+    /// to signals we can still tie to this session (context-matched daemon PID
+    /// or a zombie daemon leader whose process group still has live members).
+    pub fn daemon_pid_is_alive(session_dir: &Path) -> bool {
+        Self::daemon_pid_for_signal(session_dir).is_some()
+    }
+
+    /// Return the recorded daemon PID only when it still matches a session-
+    /// relevant live process or process group.
+    pub fn daemon_pid_for_signal(session_dir: &Path) -> Option<u32> {
+        let record = read_daemon_pid_record(session_dir)?;
+
+        #[cfg(unix)]
+        {
+            match (record.start_time_ticks, read_process_metadata(record.pid)) {
+                (Some(expected), Some(metadata)) if metadata.start_time_ticks != expected => None,
+                (Some(_), Some(ProcessMetadata { state: 'X', .. })) => None,
+                (Some(_), Some(ProcessMetadata { state: 'Z', .. }))
+                    if has_live_process_group_member(record.pid) =>
+                {
+                    Some(record.pid)
+                }
+                (Some(_), Some(_)) => Some(record.pid),
+                (Some(_), None) if is_process_alive(record.pid) => Some(record.pid),
+                (None, Some(ProcessMetadata { state: 'Z', .. }))
+                    if has_live_process_group_member(record.pid) =>
+                {
+                    Some(record.pid)
+                }
+                (None, _) if find_session_pid(session_dir) == Some(record.pid) => Some(record.pid),
+                _ => None,
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            Some(record.pid)
+        }
     }
 
     /// Zero-cost observation of whether the tool process is actively working.
@@ -160,18 +218,9 @@ fn is_reconciler_artifact(path: &Path) -> bool {
 fn is_pid_working(pid: u32) -> bool {
     #[cfg(unix)]
     {
-        let stat_path = format!("/proc/{pid}/stat");
-        let Ok(content) = fs::read_to_string(&stat_path) else {
-            // /proc not available; fall back to kill(pid, 0) existence check.
+        let Some(ProcessMetadata { state, .. }) = read_process_metadata(pid) else {
             return is_process_alive(pid);
         };
-        // Format: "pid (comm) state ..."
-        // The comm field can contain spaces and parens, so find the last ')'.
-        let Some(close_paren) = content.rfind(')') else {
-            return is_process_alive(pid);
-        };
-        let after_comm = &content[close_paren + 1..];
-        let state = after_comm.trim_start().chars().next().unwrap_or('X');
         matches!(state, 'R' | 'S' | 'D')
     }
     #[cfg(not(unix))]
@@ -179,6 +228,52 @@ fn is_pid_working(pid: u32) -> bool {
         let _ = pid;
         false
     }
+}
+
+#[cfg(unix)]
+fn read_process_metadata(pid: u32) -> Option<ProcessMetadata> {
+    let stat_path = format!("/proc/{pid}/stat");
+    let content = fs::read_to_string(stat_path).ok()?;
+    let close_paren = content.rfind(')')?;
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    let state = parts.next()?.chars().next()?;
+    let _ppid = parts.next()?;
+    let pgrp = parts.next()?.parse::<i32>().ok()?;
+    for _ in 0..16 {
+        parts.next()?;
+    }
+    let start_time_ticks = parts.next()?.parse::<u64>().ok()?;
+    Some(ProcessMetadata {
+        state,
+        pgrp,
+        start_time_ticks,
+    })
+}
+
+#[cfg(unix)]
+fn has_live_process_group_member(leader_pid: u32) -> bool {
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return false;
+    };
+    let target_pgrp = leader_pid as i32;
+
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Ok(pid) = name.parse::<u32>() else {
+            continue;
+        };
+        let Some(ProcessMetadata { state, pgrp, .. }) = read_process_metadata(pid) else {
+            continue;
+        };
+        if pgrp == target_pgrp && !matches!(state, 'Z' | 'X') {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn has_live_pid_signal(session_dir: &Path) -> bool {
@@ -228,9 +323,19 @@ fn pid_matches_session_context(
 }
 
 fn read_daemon_pid(session_dir: &Path) -> Option<u32> {
+    read_daemon_pid_record(session_dir).map(|record| record.pid)
+}
+
+fn read_daemon_pid_record(session_dir: &Path) -> Option<DaemonPidRecord> {
     let pid_path = session_dir.join(DAEMON_PID_FILE);
     let content = fs::read_to_string(&pid_path).ok()?;
-    content.trim().parse::<u32>().ok()
+    let mut parts = content.split_whitespace();
+    let pid = parts.next()?.parse::<u32>().ok()?;
+    let start_time_ticks = parts.next().and_then(|value| value.parse::<u64>().ok());
+    Some(DaemonPidRecord {
+        pid,
+        start_time_ticks,
+    })
 }
 
 fn has_output_growth_signal(session_dir: &Path, snapshot: &mut LivenessSnapshot) -> bool {
@@ -388,6 +493,12 @@ fn is_process_alive(pid: u32) -> bool {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn daemon_pid_record(pid: u32) -> String {
+        let metadata = read_process_metadata(pid).expect("process metadata");
+        format!("{pid} {}\n", metadata.start_time_ticks)
+    }
+
     #[test]
     fn lock_file_is_recent_false_when_stale() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -464,6 +575,56 @@ mod tests {
         child.kill().ok();
         child.wait().ok();
         assert_eq!(found_pid, Some(pid));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_pid_is_alive_detects_live_pid_without_context_match() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        fs::write(tmp.path().join(DAEMON_PID_FILE), daemon_pid_record(pid))
+            .expect("write daemon pid");
+
+        assert!(
+            ToolLiveness::daemon_pid_is_alive(tmp.path()),
+            "raw daemon.pid should count as alive even when cmdline matching fails"
+        );
+        assert!(
+            ToolLiveness::is_alive(tmp.path()),
+            "coarse liveness should stay true while daemon.pid still exists"
+        );
+        assert!(
+            !ToolLiveness::has_live_process(tmp.path()),
+            "context-matched process detection should remain false for this fixture"
+        );
+
+        child.kill().ok();
+        child.wait().ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_pid_is_alive_rejects_start_time_mismatch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        fs::write(tmp.path().join(DAEMON_PID_FILE), format!("{pid} 0\n"))
+            .expect("write daemon pid");
+
+        assert!(
+            !ToolLiveness::daemon_pid_is_alive(tmp.path()),
+            "start time mismatch must prevent unrelated PID reuse from blocking liveness"
+        );
+
+        child.kill().ok();
+        child.wait().ok();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- gate synthetic reconcile/session wait on daemon liveness instead of raw missing result state
- harden daemon PID liveness for PID reuse, zombie leaders, macOS command inspection, and legacy stderr-only sessions
- cover attach completion gating, legacy kill, and daemon PID regressions with new tests

## Testing
- csa review --sa-mode true --tool codex --force-ignore-tier-setting --range main...HEAD
- env CODEX_CI=0 TMPDIR=/tmp just pre-commit
- TMPDIR=/tmp cargo test -p csa-process daemon_pid
- TMPDIR=/tmp CARGO_TARGET_DIR=/tmp/cli-sub-agent-target cargo test -p cli-sub-agent session_cmds_daemon::tests

## Review History
- 01KNYBZXDV68HQ2VW1FSWYXSNC: found attach/zombie/macOS gaps
- 01KNYD8KY405ZZ1XRR5FAZXA7J: found attach completion + legacy kill gaps
- 01KNYE20S2ZCZZHJP3FTK2W6Y3: pass
- 01KNYEJR3BZ01NFS0HYBSXJ3EA: pass

Closes #670