### PR TITLE
fix(multi): batch G — env spoof hardening, bug-class artifact filter, config warning scope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "chrono",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "chrono",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "axum",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "chrono",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "chrono",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "chrono",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.278"
+version = "0.1.279"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.278"
+version = "0.1.279"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -317,10 +317,7 @@ pub(crate) fn handle_config_get(
 
     let resolved = resolve_lookup_sources_with_diagnostics(&lookup.sources, &key)?;
     if let Some(value) = resolved.value {
-        if resolved
-            .diagnostics
-            .raw_global_value_from_invalid_effective_global
-        {
+        if resolved.diagnostics.should_warn_raw_global_parse_fallback() {
             eprintln!("warning: global config has parse errors; showing raw value");
         }
         println!("{}", format_toml_value(&value));
@@ -350,6 +347,14 @@ struct ConfigGetLookup {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct LookupDiagnostics {
     raw_global_value_from_invalid_effective_global: bool,
+    raw_global_value_from_invalid_effective_project: bool,
+}
+
+impl LookupDiagnostics {
+    fn should_warn_raw_global_parse_fallback(self) -> bool {
+        self.raw_global_value_from_invalid_effective_global
+            || self.raw_global_value_from_invalid_effective_project
+    }
 }
 
 #[derive(Debug)]
@@ -508,17 +513,20 @@ fn resolve_lookup_sources_with_diagnostics(
 ) -> Result<LookupResolution> {
     let mut deferred_error = None;
     let mut saw_deferred_effective_global_error = false;
+    let mut saw_deferred_effective_project_error = false;
 
     for source in sources {
         match load_lookup_root(source) {
             Ok(Some(root)) => {
                 if let Some(value) = resolve_key(&root, key) {
+                    let raw_global_source = matches!(source, LookupSourceSpec::RawGlobal { .. });
                     return Ok(LookupResolution {
                         value: Some(value),
                         diagnostics: LookupDiagnostics {
-                            raw_global_value_from_invalid_effective_global:
-                                saw_deferred_effective_global_error
-                                    && matches!(source, LookupSourceSpec::RawGlobal { .. }),
+                            raw_global_value_from_invalid_effective_global: raw_global_source
+                                && saw_deferred_effective_global_error,
+                            raw_global_value_from_invalid_effective_project: raw_global_source
+                                && saw_deferred_effective_project_error,
                         },
                     });
                 }
@@ -534,6 +542,15 @@ fn resolve_lookup_sources_with_diagnostics(
                     }
                 ) {
                     saw_deferred_effective_global_error = true;
+                }
+                if matches!(
+                    source,
+                    LookupSourceSpec::EffectiveProject {
+                        include_global_fallback: true,
+                        ..
+                    }
+                ) {
+                    saw_deferred_effective_project_error = true;
                 }
                 deferred_error.get_or_insert(err);
             }

--- a/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
@@ -86,3 +86,67 @@ max_concurrent = "oops"
 
     assert_eq!(value, Some("auto".to_string()));
 }
+
+#[test]
+fn resolve_lookup_sources_warns_when_raw_global_fallback_follows_effective_project_parse_error() {
+    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let dir = tempfile::tempdir().unwrap();
+    let config_root = dir.path().join("xdg-config");
+    std::fs::create_dir_all(&config_root).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", dir.path());
+    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root).unwrap();
+
+    let global_dir = config_root.join("cli-sub-agent");
+    std::fs::create_dir_all(&global_dir).unwrap();
+    let global_config_path = global_dir.join("config.toml");
+    std::fs::write(
+        &global_config_path,
+        r#"
+[review]
+tool = "auto"
+
+[execution]
+min_timeout_seconds = "oops"
+"#,
+    )
+    .unwrap();
+
+    let sources = vec![
+        LookupSourceSpec::RawProject {
+            path: ProjectConfig::config_path(&project_root),
+        },
+        LookupSourceSpec::EffectiveProject {
+            project_root: project_root.clone(),
+            include_global_fallback: true,
+        },
+        LookupSourceSpec::RawGlobal {
+            path: global_config_path,
+        },
+        LookupSourceSpec::EffectiveGlobal {
+            allow_raw_fallback: false,
+        },
+    ];
+
+    let resolved = resolve_lookup_sources_with_diagnostics(&sources, "review.tool").unwrap();
+    let value = resolved
+        .value
+        .as_ref()
+        .and_then(toml::Value::as_str)
+        .map(str::to_string);
+
+    assert_eq!(value, Some("auto".to_string()));
+    assert!(
+        resolved
+            .diagnostics
+            .raw_global_value_from_invalid_effective_project
+    );
+    assert!(
+        !resolved
+            .diagnostics
+            .raw_global_value_from_invalid_effective_global
+    );
+    assert!(resolved.diagnostics.should_warn_raw_global_parse_fallback());
+}

--- a/crates/cli-sub-agent/src/review_cmd_bug_class.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class.rs
@@ -129,10 +129,10 @@ fn collapse_bug_class_review_artifacts(
     let mut grouped = BTreeMap::<ReviewArtifactGroupKey, Vec<GroupedReviewArtifact>>::new();
 
     for artifact in review_artifacts {
-        // Parent review-consolidated.json duplicates the child reviewer findings but
-        // does not carry review_meta.json, so including it here can falsely satisfy
-        // the recurrence threshold for a single multi-review execution.
-        if session_has_consolidated_artifact(project_root, &artifact.session_id)? {
+        // Parent review-consolidated.json duplicates child reviewer findings but
+        // does not carry review_meta.json. Skip only that parent artifact shape;
+        // child reviewer sessions can legitimately have consolidated output too.
+        if should_skip_bug_class_artifact(project_root, &artifact.session_id)? {
             continue;
         }
 
@@ -185,6 +185,11 @@ fn collapse_bug_class_review_artifacts(
     }
 
     Ok(collapsed)
+}
+
+fn should_skip_bug_class_artifact(project_root: &Path, session_id: &str) -> Result<bool> {
+    Ok(session_has_consolidated_artifact(project_root, session_id)?
+        && load_review_meta(project_root, session_id)?.is_none())
 }
 
 fn resolve_review_artifact_group_key(

--- a/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
@@ -393,3 +393,48 @@ fn bug_class_loader_skips_parent_consolidated_artifact_to_avoid_false_promotion(
         "one multi-review run must not self-promote a recurring bug class"
     );
 }
+
+#[test]
+fn bug_class_loader_keeps_sessions_with_review_meta_even_if_consolidated_exists() {
+    let project_dir = setup_git_repo();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+
+    let child = create_session(
+        project_dir.path(),
+        Some("review[1]: base:main"),
+        None,
+        Some("codex"),
+    )
+    .expect("child review session");
+    let child_dir = get_session_dir(project_dir.path(), &child.meta_session_id).unwrap();
+
+    write_review_artifact_file(
+        &child_dir,
+        "review-consolidated.json",
+        &sample_review_artifact(&child.meta_session_id, Severity::High, "rust/002"),
+    );
+    write_review_meta(
+        &child_dir,
+        &ReviewSessionMeta {
+            session_id: child.meta_session_id.clone(),
+            head_sha: "deadbeef".to_string(),
+            decision: "fail".to_string(),
+            verdict: "HAS_ISSUES".to_string(),
+            tool: "codex".to_string(),
+            scope: "base:main".to_string(),
+            exit_code: 1,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 7,
+            timestamp: chrono::Utc::now(),
+            diff_fingerprint: Some("sha256:shared".to_string()),
+        },
+    )
+    .expect("review meta");
+
+    let review_artifacts = load_bug_class_review_artifacts(project_dir.path())
+        .expect("child session should still be mined");
+
+    assert_eq!(review_artifacts.len(), 1);
+    assert_eq!(review_artifacts[0].session_id, child.meta_session_id);
+}

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -14,7 +14,27 @@ use csa_session::state::MetaSessionState;
 use super::AcpTransport;
 
 const SUMMARY_MAX_CHARS: usize = 200;
+const CSA_SESSION_ID_ENV: &str = "CSA_SESSION_ID";
+const CSA_DEPTH_ENV: &str = "CSA_DEPTH";
+const CSA_PROJECT_ROOT_ENV: &str = "CSA_PROJECT_ROOT";
+const CSA_TOOL_ENV: &str = "CSA_TOOL";
+const CSA_IS_SUBPROCESS_ENV: &str = "CSA_IS_SUBPROCESS";
+const CSA_PARENT_TOOL_ENV: &str = "CSA_PARENT_TOOL";
+const CSA_PARENT_SESSION_ENV: &str = "CSA_PARENT_SESSION";
 const CSA_FS_SANDBOXED_ENV: &str = "CSA_FS_SANDBOXED";
+const CSA_SESSION_DIR_ENV: &str = "CSA_SESSION_DIR";
+const CSA_OWNED_ENV_KEYS: &[&str] = &[
+    CSA_SESSION_ID_ENV,
+    CSA_DEPTH_ENV,
+    CSA_PROJECT_ROOT_ENV,
+    CSA_TOOL_ENV,
+    CSA_IS_SUBPROCESS_ENV,
+    CSA_PARENT_TOOL_ENV,
+    CSA_PARENT_SESSION_ENV,
+    CSA_FS_SANDBOXED_ENV,
+    CSA_SESSION_DIR_ENV,
+    csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
+];
 
 /// Default soft memory limit as a percentage of MemoryMax.
 /// Lowered from 80% to 70% in #568 to provide more headroom before the
@@ -112,40 +132,15 @@ impl AcpTransport {
         extra_env: Option<&HashMap<String, String>>,
     ) -> HashMap<String, String> {
         let mut env = HashMap::new();
-        env.insert(
-            "CSA_SESSION_ID".to_string(),
-            session.meta_session_id.clone(),
-        );
-        env.insert(
-            "CSA_DEPTH".to_string(),
-            (session.genealogy.depth + 1).to_string(),
-        );
-        env.insert("CSA_PROJECT_ROOT".to_string(), session.project_path.clone());
-
-        env.insert("CSA_TOOL".to_string(), self.tool_name.clone());
-        // Mark this process as a CSA subprocess so child tools can detect
-        // recursion risk (e.g. claude-code reading CLAUDE.md rules that say
-        // "use csa review"). See GitHub issue #272.
-        env.insert("CSA_IS_SUBPROCESS".to_string(), "1".to_string());
-        if let Ok(parent_tool) = std::env::var("CSA_TOOL") {
-            env.insert("CSA_PARENT_TOOL".to_string(), parent_tool);
-        }
-        if let Some(parent_session) = &session.genealogy.parent_session_id {
-            env.insert("CSA_PARENT_SESSION".to_string(), parent_session.clone());
-        }
-
         if let Some(extra) = extra_env {
             env.extend(
                 extra
                     .iter()
-                    .filter(|(k, _)| k.as_str() != CSA_FS_SANDBOXED_ENV)
+                    .filter(|(k, _)| !is_csa_owned_env_key(k))
                     .map(|(k, v)| (k.clone(), v.clone())),
             );
         }
-        if std::env::var(CSA_FS_SANDBOXED_ENV).ok().as_deref() == Some("1") {
-            env.insert(CSA_FS_SANDBOXED_ENV.to_string(), "1".to_string());
-        }
-        Self::insert_reserved_session_path_env(&mut env, session);
+        self.insert_csa_owned_env(&mut env, session);
 
         // Inject merge guard: prepend a `gh` wrapper to PATH that blocks
         // `gh pr merge` unless pr-bot has completed.  This is deterministic
@@ -159,6 +154,36 @@ impl AcpTransport {
         env
     }
 
+    fn insert_csa_owned_env(&self, env: &mut HashMap<String, String>, session: &MetaSessionState) {
+        env.insert(
+            CSA_SESSION_ID_ENV.to_string(),
+            session.meta_session_id.clone(),
+        );
+        env.insert(
+            CSA_DEPTH_ENV.to_string(),
+            (session.genealogy.depth + 1).to_string(),
+        );
+        env.insert(
+            CSA_PROJECT_ROOT_ENV.to_string(),
+            session.project_path.clone(),
+        );
+        env.insert(CSA_TOOL_ENV.to_string(), self.tool_name.clone());
+        // Mark this process as a CSA subprocess so child tools can detect
+        // recursion risk (e.g. claude-code reading CLAUDE.md rules that say
+        // "use csa review"). See GitHub issue #272.
+        env.insert(CSA_IS_SUBPROCESS_ENV.to_string(), "1".to_string());
+        if let Ok(parent_tool) = std::env::var(CSA_TOOL_ENV) {
+            env.insert(CSA_PARENT_TOOL_ENV.to_string(), parent_tool);
+        }
+        if let Some(parent_session) = &session.genealogy.parent_session_id {
+            env.insert(CSA_PARENT_SESSION_ENV.to_string(), parent_session.clone());
+        }
+        if std::env::var(CSA_FS_SANDBOXED_ENV).ok().as_deref() == Some("1") {
+            env.insert(CSA_FS_SANDBOXED_ENV.to_string(), "1".to_string());
+        }
+        Self::insert_reserved_session_path_env(env, session);
+    }
+
     fn insert_reserved_session_path_env(
         env: &mut HashMap<String, String>,
         session: &MetaSessionState,
@@ -168,7 +193,7 @@ impl AcpTransport {
             &session.meta_session_id,
         ) {
             env.insert(
-                "CSA_SESSION_DIR".to_string(),
+                CSA_SESSION_DIR_ENV.to_string(),
                 dir.to_string_lossy().into_owned(),
             );
             env.insert(
@@ -181,6 +206,10 @@ impl AcpTransport {
             tracing::warn!("failed to compute CSA_SESSION_DIR for ACP env");
         }
     }
+}
+
+fn is_csa_owned_env_key(key: &str) -> bool {
+    CSA_OWNED_ENV_KEYS.contains(&key)
 }
 
 /// Attached to `anyhow::Error` context when a sandboxed ACP execution fails,
@@ -604,6 +633,12 @@ mod tests {
         }
     }
 
+    fn sample_child_session() -> MetaSessionState {
+        let mut session = sample_session();
+        session.genealogy.parent_session_id = Some("01HPARENT000000000000000000".to_string());
+        session
+    }
+
     #[test]
     fn build_env_ignores_spoofed_sandbox_marker_from_extra_env() {
         let _env_lock = SANDBOX_ENV_LOCK.lock().expect("sandbox env lock poisoned");
@@ -634,6 +669,104 @@ mod tests {
             env.get(CSA_FS_SANDBOXED_ENV).map(String::as_str),
             Some("1"),
             "the process sandbox marker must override user extra_env"
+        );
+    }
+
+    #[test]
+    fn build_env_reapplies_csa_owned_env_after_extra_env_merge() {
+        let _env_lock = SANDBOX_ENV_LOCK.lock().expect("sandbox env lock poisoned");
+        let _sandbox_guard = ScopedEnvVar::set(CSA_FS_SANDBOXED_ENV, "1");
+        let _parent_tool_guard = ScopedEnvVar::set(CSA_TOOL_ENV, "parent-tool");
+        let transport = AcpTransport::new("claude-code", None);
+        let session = sample_child_session();
+        let extra = HashMap::from([
+            (
+                CSA_SESSION_ID_ENV.to_string(),
+                "spoofed-session".to_string(),
+            ),
+            (CSA_DEPTH_ENV.to_string(), "999".to_string()),
+            (
+                CSA_PROJECT_ROOT_ENV.to_string(),
+                "/tmp/spoofed-root".to_string(),
+            ),
+            (CSA_TOOL_ENV.to_string(), "spoofed-tool".to_string()),
+            (CSA_IS_SUBPROCESS_ENV.to_string(), "0".to_string()),
+            (
+                CSA_PARENT_TOOL_ENV.to_string(),
+                "spoofed-parent-tool".to_string(),
+            ),
+            (
+                CSA_PARENT_SESSION_ENV.to_string(),
+                "spoofed-parent-session".to_string(),
+            ),
+            (CSA_FS_SANDBOXED_ENV.to_string(), "0".to_string()),
+            (
+                CSA_SESSION_DIR_ENV.to_string(),
+                "/tmp/spoofed-session-dir".to_string(),
+            ),
+            (
+                csa_session::RESULT_TOML_PATH_CONTRACT_ENV.to_string(),
+                "/tmp/spoofed-result.toml".to_string(),
+            ),
+            ("CSA_SUPPRESS_NOTIFY".to_string(), "1".to_string()),
+        ]);
+
+        let env = transport.build_env(&session, Some(&extra));
+
+        assert_eq!(
+            env.get(CSA_SESSION_ID_ENV).map(String::as_str),
+            Some("01HTEST000000000000000000")
+        );
+        assert_eq!(env.get(CSA_DEPTH_ENV).map(String::as_str), Some("1"));
+        assert_eq!(
+            env.get(CSA_PROJECT_ROOT_ENV).map(String::as_str),
+            Some("/tmp/test")
+        );
+        assert_eq!(
+            env.get(CSA_TOOL_ENV).map(String::as_str),
+            Some("claude-code")
+        );
+        assert_eq!(
+            env.get(CSA_IS_SUBPROCESS_ENV).map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            env.get(CSA_PARENT_TOOL_ENV).map(String::as_str),
+            Some("parent-tool")
+        );
+        assert_eq!(
+            env.get(CSA_PARENT_SESSION_ENV).map(String::as_str),
+            Some("01HPARENT000000000000000000")
+        );
+        assert_eq!(env.get(CSA_FS_SANDBOXED_ENV).map(String::as_str), Some("1"));
+        assert_eq!(
+            env.get("CSA_SUPPRESS_NOTIFY").map(String::as_str),
+            Some("1"),
+            "non-reserved CSA_* settings must still flow through extra_env"
+        );
+
+        let session_dir = env
+            .get(CSA_SESSION_DIR_ENV)
+            .expect("CSA_SESSION_DIR should be present");
+        assert!(
+            session_dir.contains("/sessions/"),
+            "CSA_SESSION_DIR should be recomputed after merge, got: {session_dir}"
+        );
+        assert!(
+            session_dir.contains("01HTEST000000000000000000"),
+            "CSA_SESSION_DIR should include the session ID, got: {session_dir}"
+        );
+
+        let result_contract_path = env
+            .get(csa_session::RESULT_TOML_PATH_CONTRACT_ENV)
+            .expect("CSA_RESULT_TOML_PATH_CONTRACT should be present");
+        assert!(
+            result_contract_path.ends_with("/output/result.toml"),
+            "result contract path should be recomputed after merge, got: {result_contract_path}"
+        );
+        assert!(
+            result_contract_path.contains("01HTEST000000000000000000"),
+            "result contract path should include the session ID, got: {result_contract_path}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- **#722**: Filter ALL CSA-owned env vars from user `extra_env` before merge, then reapply authoritative values. Prevents `[tools.<tool>.env]` from spoofing `CSA_DEPTH`, `CSA_TOOL`, `CSA_IS_SUBPROCESS`, etc. Non-reserved `CSA_*` keys (e.g. `CSA_SUPPRESS_NOTIFY`) still pass through.
- **#723**: Narrow bug-class mining skip from session-level to artifact-level. Only skip sessions with `review-consolidated.json` AND no `review_meta.json` (pure parent aggregators). Child reviewer sessions with both files now correctly mined.
- **#724**: Extend config get raw-global fallback warning to trigger on deferred `EffectiveProject` parse errors (not just `EffectiveGlobal`), covering the mixed-scope path.

## Review Findings
- **HIGH (dismissed — false positive)**: Windows case-insensitive env var matching. CSA is Linux-only (bwrap/cgroups/landlock), so irrelevant.
- **MEDIUM (follow-up)**: Config warning could misattribute EffectiveProject failure from broken project config as "global config parse errors".

## Test plan
- [x] `cargo test -p csa-executor build_env_` — all 6 env tests pass
- [x] `cargo test -p cli-sub-agent bug_class_loader_` — 3 tests pass (including new consolidated+review_meta test)
- [x] `cargo test -p cli-sub-agent resolve_lookup_sources_` — 5 tests pass (including new mixed-scope test)
- [x] `just clippy` — clean
- [x] `just pre-commit` — 27/27 e2e tests pass

Closes #722, closes #723, closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)