### PR TITLE
fix(multi): batch F P0 — bug-class, config, ACP redaction, sandbox, test lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "chrono",
@@ -733,6 +733,7 @@ dependencies = [
  "directories",
  "libc",
  "serde",
+ "serial_test",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
@@ -741,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -756,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "chrono",
@@ -770,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -796,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "chrono",
@@ -813,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "axum",
@@ -848,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -866,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -901,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "chrono",
@@ -919,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4407,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.277"
+version = "0.1.278"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.277"
+version = "0.1.278"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -315,7 +315,14 @@ pub(crate) fn handle_config_get(
         global_only_lookup,
     )?;
 
-    if let Some(value) = resolve_lookup_sources(&lookup.sources, &key)? {
+    let resolved = resolve_lookup_sources_with_diagnostics(&lookup.sources, &key)?;
+    if let Some(value) = resolved.value {
+        if resolved
+            .diagnostics
+            .raw_global_value_from_invalid_effective_global
+        {
+            eprintln!("warning: global config has parse errors; showing raw value");
+        }
         println!("{}", format_toml_value(&value));
         return Ok(());
     }
@@ -338,6 +345,17 @@ pub(crate) fn handle_config_get(
 
 struct ConfigGetLookup {
     sources: Vec<LookupSourceSpec>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct LookupDiagnostics {
+    raw_global_value_from_invalid_effective_global: bool,
+}
+
+#[derive(Debug)]
+struct LookupResolution {
+    value: Option<toml::Value>,
+    diagnostics: LookupDiagnostics,
 }
 
 fn is_global_only_key(key: &str) -> bool {
@@ -479,20 +497,44 @@ fn resolve_effective_key(
     resolve_lookup_sources(&lookup.sources, key)
 }
 
+#[cfg(test)]
 fn resolve_lookup_sources(sources: &[LookupSourceSpec], key: &str) -> Result<Option<toml::Value>> {
+    Ok(resolve_lookup_sources_with_diagnostics(sources, key)?.value)
+}
+
+fn resolve_lookup_sources_with_diagnostics(
+    sources: &[LookupSourceSpec],
+    key: &str,
+) -> Result<LookupResolution> {
     let mut deferred_error = None;
+    let mut saw_deferred_effective_global_error = false;
 
     for source in sources {
         match load_lookup_root(source) {
             Ok(Some(root)) => {
                 if let Some(value) = resolve_key(&root, key) {
-                    return Ok(Some(value));
+                    return Ok(LookupResolution {
+                        value: Some(value),
+                        diagnostics: LookupDiagnostics {
+                            raw_global_value_from_invalid_effective_global:
+                                saw_deferred_effective_global_error
+                                    && matches!(source, LookupSourceSpec::RawGlobal { .. }),
+                        },
+                    });
                 }
             }
             Ok(None) => {}
             Err(err) if source.allows_deferred_error() => {
                 // Effective project lookups can fail because global config is broken.
                 // Keep going so an explicit raw project value can still be resolved.
+                if matches!(
+                    source,
+                    LookupSourceSpec::EffectiveGlobal {
+                        allow_raw_fallback: true
+                    }
+                ) {
+                    saw_deferred_effective_global_error = true;
+                }
                 deferred_error.get_or_insert(err);
             }
             Err(err) => return Err(err),
@@ -503,7 +545,10 @@ fn resolve_lookup_sources(sources: &[LookupSourceSpec], key: &str) -> Result<Opt
         return Err(err);
     }
 
-    Ok(None)
+    Ok(LookupResolution {
+        value: None,
+        diagnostics: LookupDiagnostics::default(),
+    })
 }
 
 fn collect_lookup_keys(sources: &[LookupSourceSpec]) -> Result<BTreeSet<String>> {

--- a/crates/cli-sub-agent/src/review_cmd_bug_class.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class.rs
@@ -129,6 +129,13 @@ fn collapse_bug_class_review_artifacts(
     let mut grouped = BTreeMap::<ReviewArtifactGroupKey, Vec<GroupedReviewArtifact>>::new();
 
     for artifact in review_artifacts {
+        // Parent review-consolidated.json duplicates the child reviewer findings but
+        // does not carry review_meta.json, so including it here can falsely satisfy
+        // the recurrence threshold for a single multi-review execution.
+        if session_has_consolidated_artifact(project_root, &artifact.session_id)? {
+            continue;
+        }
+
         let Some(group_key) =
             resolve_review_artifact_group_key(project_root, &artifact.session_id)?
         else {

--- a/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
@@ -29,8 +29,12 @@ fn sample_review_artifact(session_id: &str, severity: Severity, rule_id: &str) -
 }
 
 fn write_review_artifact(session_dir: &Path, artifact: &ReviewArtifact) {
+    write_review_artifact_file(session_dir, "review-findings.json", artifact);
+}
+
+fn write_review_artifact_file(session_dir: &Path, file_name: &str, artifact: &ReviewArtifact) {
     let payload = serde_json::to_string_pretty(artifact).unwrap();
-    std::fs::write(session_dir.join("review-findings.json"), payload).unwrap();
+    std::fs::write(session_dir.join(file_name), payload).unwrap();
 }
 
 #[test]
@@ -302,5 +306,90 @@ fn bug_class_loader_collapses_multi_reviewer_sessions_into_one_logical_review() 
     assert!(
         classify_recurring_bug_classes(&review_artifacts).is_empty(),
         "one logical review should not satisfy the recurrence threshold by itself"
+    );
+}
+
+#[test]
+fn bug_class_loader_skips_parent_consolidated_artifact_to_avoid_false_promotion() {
+    let project_dir = setup_git_repo();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+
+    let parent = create_session(
+        project_dir.path(),
+        Some("review: base:main"),
+        None,
+        Some("codex"),
+    )
+    .expect("parent review session");
+    let reviewer_one = create_session(
+        project_dir.path(),
+        Some("review[1]: base:main"),
+        None,
+        Some("codex"),
+    )
+    .expect("reviewer one session");
+    let reviewer_two = create_session(
+        project_dir.path(),
+        Some("review[2]: base:main"),
+        None,
+        Some("opencode"),
+    )
+    .expect("reviewer two session");
+
+    let parent_dir = get_session_dir(project_dir.path(), &parent.meta_session_id).unwrap();
+    let reviewer_one_dir =
+        get_session_dir(project_dir.path(), &reviewer_one.meta_session_id).unwrap();
+    let reviewer_two_dir =
+        get_session_dir(project_dir.path(), &reviewer_two.meta_session_id).unwrap();
+
+    write_review_artifact_file(
+        &parent_dir,
+        "review-consolidated.json",
+        &sample_review_artifact(&parent.meta_session_id, Severity::High, "rust/002"),
+    );
+    write_review_artifact(
+        &reviewer_one_dir,
+        &sample_review_artifact(&reviewer_one.meta_session_id, Severity::High, "rust/002"),
+    );
+    write_review_artifact(
+        &reviewer_two_dir,
+        &sample_review_artifact(&reviewer_two.meta_session_id, Severity::High, "rust/002"),
+    );
+
+    for session in [&reviewer_one, &reviewer_two] {
+        let session_dir = get_session_dir(project_dir.path(), &session.meta_session_id).unwrap();
+        write_review_meta(
+            &session_dir,
+            &ReviewSessionMeta {
+                session_id: session.meta_session_id.clone(),
+                head_sha: "deadbeef".to_string(),
+                decision: "fail".to_string(),
+                verdict: "HAS_ISSUES".to_string(),
+                tool: "codex".to_string(),
+                scope: "base:main".to_string(),
+                exit_code: 1,
+                fix_attempted: false,
+                fix_rounds: 0,
+                review_iterations: 7,
+                timestamp: chrono::Utc::now(),
+                diff_fingerprint: Some("sha256:shared".to_string()),
+            },
+        )
+        .expect("review meta");
+    }
+
+    let review_artifacts = load_bug_class_review_artifacts(project_dir.path())
+        .expect("multi-reviewer artifacts should collapse");
+
+    assert_eq!(review_artifacts.len(), 1);
+    assert!(
+        review_artifacts
+            .iter()
+            .all(|artifact| artifact.session_id != parent.meta_session_id),
+        "parent consolidated artifact should be skipped for bug-class extraction"
+    );
+    assert!(
+        classify_recurring_bug_classes(&review_artifacts).is_empty(),
+        "one multi-review run must not self-promote a recurring bug class"
     );
 }

--- a/crates/cli-sub-agent/tests/config_get_global_warning_e2e.rs
+++ b/crates/cli-sub-agent/tests/config_get_global_warning_e2e.rs
@@ -1,0 +1,47 @@
+use std::path::Path;
+use std::process::Command;
+
+fn csa_cmd(tmp: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"));
+    cmd
+}
+
+#[test]
+fn config_get_global_warns_when_falling_back_to_raw_invalid_global_config() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let global_dir = tmp.path().join(".config/cli-sub-agent");
+    std::fs::create_dir_all(&global_dir).expect("create global config dir");
+    std::fs::write(
+        global_dir.join("config.toml"),
+        r#"
+[review]
+tool = "auto"
+
+[defaults]
+max_concurrent = "bad"
+"#,
+    )
+    .expect("write global config");
+
+    let output = csa_cmd(tmp.path())
+        .args(["config", "get", "review.tool", "--global"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("run csa config get");
+
+    assert!(
+        output.status.success(),
+        "config get should still succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "auto");
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("warning: global config has parse errors; showing raw value"),
+        "stderr should surface the raw-value fallback warning, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/csa-config/Cargo.toml
+++ b/crates/csa-config/Cargo.toml
@@ -18,3 +18,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+serial_test = "3.4"

--- a/crates/csa-config/src/config_merge_tests.rs
+++ b/crates/csa-config/src/config_merge_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serial_test::serial;
 use tempfile::tempdir;
 
 struct EnvVarGuard {
@@ -180,6 +181,7 @@ fn test_merged_schema_version_uses_max_when_explicit() {
 }
 
 #[test]
+#[serial]
 fn test_user_config_path_returns_some() {
     let dir = tempdir().unwrap();
     let _config_home = EnvVarGuard::set("XDG_CONFIG_HOME", dir.path());
@@ -203,6 +205,7 @@ fn test_user_config_template_is_valid() {
 }
 
 #[test]
+#[serial]
 fn test_user_config_path_matches_global_config_dir() {
     let dir = tempdir().unwrap();
     let _config_home = EnvVarGuard::set("XDG_CONFIG_HOME", dir.path());

--- a/crates/csa-config/src/global_tests.rs
+++ b/crates/csa-config/src/global_tests.rs
@@ -3,6 +3,7 @@ use csa_core::gemini::{
     API_KEY_ENV, API_KEY_FALLBACK_ENV_KEY, AUTH_MODE_ENV_KEY, AUTH_MODE_OAUTH,
     NO_FLASH_FALLBACK_ENV_KEY,
 };
+use serial_test::serial;
 use std::collections::HashMap;
 
 struct EnvVarGuard {
@@ -153,6 +154,7 @@ frequent_poll_seconds = 45
 }
 
 #[test]
+#[serial]
 fn test_resolve_session_wait_long_poll_seconds_uses_legacy_config_dir_fallback() {
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");

--- a/crates/csa-executor/src/transport_acp_payload_debug.rs
+++ b/crates/csa-executor/src/transport_acp_payload_debug.rs
@@ -140,6 +140,14 @@ fn redact_args(args: &[String]) -> Vec<String> {
             continue;
         }
 
+        // Attached header form: `-HCookie: session=abc` — the header value
+        // is glued onto the flag without a space.  Redact the entire arg
+        // (consistent with --header redacting all following values).
+        if arg.starts_with("-H") && arg.len() > 2 {
+            redacted.push("<redacted>".to_string());
+            continue;
+        }
+
         if arg.starts_with('-') && arg_name_is_sensitive(arg) {
             redacted.push(arg.clone());
             redact_next = true;
@@ -280,6 +288,24 @@ mod tests {
                 "<redacted>".to_string(),
                 "--verbose".to_string(),
                 "-H".to_string(),
+                "<redacted>".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn redact_args_redacts_attached_header_flag_form() {
+        // -H<value> (no space) should be redacted entirely, same as --header
+        let args = vec![
+            "-HCookie: session=abc".to_string(),
+            "--next".to_string(),
+            "-HPrivate-Token: secret".to_string(),
+        ];
+        assert_eq!(
+            redact_args(&args),
+            vec![
+                "<redacted>".to_string(),
+                "--next".to_string(),
                 "<redacted>".to_string(),
             ]
         );

--- a/crates/csa-executor/src/transport_acp_payload_debug.rs
+++ b/crates/csa-executor/src/transport_acp_payload_debug.rs
@@ -61,6 +61,10 @@ fn redact_env_value(value: &mut Value) {
     }
 }
 
+/// Short-form flags whose following argument is an HTTP header value and must
+/// be checked for embedded credentials (e.g. `-H 'Authorization: Bearer ...'`).
+const HEADER_SHORT_FLAGS: &[&str] = &["-h"];
+
 fn arg_name_is_sensitive(value: &str) -> bool {
     let normalized = value.trim().to_ascii_lowercase();
     [
@@ -79,16 +83,28 @@ fn arg_name_is_sensitive(value: &str) -> bool {
     .any(|needle| normalized.contains(needle))
 }
 
+/// Returns `true` when `flag` is a short alias for a header flag (e.g. `-H`).
+fn is_header_short_flag(flag: &str) -> bool {
+    let normalized = flag.trim().to_ascii_lowercase();
+    HEADER_SHORT_FLAGS.contains(&normalized.as_str())
+}
+
 fn arg_value_is_sensitive(value: &str) -> bool {
     let normalized = value.trim().to_ascii_lowercase();
     normalized.contains("authorization:")
         || normalized.contains("bearer ")
         || normalized.contains("token=")
+        || normalized.contains("token:")
         || normalized.contains("api-key=")
+        || normalized.contains("api-key:")
         || normalized.contains("api_key=")
+        || normalized.contains("api_key:")
         || normalized.contains("apikey=")
+        || normalized.contains("apikey:")
         || normalized.contains("secret=")
+        || normalized.contains("secret:")
         || normalized.contains("password=")
+        || normalized.contains("password:")
 }
 
 fn arg_has_inline_sensitive_value(value: &str) -> bool {
@@ -122,6 +138,14 @@ fn redact_args(args: &[String]) -> Vec<String> {
         }
 
         if arg.starts_with('-') && arg_name_is_sensitive(arg) {
+            redacted.push(arg.clone());
+            redact_next = true;
+            continue;
+        }
+
+        // Short header flags like `-H` take the next arg as an HTTP header
+        // value that may embed credentials (e.g. `-H 'x-api-key: secret'`).
+        if is_header_short_flag(arg) {
             redacted.push(arg.clone());
             redact_next = true;
             continue;
@@ -231,6 +255,28 @@ mod tests {
                 "--api-key=<redacted>".to_string(),
                 "--api_key=<redacted>".to_string(),
                 "--header".to_string(),
+                "<redacted>".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn redact_args_redacts_short_header_flag_values() {
+        let args = vec![
+            "-H".to_string(),
+            "x-api-key: secret".to_string(),
+            "--verbose".to_string(),
+            "-H".to_string(),
+            "Content-Type: application/json".to_string(),
+        ];
+
+        assert_eq!(
+            redact_args(&args),
+            vec![
+                "-H".to_string(),
+                "<redacted>".to_string(),
+                "--verbose".to_string(),
+                "-H".to_string(),
                 "<redacted>".to_string(),
             ]
         );

--- a/crates/csa-executor/src/transport_acp_payload_debug.rs
+++ b/crates/csa-executor/src/transport_acp_payload_debug.rs
@@ -65,6 +65,7 @@ fn arg_name_is_sensitive(value: &str) -> bool {
     let normalized = value.trim().to_ascii_lowercase();
     [
         "api-key",
+        "api_key",
         "apikey",
         "auth",
         "authorization",
@@ -84,9 +85,17 @@ fn arg_value_is_sensitive(value: &str) -> bool {
         || normalized.contains("bearer ")
         || normalized.contains("token=")
         || normalized.contains("api-key=")
+        || normalized.contains("api_key=")
         || normalized.contains("apikey=")
         || normalized.contains("secret=")
         || normalized.contains("password=")
+}
+
+fn arg_has_inline_sensitive_value(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    normalized.starts_with('-')
+        && arg_name_is_sensitive(&normalized)
+        && (normalized.contains('=') || normalized.contains(':'))
 }
 
 fn redact_args(args: &[String]) -> Vec<String> {
@@ -104,6 +113,11 @@ fn redact_args(args: &[String]) -> Vec<String> {
             && arg_name_is_sensitive(name)
         {
             redacted.push(format!("{name}=<redacted>"));
+            continue;
+        }
+
+        if arg_has_inline_sensitive_value(arg) {
+            redacted.push("<redacted>".to_string());
             continue;
         }
 
@@ -192,4 +206,33 @@ pub(super) fn maybe_write_acp_payload_debug(
     let serialized = serde_json::to_string_pretty(&payload).ok()?;
     fs::write(&debug_path, format!("{serialized}\n")).ok()?;
     Some(debug_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_args;
+
+    #[test]
+    fn redact_args_redacts_inline_sensitive_values_without_consuming_following_args() {
+        let args = vec![
+            "-HAuthorization:Bearer abc123".to_string(),
+            "--safe".to_string(),
+            "--api-key=value-1".to_string(),
+            "--api_key=value-2".to_string(),
+            "--header".to_string(),
+            "Authorization: Bearer xyz987".to_string(),
+        ];
+
+        assert_eq!(
+            redact_args(&args),
+            vec![
+                "<redacted>".to_string(),
+                "--safe".to_string(),
+                "--api-key=<redacted>".to_string(),
+                "--api_key=<redacted>".to_string(),
+                "--header".to_string(),
+                "<redacted>".to_string(),
+            ]
+        );
+    }
 }

--- a/crates/csa-executor/src/transport_acp_payload_debug.rs
+++ b/crates/csa-executor/src/transport_acp_payload_debug.rs
@@ -63,7 +63,9 @@ fn redact_env_value(value: &mut Value) {
 
 /// Short-form flags whose following argument is an HTTP header value and must
 /// be checked for embedded credentials (e.g. `-H 'Authorization: Bearer ...'`).
-const HEADER_SHORT_FLAGS: &[&str] = &["-h"];
+/// Stored in ORIGINAL case — comparison is case-sensitive because `-h` (help)
+/// and `-H` (header) are different flags.
+const HEADER_SHORT_FLAGS: &[&str] = &["-H"];
 
 fn arg_name_is_sensitive(value: &str) -> bool {
     let normalized = value.trim().to_ascii_lowercase();
@@ -84,9 +86,10 @@ fn arg_name_is_sensitive(value: &str) -> bool {
 }
 
 /// Returns `true` when `flag` is a short alias for a header flag (e.g. `-H`).
+/// Case-sensitive: `-h` (help) must NOT match.
 fn is_header_short_flag(flag: &str) -> bool {
-    let normalized = flag.trim().to_ascii_lowercase();
-    HEADER_SHORT_FLAGS.contains(&normalized.as_str())
+    let trimmed = flag.trim();
+    HEADER_SHORT_FLAGS.contains(&trimmed)
 }
 
 fn arg_value_is_sensitive(value: &str) -> bool {
@@ -279,6 +282,16 @@ mod tests {
                 "-H".to_string(),
                 "<redacted>".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn redact_args_does_not_treat_lowercase_h_as_header_flag() {
+        // -h is typically "help", not "header" — must NOT arm redact_next
+        let args = vec!["-h".to_string(), "some-value".to_string()];
+        assert_eq!(
+            redact_args(&args),
+            vec!["-h".to_string(), "some-value".to_string()]
         );
     }
 }

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -14,6 +14,7 @@ use csa_session::state::MetaSessionState;
 use super::AcpTransport;
 
 const SUMMARY_MAX_CHARS: usize = 200;
+const CSA_FS_SANDBOXED_ENV: &str = "CSA_FS_SANDBOXED";
 
 /// Default soft memory limit as a percentage of MemoryMax.
 /// Lowered from 80% to 70% in #568 to provide more headroom before the
@@ -126,9 +127,6 @@ impl AcpTransport {
         // recursion risk (e.g. claude-code reading CLAUDE.md rules that say
         // "use csa review"). See GitHub issue #272.
         env.insert("CSA_IS_SUBPROCESS".to_string(), "1".to_string());
-        if std::env::var("CSA_FS_SANDBOXED").ok().as_deref() == Some("1") {
-            env.insert("CSA_FS_SANDBOXED".to_string(), "1".to_string());
-        }
         if let Ok(parent_tool) = std::env::var("CSA_TOOL") {
             env.insert("CSA_PARENT_TOOL".to_string(), parent_tool);
         }
@@ -137,7 +135,15 @@ impl AcpTransport {
         }
 
         if let Some(extra) = extra_env {
-            env.extend(extra.iter().map(|(k, v)| (k.clone(), v.clone())));
+            env.extend(
+                extra
+                    .iter()
+                    .filter(|(k, _)| k.as_str() != CSA_FS_SANDBOXED_ENV)
+                    .map(|(k, v)| (k.clone(), v.clone())),
+            );
+        }
+        if std::env::var(CSA_FS_SANDBOXED_ENV).ok().as_deref() == Some("1") {
+            env.insert(CSA_FS_SANDBOXED_ENV.to_string(), "1".to_string());
         }
         Self::insert_reserved_session_path_env(&mut env, session);
 
@@ -522,4 +528,112 @@ pub(super) fn start_memory_monitor(
         interval: std::time::Duration::from_secs(interval_secs),
         grace_period,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static SANDBOX_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation guarded by SANDBOX_ENV_LOCK.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation guarded by SANDBOX_ENV_LOCK.
+            unsafe { std::env::remove_var(key) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            // SAFETY: test-scoped env mutation guarded by SANDBOX_ENV_LOCK.
+            unsafe {
+                match self.original.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    fn sample_session() -> MetaSessionState {
+        let now = chrono::Utc::now();
+        MetaSessionState {
+            meta_session_id: "01HTEST000000000000000000".to_string(),
+            description: Some("test".to_string()),
+            project_path: "/tmp/test".to_string(),
+            branch: None,
+            created_at: now,
+            last_accessed: now,
+            genealogy: csa_session::state::Genealogy {
+                parent_session_id: None,
+                depth: 0,
+                ..Default::default()
+            },
+            tools: HashMap::new(),
+            context_status: csa_session::state::ContextStatus::default(),
+            total_token_usage: None,
+            phase: csa_session::state::SessionPhase::Active,
+            task_context: csa_session::state::TaskContext::default(),
+            turn_count: 0,
+            token_budget: None,
+            sandbox_info: None,
+            termination_reason: None,
+            is_seed_candidate: false,
+            git_head_at_creation: None,
+            last_return_packet: None,
+            change_id: None,
+            spec_id: None,
+            fork_call_timestamps: Vec::new(),
+            vcs_identity: None,
+            identity_version: 1,
+        }
+    }
+
+    #[test]
+    fn build_env_ignores_spoofed_sandbox_marker_from_extra_env() {
+        let _env_lock = SANDBOX_ENV_LOCK.lock().expect("sandbox env lock poisoned");
+        let _sandbox_guard = ScopedEnvVar::unset(CSA_FS_SANDBOXED_ENV);
+        let transport = AcpTransport::new("claude-code", None);
+        let session = sample_session();
+        let extra = HashMap::from([(CSA_FS_SANDBOXED_ENV.to_string(), "1".to_string())]);
+
+        let env = transport.build_env(&session, Some(&extra));
+
+        assert!(
+            !env.contains_key(CSA_FS_SANDBOXED_ENV),
+            "user extra_env must not be able to spoof CSA_FS_SANDBOXED"
+        );
+    }
+
+    #[test]
+    fn build_env_preserves_system_sandbox_marker_over_extra_env() {
+        let _env_lock = SANDBOX_ENV_LOCK.lock().expect("sandbox env lock poisoned");
+        let _sandbox_guard = ScopedEnvVar::set(CSA_FS_SANDBOXED_ENV, "1");
+        let transport = AcpTransport::new("claude-code", None);
+        let session = sample_session();
+        let extra = HashMap::from([(CSA_FS_SANDBOXED_ENV.to_string(), "0".to_string())]);
+
+        let env = transport.build_env(&session, Some(&extra));
+
+        assert_eq!(
+            env.get(CSA_FS_SANDBOXED_ENV).map(String::as_str),
+            Some("1"),
+            "the process sandbox marker must override user extra_env"
+        );
+    }
 }

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -112,13 +112,21 @@ impl BwrapCommandBuilder {
             }
         }
 
-        // Extra read-only bind mounts
+        // Extra read-only bind mounts.  When the dest path differs from src
+        // (remapped HOME), the mount target may not exist inside the sandbox
+        // (e.g. Gemini runtime home only seeds gemini-cli config, not gh-aider).
+        // Emit --dir for the dest parent so bubblewrap can create the mount point.
         for (src, dest) in self
             .ro_binds
             .iter()
             .cloned()
             .chain(self.implicit_ro_binds(home))
         {
+            if src != dest
+                && let Some(parent) = dest.parent()
+            {
+                cmd.args(["--dir", &parent.to_string_lossy()]);
+            }
             cmd.args(["--ro-bind", &src.to_string_lossy(), &dest.to_string_lossy()]);
         }
 
@@ -164,15 +172,18 @@ impl BwrapCommandBuilder {
                 .sandbox_home(Some(home))
                 .unwrap_or_else(|| home.to_path_buf())
                 .join(".config/gh-aider");
-            let already_visible = self.writable_paths.iter().any(|existing| {
-                existing == &gh_aider
-                    || existing == &sandbox_gh_aider
-                    || gh_aider.starts_with(existing)
-                    || sandbox_gh_aider.starts_with(existing)
-            }) || self
-                .ro_binds
+            // writable_paths are HOST paths — only compare against the HOST
+            // gh_aider path.  Comparing sandbox_gh_aider against host writable
+            // paths falsely matches when sandbox HOME is under a writable
+            // session dir (common in Gemini ACP).
+            let already_visible = self
+                .writable_paths
                 .iter()
-                .any(|(src, dest)| src == &gh_aider || dest == &sandbox_gh_aider);
+                .any(|existing| existing == &gh_aider || gh_aider.starts_with(existing))
+                || self
+                    .ro_binds
+                    .iter()
+                    .any(|(src, dest)| src == &gh_aider || dest == &sandbox_gh_aider);
             if gh_aider.exists() && !already_visible {
                 ro_binds.push((gh_aider, sandbox_gh_aider));
             }
@@ -383,6 +394,56 @@ mod tests {
         assert!(
             found_bind,
             "gh-aider config should bind from the host path into the sandbox HOME; args: {args:?}"
+        );
+
+        // --dir must precede the bind to create the mount target inside sandbox
+        let dir_pos = args
+            .iter()
+            .enumerate()
+            .find(|(_, a)| *a == "--dir" || a.as_str() == "/sandbox/runtime-home/.config")
+            .map(|(i, _)| i);
+        let bind_pos = args
+            .iter()
+            .enumerate()
+            .find(|(i, _)| {
+                args.get(*i + 1).map(|s| s.as_str()) == Some(&gh_aider.to_string_lossy())
+            })
+            .map(|(i, _)| i);
+        if let (Some(d), Some(b)) = (dir_pos, bind_pos) {
+            assert!(
+                d < b,
+                "--dir for mount target must precede --ro-bind; args: {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_bwrap_gh_aider_bind_not_skipped_when_session_dir_writable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let host_home = temp.path().join("host-home");
+        let gh_aider = host_home.join(".config/gh-aider");
+        std::fs::create_dir_all(&gh_aider).expect("create gh-aider config");
+
+        // Simulate Gemini layout: sandbox HOME is under a writable session dir
+        let session_dir = temp.path().join("session");
+        std::fs::create_dir_all(&session_dir).expect("create session dir");
+        let sandbox_home = session_dir.join("runtime/home");
+
+        let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+        builder.with_env("HOME", &sandbox_home.to_string_lossy());
+        builder.writable_paths.push(session_dir);
+        let cmd = builder.build_with_home(Some(&host_home));
+        let args = command_args(&cmd);
+
+        let found_bind = args.windows(3).any(|window| {
+            window[0] == "--ro-bind"
+                && window[1] == gh_aider.to_string_lossy()
+                && window[2] == sandbox_home.join(".config/gh-aider").to_string_lossy()
+        });
+
+        assert!(
+            found_bind,
+            "gh-aider bind must NOT be skipped just because sandbox HOME is under a writable session dir; args: {args:?}"
         );
     }
 

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -143,21 +143,38 @@ impl BwrapCommandBuilder {
         cmd
     }
 
+    fn sandbox_home(&self, host_home: Option<&Path>) -> Option<PathBuf> {
+        self.env_vars
+            .iter()
+            .rev()
+            .find_map(|(key, value)| {
+                (key == "HOME")
+                    .then(|| PathBuf::from(value))
+                    .filter(|path| path.is_absolute())
+            })
+            .or_else(|| host_home.map(Path::to_path_buf))
+    }
+
     fn implicit_ro_binds(&self, home: Option<&Path>) -> impl Iterator<Item = (PathBuf, PathBuf)> {
         let mut ro_binds = Vec::new();
 
         if let Some(home) = home {
             let gh_aider = home.join(".config/gh-aider");
-            let already_visible = self
-                .writable_paths
+            let sandbox_gh_aider = self
+                .sandbox_home(Some(home))
+                .unwrap_or_else(|| home.to_path_buf())
+                .join(".config/gh-aider");
+            let already_visible = self.writable_paths.iter().any(|existing| {
+                existing == &gh_aider
+                    || existing == &sandbox_gh_aider
+                    || gh_aider.starts_with(existing)
+                    || sandbox_gh_aider.starts_with(existing)
+            }) || self
+                .ro_binds
                 .iter()
-                .any(|existing| existing == &gh_aider || gh_aider.starts_with(existing))
-                || self
-                    .ro_binds
-                    .iter()
-                    .any(|(src, dest)| src == &gh_aider || dest == &gh_aider);
+                .any(|(src, dest)| src == &gh_aider || dest == &sandbox_gh_aider);
             if gh_aider.exists() && !already_visible {
-                ro_binds.push((gh_aider.clone(), gh_aider));
+                ro_binds.push((gh_aider, sandbox_gh_aider));
             }
         }
 
@@ -342,6 +359,30 @@ mod tests {
         assert!(
             found_sandbox_env,
             "CSA_FS_SANDBOXED=1 must be set via --setenv; args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn test_bwrap_gh_aider_bind_targets_overridden_sandbox_home() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let host_home = temp.path().join("host-home");
+        let gh_aider = host_home.join(".config/gh-aider");
+        std::fs::create_dir_all(&gh_aider).expect("create gh-aider config");
+
+        let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+        builder.with_env("HOME", "/sandbox/runtime-home");
+        let cmd = builder.build_with_home(Some(&host_home));
+        let args = command_args(&cmd);
+
+        let found_bind = args.windows(3).any(|window| {
+            window[0] == "--ro-bind"
+                && window[1] == gh_aider.to_string_lossy()
+                && window[2] == "/sandbox/runtime-home/.config/gh-aider"
+        });
+
+        assert!(
+            found_bind,
+            "gh-aider config should bind from the host path into the sandbox HOME; args: {args:?}"
         );
     }
 

--- a/scripts/hooks/check-env-dependent-tests.sh
+++ b/scripts/hooks/check-env-dependent-tests.sh
@@ -108,17 +108,33 @@ check_home_sensitive_asserts() {
             fi
         fi
 
-        # Extract the enclosing block (brace-balanced) starting at this line.
-        local line="" block="" open_only="" close_only="" depth=0
-        while IFS= read -r line; do
+        # Scan forward from the match. If we enter a brace-delimited block,
+        # keep scanning until it closes; otherwise inspect the next 5 lines.
+        local total_lines max_scan_line current_line="$line_number"
+        total_lines="$(wc -l < "$file")"
+        max_scan_line=$((line_number + 5))
+        if [ "$max_scan_line" -gt "$total_lines" ]; then
+            max_scan_line="$total_lines"
+        fi
+
+        local line="" block="" open_only="" close_only="" depth=0 found_open=false
+        while [ "$current_line" -le "$total_lines" ]; do
+            line="$(sed -n "${current_line}p" "$file")"
             block+="$line"$'\n'
             open_only="${line//[^\{]/}"
             close_only="${line//[^\}]/}"
+            if [ ${#open_only} -gt 0 ]; then
+                found_open=true
+            fi
             depth=$((depth + ${#open_only} - ${#close_only}))
-            if [ "$depth" -le 0 ]; then
+            if [ "$found_open" = true ] && [ "$depth" -le 0 ]; then
                 break
             fi
-        done < <(tail -n +"$line_number" "$file")
+            if [ "$found_open" = false ] && [ "$current_line" -ge "$max_scan_line" ]; then
+                break
+            fi
+            current_line=$((current_line + 1))
+        done
 
         # Must contain an assertion macro (any of assert!, assert_eq!, etc.)
         if ! printf '%s' "$block" | grep -Eq 'assert(_eq|_ne|_matches)?!'; then


### PR DESCRIPTION
## Summary

- **#720**: Skip parent consolidated artifacts in bug-class mining to prevent single multi-reviewer runs from falsely promoting recurring bug classes
- **#719**: Emit stderr warning when `config get --global` falls back to raw TOML after typed `GlobalConfig::load()` rejects the file
- **#682**: Redact inline/attached secret-bearing argv items in ACP debug artifacts (`-HAuthorization:Bearer...`, `-H 'x-api-key: secret'`, `--api-key=value`, `-HCookie: ...`)
- **#712**: Resolve gh-aider bwrap bind to absolute host path; filter `CSA_FS_SANDBOXED` from user `extra_env`; emit `--dir` for remapped ro_bind mount targets
- **#699**: Fix test lint scan-forward for braceless `home_dir()` matches; serialize env-mutating tests with `#[serial]`

## Review Findings Addressed

| Round | Severity | Fix |
|-------|----------|-----|
| 1 | HIGH: `-H 'x-api-key: secret'` leaked | Added `is_header_short_flag()` for `-H` |
| 2 | HIGH: bwrap visibility check mixed host/sandbox paths | Removed `sandbox_gh_aider` from writable_paths check |
| 2 | HIGH: bwrap mount target doesn't exist for remapped HOME | Added `--dir` for dest parent when src != dest |
| 3 | HIGH: `-h` (help) falsely treated as header flag | Case-sensitive comparison for `-H` |
| 4 | HIGH: `-HCookie: session=abc` leaked (attached form) | Added `starts_with("-H") && len > 2` check |

## Follow-up Issues Filed

- #722: `extra_env` can still spoof other CSA-owned env vars
- #723: bug-class consolidated-artifact skip may be too broad
- #724: config get warning doesn't trigger for mixed-scope fallback

## Test plan

- [x] `just pre-commit` passes on all 5 commits
- [x] `cargo test -p csa-executor redact_args` — 4 tests pass
- [x] `cargo test -p csa-resource bwrap` — 15 tests pass
- [x] `csa review --range main...HEAD` — only MEDIUM findings remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)