### PR TITLE
fix(sandbox): add gh-aider read-only bind, fix gemini runtime dir (#668, #676, #704)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "chrono",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "chrono",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "axum",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "chrono",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.275"
+version = "0.1.276"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.275"
+version = "0.1.276"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -11,6 +11,8 @@ use tracing::{debug, warn};
 
 const GEMINI_RUNTIME_ROOT_DIR: &str = "cli-sub-agent-gemini";
 const GEMINI_SESSION_RUNTIME_RELATIVE_PATH: &str = "runtime/gemini-home";
+const CSA_FS_SANDBOXED_ENV: &str = "CSA_FS_SANDBOXED";
+const CSA_SESSION_DIR_ENV: &str = "CSA_SESSION_DIR";
 const GEMINI_RUNTIME_SETTINGS_PATHS: &[&str] =
     &[".gemini/settings.json", ".config/gemini-cli/settings.json"];
 const GEMINI_RUNTIME_PINNED_PATH_BINARIES: &[&str] = &["node", "yarn", "gemini"];
@@ -50,8 +52,11 @@ pub(crate) fn prepare_gemini_acp_runtime(
         .cloned()
         .or_else(|| std::env::var("HOME").ok())
         .map(PathBuf::from);
+    let runtime_session_dir = session_dir
+        .map(Path::to_path_buf)
+        .or_else(|| runtime_session_dir_from_env(env));
     let tmpdir = normalize_tmpdir_env(env);
-    let runtime_home = resolve_runtime_home(session_dir, session_id, &tmpdir);
+    let runtime_home = resolve_runtime_home(runtime_session_dir.as_deref(), session_id, &tmpdir);
     seed_runtime_home(&runtime_home, source_home.as_deref())?;
     align_runtime_auth_selection(&runtime_home, env)?;
 
@@ -159,6 +164,15 @@ fn resolve_runtime_home(session_dir: Option<&Path>, session_id: &str, tmpdir: &P
 }
 
 fn normalize_tmpdir_env(env: &mut HashMap<String, String>) -> PathBuf {
+    if is_filesystem_sandboxed(env) {
+        let resolved = PathBuf::from(DEFAULT_SANDBOX_TMPDIR);
+        env.insert(
+            "TMPDIR".to_string(),
+            resolved.to_string_lossy().into_owned(),
+        );
+        return resolved;
+    }
+
     let candidate = env
         .get("TMPDIR")
         .filter(|value| !value.is_empty())
@@ -183,6 +197,17 @@ fn normalize_tmpdir_env(env: &mut HashMap<String, String>) -> PathBuf {
         resolved.to_string_lossy().into_owned(),
     );
     resolved
+}
+
+fn runtime_session_dir_from_env(env: &HashMap<String, String>) -> Option<PathBuf> {
+    env.get(CSA_SESSION_DIR_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn is_filesystem_sandboxed(env: &HashMap<String, String>) -> bool {
+    env.get(CSA_FS_SANDBOXED_ENV)
+        .is_some_and(|value| value == "1")
 }
 
 fn runtime_root_from_env(env: &HashMap<String, String>) -> PathBuf {

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -249,6 +249,41 @@ fn prepare_gemini_acp_runtime_prefers_session_dir_runtime_home() {
 }
 
 #[test]
+fn prepare_gemini_acp_runtime_uses_csa_session_dir_env_when_explicit_dir_is_missing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_dir = temp.path().join("sessions").join("01TESTSESSIONENV");
+    let source_home = temp.path().join("source-home");
+    fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "CSA_SESSION_DIR".to_string(),
+        session_dir.to_string_lossy().into_owned(),
+    );
+
+    prepare_gemini_acp_runtime(
+        &mut env,
+        None,
+        None,
+        "01TESTSESSIONENV",
+        &["--acp".to_string()],
+    )
+    .expect("prepare runtime");
+
+    let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
+    assert_eq!(
+        runtime_home,
+        session_dir.join(GEMINI_SESSION_RUNTIME_RELATIVE_PATH),
+        "runtime home should fall back to CSA_SESSION_DIR when the caller did not pass session_dir"
+    );
+}
+
+#[test]
 fn prepare_gemini_acp_runtime_falls_back_from_read_only_tmpdir() {
     let temp = tempfile::tempdir().expect("tempdir");
     let session_id = "01TESTGEMINITMPDIRFALLBACK00000001";
@@ -289,6 +324,37 @@ fn prepare_gemini_acp_runtime_falls_back_from_read_only_tmpdir() {
     let mut reset_perms = fs::metadata(&read_only_tmp).expect("metadata").permissions();
     reset_perms.set_mode(0o755);
     fs::set_permissions(&read_only_tmp, reset_perms).expect("chmod restore tmpdir");
+}
+
+#[test]
+fn prepare_gemini_acp_runtime_forces_private_tmpdir_when_sandboxed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = "01TESTGEMINISANDBOXTMP000000001";
+    let source_home = temp.path().join("source-home");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert("TMPDIR".to_string(), "/home/obj/.claude/tmp".to_string());
+    env.insert("CSA_FS_SANDBOXED".to_string(), "1".to_string());
+
+    prepare_gemini_acp_runtime(&mut env, None, None, session_id, &["--acp".to_string()])
+        .expect("prepare runtime");
+
+    assert_eq!(
+        env.get("TMPDIR"),
+        Some(&csa_resource::isolation_plan::DEFAULT_SANDBOX_TMPDIR.to_string()),
+        "sandboxed Gemini runtime should ignore inherited temp homes and use the private sandbox /tmp"
+    );
+    let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
+    assert!(
+        runtime_home.starts_with(csa_resource::isolation_plan::DEFAULT_SANDBOX_TMPDIR),
+        "sandboxed runtime home should live under the private sandbox /tmp, got: {}",
+        runtime_home.display()
+    );
 }
 
 #[test]

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -100,6 +100,9 @@ pub(super) fn gemini_sandbox_runtime_env_overrides(
     for key in [
         "HOME",
         "PATH",
+        // NOTE: Do NOT include "TMPDIR" here — the isolation plan already
+        // sets TMPDIR=/tmp for bwrap sessions. Overriding it with the host's
+        // TMPDIR would leak a read-only path into the sandbox (#704 review).
         "GEMINI_CLI_HOME",
         "XDG_CONFIG_HOME",
         "XDG_CACHE_HOME",

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -126,6 +126,9 @@ impl AcpTransport {
         // recursion risk (e.g. claude-code reading CLAUDE.md rules that say
         // "use csa review"). See GitHub issue #272.
         env.insert("CSA_IS_SUBPROCESS".to_string(), "1".to_string());
+        if std::env::var("CSA_FS_SANDBOXED").ok().as_deref() == Some("1") {
+            env.insert("CSA_FS_SANDBOXED".to_string(), "1".to_string());
+        }
         if let Ok(parent_tool) = std::env::var("CSA_TOOL") {
             env.insert("CSA_PARENT_TOOL".to_string(), parent_tool);
         }

--- a/crates/csa-executor/src/transport_tests_gemini_fallback.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_fallback.rs
@@ -561,6 +561,7 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
     let runtime_home = "/tmp/cli-sub-agent-gemini/01TEST/runtime-home";
     let mut env = HashMap::new();
     env.insert("HOME".to_string(), runtime_home.to_string());
+    env.insert("TMPDIR".to_string(), "/tmp".to_string());
     env.insert(
         "PATH".to_string(),
         "/runtime/node/bin:/runtime/yarn/bin:/usr/local/bin".to_string(),
@@ -613,6 +614,15 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
     assert_eq!(
         isolation_plan.env_overrides.get("HOME"),
         Some(&runtime_home.to_string())
+    );
+    // TMPDIR is set by IsolationPlanBuilder::with_tool_defaults(), not by
+    // gemini sandbox overrides (which must NOT override it — see #704 review).
+    // The isolation plan fixture doesn't call with_tool_defaults(), so TMPDIR
+    // won't be present here. Verify gemini overrides did NOT inject a host TMPDIR.
+    assert!(
+        !isolation_plan.env_overrides.contains_key("TMPDIR")
+            || isolation_plan.env_overrides.get("TMPDIR") == Some(&"/tmp".to_string()),
+        "gemini sandbox overrides must not override TMPDIR (isolation plan owns it)"
     );
     assert_eq!(
         isolation_plan.env_overrides.get("GEMINI_CLI_HOME"),

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -64,6 +64,10 @@ impl BwrapCommandBuilder {
 
     /// Consume the builder and produce a ready-to-spawn [`Command`].
     pub fn build(&self) -> Command {
+        self.build_with_home(std::env::var_os("HOME").as_deref().map(Path::new))
+    }
+
+    fn build_with_home(&self, home: Option<&Path>) -> Command {
         let mut cmd = Command::new("bwrap");
 
         // Read-only root filesystem
@@ -109,7 +113,12 @@ impl BwrapCommandBuilder {
         }
 
         // Extra read-only bind mounts
-        for (src, dest) in &self.ro_binds {
+        for (src, dest) in self
+            .ro_binds
+            .iter()
+            .cloned()
+            .chain(self.implicit_ro_binds(home))
+        {
             cmd.args(["--ro-bind", &src.to_string_lossy(), &dest.to_string_lossy()]);
         }
 
@@ -132,6 +141,27 @@ impl BwrapCommandBuilder {
         cmd.args(&self.tool_args);
 
         cmd
+    }
+
+    fn implicit_ro_binds(&self, home: Option<&Path>) -> impl Iterator<Item = (PathBuf, PathBuf)> {
+        let mut ro_binds = Vec::new();
+
+        if let Some(home) = home {
+            let gh_aider = home.join(".config/gh-aider");
+            let already_visible = self
+                .writable_paths
+                .iter()
+                .any(|existing| existing == &gh_aider || gh_aider.starts_with(existing))
+                || self
+                    .ro_binds
+                    .iter()
+                    .any(|(src, dest)| src == &gh_aider || dest == &gh_aider);
+            if gh_aider.exists() && !already_visible {
+                ro_binds.push((gh_aider.clone(), gh_aider));
+            }
+        }
+
+        ro_binds.into_iter()
     }
 }
 
@@ -545,6 +575,26 @@ mod tests {
         assert!(
             !has_bind_tmp,
             "bare /tmp must NOT be --bind mounted (would expose host /tmp); args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn test_bwrap_auto_ro_binds_gh_aider_config_when_present() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let gh_aider = home.path().join(".config/gh-aider");
+        std::fs::create_dir_all(&gh_aider).expect("create gh-aider dir");
+
+        let builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+        let cmd = builder.build_with_home(Some(home.path()));
+        let args = command_args(&cmd);
+
+        assert!(
+            args.windows(3).any(|window| {
+                window[0] == "--ro-bind"
+                    && window[1] == gh_aider.to_string_lossy()
+                    && window[2] == gh_aider.to_string_lossy()
+            }),
+            "~/.config/gh-aider should be explicitly re-bound read-only so sandboxed gh commands can still read the aider auth config; args: {args:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add explicit `--ro-bind` for `~/.config/gh-aider` in bwrap sandbox (#668)
- Fix gemini ACP runtime dir: prefer session-owned dir, fall back to /tmp in sandbox (#676)
- Propagate `CSA_FS_SANDBOXED` for reliable nested sandbox detection (#704)
- Remove TMPDIR from gemini sandbox overrides (isolation plan owns it)

## Test plan
- [x] `just pre-commit` passes
- [x] Regression tests for bwrap mount and gemini runtime dir
- [x] Review completed twice — HIGH TMPDIR finding fixed, MEDIUMs filed as #712

Closes #668, closes #676, closes #704, closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)