### PR TITLE
fix(commit): fix empty-prompt security-audit step and self-locking session (#677)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "chrono",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "chrono",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "axum",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "chrono",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.274"
+version = "0.1.275"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.274"
+version = "0.1.275"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -57,6 +57,15 @@ pub(crate) enum ParentSessionSource {
     ExplicitOnly,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionCreationMode {
+    /// Reuse the daemon-preassigned session ID when present. This is the
+    /// normal top-level CLI behavior.
+    DaemonManaged,
+    /// Always allocate a fresh child session ID, even inside a daemon child.
+    FreshChild,
+}
+
 pub(crate) fn resolve_idle_timeout_seconds(
     config: Option<&ProjectConfig>,
     cli_override: Option<u64>,

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -12,7 +12,7 @@ use super::result_contract::{
     clear_expected_result_artifacts_for_prompt, enforce_result_toml_path_contract,
 };
 use super::{
-    MemoryInjectionOptions, ParentSessionSource, SessionExecutionResult,
+    MemoryInjectionOptions, ParentSessionSource, SessionCreationMode, SessionExecutionResult,
     resolve_liveness_dead_seconds, resolve_mcp_servers, run_pipeline_hook,
 };
 use crate::memory_capture;
@@ -29,7 +29,9 @@ use csa_hooks::{
 use csa_lock::acquire_lock;
 use csa_process::ExecutionResult;
 use csa_resource::{ResourceGuard, ResourceLimits};
-use csa_session::{ToolState, compute_cooldown_wait, create_session, get_session_dir};
+use csa_session::{
+    ToolState, compute_cooldown_wait, create_session, create_session_fresh, get_session_dir,
+};
 
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, fields(tool = %tool, session = ?session_arg))]
@@ -132,6 +134,7 @@ pub(crate) async fn execute_with_session_and_meta(
         memory_injection,
         global_config,
         ParentSessionSource::ExplicitOrEnv,
+        SessionCreationMode::DaemonManaged,
         no_fs_sandbox,
         readonly_project_root,
         extra_writable,
@@ -162,6 +165,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     memory_injection: Option<&MemoryInjectionOptions>,
     global_config: Option<&GlobalConfig>,
     parent_session_source: ParentSessionSource,
+    session_creation_mode: SessionCreationMode,
     no_fs_sandbox: bool,
     readonly_project_root: bool,
     extra_writable: &[PathBuf],
@@ -204,12 +208,20 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             }
             ParentSessionSource::ExplicitOnly => parent,
         };
-        let mut new_session = create_session(
-            project_root,
-            effective_description.as_deref(),
-            parent_id.as_deref(),
-            Some(tool.as_str()),
-        )?;
+        let mut new_session = match session_creation_mode {
+            SessionCreationMode::DaemonManaged => create_session(
+                project_root,
+                effective_description.as_deref(),
+                parent_id.as_deref(),
+                Some(tool.as_str()),
+            )?,
+            SessionCreationMode::FreshChild => create_session_fresh(
+                project_root,
+                effective_description.as_deref(),
+                parent_id.as_deref(),
+                Some(tool.as_str()),
+            )?,
+        };
         new_session.task_context = csa_session::TaskContext {
             task_type: task_type.map(|s| s.to_string()),
             tier_name: tier_name.map(|s| s.to_string()),

--- a/crates/cli-sub-agent/src/pipeline_tests_tail.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_tail.rs
@@ -722,6 +722,7 @@ async fn execute_with_session_and_meta_explicit_only_ignores_inherited_parent_se
         None,
         None,
         ParentSessionSource::ExplicitOnly,
+        SessionCreationMode::DaemonManaged,
         false, // no_fs_sandbox
         false, // readonly_project_root
         &[],   // extra_writable

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -685,5 +685,9 @@ mod tests_pr_bot;
 mod tests_chunked;
 
 #[cfg(test)]
+#[path = "plan_cmd_tests_commit.rs"]
+mod tests_commit;
+
+#[cfg(test)]
 #[path = "plan_cmd_override_tests.rs"]
 mod override_tests;

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -9,7 +9,9 @@ use csa_config::ProjectConfig;
 use csa_core::types::{OutputFormat, ToolName};
 use csa_process::check_tool_installed;
 
-use crate::pipeline::execute_with_session_and_meta;
+use crate::pipeline::{
+    ParentSessionSource, SessionCreationMode, execute_with_session_and_meta_with_parent_source,
+};
 use crate::run_helpers::build_executor;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
@@ -217,15 +219,16 @@ pub(super) async fn execute_csa_step(
         .map(str::trim)
         .filter(|session| !session.is_empty())
         .map(str::to_string);
+    let parent_session_id = std::env::var("CSA_SESSION_ID").ok();
     let execute_once = |session_arg: Option<String>| {
-        execute_with_session_and_meta(
+        execute_with_session_and_meta_with_parent_source(
             &executor,
             tool_name,
             prompt,
             OutputFormat::Json,
             session_arg,
             Some("plan-step".to_string()),
-            std::env::var("CSA_SESSION_ID").ok(),
+            parent_session_id.clone(),
             project_root,
             config,
             extra_env.as_ref(),
@@ -238,6 +241,8 @@ pub(super) async fn execute_csa_step(
             None,
             None,
             None,
+            ParentSessionSource::ExplicitOnly,
+            SessionCreationMode::FreshChild,
             false, // no_fs_sandbox
             false, // readonly_project_root
             &[],   // extra_writable

--- a/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
@@ -1,0 +1,135 @@
+use super::*;
+#[cfg(unix)]
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use std::collections::HashMap;
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use weave::compiler::{FailAction, PlanStep, plan_from_toml};
+
+#[cfg(unix)]
+struct ScopedEnvVarRestore {
+    key: &'static str,
+    original: Option<String>,
+}
+
+#[cfg(unix)]
+impl ScopedEnvVarRestore {
+    fn set(key: &'static str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation while ScopedSessionSandbox holds TEST_ENV_LOCK.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ScopedEnvVarRestore {
+    fn drop(&mut self) {
+        // SAFETY: restoration of test-scoped env mutation while TEST_ENV_LOCK is held.
+        unsafe {
+            match self.original.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn workspace_root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+}
+
+#[test]
+fn commit_workflow_csa_dispatch_steps_have_non_empty_prompts() {
+    let workflow_path = workspace_root().join("patterns/commit/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+
+    for title in ["Security Audit", "Pre-Commit Review"] {
+        let step = plan
+            .steps
+            .iter()
+            .find(|step| step.title == title)
+            .unwrap_or_else(|| panic!("missing commit workflow step '{title}'"));
+        assert_eq!(step.tool.as_deref(), Some("csa"));
+        assert!(
+            !step.prompt.trim().is_empty(),
+            "commit workflow step '{title}' must not dispatch an empty CSA prompt"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn execute_step_csa_nested_plan_uses_fresh_child_session() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&tmp);
+    let project_root = tmp.path();
+
+    let bin_dir = project_root.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let fake_opencode = bin_dir.join("opencode");
+    fs::write(&fake_opencode, "#!/bin/sh\nprintf 'plan-child-ok\\n'\n").unwrap();
+    let mut perms = fs::metadata(&fake_opencode).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&fake_opencode, perms).unwrap();
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+    let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
+
+    let parent =
+        csa_session::create_session(project_root, Some("plan-parent"), None, Some("opencode"))
+            .unwrap();
+    let parent_dir = csa_session::get_session_dir(project_root, &parent.meta_session_id).unwrap();
+    let _parent_lock = csa_lock::acquire_lock(&parent_dir, "opencode", "outer plan step").unwrap();
+
+    let parent_dir_str = parent_dir.display().to_string();
+    let project_root_str = project_root.display().to_string();
+    let _csa_session_id = ScopedEnvVarRestore::set("CSA_SESSION_ID", &parent.meta_session_id);
+    let _daemon_session_id =
+        ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_ID", &parent.meta_session_id);
+    let _daemon_session_dir = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_DIR", &parent_dir_str);
+    let _daemon_project_root =
+        ScopedEnvVarRestore::set("CSA_DAEMON_PROJECT_ROOT", &project_root_str);
+
+    let step = PlanStep {
+        id: 1,
+        title: "nested-plan-child".into(),
+        tool: Some("opencode".into()),
+        prompt: "Inspect the staged diff and report success.".into(),
+        tier: None,
+        depends_on: vec![],
+        on_fail: FailAction::Abort,
+        condition: None,
+        loop_var: None,
+        session: None,
+    };
+
+    let vars = HashMap::new();
+    let result = execute_step(&step, &vars, project_root, None, None).await;
+
+    assert_eq!(
+        result.exit_code, 0,
+        "nested plan-step CSA execution should succeed instead of self-locking: error={:?}",
+        result.error
+    );
+    let child_id = result
+        .session_id
+        .as_deref()
+        .expect("plan step should record child session id");
+    assert_ne!(
+        child_id, parent.meta_session_id,
+        "plan step must allocate a fresh child session instead of reusing the daemon session"
+    );
+
+    let child = csa_session::load_session(project_root, child_id).unwrap();
+    assert_eq!(
+        child.genealogy.parent_session_id.as_deref(),
+        Some(parent.meta_session_id.as_str()),
+        "fresh plan child session should point back to the plan runner session"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -107,6 +107,7 @@ pub(super) async fn execute_review(
         None,
         Some(global_config),
         crate::pipeline::ParentSessionSource::ExplicitOnly,
+        crate::pipeline::SessionCreationMode::DaemonManaged,
         no_fs_sandbox,
         readonly_project_root,
         extra_writable,

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -74,7 +74,7 @@ pub use vcs_backends::{GitBackend, JjBackend, create_vcs_backend};
 // Re-export manager functions
 pub use manager::{
     CONTRACT_RESULT_ARTIFACT_PATH, LEGACY_USER_RESULT_ARTIFACT_PATH, RESULT_TOML_PATH_CONTRACT_ENV,
-    complete_session, contract_result_path, create_session, delete_session,
+    complete_session, contract_result_path, create_session, create_session_fresh, delete_session,
     delete_session_from_root, detect_git_head, find_sessions, get_session_dir,
     get_session_dir_global, get_session_root, legacy_user_result_path,
     list_all_project_session_roots, list_all_sessions, list_all_sessions_all_projects,

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -32,6 +32,12 @@ const DAEMON_SESSION_ID_ENV: &str = "CSA_DAEMON_SESSION_ID";
 const DAEMON_SESSION_DIR_ENV: &str = "CSA_DAEMON_SESSION_DIR";
 const DAEMON_PROJECT_ROOT_ENV: &str = "CSA_DAEMON_PROJECT_ROOT";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionIdStrategy {
+    DaemonAware,
+    Fresh,
+}
+
 fn preassigned_daemon_session_id() -> Option<String> {
     let session_id = std::env::var(DAEMON_SESSION_ID_ENV)
         .ok()
@@ -62,10 +68,37 @@ pub fn create_session(
     tool: Option<&str>,
 ) -> Result<MetaSessionState> {
     let base_dir = get_session_root(project_path)?;
-    create_session_in(&base_dir, project_path, description, parent_id, tool)
+    create_session_in_with_strategy(
+        &base_dir,
+        project_path,
+        description,
+        parent_id,
+        tool,
+        SessionIdStrategy::DaemonAware,
+    )
 }
 
-/// Internal implementation: create session in explicit base directory
+/// Create a child session with a fresh ULID even when daemon session env vars
+/// are present in the current process.
+pub fn create_session_fresh(
+    project_path: &Path,
+    description: Option<&str>,
+    parent_id: Option<&str>,
+    tool: Option<&str>,
+) -> Result<MetaSessionState> {
+    let base_dir = get_session_root(project_path)?;
+    create_session_in_with_strategy(
+        &base_dir,
+        project_path,
+        description,
+        parent_id,
+        tool,
+        SessionIdStrategy::Fresh,
+    )
+}
+
+/// Internal implementation: create session in explicit base directory.
+#[cfg(test)]
 pub(crate) fn create_session_in(
     base_dir: &Path,
     project_path: &Path,
@@ -73,17 +106,37 @@ pub(crate) fn create_session_in(
     parent_id: Option<&str>,
     tool: Option<&str>,
 ) -> Result<MetaSessionState> {
+    create_session_in_with_strategy(
+        base_dir,
+        project_path,
+        description,
+        parent_id,
+        tool,
+        SessionIdStrategy::DaemonAware,
+    )
+}
+
+fn create_session_in_with_strategy(
+    base_dir: &Path,
+    project_path: &Path,
+    description: Option<&str>,
+    parent_id: Option<&str>,
+    tool: Option<&str>,
+    session_id_strategy: SessionIdStrategy,
+) -> Result<MetaSessionState> {
     // Daemon child processes pre-assign a session ID via env so that the
-    // pipeline session directory matches the daemon spool directory. Ignore a
-    // bare inherited session ID unless the rest of the daemon context was also
-    // seeded; otherwise nested commands and tests collapse multiple sessions
-    // onto the caller's daemon session directory.
-    let session_id = match preassigned_daemon_session_id() {
-        Some(id) => {
-            validate_session_id(&id)?;
-            id
-        }
-        None => new_session_id(),
+    // pipeline session directory matches the daemon spool directory. Nested
+    // child sessions must opt out of that binding so they do not collapse onto
+    // the caller's own daemon session.
+    let session_id = match session_id_strategy {
+        SessionIdStrategy::DaemonAware => match preassigned_daemon_session_id() {
+            Some(id) => {
+                validate_session_id(&id)?;
+                id
+            }
+            None => new_session_id(),
+        },
+        SessionIdStrategy::Fresh => new_session_id(),
     };
     let session_dir = get_session_dir_in(base_dir, &session_id);
     let normalized_project_path = normalize_project_path(project_path);

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -129,6 +129,14 @@ Tool: csa
 Tier: tier-2-standard
 OnFail: abort
 
+Run the security audit directly in this CSA step.
+- Review the staged changes and associated tests.
+- Perform the full three-phase audit: test completeness, vulnerability scan, and code quality.
+- Emit `CSA_VAR:AUDIT_FAIL=true` when blocking issues exist; otherwise emit `CSA_VAR:AUDIT_FAIL=false`.
+- Emit `CSA_VAR:AUDIT_PASS_DEFERRED=true` when only deferred follow-up issues remain; otherwise emit `CSA_VAR:AUDIT_PASS_DEFERRED=false`.
+- Blocking issues take precedence over deferred ones.
+- End with a concise audit report and a final verdict: PASS, PASS_DEFERRED, or FAIL.
+
 ## INCLUDE security-audit
 
 Three-phase audit: test completeness, vulnerability scan, code quality.
@@ -155,6 +163,12 @@ immediate post-commit fixing.
 
 Tool: csa
 Tier: tier-2-standard
+
+Run the staged-diff review directly in this CSA step.
+- Inspect `git diff --cached` for correctness, regressions, security issues, and test gaps.
+- Emit `CSA_VAR:REVIEW_HAS_ISSUES=true` when fixes are required before commit; otherwise emit `CSA_VAR:REVIEW_HAS_ISSUES=false`.
+- If issues exist, explain exactly what must be fixed before commit proceeds.
+- Preserve the AGENTS.md compliance checklist and rule checks below.
 
 ## INCLUDE ai-reviewed-commit
 

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -219,7 +219,14 @@ on_fail = "abort"
 id = 8
 title = "Security Audit"
 tool = "csa"
-prompt = ""
+prompt = """
+Run the security audit directly in this CSA step.
+- Review the staged changes and associated tests.
+- Perform the full three-phase audit: test completeness, vulnerability scan, and code quality.
+- Emit `CSA_VAR:AUDIT_FAIL=true` when blocking issues exist; otherwise emit `CSA_VAR:AUDIT_FAIL=false`.
+- Emit `CSA_VAR:AUDIT_PASS_DEFERRED=true` when only deferred follow-up issues remain; otherwise emit `CSA_VAR:AUDIT_PASS_DEFERRED=false`.
+- Blocking issues take precedence over deferred ones.
+- End with a concise audit report and a final verdict: PASS, PASS_DEFERRED, or FAIL."""
 tier = "tier-2-standard"
 on_fail = "abort"
 
@@ -250,7 +257,12 @@ condition = "${AUDIT_PASS_DEFERRED}"
 id = 12
 title = "Pre-Commit Review"
 tool = "csa"
-prompt = ""
+prompt = """
+Run the staged-diff review directly in this CSA step.
+- Inspect `git diff --cached` for correctness, regressions, security issues, and test gaps.
+- Emit `CSA_VAR:REVIEW_HAS_ISSUES=true` when fixes are required before commit; otherwise emit `CSA_VAR:REVIEW_HAS_ISSUES=false`.
+- If issues exist, explain exactly what must be fixed before commit proceeds.
+- Preserve the AGENTS.md compliance checklist and rule checks below."""
 tier = "tier-2-standard"
 on_fail = "abort"
 


### PR DESCRIPTION
## Summary
- Give Security Audit and Pre-Commit Review steps real CSA prompts instead of empty strings
- Fix self-referential parent_session_id in plan-step CSA dispatch: nested steps now allocate fresh child session IDs
- Add regression test in plan_cmd_tests_commit.rs

## Test plan
- [x] `just pre-commit` passes
- [x] New regression test verifies non-empty prompts and fresh child sessions
- [x] Review completed (MEDIUM finding filed as #710)

Closes #677, closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)