### PR TITLE
fix(ci): set fail-fast false and add env-dependent test lint (#641, #642)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "chrono",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "chrono",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "axum",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "chrono",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.268"
+version = "0.1.269"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.268"
+version = "0.1.269"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-config/src/config_merge_tests.rs
+++ b/crates/csa-config/src/config_merge_tests.rs
@@ -1,6 +1,32 @@
 use super::*;
 use tempfile::tempdir;
 
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation is reverted in Drop.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation is reverted in Drop.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 #[test]
 fn test_merge_tiers_deep_merge() {
     let user_toml: toml::Value = toml::from_str(
@@ -155,15 +181,13 @@ fn test_merged_schema_version_uses_max_when_explicit() {
 
 #[test]
 fn test_user_config_path_returns_some() {
-    // On a normal system with HOME set, this should return Some
-    let path = ProjectConfig::user_config_path();
-    if std::env::var("HOME").is_ok() {
-        assert!(path.is_some());
-        let p = path.unwrap();
-        assert!(p.to_string_lossy().contains("cli-sub-agent"));
-        assert!(p.to_string_lossy().contains("config.toml"));
-    }
-    // In containers without HOME, it's OK to return None
+    let dir = tempdir().unwrap();
+    let _config_home = EnvVarGuard::set("XDG_CONFIG_HOME", dir.path());
+
+    let path = ProjectConfig::user_config_path()
+        .expect("XDG_CONFIG_HOME should make config path available");
+    assert!(path.to_string_lossy().contains("cli-sub-agent"));
+    assert!(path.to_string_lossy().contains("config.toml"));
 }
 
 #[test]
@@ -180,11 +204,12 @@ fn test_user_config_template_is_valid() {
 
 #[test]
 fn test_user_config_path_matches_global_config_dir() {
+    let dir = tempdir().unwrap();
+    let _config_home = EnvVarGuard::set("XDG_CONFIG_HOME", dir.path());
+
     // After unification, user-level ProjectConfig and GlobalConfig share the same directory.
-    if std::env::var("HOME").is_err() {
-        return; // Skip in containers
-    }
-    let user_path = ProjectConfig::user_config_path().unwrap();
+    let user_path = ProjectConfig::user_config_path()
+        .expect("user config path should resolve inside test XDG config dir");
     let global_path = crate::GlobalConfig::config_path().unwrap();
     assert_eq!(
         user_path.parent(),

--- a/justfile
+++ b/justfile
@@ -156,13 +156,14 @@ check-version-bumped:
         exit 1
     fi
 
-# Run all checks: monolith guard, Chinese character detection, formatting, linting, and tests.
+# Run all checks: monolith guard, env-dependent test lint, Chinese character detection, formatting, linting, and tests.
 pre-commit:
     just find-monolith-files
     just check-generated-artifacts
     just check-version-bumped
     just check-chinese
     just fmt
+    ./scripts/hooks/check-env-dependent-tests.sh
     just deny
     just clippy
     just test

--- a/scripts/hooks/check-env-dependent-tests.sh
+++ b/scripts/hooks/check-env-dependent-tests.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Pre-commit: catch Rust tests that rely on host HOME/PATH behavior.
+#
+# Scans ALL *.rs files under crates/:
+# - Test-named files (tests/*.rs, *_test*.rs, etc.) are scanned entirely.
+# - Other files are scanned only within #[cfg(test)] blocks.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+declare -a violations=()
+
+record_violation() {
+    local file="$1"
+    local line="$2"
+    local message="$3"
+    violations+=("$file:$line: $message")
+}
+
+# Given a file and the line number of a #[cfg(test)] attribute, extract
+# the range of lines belonging to the cfg(test) block (the item that
+# follows the attribute — typically `mod tests { ... }`).
+# Outputs: "start_line end_line"
+cfg_test_range() {
+    local file="$1"
+    local attr_line="$2"
+    local total_lines
+    total_lines="$(wc -l < "$file")"
+
+    # Find the opening brace of the item following the attribute.
+    local line_num="$attr_line"
+    local depth=0
+    local found_open=false
+    local line=""
+    local open_only=""
+    local close_only=""
+
+    while [ "$line_num" -le "$total_lines" ]; do
+        line="$(sed -n "${line_num}p" "$file")"
+        open_only="${line//[^\{]/}"
+        close_only="${line//[^\}]/}"
+        depth=$((depth + ${#open_only} - ${#close_only}))
+        if [ ${#open_only} -gt 0 ] && [ "$found_open" = false ]; then
+            found_open=true
+        fi
+        if [ "$found_open" = true ] && [ "$depth" -le 0 ]; then
+            echo "$attr_line $line_num"
+            return
+        fi
+        line_num=$((line_num + 1))
+    done
+    # If we couldn't find the end, return to end of file.
+    echo "$attr_line $total_lines"
+}
+
+# Check whether a given line number falls inside any #[cfg(test)] block
+# in the file.  Uses the pre-computed ranges passed via the array name.
+# Arguments: line_number ranges_string
+# ranges_string is space-separated pairs: "start1 end1 start2 end2 ..."
+line_in_test_block() {
+    local target="$1"
+    shift
+    local ranges=("$@")
+    local i=0
+    while [ "$i" -lt "${#ranges[@]}" ]; do
+        local rstart="${ranges[$i]}"
+        local rend="${ranges[$((i+1))]}"
+        if [ "$target" -ge "$rstart" ] && [ "$target" -le "$rend" ]; then
+            return 0
+        fi
+        i=$((i + 2))
+    done
+    return 1
+}
+
+# Returns true if the file name matches common Rust test file patterns.
+is_test_named_file() {
+    local file="$1"
+    case "$file" in
+        */tests/*.rs|*/tests.rs|*_tests.rs|*_tests_*.rs|*_test.rs|*_test_*.rs|*/test_*.rs)
+            return 0 ;;
+    esac
+    return 1
+}
+
+# Scan a file for home_dir() / env::var("HOME") near assertion macros
+# without a .exists() guard.
+# Arguments: file [ranges...]
+# If ranges is empty, scan the whole file; otherwise only lines in ranges.
+check_home_sensitive_asserts() {
+    local file="$1"
+    shift
+    local ranges=("$@")
+    local scan_all=false
+    if [ "${#ranges[@]}" -eq 0 ]; then
+        scan_all=true
+    fi
+
+    local line_number=""
+    while IFS=: read -r line_number _; do
+        [ -n "$line_number" ] || continue
+
+        # If we have ranges, skip lines outside test blocks.
+        if [ "$scan_all" = false ]; then
+            if ! line_in_test_block "$line_number" "${ranges[@]}"; then
+                continue
+            fi
+        fi
+
+        # Extract the enclosing block (brace-balanced) starting at this line.
+        local line="" block="" open_only="" close_only="" depth=0
+        while IFS= read -r line; do
+            block+="$line"$'\n'
+            open_only="${line//[^\{]/}"
+            close_only="${line//[^\}]/}"
+            depth=$((depth + ${#open_only} - ${#close_only}))
+            if [ "$depth" -le 0 ]; then
+                break
+            fi
+        done < <(tail -n +"$line_number" "$file")
+
+        # Must contain an assertion macro (any of assert!, assert_eq!, etc.)
+        if ! printf '%s' "$block" | grep -Eq 'assert(_eq|_ne|_matches)?!'; then
+            continue
+        fi
+
+        # Skip if guarded: .exists() check, or if-let-Some wrapping home_dir().
+        if printf '%s' "$block" | grep -Eq '\.exists\('; then
+            continue
+        fi
+        if printf '%s' "$block" | grep -Eq 'if let Some\(.*\)\s*=\s*(home_dir|env::var)'; then
+            continue
+        fi
+
+        record_violation \
+            "$file" \
+            "$line_number" \
+            "HOME-derived value used near assertion without '.exists()' guard"
+    done < <(grep -nE 'home_dir\(|env::var\([[:space:]]*"HOME"' "$file" 2>/dev/null || true)
+}
+
+# Scan a file for Command::new("which") or Command::new("where") in tests.
+# Arguments: file [ranges...]
+check_which_where_processes() {
+    local file="$1"
+    shift
+    local ranges=("$@")
+    local scan_all=false
+    if [ "${#ranges[@]}" -eq 0 ]; then
+        scan_all=true
+    fi
+
+    local line_number="" matched=""
+    while IFS=: read -r line_number matched; do
+        [ -n "$line_number" ] || continue
+
+        if [ "$scan_all" = false ]; then
+            if ! line_in_test_block "$line_number" "${ranges[@]}"; then
+                continue
+            fi
+        fi
+
+        record_violation \
+            "$file" \
+            "$line_number" \
+            "test shells out to ${matched}; avoid host-specific binary discovery"
+    done < <(grep -nE 'Command::new\([[:space:]]*"(which|where)"' "$file" 2>/dev/null || true)
+}
+
+# --- Main ---
+
+while IFS= read -r file; do
+    if is_test_named_file "$file"; then
+        # Entire file is test context — scan everything.
+        check_home_sensitive_asserts "$file"
+        check_which_where_processes "$file"
+    else
+        # Only scan within #[cfg(test)] blocks.
+        cfg_lines=()
+        while IFS= read -r ln; do
+            cfg_lines+=("$ln")
+        done < <(grep -nE '^\s*#\[cfg\(test\)\]' "$file" 2>/dev/null | cut -d: -f1)
+
+        if [ "${#cfg_lines[@]}" -eq 0 ]; then
+            continue
+        fi
+
+        # Build ranges array.
+        ranges=()
+        for ln in "${cfg_lines[@]}"; do
+            range_pair="$(cfg_test_range "$file" "$ln")"
+            # shellcheck disable=SC2086
+            ranges+=($range_pair)
+        done
+
+        check_home_sensitive_asserts "$file" "${ranges[@]}"
+        check_which_where_processes "$file" "${ranges[@]}"
+    fi
+done < <(git ls-files 'crates/**.rs')
+
+if [ "${#violations[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+echo ""
+echo "=========================================="
+echo "ERROR: Environment-dependent Rust tests detected."
+echo "=========================================="
+printf '%s\n' "${violations[@]}"
+echo ""
+echo "Actionable hints:"
+echo "- Guard HOME-derived filesystem assertions with 'if path.exists()' or a parent '.exists()' check that matches production behavior."
+echo "- Prefer explicit temp directories or injected XDG/HOME env vars in tests instead of reading the host environment."
+echo "- Do not shell out to 'which' or 'where' in tests; build a fake PATH or create the binary path directly."
+echo "=========================================="
+exit 1


### PR DESCRIPTION
## Summary
- **#641**: Verified all CI workflow matrix blocks already have `fail-fast: false` — no YAML changes needed (PR #635 covered them)
- **#642**: Added `scripts/hooks/check-env-dependent-tests.sh` grep-based lint that detects env-dependent test assertions (`home_dir()`, `env::var("HOME")`, `Command::new("which")`) in `#[cfg(test)]` blocks. Wired into `just pre-commit`. Fixed existing env-dependent test in `crates/csa-config/src/config_merge_tests.rs` using `XDG_CONFIG_HOME` tempdir + `EnvVarGuard` pattern.

## Review findings deferred
- MEDIUM: Shell script brace-balancing can miss multi-line `home_dir()` + assert patterns (#699)
- MEDIUM: `EnvVarGuard` env mutation without `serial_test` serialization (#699)

## Test plan
- [x] `just pre-commit` passes (fmt, clippy, deny, 3404 unit tests, 27 e2e tests, env-lint)
- [x] New lint script has zero false positives on current codebase
- [x] Scans ALL `*.rs` files under `crates/`, with context-aware `#[cfg(test)]` block detection

Closes #641, closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)