### PR TITLE
feat(hooks): add CSA_SKIP_REVIEW_CHECK bypass with audit trail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "chrono",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "chrono",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "axum",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "chrono",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.266"
+version = "0.1.267"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -9,95 +9,30 @@
 
 set -euo pipefail
 
-# Skip if not in a csa-managed project
+bash scripts/hooks/review-check.sh
+
+# Skip pr-bot warning when csa is unavailable or the branch is protected.
 if ! command -v csa >/dev/null 2>&1; then
   exit 0
 fi
 
 CURRENT_HEAD="$(git rev-parse HEAD)"
 CURRENT_BRANCH="$(git branch --show-current)"
-
-# For colocated jj repos, also capture jj change_id
-JJ_CHANGE_ID=""
-if command -v jj >/dev/null 2>&1 && [ -d ".jj" ]; then
-  JJ_CHANGE_ID="$(jj log --no-graph -r @ -T change_id 2>/dev/null || true)"
-fi
-
-# Skip for main/dev branches (direct pushes are blocked by branch protection)
 if [ "${CURRENT_BRANCH}" = "main" ] || [ "${CURRENT_BRANCH}" = "dev" ]; then
   exit 0
 fi
 
-REVIEW_DESCRIPTION_PATTERN='^review(\[[0-9]+\])?: '
-
-# Query review sessions for the current branch.
-# Match against commit_id (Git SHA) OR change_id (jj logical ID).
-REVIEW_SESSION_HEAD=""
-LATEST_BRANCH_REVIEW=""
-if csa session list --format json >/dev/null 2>&1; then
-  REVIEW_SESSION_HEAD="$(
-    csa session list --format json 2>/dev/null \
-      | jq -r --arg branch "${CURRENT_BRANCH}" \
-              --arg head "${CURRENT_HEAD}" \
-              --arg jj_cid "${JJ_CHANGE_ID}" \
-              --arg review_pattern "${REVIEW_DESCRIPTION_PATTERN}" '
-          [
-            .[]
-            | select((.description // "") | test($review_pattern))
-            | select((.branch // "") == $branch)
-            | select(
-                # Match by commit_id in vcs_identity (v2 sessions)
-                (.vcs_identity.commit_id // "") == $head
-                # OR by change_id for legacy sessions
-                or (.change_id // "") == $head
-                # OR by jj change_id if available
-                or ($jj_cid != "" and ((.vcs_identity.change_id // "") == $jj_cid))
-                or ($jj_cid != "" and ((.change_id // "") == $jj_cid))
-              )
-            | .session_id
-          ]
-          | first // empty
-        ' 2>/dev/null || true
-  )"
-  LATEST_BRANCH_REVIEW="$(
-    csa session list --format json 2>/dev/null \
-      | jq -r --arg branch "${CURRENT_BRANCH}" --arg review_pattern "${REVIEW_DESCRIPTION_PATTERN}" '
-          [
-            .[]
-            | select((.description // "") | test($review_pattern))
-            | select((.branch // "") == $branch)
-            | .change_id
-          ]
-          | first // empty
-        ' 2>/dev/null || true
-  )"
-fi
-
-if [ -n "${REVIEW_SESSION_HEAD}" ]; then
-  echo "pre-push: Review verified for HEAD ${CURRENT_HEAD:0:11}."
-
-  # Check for pr-bot marker on branches with open PRs (WARNING only, never blocks)
-  if command -v gh >/dev/null 2>&1; then
-    PR_NUMBER="$(gh pr list --head "${CURRENT_BRANCH}" --state open --json number -q '.[0].number' 2>/dev/null || true)"
-    if [ -n "${PR_NUMBER}" ]; then
-      REPO_SLUG="$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null | tr '/' '_')" || true
-      if [ -z "${REPO_SLUG}" ]; then
-        REPO_SLUG="$(git remote get-url origin 2>/dev/null | sed -E 's#^(https?://[^/]+/|ssh://[^/]+/|[^:]+:)##; s/\.git$//' | tr '/' '_')"
-      fi
-      MARKER_FILE="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${REPO_SLUG}/${PR_NUMBER}-${CURRENT_HEAD}.done"
-      if [ ! -f "${MARKER_FILE}" ]; then
-        echo -e "\033[33mWARNING: Branch has open PR #${PR_NUMBER} but no pr-bot marker for HEAD ${CURRENT_HEAD:0:11}; run pr-bot before merge\033[0m" >&2
-      fi
+# Check for pr-bot marker on branches with open PRs (WARNING only, never blocks)
+if command -v gh >/dev/null 2>&1; then
+  PR_NUMBER="$(gh pr list --head "${CURRENT_BRANCH}" --state open --json number -q '.[0].number' 2>/dev/null || true)"
+  if [ -n "${PR_NUMBER}" ]; then
+    REPO_SLUG="$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null | tr '/' '_')" || true
+    if [ -z "${REPO_SLUG}" ]; then
+      REPO_SLUG="$(git remote get-url origin 2>/dev/null | sed -E 's#^(https?://[^/]+/|ssh://[^/]+/|[^:]+:)##; s/\.git$//' | tr '/' '_')"
+    fi
+    MARKER_FILE="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${REPO_SLUG}/${PR_NUMBER}-${CURRENT_HEAD}.done"
+    if [ ! -f "${MARKER_FILE}" ]; then
+      echo -e "\033[33mWARNING: Branch has open PR #${PR_NUMBER} but no pr-bot marker for HEAD ${CURRENT_HEAD:0:11}; run pr-bot before merge\033[0m" >&2
     fi
   fi
-
-  exit 0
 fi
-
-if [ -n "${LATEST_BRANCH_REVIEW}" ]; then
-  echo "ERROR: Push blocked — latest recorded review for ${CURRENT_BRANCH} is ${LATEST_BRANCH_REVIEW:0:11}, not ${CURRENT_HEAD:0:11}." >&2
-else
-  echo "ERROR: Push blocked — no csa review session recorded for ${CURRENT_BRANCH} at HEAD ${CURRENT_HEAD:0:11}." >&2
-fi
-echo "Run 'csa review --range main...HEAD' before pushing." >&2
-exit 1

--- a/scripts/hooks/review-check.sh
+++ b/scripts/hooks/review-check.sh
@@ -9,6 +9,18 @@
 
 set -euo pipefail
 
+if [ "${CSA_SKIP_REVIEW_CHECK:-0}" = "1" ]; then
+  timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  head_sha="$(git rev-parse HEAD 2>/dev/null || echo "<unknown-head>")"
+  author_email="$(git config user.email 2>/dev/null || echo "<unknown-email>")"
+  reason="${CSA_SKIP_REVIEW_CHECK_REASON:-<unspecified>}"
+
+  mkdir -p .csa
+  printf '%s %s %s %s\n' "${timestamp}" "${head_sha}" "${author_email}" "${reason}" >> .csa/review-bypass.log
+  echo "WARNING: review-check bypassed via CSA_SKIP_REVIEW_CHECK=1 for ${head_sha:0:11}; logged to .csa/review-bypass.log. Reason: ${reason}" >&2
+  exit 0
+fi
+
 # Skip if not in a csa-managed project
 if ! command -v csa >/dev/null 2>&1; then
   exit 0

--- a/scripts/hooks/review-check.sh
+++ b/scripts/hooks/review-check.sh
@@ -13,7 +13,13 @@ if [ "${CSA_SKIP_REVIEW_CHECK:-0}" = "1" ]; then
   timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   head_sha="$(git rev-parse HEAD 2>/dev/null || echo "<unknown-head>")"
   author_email="$(git config user.email 2>/dev/null || echo "<unknown-email>")"
-  reason="${CSA_SKIP_REVIEW_CHECK_REASON:-<unspecified>}"
+  raw_reason="${CSA_SKIP_REVIEW_CHECK_REASON:-<unspecified>}"
+  reason="$(
+    printf '%s' "${raw_reason}" \
+      | tr '\r\n\t' '   ' \
+      | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//'
+  )"
+  [ -z "${reason}" ] && reason="<unspecified>"
 
   mkdir -p .csa
   printf '%s %s %s %s\n' "${timestamp}" "${head_sha}" "${author_email}" "${reason}" >> .csa/review-bypass.log


### PR DESCRIPTION
## Summary
- Add `CSA_SKIP_REVIEW_CHECK=1` env var bypass to `scripts/hooks/review-check.sh`
- Audit trail: logs bypass to `.csa/review-bypass.log` (timestamp, HEAD, author, reason)
- Follows `CSA_SKIP_VERSION_CHECK` precedent from `version-check.sh`

Closes #639

## Test plan
- [x] Manual test: `CSA_SKIP_REVIEW_CHECK=1 CSA_SKIP_REVIEW_CHECK_REASON="test" bash scripts/hooks/review-check.sh` exits 0 and logs
- [x] Without env var: existing review-check logic runs unchanged
- [x] `TMPDIR=/tmp just pre-commit` passes under isolated `XDG_CONFIG_HOME` (default env currently has an unrelated global-config-sensitive test failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
