### PR TITLE
fix(multi): batch H — tier/model-spec conflict, no-failover wiring, hook project_root, model-spec docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "chrono",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "chrono",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "axum",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "chrono",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "chrono",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "chrono",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.279"
+version = "0.1.280"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.279"
+version = "0.1.280"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -155,7 +155,8 @@ pub enum Commands {
         /// Working directory (defaults to CWD)
         #[arg(long)]
         cd: Option<String>,
-        /// Model spec: tool/provider/model/thinking_budget
+        /// Exact model selector in `tool/provider/model/thinking` format.
+        /// Use this for a single fixed model choice; use `--tier` for tier-managed routing and failover.
         #[arg(long)]
         model_spec: Option<String>,
         /// Override tool default model (opaque string, passed through to tool)
@@ -174,7 +175,7 @@ pub enum Commands {
         #[arg(long)]
         force_override_user_config: bool,
 
-        /// Disable automatic 429 failover to alternative tools
+        /// Disable all retry/failover paths (cross-tool 429, ACP crash, Gemini rate-limit). Pair with --model-spec to fail fast.
         #[arg(long)]
         no_failover: bool,
 

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -54,7 +54,8 @@ pub struct ReviewArgs {
     #[arg(short, long)]
     pub model: Option<String>,
 
-    /// Model spec: tool/provider/model/thinking_budget
+    /// Exact model selector in `tool/provider/model/thinking` format.
+    /// Use this for a single fixed model choice; use `--tier` for tier-managed routing and failover.
     #[arg(long)]
     pub model_spec: Option<String>,
 
@@ -63,7 +64,9 @@ pub struct ReviewArgs {
     #[arg(long)]
     pub thinking: Option<String>,
 
-    /// Disable automatic failover to alternative tools
+    /// Disable automatic retry/failover on transient errors (cross-tool 429 failover,
+    /// same-tool ACP crash retry, Gemini rate-limit/quota retry phases, debate outer
+    /// retry loop). Useful with --model-spec to pin an exact selection and fail fast.
     #[arg(long)]
     pub no_failover: bool,
 
@@ -315,7 +318,8 @@ pub struct DebateArgs {
     #[arg(short, long)]
     pub model: Option<String>,
 
-    /// Model spec: tool/provider/model/thinking_budget
+    /// Exact model selector in `tool/provider/model/thinking` format.
+    /// Use this for a single fixed model choice; use `--tier` for tier-managed routing and failover.
     #[arg(long)]
     pub model_spec: Option<String>,
 
@@ -323,7 +327,9 @@ pub struct DebateArgs {
     #[arg(long)]
     pub thinking: Option<String>,
 
-    /// Disable automatic failover to alternative tools
+    /// Disable automatic retry/failover on transient errors (cross-tool 429 failover,
+    /// same-tool ACP crash retry, Gemini rate-limit/quota retry phases, debate outer
+    /// retry loop). Useful with --model-spec to pin an exact selection and fail fast.
     #[arg(long)]
     pub no_failover: bool,
 

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -29,6 +29,15 @@ pub(crate) enum DebateMode {
     SameModelAdversarial,
 }
 
+fn debate_execution_env_options(no_failover: bool) -> ExecutionEnvOptions {
+    let options = ExecutionEnvOptions::with_no_flash_fallback();
+    if no_failover {
+        options.with_no_failover()
+    } else {
+        options
+    }
+}
+
 pub(crate) async fn handle_debate(
     args: DebateArgs,
     current_depth: u32,
@@ -279,7 +288,7 @@ pub(crate) async fn handle_debate(
     // 7. Get env injection from global config (with no-flash + api key fallback)
     let extra_env_owned = global_config.build_execution_env(
         executor.tool_name(),
-        ExecutionEnvOptions::with_no_flash_fallback(),
+        debate_execution_env_options(args.no_failover),
     );
     let extra_env = extra_env_owned.as_ref();
     let idle_timeout_seconds =
@@ -362,6 +371,7 @@ pub(crate) async fn handle_debate(
                         if should_retry_debate_after_error(
                             &DebateErrorKind::Transient(reason.clone()),
                             retry_count,
+                            args.no_failover,
                         ) =>
                     {
                         if first_error_context.is_none() {
@@ -397,6 +407,7 @@ pub(crate) async fn handle_debate(
                 if should_retry_debate_after_error(
                     &DebateErrorKind::Transient(reason.clone()),
                     retry_count,
+                    args.no_failover,
                 ) =>
             {
                 if first_error_context.is_none() {
@@ -557,7 +568,14 @@ fn ensure_debate_wall_clock_within_timeout(
     Ok(())
 }
 
-fn should_retry_debate_after_error(kind: &DebateErrorKind, retry_count: u8) -> bool {
+fn should_retry_debate_after_error(
+    kind: &DebateErrorKind,
+    retry_count: u8,
+    no_failover: bool,
+) -> bool {
+    if no_failover {
+        return false;
+    }
     matches!(kind, DebateErrorKind::Transient(_)) && retry_count < 1
 }
 

--- a/crates/cli-sub-agent/src/debate_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_resolve.rs
@@ -31,6 +31,7 @@ pub(crate) fn resolve_debate_tool(
         cli_tier,
         force_ignore_tier_setting,
     )?;
+    crate::run_helpers::validate_model_spec_tier_conflict(arg_model_spec, cli_tier, "debate")?;
 
     if let Some(model_spec) = arg_model_spec {
         let (tool, resolved_model_spec, _) = crate::run_helpers::resolve_tool_and_model(

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -56,6 +56,29 @@ fn resolve_debate_tool_prefers_model_spec_override() {
 }
 
 #[test]
+fn resolve_debate_tool_rejects_model_spec_with_tier() {
+    let global = GlobalConfig::default();
+    let cfg = project_config_with_enabled_tools(&["codex"]);
+    let err = resolve_debate_tool(
+        None,
+        Some("codex/openai/gpt-5.4/xhigh"),
+        Some(&cfg),
+        &global,
+        Some("claude-code"),
+        std::path::Path::new("/tmp/test-project"),
+        false,
+        Some("tier-2-standard"),
+        false,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("--model-spec and --tier are mutually exclusive"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
 fn resolve_debate_thinking_prefers_cli_over_config() {
     let thinking = resolve_debate_thinking(Some("low"), Some("high"), false);
     assert_eq!(thinking.as_deref(), Some("low"));
@@ -110,15 +133,29 @@ fn retry_policy_only_retries_transient_once() {
 
     assert!(should_retry_debate_after_error(
         &DebateErrorKind::Transient("oom".to_string()),
-        0
+        0,
+        false
     ));
     assert!(!should_retry_debate_after_error(
         &DebateErrorKind::Transient("oom".to_string()),
-        1
+        1,
+        false
     ));
     assert!(!should_retry_debate_after_error(
         &DebateErrorKind::Deterministic("arg".to_string()),
-        0
+        0,
+        false
+    ));
+}
+
+#[test]
+fn retry_policy_suppressed_when_no_failover() {
+    use crate::debate_errors::DebateErrorKind;
+
+    assert!(!should_retry_debate_after_error(
+        &DebateErrorKind::Transient("oom".to_string()),
+        0,
+        true
     ));
 }
 

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -36,6 +36,9 @@ pub(crate) mod design_context;
 #[path = "pipeline_session_exec.rs"]
 mod session_exec;
 
+#[path = "pipeline_session_exec_failover.rs"]
+mod session_exec_failover;
+
 #[path = "pipeline_session_hooks.rs"]
 mod session_hooks;
 

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -33,6 +33,8 @@ use csa_session::{
     ToolState, compute_cooldown_wait, create_session, create_session_fresh, get_session_dir,
 };
 
+use super::session_exec_failover::apply_transport_failover_overrides;
+
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, fields(tool = %tool, session = ?session_arg))]
 pub(crate) async fn execute_with_session(
@@ -586,6 +588,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     execute_options =
         execute_options.with_output_spool_rotation(spool_max_bytes, spool_keep_rotated);
     execute_options.output_spool = Some(session_dir.join("output.log"));
+    apply_transport_failover_overrides(&mut execute_options, merged_env_ref);
 
     crate::pipeline_sandbox::record_sandbox_telemetry(&execute_options, &mut session);
     crate::pipeline_sandbox::maybe_inflate_balloon(tool.as_str());

--- a/crates/cli-sub-agent/src/pipeline_session_exec_failover.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_failover.rs
@@ -1,0 +1,39 @@
+//! Transport failover override helpers applied to session execution.
+
+use csa_core::env::NO_FAILOVER_ENV_KEY;
+
+pub(super) fn apply_transport_failover_overrides(
+    execute_options: &mut csa_executor::ExecuteOptions,
+    merged_env: Option<&std::collections::HashMap<String, String>>,
+) {
+    if merged_env.is_some_and(|env| env.contains_key(NO_FAILOVER_ENV_KEY)) {
+        execute_options.acp_crash_max_attempts = 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_transport_failover_overrides_disables_acp_crash_retry() {
+        let mut execute_options =
+            csa_executor::ExecuteOptions::new(csa_process::StreamMode::BufferOnly, 60);
+        let env =
+            std::collections::HashMap::from([(NO_FAILOVER_ENV_KEY.to_string(), "1".to_string())]);
+
+        apply_transport_failover_overrides(&mut execute_options, Some(&env));
+
+        assert_eq!(execute_options.acp_crash_max_attempts, 1);
+    }
+
+    #[test]
+    fn apply_transport_failover_overrides_preserves_default_without_flag() {
+        let mut execute_options =
+            csa_executor::ExecuteOptions::new(csa_process::StreamMode::BufferOnly, 60);
+
+        apply_transport_failover_overrides(&mut execute_options, None);
+
+        assert_eq!(execute_options.acp_crash_max_attempts, 2);
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -78,6 +78,7 @@ fn review_decision_from_verdict(verdict: &str) -> ReviewDecision {
 pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Result<i32> {
     // 1. Determine project root
     let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
+    let project_root_for_hooks = project_root.display().to_string();
 
     // 2. Load config and validate recursion depth
     let Some((config, global_config)) =
@@ -350,6 +351,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             initial_response_timeout_seconds,
             args.force_override_user_config,
             args.force_ignore_tier_setting,
+            args.no_failover,
             args.no_fs_sandbox,
             readonly_project_root,
             &args.extra_writable,
@@ -451,6 +453,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
                         ("decision", decision.as_str()),
                         ("verdict", verdict),
                         ("scope", &scope),
+                        ("project_root", project_root_for_hooks.as_str()),
                     ],
                     &project_root,
                 ),
@@ -493,6 +496,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             initial_response_timeout_seconds,
             force_override_user_config: args.force_override_user_config,
             force_ignore_tier_setting: args.force_ignore_tier_setting,
+            no_failover: args.no_failover,
             no_fs_sandbox: args.no_fs_sandbox,
             extra_writable: &args.extra_writable,
             timeout: args.timeout,
@@ -518,6 +522,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
                     ("decision", if fix_passed { "pass" } else { "fail" }),
                     ("verdict", if fix_passed { CLEAN } else { verdict }),
                     ("scope", &scope_for_hook),
+                    ("project_root", project_root_for_hooks.as_str()),
                 ],
                 &project_root,
             ),
@@ -613,6 +618,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
                 initial_response_timeout_seconds,
                 reviewer_force_override,
                 args.force_ignore_tier_setting,
+                args.no_failover,
                 reviewer_no_fs_sandbox,
                 readonly_project_root,
                 &reviewer_extra_writable,

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -15,6 +15,15 @@ use super::output::{
     is_review_output_empty,
 };
 
+fn review_execution_env_options(no_failover: bool) -> ExecutionEnvOptions {
+    let options = ExecutionEnvOptions::with_no_flash_fallback();
+    if no_failover {
+        options.with_no_failover()
+    } else {
+        options
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn execute_review(
     tool: ToolName,
@@ -34,6 +43,7 @@ pub(super) async fn execute_review(
     initial_response_timeout_seconds: Option<u64>,
     force_override_user_config: bool,
     force_ignore_tier_setting: bool,
+    no_failover: bool,
     no_fs_sandbox: bool,
     readonly_project_root: bool,
     extra_writable: &[PathBuf],
@@ -72,7 +82,7 @@ pub(super) async fn execute_review(
 
     let extra_env_owned = global_config.build_execution_env(
         executor.tool_name(),
-        ExecutionEnvOptions::with_no_flash_fallback(),
+        review_execution_env_options(no_failover),
     );
     let extra_env = extra_env_owned.as_ref();
     let _slot_guard = crate::pipeline::acquire_slot(&executor, global_config)?;
@@ -296,6 +306,7 @@ printf 'tool mutation\\n' >> tracked.txt\n",
             None,  // initial_response_timeout_seconds
             false, // force_override_user_config
             false, // force_ignore_tier_setting
+            false, // no_failover
             false, // no_fs_sandbox
             false, // readonly_project_root
             &[],   // extra_writable

--- a/crates/cli-sub-agent/src/review_cmd_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix.rs
@@ -29,6 +29,7 @@ pub(crate) struct FixLoopContext<'a> {
     pub initial_response_timeout_seconds: Option<u64>,
     pub force_override_user_config: bool,
     pub force_ignore_tier_setting: bool,
+    pub no_failover: bool,
     pub no_fs_sandbox: bool,
     pub extra_writable: &'a [PathBuf],
     pub timeout: Option<u64>,
@@ -79,6 +80,7 @@ pub(crate) async fn run_fix_loop(ctx: FixLoopContext<'_>) -> Result<i32> {
             ctx.initial_response_timeout_seconds,
             ctx.force_override_user_config,
             ctx.force_ignore_tier_setting,
+            ctx.no_failover,
             ctx.no_fs_sandbox,
             false, // fix pass must write — override readonly_project_root
             ctx.extra_writable,

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -97,6 +97,7 @@ pub(crate) fn resolve_review_tool(
         cli_tier,
         force_ignore_tier_setting,
     )?;
+    crate::run_helpers::validate_model_spec_tier_conflict(arg_model_spec, cli_tier, "review")?;
 
     if let Some(model_spec) = arg_model_spec {
         let (tool, resolved_model_spec, _) = crate::run_helpers::resolve_tool_and_model(

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -779,5 +779,8 @@ mod tier_tests;
 #[path = "review_cmd_tests_tail.rs"]
 mod tail_tests;
 
+#[path = "review_cmd_tests_no_failover.rs"]
+mod no_failover_tests;
+
 #[path = "review_cmd_bug_class_tests.rs"]
 mod bug_class_tests;

--- a/crates/cli-sub-agent/src/review_cmd_tests_no_failover.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_no_failover.rs
@@ -1,0 +1,26 @@
+//! Tests for --no-failover / --tier / --model-spec conflict handling in csa review.
+
+use super::*;
+
+#[test]
+fn resolve_review_tool_rejects_model_spec_with_tier() {
+    let global = GlobalConfig::default();
+    let cfg = project_config_with_enabled_tools(&["codex"]);
+    let err = resolve_review_tool(
+        None,
+        Some("codex/openai/gpt-5.4/xhigh"),
+        Some(&cfg),
+        &global,
+        Some("claude-code"),
+        std::path::Path::new("/tmp/test-project"),
+        false,
+        Some("tier-2-standard"),
+        false,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("--model-spec and --tier are mutually exclusive"),
+        "unexpected error: {err:#}"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -599,6 +599,7 @@ async fn execute_review_ignores_inherited_csa_session_id_without_explicit_sessio
         None,  // initial_response_timeout_seconds
         false, // force_override_user_config
         false, // force_ignore_tier_setting
+        false, // no_failover
         false, // no_fs_sandbox
         false, // readonly_project_root
         &[],   // extra_writable

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -326,9 +326,10 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             effective_session_arg = new_eff;
         }
 
-        let extra_env = request
-            .global_config
-            .build_execution_env(tool_name_str, ExecutionEnvOptions::default());
+        let extra_env = request.global_config.build_execution_env(
+            tool_name_str,
+            ExecutionEnvOptions::from_no_failover(request.no_failover),
+        );
         let mut effective_prompt = if let Some(ref fork_res) = fork_resolution {
             if let Some(ref ctx) = fork_res.context_prefix {
                 info!(

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
@@ -173,6 +173,7 @@ pub(crate) fn resolve_tool_by_strategy(
     tier: Option<&str>,
     force_ignore_tier_setting: bool,
 ) -> Result<StrategyResolution> {
+    crate::run_helpers::validate_model_spec_tier_conflict(model_spec, tier, "run")?;
     match strategy {
         ToolSelectionStrategy::Explicit(t) => {
             let (tool, ms, m) = resolve_tool_and_model(

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -40,6 +40,21 @@ pub(crate) fn validate_tool_tier_override_flags(
     Ok(())
 }
 
+pub(crate) fn validate_model_spec_tier_conflict(
+    model_spec: Option<&str>,
+    tier: Option<&str>,
+    command: &str,
+) -> Result<()> {
+    if model_spec.is_some() && tier.is_some() {
+        anyhow::bail!(
+            "Conflicting routing flags for `csa {command}`: --model-spec and --tier are mutually exclusive.\n\
+             Use --model-spec for an exact `tool/provider/model/thinking` selection, or use --tier for tier-managed routing and failover."
+        );
+    }
+
+    Ok(())
+}
+
 /// Resolve tool and model from CLI args and config.
 ///
 /// Returns (tool, model_spec, model) where:

--- a/crates/cli-sub-agent/src/todo_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_cmd.rs
@@ -72,6 +72,10 @@ pub(crate) fn handle_create(
             "todo_root".to_string(),
             manager.todos_dir().display().to_string(),
         );
+        hook_vars.insert(
+            "project_root".to_string(),
+            project_root.display().to_string(),
+        );
         if let Err(e) = run_hooks_for_event(HookEvent::TodoCreate, &hooks_config, &hook_vars) {
             warn!("TodoCreate hook failed: {}", e);
         }
@@ -137,6 +141,10 @@ pub(crate) fn handle_save(
             hook_vars.insert(
                 "todo_root".to_string(),
                 manager.todos_dir().display().to_string(),
+            );
+            hook_vars.insert(
+                "project_root".to_string(),
+                project_root.display().to_string(),
             );
             hook_vars.insert("version".to_string(), version.to_string());
             hook_vars.insert("message".to_string(), commit_msg);

--- a/crates/csa-config/src/global_env.rs
+++ b/crates/csa-config/src/global_env.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 
-use csa_core::gemini::{
-    API_KEY_ENV, API_KEY_FALLBACK_ENV_KEY, AUTH_MODE_ENV_KEY, AUTH_MODE_OAUTH,
-    NO_FLASH_FALLBACK_ENV_KEY, is_gemini_tool,
+use csa_core::{
+    env::NO_FAILOVER_ENV_KEY,
+    gemini::{
+        API_KEY_ENV, API_KEY_FALLBACK_ENV_KEY, AUTH_MODE_ENV_KEY, AUTH_MODE_OAUTH,
+        NO_FLASH_FALLBACK_ENV_KEY, is_gemini_tool,
+    },
 };
 
 use crate::global::GlobalConfig;
@@ -10,13 +13,31 @@ use crate::global::GlobalConfig;
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ExecutionEnvOptions {
     pub no_flash_fallback: bool,
+    pub no_failover: bool,
 }
 
 impl ExecutionEnvOptions {
     pub const fn with_no_flash_fallback() -> Self {
         Self {
             no_flash_fallback: true,
+            no_failover: false,
         }
+    }
+
+    pub const fn with_no_failover(mut self) -> Self {
+        self.no_failover = true;
+        self
+    }
+
+    pub const fn from_no_failover(no_failover: bool) -> Self {
+        let mut opts = Self {
+            no_flash_fallback: false,
+            no_failover: false,
+        };
+        if no_failover {
+            opts.no_failover = true;
+        }
+        opts
     }
 }
 
@@ -28,6 +49,13 @@ impl GlobalConfig {
         options: ExecutionEnvOptions,
     ) -> Option<HashMap<String, String>> {
         let mut env = self.env_vars(tool).cloned().unwrap_or_default();
+        // Drop any user-configured attempt to spoof CSA-owned execution env.
+        env.remove(NO_FAILOVER_ENV_KEY);
+        env.remove(NO_FLASH_FALLBACK_ENV_KEY);
+
+        if options.no_failover {
+            env.insert(NO_FAILOVER_ENV_KEY.to_string(), "1".to_string());
+        }
 
         if is_gemini_tool(tool) {
             let legacy_api_key = env.remove(API_KEY_ENV);

--- a/crates/csa-config/src/global_tests.rs
+++ b/crates/csa-config/src/global_tests.rs
@@ -1,7 +1,10 @@
 use super::*;
-use csa_core::gemini::{
-    API_KEY_ENV, API_KEY_FALLBACK_ENV_KEY, AUTH_MODE_ENV_KEY, AUTH_MODE_OAUTH,
-    NO_FLASH_FALLBACK_ENV_KEY,
+use csa_core::{
+    env::NO_FAILOVER_ENV_KEY,
+    gemini::{
+        API_KEY_ENV, API_KEY_FALLBACK_ENV_KEY, AUTH_MODE_ENV_KEY, AUTH_MODE_OAUTH,
+        NO_FLASH_FALLBACK_ENV_KEY,
+    },
 };
 use serial_test::serial;
 use std::collections::HashMap;
@@ -290,6 +293,49 @@ fn test_build_execution_env_promotes_legacy_api_key_to_fallback_and_no_flash() {
     assert_eq!(
         env.get(NO_FLASH_FALLBACK_ENV_KEY).map(String::as_str),
         Some("1")
+    );
+    assert_eq!(env.get("OTHER_VAR").map(String::as_str), Some("keep"));
+}
+
+#[test]
+fn test_build_execution_env_marks_no_failover_when_requested() {
+    let mut config = GlobalConfig::default();
+    config.tools.insert(
+        "codex".to_string(),
+        GlobalToolConfig {
+            env: HashMap::from([("OTHER_VAR".to_string(), "keep".to_string())]),
+            ..Default::default()
+        },
+    );
+
+    let env = config
+        .build_execution_env("codex", ExecutionEnvOptions::default().with_no_failover())
+        .unwrap();
+    assert_eq!(env.get(NO_FAILOVER_ENV_KEY).map(String::as_str), Some("1"));
+    assert_eq!(env.get("OTHER_VAR").map(String::as_str), Some("keep"));
+}
+
+#[test]
+fn test_build_execution_env_drops_user_configured_no_failover_spoof() {
+    let mut config = GlobalConfig::default();
+    config.tools.insert(
+        "codex".to_string(),
+        GlobalToolConfig {
+            env: HashMap::from([
+                (NO_FAILOVER_ENV_KEY.to_string(), "1".to_string()),
+                ("OTHER_VAR".to_string(), "keep".to_string()),
+            ]),
+            ..Default::default()
+        },
+    );
+
+    // Without --no-failover, the CLI should win: user's spoofed value is dropped.
+    let env = config
+        .build_execution_env("codex", ExecutionEnvOptions::default())
+        .unwrap();
+    assert!(
+        !env.contains_key(NO_FAILOVER_ENV_KEY),
+        "user config must not be able to spoof _CSA_NO_FAILOVER"
     );
     assert_eq!(env.get("OTHER_VAR").map(String::as_str), Some("keep"));
 }

--- a/crates/csa-core/src/env.rs
+++ b/crates/csa-core/src/env.rs
@@ -1,0 +1,2 @@
+/// Reserved executor env var that disables automatic runtime failover/retry paths.
+pub const NO_FAILOVER_ENV_KEY: &str = "_CSA_NO_FAILOVER";

--- a/crates/csa-core/src/lib.rs
+++ b/crates/csa-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audit;
 pub mod consensus;
+pub mod env;
 pub mod error;
 pub mod gemini;
 pub mod types;

--- a/crates/csa-executor/src/transport_gemini_retry.rs
+++ b/crates/csa-executor/src/transport_gemini_retry.rs
@@ -1,10 +1,13 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use csa_core::gemini::{
-    API_KEY_ENV as GEMINI_API_KEY_ENV, API_KEY_FALLBACK_ENV_KEY, AUTH_MODE_API_KEY,
-    AUTH_MODE_ENV_KEY as GEMINI_AUTH_MODE_ENV_KEY, AUTH_MODE_OAUTH, NO_FLASH_FALLBACK_ENV_KEY,
-    detect_rate_limit_pattern,
+use csa_core::{
+    env::NO_FAILOVER_ENV_KEY,
+    gemini::{
+        API_KEY_ENV as GEMINI_API_KEY_ENV, API_KEY_FALLBACK_ENV_KEY, AUTH_MODE_API_KEY,
+        AUTH_MODE_ENV_KEY as GEMINI_AUTH_MODE_ENV_KEY, AUTH_MODE_OAUTH, NO_FLASH_FALLBACK_ENV_KEY,
+        detect_rate_limit_pattern,
+    },
 };
 use csa_process::ExecutionResult;
 
@@ -13,6 +16,8 @@ use csa_process::ExecutionResult;
 ///   Phase 2 (attempt 2): Original model + API key auth
 ///   Phase 3 (attempt 3): Flash model  + API key auth
 pub(crate) const GEMINI_RATE_LIMIT_MAX_ATTEMPTS: u8 = 3;
+/// When `_CSA_NO_FAILOVER` is set, disable all Gemini retry/failover phases.
+pub(crate) const GEMINI_RATE_LIMIT_NO_FAILOVER_ATTEMPTS: u8 = 1;
 /// When `_CSA_NO_FLASH_FALLBACK` is set, skip phase 3 (flash model).
 pub(crate) const GEMINI_RATE_LIMIT_NO_FLASH_ATTEMPTS: u8 = 2;
 #[cfg(test)]
@@ -24,6 +29,10 @@ pub(crate) const GEMINI_RATE_LIMIT_FLASH_MODEL: &str = "gemini-3-flash-preview";
 
 pub(crate) fn gemini_is_no_flash(extra_env: Option<&HashMap<String, String>>) -> bool {
     extra_env.is_some_and(|env| env.contains_key(NO_FLASH_FALLBACK_ENV_KEY))
+}
+
+pub(crate) fn gemini_is_no_failover(extra_env: Option<&HashMap<String, String>>) -> bool {
+    extra_env.is_some_and(|env| env.contains_key(NO_FAILOVER_ENV_KEY))
 }
 
 pub(crate) fn gemini_rate_limit_backoff(attempt: u8) -> Duration {
@@ -53,7 +62,9 @@ pub(crate) fn gemini_should_use_api_key(attempt: u8) -> bool {
 }
 
 pub(crate) fn gemini_max_attempts(extra_env: Option<&HashMap<String, String>>) -> u8 {
-    if gemini_is_no_flash(extra_env) {
+    if gemini_is_no_failover(extra_env) {
+        GEMINI_RATE_LIMIT_NO_FAILOVER_ATTEMPTS
+    } else if gemini_is_no_flash(extra_env) {
         GEMINI_RATE_LIMIT_NO_FLASH_ATTEMPTS
     } else {
         GEMINI_RATE_LIMIT_MAX_ATTEMPTS

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -706,3 +706,26 @@ fn test_no_flash_fallback_stops_retry_after_attempt_2() {
             .is_some()
     );
 }
+
+#[test]
+fn test_no_failover_stops_retry_after_attempt_1() {
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+    let execution = ExecutionResult {
+        summary: "failed".to_string(),
+        output: String::new(),
+        stderr_output: "HTTP 429 Too Many Requests".to_string(),
+        exit_code: 1,
+        peak_memory_mb: None,
+    };
+    let mut env = HashMap::new();
+    env.insert("_CSA_NO_FAILOVER".to_string(), "1".to_string());
+
+    assert!(
+        transport
+            .should_retry_gemini_rate_limited(&execution, 1, Some(&env))
+            .is_none()
+    );
+}


### PR DESCRIPTION
## Summary
- **#707**: Error clearly when --tier and --model-spec are passed together to csa run / review / debate. Wire --no-failover through to executor via reserved env key \`_CSA_NO_FAILOVER\`: reduces ACP crash retries, disables Gemini rate-limit failover phases, and gates debate outer Transient retry.
- **#701**: Add project_root to hook variables at todo_create, todo_save, and post-review hook execution points.
- **#667**: Rewrite --model-spec help text in run/review/debate CLI defs explaining the tool/provider/model/thinking format and contrast with --tier.
- Added anti-spoof filter in \`build_execution_env\`: drops user-configured \`_CSA_NO_FAILOVER\` / \`_CSA_NO_FLASH_FALLBACK\` before applying CLI-requested options (follow-on hardening from #722).

## Deferred
- **#710** (commit workflow weave include): codex's initial fix required a full workflow.toml regeneration that introduced unrelated breaking changes (empty-body rejection, unsupported NOT syntax in publish guards). Reverted to keep Batch H shippable; will retry in a focused PR.

## Review Findings
- **HIGH**: fixed (csa run --no-failover now wired via ExecutionEnvOptions::from_no_failover)
- **HIGH**: fixed (debate outer Transient retry now gated on no_failover)
- **HIGH**: fixed (user config can no longer spoof _CSA_NO_FAILOVER)
- **MEDIUM** → filed as #727: csa run tier/model-spec conflict not routed through pre-exec result wrapper
- **MEDIUM** → filed as #728: --model-spec with tiers still requires --force-ignore-tier-setting

## Test plan
- [x] \`cargo test -p cli-sub-agent resolve_review_tool_rejects_model_spec_with_tier\` — pass
- [x] \`cargo test -p cli-sub-agent retry_policy_suppressed_when_no_failover\` — pass
- [x] \`cargo test -p csa-config test_build_execution_env_drops_user_configured_no_failover_spoof\` — pass
- [x] \`cargo test -p csa-executor test_no_failover_stops_retry_after_attempt_1\` — pass
- [x] \`just clippy\` clean
- [x] \`just pre-commit\` passes (27/27 e2e)

Closes #707, closes #701, closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)