### PR TITLE
fix(sa-mode): operational frictions (#653)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "chrono",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "chrono",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "axum",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "chrono",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.264"
+version = "0.1.265"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.264"
+version = "0.1.265"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/error_hints.rs
+++ b/crates/cli-sub-agent/src/error_hints.rs
@@ -18,7 +18,7 @@ const HINT_SLOT_EXHAUSTED: &str = "hint: free slots with 'csa gc' or wait with '
 const HINT_SESSION_NOT_FOUND: &str = "hint: list available sessions with 'csa session list'";
 const HINT_CONFIG_ERROR: &str =
     "hint: validate config with 'csa config validate' or reinitialize with 'csa init'";
-const HINT_GEMINI_RUNTIME_HOME: &str = "hint: Gemini ACP needs a writable runtime home; upgrade to a build that seeds it under CSA session state, or re-run with TMPDIR=/tmp";
+const HINT_GEMINI_RUNTIME_HOME: &str = "hint: Gemini ACP needs a writable runtime home; current builds pin TMPDIR to /tmp and seed under CSA session state, but older builds may still need re-run with TMPDIR=/tmp";
 
 pub fn suggest_fix(err: &Error) -> Option<String> {
     for cause in err.chain() {

--- a/crates/cli-sub-agent/src/error_hints.rs
+++ b/crates/cli-sub-agent/src/error_hints.rs
@@ -18,7 +18,7 @@ const HINT_SLOT_EXHAUSTED: &str = "hint: free slots with 'csa gc' or wait with '
 const HINT_SESSION_NOT_FOUND: &str = "hint: list available sessions with 'csa session list'";
 const HINT_CONFIG_ERROR: &str =
     "hint: validate config with 'csa config validate' or reinitialize with 'csa init'";
-const HINT_GEMINI_RUNTIME_HOME: &str = "hint: Gemini ACP needs a writable runtime home; current builds pin TMPDIR to /tmp and seed under CSA session state, but older builds may still need re-run with TMPDIR=/tmp";
+const HINT_GEMINI_RUNTIME_HOME: &str = "hint: Gemini ACP needs a writable runtime home; current builds pin TMPDIR to a writable sandbox temp dir (private /tmp in bwrap, session tmp elsewhere) and seed under CSA session state, but older builds may still need re-run with TMPDIR=/tmp";
 
 pub fn suggest_fix(err: &Error) -> Option<String> {
     for cause in err.chain() {

--- a/crates/cli-sub-agent/src/pipeline_result_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_result_contract.rs
@@ -1,9 +1,11 @@
 //! Result.toml path contract enforcement for session execution.
 //!
 //! When a prompt contains the contract marker `csa_result_toml_path_contract=1`,
-//! the session output must contain the absolute path to a valid `result.toml` or
-//! `user-result.toml` file inside the session directory.  If the contract is
-//! violated the execution result is coerced to failure.
+//! the session output must contain the absolute path to a valid `result.toml`
+//! artifact inside the session directory. Accepted paths are the runtime
+//! session root (`result.toml`), the canonical output-sidecar
+//! (`output/result.toml`), or the legacy sidecar (`output/user-result.toml`).
+//! If the contract is violated the execution result is coerced to failure.
 
 use std::path::Path;
 use tracing::warn;
@@ -25,9 +27,12 @@ pub(crate) fn enforce_result_toml_path_contract(
 
     if !result_file_cleared {
         let expected_path = session_dir.join("result.toml");
+        let legacy_output_path = csa_session::legacy_user_result_path(session_dir);
         let reason = format!(
-            "contract violation: failed to clear pre-existing result.toml '{}' before execution; refusing to trust stale file",
-            expected_path.display()
+            "contract violation: failed to clear pre-existing result artifacts '{}', '{}', and '{}' before execution; refusing to trust stale files",
+            expected_path.display(),
+            csa_session::contract_result_path(session_dir).display(),
+            legacy_output_path.display()
         );
         warn!(
             summary = %result.summary,
@@ -45,14 +50,34 @@ pub(crate) fn enforce_result_toml_path_contract(
 
     let path_candidate = contract_result_toml_path_candidate(result);
     let expected_path = session_dir.join("result.toml");
-    let expected_user_result_path = session_dir.join("output").join("user-result.toml");
+    let expected_contract_output_path = csa_session::contract_result_path(session_dir);
+    let expected_user_result_path = csa_session::legacy_user_result_path(session_dir);
     if path_matches_expected_contract_result(path_candidate, &expected_path)
+        || path_matches_expected_contract_result(path_candidate, &expected_contract_output_path)
         || path_matches_expected_contract_result(path_candidate, &expected_user_result_path)
     {
         return;
     }
 
-    if user_result_fallback_is_valid(&expected_user_result_path) {
+    if sidecar_result_fallback_is_valid(&expected_contract_output_path) {
+        let warning = format!(
+            "contract warning: output/summary path mismatch; accepted fallback artifact '{}'",
+            expected_contract_output_path.display()
+        );
+        warn!(
+            summary = %result.summary,
+            fallback = %expected_contract_output_path.display(),
+            "Session output path did not match contract; accepting verified output/result.toml fallback"
+        );
+        if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+            result.stderr_output.push('\n');
+        }
+        result.stderr_output.push_str(&warning);
+        result.stderr_output.push('\n');
+        return;
+    }
+
+    if sidecar_result_fallback_is_valid(&expected_user_result_path) {
         let warning = format!(
             "contract warning: output/summary path mismatch; accepted fallback artifact '{}'",
             expected_user_result_path.display()
@@ -94,14 +119,16 @@ pub(crate) fn enforce_result_toml_path_contract(
 
     let reason = if path_candidate.is_empty() {
         format!(
-            "contract violation: expected existing absolute result path '{}' or '{}' in output/summary, but output and summary were empty",
+            "contract violation: expected existing absolute result path '{}', '{}', or '{}' in output/summary, but output and summary were empty",
             expected_path.display(),
+            expected_contract_output_path.display(),
             expected_user_result_path.display()
         )
     } else {
         format!(
-            "contract violation: expected existing absolute result path '{}' or '{}' in output/summary, got '{path_candidate}'",
+            "contract violation: expected existing absolute result path '{}', '{}', or '{}' in output/summary, got '{path_candidate}'",
             expected_path.display(),
+            expected_contract_output_path.display(),
             expected_user_result_path.display()
         )
     };
@@ -287,7 +314,7 @@ fn expected_contract_file_is_valid(path: &Path) -> bool {
     true
 }
 
-fn user_result_fallback_is_valid(path: &Path) -> bool {
+fn sidecar_result_fallback_is_valid(path: &Path) -> bool {
     if !expected_contract_file_is_valid(path) {
         return false;
     }
@@ -371,6 +398,16 @@ pub(super) fn clear_expected_result_toml(path: &Path) -> bool {
             false
         }
     }
+}
+
+pub(super) fn clear_expected_result_tomls(session_dir: &Path) -> bool {
+    let session_result_path = session_dir.join("result.toml");
+    let contract_output_path = csa_session::contract_result_path(session_dir);
+    let legacy_output_path = csa_session::legacy_user_result_path(session_dir);
+    let session_cleared = clear_expected_result_toml(&session_result_path);
+    let contract_output_cleared = clear_expected_result_toml(&contract_output_path);
+    let legacy_output_cleared = clear_expected_result_toml(&legacy_output_path);
+    session_cleared && contract_output_cleared && legacy_output_cleared
 }
 
 fn normalize_contract_path_candidate(path: &str) -> &str {

--- a/crates/cli-sub-agent/src/pipeline_result_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_result_contract.rs
@@ -74,6 +74,7 @@ pub(crate) fn enforce_result_toml_path_contract(
         }
         result.stderr_output.push_str(&warning);
         result.stderr_output.push('\n');
+        rewrite_contract_output_last_line(result, &expected_contract_output_path);
         return;
     }
 
@@ -92,6 +93,7 @@ pub(crate) fn enforce_result_toml_path_contract(
         }
         result.stderr_output.push_str(&warning);
         result.stderr_output.push('\n');
+        rewrite_contract_output_last_line(result, &expected_user_result_path);
         return;
     }
 
@@ -114,6 +116,7 @@ pub(crate) fn enforce_result_toml_path_contract(
         }
         result.stderr_output.push_str(&warning);
         result.stderr_output.push('\n');
+        rewrite_contract_output_last_line(result, &expected_path);
         return;
     }
 
@@ -144,6 +147,14 @@ pub(crate) fn enforce_result_toml_path_contract(
     result.stderr_output.push('\n');
     result.summary = reason;
     result.exit_code = 1;
+}
+
+fn rewrite_contract_output_last_line(result: &mut ExecutionResult, accepted_path: &Path) {
+    if !result.output.is_empty() && !result.output.ends_with('\n') {
+        result.output.push('\n');
+    }
+    result.output.push_str(&accepted_path.to_string_lossy());
+    result.output.push('\n');
 }
 
 fn prompt_requires_result_toml_path(prompt: &str) -> bool {

--- a/crates/cli-sub-agent/src/pipeline_result_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_result_contract.rs
@@ -400,11 +400,15 @@ pub(super) fn clear_expected_result_toml(path: &Path) -> bool {
     }
 }
 
-pub(super) fn clear_expected_result_tomls(session_dir: &Path) -> bool {
+pub(super) fn clear_expected_result_artifacts_for_prompt(prompt: &str, session_dir: &Path) -> bool {
     let session_result_path = session_dir.join("result.toml");
+    let session_cleared = clear_expected_result_toml(&session_result_path);
+    if !prompt_requires_result_toml_path(prompt) {
+        return session_cleared;
+    }
+
     let contract_output_path = csa_session::contract_result_path(session_dir);
     let legacy_output_path = csa_session::legacy_user_result_path(session_dir);
-    let session_cleared = clear_expected_result_toml(&session_result_path);
     let contract_output_cleared = clear_expected_result_toml(&contract_output_path);
     let legacy_output_cleared = clear_expected_result_toml(&legacy_output_path);
     session_cleared && contract_output_cleared && legacy_output_cleared

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -24,6 +24,15 @@ pub(crate) enum SandboxResolution {
     RequiredButUnavailable(String),
 }
 
+fn resolve_session_dir_for_sandbox(project_root: &Path, session_id: &str) -> PathBuf {
+    csa_session::manager::get_session_dir(project_root, session_id).unwrap_or_else(|_| {
+        std::env::temp_dir()
+            .join("cli-sub-agent")
+            .join("sessions")
+            .join(session_id)
+    })
+}
+
 /// Resolve sandbox configuration from project config and enforcement mode.
 ///
 /// Returns `SandboxResolution::Ok` with the options (possibly enriched with
@@ -100,6 +109,7 @@ pub(crate) fn resolve_sandbox_options(
         }
 
         // Build IsolationPlan via builder (BestEffort for profile defaults).
+        let session_dir = resolve_session_dir_for_sandbox(project_root, session_id);
         let mut builder = IsolationPlanBuilder::new(ResourceEnforcementMode::BestEffort)
             .with_resource_capability(resource_cap)
             .with_filesystem_capability(fs_cap)
@@ -108,12 +118,7 @@ pub(crate) fn resolve_sandbox_options(
                 defaults.memory_swap_max_mb,
                 None, // pids_max not available from profile defaults
             )
-            .with_tool_defaults(
-                tool_name,
-                project_root,
-                // No session dir available; use a temporary placeholder.
-                &std::env::temp_dir(),
-            )
+            .with_tool_defaults(tool_name, project_root, &session_dir)
             .with_readonly_project_root(readonly_project_root);
 
         // CSA runtime writable paths (best-effort for profile defaults).
@@ -231,8 +236,7 @@ pub(crate) fn resolve_sandbox_options(
     }
 
     // Resolve project root and session dir for tool-specific writable paths.
-    let session_dir = csa_session::manager::get_session_dir(project_root, session_id)
-        .unwrap_or_else(|_| std::env::temp_dir());
+    let session_dir = resolve_session_dir_for_sandbox(project_root, session_id);
 
     let memory_swap_max_mb = cfg.sandbox_memory_swap_max_mb(tool_name);
     let pids_max = cfg.sandbox_pids_max();

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -140,6 +140,21 @@ fn test_none_config_heavyweight_gets_sandbox() {
         assert!(ctx.best_effort, "Profile defaults should use best-effort");
         assert_eq!(ctx.tool_name, "claude-code");
         assert_eq!(ctx.session_id, "test-session");
+
+        let expected_tmpdir = match ctx.isolation_plan.filesystem {
+            csa_resource::FilesystemCapability::Bwrap => PathBuf::from("/tmp"),
+            csa_resource::FilesystemCapability::Landlock
+            | csa_resource::FilesystemCapability::None => {
+                csa_session::manager::get_session_dir(&current_project_root(), "test-session")
+                    .expect("session dir")
+                    .join("tmp")
+            }
+        };
+        assert_eq!(
+            ctx.isolation_plan.env_overrides.get("TMPDIR"),
+            Some(&expected_tmpdir.to_string_lossy().into_owned()),
+            "sandbox TMPDIR should match the active filesystem capability"
+        );
     }
 }
 

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -8,7 +8,7 @@ use std::{
 use tracing::{debug, info, warn};
 
 use super::prompt_guard::emit_prompt_guard_to_caller;
-use super::result_contract::{clear_expected_result_toml, enforce_result_toml_path_contract};
+use super::result_contract::{clear_expected_result_tomls, enforce_result_toml_path_contract};
 use super::{
     MemoryInjectionOptions, ParentSessionSource, SessionExecutionResult,
     resolve_liveness_dead_seconds, resolve_mcp_servers, run_pipeline_hook,
@@ -437,7 +437,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
                 })
         });
 
-    let result_file_cleared = clear_expected_result_toml(&session_dir.join("result.toml"));
+    let result_file_cleared = clear_expected_result_tomls(&session_dir);
     let execution_start_time = chrono::Utc::now();
     // Build session config with MCP servers (if global config provided).
     let session_config = global_config.map(|gc| {

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -8,7 +8,9 @@ use std::{
 use tracing::{debug, info, warn};
 
 use super::prompt_guard::emit_prompt_guard_to_caller;
-use super::result_contract::{clear_expected_result_tomls, enforce_result_toml_path_contract};
+use super::result_contract::{
+    clear_expected_result_artifacts_for_prompt, enforce_result_toml_path_contract,
+};
 use super::{
     MemoryInjectionOptions, ParentSessionSource, SessionExecutionResult,
     resolve_liveness_dead_seconds, resolve_mcp_servers, run_pipeline_hook,
@@ -437,7 +439,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
                 })
         });
 
-    let result_file_cleared = clear_expected_result_tomls(&session_dir);
+    let result_file_cleared = clear_expected_result_artifacts_for_prompt(prompt, &session_dir);
     let execution_start_time = chrono::Utc::now();
     // Build session config with MCP servers (if global config provided).
     let session_config = global_config.map(|gc| {

--- a/crates/cli-sub-agent/src/pipeline_tests_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_contract.rs
@@ -45,6 +45,33 @@ fn result_toml_path_contract_extracts_embedded_path() {
 }
 
 #[test]
+fn result_toml_path_contract_accepts_output_result_artifact_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let output_dir = temp.path().join("output");
+    fs::create_dir_all(&output_dir).unwrap();
+    let result_path = output_dir.join("result.toml");
+    fs::write(&result_path, "status = \"success\"\nsummary = \"done\"\n").unwrap();
+
+    let mut result = ExecutionResult {
+        output: format!("{}\n", result_path.display()),
+        stderr_output: String::new(),
+        summary: "completed all tasks successfully".to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+    };
+
+    enforce_result_toml_contract_now(
+        "CSA_RESULT_TOML_PATH_CONTRACT=1",
+        "",
+        temp.path(),
+        &mut result,
+    );
+
+    assert_eq!(result.exit_code, 0);
+    assert!(result.stderr_output.is_empty());
+}
+
+#[test]
 fn result_toml_path_contract_accepts_verified_session_result_fallback() {
     let temp = tempfile::tempdir().unwrap();
     let result_path = temp.path().join("result.toml");
@@ -196,4 +223,54 @@ fn result_toml_path_contract_fails_when_output_summary_empty_and_no_disk_file() 
     assert_eq!(result.exit_code, 1);
     assert!(result.summary.contains("output and summary were empty"));
     assert!(result.stderr_output.contains("contract violation"));
+}
+
+#[test]
+fn clear_expected_result_tomls_removes_all_stale_result_artifacts() {
+    let temp = tempfile::tempdir().unwrap();
+    let output_dir = temp.path().join("output");
+    fs::create_dir_all(&output_dir).unwrap();
+    let session_result = temp.path().join("result.toml");
+    let output_result = output_dir.join("result.toml");
+    let legacy_output_result = output_dir.join("user-result.toml");
+    fs::write(&session_result, "status = \"stale\"\n").unwrap();
+    fs::write(&output_result, "status = \"stale\"\n").unwrap();
+    fs::write(&legacy_output_result, "status = \"stale\"\n").unwrap();
+
+    assert!(crate::pipeline::result_contract::clear_expected_result_tomls(temp.path()));
+    assert!(!session_result.exists());
+    assert!(!output_result.exists());
+    assert!(!legacy_output_result.exists());
+}
+
+#[test]
+fn sa_skill_docs_reference_contract_result_path_and_plain_git_commit() {
+    let sa_skill = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../patterns/sa/skills/sa/SKILL.md"
+    ));
+    assert!(
+        sa_skill.contains("$CSA_RESULT_TOML_PATH_CONTRACT"),
+        "SA dispatch templates must direct child sessions to the injected result path contract"
+    );
+    assert!(
+        sa_skill.contains("plain `git commit`"),
+        "SA skill should document plain git commit for child-session commits"
+    );
+}
+
+#[test]
+fn split_project_docs_skill_uses_plain_git_commit() {
+    let skill = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../skills/split-project-docs/SKILL.md"
+    ));
+    assert!(
+        skill.contains("plain `git commit`"),
+        "split-project-docs should document plain git commit in CSA child sessions"
+    );
+    assert!(
+        !skill.contains("Use `/commit` skill"),
+        "split-project-docs should no longer require the unavailable /commit shortcut"
+    );
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_contract.rs
@@ -75,6 +75,7 @@ fn result_toml_path_contract_accepts_output_result_artifact_path() {
 fn result_toml_path_contract_accepts_verified_session_result_fallback() {
     let temp = tempfile::tempdir().unwrap();
     let result_path = temp.path().join("result.toml");
+    let path_str = result_path.display().to_string();
     fs::write(
         &result_path,
         "status = \"success\"\nsummary = \"task complete\"\n",
@@ -107,6 +108,11 @@ fn result_toml_path_contract_accepts_verified_session_result_fallback() {
         result
             .stderr_output
             .contains("contract warning: output/summary path not found")
+    );
+    assert_eq!(
+        result.output.lines().last(),
+        Some(path_str.as_str()),
+        "accepted fallback must become the last output line so managers consume the verified path"
     );
 }
 
@@ -174,7 +180,8 @@ fn result_toml_path_contract_handles_verbose_multiline_output() {
 #[test]
 fn result_toml_path_contract_accepts_disk_fallback_when_output_and_summary_are_empty() {
     let temp = tempfile::tempdir().unwrap();
-    fs::write(temp.path().join("result.toml"), "status = \"success\"\n").unwrap();
+    let result_path = temp.path().join("result.toml");
+    fs::write(&result_path, "status = \"success\"\n").unwrap();
     let mut result = ExecutionResult {
         output: " \n\t\n".to_string(),
         stderr_output: String::new(),
@@ -198,6 +205,11 @@ fn result_toml_path_contract_accepts_disk_fallback_when_output_and_summary_are_e
         result
             .stderr_output
             .contains("contract warning: output/summary path not found")
+    );
+    assert_eq!(
+        result.output.lines().last(),
+        Some(result_path.to_string_lossy().as_ref()),
+        "accepted disk fallback must surface the verified path as the final output line"
     );
 }
 
@@ -294,6 +306,48 @@ fn sa_skill_docs_reference_contract_result_path_and_plain_git_commit() {
         sa_skill.contains("plain `git commit`"),
         "SA skill should document plain git commit for child-session commits"
     );
+}
+
+#[test]
+fn sa_pattern_and_workflow_dispatch_templates_propagate_sa_mode() {
+    let pattern = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../patterns/sa/PATTERN.md"
+    ));
+    let workflow = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../patterns/sa/workflow.toml"
+    ));
+
+    for expected in [
+        "SID=$(csa run --sa-mode true --prompt-file \"${PROMPT_FILE}\")",
+        "SID=$(csa run --sa-mode true --session \"${SESSION_ID}\" --prompt-file \"${IMPL_FILE}\")",
+        "SID=$(csa run --sa-mode true --session \"${SESSION_ID}\" --prompt-file \"${RESUME_FILE}\")",
+    ] {
+        assert!(
+            pattern.contains(expected),
+            "SA pattern must propagate --sa-mode true in dispatch template: {expected}"
+        );
+        assert!(
+            workflow.contains(expected),
+            "SA workflow must propagate --sa-mode true in dispatch template: {expected}"
+        );
+    }
+
+    for legacy in [
+        "SID=$(csa run --prompt-file \"${PROMPT_FILE}\")",
+        "SID=$(csa run --session \"${SESSION_ID}\" --prompt-file \"${IMPL_FILE}\")",
+        "SID=$(csa run --session \"${SESSION_ID}\" --prompt-file \"${RESUME_FILE}\")",
+    ] {
+        assert!(
+            !pattern.contains(legacy),
+            "legacy SA pattern dispatch without --sa-mode true must be removed: {legacy}"
+        );
+        assert!(
+            !workflow.contains(legacy),
+            "legacy SA workflow dispatch without --sa-mode true must be removed: {legacy}"
+        );
+    }
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/pipeline_tests_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_contract.rs
@@ -237,10 +237,47 @@ fn clear_expected_result_tomls_removes_all_stale_result_artifacts() {
     fs::write(&output_result, "status = \"stale\"\n").unwrap();
     fs::write(&legacy_output_result, "status = \"stale\"\n").unwrap();
 
-    assert!(crate::pipeline::result_contract::clear_expected_result_tomls(temp.path()));
+    assert!(
+        crate::pipeline::result_contract::clear_expected_result_artifacts_for_prompt(
+            crate::pipeline::result_contract::RESULT_TOML_PATH_CONTRACT_MARKER,
+            temp.path()
+        )
+    );
     assert!(!session_result.exists());
     assert!(!output_result.exists());
     assert!(!legacy_output_result.exists());
+}
+
+#[test]
+fn clear_expected_result_artifacts_for_plain_prompt_preserves_sidecars() {
+    let temp = tempfile::tempdir().unwrap();
+    let output_dir = temp.path().join("output");
+    fs::create_dir_all(&output_dir).unwrap();
+    let session_result = temp.path().join("result.toml");
+    let output_result = output_dir.join("result.toml");
+    let legacy_output_result = output_dir.join("user-result.toml");
+    fs::write(&session_result, "status = \"stale\"\n").unwrap();
+    fs::write(&output_result, "status = \"preserve\"\n").unwrap();
+    fs::write(&legacy_output_result, "status = \"preserve\"\n").unwrap();
+
+    assert!(
+        crate::pipeline::result_contract::clear_expected_result_artifacts_for_prompt(
+            "plain follow-up without contract marker",
+            temp.path()
+        )
+    );
+    assert!(
+        !session_result.exists(),
+        "session-root result.toml remains scratch state and should still be cleared"
+    );
+    assert!(
+        output_result.exists(),
+        "canonical contract sidecar must survive non-contract follow-up turns"
+    );
+    assert!(
+        legacy_output_result.exists(),
+        "legacy sidecar must survive non-contract follow-up turns"
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/pipeline_tests_tail.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_tail.rs
@@ -140,7 +140,7 @@ fn result_toml_path_contract_fails_closed_when_preclear_failed() {
     assert!(
         result
             .summary
-            .contains("failed to clear pre-existing result.toml")
+            .contains("failed to clear pre-existing result artifacts")
     );
     assert!(result.stderr_output.contains("contract violation"));
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_tail.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_tail.rs
@@ -402,6 +402,11 @@ summary = "ok"
             .stderr_output
             .contains("contract warning: output/summary path mismatch")
     );
+    assert_eq!(
+        result.output.lines().last(),
+        Some(user_result_path.to_string_lossy().as_ref()),
+        "accepted user-result fallback must become the final output line"
+    );
 }
 
 #[test]

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -271,6 +271,7 @@ impl Executor {
         if let Some(env) = extra_env {
             Self::inject_env(&mut cmd, env);
         }
+        Self::inject_session_path_env(&mut cmd, session);
         let gemini_include_directories =
             gemini_include_directories(extra_env, prompt, Some(Path::new(&session.project_path)));
         let (prompt_transport, stdin_data) = self.select_prompt_transport(prompt);
@@ -472,24 +473,7 @@ impl Executor {
         cmd.env("CSA_SESSION_ID", &session.meta_session_id);
         cmd.env("CSA_DEPTH", (session.genealogy.depth + 1).to_string());
         cmd.env("CSA_PROJECT_ROOT", &session.project_path);
-
-        // CSA_SESSION_DIR: absolute path to this session's state directory
-        match csa_session::manager::get_session_dir(
-            Path::new(&session.project_path),
-            &session.meta_session_id,
-        ) {
-            Ok(dir) => {
-                cmd.env("CSA_SESSION_DIR", dir.to_string_lossy().as_ref());
-                let contract_result_path = csa_session::contract_result_path(&dir);
-                cmd.env(
-                    csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
-                    contract_result_path.to_string_lossy().into_owned(),
-                );
-            }
-            Err(e) => {
-                tracing::warn!("failed to compute CSA_SESSION_DIR: {e:#}");
-            }
-        }
+        Self::inject_session_path_env(&mut cmd, session);
 
         // CSA_TOOL: tells the child process which tool it is running as
         cmd.env("CSA_TOOL", self.tool_name());
@@ -504,6 +488,26 @@ impl Executor {
         }
 
         cmd
+    }
+
+    fn inject_session_path_env(cmd: &mut Command, session: &MetaSessionState) {
+        match csa_session::manager::get_session_dir(
+            Path::new(&session.project_path),
+            &session.meta_session_id,
+        ) {
+            Ok(dir) => {
+                cmd.env("CSA_SESSION_DIR", dir.to_string_lossy().into_owned());
+                cmd.env(
+                    csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
+                    csa_session::contract_result_path(&dir)
+                        .to_string_lossy()
+                        .into_owned(),
+                );
+            }
+            Err(e) => {
+                tracing::warn!("failed to compute CSA_SESSION_DIR: {e:#}");
+            }
+        }
     }
 
     fn transport(&self, session_config: Option<SessionConfig>) -> Box<dyn Transport> {

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -480,6 +480,11 @@ impl Executor {
         ) {
             Ok(dir) => {
                 cmd.env("CSA_SESSION_DIR", dir.to_string_lossy().as_ref());
+                let contract_result_path = csa_session::contract_result_path(&dir);
+                cmd.env(
+                    csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
+                    contract_result_path.to_string_lossy().into_owned(),
+                );
             }
             Err(e) => {
                 tracing::warn!("failed to compute CSA_SESSION_DIR: {e:#}");

--- a/crates/csa-executor/src/executor_build_cmd_tests.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests.rs
@@ -220,6 +220,58 @@ fn test_build_command_extra_env_injection() {
     );
 }
 
+#[test]
+fn test_build_command_reserved_session_paths_override_extra_env() {
+    let exec = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+    };
+    let session = make_test_session();
+    let mut extra = HashMap::new();
+    extra.insert(
+        "CSA_SESSION_DIR".to_string(),
+        "/tmp/fake-session".to_string(),
+    );
+    extra.insert(
+        csa_session::RESULT_TOML_PATH_CONTRACT_ENV.to_string(),
+        "/tmp/fake-session/result.toml".to_string(),
+    );
+
+    let (cmd, stdin_data) = exec.build_command("test", None, &session, Some(&extra));
+    assert!(stdin_data.is_none(), "Short prompts should stay on argv");
+
+    let envs: Vec<_> = cmd.as_std().get_envs().collect();
+    let env_map: HashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> = envs.into_iter().collect();
+
+    let session_dir = env_map
+        .get(std::ffi::OsStr::new("CSA_SESSION_DIR"))
+        .expect("CSA_SESSION_DIR should be present")
+        .expect("CSA_SESSION_DIR should have a value")
+        .to_string_lossy();
+    assert!(
+        session_dir.contains("/sessions/"),
+        "reserved session dir should override extra_env, got: {session_dir}"
+    );
+    assert!(
+        session_dir.contains("01HTEST000000000000000000"),
+        "reserved session dir should include the session ID, got: {session_dir}"
+    );
+
+    let result_contract_path = env_map
+        .get(std::ffi::OsStr::new("CSA_RESULT_TOML_PATH_CONTRACT"))
+        .expect("CSA_RESULT_TOML_PATH_CONTRACT should be present")
+        .expect("CSA_RESULT_TOML_PATH_CONTRACT should have a value")
+        .to_string_lossy();
+    assert!(
+        result_contract_path.ends_with("/output/result.toml"),
+        "reserved result contract path should override extra_env, got: {result_contract_path}"
+    );
+    assert!(
+        result_contract_path.contains("01HTEST000000000000000000"),
+        "reserved result contract path should include the session ID, got: {result_contract_path}"
+    );
+}
+
 // ── build_command: per-tool args structure ───────────────────────
 
 #[test]

--- a/crates/csa-executor/src/executor_build_cmd_tests.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests.rs
@@ -100,6 +100,19 @@ fn test_build_command_sets_csa_session_dir() {
         session_dir_str.contains("01HTEST000000000000000000"),
         "CSA_SESSION_DIR should contain the session ID, got: {session_dir_str}"
     );
+    let result_contract_path = env_map
+        .get(std::ffi::OsStr::new("CSA_RESULT_TOML_PATH_CONTRACT"))
+        .expect("CSA_RESULT_TOML_PATH_CONTRACT should be present")
+        .expect("CSA_RESULT_TOML_PATH_CONTRACT should have a value");
+    let result_contract_path = result_contract_path.to_string_lossy();
+    assert!(
+        result_contract_path.ends_with("/output/result.toml"),
+        "contract path should target the session output/result.toml artifact, got: {result_contract_path}"
+    );
+    assert!(
+        result_contract_path.contains("01HTEST000000000000000000"),
+        "contract path should include the session ID, got: {result_contract_path}"
+    );
 }
 
 #[test]

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -455,6 +455,7 @@ impl AcpTransport {
         if self.tool_name == "gemini-cli" {
             let launch = prepare_gemini_acp_runtime(
                 &mut env,
+                Some(working_dir.as_path()),
                 session_dir.as_deref(),
                 &session.meta_session_id,
                 &acp_args,

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -40,6 +40,7 @@ pub(crate) struct GeminiAcpLaunch {
 
 pub(crate) fn prepare_gemini_acp_runtime(
     env: &mut HashMap<String, String>,
+    project_dir: Option<&Path>,
     session_dir: Option<&Path>,
     session_id: &str,
     base_args: &[String],
@@ -93,7 +94,7 @@ pub(crate) fn prepare_gemini_acp_runtime(
         .map(OsStr::new)
         .map(std::ffi::OsString::from)
         .or_else(|| std::env::var_os("PATH"));
-    if let Some(path) = pin_non_shim_runtime_path(inherited_path.as_deref(), env)? {
+    if let Some(path) = pin_non_shim_runtime_path(inherited_path.as_deref(), env, project_dir)? {
         env.insert("PATH".to_string(), path);
     }
     for key in GEMINI_RUNTIME_SHIM_ENV_VARS {
@@ -106,7 +107,9 @@ pub(crate) fn prepare_gemini_acp_runtime(
         .map(std::ffi::OsString::from)
         .or(inherited_path);
 
-    if let Some(launch) = resolve_non_shim_gemini_launch(path_env.as_deref(), env, base_args)? {
+    if let Some(launch) =
+        resolve_non_shim_gemini_launch(path_env.as_deref(), env, project_dir, base_args)?
+    {
         debug!(
             command = %launch.command,
             runtime_home = %runtime_home.display(),
@@ -477,6 +480,7 @@ fn mirror_directory_link(source: &Path, target: &Path) {
 fn pin_non_shim_runtime_path(
     path_env: Option<&OsStr>,
     env: &HashMap<String, String>,
+    project_dir: Option<&Path>,
 ) -> Result<Option<String>> {
     let Some(path_env) = path_env else {
         return Ok(None);
@@ -485,7 +489,7 @@ fn pin_non_shim_runtime_path(
     let original_entries: Vec<PathBuf> = std::env::split_paths(path_env).collect();
     let mut pinned_dirs = Vec::new();
     for binary in GEMINI_RUNTIME_PINNED_PATH_BINARIES {
-        if let Some(dir) = find_direct_tool_dir(binary, Some(path_env), env)?
+        if let Some(dir) = find_direct_tool_dir(binary, Some(path_env), env, project_dir)?
             && !pinned_dirs.contains(&dir)
         {
             pinned_dirs.push(dir);
@@ -512,8 +516,9 @@ fn find_direct_tool_dir(
     name: &str,
     path_env: Option<&OsStr>,
     env: &HashMap<String, String>,
+    project_dir: Option<&Path>,
 ) -> Result<Option<PathBuf>> {
-    Ok(find_direct_tool_path(name, path_env, env)?
+    Ok(find_direct_tool_path(name, path_env, env, project_dir)?
         .and_then(|path| path.parent().map(PathBuf::from)))
 }
 
@@ -536,12 +541,13 @@ fn find_direct_tool_path(
     name: &str,
     path_env: Option<&OsStr>,
     env: &HashMap<String, String>,
+    project_dir: Option<&Path>,
 ) -> Result<Option<PathBuf>> {
     if let Some(candidate) = find_non_mise_path_entry(name, path_env) {
         return Ok(Some(candidate));
     }
 
-    resolve_mise_which_path(name, path_env, env)
+    resolve_mise_which_path(name, path_env, env, project_dir)
 }
 
 fn find_non_mise_path_entry(name: &str, path_env: Option<&OsStr>) -> Option<PathBuf> {
@@ -571,19 +577,17 @@ fn resolve_mise_which_path(
     name: &str,
     path_env: Option<&OsStr>,
     env: &HashMap<String, String>,
+    project_dir: Option<&Path>,
 ) -> Result<Option<PathBuf>> {
     let Some(mise_path) = find_path_entry("mise", path_env) else {
         return Ok(None);
     };
 
     let mut command = Command::new(&mise_path);
-    let tmpdir = env
-        .get("TMPDIR")
-        .filter(|value| !value.is_empty())
-        .cloned()
-        .or_else(|| std::env::var("TMPDIR").ok())
-        .unwrap_or_else(|| DEFAULT_SANDBOX_TMPDIR.to_string());
-    command.arg("-C").arg(&tmpdir).arg("which").arg(name);
+    if let Some(project_dir) = project_dir {
+        command.arg("-C").arg(project_dir);
+    }
+    command.arg("which").arg(name);
     for key in [
         "HOME",
         "PATH",
@@ -628,9 +632,11 @@ fn resolve_mise_which_path(
 fn resolve_non_shim_gemini_launch(
     path_env: Option<&OsStr>,
     env: &HashMap<String, String>,
+    project_dir: Option<&Path>,
     base_args: &[String],
 ) -> Result<Option<GeminiAcpLaunch>> {
-    let Some(gemini_candidate) = find_direct_tool_path("gemini", path_env, env)? else {
+    let Some(gemini_candidate) = find_direct_tool_path("gemini", path_env, env, project_dir)?
+    else {
         return Ok(None);
     };
 
@@ -639,7 +645,8 @@ fn resolve_non_shim_gemini_launch(
         .is_some_and(|extension| extension == "js")
         || is_node_script(&gemini_candidate)
     {
-        let Some(node_candidate) = find_direct_tool_path("node", path_env, env)? else {
+        let Some(node_candidate) = find_direct_tool_path("node", path_env, env, project_dir)?
+        else {
             return Ok(None);
         };
 

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -577,14 +577,17 @@ fn resolve_mise_which_path(
     };
 
     let mut command = Command::new(&mise_path);
-    command
-        .arg("-C")
-        .arg(std::env::temp_dir())
-        .arg("which")
-        .arg(name);
+    let tmpdir = env
+        .get("TMPDIR")
+        .filter(|value| !value.is_empty())
+        .cloned()
+        .or_else(|| std::env::var("TMPDIR").ok())
+        .unwrap_or_else(|| DEFAULT_SANDBOX_TMPDIR.to_string());
+    command.arg("-C").arg(&tmpdir).arg("which").arg(name);
     for key in [
         "HOME",
         "PATH",
+        "TMPDIR",
         "XDG_CONFIG_HOME",
         "XDG_CACHE_HOME",
         "XDG_STATE_HOME",

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
+use csa_resource::isolation_plan::DEFAULT_SANDBOX_TMPDIR;
 use serde_json::{Map, Value};
 use tracing::{debug, warn};
 
@@ -48,7 +49,8 @@ pub(crate) fn prepare_gemini_acp_runtime(
         .cloned()
         .or_else(|| std::env::var("HOME").ok())
         .map(PathBuf::from);
-    let runtime_home = resolve_runtime_home(session_dir, session_id);
+    let tmpdir = normalize_tmpdir_env(env);
+    let runtime_home = resolve_runtime_home(session_dir, session_id, &tmpdir);
     seed_runtime_home(&runtime_home, source_home.as_deref())?;
     align_runtime_auth_selection(&runtime_home, env)?;
 
@@ -124,7 +126,7 @@ pub(crate) fn prepare_gemini_acp_runtime(
 }
 
 pub(crate) fn gemini_runtime_home_from_env(env: &HashMap<String, String>) -> Option<PathBuf> {
-    let runtime_root = std::env::temp_dir().join(GEMINI_RUNTIME_ROOT_DIR);
+    let runtime_root = runtime_root_from_env(env);
     let session_relative_path = Path::new(GEMINI_SESSION_RUNTIME_RELATIVE_PATH);
     let candidates = [
         env.get("GEMINI_CLI_HOME").map(PathBuf::from),
@@ -145,14 +147,70 @@ pub(crate) fn gemini_runtime_home_from_env(env: &HashMap<String, String>) -> Opt
         .find(|path| path.starts_with(&runtime_root) || path.ends_with(session_relative_path))
 }
 
-fn resolve_runtime_home(session_dir: Option<&Path>, session_id: &str) -> PathBuf {
+fn resolve_runtime_home(session_dir: Option<&Path>, session_id: &str, tmpdir: &Path) -> PathBuf {
     if let Some(session_dir) = session_dir {
         return session_dir.join(GEMINI_SESSION_RUNTIME_RELATIVE_PATH);
     }
 
-    std::env::temp_dir()
+    tmpdir.join(GEMINI_RUNTIME_ROOT_DIR).join(session_id)
+}
+
+fn normalize_tmpdir_env(env: &mut HashMap<String, String>) -> PathBuf {
+    let candidate = env
+        .get("TMPDIR")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("TMPDIR").map(PathBuf::from));
+
+    let resolved = match candidate {
+        Some(path) if tmpdir_probe_writable(&path).is_ok() => path,
+        Some(path) => {
+            warn!(
+                tmpdir = %path.display(),
+                fallback = DEFAULT_SANDBOX_TMPDIR,
+                "TMPDIR is not writable for Gemini ACP runtime; falling back to /tmp"
+            );
+            PathBuf::from(DEFAULT_SANDBOX_TMPDIR)
+        }
+        None => PathBuf::from(DEFAULT_SANDBOX_TMPDIR),
+    };
+
+    env.insert(
+        "TMPDIR".to_string(),
+        resolved.to_string_lossy().into_owned(),
+    );
+    resolved
+}
+
+fn runtime_root_from_env(env: &HashMap<String, String>) -> PathBuf {
+    env.get("TMPDIR")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("TMPDIR").map(PathBuf::from))
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_SANDBOX_TMPDIR))
         .join(GEMINI_RUNTIME_ROOT_DIR)
-        .join(session_id)
+}
+
+fn tmpdir_probe_writable(path: &Path) -> Result<()> {
+    fs::create_dir_all(path)
+        .with_context(|| format!("failed to create TMPDIR candidate {}", path.display()))?;
+
+    let probe_path = path.join(format!(
+        ".csa-gemini-tmpdir-probe-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe_path)
+        .with_context(|| format!("failed to create TMPDIR probe {}", probe_path.display()))?;
+    drop(file);
+    let _ = fs::remove_file(&probe_path);
+    Ok(())
 }
 
 fn seed_runtime_home(runtime_home: &Path, source_home: Option<&Path>) -> Result<()> {

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -77,9 +77,14 @@ fn prepare_gemini_acp_runtime_sets_runtime_home_and_resolves_direct_launch() {
         csa_core::gemini::AUTH_MODE_OAUTH.to_string(),
     );
 
-    let launch =
-        prepare_gemini_acp_runtime(&mut env, None, &session_id, &["--acp".to_string()])
-            .expect("prepare runtime");
+    let launch = prepare_gemini_acp_runtime(
+        &mut env,
+        None,
+        None,
+        &session_id,
+        &["--acp".to_string()],
+    )
+    .expect("prepare runtime");
 
     assert_eq!(launch.command, node_path.to_string_lossy());
     assert_eq!(launch.args[0], "--no-warnings=DEP0040");
@@ -158,7 +163,7 @@ fn prepare_gemini_acp_runtime_pins_mise_dirs_under_runtime_home() {
         source_home.to_string_lossy().into_owned(),
     );
 
-    prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
+    prepare_gemini_acp_runtime(&mut env, None, None, session_id, &["--acp".to_string()])
         .expect("prepare runtime");
 
     let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
@@ -224,6 +229,7 @@ fn prepare_gemini_acp_runtime_prefers_session_dir_runtime_home() {
 
     prepare_gemini_acp_runtime(
         &mut env,
+        None,
         Some(session_dir.as_path()),
         "01TESTSESSIONDIR",
         &["--acp".to_string()],
@@ -265,7 +271,7 @@ fn prepare_gemini_acp_runtime_falls_back_from_read_only_tmpdir() {
         read_only_tmp.to_string_lossy().into_owned(),
     );
 
-    prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
+    prepare_gemini_acp_runtime(&mut env, None, None, session_id, &["--acp".to_string()])
         .expect("prepare runtime");
 
     assert_eq!(
@@ -335,7 +341,7 @@ fn prepare_gemini_acp_runtime_pins_non_shim_runtime_bins_on_path() {
         shims_dir.display().to_string(),
     );
 
-    prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
+    prepare_gemini_acp_runtime(&mut env, None, None, session_id, &["--acp".to_string()])
         .expect("prepare runtime");
 
     let prepared_path = env.get("PATH").expect("prepared path");
@@ -406,9 +412,14 @@ fn prepare_gemini_acp_runtime_resolves_mise_shims_via_mise_which() {
         shims_dir.display().to_string(),
     );
 
-    let launch =
-        prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
-            .expect("prepare runtime");
+    let launch = prepare_gemini_acp_runtime(
+        &mut env,
+        None,
+        None,
+        session_id,
+        &["--acp".to_string()],
+    )
+    .expect("prepare runtime");
 
     assert_eq!(launch.command, node_dir.join("node").to_string_lossy());
     assert_eq!(launch.args[1], real_script.to_string_lossy());
@@ -426,12 +437,14 @@ fn prepare_gemini_acp_runtime_resolves_mise_shims_via_mise_which() {
 }
 
 #[test]
-fn prepare_gemini_acp_runtime_passes_runtime_tmpdir_to_mise_which() {
+fn prepare_gemini_acp_runtime_passes_project_dir_to_mise_which() {
     let temp = tempfile::tempdir().expect("tempdir");
     let session_id = "01TESTGEMINIMISETMPDIR0000000001";
     let source_home = temp.path().join("source-home");
+    let project_dir = temp.path().join("project");
     let runtime_tmp = temp.path().join("runtime-tmp");
     fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+    fs::create_dir_all(&project_dir).expect("create project dir");
     fs::create_dir_all(&runtime_tmp).expect("create runtime tmp");
 
     let shims_dir = temp.path().join("shims");
@@ -458,7 +471,8 @@ fn prepare_gemini_acp_runtime_passes_runtime_tmpdir_to_mise_which() {
     write_executable(
         &mise_path,
         &format!(
-            "#!/bin/sh\nexpected_tmpdir='{}'\nif [ \"$1\" != \"-C\" ] || [ \"$2\" != \"$expected_tmpdir\" ]; then exit 1; fi\nif [ \"$TMPDIR\" != \"$expected_tmpdir\" ]; then exit 1; fi\nshift 2\nif [ \"$1\" = \"which\" ]; then\n  case \"$2\" in\n    gemini) printf '%s\\n' '{}' ;;\n    node) printf '%s\\n' '{}' ;;\n    yarn) printf '%s\\n' '{}' ;;\n    *) exit 1 ;;\n  esac\n  exit 0\nfi\nexit 1\n",
+            "#!/bin/sh\nexpected_project_dir='{}'\nexpected_tmpdir='{}'\nif [ \"$1\" != \"-C\" ] || [ \"$2\" != \"$expected_project_dir\" ]; then exit 1; fi\nif [ \"$TMPDIR\" != \"$expected_tmpdir\" ]; then exit 1; fi\nshift 2\nif [ \"$1\" = \"which\" ]; then\n  case \"$2\" in\n    gemini) printf '%s\\n' '{}' ;;\n    node) printf '%s\\n' '{}' ;;\n    yarn) printf '%s\\n' '{}' ;;\n    *) exit 1 ;;\n  esac\n  exit 0\nfi\nexit 1\n",
+            project_dir.display(),
             runtime_tmp.display(),
             real_dir.join("gemini").display(),
             node_dir.join("node").display(),
@@ -485,9 +499,14 @@ fn prepare_gemini_acp_runtime_passes_runtime_tmpdir_to_mise_which() {
         shims_dir.display().to_string(),
     );
 
-    let launch =
-        prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
-            .expect("prepare runtime");
+    let launch = prepare_gemini_acp_runtime(
+        &mut env,
+        Some(project_dir.as_path()),
+        None,
+        session_id,
+        &["--acp".to_string()],
+    )
+    .expect("prepare runtime");
 
     assert_eq!(launch.command, node_dir.join("node").to_string_lossy());
     assert_eq!(env.get("TMPDIR"), Some(&runtime_tmp.to_string_lossy().into_owned()));
@@ -510,7 +529,7 @@ fn prepare_gemini_acp_runtime_rewrites_runtime_auth_selection_for_api_key_phase(
         csa_core::gemini::AUTH_MODE_OAUTH.to_string(),
     );
 
-    prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
+    prepare_gemini_acp_runtime(&mut env, None, None, session_id, &["--acp".to_string()])
         .expect("prepare oauth runtime");
     let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
     assert_eq!(
@@ -528,7 +547,7 @@ fn prepare_gemini_acp_runtime_rewrites_runtime_auth_selection_for_api_key_phase(
         "fallback-key".to_string(),
     );
 
-    prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
+    prepare_gemini_acp_runtime(&mut env, None, None, session_id, &["--acp".to_string()])
         .expect("prepare api key runtime");
     assert_eq!(
         read_selected_auth_type(&runtime_home.join(".gemini/settings.json")),

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -243,6 +243,49 @@ fn prepare_gemini_acp_runtime_prefers_session_dir_runtime_home() {
 }
 
 #[test]
+fn prepare_gemini_acp_runtime_falls_back_from_read_only_tmpdir() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = "01TESTGEMINITMPDIRFALLBACK00000001";
+    let source_home = temp.path().join("source-home");
+    let read_only_tmp = temp.path().join("read-only-tmp");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+    fs::create_dir_all(&read_only_tmp).expect("create read-only tmp");
+
+    let mut perms = fs::metadata(&read_only_tmp).expect("metadata").permissions();
+    perms.set_mode(0o555);
+    fs::set_permissions(&read_only_tmp, perms).expect("chmod read-only tmp");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "TMPDIR".to_string(),
+        read_only_tmp.to_string_lossy().into_owned(),
+    );
+
+    prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
+        .expect("prepare runtime");
+
+    assert_eq!(
+        env.get("TMPDIR"),
+        Some(&csa_resource::isolation_plan::DEFAULT_SANDBOX_TMPDIR.to_string()),
+        "runtime setup should fall back to /tmp when inherited TMPDIR is not writable"
+    );
+    let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
+    assert!(
+        runtime_home.starts_with(csa_resource::isolation_plan::DEFAULT_SANDBOX_TMPDIR),
+        "runtime home should relocate under /tmp after TMPDIR fallback, got: {}",
+        runtime_home.display()
+    );
+
+    let mut reset_perms = fs::metadata(&read_only_tmp).expect("metadata").permissions();
+    reset_perms.set_mode(0o755);
+    fs::set_permissions(&read_only_tmp, reset_perms).expect("chmod restore tmpdir");
+}
+
+#[test]
 fn prepare_gemini_acp_runtime_pins_non_shim_runtime_bins_on_path() {
     let temp = tempfile::tempdir().expect("tempdir");
     let session_id = "01TESTGEMINIPATHPINNING0000000001";

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -426,6 +426,74 @@ fn prepare_gemini_acp_runtime_resolves_mise_shims_via_mise_which() {
 }
 
 #[test]
+fn prepare_gemini_acp_runtime_passes_runtime_tmpdir_to_mise_which() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = "01TESTGEMINIMISETMPDIR0000000001";
+    let source_home = temp.path().join("source-home");
+    let runtime_tmp = temp.path().join("runtime-tmp");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+    fs::create_dir_all(&runtime_tmp).expect("create runtime tmp");
+
+    let shims_dir = temp.path().join("shims");
+    let real_dir = temp.path().join("real");
+    let node_dir = temp.path().join("node");
+    let yarn_dir = temp.path().join("yarn");
+    fs::create_dir_all(&shims_dir).expect("create shims dir");
+    fs::create_dir_all(real_dir.join("dist")).expect("create real dist dir");
+    fs::create_dir_all(&node_dir).expect("create node dir");
+    fs::create_dir_all(&yarn_dir).expect("create yarn dir");
+
+    let real_script = real_dir.join("dist").join("index.js");
+    fs::write(
+        &real_script,
+        "#!/usr/bin/env -S node --no-warnings=DEP0040\nconsole.log('gemini');\n",
+    )
+    .expect("write real script");
+    std::os::unix::fs::symlink(&real_script, real_dir.join("gemini"))
+        .expect("symlink real gemini");
+    write_executable(&node_dir.join("node"), "#!/bin/sh\nexit 0\n");
+    write_executable(&yarn_dir.join("yarn"), "#!/bin/sh\nexit 0\n");
+
+    let mise_path = shims_dir.join("mise");
+    write_executable(
+        &mise_path,
+        &format!(
+            "#!/bin/sh\nexpected_tmpdir='{}'\nif [ \"$1\" != \"-C\" ] || [ \"$2\" != \"$expected_tmpdir\" ]; then exit 1; fi\nif [ \"$TMPDIR\" != \"$expected_tmpdir\" ]; then exit 1; fi\nshift 2\nif [ \"$1\" = \"which\" ]; then\n  case \"$2\" in\n    gemini) printf '%s\\n' '{}' ;;\n    node) printf '%s\\n' '{}' ;;\n    yarn) printf '%s\\n' '{}' ;;\n    *) exit 1 ;;\n  esac\n  exit 0\nfi\nexit 1\n",
+            runtime_tmp.display(),
+            real_dir.join("gemini").display(),
+            node_dir.join("node").display(),
+            yarn_dir.join("yarn").display(),
+        ),
+    );
+    std::os::unix::fs::symlink(&mise_path, shims_dir.join("gemini")).expect("symlink gemini");
+    std::os::unix::fs::symlink(&mise_path, shims_dir.join("node")).expect("symlink node");
+    std::os::unix::fs::symlink(&mise_path, shims_dir.join("yarn")).expect("symlink yarn");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert("PATH".to_string(), shims_dir.to_string_lossy().into_owned());
+    env.insert(
+        "TMPDIR".to_string(),
+        runtime_tmp.to_string_lossy().into_owned(),
+    );
+    env.insert("MISE_SHIM".to_string(), shims_dir.display().to_string());
+    env.insert(
+        "MISE_SHIMS_DIR".to_string(),
+        shims_dir.display().to_string(),
+    );
+
+    let launch =
+        prepare_gemini_acp_runtime(&mut env, None, session_id, &["--acp".to_string()])
+            .expect("prepare runtime");
+
+    assert_eq!(launch.command, node_dir.join("node").to_string_lossy());
+    assert_eq!(env.get("TMPDIR"), Some(&runtime_tmp.to_string_lossy().into_owned()));
+}
+
+#[test]
 fn prepare_gemini_acp_runtime_rewrites_runtime_auth_selection_for_api_key_phase() {
     let temp = tempfile::tempdir().expect("tempdir");
     let session_id = "01TESTGEMINIAUTHSWITCH0000000001";

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -120,7 +120,40 @@ impl AcpTransport {
             (session.genealogy.depth + 1).to_string(),
         );
         env.insert("CSA_PROJECT_ROOT".to_string(), session.project_path.clone());
-        // CSA_SESSION_DIR: absolute path to the session state directory
+
+        env.insert("CSA_TOOL".to_string(), self.tool_name.clone());
+        // Mark this process as a CSA subprocess so child tools can detect
+        // recursion risk (e.g. claude-code reading CLAUDE.md rules that say
+        // "use csa review"). See GitHub issue #272.
+        env.insert("CSA_IS_SUBPROCESS".to_string(), "1".to_string());
+        if let Ok(parent_tool) = std::env::var("CSA_TOOL") {
+            env.insert("CSA_PARENT_TOOL".to_string(), parent_tool);
+        }
+        if let Some(parent_session) = &session.genealogy.parent_session_id {
+            env.insert("CSA_PARENT_SESSION".to_string(), parent_session.clone());
+        }
+
+        if let Some(extra) = extra_env {
+            env.extend(extra.iter().map(|(k, v)| (k.clone(), v.clone())));
+        }
+        Self::insert_reserved_session_path_env(&mut env, session);
+
+        // Inject merge guard: prepend a `gh` wrapper to PATH that blocks
+        // `gh pr merge` unless pr-bot has completed.  This is deterministic
+        // environment-level enforcement — the tool subprocess cannot bypass it.
+        //
+        // Only applied to ACP tools (claude-code, codex) which have autonomous
+        // bash execution.  Legacy tools (gemini-cli, opencode) are text-mode
+        // and cannot independently call `gh pr merge`.
+        csa_hooks::merge_guard::inject_merge_guard_env(&mut env);
+
+        env
+    }
+
+    fn insert_reserved_session_path_env(
+        env: &mut HashMap<String, String>,
+        session: &MetaSessionState,
+    ) {
         if let Ok(dir) = csa_session::manager::get_session_dir(
             Path::new(&session.project_path),
             &session.meta_session_id,
@@ -138,33 +171,6 @@ impl AcpTransport {
         } else {
             tracing::warn!("failed to compute CSA_SESSION_DIR for ACP env");
         }
-
-        env.insert("CSA_TOOL".to_string(), self.tool_name.clone());
-        // Mark this process as a CSA subprocess so child tools can detect
-        // recursion risk (e.g. claude-code reading CLAUDE.md rules that say
-        // "use csa review"). See GitHub issue #272.
-        env.insert("CSA_IS_SUBPROCESS".to_string(), "1".to_string());
-        if let Ok(parent_tool) = std::env::var("CSA_TOOL") {
-            env.insert("CSA_PARENT_TOOL".to_string(), parent_tool);
-        }
-        if let Some(parent_session) = &session.genealogy.parent_session_id {
-            env.insert("CSA_PARENT_SESSION".to_string(), parent_session.clone());
-        }
-
-        if let Some(extra) = extra_env {
-            env.extend(extra.iter().map(|(k, v)| (k.clone(), v.clone())));
-        }
-
-        // Inject merge guard: prepend a `gh` wrapper to PATH that blocks
-        // `gh pr merge` unless pr-bot has completed.  This is deterministic
-        // environment-level enforcement — the tool subprocess cannot bypass it.
-        //
-        // Only applied to ACP tools (claude-code, codex) which have autonomous
-        // bash execution.  Legacy tools (gemini-cli, opencode) are text-mode
-        // and cannot independently call `gh pr merge`.
-        csa_hooks::merge_guard::inject_merge_guard_env(&mut env);
-
-        env
     }
 }
 

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -129,6 +129,12 @@ impl AcpTransport {
                 "CSA_SESSION_DIR".to_string(),
                 dir.to_string_lossy().into_owned(),
             );
+            env.insert(
+                csa_session::RESULT_TOML_PATH_CONTRACT_ENV.to_string(),
+                csa_session::contract_result_path(&dir)
+                    .to_string_lossy()
+                    .into_owned(),
+            );
         } else {
             tracing::warn!("failed to compute CSA_SESSION_DIR for ACP env");
         }

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -205,6 +205,17 @@ fn test_acp_build_env_includes_csa_session_dir() {
         session_dir.contains("01HTEST000000000000000000"),
         "CSA_SESSION_DIR should contain the session ID, got: {session_dir}"
     );
+    let result_contract_path = env
+        .get("CSA_RESULT_TOML_PATH_CONTRACT")
+        .expect("CSA_RESULT_TOML_PATH_CONTRACT should be present in env");
+    assert!(
+        result_contract_path.ends_with("/output/result.toml"),
+        "contract path should point to output/result.toml, got: {result_contract_path}"
+    );
+    assert!(
+        result_contract_path.contains("01HTEST000000000000000000"),
+        "contract path should include the session ID, got: {result_contract_path}"
+    );
 }
 
 #[test]

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -219,6 +219,74 @@ fn test_acp_build_env_includes_csa_session_dir() {
 }
 
 #[test]
+fn test_acp_build_env_reserved_session_paths_override_extra_env() {
+    let transport = AcpTransport::new("claude-code", None);
+    let now = chrono::Utc::now();
+    let session = csa_session::state::MetaSessionState {
+        meta_session_id: "01HTEST000000000000000000".to_string(),
+        description: Some("test".to_string()),
+        project_path: "/tmp/test".to_string(),
+        branch: None,
+        created_at: now,
+        last_accessed: now,
+        genealogy: csa_session::state::Genealogy {
+            parent_session_id: None,
+            depth: 0,
+            ..Default::default()
+        },
+        tools: HashMap::new(),
+        context_status: csa_session::state::ContextStatus::default(),
+        total_token_usage: None,
+        phase: csa_session::state::SessionPhase::Active,
+        task_context: csa_session::state::TaskContext::default(),
+        turn_count: 0,
+        token_budget: None,
+        sandbox_info: None,
+        termination_reason: None,
+        is_seed_candidate: false,
+        git_head_at_creation: None,
+        last_return_packet: None,
+        change_id: None,
+        spec_id: None,
+        fork_call_timestamps: Vec::new(),
+        vcs_identity: None,
+        identity_version: 1,
+    };
+
+    let mut extra = HashMap::new();
+    extra.insert("CSA_SESSION_DIR".to_string(), "/tmp/fake-session".to_string());
+    extra.insert(
+        csa_session::RESULT_TOML_PATH_CONTRACT_ENV.to_string(),
+        "/tmp/fake-session/result.toml".to_string(),
+    );
+
+    let env = transport.build_env(&session, Some(&extra));
+    let session_dir = env
+        .get("CSA_SESSION_DIR")
+        .expect("CSA_SESSION_DIR should be present");
+    assert!(
+        session_dir.contains("/sessions/"),
+        "reserved session dir should override extra_env, got: {session_dir}"
+    );
+    assert!(
+        session_dir.contains("01HTEST000000000000000000"),
+        "reserved session dir should include the session ID, got: {session_dir}"
+    );
+
+    let result_contract_path = env
+        .get("CSA_RESULT_TOML_PATH_CONTRACT")
+        .expect("CSA_RESULT_TOML_PATH_CONTRACT should be present");
+    assert!(
+        result_contract_path.ends_with("/output/result.toml"),
+        "reserved result contract path should override extra_env, got: {result_contract_path}"
+    );
+    assert!(
+        result_contract_path.contains("01HTEST000000000000000000"),
+        "reserved result contract path should include the session ID, got: {result_contract_path}"
+    );
+}
+
+#[test]
 fn test_resume_session_id_extraction() {
     let now = chrono::Utc::now();
     let tool_state = ToolState {

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -316,6 +316,37 @@ mod tests {
     }
 
     #[test]
+    fn test_bwrap_from_isolation_plan_sets_tmpdir_override() {
+        let mut env_overrides = HashMap::new();
+        env_overrides.insert("TMPDIR".to_string(), "/tmp".to_string());
+        let plan = IsolationPlan {
+            resource: ResourceCapability::None,
+            filesystem: FilesystemCapability::Bwrap,
+            writable_paths: vec![PathBuf::from("/project")],
+            env_overrides,
+            degraded_reasons: Vec::new(),
+            memory_max_mb: None,
+            memory_swap_max_mb: None,
+            pids_max: None,
+            readonly_project_root: false,
+            project_root: Some(PathBuf::from("/project")),
+            soft_limit_percent: None,
+            memory_monitor_interval_seconds: None,
+        };
+
+        let cmd = from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("should produce command");
+        let args = command_args(&cmd);
+        let found_tmpdir_env = args
+            .windows(3)
+            .any(|window| window == ["--setenv", "TMPDIR", "/tmp"]);
+
+        assert!(
+            found_tmpdir_env,
+            "TMPDIR must be pinned inside bwrap env overrides; args: {args:?}"
+        );
+    }
+
+    #[test]
     fn test_bwrap_readonly_project_root() {
         let plan = IsolationPlan {
             resource: ResourceCapability::None,

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 use crate::filesystem_sandbox::FilesystemCapability;
 use crate::sandbox::ResourceCapability;
 
+pub const DEFAULT_SANDBOX_TMPDIR: &str = "/tmp";
+
 // ---------------------------------------------------------------------------
 // EnforcementMode (local copy)
 // ---------------------------------------------------------------------------
@@ -196,6 +198,8 @@ impl IsolationPlanBuilder {
         self.project_root = Some(project_root.to_path_buf());
         self.writable_paths.push(project_root.to_path_buf());
         self.writable_paths.push(session_dir.to_path_buf());
+        self.env_overrides
+            .insert("TMPDIR".to_string(), DEFAULT_SANDBOX_TMPDIR.to_string());
 
         // Submodule detection: if .git is a file (not a directory), the project
         // root is inside a git submodule.  Walk up to find the superproject root

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -182,8 +182,10 @@ impl IsolationPlanBuilder {
     /// Apply per-tool default paths and environment overrides.
     ///
     /// Always adds `project_root`, `session_dir`, and common writable paths
-    /// that all tools need (XDG state dir, mise cache, TMPDIR).  Tool-specific
-    /// config directories are appended based on `tool_name`.
+    /// that all tools need (XDG state dir, mise cache). It also injects a
+    /// writable `TMPDIR`: bwrap uses its private `/tmp`, while Landlock and
+    /// unsandboxed paths use a session-owned `tmp/` subdirectory.
+    /// Tool-specific config directories are appended based on `tool_name`.
     ///
     /// When `project_root` is inside a git submodule (`.git` is a file, not a
     /// directory), the superproject root is discovered by walking ancestors and
@@ -198,10 +200,11 @@ impl IsolationPlanBuilder {
         self.project_root = Some(project_root.to_path_buf());
         self.writable_paths.push(project_root.to_path_buf());
         self.writable_paths.push(session_dir.to_path_buf());
-        self.writable_paths
-            .push(PathBuf::from(DEFAULT_SANDBOX_TMPDIR));
-        self.env_overrides
-            .insert("TMPDIR".to_string(), DEFAULT_SANDBOX_TMPDIR.to_string());
+        let sandbox_tmpdir = sandbox_tmpdir_for_capability(self.filesystem, session_dir);
+        self.env_overrides.insert(
+            "TMPDIR".to_string(),
+            sandbox_tmpdir.to_string_lossy().into_owned(),
+        );
 
         // Submodule detection: if .git is a file (not a directory), the project
         // root is inside a git submodule.  Walk up to find the superproject root
@@ -368,6 +371,13 @@ impl IsolationPlanBuilder {
             soft_limit_percent: self.soft_limit_percent,
             memory_monitor_interval_seconds: self.memory_monitor_interval_seconds,
         })
+    }
+}
+
+fn sandbox_tmpdir_for_capability(filesystem: FilesystemCapability, session_dir: &Path) -> PathBuf {
+    match filesystem {
+        FilesystemCapability::Bwrap => PathBuf::from(DEFAULT_SANDBOX_TMPDIR),
+        FilesystemCapability::Landlock | FilesystemCapability::None => session_dir.join("tmp"),
     }
 }
 

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -198,6 +198,8 @@ impl IsolationPlanBuilder {
         self.project_root = Some(project_root.to_path_buf());
         self.writable_paths.push(project_root.to_path_buf());
         self.writable_paths.push(session_dir.to_path_buf());
+        self.writable_paths
+            .push(PathBuf::from(DEFAULT_SANDBOX_TMPDIR));
         self.env_overrides
             .insert("TMPDIR".to_string(), DEFAULT_SANDBOX_TMPDIR.to_string());
 

--- a/crates/csa-resource/src/isolation_plan_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_tests.rs
@@ -91,6 +91,11 @@ fn test_tool_defaults_claude_code() {
 
     assert!(plan.writable_paths.contains(&project));
     assert!(plan.writable_paths.contains(&session));
+    assert_eq!(
+        plan.env_overrides.get("TMPDIR").map(String::as_str),
+        Some(DEFAULT_SANDBOX_TMPDIR),
+        "all sandboxed tool sessions should pin TMPDIR to /tmp"
+    );
 
     if let Some(home) = home_dir() {
         // Tool config dir is only added if it exists on disk (matches

--- a/crates/csa-resource/src/isolation_plan_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_tests.rs
@@ -91,6 +91,11 @@ fn test_tool_defaults_claude_code() {
 
     assert!(plan.writable_paths.contains(&project));
     assert!(plan.writable_paths.contains(&session));
+    assert!(
+        plan.writable_paths
+            .contains(&PathBuf::from(DEFAULT_SANDBOX_TMPDIR)),
+        "all sandboxed tool sessions should authorize /tmp writes alongside TMPDIR=/tmp"
+    );
     assert_eq!(
         plan.env_overrides.get("TMPDIR").map(String::as_str),
         Some(DEFAULT_SANDBOX_TMPDIR),

--- a/crates/csa-resource/src/isolation_plan_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_tests.rs
@@ -92,14 +92,15 @@ fn test_tool_defaults_claude_code() {
     assert!(plan.writable_paths.contains(&project));
     assert!(plan.writable_paths.contains(&session));
     assert!(
-        plan.writable_paths
+        !plan
+            .writable_paths
             .contains(&PathBuf::from(DEFAULT_SANDBOX_TMPDIR)),
-        "all sandboxed tool sessions should authorize /tmp writes alongside TMPDIR=/tmp"
+        "bwrap uses a private tmpfs /tmp and must not bind the host /tmp"
     );
     assert_eq!(
         plan.env_overrides.get("TMPDIR").map(String::as_str),
         Some(DEFAULT_SANDBOX_TMPDIR),
-        "all sandboxed tool sessions should pin TMPDIR to /tmp"
+        "bwrap-backed sessions should pin TMPDIR to the sandbox-private /tmp"
     );
 
     if let Some(home) = home_dir() {
@@ -160,6 +161,32 @@ fn test_tool_defaults_claude_code() {
             );
         }
     }
+}
+
+#[test]
+fn test_tool_defaults_landlock_uses_session_tmpdir() {
+    let project = PathBuf::from("/tmp/project");
+    let session = PathBuf::from("/tmp/session");
+
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Landlock)
+        .with_tool_defaults("claude-code", &project, &session)
+        .build()
+        .expect("should succeed");
+
+    assert!(plan.writable_paths.contains(&project));
+    assert!(plan.writable_paths.contains(&session));
+    assert!(
+        !plan
+            .writable_paths
+            .contains(&PathBuf::from(DEFAULT_SANDBOX_TMPDIR)),
+        "landlock must not grant host /tmp as writable just to satisfy TMPDIR"
+    );
+    assert_eq!(
+        plan.env_overrides.get("TMPDIR"),
+        Some(&session.join("tmp").to_string_lossy().into_owned()),
+        "landlock-backed sessions should pin TMPDIR to a session-owned tmp dir"
+    );
 }
 
 #[test]

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -73,8 +73,10 @@ pub use vcs_backends::{GitBackend, JjBackend, create_vcs_backend};
 
 // Re-export manager functions
 pub use manager::{
-    complete_session, create_session, delete_session, delete_session_from_root, detect_git_head,
-    find_sessions, get_session_dir, get_session_dir_global, get_session_root,
+    CONTRACT_RESULT_ARTIFACT_PATH, LEGACY_USER_RESULT_ARTIFACT_PATH, RESULT_TOML_PATH_CONTRACT_ENV,
+    complete_session, contract_result_path, create_session, delete_session,
+    delete_session_from_root, detect_git_head, find_sessions, get_session_dir,
+    get_session_dir_global, get_session_root, legacy_user_result_path,
     list_all_project_session_roots, list_all_sessions, list_all_sessions_all_projects,
     list_artifacts, list_sessions, list_sessions_from_root, list_sessions_from_root_readonly,
     load_metadata, load_result, load_session, load_session_global_exact, resolve_fork_source,

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -20,7 +20,10 @@ pub use manager_paths::{get_session_dir, get_session_root};
 pub use manager_paths::{get_session_dir_global, list_all_project_session_roots};
 use manager_paths::{get_session_dir_in, resolve_read_base_dir, resolve_write_base_dir};
 use manager_paths::{legacy_session_root, normalize_project_path};
-pub use manager_result::{list_artifacts, load_result, save_result};
+pub use manager_result::{
+    CONTRACT_RESULT_ARTIFACT_PATH, LEGACY_USER_RESULT_ARTIFACT_PATH, RESULT_TOML_PATH_CONTRACT_ENV,
+    contract_result_path, legacy_user_result_path, list_artifacts, load_result, save_result,
+};
 #[cfg(test)]
 pub(crate) use manager_result::{list_artifacts_in, load_result_in, save_result_in};
 

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -2,11 +2,13 @@ use crate::result::{RESULT_FILE_NAME, SessionArtifact, SessionResult};
 use crate::validate::validate_session_id;
 use anyhow::{Context, Result, bail};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const TRANSCRIPT_FILE_NAME: &str = "acp-events.jsonl";
 const USER_RESULT_FILE_NAME: &str = "user-result.toml";
-const USER_RESULT_ARTIFACT_PATH: &str = "output/user-result.toml";
+pub const RESULT_TOML_PATH_CONTRACT_ENV: &str = "CSA_RESULT_TOML_PATH_CONTRACT";
+pub const CONTRACT_RESULT_ARTIFACT_PATH: &str = "output/result.toml";
+pub const LEGACY_USER_RESULT_ARTIFACT_PATH: &str = "output/user-result.toml";
 const RUNTIME_RESULT_KEYS: [&str; 8] = [
     "status",
     "exit_code",
@@ -60,7 +62,7 @@ pub(crate) fn save_result_in(
         };
         preserve_user_result_snapshot(&session_dir, contents)?;
     }
-    retain_user_result_artifact_if_snapshot_exists(&session_dir, &mut persisted_result)?;
+    retain_sidecar_result_artifacts_if_present(&session_dir, &mut persisted_result)?;
 
     let runtime_table = session_result_to_table(&persisted_result)?;
     let mut merged_table = existing_table.unwrap_or_default();
@@ -97,35 +99,51 @@ fn preserve_user_result_snapshot(session_dir: &Path, contents: &str) -> Result<(
     })
 }
 
-fn retain_user_result_artifact_if_snapshot_exists(
+pub fn contract_result_path(session_dir: &Path) -> PathBuf {
+    session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH)
+}
+
+pub fn legacy_user_result_path(session_dir: &Path) -> PathBuf {
+    session_dir.join(LEGACY_USER_RESULT_ARTIFACT_PATH)
+}
+
+fn retain_sidecar_result_artifacts_if_present(
     session_dir: &Path,
     result: &mut SessionResult,
 ) -> Result<()> {
-    let snapshot_path = session_dir.join(USER_RESULT_ARTIFACT_PATH);
+    retain_result_artifact_if_present(session_dir, result, CONTRACT_RESULT_ARTIFACT_PATH)?;
+    retain_result_artifact_if_present(session_dir, result, LEGACY_USER_RESULT_ARTIFACT_PATH)?;
+    Ok(())
+}
+
+fn retain_result_artifact_if_present(
+    session_dir: &Path,
+    result: &mut SessionResult,
+    artifact_path: &str,
+) -> Result<()> {
+    let snapshot_path = session_dir.join(artifact_path);
     if !snapshot_path.exists() {
         return Ok(());
     }
     if !snapshot_path.is_file() {
         bail!(
-            "User result snapshot path exists but is not a file: {}",
+            "Result artifact path exists but is not a file: {}",
             snapshot_path.display()
         );
     }
-    ensure_user_result_artifact(result);
+    ensure_result_artifact(result, artifact_path);
     Ok(())
 }
 
-fn ensure_user_result_artifact(result: &mut SessionResult) {
+fn ensure_result_artifact(result: &mut SessionResult, artifact_path: &str) {
     if result
         .artifacts
         .iter()
-        .any(|artifact| artifact.path == USER_RESULT_ARTIFACT_PATH)
+        .any(|artifact| artifact.path == artifact_path)
     {
         return;
     }
-    result
-        .artifacts
-        .push(SessionArtifact::new(USER_RESULT_ARTIFACT_PATH));
+    result.artifacts.push(SessionArtifact::new(artifact_path));
 }
 
 fn session_result_to_table(result: &SessionResult) -> Result<toml::Table> {

--- a/crates/csa-session/src/manager_tests_tail.rs
+++ b/crates/csa-session/src/manager_tests_tail.rs
@@ -216,6 +216,42 @@ artifacts = [1, 2]
 }
 
 #[test]
+fn test_save_result_retain_contract_result_artifact_when_output_result_exists() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    std::fs::write(
+        manager_result::contract_result_path(&session_dir),
+        "status = \"success\"\nsummary = \"manager-facing report\"\n",
+    )
+    .unwrap();
+
+    let now = chrono::Utc::now();
+    let runtime_result = crate::result::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "runtime summary".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        peak_memory_mb: None,
+    };
+    save_result_in(td.path(), &state.meta_session_id, &runtime_result).unwrap();
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .unwrap();
+    assert!(
+        loaded
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == manager_result::CONTRACT_RESULT_ARTIFACT_PATH)
+    );
+}
+
+#[test]
 fn test_save_result_does_not_overwrite_existing_sidecar_snapshot() {
     let td = tempdir().unwrap();
     let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();

--- a/patterns/sa/PATTERN.md
+++ b/patterns/sa/PATTERN.md
@@ -67,7 +67,7 @@ Layer 1 (claude-code) will:
 1. Spawn up to 3 parallel Layer 2 workers for codebase exploration
 2. Synthesize findings into TODO draft
 3. Run adversarial debate via csa debate
-4. Write `result.toml` to `$CSA_SESSION_DIR/result.toml` (with `todo_path = "$CSA_SESSION_DIR/artifacts/TODO.md"`)
+4. Write `result.toml` to `$CSA_RESULT_TOML_PATH_CONTRACT` (fallback: `$CSA_SESSION_DIR/result.toml`; `todo_path = "$CSA_SESSION_DIR/artifacts/TODO.md"`)
 5. Treat `csa session wait` timeout or sparse early output as a wait-state, not failure. In slow Rust repos, 30-60 minutes can be normal. Re-wait on the same session instead of launching duplicate planning/review/debate sessions.
 
 ```bash

--- a/patterns/sa/PATTERN.md
+++ b/patterns/sa/PATTERN.md
@@ -71,7 +71,7 @@ Layer 1 (claude-code) will:
 5. Treat `csa session wait` timeout or sparse early output as a wait-state, not failure. In slow Rust repos, 30-60 minutes can be normal. Re-wait on the same session instead of launching duplicate planning/review/debate sessions.
 
 ```bash
-SID=$(csa run --prompt-file "${PROMPT_FILE}")
+SID=$(csa run --sa-mode true --prompt-file "${PROMPT_FILE}")
 scripts/csa/session-wait-until-done.sh "$SID"
 ```
 
@@ -145,7 +145,7 @@ failures as justification for disabling hooks.
 ```bash
 IMPL_FILE=$(mktemp /tmp/sa-impl-XXXXXX.txt)
 echo "CSA_VAR:IMPL_FILE=$IMPL_FILE"
-SID=$(csa run --session "${SESSION_ID}" --prompt-file "${IMPL_FILE}")
+SID=$(csa run --sa-mode true --session "${SESSION_ID}" --prompt-file "${IMPL_FILE}")
 scripts/csa/session-wait-until-done.sh "$SID"
 ```
 
@@ -162,7 +162,7 @@ Resume Layer 1 with user's revision feedback.
 ```bash
 RESUME_FILE=$(mktemp /tmp/sa-resume-XXXXXX.txt)
 echo "CSA_VAR:RESUME_FILE=$RESUME_FILE"
-SID=$(csa run --session "${SESSION_ID}" --prompt-file "${RESUME_FILE}")
+SID=$(csa run --sa-mode true --session "${SESSION_ID}" --prompt-file "${RESUME_FILE}")
 scripts/csa/session-wait-until-done.sh "$SID"
 ```
 

--- a/patterns/sa/skills/sa/SKILL.md
+++ b/patterns/sa/skills/sa/SKILL.md
@@ -158,13 +158,13 @@ Every task prompt MUST include:
 
 Example DONE WHEN:
 
-- `DONE WHEN: result.toml exists at $CSA_SESSION_DIR/result.toml and status is success.`
+- `DONE WHEN: result.toml exists at $CSA_RESULT_TOML_PATH_CONTRACT and status is success.`
 - `DONE WHEN: just pre-commit exits 0 and result.toml status is success.`
 
 ### Employee -> Manager (`result.toml`)
 
 Employees MUST return a self-contained report that allows manager decision without opening any source/artifact content.
-Employees MUST write this file to `$CSA_SESSION_DIR/result.toml` and print that path only.
+Employees MUST write this file to `$CSA_RESULT_TOML_PATH_CONTRACT` (fallback: `$CSA_SESSION_DIR/result.toml`) and print that path only.
 
 Required schema:
 
@@ -273,7 +273,7 @@ User APPROVE
   -> Manager writes implementation prompt file
   -> Manager dispatches Layer 1 with session continuity
   -> Layer 1 implements autonomously
-  -> Layer 1 performs validation/review/commit workflow
+  -> Layer 1 performs validation/review/commit workflow (use plain `git commit` with hooks enabled if a commit is required inside the CSA child session)
   -> Layer 1 returns result.toml (commit_hash, review_result, summary)
   -> Manager reads result.toml only
   -> Manager reports outcome to user
@@ -317,7 +317,7 @@ INPUT:
 OUTPUT FORMAT:
 - CONTRACT MARKER: CSA_RESULT_TOML_PATH_CONTRACT=1
 - Write TODO artifact to $CSA_SESSION_DIR/artifacts/TODO.md
-- Write manager-facing result.toml to $CSA_SESSION_DIR/result.toml using required schema
+- Write manager-facing result.toml to $CSA_RESULT_TOML_PATH_CONTRACT using required schema
 - Print ONLY the absolute result.toml path
 
 SCOPE:
@@ -326,8 +326,8 @@ SCOPE:
 
 DONE WHEN:
 - $CSA_SESSION_DIR/artifacts/TODO.md exists
-- $CSA_SESSION_DIR/result.toml exists with status in {success, partial, needs_clarification, error}
-- $CSA_SESSION_DIR/result.toml contains [result], [report], [timing], [tool], [artifacts]
+- $CSA_RESULT_TOML_PATH_CONTRACT exists with status in {success, partial, needs_clarification, error}
+- $CSA_RESULT_TOML_PATH_CONTRACT contains [result], [report], [timing], [tool], [artifacts]
 PLAN_EOF
 
 SID=$(csa run --sa-mode true --prompt-file "$PROMPT_FILE")
@@ -358,7 +358,7 @@ INPUT:
 OUTPUT FORMAT:
 - CONTRACT MARKER: CSA_RESULT_TOML_PATH_CONTRACT=1
 - Perform implementation and validation autonomously
-- Write manager-facing result.toml to $CSA_SESSION_DIR/result.toml using required schema
+- Write manager-facing result.toml to $CSA_RESULT_TOML_PATH_CONTRACT using required schema
 - Include commit_hash/review_result in [artifacts] when available
 - Print ONLY the absolute result.toml path
 
@@ -366,10 +366,11 @@ SCOPE:
 - You choose HOW to implement.
 - You may spawn Layer 2 workers.
 - You must perform appropriate review before reporting success.
+- If a commit is needed inside the child session, use plain `git commit` with hooks enabled.
 
 DONE WHEN:
 - Implementation tasks are complete or explicitly marked partial/error
-- $CSA_SESSION_DIR/result.toml exists and is self-contained for manager decision
+- $CSA_RESULT_TOML_PATH_CONTRACT exists and is self-contained for manager decision
 IMPL_EOF
 
 SID=$(csa run --sa-mode true --session "$SESSION_ID" --prompt-file "$PROMPT_FILE")
@@ -395,7 +396,7 @@ INPUT:
 OUTPUT FORMAT:
 - CONTRACT MARKER: CSA_RESULT_TOML_PATH_CONTRACT=1
 - Run independent verification (e.g. csa review --diff or csa debate)
-- Write manager-facing result.toml to $CSA_SESSION_DIR/result.toml
+- Write manager-facing result.toml to $CSA_RESULT_TOML_PATH_CONTRACT
 - In [report], clearly state agreement/disagreement and why
 - Print ONLY the absolute result.toml path
 
@@ -405,7 +406,7 @@ SCOPE:
 
 DONE WHEN:
 - Verification completed
-- $CSA_SESSION_DIR/result.toml includes clear verdict in summary/report
+- $CSA_RESULT_TOML_PATH_CONTRACT includes clear verdict in summary/report
 VERIFY_EOF
 
 SID=$(csa run --sa-mode true --prompt-file "$PROMPT_FILE")

--- a/patterns/sa/workflow.toml
+++ b/patterns/sa/workflow.toml
@@ -124,7 +124,7 @@ Layer 1 (claude-code) will:
    same session instead of launching duplicate planning/review/debate sessions.
 
 ```bash
-SID=$(csa run --prompt-file "${PROMPT_FILE}")
+SID=$(csa run --sa-mode true --prompt-file "${PROMPT_FILE}")
 scripts/csa/session-wait-until-done.sh "$SID"
 ```"""
 on_fail = "abort"
@@ -196,7 +196,7 @@ Fix the underlying issues to ensure codebase integrity.
 ```bash
 IMPL_FILE=$(mktemp /tmp/sa-impl-XXXXXX.txt)
 echo "CSA_VAR:IMPL_FILE=$IMPL_FILE"
-SID=$(csa run --session "${SESSION_ID}" --prompt-file "${IMPL_FILE}")
+SID=$(csa run --sa-mode true --session "${SESSION_ID}" --prompt-file "${IMPL_FILE}")
 scripts/csa/session-wait-until-done.sh "$SID"
 ```"""
 on_fail = "abort"
@@ -212,7 +212,7 @@ Resume Layer 1 with user's revision feedback.
 ```bash
 RESUME_FILE=$(mktemp /tmp/sa-resume-XXXXXX.txt)
 echo "CSA_VAR:RESUME_FILE=$RESUME_FILE"
-SID=$(csa run --session "${SESSION_ID}" --prompt-file "${RESUME_FILE}")
+SID=$(csa run --sa-mode true --session "${SESSION_ID}" --prompt-file "${RESUME_FILE}")
 scripts/csa/session-wait-until-done.sh "$SID"
 ```"""
 on_fail = "abort"

--- a/patterns/sa/workflow.toml
+++ b/patterns/sa/workflow.toml
@@ -118,7 +118,7 @@ Layer 1 (claude-code) will:
 1. Spawn up to 3 parallel Layer 2 workers for codebase exploration
 2. Synthesize findings into TODO draft
 3. Run adversarial debate via csa debate
-4. Write `result.toml` to `$CSA_SESSION_DIR/result.toml` (with `todo_path = "$CSA_SESSION_DIR/artifacts/TODO.md"`)
+4. Write `result.toml` to `$CSA_RESULT_TOML_PATH_CONTRACT` (fallback: `$CSA_SESSION_DIR/result.toml`; `todo_path = "$CSA_SESSION_DIR/artifacts/TODO.md"`)
 5. Treat `csa session wait` timeout or sparse early output as a wait-state, not
    failure. In slow Rust repos, 30-60 minutes can be normal. Re-wait on the
    same session instead of launching duplicate planning/review/debate sessions.

--- a/skills/split-project-docs/SKILL.md
+++ b/skills/split-project-docs/SKILL.md
@@ -134,7 +134,7 @@ done
 
 ### Phase 5: Commit
 
-Use `/commit` skill. Suggested scope: `docs`.
+Use plain `git commit` with hooks enabled. Suggested scope: `docs`.
 
 Message pattern: `docs(<scope>): split <filename> into condensed summary + N reference files`
 
@@ -150,5 +150,5 @@ Message pattern: `docs(<scope>): split <filename> into condensed summary + N ref
 ## Integration
 
 - **Triggered by**: `just find-monolith-files` flagging a .md file
-- **Uses**: `/commit` skill for final commit
+- **Uses**: plain `git commit` for final commit
 - **Complements**: `split-monolith-files` skill (for code files, not docs)


### PR DESCRIPTION
## Summary

Fixes 3 SA-mode operational frictions from #653:

1. **TMPDIR read-only in sandbox** (MEDIUM): sandbox tempdir now scoped by capability and falls back to `/tmp` so gemini runtime home creation succeeds
2. **`$CSA_RESULT_TOML_PATH_CONTRACT` not injected** (MEDIUM): SA-mode dispatch now injects the env var pointing at canonical result.toml path; result contracts are hardened
3. **`/commit` skill unavailable** (LOW): documented the limitation

## Test plan
- [x] `TMPDIR=/tmp just pre-commit` passes
- [x] Cumulative codex review PASS
- [ ] Smoke test: SA-mode sub-agent env shows both `CSA_RESULT_TOML_PATH_CONTRACT` and `TMPDIR=/tmp`, and `csa review` inside a sub-agent succeeds on first try

Closes #653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
