### PR TITLE
fix(routing): --model-spec bypasses tier whitelist for exact selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "chrono",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "chrono",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "axum",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "chrono",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "chrono",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "chrono",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.280"
+version = "0.1.281"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.280"
+version = "0.1.281"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
@@ -24,6 +24,7 @@ pub(crate) async fn handle_claude_sub_agent(
     let prompt = crate::run_helpers::read_prompt(args.question)?;
 
     // 6. Resolve tool
+    let user_explicit_tool = args.tool.is_some();
     let parent_tool = crate::run_helpers::detect_parent_tool();
     let tool = resolve_claude_tool(
         args.tool,
@@ -41,12 +42,12 @@ pub(crate) async fn handle_claude_sub_agent(
             args.model.as_deref(),
             config.as_ref(),
             &project_root,
-            false, // claude-sub-agent does not support --force
-            false, // claude-sub-agent does not support --force-override-user-config
-            false, // sub-agent dispatch always uses explicit tool
-            None,  // claude-sub-agent does not support --tier
-            false, // claude-sub-agent does not support --force-ignore-tier-setting
-            false, // user-explicit tool
+            false,               // claude-sub-agent does not support --force
+            false,               // claude-sub-agent does not support --force-override-user-config
+            false,               // claude-sub-agent does not require edit-capable tool filtering
+            None,                // claude-sub-agent does not support --tier
+            false,               // claude-sub-agent does not support --force-ignore-tier-setting
+            !user_explicit_tool, // auto-selected unless the caller explicitly passed --tool
         )?;
 
     // 8. Build executor and validate tool
@@ -59,7 +60,10 @@ pub(crate) async fn handle_claude_sub_agent(
             project: config.as_ref(),
             global: Some(&global_config),
         },
-        true,  // enforce tier whitelist for sub-agent execution
+        // enforce tier whitelist for sub-agent execution, except when the caller
+        // provided an exact --model-spec (matching the csa run / review / debate
+        // escape-hatch semantic so the CLI contract is consistent).
+        args.model_spec.is_none(),
         false, // claude-sub-agent does not support --force-override-user-config
         false, // scoped to `csa run --tool`, not sub-agent orchestration
     )
@@ -317,6 +321,39 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(tool, ToolName::Codex));
+    }
+
+    #[test]
+    fn resolve_model_spec_bypasses_tier_block_for_auto_selected_claude_sub_agent_tool() {
+        let global = GlobalConfig::default();
+        let cfg = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+        let tool = resolve_claude_tool(
+            None,
+            Some(&cfg),
+            &global,
+            Some("claude-code"),
+            std::path::Path::new("/tmp/test-project"),
+        )
+        .unwrap();
+
+        let (tool_name, model_spec, model) = crate::run_helpers::resolve_tool_and_model(
+            Some(tool),
+            Some("codex/openai/gpt-5.4/high"),
+            None,
+            Some(&cfg),
+            std::path::Path::new("/tmp/test-project"),
+            false,
+            false,
+            false,
+            None,
+            false,
+            true,
+        )
+        .expect("auto-selected claude-sub-agent tool should not block explicit model_spec");
+
+        assert_eq!(tool_name, ToolName::Codex);
+        assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/high"));
+        assert!(model.is_none());
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -19,7 +19,6 @@ pub use cli_doctor::*;
 #[path = "cli_review.rs"]
 mod cli_review;
 pub use cli_review::*;
-
 #[path = "cli_tokuin.rs"]
 mod cli_tokuin;
 pub use cli_tokuin::*;
@@ -155,8 +154,8 @@ pub enum Commands {
         /// Working directory (defaults to CWD)
         #[arg(long)]
         cd: Option<String>,
-        /// Exact model selector in `tool/provider/model/thinking` format.
-        /// Use this for a single fixed model choice; use `--tier` for tier-managed routing and failover.
+        /// Exact `tool/provider/model/thinking` selector for a single fixed model choice.
+        /// Implicitly bypasses tier whitelist; no need to pair with --force-ignore-tier-setting.
         #[arg(long)]
         model_spec: Option<String>,
         /// Override tool default model (opaque string, passed through to tool)

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -48,7 +48,8 @@ pub(super) async fn execute_review(
     readonly_project_root: bool,
     extra_writable: &[PathBuf],
 ) -> Result<crate::pipeline::SessionExecutionResult> {
-    let enforce_tier = tier_model_spec.is_some() && !force_ignore_tier_setting;
+    let enforce_tier =
+        tier_name.is_some() && tier_model_spec.is_some() && !force_ignore_tier_setting;
     let executor = crate::pipeline::build_and_validate_executor(
         &tool,
         tier_model_spec.as_deref(),
@@ -336,6 +337,92 @@ printf 'tool mutation\\n' >> tracked.txt\n",
         assert_eq!(
             std::fs::read_to_string(project_dir.path().join("tracked.txt")).unwrap(),
             "baseline\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn execute_review_model_spec_bypasses_tier_enforcement_without_active_tier() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let project_dir = setup_git_repo();
+        let _sandbox = ScopedSessionSandbox::new(&project_dir);
+        let bin_dir = project_dir.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let fake_opencode = bin_dir.join("opencode");
+        std::fs::write(
+            &fake_opencode,
+            "#!/bin/sh\n\
+printf '%s\\n' \
+'<!-- CSA:SECTION:summary -->' \
+'Explicit model spec review succeeded.' \
+'<!-- CSA:SECTION:summary:END -->' \
+'' \
+'<!-- CSA:SECTION:details -->' \
+'Explicit model spec bypassed tier enforcement.' \
+'<!-- CSA:SECTION:details:END -->' \
+'' \
+'PASS'\n",
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&fake_opencode).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_opencode, perms).unwrap();
+
+        let inherited_path = std::env::var("PATH").unwrap_or_default();
+        let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+        let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
+
+        let mut config = project_config_with_enabled_tools(&["opencode", "gemini-cli"]);
+        config.tiers.insert(
+            "quality".to_string(),
+            csa_config::config::TierConfig {
+                description: "Test tier".to_string(),
+                models: vec!["gemini-cli/google/default/xhigh".to_string()],
+                strategy: csa_config::TierStrategy::default(),
+                token_budget: None,
+                max_turns: None,
+            },
+        );
+
+        let global = GlobalConfig::default();
+        let result = execute_review(
+            ToolName::Opencode,
+            "scope=uncommitted mode=review-only security=auto".to_string(),
+            None,
+            None,
+            Some("opencode/provider/model/medium".to_string()),
+            None, // tier_name
+            None, // thinking
+            "review: model-spec-bypasses-tier-regression".to_string(),
+            project_dir.path(),
+            Some(&config),
+            &global,
+            ReviewRoutingMetadata {
+                project_profile: ProjectProfile::Unknown,
+                detection_method: "auto",
+            },
+            csa_process::StreamMode::BufferOnly,
+            crate::pipeline::DEFAULT_IDLE_TIMEOUT_SECONDS,
+            None,  // initial_response_timeout_seconds
+            false, // force_override_user_config
+            false, // force_ignore_tier_setting
+            false, // no_failover
+            false, // no_fs_sandbox
+            false, // readonly_project_root
+            &[],   // extra_writable
+        )
+        .await
+        .expect("explicit review model spec should bypass tier enforcement");
+
+        assert_eq!(result.execution.exit_code, 0);
+        assert!(
+            result
+                .execution
+                .output
+                .contains("Explicit model spec review succeeded."),
+            "expected structured review output, got: {}",
+            result.execution.output
         );
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -43,6 +43,7 @@ pub(crate) struct RunLoopRequest<'a> {
     pub(crate) strategy: ToolSelectionStrategy,
     pub(crate) initial_tool: ToolName,
     pub(crate) initial_model_spec: Option<String>,
+    pub(crate) user_model_spec_explicit: bool, // CLI `--model-spec`: exact selection, disables tier enforcement.
     pub(crate) initial_model: Option<String>,
     pub(crate) runtime_fallback_candidates: Vec<ToolName>,
     pub(crate) project_root: &'a Path,
@@ -153,7 +154,8 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
     let mut is_auto_seed_fork = request.is_auto_seed_fork;
     let mut session_arg = request.session_arg;
     let mut effective_session_arg = request.effective_session_arg;
-
+    let enforce_tier =
+        !request.force && !request.force_ignore_tier_setting && !request.user_model_spec_explicit;
     let result = loop {
         attempts += 1;
 
@@ -166,7 +168,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 project: request.config,
                 global: Some(request.global_config),
             },
-            !request.force && !request.force_ignore_tier_setting,
+            enforce_tier,
             request.force_override_user_config,
             matches!(request.strategy, ToolSelectionStrategy::Explicit(_)),
         )

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use tracing::{info, warn};
 
 use csa_config::ProjectConfig;
-use csa_core::types::{OutputFormat, ToolArg};
+use csa_core::types::{OutputFormat, ToolArg, ToolSelectionStrategy};
 use csa_lock::SessionLock;
 
 use crate::cli::ReturnTarget;
@@ -33,9 +33,10 @@ fn resolve_run_tier_context(
     strategy_resolved_tier_name: Option<String>,
     fallback_tier_name: Option<String>,
     force_ignore_tier_setting: bool,
+    user_model_spec_explicit: bool,
     user_explicit_tool: bool,
 ) -> (bool, bool, Option<String>) {
-    if force_ignore_tier_setting {
+    if force_ignore_tier_setting || user_model_spec_explicit {
         return (false, false, None);
     }
 
@@ -220,6 +221,16 @@ pub(crate) async fn handle_run(
         Some(ToolArg::Specific(tool)) => Some(tool.as_str()),
         _ => None,
     };
+    let fallback_description = crate::run_helpers::truncate_prompt(&prompt_text, 80);
+    let pre_exec_description = description
+        .as_deref()
+        .or(skill_session_tag.as_deref())
+        .or(Some(fallback_description.as_str()));
+    let pre_exec_parent = if is_fork {
+        session_arg.as_deref().or(parent.as_deref())
+    } else {
+        parent.as_deref()
+    };
 
     // Enforce tier routing: when tiers are configured, explicit --tool (any
     // value, including "auto") is blocked unless --tier is also specified or
@@ -240,16 +251,6 @@ pub(crate) async fn handle_run(
              Available tiers: {}",
             tier_list.join(", ")
         );
-        let fallback_description = crate::run_helpers::truncate_prompt(&prompt_text, 80);
-        let pre_exec_description = description
-            .as_deref()
-            .or(skill_session_tag.as_deref())
-            .or(Some(fallback_description.as_str()));
-        let pre_exec_parent = if is_fork {
-            session_arg.as_deref().or(parent.as_deref())
-        } else {
-            parent.as_deref()
-        };
         return Err(crate::session_guard::persist_pre_exec_error_result(
             crate::session_guard::PreExecErrorCtx {
                 project_root: &project_root,
@@ -307,7 +308,29 @@ pub(crate) async fn handle_run(
         needs_edit,
         effective_tier.as_deref(),
         force_ignore_tier_setting,
-    )?;
+    )
+    .map_err(|err| {
+        if err.to_string().contains("Conflicting routing flags") {
+            crate::session_guard::persist_pre_exec_error_result(
+                crate::session_guard::PreExecErrorCtx {
+                    project_root: &project_root,
+                    session_id: if is_fork {
+                        None
+                    } else {
+                        session_arg.as_deref()
+                    },
+                    description: pre_exec_description,
+                    parent: pre_exec_parent,
+                    tool_name: explicit_tool_name,
+                    task_type: Some("run"),
+                    tier_name: effective_tier.as_deref(),
+                    error: err,
+                },
+            )
+        } else {
+            err
+        }
+    })?;
     let heterogeneous_runtime_fallback_candidates = strategy_result.runtime_fallback_candidates;
     let resolved_model_spec = strategy_result.model_spec;
     let resolved_model = strategy_result.model;
@@ -409,6 +432,7 @@ pub(crate) async fn handle_run(
     });
     // Force-ignore bypass must not revive a tier at runtime, but ordinary
     // auto/default routing still keeps its existing fallback tier context.
+    let user_model_spec_explicit = model_spec.is_some();
     let (tier_auto_select, failover_on_crash_enabled, resolved_tier_name) =
         resolve_run_tier_context(
             config.as_ref(),
@@ -416,6 +440,7 @@ pub(crate) async fn handle_run(
             strategy_resolved_tier_name,
             fallback_tier_name,
             force_ignore_tier_setting,
+            user_model_spec_explicit,
             user_explicit_tool,
         );
     let context_load_options = skill_agent
@@ -425,10 +450,16 @@ pub(crate) async fn handle_run(
         query_override: memory_query,
     };
 
+    let loop_strategy = if user_model_spec_explicit {
+        ToolSelectionStrategy::Explicit(resolved_tool)
+    } else {
+        strategy
+    };
     let loop_completion = execute_run_loop(RunLoopRequest {
-        strategy,
+        strategy: loop_strategy,
         initial_tool: resolved_tool,
         initial_model_spec: resolved_model_spec,
+        user_model_spec_explicit,
         initial_model: resolved_model,
         runtime_fallback_candidates: heterogeneous_runtime_fallback_candidates,
         project_root: &project_root,
@@ -520,6 +551,10 @@ pub(crate) async fn handle_run(
 }
 
 #[cfg(test)]
+#[path = "run_cmd_execute_pre_exec_tests.rs"]
+mod pre_exec_tests;
+
+#[cfg(test)]
 mod tests {
     use super::resolve_run_tier_context;
     use chrono::Utc;
@@ -578,6 +613,7 @@ mod tests {
                 None,
                 false,
                 false,
+                false,
             );
 
         assert!(tier_auto_select);
@@ -594,6 +630,7 @@ mod tests {
                 Some("tier-3-complex".to_string()),
                 Some("tier-2-standard".to_string()),
                 true,
+                false,
                 true,
             );
 
@@ -612,6 +649,7 @@ mod tests {
                 Some("tier-3-complex".to_string()),
                 false,
                 false,
+                false,
             );
 
         assert!(tier_auto_select);
@@ -627,6 +665,7 @@ mod tests {
                 "codex",
                 None,
                 Some("tier-3-complex".to_string()),
+                false,
                 false,
                 true,
             );
@@ -646,11 +685,30 @@ mod tests {
                 Some("tier-3-complex".to_string()),
                 None,
                 false,
+                false,
                 true,
             );
 
         assert!(!tier_auto_select);
         assert!(failover_on_crash_enabled);
         assert_eq!(resolved_tier_name.as_deref(), Some("tier-3-complex"));
+    }
+
+    #[test]
+    fn resolve_run_tier_context_drops_tier_for_explicit_model_spec() {
+        let (tier_auto_select, failover_on_crash_enabled, resolved_tier_name) =
+            resolve_run_tier_context(
+                None,
+                "codex",
+                None,
+                Some("tier-3-complex".to_string()),
+                false,
+                true,
+                false,
+            );
+
+        assert!(!tier_auto_select);
+        assert!(!failover_on_crash_enabled);
+        assert!(resolved_tier_name.is_none());
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -1,0 +1,147 @@
+use super::handle_run;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_config::{ProjectConfig, ProjectMeta, ResourcesConfig, TierStrategy, ToolConfig};
+use csa_core::types::OutputFormat;
+use std::collections::HashMap;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn run_config_with_tier(
+    tier_name: &str,
+    models: Vec<&str>,
+    enabled_tools: &[&str],
+) -> ProjectConfig {
+    let mut tool_map = HashMap::new();
+    for tool in csa_config::global::all_known_tools() {
+        let name = tool.as_str();
+        tool_map.insert(
+            name.to_string(),
+            ToolConfig {
+                enabled: enabled_tools.contains(&name),
+                ..Default::default()
+            },
+        );
+    }
+
+    let mut config = ProjectConfig {
+        schema_version: csa_config::config::CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: chrono::Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: tool_map,
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+    config.tiers.insert(
+        tier_name.to_string(),
+        csa_config::config::TierConfig {
+            description: "Test tier".to_string(),
+            models: models.into_iter().map(String::from).collect(),
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    config
+}
+
+fn write_project_config(project_root: &Path, config: &ProjectConfig) {
+    let config_path = ProjectConfig::config_path(project_root);
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(config_path, toml::to_string_pretty(config).unwrap()).unwrap();
+}
+
+#[tokio::test]
+async fn handle_run_persists_result_for_model_spec_tier_conflict() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let config = run_config_with_tier(
+        "default",
+        vec!["gemini-cli/google/default/xhigh"],
+        &["gemini-cli", "codex"],
+    );
+    write_project_config(project_dir.path(), &config);
+
+    let err = handle_run(
+        None,
+        None,
+        None,
+        Some("inspect the repository".to_string()),
+        None,
+        None,
+        None,
+        false,
+        None,
+        false,
+        None,
+        false,
+        None,
+        None,
+        false,
+        Some(project_dir.path().display().to_string()),
+        Some("codex/openai/gpt-5.4/high".to_string()),
+        None,
+        None,
+        false,
+        false,
+        false,
+        false,
+        None,
+        None,
+        None,
+        false,
+        false,
+        None,
+        0,
+        OutputFormat::Text,
+        csa_process::StreamMode::BufferOnly,
+        Some("default".to_string()),
+        false,
+        false,
+        Vec::new(),
+    )
+    .await
+    .expect_err("model-spec + tier conflict must return an error");
+
+    assert!(
+        err.chain()
+            .any(|cause| cause.to_string().contains("Conflicting routing flags")),
+        "unexpected error chain: {err:#}"
+    );
+    assert!(
+        err.chain().any(|cause| cause
+            .to_string()
+            .contains("--model-spec and --tier are mutually exclusive")),
+        "tier/model-spec conflict hint should be present: {err:#}"
+    );
+
+    let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
+    assert_eq!(sessions.len(), 1, "expected one failed run session");
+
+    let result = csa_session::load_result(project_dir.path(), &sessions[0].meta_session_id)
+        .unwrap()
+        .expect("result.toml must be written for pre-exec routing conflicts");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(result.summary.contains("pre-exec:"));
+    assert!(
+        result
+            .summary
+            .contains("--model-spec and --tier are mutually exclusive")
+    );
+}

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
@@ -303,7 +303,11 @@ fn resolve_heterogeneous_preferred(
 
         match heterogeneous_candidates.first().copied() {
             Some(tool) => {
-                let fallback = heterogeneous_candidates.into_iter().skip(1).collect();
+                let fallback = if model_spec.is_some() {
+                    Vec::new()
+                } else {
+                    heterogeneous_candidates.into_iter().skip(1).collect()
+                };
                 let (t, ms, m) = resolve_tool_and_model(
                     Some(tool),
                     model_spec,
@@ -753,3 +757,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "run_cmd_tool_selection_model_spec_tests.rs"]
+mod model_spec_tests;

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection_model_spec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection_model_spec_tests.rs
@@ -1,0 +1,86 @@
+use super::resolve_tool_by_strategy;
+use csa_config::global::DefaultsConfig;
+use csa_config::{
+    GlobalConfig, ProjectConfig, ProjectMeta, ResourcesConfig, TierStrategy, ToolConfig,
+};
+use csa_core::types::ToolSelectionStrategy;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+#[test]
+fn resolve_tool_by_strategy_model_spec_disables_default_tier_and_runtime_fallbacks() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut tools = HashMap::new();
+    for tool in csa_config::global::all_known_tools() {
+        let name = tool.as_str();
+        tools.insert(
+            name.to_string(),
+            ToolConfig {
+                enabled: matches!(name, "codex" | "openai-compat" | "gemini-cli"),
+                ..Default::default()
+            },
+        );
+    }
+    let config = ProjectConfig {
+        schema_version: csa_config::config::CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: chrono::Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools,
+        review: None,
+        debate: None,
+        tiers: HashMap::from([(
+            "tier-3-complex".to_string(),
+            csa_config::config::TierConfig {
+                description: "Test tier".to_string(),
+                models: vec!["openai-compat/openai/gpt-5-codex/high".to_string()],
+                strategy: TierStrategy::default(),
+                token_budget: None,
+                max_turns: None,
+            },
+        )]),
+        tier_mapping: HashMap::from([("default".to_string(), "tier-3-complex".to_string())]),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+    let global_config = GlobalConfig {
+        defaults: DefaultsConfig {
+            tool: Some("codex".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let resolution = resolve_tool_by_strategy(
+        &ToolSelectionStrategy::HeterogeneousPreferred,
+        Some("codex/openai/gpt-5.4/high"),
+        None,
+        Some(&config),
+        &global_config,
+        tmp.path(),
+        false,
+        false,
+        false,
+        None,
+        false,
+    )
+    .expect("resolve tool by explicit model_spec");
+
+    assert_eq!(
+        resolution.model_spec.as_deref(),
+        Some("codex/openai/gpt-5.4/high")
+    );
+    assert!(resolution.resolved_tier_name.is_none());
+    assert!(resolution.runtime_fallback_candidates.is_empty());
+}

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -84,14 +84,15 @@ pub(crate) fn resolve_tool_and_model(
     let bypass_tier = force_ignore_tier_setting || force_override_user_config;
 
     // Enforce tier routing: block direct --tool/--model/--thinking when tiers are configured,
-    // unless --force-ignore-tier-setting (or --force) is active.
+    // unless --force-ignore-tier-setting (or --force) is active. --model-spec is the
+    // exact-selection escape hatch and is handled below.
     // Auto-resolved tools (from HeterogeneousPreferred etc.) don't count as user-explicit.
     let tool_triggers_enforcement = tool.is_some() && !tool_is_auto_resolved;
     validate_tool_tier_override_flags(tool_triggers_enforcement, tier, force_ignore_tier_setting)?;
     if tiers_configured
         && !bypass_tier
         && tier.is_none()
-        && (tool_triggers_enforcement || model_spec.is_some() || model.is_some())
+        && (tool_triggers_enforcement || model.is_some())
     {
         let cfg = config.unwrap();
         let mut tier_list = String::new();
@@ -103,7 +104,7 @@ pub(crate) fn resolve_tool_and_model(
         }
         let alias_hint = cfg.format_tier_aliases();
         anyhow::bail!(
-            "Direct --tool/--model/--model-spec/--thinking is restricted when tiers are configured.\n\
+            "Direct --tool/--model/--thinking is restricted when tiers are configured.\n\
              Use --tier <name> to specify which tier's model/thinking config to use, \
              or add --force-ignore-tier-setting to override.\n\
              Available tiers: [{tier_list}]{alias_hint}\n\
@@ -184,20 +185,15 @@ pub(crate) fn resolve_tool_and_model(
         return Ok((resolution.tool, Some(resolution.model_spec), resolved_model));
     }
 
-    // Case 1: model_spec provided → parse it to get tool
+    // Case 1: model_spec provided → parse it to get tool. --model-spec is the
+    // exact-selection escape hatch and implicitly bypasses tier whitelist;
+    // enforce_tool_enabled still applies.
     if let Some(spec) = model_spec {
         let parsed = ModelSpec::parse(spec)?;
         let tool_name = parse_tool_name(&parsed.tool)?;
         // Enforce tool enablement from user config
         if let Some(cfg) = config {
             cfg.enforce_tool_enabled(tool_name.as_str(), force_override_user_config)?;
-        }
-        // Enforce tier whitelist: model-spec must appear in tiers
-        if !force
-            && !bypass_tier
-            && let Some(cfg) = config
-        {
-            cfg.enforce_tier_whitelist(tool_name.as_str(), Some(spec))?;
         }
         return Ok((tool_name, Some(spec.to_string()), None));
     }

--- a/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
@@ -347,17 +347,19 @@ fn resolve_tool_and_model_blocks_direct_tool_when_tiers_configured() {
     );
 }
 
-/// When tiers are configured, direct --model-spec without --force-ignore-tier-setting is blocked.
+/// When tiers are configured, --model-spec is the exact-selection escape hatch and
+/// implicitly bypasses the tier whitelist. `enforce_tool_enabled` still applies (see
+/// `resolve_tool_and_model_disabled_tool_model_spec_errors`).
 #[test]
-fn resolve_tool_and_model_blocks_direct_model_spec_when_tiers_configured() {
+fn resolve_tool_and_model_allows_model_spec_exact_selection_when_tiers_configured() {
     let cfg = config_with_tier(
         "default",
         vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli"],
+        &["gemini-cli", "codex"],
     );
     let result = super::resolve_tool_and_model(
         None,
-        Some("gemini-cli/google/gemini-3.1-pro/high"),
+        Some("codex/openai/gpt-5.4/high"),
         None,
         Some(&cfg),
         std::path::Path::new("/tmp"),
@@ -368,12 +370,15 @@ fn resolve_tool_and_model_blocks_direct_model_spec_when_tiers_configured() {
         false,
         false, // tool_is_auto_resolved
     );
-    assert!(result.is_err());
-    let msg = result.unwrap_err().to_string();
     assert!(
-        msg.contains("restricted when tiers are configured"),
-        "unexpected error: {msg}"
+        result.is_ok(),
+        "model-spec should bypass tier whitelist: {}",
+        result.unwrap_err()
     );
+    let (tool, model_spec, model) = result.unwrap();
+    assert_eq!(tool, ToolName::Codex);
+    assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/high"));
+    assert!(model.is_none());
 }
 
 /// When tiers are configured, direct --model alone (no --tool, no --model-spec) is blocked.

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -131,11 +131,21 @@ OnFail: abort
 
 Run the security audit directly in this CSA step.
 - Review the staged changes and associated tests.
-- Perform the full three-phase audit: test completeness, vulnerability scan, and code quality.
+- Phase 1: test completeness.
+  - For each changed public function, verify normal-path, edge/boundary, and error-condition coverage.
+  - Ask whether there is a missing test case you can still propose; treat missing coverage in changed code as blocking unless it is clearly deferred outside the current scope.
+- Phase 2: vulnerability scan.
+  - For external-input handling, check input validation and size/length limits.
+  - Check panic paths on untrusted input (`unwrap`, `expect`, index access).
+  - Check crafted-input resource exhaustion risks.
+  - Check timing-attack exposure for secrets.
+  - Check integer overflow handling.
+- Phase 3: code quality.
+  - Check for debug code, hardcoded secrets, commented-out code, TODO/FIXME security items, and incomplete error handling on untrusted input.
 - Emit `CSA_VAR:AUDIT_FAIL=true` when blocking issues exist; otherwise emit `CSA_VAR:AUDIT_FAIL=false`.
 - Emit `CSA_VAR:AUDIT_PASS_DEFERRED=true` when only deferred follow-up issues remain; otherwise emit `CSA_VAR:AUDIT_PASS_DEFERRED=false`.
 - Blocking issues take precedence over deferred ones.
-- End with a concise audit report and a final verdict: PASS, PASS_DEFERRED, or FAIL.
+- End with a concise structured audit report and a final verdict: PASS, PASS_DEFERRED, or FAIL.
 
 ## INCLUDE security-audit
 
@@ -166,6 +176,14 @@ Tier: tier-2-standard
 
 Run the staged-diff review directly in this CSA step.
 - Inspect `git diff --cached` for correctness, regressions, security issues, and test gaps.
+- Use an authorship-aware review strategy.
+  - Self-authored changes from this session: review with the adversarial rigor of `csa debate`.
+  - Other-authored changes: review with the `csa review --diff --allow-fallback` standard.
+- Check the applicable AGENTS.md chain for every staged file.
+- Explicitly check rule 009 (error handling), rule 014 (security), and rule 016 (testing).
+- If staged changes touch `PATTERN.md` or `workflow.toml`, check rule 027 `pattern-workflow-sync`.
+- If staged changes touch process spawning or lifecycle code, check Rust rule 015 `subprocess-lifecycle`.
+- If the implementation session is available, you may optionally use fork-based self-review guidance such as `csa review --fork-from <impl-session-id> --diff` for zero-cost context reuse.
 - Emit `CSA_VAR:REVIEW_HAS_ISSUES=true` when fixes are required before commit; otherwise emit `CSA_VAR:REVIEW_HAS_ISSUES=false`.
 - If issues exist, explain exactly what must be fixed before commit proceeds.
 - Preserve the AGENTS.md compliance checklist and rule checks below.

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -222,11 +222,21 @@ tool = "csa"
 prompt = """
 Run the security audit directly in this CSA step.
 - Review the staged changes and associated tests.
-- Perform the full three-phase audit: test completeness, vulnerability scan, and code quality.
+- Phase 1: test completeness.
+  - For each changed public function, verify normal-path, edge/boundary, and error-condition coverage.
+  - Ask whether there is a missing test case you can still propose; treat missing coverage in changed code as blocking unless it is clearly deferred outside the current scope.
+- Phase 2: vulnerability scan.
+  - For external-input handling, check input validation and size/length limits.
+  - Check panic paths on untrusted input (`unwrap`, `expect`, index access).
+  - Check crafted-input resource exhaustion risks.
+  - Check timing-attack exposure for secrets.
+  - Check integer overflow handling.
+- Phase 3: code quality.
+  - Check for debug code, hardcoded secrets, commented-out code, TODO/FIXME security items, and incomplete error handling on untrusted input.
 - Emit `CSA_VAR:AUDIT_FAIL=true` when blocking issues exist; otherwise emit `CSA_VAR:AUDIT_FAIL=false`.
 - Emit `CSA_VAR:AUDIT_PASS_DEFERRED=true` when only deferred follow-up issues remain; otherwise emit `CSA_VAR:AUDIT_PASS_DEFERRED=false`.
 - Blocking issues take precedence over deferred ones.
-- End with a concise audit report and a final verdict: PASS, PASS_DEFERRED, or FAIL."""
+- End with a concise structured audit report and a final verdict: PASS, PASS_DEFERRED, or FAIL."""
 tier = "tier-2-standard"
 on_fail = "abort"
 
@@ -260,6 +270,14 @@ tool = "csa"
 prompt = """
 Run the staged-diff review directly in this CSA step.
 - Inspect `git diff --cached` for correctness, regressions, security issues, and test gaps.
+- Use an authorship-aware review strategy.
+  - Self-authored changes from this session: review with the adversarial rigor of `csa debate`.
+  - Other-authored changes: review with the `csa review --diff --allow-fallback` standard.
+- Check the applicable AGENTS.md chain for every staged file.
+- Explicitly check rule 009 (error handling), rule 014 (security), and rule 016 (testing).
+- If staged changes touch `PATTERN.md` or `workflow.toml`, check rule 027 `pattern-workflow-sync`.
+- If staged changes touch process spawning or lifecycle code, check Rust rule 015 `subprocess-lifecycle`.
+- If the implementation session is available, you may optionally use fork-based self-review guidance such as `csa review --fork-from <impl-session-id> --diff` for zero-cost context reuse.
 - Emit `CSA_VAR:REVIEW_HAS_ISSUES=true` when fixes are required before commit; otherwise emit `CSA_VAR:REVIEW_HAS_ISSUES=false`.
 - If issues exist, explain exactly what must be fixed before commit proceeds.
 - Preserve the AGENTS.md compliance checklist and rule checks below."""
@@ -311,16 +329,33 @@ id = 17
 title = "Generate Commit Message Parts"
 tool = "bash"
 prompt = '''
-Generate a deterministic Conventional Commits subject/body split from staged files.
-Avoid model-dependent loops in commit-message generation.
+Generate a Conventional Commits subject/body split from staged files. The body
+MUST contain a short description of what changed followed by the AI Reviewer
+Metadata block. Generate the metadata from the actual staged changes, design
+decisions made during implementation, and reviewer guidance needed for careful
+inspection. Prefer a richer `${COMMIT_BODY}` supplied by an upstream AI step
+when available; otherwise fall back to the helper script.
 
 ```bash
 set -euo pipefail
 COMMIT_SUBJECT_LOCAL="$(scripts/gen_commit_msg.sh --subject "${SCOPE:-}")"
-COMMIT_BODY_LOCAL="$(scripts/gen_commit_msg.sh --body "${SCOPE:-}")"
+COMMIT_BODY_RAW="${COMMIT_BODY:-}"
+
+if [ -n "${COMMIT_BODY_RAW}" ] && [ "${COMMIT_BODY_RAW}" != '""' ]; then
+  if ! COMMIT_BODY_LOCAL="$(printf '%s' "${COMMIT_BODY_RAW}" | jq -er . 2>/dev/null)"; then
+    COMMIT_BODY_LOCAL="${COMMIT_BODY_RAW}"
+  fi
+else
+  COMMIT_BODY_LOCAL="$(scripts/gen_commit_msg.sh --body "${SCOPE:-}")"
+fi
 
 if [ -z "${COMMIT_SUBJECT_LOCAL}" ]; then
   echo "ERROR: Commit subject is empty." >&2
+  exit 1
+fi
+
+if [ -z "$(printf '%s' "${COMMIT_BODY_LOCAL}" | tr -d '[:space:]')" ]; then
+  echo "ERROR: Commit body is empty. AI-era commit format requires a summary and metadata block." >&2
   exit 1
 fi
 

--- a/scripts/gen_commit_msg.sh
+++ b/scripts/gen_commit_msg.sh
@@ -11,6 +11,114 @@ Options:
 EOF
 }
 
+component_for_file() {
+  local file="$1"
+
+  case "${file}" in
+    crates/*)
+      printf 'crate %s' "$(printf '%s' "${file}" | cut -d/ -f2)"
+      ;;
+    patterns/*)
+      printf 'pattern %s' "$(printf '%s' "${file}" | cut -d/ -f2)"
+      ;;
+    scripts/*)
+      printf 'scripts'
+      ;;
+    tests/*|*/tests/*|*_test.rs|*.spec.ts|*.test.ts)
+      printf 'tests'
+      ;;
+    docs/*|drafts/*|*.md)
+      printf 'docs'
+      ;;
+    Cargo.toml|Cargo.lock|weave.lock|*/Cargo.toml|*/Cargo.lock|*/weave.lock)
+      printf 'workspace metadata'
+      ;;
+    */*)
+      printf '%s' "${file%%/*}"
+      ;;
+    *)
+      printf 'repo root files'
+      ;;
+  esac
+}
+
+collect_components() {
+  local file component existing
+
+  components=()
+  for file in "${staged_files[@]}"; do
+    component="$(component_for_file "${file}")"
+    for existing in "${components[@]:-}"; do
+      if [[ "${existing}" == "${component}" ]]; then
+        component=""
+        break
+      fi
+    done
+
+    if [[ -n "${component}" ]]; then
+      components+=("${component}")
+    fi
+  done
+}
+
+describe_components() {
+  local total preview_count
+
+  total="${#components[@]}"
+  if [[ "${total}" -eq 0 ]]; then
+    printf 'the staged files'
+    return
+  fi
+
+  if [[ "${total}" -eq 1 ]]; then
+    printf '%s' "${components[0]}"
+    return
+  fi
+
+  if [[ "${total}" -eq 2 ]]; then
+    printf '%s and %s' "${components[0]}" "${components[1]}"
+    return
+  fi
+
+  preview_count=3
+  if [[ "${total}" -lt "${preview_count}" ]]; then
+    preview_count="${total}"
+  fi
+
+  printf '%s, %s, and %s' "${components[0]}" "${components[1]}" "${components[2]}"
+  if [[ "${total}" -gt "${preview_count}" ]]; then
+    printf ' (+%s more)' "$((total - preview_count))"
+  fi
+}
+
+build_commit_body() {
+  local summary targets
+
+  collect_components
+  targets="$(describe_components)"
+
+  if [[ "${is_release}" == "true" ]]; then
+    summary="Bump the staged release metadata touching ${targets}."
+  elif [[ "${is_docs_only}" == "true" ]]; then
+    summary="Refresh the staged documentation touching ${targets}."
+  elif [[ "${is_tests_only}" == "true" ]]; then
+    summary="Update the staged test coverage touching ${targets}."
+  elif [[ "${has_new_non_test_code}" == "true" ]]; then
+    summary="Add the staged functionality touching ${targets}."
+  else
+    summary="Update the staged changes touching ${targets}."
+  fi
+
+  cat <<EOF
+${summary}
+
+### AI Reviewer Metadata
+- **Design Intent**: Capture the staged changes in a non-empty fallback commit body when no richer upstream summary was provided.
+- **Key Decisions**: Derive this fallback from the staged file set and preserve the AI Reviewer Metadata scaffold required by the audited commit workflow.
+- **Reviewer Guidance**: Verify the staged diff still matches this generated summary and expand the metadata when the change needs task-specific rationale.
+EOF
+}
+
 mode="full"
 scope_input=""
 
@@ -126,6 +234,7 @@ else
 fi
 
 commit_body=""
+commit_body="$(build_commit_body)"
 
 case "${mode}" in
   subject)


### PR DESCRIPTION
## Summary
- preserve exact `--model-spec` selection across `csa run` and `csa review`
- keep pre-exec routing conflicts persisted and add regression coverage for run/review model-spec handling
- make the commit workflow helper emit a non-empty fallback body so audited commit generation does not abort when no upstream `COMMIT_BODY` exists

## Verification
- `just pre-commit`
- `csa review --range main...HEAD --sa-mode true --tool codex --force-ignore-tier-setting --timeout 3600`

Closes #727
Closes #728
Closes #710

Follow-ups: #730, #731