### PR TITLE
fix(csa): close #752 bug4 (commit nest) + bug2 defensive gc scope reap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "chrono",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "chrono",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "axum",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "chrono",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "chrono",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "chrono",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.285"
+version = "0.1.286"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.285"
+version = "0.1.286"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -4,6 +4,7 @@ use tracing::{info, warn};
 
 use csa_config::{GcConfig, GlobalConfig};
 use csa_core::types::OutputFormat;
+use csa_resource::cleanup_orphan_scopes;
 use csa_session::{
     PhaseEvent, delete_session, get_session_dir, get_session_root, list_sessions, save_session_in,
 };
@@ -30,6 +31,7 @@ pub(crate) fn handle_gc(
     let mut orphan_dirs_removed = 0;
     let mut expired_sessions_removed = 0;
     let mut sessions_retired = 0u64;
+    let mut orphan_scopes_cleaned = 0u64;
 
     if dry_run {
         eprintln!("[dry-run] No changes will be made.");
@@ -185,6 +187,26 @@ pub(crate) fn handle_gc(
 
     let transcript_stats = cleanup_project_transcripts(&session_root, gc_config, dry_run);
 
+    if dry_run {
+        eprintln!("[dry-run] Would scan for orphan csa-*.scope units with 0 active PIDs");
+    } else {
+        match cleanup_orphan_scopes() {
+            Ok(cleaned) => {
+                orphan_scopes_cleaned = cleaned.len() as u64;
+                for scope in cleaned {
+                    info!(
+                        scope = %scope.unit_name,
+                        active_pids = scope.active_pids,
+                        "Stopped orphan cgroup scope (stale unit with no live processes)"
+                    );
+                }
+            }
+            Err(err) => {
+                warn!(error = %err, "Failed to enumerate orphan cgroup scopes; skipping");
+            }
+        }
+    }
+
     let mut stale_slots_cleaned = 0;
     if let Ok(slots_dir) = GlobalConfig::slots_dir()
         && slots_dir.exists()
@@ -237,6 +259,7 @@ pub(crate) fn handle_gc(
                 "transcripts_removed": transcript_stats.files_removed,
                 "transcript_bytes_reclaimed": transcript_stats.bytes_reclaimed,
                 "stale_slots_cleaned": stale_slots_cleaned,
+                "orphan_scopes_cleaned": orphan_scopes_cleaned,
             });
             if max_age_days.is_some() {
                 summary["expired_sessions_removed"] = serde_json::json!(expired_sessions_removed);
@@ -264,6 +287,7 @@ pub(crate) fn handle_gc(
                 prefix, transcript_stats.files_removed, transcript_stats.bytes_reclaimed
             );
             eprintln!("{prefix}  Stale slots cleaned: {stale_slots_cleaned}");
+            eprintln!("{prefix}  Orphan cgroup scopes cleaned: {orphan_scopes_cleaned}");
         }
     }
 
@@ -504,6 +528,27 @@ pub(crate) fn handle_gc_global(
             total_transcript_bytes_reclaimed.saturating_add(transcript_stats.bytes_reclaimed);
     }
 
+    let mut orphan_scopes_cleaned = 0u64;
+    if dry_run {
+        eprintln!("[dry-run] Would scan for orphan csa-*.scope units with 0 active PIDs");
+    } else {
+        match cleanup_orphan_scopes() {
+            Ok(cleaned) => {
+                orphan_scopes_cleaned = cleaned.len() as u64;
+                for scope in cleaned {
+                    info!(
+                        scope = %scope.unit_name,
+                        active_pids = scope.active_pids,
+                        "Stopped orphan cgroup scope (stale unit with no live processes)"
+                    );
+                }
+            }
+            Err(err) => {
+                warn!(error = %err, "Failed to enumerate orphan cgroup scopes; skipping");
+            }
+        }
+    }
+
     let mut stale_slots_cleaned = 0u64;
     if let Ok(slots_dir) = GlobalConfig::slots_dir()
         && slots_dir.exists()
@@ -559,6 +604,7 @@ pub(crate) fn handle_gc_global(
                 "transcripts_removed": total_transcripts_removed,
                 "transcript_bytes_reclaimed": total_transcript_bytes_reclaimed,
                 "stale_slots_cleaned": stale_slots_cleaned,
+                "orphan_scopes_cleaned": orphan_scopes_cleaned,
             });
             if max_age_days.is_some() {
                 summary["expired_sessions_removed"] = serde_json::json!(total_expired_sessions);
@@ -589,6 +635,7 @@ pub(crate) fn handle_gc_global(
                 "{prefix}  Transcript files removed: {total_transcripts_removed} ({total_transcript_bytes_reclaimed} bytes)"
             );
             eprintln!("{prefix}  Stale slots cleaned: {stale_slots_cleaned}");
+            eprintln!("{prefix}  Orphan cgroup scopes cleaned: {orphan_scopes_cleaned}");
         }
     }
 

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -24,7 +24,7 @@ Initialize and declare workflow variables.
 - `${COMMIT_SUBJECT}`: Generated or provided commit subject
 - `${COMMIT_BODY}`: Generated or provided commit body
 - `${COMMIT_MESSAGE_FILE}`: Path to temporary commit message file
-- `${SKIP_PUBLISH}`: Set to `"true"` to skip auto-PR (parent workflow handles publish)
+- `${SKIP_PUBLISH}`: Set to `"true"` to skip auto-PR (parent workflow handles publish). Workflow auto-activates this when `CSA_SKIP_PUBLISH=true` or when running inside a CSA session (`CSA_DEPTH` set and non-zero) to keep employee sessions orchestration-pure — the Layer 0 orchestrator owns publish/pr-bot (#752 Bug 4).
 - `${ENABLE_REVIEW_LOOP}`: Set to `"true"` to run iterative review loop
 - `${AUDIT_FAIL}`: Set by `security-audit` if blocking issues found
 - `${AUDIT_PASS_DEFERRED}`: Set by `security-audit` if non-blocking issues found
@@ -425,7 +425,9 @@ OnFail: abort
 Push, create or reuse the PR, then synchronously run the post-create helper.
 This makes PR creation + pr-bot a single shell-enforced transaction.
 Runs by default when standalone. Skipped when parent workflow sets
-`CSA_SKIP_PUBLISH=true`.
+`CSA_SKIP_PUBLISH=true`, or automatically when invoked from inside a CSA
+session (`CSA_DEPTH` set and non-zero) — the Layer 0 orchestrator owns the
+publish/pr-bot transaction in that case.
 
 ```bash
 set -euo pipefail

--- a/patterns/commit/skills/commit/SKILL.md
+++ b/patterns/commit/skills/commit/SKILL.md
@@ -78,7 +78,10 @@ breaks prompt-guard propagation.
 8. **Commit**: `git commit -m "${COMMIT_MSG}"`.
 9. **Auto PR** (standalone by default): Push branch, create PR targeting main, invoke `/pr-bot`.
    Runs automatically when commit is standalone. Skipped when parent workflow
-   (mktsk/dev2merge) sets `CSA_SKIP_PUBLISH=true` to handle publish itself.
+   (mktsk/dev2merge) sets `CSA_SKIP_PUBLISH=true`, or automatically when
+   invoked from inside a CSA session (`CSA_DEPTH` set and non-zero) so that
+   employee sessions stay orchestration-pure and only the Layer 0 orchestrator
+   runs the PR + pr-bot transaction (#752 Bug 4).
    - **NOTE**: `/pr-bot` internally runs a **separate cumulative review** (`csa review --range main...HEAD`) covering ALL commits on the branch before push. This is distinct from Step 6's per-commit review (`csa review --diff`). Do NOT skip pr-bot's internal review even if Step 6 passed.
 
 ## Two-Layer Review Architecture

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -110,8 +110,15 @@ Initialize and declare workflow variables.
 # Bridge CSA_SKIP_PUBLISH env var to workflow variable.
 # When parent workflow (mktsk/dev2merge) sets CSA_SKIP_PUBLISH=true, auto-PR is skipped.
 # When standalone, CSA_SKIP_PUBLISH is unset → auto-PR runs after commit.
+# Also auto-skip when running inside a CSA session (CSA_DEPTH>0) — the Layer 0
+# orchestrator owns publish/pr-bot. Letting an employee session invoke /pr-bot
+# nests another `csa plan run` and can trip the recursion-ceiling guard or leak
+# grandchild processes if the chain fails mid-flight (see #752 Bug 4).
 if [ "${CSA_SKIP_PUBLISH:-}" = "true" ]; then
   echo "CSA_VAR:SKIP_PUBLISH=true"
+elif [ "${CSA_DEPTH:-0}" != "0" ] && [ -n "${CSA_DEPTH:-}" ]; then
+  echo "CSA_VAR:SKIP_PUBLISH=true"
+  echo "INFO: Detected CSA_DEPTH=${CSA_DEPTH}; auto-skipping pr-bot to keep employee sessions orchestration-pure."
 else
   echo "CSA_VAR:SKIP_PUBLISH=${SKIP_PUBLISH:-false}"
 fi

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.285"
-weave = "0.1.285"
+csa = "0.1.286"
+weave = "0.1.286"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes the two remaining actionable bugs from #752 (Bugs 2 & 4).

- **Bug 4** — `/commit` skill nested pr-bot inside employee sessions. `patterns/commit/workflow.toml` now auto-activates `SKIP_PUBLISH` when `CSA_DEPTH` is set and non-zero, so employee sessions stop at the commit and the Layer 0 orchestrator owns the publish/pr-bot transaction. Verified with an 8-case shell matrix (CSA_SKIP_PUBLISH / CSA_DEPTH / SKIP_PUBLISH precedence). PATTERN.md + SKILL.md updated in lockstep per rule 027.
- **Bug 2 (defensive)** — `csa gc` / `csa gc --global` now call `csa_resource::cleanup_orphan_scopes()` to reap `csa-*.scope` systemd units whose PID count has fallen to zero. Stops dead scopes from accumulating after abnormal daemon exits (SIGKILL / crash) — the failure mode behind the OS-freeze incidents logged in #752's update comment. Strictly safe: only stops scopes with 0 active PIDs (same policy as the underlying function), so live sessions are untouched.

Bug 3 was already closed by PR #758. Bug 1's structural liveness check already lives in `ensure_terminal_result_for_dead_active_session_impl`; the Round-4 false-positive needs a repro before we tighten the grace window further, so deferred intentionally.

## Test plan

- [x] `just pre-commit` exits 0 (fmt + clippy + deny + test + test-e2e)
- [x] Bash matrix for SKIP_PUBLISH bridge: 8/8 cases pass (standalone, CSA_SKIP_PUBLISH=true, CSA_DEPTH=1/3, CSA_DEPTH=0, empty CSA_DEPTH, both flags, SKIP_PUBLISH passthrough)
- [x] `weave compile patterns/commit/PATTERN.md` exits 0 (PATTERN.md↔workflow.toml sync per rule 027)
- [x] `csa gc --dry-run` reports "Would scan for orphan csa-\*.scope units with 0 active PIDs" and new "Orphan cgroup scopes cleaned" line
- [x] Manual audit of diff (csa self-review blocked by an independent session-registration bug — investigated separately)

## Self-review caveat

Tried `csa review --tool codex` four ways (with/without `--sa-mode`, with/without `--no-fs-sandbox`). Session gets dispatched and the daemon runs, but the session isn't registered in the central list (`csa session wait` returns "not found" while the daemon process is still alive). A trivial `csa run --ephemeral "reply 42"` dispatch DID succeed end-to-end (exit 0, codex output "42"), which confirms the codex transport itself is healthy — this smells like a `csa review` + quality-gate interaction bug where the pre-flight gate pipeline deadlocks with the session registrar. Filing separately; does not block this PR because the diff is small, well-contained, and passes all local gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)