### PR TITLE
fix(build): gate CODEX_CI fallback on sandboxed target writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ strix_runs
 # Review artifacts
 result.toml
 .letta/
+/.target-review-*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "chrono",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "chrono",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "axum",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "chrono",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "chrono",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "chrono",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.281"
+version = "0.1.282"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.281"
+version = "0.1.282"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/justfile
+++ b/justfile
@@ -17,11 +17,10 @@ _repo_root := `git rev-parse --show-superproject-working-tree 2>/dev/null | grep
 # Just already executes repository-controlled code, so trust this checkout's
 # mise config and avoid interactive trust prompts on sandboxed commit paths.
 export MISE_TRUSTED_CONFIG_PATHS := _repo_root
-# Codex CI runs cargo against a mirrored workspace path that is not writable for
-# lock files. Keep the fallback target/state dirs inside the repo so clippy and
-# nextest do not lose incremental artifacts under tmpfs-backed `/tmp`.
-_codex_ci_root := `repo_root=$(git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel); if [ "${CODEX_CI:-0}" = "1" ]; then dir="$repo_root/.tmp/codex-ci"; mkdir -p "$dir"; printf '%s' "$dir"; fi`
-_cargo_target_dir := `repo_root=$(git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel); if [ "${CODEX_CI:-0}" = "1" ]; then dir="$repo_root/.tmp/codex-ci/target"; mkdir -p "$dir"; printf '%s' "$dir"; else printf '%s' "$repo_root/target"; fi`
+# Codex CI only needs the repo-local fallback in the real sandbox path. Local
+# CODEX_CI shells should keep using the normal workspace target directory.
+_codex_ci_root := `scripts/resolve-codex-ci-path.sh root`
+_cargo_target_dir := `scripts/resolve-codex-ci-path.sh target`
 
 # Keep cargo state local to avoid host pollution (Optional)
 # export CARGO_HOME := _repo_root + "/.cargo-local"
@@ -163,6 +162,7 @@ pre-commit:
     just find-monolith-files
     just check-generated-artifacts
     just check-version-bumped
+    just check-codex-ci-target-routing
     just check-chinese
     just fmt
     ./scripts/hooks/check-env-dependent-tests.sh
@@ -178,6 +178,10 @@ pre-commit:
 check-chinese:
     @echo "Checking for Chinese characters..."
     @! rg "\p{Script=Han}" . --vimgrep --glob '!target/**' --glob '!.git/**' --glob '!**/i18n/*.ftl' --glob '!skills/mktd/**' --glob '!tests/fixtures/**' --glob '!.claude/rules/**' --glob '!.agents/**' --glob '!CLAUDE.md' --glob '!GEMINI.md'
+
+# Verify CODEX_CI keeps using ./target locally and only falls back when needed.
+check-codex-ci-target-routing:
+    ./scripts/check-codex-ci-target-routing.sh
 
 # Format code and auto-stage modified .rs files.
 # This allows 'just fmt' to be run immediately before commit without manual 'git add'.
@@ -208,21 +212,21 @@ deny:
 
 # Run all tests in the workspace.
 test:
-    if [ "${CODEX_CI:-0}" = "1" ]; then dir="{{_codex_ci_root}}/xdg-state"; mkdir -p "$dir"; XDG_STATE_HOME="$dir" CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --workspace --all-features; else CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --workspace --all-features; fi
+    if [ -n "{{_codex_ci_root}}" ]; then dir="{{_codex_ci_root}}/xdg-state"; mkdir -p "$dir"; XDG_STATE_HOME="$dir" CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --workspace --all-features; else CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --workspace --all-features; fi
 
 # Run e2e tests only.
 test-e2e:
-    if [ "${CODEX_CI:-0}" = "1" ]; then dir="{{_codex_ci_root}}/xdg-state"; mkdir -p "$dir"; XDG_STATE_HOME="$dir" CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --package cli-sub-agent --test e2e --all-features; else CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --package cli-sub-agent --test e2e --all-features; fi
+    if [ -n "{{_codex_ci_root}}" ]; then dir="{{_codex_ci_root}}/xdg-state"; mkdir -p "$dir"; XDG_STATE_HOME="$dir" CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --package cli-sub-agent --test e2e --all-features; else CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --package cli-sub-agent --test e2e --all-features; fi
 
 # Run tests for a specific package.
 # Usage: just test-p my-crate
 test-p package:
-    if [ "${CODEX_CI:-0}" = "1" ]; then dir="{{_codex_ci_root}}/xdg-state"; mkdir -p "$dir"; XDG_STATE_HOME="$dir" CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run -p {{package}} --all-features; else CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run -p {{package}} --all-features; fi
+    if [ -n "{{_codex_ci_root}}" ]; then dir="{{_codex_ci_root}}/xdg-state"; mkdir -p "$dir"; XDG_STATE_HOME="$dir" CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run -p {{package}} --all-features; else CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run -p {{package}} --all-features; fi
 
 # Run tests matching a specific pattern/name.
 # Usage: just test-f login_validation
 test-f pattern:
-    if [ "${CODEX_CI:-0}" = "1" ]; then dir="{{_codex_ci_root}}/xdg-state"; mkdir -p "$dir"; XDG_STATE_HOME="$dir" CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --workspace --all-features -E 'test({{pattern}})'; else CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --workspace --all-features -E 'test({{pattern}})'; fi
+    if [ -n "{{_codex_ci_root}}" ]; then dir="{{_codex_ci_root}}/xdg-state"; mkdir -p "$dir"; XDG_STATE_HOME="$dir" CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --workspace --all-features -E 'test({{pattern}})'; else CARGO_TARGET_DIR="{{_cargo_target_dir}}" cargo nextest run --workspace --all-features -E 'test({{pattern}})'; fi
 
 # ==============================================================================
 # 🛠 Git Helpers

--- a/scripts/check-codex-ci-target-routing.sh
+++ b/scripts/check-codex-ci-target-routing.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+checkout_root="$(git -C "$script_dir/.." rev-parse --show-toplevel)"
+scratch_parent="$checkout_root/.tmp/check-codex-ci-target-routing"
+mkdir -p "$scratch_parent"
+
+repo_root="$(mktemp -d "$scratch_parent/repo.XXXXXX")"
+trap 'chmod -R u+w "$repo_root" 2>/dev/null || true; rm -rf "$repo_root"' EXIT
+
+target_dir="$repo_root/target"
+fallback_target="$repo_root/.tmp/codex-ci/target"
+
+expect_eq() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+
+    if [ "$actual" != "$expected" ]; then
+        echo "ERROR: $message" >&2
+        echo "expected: $expected" >&2
+        echo "actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+local_target="$(env -u CSA_FS_SANDBOXED CODEX_CI=1 scripts/resolve-codex-ci-path.sh target "$repo_root")"
+expect_eq "$target_dir" "$local_target" "local CODEX_CI shell should keep using ./target when writable"
+
+sandbox_target="$(CODEX_CI=1 CSA_FS_SANDBOXED=1 scripts/resolve-codex-ci-path.sh target "$repo_root")"
+expect_eq "$fallback_target" "$sandbox_target" "sandboxed CODEX_CI shell should use the repo-local fallback target"

--- a/scripts/resolve-codex-ci-path.sh
+++ b/scripts/resolve-codex-ci-path.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 <root|target> [repo_root]" >&2
+    exit 2
+}
+
+mode="${1:-}"
+if [ -z "$mode" ]; then
+    usage
+fi
+if [ "$#" -gt 2 ]; then
+    usage
+fi
+
+case "$mode" in
+    root|target) ;;
+    *)
+        usage
+        ;;
+esac
+
+repo_root="${2:-$(git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel)}"
+target_dir="$repo_root/target"
+fallback_root="$repo_root/.tmp/codex-ci"
+fallback_target="$fallback_root/target"
+
+use_fallback=false
+if [ "${CODEX_CI:-0}" = "1" ]; then
+    # The real codex sandbox marks itself explicitly, so local CODEX_CI shells
+    # can keep using ./target while the sandbox path still gets its fallback.
+    if [ "${CSA_FS_SANDBOXED:-0}" = "1" ]; then
+        use_fallback=true
+    fi
+fi
+
+case "$mode" in
+    root)
+        if [ "$use_fallback" = true ]; then
+            mkdir -p "$fallback_root"
+            printf '%s' "$fallback_root"
+        fi
+        ;;
+    target)
+        if [ "$use_fallback" = true ]; then
+            mkdir -p "$fallback_target"
+            printf '%s' "$fallback_target"
+        else
+            printf '%s' "$target_dir"
+        fi
+        ;;
+esac


### PR DESCRIPTION
## Summary
- gate the `CODEX_CI` cargo-target fallback on `CSA_FS_SANDBOXED=1` so local `CODEX_CI` shells keep using `./target`
- add a small pre-commit routing smoke check and keep its scratch space under the repo-local `.tmp/` tree
- ignore `.target-review-*`, bump the workspace patch version required by this repo, and clean the orphaned `.tmp` cargo target trees during validation

## Validation
- `./scripts/check-codex-ci-target-routing.sh`
- `TMPDIR=/proc ./scripts/check-codex-ci-target-routing.sh`
- `CODEX_CI=1 just pre-commit`
- `csa review --range main...HEAD --sa-mode true --tool codex --force-ignore-tier-setting --timeout 3600`

## Notes
- Follow-up issue for the untouched pre-existing checklist drift: #736
- `.csa/review-checklist.md` had pre-existing unstaged changes and was intentionally left out of this branch