### PR TITLE
feat(cli): add todo update, session list filters, and positional session ID (#636, #649, #650)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "axum",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.270"
+version = "0.1.271"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.270"
+version = "0.1.271"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -24,12 +24,28 @@ pub enum SessionCommands {
         /// List sessions from all projects (incompatible with --tree)
         #[arg(long, conflicts_with = "tree")]
         all_projects: bool,
+
+        /// Show only the N most recent sessions
+        #[arg(long)]
+        limit: Option<usize>,
+
+        /// Show sessions accessed since a duration ago (e.g., "1h", "30m", "2d")
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Filter by session status (active, retired, failed, error)
+        #[arg(long)]
+        status: Option<String>,
     },
 
     /// Compress session context (gemini-cli: /compress, others: /compact)
     Compress {
+        /// Session ULID or prefix (positional alternative to --session)
+        #[arg(conflicts_with = "session")]
+        session_id: Option<String>,
+
         #[arg(short, long)]
-        session: String,
+        session: Option<String>,
 
         /// Working directory (defaults to CWD)
         #[arg(long)]
@@ -38,8 +54,12 @@ pub enum SessionCommands {
 
     /// Delete a session
     Delete {
+        /// Session ULID or prefix (positional alternative to --session)
+        #[arg(conflicts_with = "session")]
+        session_id: Option<String>,
+
         #[arg(short, long)]
-        session: String,
+        session: Option<String>,
 
         /// Working directory (defaults to CWD)
         #[arg(long)]
@@ -67,9 +87,13 @@ pub enum SessionCommands {
 
     /// View session logs
     Logs {
+        /// Session ULID or prefix (positional alternative to --session)
+        #[arg(conflicts_with = "session")]
+        session_id: Option<String>,
+
         /// Session ULID or prefix
         #[arg(short, long)]
-        session: String,
+        session: Option<String>,
 
         /// Show only last N lines
         #[arg(long)]
@@ -86,9 +110,13 @@ pub enum SessionCommands {
 
     /// Check whether a session is still alive using filesystem liveness signals
     IsAlive {
+        /// Session ID or prefix (positional alternative to --session)
+        #[arg(conflicts_with = "session")]
+        session_id: Option<String>,
+
         /// Session ID or prefix
         #[arg(short, long)]
-        session: String,
+        session: Option<String>,
 
         /// Working directory
         #[arg(long)]
@@ -97,9 +125,13 @@ pub enum SessionCommands {
 
     /// Show the last execution result for a session
     Result {
+        /// Session ID or prefix (positional alternative to --session)
+        #[arg(conflicts_with = "session")]
+        session_id: Option<String>,
+
         /// Session ID or prefix
         #[arg(short, long)]
-        session: String,
+        session: Option<String>,
 
         /// Output as JSON instead of human-readable
         #[arg(long)]
@@ -124,9 +156,13 @@ pub enum SessionCommands {
 
     /// List artifacts in a session's output directory
     Artifacts {
+        /// Session ID or prefix (positional alternative to --session)
+        #[arg(conflicts_with = "session")]
+        session_id: Option<String>,
+
         /// Session ID or prefix
         #[arg(short, long)]
-        session: String,
+        session: Option<String>,
 
         /// Working directory
         #[arg(long)]
@@ -199,9 +235,13 @@ pub enum SessionCommands {
     /// Timeout comes from `~/.config/cli-sub-agent/config.toml` `[kv_cache].long_poll_seconds`
     /// with a legacy 250s fallback when `[kv_cache]` is absent.
     Wait {
+        /// Session ID to wait for (positional alternative to --session)
+        #[arg(conflicts_with = "session")]
+        session_id: Option<String>,
+
         /// Session ID to wait for
         #[arg(long)]
-        session: String,
+        session: Option<String>,
 
         /// Working directory
         #[arg(long)]
@@ -210,9 +250,13 @@ pub enum SessionCommands {
 
     /// Kill a running daemon session (SIGTERM, then SIGKILL after grace period)
     Kill {
+        /// Session ID to kill (positional alternative to --session)
+        #[arg(conflicts_with = "session")]
+        session_id: Option<String>,
+
         /// Session ID to kill
         #[arg(long)]
-        session: String,
+        session: Option<String>,
 
         /// Working directory
         #[arg(long)]
@@ -221,9 +265,13 @@ pub enum SessionCommands {
 
     /// Attach to a running daemon session (tail live output/stderr until the daemon exits)
     Attach {
+        /// Session ID to attach to (positional alternative to --session)
+        #[arg(conflicts_with = "session")]
+        session_id: Option<String>,
+
         /// Session ID to attach to
         #[arg(long)]
-        session: String,
+        session: Option<String>,
 
         /// Show stderr alongside stdout
         #[arg(long)]

--- a/crates/cli-sub-agent/src/cli_todo.rs
+++ b/crates/cli-sub-agent/src/cli_todo.rs
@@ -127,7 +127,29 @@ pub enum TodoCommands {
         cd: Option<String>,
     },
 
-    /// Update a TODO plan's status
+    /// Update a TODO plan (title, status, description)
+    Update {
+        /// Timestamp of the TODO plan
+        timestamp: String,
+
+        /// New title
+        #[arg(long)]
+        title: Option<String>,
+
+        /// New status (draft, debating, approved, implementing, done)
+        #[arg(long)]
+        status: Option<String>,
+
+        /// New description (overwrites TODO.md content)
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Working directory
+        #[arg(long)]
+        cd: Option<String>,
+    },
+
+    /// Update a TODO plan's status (convenience alias for `update --status`)
     Status {
         /// Timestamp of the TODO plan
         timestamp: String,

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -640,6 +640,15 @@ async fn run() -> Result<()> {
             } => {
                 todo_cmd::handle_show(timestamp, version, path, spec, refs, cd)?;
             }
+            TodoCommands::Update {
+                timestamp,
+                title,
+                status,
+                description,
+                cd,
+            } => {
+                todo_cmd::handle_update(timestamp, title, status, description, cd)?;
+            }
             TodoCommands::Status {
                 timestamp,
                 status,

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -43,12 +43,43 @@ pub(crate) use reconcile::{
     ensure_terminal_result_for_dead_active_session, retire_if_dead_with_result,
 };
 
+/// Parse a human-friendly duration string (e.g., "1h", "30m", "2d") into
+/// a `chrono::Duration`. Supports `s` (seconds), `m` (minutes), `h` (hours),
+/// and `d` (days).
+fn parse_duration_filter(s: &str) -> Result<chrono::Duration> {
+    let s = s.trim();
+    if s.is_empty() {
+        anyhow::bail!("Duration string cannot be empty");
+    }
+
+    let (num_str, unit) = s.split_at(s.len() - 1);
+    let num: i64 = num_str.parse().map_err(|_| {
+        anyhow::anyhow!("Invalid duration: '{s}'. Expected: <number><unit> (e.g., 1h, 30m, 2d)")
+    })?;
+
+    match unit {
+        "s" => Ok(chrono::Duration::seconds(num)),
+        "m" => Ok(chrono::Duration::minutes(num)),
+        "h" => Ok(chrono::Duration::hours(num)),
+        "d" => Ok(chrono::Duration::days(num)),
+        _ => anyhow::bail!("Unknown duration unit '{unit}'. Supported: s, m, h, d"),
+    }
+}
+
+/// Filter options for `csa session list`.
+pub(crate) struct SessionListFilters {
+    pub limit: Option<usize>,
+    pub since: Option<String>,
+    pub status: Option<String>,
+}
+
 pub(crate) fn handle_session_list(
     cd: Option<String>,
     branch: Option<String>,
     tool: Option<String>,
     tree: bool,
     all_projects: bool,
+    filters: SessionListFilters,
     format: OutputFormat,
 ) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
@@ -59,11 +90,33 @@ pub(crate) fn handle_session_list(
             list_sessions_tree_filtered(&project_root, tool_filter.as_deref(), branch.as_deref())?;
         print!("{tree_output}");
     } else {
-        let sessions = if all_projects {
+        let mut sessions = if all_projects {
             select_sessions_for_list_all_projects(branch.as_deref(), tool_filter.as_deref())?
         } else {
             select_sessions_for_list(&project_root, branch.as_deref(), tool_filter.as_deref())?
         };
+
+        // --since filter: keep only sessions accessed after the cutoff
+        if let Some(ref since_str) = filters.since {
+            let duration = parse_duration_filter(since_str)?;
+            let cutoff = chrono::Utc::now() - duration;
+            sessions.retain(|s| s.last_accessed >= cutoff);
+        }
+
+        // --status filter: match resolved status string (case-insensitive)
+        if let Some(ref status_filter) = filters.status {
+            let filter_lower = status_filter.to_ascii_lowercase();
+            sessions.retain(|s| {
+                let resolved = resolve_session_status(s).to_ascii_lowercase();
+                resolved == filter_lower
+            });
+        }
+
+        // --limit: keep only the N most recent (list is already sorted newest-first)
+        if let Some(n) = filters.limit {
+            sessions.truncate(n);
+        }
+
         if sessions.is_empty() {
             match format {
                 OutputFormat::Json => {

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -10,6 +10,14 @@ use crate::session_cmds;
 use csa_config::{DEFAULT_KV_CACHE_LONG_POLL_SECS, GlobalConfig, ProjectConfig};
 use csa_core::types::OutputFormat;
 
+/// Resolve session ID from positional arg or --session flag.
+/// Positional takes precedence when both are provided.
+fn resolve_session_id(positional: Option<String>, flag: Option<String>) -> Result<String> {
+    positional
+        .or(flag)
+        .ok_or_else(|| anyhow::anyhow!("session ID is required (positional or --session)"))
+}
+
 pub(crate) fn dispatch(cmd: SessionCommands, output_format: OutputFormat) -> Result<()> {
     match cmd {
         SessionCommands::List {
@@ -18,14 +26,39 @@ pub(crate) fn dispatch(cmd: SessionCommands, output_format: OutputFormat) -> Res
             tool,
             tree,
             all_projects,
+            limit,
+            since,
+            status,
         } => {
-            session_cmds::handle_session_list(cd, branch, tool, tree, all_projects, output_format)?;
+            session_cmds::handle_session_list(
+                cd,
+                branch,
+                tool,
+                tree,
+                all_projects,
+                session_cmds::SessionListFilters {
+                    limit,
+                    since,
+                    status,
+                },
+                output_format,
+            )?;
         }
-        SessionCommands::Compress { session, cd } => {
-            session_cmds::handle_session_compress(session, cd)?;
+        SessionCommands::Compress {
+            session_id,
+            session,
+            cd,
+        } => {
+            let sid = resolve_session_id(session_id, session)?;
+            session_cmds::handle_session_compress(sid, cd)?;
         }
-        SessionCommands::Delete { session, cd } => {
-            session_cmds::handle_session_delete(session, cd)?;
+        SessionCommands::Delete {
+            session_id,
+            session,
+            cd,
+        } => {
+            let sid = resolve_session_id(session_id, session)?;
+            session_cmds::handle_session_delete(sid, cd)?;
         }
         SessionCommands::Clean {
             days,
@@ -36,20 +69,28 @@ pub(crate) fn dispatch(cmd: SessionCommands, output_format: OutputFormat) -> Res
             session_cmds::handle_session_clean(days, dry_run, tool, cd)?;
         }
         SessionCommands::Logs {
+            session_id,
             session,
             tail,
             events,
             cd,
         } => {
-            session_cmds::handle_session_logs(session, tail, events, cd)?;
+            let sid = resolve_session_id(session_id, session)?;
+            session_cmds::handle_session_logs(sid, tail, events, cd)?;
         }
-        SessionCommands::IsAlive { session, cd } => {
-            let alive = session_cmds::handle_session_is_alive(session, cd)?;
+        SessionCommands::IsAlive {
+            session_id,
+            session,
+            cd,
+        } => {
+            let sid = resolve_session_id(session_id, session)?;
+            let alive = session_cmds::handle_session_is_alive(sid, cd)?;
             let _ = std::io::stdout().flush();
             let _ = std::io::stderr().flush();
             std::process::exit(if alive { 0 } else { 1 });
         }
         SessionCommands::Result {
+            session_id,
             session,
             json,
             summary,
@@ -57,8 +98,9 @@ pub(crate) fn dispatch(cmd: SessionCommands, output_format: OutputFormat) -> Res
             full,
             cd,
         } => {
+            let sid = resolve_session_id(session_id, session)?;
             session_cmds::handle_session_result(
-                session,
+                sid,
                 json,
                 cd,
                 session_cmds::StructuredOutputOpts {
@@ -68,8 +110,13 @@ pub(crate) fn dispatch(cmd: SessionCommands, output_format: OutputFormat) -> Res
                 },
             )?;
         }
-        SessionCommands::Artifacts { session, cd } => {
-            session_cmds::handle_session_artifacts(session, cd)?;
+        SessionCommands::Artifacts {
+            session_id,
+            session,
+            cd,
+        } => {
+            let sid = resolve_session_id(session_id, session)?;
+            session_cmds::handle_session_artifacts(sid, cd)?;
         }
         SessionCommands::Log { session, cd } => {
             session_cmds::handle_session_log(session, cd)?;
@@ -91,22 +138,34 @@ pub(crate) fn dispatch(cmd: SessionCommands, output_format: OutputFormat) -> Res
         } => {
             session_cmds::handle_session_tool_output(session, index, list, cd)?;
         }
-        SessionCommands::Wait { session, cd } => {
+        SessionCommands::Wait {
+            session_id,
+            session,
+            cd,
+        } => {
+            let sid = resolve_session_id(session_id, session)?;
             let wait_timeout = resolve_daemon_wait_timeout(cd.as_deref());
-            let exit_code = session_cmds::handle_session_wait(session, cd, wait_timeout)?;
+            let exit_code = session_cmds::handle_session_wait(sid, cd, wait_timeout)?;
             let _ = std::io::stdout().flush();
             let _ = std::io::stderr().flush();
             std::process::exit(exit_code);
         }
-        SessionCommands::Kill { session, cd } => {
-            session_cmds::handle_session_kill(session, cd)?;
+        SessionCommands::Kill {
+            session_id,
+            session,
+            cd,
+        } => {
+            let sid = resolve_session_id(session_id, session)?;
+            session_cmds::handle_session_kill(sid, cd)?;
         }
         SessionCommands::Attach {
+            session_id,
             session,
             stderr,
             cd,
         } => {
-            let exit_code = session_cmds::handle_session_attach(session, stderr, cd)?;
+            let sid = resolve_session_id(session_id, session)?;
+            let exit_code = session_cmds::handle_session_attach(sid, stderr, cd)?;
             let _ = std::io::stdout().flush();
             let _ = std::io::stderr().flush();
             std::process::exit(exit_code);

--- a/crates/cli-sub-agent/src/todo_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_cmd.rs
@@ -415,6 +415,85 @@ fn criterion_status_label(status: CriterionStatus) -> &'static str {
     }
 }
 
+pub(crate) fn handle_update(
+    timestamp: String,
+    title: Option<String>,
+    status: Option<String>,
+    description: Option<String>,
+    cd: Option<String>,
+) -> Result<()> {
+    if title.is_none() && status.is_none() && description.is_none() {
+        anyhow::bail!(
+            "At least one of --title, --status, or --description is required for `todo update`"
+        );
+    }
+
+    let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+    let manager = TodoManager::new(&project_root)?;
+
+    // Validate plan exists
+    let plan = manager.load(&timestamp)?;
+
+    // --- Validate ALL inputs BEFORE any mutations (atomicity) ---
+    let parsed_status = status
+        .as_ref()
+        .map(|s| {
+            s.parse::<TodoStatus>()
+                .map_err(|e| anyhow::anyhow!("invalid status '{}': {}", s, e))
+        })
+        .transpose()?;
+
+    // --- Apply mutations (all validation passed) ---
+    let mut changed_fields: Vec<&str> = Vec::new();
+    let mut changed_files: Vec<String> = Vec::new();
+
+    if let Some(ref new_title) = title {
+        manager.update_title(&timestamp, new_title)?;
+        changed_fields.push("title");
+        changed_files.push(format!("{timestamp}/metadata.toml"));
+    }
+
+    if let Some(new_status) = parsed_status
+        && plan.metadata.status != new_status
+    {
+        manager.update_status(&timestamp, new_status)?;
+        changed_fields.push("status");
+        changed_files.push(format!("{timestamp}/metadata.toml"));
+    }
+
+    if let Some(ref new_description) = description {
+        manager.write_todo_md(&timestamp, new_description)?;
+        changed_fields.push("description");
+        changed_files.push(format!("{timestamp}/TODO.md"));
+        // write_todo_md also bumps updated_at in metadata.toml
+        changed_files.push(format!("{timestamp}/metadata.toml"));
+    }
+
+    if changed_fields.is_empty() {
+        eprintln!("No changes applied to plan '{timestamp}'.");
+    } else {
+        // Auto-commit only the files that were actually changed (don't stage unrelated dirty files)
+        csa_todo::git::ensure_git_init(manager.todos_dir())?;
+        changed_files.dedup();
+        let file_refs: Vec<&str> = changed_files.iter().map(|s| s.as_str()).collect();
+        let commit_msg = format!("update {}: {}", timestamp, changed_fields.join(", "));
+        match csa_todo::git::save_files(manager.todos_dir(), &timestamp, &file_refs, &commit_msg)? {
+            Some(hash) => {
+                eprintln!(
+                    "Updated plan '{timestamp}': {} ({})",
+                    changed_fields.join(", "),
+                    hash
+                );
+            }
+            None => {
+                eprintln!("Updated plan '{timestamp}': {}", changed_fields.join(", "));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 pub(crate) fn handle_status(timestamp: String, status: String, cd: Option<String>) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
     let manager = TodoManager::new(&project_root)?;

--- a/crates/csa-todo/src/git.rs
+++ b/crates/csa-todo/src/git.rs
@@ -199,6 +199,20 @@ pub fn save_file(
     save_paths(todos_dir, timestamp, &[file], message)
 }
 
+/// Stage and commit multiple files within a plan directory.
+///
+/// `files` are paths relative to `todos_dir` (e.g. `["20260211T023000/metadata.toml",
+/// "20260211T023000/TODO.md"]`).
+/// Returns the short commit hash, or `None` if there were no changes to commit.
+pub fn save_files(
+    todos_dir: &Path,
+    timestamp: &str,
+    files: &[&str],
+    message: &str,
+) -> Result<Option<String>> {
+    save_paths(todos_dir, timestamp, files, message)
+}
+
 /// Internal: stage given paths and commit.
 fn save_paths(
     todos_dir: &Path,

--- a/crates/csa-todo/src/lib.rs
+++ b/crates/csa-todo/src/lib.rs
@@ -206,6 +206,17 @@ impl TodoManager {
         })
     }
 
+    /// Update the title of a TODO plan.
+    pub fn update_title(&self, timestamp: &str, title: &str) -> Result<TodoPlan> {
+        self.with_write_lock(|| {
+            let mut plan = self.load_inner(timestamp)?;
+            plan.metadata.title = title.to_string();
+            plan.metadata.updated_at = Utc::now();
+            self.write_metadata(&plan)?;
+            Ok(plan)
+        })
+    }
+
     /// Link a CSA session ID to a TODO plan (idempotent).
     pub fn link_session(&self, timestamp: &str, session_id: &str) -> Result<TodoPlan> {
         self.with_write_lock(|| {


### PR DESCRIPTION
## Summary
- **#636**: Added `csa todo update <TIMESTAMP> [--title X] [--status Y] [--description Z]` with validate-before-mutate atomicity. Existing `csa todo status` preserved as alias.
- **#649**: Added `--limit N`, `--since <duration>`, `--status <status>` filters to `csa session list`. Duration supports s/m/h/d suffixes.
- **#650**: All session subcommands (wait, logs, result, kill, attach, artifacts, compress, delete, is-alive) now accept positional SESSION_ID as alternative to `--session`.

## Review findings deferred
- `todo update --title` only updates metadata, not TODO.md body heading (#703)
- `todo update` not idempotent for same-value updates (#703)
- `session list --tree` silently ignores filter flags (#703)

## Test plan
- [x] `just pre-commit` passes (3381 unit tests, 27 e2e tests)
- [x] 4 rounds of codex review, all HIGHs fixed or assessed as display-only (#703)

Closes #636, closes #649, closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)