### PR TITLE
fix(executor): gemini-cli ACP cluster (#644 #645 #656)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "chrono",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "chrono",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "axum",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "chrono",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.263"
+version = "0.1.264"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.263"
+version = "0.1.264"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/error_hints.rs
+++ b/crates/cli-sub-agent/src/error_hints.rs
@@ -18,6 +18,7 @@ const HINT_SLOT_EXHAUSTED: &str = "hint: free slots with 'csa gc' or wait with '
 const HINT_SESSION_NOT_FOUND: &str = "hint: list available sessions with 'csa session list'";
 const HINT_CONFIG_ERROR: &str =
     "hint: validate config with 'csa config validate' or reinitialize with 'csa init'";
+const HINT_GEMINI_RUNTIME_HOME: &str = "hint: Gemini ACP needs a writable runtime home; upgrade to a build that seeds it under CSA session state, or re-run with TMPDIR=/tmp";
 
 pub fn suggest_fix(err: &Error) -> Option<String> {
     for cause in err.chain() {
@@ -83,6 +84,13 @@ pub fn suggest_fix(err: &Error) -> Option<String> {
             || chain_text.contains("parse"))
     {
         return Some(HINT_CONFIG_ERROR.to_string());
+    }
+
+    if chain_text.contains("failed to create gemini runtime dir")
+        || (chain_text.contains("gemini runtime dir")
+            && chain_text.contains("read-only file system"))
+    {
+        return Some(HINT_GEMINI_RUNTIME_HOME.to_string());
     }
 
     None
@@ -170,6 +178,14 @@ mod tests {
     fn test_config_error_hint() {
         let err = anyhow::anyhow!("config parse error: invalid value");
         assert_eq!(suggest_fix(&err).as_deref(), Some(HINT_CONFIG_ERROR));
+    }
+
+    #[test]
+    fn test_gemini_runtime_home_hint() {
+        let err = anyhow::anyhow!(
+            "failed to create gemini runtime dir /home/obj/.claude/tmp/cli-sub-agent-gemini/01ABC/.gemini: Read-only file system (os error 30)"
+        );
+        assert_eq!(suggest_fix(&err).as_deref(), Some(HINT_GEMINI_RUNTIME_HOME));
     }
 
     #[test]

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -10,12 +10,11 @@ use crate::transport_gemini_retry::{
 };
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
-use csa_acp::{SessionConfig, SessionEvent};
+use csa_acp::SessionConfig;
 use csa_process::{
     ExecutionResult, SpawnOptions, StreamMode, spawn_tool_sandboxed, spawn_tool_with_options,
     wait_and_capture_with_idle_timeout,
 };
-use csa_resource::isolation_plan::IsolationPlan;
 use csa_session::state::{MetaSessionState, ToolState};
 
 #[path = "transport_meta.rs"]
@@ -50,29 +49,13 @@ pub use transport_fork::{ForkInfo, ForkMethod, ForkRequest};
 mod transport_factory;
 pub use transport_factory::{TransportFactory, TransportMode};
 
-#[derive(Debug, Clone)]
-pub struct SandboxTransportConfig {
-    pub isolation_plan: IsolationPlan,
-    pub tool_name: String,
-    pub best_effort: bool,
-    pub session_id: String,
-}
-#[derive(Debug, Clone)]
-pub struct TransportOptions<'a> {
-    pub stream_mode: StreamMode,
-    pub idle_timeout_seconds: u64,
-    pub acp_crash_max_attempts: u8,
-    pub initial_response_timeout_seconds: Option<u64>,
-    pub liveness_dead_seconds: u64,
-    pub stdin_write_timeout_seconds: u64,
-    pub acp_init_timeout_seconds: u64,
-    pub termination_grace_period_seconds: u64,
-    pub output_spool: Option<&'a Path>,
-    pub output_spool_max_bytes: u64,
-    pub output_spool_keep_rotated: bool,
-    pub setting_sources: Option<Vec<String>>,
-    pub sandbox: Option<&'a SandboxTransportConfig>,
-}
+#[path = "transport_acp_payload_debug.rs"]
+mod transport_acp_payload_debug;
+use transport_acp_payload_debug::{AcpPayloadDebugRequest, maybe_write_acp_payload_debug};
+
+#[path = "transport_types.rs"]
+mod transport_types;
+pub use transport_types::{SandboxTransportConfig, TransportOptions, TransportResult};
 
 #[async_trait]
 pub trait Transport: Send + Sync {
@@ -87,14 +70,6 @@ pub trait Transport: Send + Sync {
 
     #[cfg(test)]
     fn as_any(&self) -> &dyn std::any::Any;
-}
-
-#[derive(Debug, Clone)]
-pub struct TransportResult {
-    pub execution: ExecutionResult,
-    pub provider_session_id: Option<String>,
-    pub events: Vec<SessionEvent>,
-    pub metadata: csa_acp::StreamingMetadata,
 }
 
 fn should_stream_acp_stdout_to_stderr(
@@ -515,6 +490,17 @@ impl AcpTransport {
             options.setting_sources.as_deref(),
             self.session_config.as_ref(),
         );
+        let acp_payload_debug_path = maybe_write_acp_payload_debug(AcpPayloadDebugRequest {
+            env: &env,
+            tool_name: &self.tool_name,
+            command: &acp_command,
+            args: &acp_args,
+            working_dir: &working_dir,
+            resume_session_id: resume_session_id.as_deref(),
+            system_prompt: system_prompt.as_deref(),
+            session_meta: session_meta.as_ref(),
+            prompt: &prompt,
+        });
         let stream_stdout_to_stderr =
             should_stream_acp_stdout_to_stderr(options.stream_mode, options.output_spool);
         let output_spool = options.output_spool.map(std::path::Path::to_path_buf);
@@ -633,7 +619,17 @@ impl AcpTransport {
                 }
             })
             .await
-            .map_err(classify_join_error)??;
+            .map_err(classify_join_error)?
+            .map_err(|error| {
+                if let Some(path) = acp_payload_debug_path.as_deref() {
+                    error.context(format!(
+                        "ACP payload debug written to {}",
+                        path.display()
+                    ))
+                } else {
+                    error
+                }
+            })?;
         let execution = ExecutionResult {
             summary: build_summary(&output.output, &output.stderr, output.exit_code),
             output: output.output,
@@ -786,6 +782,7 @@ impl Transport for AcpTransport {
 #[cfg(test)]
 mod tests {
     use csa_acp::SessionConfig;
+    use csa_resource::isolation_plan::IsolationPlan;
 
     use super::*;
     use crate::transport_gemini_retry::*;

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -55,6 +55,7 @@ use transport_acp_payload_debug::{AcpPayloadDebugRequest, maybe_write_acp_payloa
 
 #[path = "transport_types.rs"]
 mod transport_types;
+use transport_types::should_stream_acp_stdout_to_stderr;
 pub use transport_types::{SandboxTransportConfig, TransportOptions, TransportResult};
 
 #[async_trait]
@@ -70,14 +71,6 @@ pub trait Transport: Send + Sync {
 
     #[cfg(test)]
     fn as_any(&self) -> &dyn std::any::Any;
-}
-
-fn should_stream_acp_stdout_to_stderr(
-    stream_mode: StreamMode,
-    output_spool: Option<&Path>,
-) -> bool {
-    !(matches!(stream_mode, StreamMode::BufferOnly)
-        || output_spool.is_some() && std::env::var_os("CSA_DAEMON_SESSION_ID").is_some())
 }
 
 #[derive(Debug, Clone)]
@@ -455,10 +448,17 @@ impl AcpTransport {
         let mut acp_args = acp_args.to_vec();
         let prompt = prompt.to_string();
         let resume_session_id = resume_session_id.map(String::from);
+        let session_dir =
+            csa_session::manager::get_session_dir(&working_dir, &session.meta_session_id).ok();
 
         let mut gemini_runtime_home = None;
         if self.tool_name == "gemini-cli" {
-            let launch = prepare_gemini_acp_runtime(&mut env, &session.meta_session_id, &acp_args)?;
+            let launch = prepare_gemini_acp_runtime(
+                &mut env,
+                session_dir.as_deref(),
+                &session.meta_session_id,
+                &acp_args,
+            )?;
             acp_command = launch.command;
             acp_args = launch.args;
             gemini_runtime_home = gemini_runtime_home_from_env(&env);
@@ -492,6 +492,7 @@ impl AcpTransport {
         );
         let acp_payload_debug_path = maybe_write_acp_payload_debug(AcpPayloadDebugRequest {
             env: &env,
+            session_dir: session_dir.as_deref(),
             tool_name: &self.tool_name,
             command: &acp_command,
             args: &acp_args,

--- a/crates/csa-executor/src/transport_acp_payload_debug.rs
+++ b/crates/csa-executor/src/transport_acp_payload_debug.rs
@@ -10,6 +10,7 @@ const ACP_PAYLOAD_DEBUG_REL_PATH: &str = "output/acp-payload-debug.json";
 
 pub(super) struct AcpPayloadDebugRequest<'a> {
     pub(super) env: &'a HashMap<String, String>,
+    pub(super) session_dir: Option<&'a Path>,
     pub(super) tool_name: &'a str,
     pub(super) command: &'a str,
     pub(super) args: &'a [String],
@@ -24,7 +25,7 @@ pub(super) struct AcpPayloadDebugRequest<'a> {
 struct AcpPayloadDebug<'a> {
     tool_name: &'a str,
     command: &'a str,
-    args: &'a [String],
+    args: Vec<String>,
     working_dir: String,
     resume_session_id: Option<&'a str>,
     system_prompt: Option<&'a str>,
@@ -60,6 +61,69 @@ fn redact_env_value(value: &mut Value) {
     }
 }
 
+fn arg_name_is_sensitive(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    [
+        "api-key",
+        "apikey",
+        "auth",
+        "authorization",
+        "bearer",
+        "header",
+        "password",
+        "secret",
+        "token",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn arg_value_is_sensitive(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    normalized.contains("authorization:")
+        || normalized.contains("bearer ")
+        || normalized.contains("token=")
+        || normalized.contains("api-key=")
+        || normalized.contains("apikey=")
+        || normalized.contains("secret=")
+        || normalized.contains("password=")
+}
+
+fn redact_args(args: &[String]) -> Vec<String> {
+    let mut redacted = Vec::with_capacity(args.len());
+    let mut redact_next = false;
+
+    for arg in args {
+        if redact_next {
+            redacted.push("<redacted>".to_string());
+            redact_next = false;
+            continue;
+        }
+
+        if let Some((name, _value)) = arg.split_once('=')
+            && arg_name_is_sensitive(name)
+        {
+            redacted.push(format!("{name}=<redacted>"));
+            continue;
+        }
+
+        if arg.starts_with('-') && arg_name_is_sensitive(arg) {
+            redacted.push(arg.clone());
+            redact_next = true;
+            continue;
+        }
+
+        if arg_value_is_sensitive(arg) {
+            redacted.push("<redacted>".to_string());
+            continue;
+        }
+
+        redacted.push(arg.clone());
+    }
+
+    redacted
+}
+
 fn redact_session_meta(
     session_meta: Option<&serde_json::Map<String, Value>>,
 ) -> Option<serde_json::Map<String, Value>> {
@@ -69,6 +133,17 @@ fn redact_session_meta(
                 for (key, entry) in map.iter_mut() {
                     if key == "env" {
                         redact_env_value(entry);
+                    } else if key == "args" {
+                        if let Value::Array(items) = entry {
+                            let args = items
+                                .iter()
+                                .filter_map(Value::as_str)
+                                .map(ToString::to_string)
+                                .collect::<Vec<_>>();
+                            *entry = Value::Array(
+                                redact_args(&args).into_iter().map(Value::String).collect(),
+                            );
+                        }
                     } else {
                         redact_nested_env_maps(entry);
                     }
@@ -95,8 +170,7 @@ pub(super) fn maybe_write_acp_payload_debug(
         return None;
     }
 
-    let session_dir = request.env.get("CSA_SESSION_DIR")?;
-    let debug_path = Path::new(session_dir).join(ACP_PAYLOAD_DEBUG_REL_PATH);
+    let debug_path = request.session_dir?.join(ACP_PAYLOAD_DEBUG_REL_PATH);
     if let Some(parent) = debug_path.parent()
         && fs::create_dir_all(parent).is_err()
     {
@@ -106,7 +180,7 @@ pub(super) fn maybe_write_acp_payload_debug(
     let payload = AcpPayloadDebug {
         tool_name: request.tool_name,
         command: request.command,
-        args: request.args,
+        args: redact_args(request.args),
         working_dir: request.working_dir.display().to_string(),
         resume_session_id: request.resume_session_id,
         system_prompt: request.system_prompt,

--- a/crates/csa-executor/src/transport_acp_payload_debug.rs
+++ b/crates/csa-executor/src/transport_acp_payload_debug.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
+use serde_json::Value;
 
 pub(crate) const ACP_PAYLOAD_DEBUG_ENV: &str = "CSA_DEBUG_ACP_PAYLOAD";
 const ACP_PAYLOAD_DEBUG_REL_PATH: &str = "output/acp-payload-debug.json";
@@ -27,25 +28,70 @@ struct AcpPayloadDebug<'a> {
     working_dir: String,
     resume_session_id: Option<&'a str>,
     system_prompt: Option<&'a str>,
-    session_meta: Option<&'a serde_json::Map<String, serde_json::Value>>,
+    session_meta: Option<serde_json::Map<String, Value>>,
     prompt_chars: usize,
     prompt_preview: String,
     prompt: &'a str,
 }
 
-fn acp_payload_debug_enabled() -> bool {
+fn debug_flag_enabled(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+}
+
+fn acp_payload_debug_enabled(env: &HashMap<String, String>) -> bool {
+    if let Some(value) = env.get(ACP_PAYLOAD_DEBUG_ENV) {
+        return debug_flag_enabled(value);
+    }
+
     std::env::var(ACP_PAYLOAD_DEBUG_ENV)
-        .map(|value| {
-            let normalized = value.trim().to_ascii_lowercase();
-            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
-        })
+        .map(|value| debug_flag_enabled(&value))
         .unwrap_or(false)
+}
+
+fn redact_env_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for entry in map.values_mut() {
+                *entry = Value::String("<redacted>".to_string());
+            }
+        }
+        _ => *value = Value::String("<redacted>".to_string()),
+    }
+}
+
+fn redact_session_meta(
+    session_meta: Option<&serde_json::Map<String, Value>>,
+) -> Option<serde_json::Map<String, Value>> {
+    fn redact_nested_env_maps(value: &mut Value) {
+        match value {
+            Value::Object(map) => {
+                for (key, entry) in map.iter_mut() {
+                    if key == "env" {
+                        redact_env_value(entry);
+                    } else {
+                        redact_nested_env_maps(entry);
+                    }
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    redact_nested_env_maps(item);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut value = Value::Object(session_meta?.clone());
+    redact_nested_env_maps(&mut value);
+    value.as_object().cloned()
 }
 
 pub(super) fn maybe_write_acp_payload_debug(
     request: AcpPayloadDebugRequest<'_>,
 ) -> Option<PathBuf> {
-    if !acp_payload_debug_enabled() {
+    if !acp_payload_debug_enabled(request.env) {
         return None;
     }
 
@@ -64,7 +110,7 @@ pub(super) fn maybe_write_acp_payload_debug(
         working_dir: request.working_dir.display().to_string(),
         resume_session_id: request.resume_session_id,
         system_prompt: request.system_prompt,
-        session_meta: request.session_meta,
+        session_meta: redact_session_meta(request.session_meta),
         prompt_chars: request.prompt.chars().count(),
         prompt_preview: request.prompt.chars().take(2000).collect(),
         prompt: request.prompt,

--- a/crates/csa-executor/src/transport_acp_payload_debug.rs
+++ b/crates/csa-executor/src/transport_acp_payload_debug.rs
@@ -1,0 +1,75 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+pub(crate) const ACP_PAYLOAD_DEBUG_ENV: &str = "CSA_DEBUG_ACP_PAYLOAD";
+const ACP_PAYLOAD_DEBUG_REL_PATH: &str = "output/acp-payload-debug.json";
+
+pub(super) struct AcpPayloadDebugRequest<'a> {
+    pub(super) env: &'a HashMap<String, String>,
+    pub(super) tool_name: &'a str,
+    pub(super) command: &'a str,
+    pub(super) args: &'a [String],
+    pub(super) working_dir: &'a Path,
+    pub(super) resume_session_id: Option<&'a str>,
+    pub(super) system_prompt: Option<&'a str>,
+    pub(super) session_meta: Option<&'a serde_json::Map<String, serde_json::Value>>,
+    pub(super) prompt: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct AcpPayloadDebug<'a> {
+    tool_name: &'a str,
+    command: &'a str,
+    args: &'a [String],
+    working_dir: String,
+    resume_session_id: Option<&'a str>,
+    system_prompt: Option<&'a str>,
+    session_meta: Option<&'a serde_json::Map<String, serde_json::Value>>,
+    prompt_chars: usize,
+    prompt_preview: String,
+    prompt: &'a str,
+}
+
+fn acp_payload_debug_enabled() -> bool {
+    std::env::var(ACP_PAYLOAD_DEBUG_ENV)
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
+}
+
+pub(super) fn maybe_write_acp_payload_debug(
+    request: AcpPayloadDebugRequest<'_>,
+) -> Option<PathBuf> {
+    if !acp_payload_debug_enabled() {
+        return None;
+    }
+
+    let session_dir = request.env.get("CSA_SESSION_DIR")?;
+    let debug_path = Path::new(session_dir).join(ACP_PAYLOAD_DEBUG_REL_PATH);
+    if let Some(parent) = debug_path.parent()
+        && fs::create_dir_all(parent).is_err()
+    {
+        return None;
+    }
+
+    let payload = AcpPayloadDebug {
+        tool_name: request.tool_name,
+        command: request.command,
+        args: request.args,
+        working_dir: request.working_dir.display().to_string(),
+        resume_session_id: request.resume_session_id,
+        system_prompt: request.system_prompt,
+        session_meta: request.session_meta,
+        prompt_chars: request.prompt.chars().count(),
+        prompt_preview: request.prompt.chars().take(2000).collect(),
+        prompt: request.prompt,
+    };
+    let serialized = serde_json::to_string_pretty(&payload).ok()?;
+    fs::write(&debug_path, format!("{serialized}\n")).ok()?;
+    Some(debug_path)
+}

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -9,6 +9,7 @@ use serde_json::{Map, Value};
 use tracing::{debug, warn};
 
 const GEMINI_RUNTIME_ROOT_DIR: &str = "cli-sub-agent-gemini";
+const GEMINI_SESSION_RUNTIME_RELATIVE_PATH: &str = "runtime/gemini-home";
 const GEMINI_RUNTIME_SETTINGS_PATHS: &[&str] =
     &[".gemini/settings.json", ".config/gemini-cli/settings.json"];
 const GEMINI_RUNTIME_PINNED_PATH_BINARIES: &[&str] = &["node", "yarn", "gemini"];
@@ -46,9 +47,7 @@ pub(crate) fn prepare_gemini_acp_runtime(
         .cloned()
         .or_else(|| std::env::var("HOME").ok())
         .map(PathBuf::from);
-    let runtime_home = std::env::temp_dir()
-        .join(GEMINI_RUNTIME_ROOT_DIR)
-        .join(session_id);
+    let runtime_home = resolve_runtime_home(env, session_id);
     seed_runtime_home(&runtime_home, source_home.as_deref())?;
     align_runtime_auth_selection(&runtime_home, env)?;
 
@@ -125,6 +124,7 @@ pub(crate) fn prepare_gemini_acp_runtime(
 
 pub(crate) fn gemini_runtime_home_from_env(env: &HashMap<String, String>) -> Option<PathBuf> {
     let runtime_root = std::env::temp_dir().join(GEMINI_RUNTIME_ROOT_DIR);
+    let session_relative_path = Path::new(GEMINI_SESSION_RUNTIME_RELATIVE_PATH);
     let candidates = [
         env.get("GEMINI_CLI_HOME").map(PathBuf::from),
         env.get("HOME").map(PathBuf::from),
@@ -141,7 +141,17 @@ pub(crate) fn gemini_runtime_home_from_env(env: &HashMap<String, String>) -> Opt
     candidates
         .into_iter()
         .flatten()
-        .find(|path| path.starts_with(&runtime_root))
+        .find(|path| path.starts_with(&runtime_root) || path.ends_with(session_relative_path))
+}
+
+fn resolve_runtime_home(env: &HashMap<String, String>, session_id: &str) -> PathBuf {
+    if let Some(session_dir) = env.get("CSA_SESSION_DIR").filter(|value| !value.is_empty()) {
+        return PathBuf::from(session_dir).join(GEMINI_SESSION_RUNTIME_RELATIVE_PATH);
+    }
+
+    std::env::temp_dir()
+        .join(GEMINI_RUNTIME_ROOT_DIR)
+        .join(session_id)
 }
 
 fn seed_runtime_home(runtime_home: &Path, source_home: Option<&Path>) -> Result<()> {

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -39,6 +39,7 @@ pub(crate) struct GeminiAcpLaunch {
 
 pub(crate) fn prepare_gemini_acp_runtime(
     env: &mut HashMap<String, String>,
+    session_dir: Option<&Path>,
     session_id: &str,
     base_args: &[String],
 ) -> Result<GeminiAcpLaunch> {
@@ -47,7 +48,7 @@ pub(crate) fn prepare_gemini_acp_runtime(
         .cloned()
         .or_else(|| std::env::var("HOME").ok())
         .map(PathBuf::from);
-    let runtime_home = resolve_runtime_home(env, session_id);
+    let runtime_home = resolve_runtime_home(session_dir, session_id);
     seed_runtime_home(&runtime_home, source_home.as_deref())?;
     align_runtime_auth_selection(&runtime_home, env)?;
 
@@ -144,9 +145,9 @@ pub(crate) fn gemini_runtime_home_from_env(env: &HashMap<String, String>) -> Opt
         .find(|path| path.starts_with(&runtime_root) || path.ends_with(session_relative_path))
 }
 
-fn resolve_runtime_home(env: &HashMap<String, String>, session_id: &str) -> PathBuf {
-    if let Some(session_dir) = env.get("CSA_SESSION_DIR").filter(|value| !value.is_empty()) {
-        return PathBuf::from(session_dir).join(GEMINI_SESSION_RUNTIME_RELATIVE_PATH);
+fn resolve_runtime_home(session_dir: Option<&Path>, session_id: &str) -> PathBuf {
+    if let Some(session_dir) = session_dir {
+        return session_dir.join(GEMINI_SESSION_RUNTIME_RELATIVE_PATH);
     }
 
     std::env::temp_dir()

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -78,7 +78,8 @@ fn prepare_gemini_acp_runtime_sets_runtime_home_and_resolves_direct_launch() {
     );
 
     let launch =
-        prepare_gemini_acp_runtime(&mut env, &session_id, &["--acp".to_string()]).expect("prepare runtime");
+        prepare_gemini_acp_runtime(&mut env, None, &session_id, &["--acp".to_string()])
+            .expect("prepare runtime");
 
     assert_eq!(launch.command, node_path.to_string_lossy());
     assert_eq!(launch.args[0], "--no-warnings=DEP0040");
@@ -157,7 +158,7 @@ fn prepare_gemini_acp_runtime_pins_mise_dirs_under_runtime_home() {
         source_home.to_string_lossy().into_owned(),
     );
 
-    prepare_gemini_acp_runtime(&mut env, session_id, &["--acp".to_string()])
+    prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
         .expect("prepare runtime");
 
     let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
@@ -208,7 +209,10 @@ fn prepare_gemini_acp_runtime_prefers_session_dir_runtime_home() {
     );
     env.insert(
         "CSA_SESSION_DIR".to_string(),
-        session_dir.to_string_lossy().into_owned(),
+        temp.path()
+            .join("spoofed-session")
+            .to_string_lossy()
+            .into_owned(),
     );
     env.insert(
         "TMPDIR".to_string(),
@@ -218,14 +222,19 @@ fn prepare_gemini_acp_runtime_prefers_session_dir_runtime_home() {
             .into_owned(),
     );
 
-    prepare_gemini_acp_runtime(&mut env, "01TESTSESSIONDIR", &["--acp".to_string()])
-        .expect("prepare runtime");
+    prepare_gemini_acp_runtime(
+        &mut env,
+        Some(session_dir.as_path()),
+        "01TESTSESSIONDIR",
+        &["--acp".to_string()],
+    )
+    .expect("prepare runtime");
 
     let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
     assert_eq!(
         runtime_home,
         session_dir.join(GEMINI_SESSION_RUNTIME_RELATIVE_PATH),
-        "runtime home should live under the writable CSA session dir instead of ambient TMPDIR"
+        "runtime home should trust the internally resolved session dir instead of any env override"
     );
     assert!(
         runtime_home.join(".gemini").is_dir(),
@@ -283,7 +292,7 @@ fn prepare_gemini_acp_runtime_pins_non_shim_runtime_bins_on_path() {
         shims_dir.display().to_string(),
     );
 
-    prepare_gemini_acp_runtime(&mut env, session_id, &["--acp".to_string()])
+    prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
         .expect("prepare runtime");
 
     let prepared_path = env.get("PATH").expect("prepared path");
@@ -355,7 +364,8 @@ fn prepare_gemini_acp_runtime_resolves_mise_shims_via_mise_which() {
     );
 
     let launch =
-        prepare_gemini_acp_runtime(&mut env, session_id, &["--acp".to_string()]).expect("prepare runtime");
+        prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
+            .expect("prepare runtime");
 
     assert_eq!(launch.command, node_dir.join("node").to_string_lossy());
     assert_eq!(launch.args[1], real_script.to_string_lossy());
@@ -389,7 +399,7 @@ fn prepare_gemini_acp_runtime_rewrites_runtime_auth_selection_for_api_key_phase(
         csa_core::gemini::AUTH_MODE_OAUTH.to_string(),
     );
 
-    prepare_gemini_acp_runtime(&mut env, session_id, &["--acp".to_string()])
+    prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
         .expect("prepare oauth runtime");
     let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
     assert_eq!(
@@ -407,7 +417,7 @@ fn prepare_gemini_acp_runtime_rewrites_runtime_auth_selection_for_api_key_phase(
         "fallback-key".to_string(),
     );
 
-    prepare_gemini_acp_runtime(&mut env, session_id, &["--acp".to_string()])
+    prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
         .expect("prepare api key runtime");
     assert_eq!(
         read_selected_auth_type(&runtime_home.join(".gemini/settings.json")),

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -194,6 +194,46 @@ fn prepare_gemini_acp_runtime_pins_mise_dirs_under_runtime_home() {
 }
 
 #[test]
+fn prepare_gemini_acp_runtime_prefers_session_dir_runtime_home() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_dir = temp.path().join("sessions").join("01TESTSESSIONDIR");
+    let source_home = temp.path().join("source-home");
+    fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "CSA_SESSION_DIR".to_string(),
+        session_dir.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "TMPDIR".to_string(),
+        temp.path()
+            .join("read-only-tmp")
+            .to_string_lossy()
+            .into_owned(),
+    );
+
+    prepare_gemini_acp_runtime(&mut env, "01TESTSESSIONDIR", &["--acp".to_string()])
+        .expect("prepare runtime");
+
+    let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
+    assert_eq!(
+        runtime_home,
+        session_dir.join(GEMINI_SESSION_RUNTIME_RELATIVE_PATH),
+        "runtime home should live under the writable CSA session dir instead of ambient TMPDIR"
+    );
+    assert!(
+        runtime_home.join(".gemini").is_dir(),
+        "runtime seed should succeed under session-owned runtime home"
+    );
+}
+
+#[test]
 fn prepare_gemini_acp_runtime_pins_non_shim_runtime_bins_on_path() {
     let temp = tempfile::tempdir().expect("tempdir");
     let session_id = "01TESTGEMINIPATHPINNING0000000001";
@@ -406,6 +446,18 @@ fn gemini_runtime_home_from_env_rejects_regular_home_paths() {
     );
 
     assert_eq!(gemini_runtime_home_from_env(&env), None);
+}
+
+#[test]
+fn gemini_runtime_home_from_env_accepts_session_dir_runtime_home() {
+    let runtime_home = PathBuf::from("/tmp/csa-sessions/01TEST/runtime/gemini-home");
+    let mut env = HashMap::new();
+    env.insert(
+        "GEMINI_CLI_HOME".to_string(),
+        runtime_home.to_string_lossy().into_owned(),
+    );
+
+    assert_eq!(gemini_runtime_home_from_env(&env), Some(runtime_home));
 }
 
 fn read_selected_auth_type(settings_path: &Path) -> Option<String> {

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -121,7 +121,7 @@ fn test_daemon_mode_disables_acp_stderr_streaming_when_output_spool_exists() {
     unsafe { std::env::set_var(DAEMON_SESSION_ID_ENV, "01KTESTSESSION") };
 
     let spool_path = std::path::Path::new("/tmp/output.log");
-    assert!(!super::should_stream_acp_stdout_to_stderr(
+    assert!(!super::transport_types::should_stream_acp_stdout_to_stderr(
         StreamMode::TeeToStderr,
         Some(spool_path)
     ));
@@ -137,7 +137,7 @@ fn test_foreground_mode_keeps_acp_stderr_streaming_even_with_output_spool() {
     unsafe { std::env::remove_var(DAEMON_SESSION_ID_ENV) };
 
     let spool_path = std::path::Path::new("/tmp/output.log");
-    assert!(super::should_stream_acp_stdout_to_stderr(
+    assert!(super::transport_types::should_stream_acp_stdout_to_stderr(
         StreamMode::TeeToStderr,
         Some(spool_path)
     ));
@@ -152,7 +152,7 @@ fn test_daemon_mode_without_output_spool_keeps_acp_stderr_streaming() {
     // SAFETY: guarded by DAEMON_ENV_LOCK for this test.
     unsafe { std::env::set_var(DAEMON_SESSION_ID_ENV, "01KTESTSESSION") };
 
-    assert!(super::should_stream_acp_stdout_to_stderr(
+    assert!(super::transport_types::should_stream_acp_stdout_to_stderr(
         StreamMode::TeeToStderr,
         None
     ));
@@ -168,6 +168,7 @@ fn test_maybe_write_acp_payload_debug_requires_flag_and_session_dir() {
     let path = super::transport_acp_payload_debug::maybe_write_acp_payload_debug(
         super::transport_acp_payload_debug::AcpPayloadDebugRequest {
             env: &HashMap::new(),
+            session_dir: None,
             tool_name: "gemini-cli",
             command: "gemini",
             args: &["--acp".to_string()],
@@ -192,7 +193,10 @@ fn test_maybe_write_acp_payload_debug_writes_json_artifact() {
     env.insert(ACP_PAYLOAD_DEBUG_ENV.to_string(), "1".to_string());
     env.insert(
         "CSA_SESSION_DIR".to_string(),
-        session_dir.to_string_lossy().into_owned(),
+        temp.path()
+            .join("spoofed-session")
+            .to_string_lossy()
+            .into_owned(),
     );
 
     let mut session_meta = serde_json::Map::new();
@@ -205,6 +209,14 @@ fn test_maybe_write_acp_payload_debug_writes_json_artifact() {
         serde_json::json!({
             "demo": {
                 "command": "demo-mcp",
+                "args": [
+                    "--api-key",
+                    "secret-token",
+                    "--header",
+                    "Authorization: Bearer abc123",
+                    "--safe",
+                    "value"
+                ],
                 "env": {
                     "API_KEY": "secret-token",
                     "OTHER_SECRET": "another-secret"
@@ -216,6 +228,7 @@ fn test_maybe_write_acp_payload_debug_writes_json_artifact() {
     let debug_path = super::transport_acp_payload_debug::maybe_write_acp_payload_debug(
         super::transport_acp_payload_debug::AcpPayloadDebugRequest {
             env: &env,
+            session_dir: Some(session_dir.as_path()),
             tool_name: "gemini-cli",
             command: "gemini",
             args: &["--acp".to_string()],
@@ -227,6 +240,11 @@ fn test_maybe_write_acp_payload_debug_writes_json_artifact() {
         },
     )
     .expect("debug artifact");
+    assert!(
+        debug_path.starts_with(&session_dir),
+        "debug artifact should use the trusted session dir, got {}",
+        debug_path.display()
+    );
 
     let raw = std::fs::read_to_string(&debug_path).expect("read debug artifact");
     let json: serde_json::Value = serde_json::from_str(&raw).expect("parse debug artifact");
@@ -235,6 +253,7 @@ fn test_maybe_write_acp_payload_debug_writes_json_artifact() {
     assert_eq!(json["resume_session_id"], "provider-session");
     assert_eq!(json["prompt_chars"], 16);
     assert_eq!(json["prompt"], "full prompt body");
+    assert_eq!(json["args"], serde_json::json!(["--acp"]));
     assert_eq!(json["session_meta"]["review"]["mode"], "readonly");
     assert_eq!(
         json["session_meta"]["mcpServers"]["demo"]["env"]["API_KEY"],
@@ -243,6 +262,17 @@ fn test_maybe_write_acp_payload_debug_writes_json_artifact() {
     assert_eq!(
         json["session_meta"]["mcpServers"]["demo"]["env"]["OTHER_SECRET"],
         "<redacted>"
+    );
+    assert_eq!(
+        json["session_meta"]["mcpServers"]["demo"]["args"],
+        serde_json::json!([
+            "--api-key",
+            "<redacted>",
+            "--header",
+            "<redacted>",
+            "--safe",
+            "value"
+        ])
     );
 }
 

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -27,6 +27,13 @@ impl ScopedEnvVar {
         unsafe { std::env::set_var(key, value) };
         Self { key, original }
     }
+
+    fn unset(key: &'static str) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::remove_var(key) };
+        Self { key, original }
+    }
 }
 
 impl Drop for ScopedEnvVar {
@@ -178,10 +185,11 @@ fn test_maybe_write_acp_payload_debug_requires_flag_and_session_dir() {
 #[test]
 fn test_maybe_write_acp_payload_debug_writes_json_artifact() {
     let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
-    let _debug_flag = ScopedEnvVar::set(ACP_PAYLOAD_DEBUG_ENV, "1");
+    let _debug_flag = ScopedEnvVar::unset(ACP_PAYLOAD_DEBUG_ENV);
     let temp = tempfile::tempdir().expect("tempdir");
     let session_dir = temp.path().join("session");
     let mut env = HashMap::new();
+    env.insert(ACP_PAYLOAD_DEBUG_ENV.to_string(), "1".to_string());
     env.insert(
         "CSA_SESSION_DIR".to_string(),
         session_dir.to_string_lossy().into_owned(),
@@ -191,6 +199,18 @@ fn test_maybe_write_acp_payload_debug_writes_json_artifact() {
     session_meta.insert(
         "review".to_string(),
         serde_json::json!({"mode": "readonly"}),
+    );
+    session_meta.insert(
+        "mcpServers".to_string(),
+        serde_json::json!({
+            "demo": {
+                "command": "demo-mcp",
+                "env": {
+                    "API_KEY": "secret-token",
+                    "OTHER_SECRET": "another-secret"
+                }
+            }
+        }),
     );
 
     let debug_path = super::transport_acp_payload_debug::maybe_write_acp_payload_debug(
@@ -216,6 +236,14 @@ fn test_maybe_write_acp_payload_debug_writes_json_artifact() {
     assert_eq!(json["prompt_chars"], 16);
     assert_eq!(json["prompt"], "full prompt body");
     assert_eq!(json["session_meta"]["review"]["mode"], "readonly");
+    assert_eq!(
+        json["session_meta"]["mcpServers"]["demo"]["env"]["API_KEY"],
+        "<redacted>"
+    );
+    assert_eq!(
+        json["session_meta"]["mcpServers"]["demo"]["env"]["OTHER_SECRET"],
+        "<redacted>"
+    );
 }
 
 // --- 3-phase Gemini fallback chain integration tests ---

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
 
 const DAEMON_SESSION_ID_ENV: &str = "CSA_DAEMON_SESSION_ID";
+const ACP_PAYLOAD_DEBUG_ENV: &str = super::transport_acp_payload_debug::ACP_PAYLOAD_DEBUG_ENV;
 static DAEMON_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 fn restore_env_var(key: &str, original: Option<String>) {
@@ -10,6 +12,26 @@ fn restore_env_var(key: &str, original: Option<String>) {
             Some(value) => std::env::set_var(key, value),
             None => std::env::remove_var(key),
         }
+    }
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        restore_env_var(self.key, self.original.take());
     }
 }
 
@@ -129,6 +151,71 @@ fn test_daemon_mode_without_output_spool_keeps_acp_stderr_streaming() {
     ));
 
     restore_env_var(DAEMON_SESSION_ID_ENV, original);
+}
+
+#[test]
+fn test_maybe_write_acp_payload_debug_requires_flag_and_session_dir() {
+    let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
+    let _debug_flag = ScopedEnvVar::set(ACP_PAYLOAD_DEBUG_ENV, "0");
+
+    let path = super::transport_acp_payload_debug::maybe_write_acp_payload_debug(
+        super::transport_acp_payload_debug::AcpPayloadDebugRequest {
+            env: &HashMap::new(),
+            tool_name: "gemini-cli",
+            command: "gemini",
+            args: &["--acp".to_string()],
+            working_dir: std::path::Path::new("/tmp"),
+            resume_session_id: None,
+            system_prompt: None,
+            session_meta: None,
+            prompt: "prompt",
+        },
+    );
+
+    assert!(path.is_none(), "debug artifact should stay disabled by default");
+}
+
+#[test]
+fn test_maybe_write_acp_payload_debug_writes_json_artifact() {
+    let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
+    let _debug_flag = ScopedEnvVar::set(ACP_PAYLOAD_DEBUG_ENV, "1");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_dir = temp.path().join("session");
+    let mut env = HashMap::new();
+    env.insert(
+        "CSA_SESSION_DIR".to_string(),
+        session_dir.to_string_lossy().into_owned(),
+    );
+
+    let mut session_meta = serde_json::Map::new();
+    session_meta.insert(
+        "review".to_string(),
+        serde_json::json!({"mode": "readonly"}),
+    );
+
+    let debug_path = super::transport_acp_payload_debug::maybe_write_acp_payload_debug(
+        super::transport_acp_payload_debug::AcpPayloadDebugRequest {
+            env: &env,
+            tool_name: "gemini-cli",
+            command: "gemini",
+            args: &["--acp".to_string()],
+            working_dir: std::path::Path::new("/repo"),
+            resume_session_id: Some("provider-session"),
+            system_prompt: Some("system prompt"),
+            session_meta: Some(&session_meta),
+            prompt: "full prompt body",
+        },
+    )
+    .expect("debug artifact");
+
+    let raw = std::fs::read_to_string(&debug_path).expect("read debug artifact");
+    let json: serde_json::Value = serde_json::from_str(&raw).expect("parse debug artifact");
+    assert_eq!(json["tool_name"], "gemini-cli");
+    assert_eq!(json["command"], "gemini");
+    assert_eq!(json["resume_session_id"], "provider-session");
+    assert_eq!(json["prompt_chars"], 16);
+    assert_eq!(json["prompt"], "full prompt body");
+    assert_eq!(json["session_meta"]["review"]["mode"], "readonly");
 }
 
 // --- 3-phase Gemini fallback chain integration tests ---

--- a/crates/csa-executor/src/transport_types.rs
+++ b/crates/csa-executor/src/transport_types.rs
@@ -1,0 +1,38 @@
+use std::path::Path;
+
+use csa_acp::SessionEvent;
+use csa_process::{ExecutionResult, StreamMode};
+use csa_resource::isolation_plan::IsolationPlan;
+
+#[derive(Debug, Clone)]
+pub struct SandboxTransportConfig {
+    pub isolation_plan: IsolationPlan,
+    pub tool_name: String,
+    pub best_effort: bool,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransportOptions<'a> {
+    pub stream_mode: StreamMode,
+    pub idle_timeout_seconds: u64,
+    pub acp_crash_max_attempts: u8,
+    pub initial_response_timeout_seconds: Option<u64>,
+    pub liveness_dead_seconds: u64,
+    pub stdin_write_timeout_seconds: u64,
+    pub acp_init_timeout_seconds: u64,
+    pub termination_grace_period_seconds: u64,
+    pub output_spool: Option<&'a Path>,
+    pub output_spool_max_bytes: u64,
+    pub output_spool_keep_rotated: bool,
+    pub setting_sources: Option<Vec<String>>,
+    pub sandbox: Option<&'a SandboxTransportConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransportResult {
+    pub execution: ExecutionResult,
+    pub provider_session_id: Option<String>,
+    pub events: Vec<SessionEvent>,
+    pub metadata: csa_acp::StreamingMetadata,
+}

--- a/crates/csa-executor/src/transport_types.rs
+++ b/crates/csa-executor/src/transport_types.rs
@@ -36,3 +36,11 @@ pub struct TransportResult {
     pub events: Vec<SessionEvent>,
     pub metadata: csa_acp::StreamingMetadata,
 }
+
+pub(super) fn should_stream_acp_stdout_to_stderr(
+    stream_mode: StreamMode,
+    output_spool: Option<&Path>,
+) -> bool {
+    !(matches!(stream_mode, StreamMode::BufferOnly)
+        || output_spool.is_some() && std::env::var_os("CSA_DAEMON_SESSION_ID").is_some())
+}


### PR DESCRIPTION
## Summary

Fixes three related gemini-cli ACP failures as one cluster:
- #644: sandboxed ACP initialization timed out after 300s
- #645: ACP initialization timed out with OAuth failure even though standalone `gemini-cli` worked
- #656: `csa review` with `gemini-cli` failed with an invalid-argument ACP request

## Test plan
- [x] `TMPDIR=/tmp just pre-commit` passes
- [x] cumulative codex review completed on `main...HEAD`
- [ ] smoke test: `csa run --tool gemini-cli --prompt "hello"` does not crash

## Review follow-up
- Medium review finding tracked in #682
- Low finding noted and intentionally not blocking merge under severity-tiered policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)