### PR TITLE
fix(multi): pr-bot auto-review wait + CI baseline test graceful-skip (#745, #746)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@v2
 
+      - name: Install ripgrep
+        run: mise use -g ripgrep
+
       - name: Install cargo tools
         uses: taiki-e/install-action@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "chrono",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "chrono",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "axum",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "chrono",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "chrono",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "chrono",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.283"
+version = "0.1.284"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.283"
+version = "0.1.284"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
@@ -27,6 +27,13 @@ impl Drop for EnvVarGuard {
     }
 }
 
+fn write_global_config(contents: &str) -> std::path::PathBuf {
+    let path = csa_config::GlobalConfig::config_path().expect("resolve global config path");
+    std::fs::create_dir_all(path.parent().expect("global config dir")).unwrap();
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
 #[test]
 fn build_config_get_lookup_global_kv_cache_returns_not_found_when_key_is_absent() {
     let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
@@ -36,16 +43,12 @@ fn build_config_get_lookup_global_kv_cache_returns_not_found_when_key_is_absent(
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(
-        global_dir.join("config.toml"),
+    write_global_config(
         r#"
 [review]
 tool = "auto"
 "#,
-    )
-    .unwrap();
+    );
 
     let lookup = build_config_get_lookup(None, "kv_cache.long_poll_seconds", false, true).unwrap();
     let value = resolve_lookup_sources(&lookup.sources, "kv_cache.long_poll_seconds").unwrap();
@@ -65,10 +68,7 @@ fn resolve_lookup_sources_global_raw_match_survives_invalid_unrelated_global_fie
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(
-        global_dir.join("config.toml"),
+    write_global_config(
         r#"
 [review]
 tool = "auto"
@@ -76,8 +76,7 @@ tool = "auto"
 [defaults]
 max_concurrent = "oops"
 "#,
-    )
-    .unwrap();
+    );
 
     let lookup = build_config_get_lookup(None, "review.tool", false, true).unwrap();
     let value = resolve_lookup_sources(&lookup.sources, "review.tool")
@@ -99,11 +98,7 @@ fn resolve_lookup_sources_warns_when_raw_global_fallback_follows_effective_proje
     let project_root = dir.path().join("project");
     std::fs::create_dir_all(&project_root).unwrap();
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    let global_config_path = global_dir.join("config.toml");
-    std::fs::write(
-        &global_config_path,
+    let global_config_path = write_global_config(
         r#"
 [review]
 tool = "auto"
@@ -111,8 +106,7 @@ tool = "auto"
 [execution]
 min_timeout_seconds = "oops"
 "#,
-    )
-    .unwrap();
+    );
 
     let sources = vec![
         LookupSourceSpec::RawProject {

--- a/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
@@ -31,6 +31,12 @@ fn write_global_config(contents: &str) -> std::path::PathBuf {
     let path = csa_config::GlobalConfig::config_path().expect("resolve global config path");
     std::fs::create_dir_all(path.parent().expect("global config dir")).unwrap();
     std::fs::write(&path, contents).unwrap();
+    if let Some(user_path) = csa_config::ProjectConfig::user_config_path()
+        && user_path != path
+    {
+        std::fs::create_dir_all(user_path.parent().expect("user config dir")).unwrap();
+        std::fs::write(&user_path, contents).unwrap();
+    }
     path
 }
 

--- a/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
@@ -28,16 +28,25 @@ impl Drop for EnvVarGuard {
 }
 
 fn write_global_config(contents: &str) -> std::path::PathBuf {
-    let path = csa_config::GlobalConfig::config_path().expect("resolve global config path");
-    std::fs::create_dir_all(path.parent().expect("global config dir")).unwrap();
-    std::fs::write(&path, contents).unwrap();
-    if let Some(user_path) = csa_config::ProjectConfig::user_config_path()
-        && user_path != path
-    {
-        std::fs::create_dir_all(user_path.parent().expect("user config dir")).unwrap();
-        std::fs::write(&user_path, contents).unwrap();
+    // Mirror every production read path. Both `GlobalConfig::load()` and
+    // `ProjectConfig::load()` resolve the user-level config via
+    // `paths::config_dir().join("config.toml")`, so the test fixture must
+    // populate whatever that resolver returns for the current environment.
+    // Also populate `GlobalConfig::config_path()` (the canonical write path)
+    // so `LookupSourceSpec::RawGlobal` consumers see the same bytes on
+    // platforms where the read and write resolvers can disagree.
+    let read_path =
+        csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
+    std::fs::create_dir_all(read_path.parent().expect("user config dir")).unwrap();
+    std::fs::write(&read_path, contents).unwrap();
+    let write_path = csa_config::GlobalConfig::config_path().expect("resolve global config path");
+    if write_path != read_path {
+        std::fs::create_dir_all(write_path.parent().expect("global config dir")).unwrap();
+        std::fs::write(&write_path, contents).unwrap();
     }
-    path
+    // Return the read path so callers wiring `LookupSourceSpec::RawGlobal` use
+    // the same file that `ProjectConfig::load` will read from.
+    read_path
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/config_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_tests.rs
@@ -29,6 +29,13 @@ impl Drop for EnvVarGuard {
     }
 }
 
+fn write_global_config(contents: &str) -> std::path::PathBuf {
+    let path = csa_config::GlobalConfig::config_path().expect("resolve global config path");
+    std::fs::create_dir_all(path.parent().expect("global config dir")).unwrap();
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
 #[test]
 fn resolve_key_scalar() {
     let root: toml::Value = toml::from_str("[review]\ntool = \"auto\"\n").unwrap();
@@ -169,18 +176,14 @@ fn resolve_effective_execution_key_uses_global_fallback_when_project_missing() {
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(
-        global_dir.join("config.toml"),
+    write_global_config(
         r#"
 schema_version = 1
 [execution]
 min_timeout_seconds = 3600
 auto_weave_upgrade = true
 "#,
-    )
-    .unwrap();
+    );
 
     let timeout = resolve_effective_execution_key(dir.path(), "execution.min_timeout_seconds")
         .unwrap()
@@ -262,17 +265,13 @@ fn resolve_effective_global_key_uses_configured_kv_cache_values() {
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(
-        global_dir.join("config.toml"),
+    write_global_config(
         r#"
 [kv_cache]
 frequent_poll_seconds = 45
 long_poll_seconds = 3000
 "#,
-    )
-    .unwrap();
+    );
 
     let frequent = resolve_effective_global_key("kv_cache.frequent_poll_seconds")
         .unwrap()
@@ -294,17 +293,13 @@ fn resolve_effective_global_key_sanitizes_zero_kv_cache_values() {
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(
-        global_dir.join("config.toml"),
+    write_global_config(
         r#"
 [kv_cache]
 frequent_poll_seconds = 0
 long_poll_seconds = 0
 "#,
-    )
-    .unwrap();
+    );
 
     let frequent = resolve_effective_global_key("kv_cache.frequent_poll_seconds")
         .unwrap()
@@ -326,16 +321,12 @@ fn resolve_effective_key_ignores_project_kv_cache_override() {
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(
-        global_dir.join("config.toml"),
+    write_global_config(
         r#"
 [kv_cache]
 long_poll_seconds = 3000
 "#,
-    )
-    .unwrap();
+    );
 
     let csa_dir = dir.path().join(".csa");
     std::fs::create_dir_all(&csa_dir).unwrap();
@@ -422,16 +413,12 @@ fn build_config_get_lookup_prefers_effective_values_for_known_sections() {
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(
-        global_dir.join("config.toml"),
+    write_global_config(
         r#"
 [tools.codex]
 enabled = false
 "#,
-    )
-    .unwrap();
+    );
 
     let csa_dir = dir.path().join(".csa");
     std::fs::create_dir_all(&csa_dir).unwrap();
@@ -463,17 +450,13 @@ fn resolve_effective_key_redacts_global_memory_api_keys_in_project_scoped_lookup
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(
-        global_dir.join("config.toml"),
+    write_global_config(
         r#"
 [memory.llm]
 enabled = true
 api_key = "sk-super-secret-5982"
 "#,
-    )
-    .unwrap();
+    );
 
     let csa_dir = dir.path().join(".csa");
     std::fs::create_dir_all(&csa_dir).unwrap();
@@ -545,9 +528,7 @@ fn resolve_lookup_sources_falls_back_to_raw_project_for_known_sections_when_glob
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(global_dir.join("config.toml"), "{{invalid toml").unwrap();
+    write_global_config("{{invalid toml");
 
     let csa_dir = dir.path().join(".csa");
     std::fs::create_dir_all(&csa_dir).unwrap();
@@ -579,9 +560,7 @@ fn resolve_lookup_sources_returns_project_raw_match_before_global_parse() {
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(global_dir.join("config.toml"), "{{invalid toml").unwrap();
+    write_global_config("{{invalid toml");
 
     let csa_dir = dir.path().join(".csa");
     std::fs::create_dir_all(&csa_dir).unwrap();
@@ -614,16 +593,12 @@ fn resolve_lookup_sources_invalid_project_raw_still_errors_before_global_match()
     let _home_guard = EnvVarGuard::set("HOME", dir.path());
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
-    let global_dir = config_root.join("cli-sub-agent");
-    std::fs::create_dir_all(&global_dir).unwrap();
-    std::fs::write(
-        global_dir.join("config.toml"),
+    write_global_config(
         r#"
 [execution]
 min_timeout_seconds = 3600
 "#,
-    )
-    .unwrap();
+    );
 
     let csa_dir = dir.path().join(".csa");
     std::fs::create_dir_all(&csa_dir).unwrap();

--- a/crates/cli-sub-agent/src/config_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_tests.rs
@@ -711,9 +711,13 @@ fn handle_config_edit_supports_quoted_editor_path_with_embedded_args() {
 
     let captured_args = std::fs::read_to_string(&captured_args_path).unwrap();
     let captured_lines: Vec<_> = captured_args.lines().collect();
+    // `handle_config_edit` canonicalizes the project root (resolves symlinks
+    // like macOS's `/var` -> `/private/var`), so compare against the
+    // canonicalized config path instead of the raw tempdir join.
+    let expected_config_path = config_path.canonicalize().unwrap();
     assert_eq!(
         captured_lines,
-        vec!["--wait", config_path.to_str().unwrap()]
+        vec!["--wait", expected_config_path.to_str().unwrap()]
     );
 }
 

--- a/crates/cli-sub-agent/src/config_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_tests.rs
@@ -30,10 +30,23 @@ impl Drop for EnvVarGuard {
 }
 
 fn write_global_config(contents: &str) -> std::path::PathBuf {
-    let path = csa_config::GlobalConfig::config_path().expect("resolve global config path");
-    std::fs::create_dir_all(path.parent().expect("global config dir")).unwrap();
-    std::fs::write(&path, contents).unwrap();
-    path
+    // Mirror every production read path. Both `GlobalConfig::load()` and
+    // `ProjectConfig::load()` resolve the user-level config via
+    // `paths::config_dir().join("config.toml")`, so the test fixture must
+    // populate whatever that resolver returns for the current environment.
+    // Also populate `GlobalConfig::config_path()` (the canonical write path)
+    // so production code and tests agree on which bytes they see on
+    // platforms where the read and write resolvers can disagree.
+    let read_path =
+        csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
+    std::fs::create_dir_all(read_path.parent().expect("user config dir")).unwrap();
+    std::fs::write(&read_path, contents).unwrap();
+    let write_path = csa_config::GlobalConfig::config_path().expect("resolve global config path");
+    if write_path != read_path {
+        std::fs::create_dir_all(write_path.parent().expect("global config dir")).unwrap();
+        std::fs::write(&write_path, contents).unwrap();
+    }
+    read_path
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/pipeline_gate_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_gate_tests.rs
@@ -555,7 +555,8 @@ async fn test_evaluate_gate_lefthook_fallback() {
         .await
         .unwrap();
 
-    // Create lefthook config but no binary on PATH (likely in CI)
+    // Create lefthook config. Whether the binary is on PATH varies per env
+    // (CI pre-commit job installs it via mise; bare CI `Test` job does not).
     std::fs::write(
         dir.path().join("lefthook.yml"),
         "pre-commit:\n  commands:\n    lint:\n      run: echo ok\n",
@@ -566,10 +567,18 @@ async fn test_evaluate_gate_lefthook_fallback() {
         .await
         .unwrap();
 
-    // If lefthook is on PATH: gate runs (lefthook run pre-commit).
-    // If lefthook is NOT on PATH: gate is skipped (no gate found).
-    // Either way, the function should not error.
-    assert!(result.passed());
+    // If lefthook is NOT on PATH: gate is skipped (no gate found) -> passed.
+    // If lefthook IS on PATH: gate runs `lefthook run pre-commit ...`; the exit
+    // code depends on the installed lefthook version and tempdir git state,
+    // so only assert the command was resolved to the lefthook invocation.
+    if which::which("lefthook").is_err() {
+        assert!(result.passed(), "expected skip when lefthook missing");
+    } else {
+        assert_eq!(
+            result.command, "lefthook run pre-commit --no-auto-install",
+            "expected lefthook fallback command when binary is on PATH"
+        );
+    }
 
     // SAFETY: Restoring env.
     unsafe { clear_depth() };

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -315,6 +315,12 @@ fn pr_bot_artifacts_paginate_reusable_current_head_review_lookup() {
                     .contains(r#"--jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'")"#),
                 "{artifact} helper occurrence {occurrence} must flatten paginated review pages before sorting reusable review records"
             );
+            assert!(
+                helper.contains(
+                    r#"| sort_by(.submitted_at) | last | select(. != null) | [.id, .submitted_at] | @tsv) // ""'"#
+                ),
+                "{artifact} helper occurrence {occurrence} must guard null reusable review records so empty result variables stay empty instead of rendering a tab"
+            );
         }
     }
 }

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -291,6 +291,35 @@ fn pr_bot_artifacts_paginate_current_head_trigger_lookup() {
 }
 
 #[test]
+fn pr_bot_artifacts_paginate_reusable_current_head_review_lookup() {
+    for artifact in [
+        "patterns/pr-bot/workflow.toml",
+        "patterns/pr-bot/PATTERN.md",
+    ] {
+        let text = pr_bot_artifact_text(artifact);
+        for occurrence in 0..2 {
+            let helper = extract_nth_shell_function(
+                &text,
+                "query_reusable_current_head_review_record",
+                occurrence,
+                artifact,
+            );
+            assert!(
+                helper.contains(
+                    r#"gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100""#
+                ),
+                "{artifact} helper occurrence {occurrence} must paginate and slurp pull-request reviews"
+            );
+            assert!(
+                helper
+                    .contains(r#"--jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'")"#),
+                "{artifact} helper occurrence {occurrence} must flatten paginated review pages before sorting reusable review records"
+            );
+        }
+    }
+}
+
+#[test]
 fn pr_bot_artifacts_recovery_probe_reuses_null_commit_reviews() {
     for artifact in [
         "patterns/pr-bot/workflow.toml",
@@ -304,6 +333,17 @@ fn pr_bot_artifacts_recovery_probe_reuses_null_commit_reviews() {
                 occurrence,
                 artifact,
             );
+            assert!(
+                helper.contains(
+                    r#"gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100""#
+                ),
+                "{artifact} recovery helper occurrence {occurrence} must paginate and slurp pull-request reviews"
+            );
+            assert!(
+                helper
+                    .contains(r#"--jq '[.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'")"#),
+                "{artifact} recovery helper occurrence {occurrence} must flatten paginated review pages before selecting current-window signals"
+            );
             let expected = format!(
                 "select(.submitted_at >= \"'\"${{{}}}\"'\") | select(.commit_id == \"'\"${{CURRENT_SHA}}\"'\" or .commit_id == null) | .submitted_at",
                 window_var
@@ -311,6 +351,42 @@ fn pr_bot_artifacts_recovery_probe_reuses_null_commit_reviews() {
             assert!(
                 helper.contains(&expected),
                 "{artifact} recovery helper occurrence {occurrence} must treat null commit_id reviews as valid current-head signals"
+            );
+        }
+    }
+}
+
+#[test]
+fn pr_bot_artifacts_paginate_review_event_counts() {
+    for artifact in [
+        "patterns/pr-bot/workflow.toml",
+        "patterns/pr-bot/PATTERN.md",
+    ] {
+        let text = pr_bot_artifact_text(artifact);
+        assert_eq!(
+            text.matches(
+                r#"gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100""#
+            )
+            .count(),
+            0,
+            "{artifact} must slurp every paginated pull-request reviews query"
+        );
+        assert_eq!(
+            text.matches(
+                r#"gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100""#
+            )
+            .count(),
+            6,
+            "{artifact} must slurp all six paginated pull-request review queries"
+        );
+        for window_var in ["BOT_REVIEW_WINDOW_START", "POST_FIX_REVIEW_WINDOW_START"] {
+            let expected = format!(
+                "[.[][] | select(.user.login == \"'\"${{CLOUD_BOT_LOGIN}}\"'\") | select(.submitted_at >= \"'\"${{{}}}\"'\") | select(.commit_id == \"'\"${{CURRENT_SHA}}\"'\" or .commit_id == null)] | length",
+                window_var
+            );
+            assert!(
+                text.contains(&expected),
+                "{artifact} must flatten paginated review pages before counting review events for {window_var}"
             );
         }
     }

--- a/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
@@ -44,6 +44,11 @@ fn recurring_bug_class_skill_extraction_runs_for_high_severity_review_completion
     let config_home = temp.path().join("config");
     std::fs::create_dir_all(&config_home).unwrap();
     let _config_guard = ScopedEnvVarRestore::set("XDG_CONFIG_HOME", config_home.to_str().unwrap());
+    // macOS's `directories` crate ignores `XDG_CONFIG_HOME` and resolves
+    // `$HOME/Library/Application Support`, so redirect HOME too. Without
+    // this, the production extractor writes skills into the real runner
+    // home on macOS and the assertion below cannot find them.
+    let _home_guard = ScopedEnvVarRestore::set("HOME", temp.path().to_str().unwrap());
     let project_root = temp.path().join("project");
     std::fs::create_dir_all(&project_root).unwrap();
 
@@ -69,7 +74,13 @@ fn recurring_bug_class_skill_extraction_runs_for_high_severity_review_completion
     )
     .expect("skill extraction should succeed");
 
-    let skill_dir = config_home.join("cli-sub-agent/skills/code-quality-rust");
+    // Resolve the skill directory through the same production resolver that
+    // `SkillExtractor::from_global_config()` uses, so the lookup stays
+    // correct on platforms where `directories` ignores `XDG_CONFIG_HOME`
+    // (e.g. macOS, which uses `$HOME/Library/Application Support`).
+    let skill_dir = csa_config::paths::config_dir_write()
+        .expect("resolve config dir")
+        .join("skills/code-quality-rust");
     assert!(skill_dir.join("SKILL.md").is_file());
     assert!(
         std::fs::read_to_string(skill_dir.join("references/detailed-patterns.md"))

--- a/crates/cli-sub-agent/tests/config_get_global_warning_e2e.rs
+++ b/crates/cli-sub-agent/tests/config_get_global_warning_e2e.rs
@@ -29,6 +29,8 @@ impl Drop for EnvVarGuard {
 }
 
 fn global_config_path(tmp: &Path) -> std::path::PathBuf {
+    // Mirror the production resolver so the test writes the same platform-specific
+    // global path that `csa config get --global` reads on Linux and macOS.
     let _home_guard = EnvVarGuard::set("HOME", tmp);
     let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", tmp.join(".config"));
     csa_config::GlobalConfig::config_path().expect("resolve global config path")

--- a/crates/cli-sub-agent/tests/config_get_global_warning_e2e.rs
+++ b/crates/cli-sub-agent/tests/config_get_global_warning_e2e.rs
@@ -1,5 +1,38 @@
+use serial_test::serial;
 use std::path::Path;
 use std::process::Command;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation is reverted in Drop.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation is reverted in Drop.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn global_config_path(tmp: &Path) -> std::path::PathBuf {
+    let _home_guard = EnvVarGuard::set("HOME", tmp);
+    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", tmp.join(".config"));
+    csa_config::GlobalConfig::config_path().expect("resolve global config path")
+}
 
 fn csa_cmd(tmp: &Path) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
@@ -10,12 +43,14 @@ fn csa_cmd(tmp: &Path) -> Command {
 }
 
 #[test]
+#[serial]
 fn config_get_global_warns_when_falling_back_to_raw_invalid_global_config() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let global_dir = tmp.path().join(".config/cli-sub-agent");
+    let global_config_path = global_config_path(tmp.path());
+    let global_dir = global_config_path.parent().expect("global config dir");
     std::fs::create_dir_all(&global_dir).expect("create global config dir");
     std::fs::write(
-        global_dir.join("config.toml"),
+        &global_config_path,
         r#"
 [review]
 tool = "auto"

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -7,9 +7,36 @@ mod cli_defs;
 use clap::Parser;
 use cli_defs::{AuditCommands, Cli, Commands, McpHubCommands, validate_command_args};
 use csa_core::types::OutputFormat;
+use serial_test::serial;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation is reverted in Drop.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation is reverted in Drop.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
 
 /// Create a [`Command`] pointing at the built `csa` binary with HOME, XDG_STATE_HOME,
 /// and XDG_CONFIG_HOME redirected to the given temp directory so tests never touch
@@ -20,6 +47,14 @@ fn csa_cmd(tmp: &std::path::Path) -> Command {
         .env("XDG_STATE_HOME", tmp.join(".local/state"))
         .env("XDG_CONFIG_HOME", tmp.join(".config"));
     cmd
+}
+
+fn global_config_path(tmp: &Path) -> std::path::PathBuf {
+    // Mirror the production resolver so the test writes the same platform-specific
+    // global path that `csa config get` reads on Linux and macOS.
+    let _home_guard = EnvVarGuard::set("HOME", tmp);
+    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", tmp.join(".config"));
+    csa_config::GlobalConfig::config_path().expect("resolve global config path")
 }
 
 /// Run `csa init` (minimal mode) inside the given temp directory.
@@ -347,12 +382,14 @@ memory_max_mb = 1024
 }
 
 #[test]
+#[serial]
 fn config_get_prefers_effective_tool_state_over_raw_project_value() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let global_dir = tmp.path().join(".config/cli-sub-agent");
+    let global_config_path = global_config_path(tmp.path());
+    let global_dir = global_config_path.parent().expect("global config dir");
     std::fs::create_dir_all(&global_dir).expect("create global config dir");
     std::fs::write(
-        global_dir.join("config.toml"),
+        &global_config_path,
         r#"
 [tools.codex]
 enabled = false
@@ -383,12 +420,14 @@ enabled = true
 }
 
 #[test]
+#[serial]
 fn config_get_redacts_global_memory_api_keys_in_project_scoped_lookups() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let global_dir = tmp.path().join(".config/cli-sub-agent");
+    let global_config_path = global_config_path(tmp.path());
+    let global_dir = global_config_path.parent().expect("global config dir");
     std::fs::create_dir_all(&global_dir).expect("create global config dir");
     std::fs::write(
-        global_dir.join("config.toml"),
+        &global_config_path,
         r#"
 [memory.llm]
 enabled = true
@@ -428,12 +467,13 @@ inject = true
 }
 
 #[test]
+#[serial]
 fn config_get_falls_back_to_raw_project_value_when_global_config_is_invalid() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let global_dir = tmp.path().join(".config/cli-sub-agent");
+    let global_config_path = global_config_path(tmp.path());
+    let global_dir = global_config_path.parent().expect("global config dir");
     std::fs::create_dir_all(&global_dir).expect("create global config dir");
-    std::fs::write(global_dir.join("config.toml"), "{{invalid toml")
-        .expect("write invalid global config");
+    std::fs::write(&global_config_path, "{{invalid toml").expect("write invalid global config");
 
     let config_path = csa_config::ProjectConfig::config_path(tmp.path());
     std::fs::create_dir_all(config_path.parent().expect("config dir")).expect("create config dir");

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -7,36 +7,9 @@ mod cli_defs;
 use clap::Parser;
 use cli_defs::{AuditCommands, Cli, Commands, McpHubCommands, validate_command_args};
 use csa_core::types::OutputFormat;
-use serial_test::serial;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
-
-struct EnvVarGuard {
-    key: &'static str,
-    original: Option<String>,
-}
-
-impl EnvVarGuard {
-    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-        let original = std::env::var(key).ok();
-        // SAFETY: test-scoped env mutation is reverted in Drop.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, original }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        // SAFETY: test-scoped env mutation is reverted in Drop.
-        unsafe {
-            match self.original.as_deref() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-}
 
 /// Create a [`Command`] pointing at the built `csa` binary with HOME, XDG_STATE_HOME,
 /// and XDG_CONFIG_HOME redirected to the given temp directory so tests never touch
@@ -52,9 +25,11 @@ fn csa_cmd(tmp: &std::path::Path) -> Command {
 fn global_config_path(tmp: &Path) -> std::path::PathBuf {
     // Mirror the production resolver so the test writes the same platform-specific
     // global path that `csa config get` reads on Linux and macOS.
-    let _home_guard = EnvVarGuard::set("HOME", tmp);
-    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", tmp.join(".config"));
-    csa_config::GlobalConfig::config_path().expect("resolve global config path")
+    if cfg!(target_os = "macos") {
+        tmp.join("Library/Application Support/cli-sub-agent/config.toml")
+    } else {
+        tmp.join(".config/cli-sub-agent/config.toml")
+    }
 }
 
 /// Run `csa init` (minimal mode) inside the given temp directory.
@@ -382,7 +357,6 @@ memory_max_mb = 1024
 }
 
 #[test]
-#[serial]
 fn config_get_prefers_effective_tool_state_over_raw_project_value() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let global_config_path = global_config_path(tmp.path());
@@ -420,7 +394,6 @@ enabled = true
 }
 
 #[test]
-#[serial]
 fn config_get_redacts_global_memory_api_keys_in_project_scoped_lookups() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let global_config_path = global_config_path(tmp.path());
@@ -467,7 +440,6 @@ inject = true
 }
 
 #[test]
-#[serial]
 fn config_get_falls_back_to_raw_project_value_when_global_config_is_invalid() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let global_config_path = global_config_path(tmp.path());

--- a/deny.toml
+++ b/deny.toml
@@ -32,7 +32,6 @@ allow = [
     "MPL-2.0",
     "Zlib",
     "CDLA-Permissive-2.0",
-    "OpenSSL",
 ]
 # xurl-core is pre-release (0.0.0-dev) with no license field in manifest yet.
 # Upstream repo (github.com/Xuanwo/xurl) is Apache-2.0 licensed.
@@ -48,6 +47,10 @@ license-files = []
 [bans]
 multiple-versions = "warn"
 wildcards = "allow"
+skip = [
+    # agent-teams/cc-sdk -> reqwest 0.11 and tokuin/tiktoken-rs still pin base64 0.21.x.
+    { crate = "base64@0.21.7", reason = "old reqwest 0.11 and tiktoken-rs transitive chain still require 0.21.7" },
+]
 
 [sources]
 unknown-registry = "warn"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -380,7 +380,7 @@ query_latest_current_head_trigger_ts() {
 query_reusable_current_head_review_record() {
   local latest_trigger_ts="${1:-}"
   gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
+    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | select(. != null) | [.id, .submitted_at] | @tsv) // ""' \
     2>/dev/null
 }
 
@@ -1213,7 +1213,7 @@ query_latest_current_head_trigger_ts() {
 query_reusable_current_head_review_record() {
   local latest_trigger_ts="${1:-}"
   gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
+    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | select(. != null) | [.id, .submitted_at] | @tsv) // ""' \
     2>/dev/null
 }
 

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -379,8 +379,8 @@ query_latest_current_head_trigger_ts() {
 
 query_reusable_current_head_review_record() {
   local latest_trigger_ts="${1:-}"
-  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '([.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
+  gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
     2>/dev/null
 }
 
@@ -446,8 +446,8 @@ BOT_REVIEW_WINDOW_START="${WAIT_BASE_TS}"
 
 # --- Delegate remaining polling to CSA-managed step ---
 query_current_window_current_head_review_ts() {
-  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '[.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${WAIT_BASE_TS}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null) | .submitted_at] | sort | last // ""' \
+  gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+    --jq '[.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${WAIT_BASE_TS}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null) | .submitted_at] | sort | last // ""' \
     2>/dev/null
 }
 
@@ -520,8 +520,8 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   else
     set +e
     REVIEW_EVENT_RAW="$(
-      gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-        --jq '[.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null)] | length' \
+      gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+        --jq '[.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null)] | length' \
         2>/dev/null
     )"
     REVIEW_EVENT_RC=$?
@@ -1212,8 +1212,8 @@ query_latest_current_head_trigger_ts() {
 
 query_reusable_current_head_review_record() {
   local latest_trigger_ts="${1:-}"
-  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '([.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
+  gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
     2>/dev/null
 }
 
@@ -1256,8 +1256,8 @@ sleep "${CLOUD_BOT_WAIT_SECONDS}"
 POST_FIX_REVIEW_WINDOW_START="${RETRIGGER_TS}"
 
 query_current_window_current_head_review_ts() {
-  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '[.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${RETRIGGER_TS}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null) | .submitted_at] | sort | last // ""' \
+  gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+    --jq '[.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${RETRIGGER_TS}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null) | .submitted_at] | sort | last // ""' \
     2>/dev/null
 }
 
@@ -1332,8 +1332,8 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   else
     set +e
     REVIEW_EVENT_RAW="$(
-      gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-        --jq '[.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null)] | length' \
+      gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+        --jq '[.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null)] | length' \
         2>/dev/null
     )"
     REVIEW_EVENT_RC=$?

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -663,8 +663,8 @@ query_latest_current_head_trigger_ts() {
 
 query_reusable_current_head_review_record() {
   local latest_trigger_ts="${1:-}"
-  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '([.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
+  gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
     2>/dev/null
 }
 
@@ -730,8 +730,8 @@ BOT_REVIEW_WINDOW_START="${WAIT_BASE_TS}"
 
 # --- Delegate remaining polling to CSA-managed step ---
 query_current_window_current_head_review_ts() {
-  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '[.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${WAIT_BASE_TS}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null) | .submitted_at] | sort | last // ""' \
+  gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+    --jq '[.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${WAIT_BASE_TS}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null) | .submitted_at] | sort | last // ""' \
     2>/dev/null
 }
 
@@ -804,8 +804,8 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   else
     set +e
     REVIEW_EVENT_RAW="$(
-      gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-        --jq '[.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null)] | length' \
+      gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+        --jq '[.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null)] | length' \
         2>/dev/null
     )"
     REVIEW_EVENT_RC=$?
@@ -1482,8 +1482,8 @@ query_latest_current_head_trigger_ts() {
 
 query_reusable_current_head_review_record() {
   local latest_trigger_ts="${1:-}"
-  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '([.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
+  gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
     2>/dev/null
 }
 
@@ -1526,8 +1526,8 @@ sleep "${CLOUD_BOT_WAIT_SECONDS}"
 POST_FIX_REVIEW_WINDOW_START="${RETRIGGER_TS}"
 
 query_current_window_current_head_review_ts() {
-  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '[.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${RETRIGGER_TS}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null) | .submitted_at] | sort | last // ""' \
+  gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+    --jq '[.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${RETRIGGER_TS}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null) | .submitted_at] | sort | last // ""' \
     2>/dev/null
 }
 
@@ -1602,8 +1602,8 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   else
     set +e
     REVIEW_EVENT_RAW="$(
-      gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-        --jq '[.[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null)] | length' \
+      gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
+        --jq '[.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null)] | length' \
         2>/dev/null
     )"
     REVIEW_EVENT_RC=$?

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -664,7 +664,7 @@ query_latest_current_head_trigger_ts() {
 query_reusable_current_head_review_record() {
   local latest_trigger_ts="${1:-}"
   gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
+    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | select(. != null) | [.id, .submitted_at] | @tsv) // ""' \
     2>/dev/null
 }
 
@@ -1483,7 +1483,7 @@ query_latest_current_head_trigger_ts() {
 query_reusable_current_head_review_record() {
   local latest_trigger_ts="${1:-}"
   gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" \
-    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | [.id, .submitted_at] | @tsv) // ""' \
+    --jq '([.[][] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or (.commit_id == null and "'"${latest_trigger_ts}"'" != "" and .submitted_at >= "'"${latest_trigger_ts}"'")) | {id: (.id | tostring), submitted_at: .submitted_at}] | sort_by(.submitted_at) | last | select(. != null) | [.id, .submitted_at] | @tsv) // ""' \
     2>/dev/null
 }
 


### PR DESCRIPTION
## Summary
- round 1 fixed null `commit_id` handling and comment-endpoint pagination coverage.
- round 2 reused scoped current-head review objects and added targeted regression tests.
- round 3 fixes the remaining `pulls/.../reviews` pagination gap by adding `--slurp` plus `.[][]` flattening across reusable-review lookup, current-window probes, and review-event counts.

## Validation
- `cargo test -p cli-sub-agent pr_bot_artifacts_`
- `just pre-commit`
- `csa review --range main...HEAD --sa-mode true` => PASS (`01KP2C3DPFEFGG856ZMHE39V3K`)

## Traceability
- Round 1 review session: `01KP296HDTQXH5PY9TDX30KQEC`
- Round 2 review session: `01KP2ABCKZ8VR532FQZSYBDP9T`
