### PR TITLE
fix(dev2merge): force full pipeline on empty-diff feature branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "chrono",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "chrono",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "axum",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "chrono",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "chrono",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "chrono",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.287"
+version = "0.1.288"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.287"
+version = "0.1.288"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -53,13 +53,21 @@ Tool: bash
 OnFail: abort
 
 Detect whether changes are docs/config-only. When FAST_PATH=true,
-skip mktd/mktsk/debate but keep L1/L2 quality checks.
+skip mktd/mktsk/debate but keep L1/L2 quality checks. An empty diff
+vs the base branch is NOT docs-only; it must stay on the full plan
+path to avoid no-op commit/version-bump steps.
 
 ```bash
 set -euo pipefail
 CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
+TOTAL_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -c . || true)"
 TOTAL_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
-if [ "${CODE_FILES}" -eq 0 ] && [ "${TOTAL_INSERTIONS:-0}" -lt 100 ]; then
+if [ "${TOTAL_FILES}" -eq 0 ]; then
+  # Empty diff means HEAD matches the base branch; do not treat that as docs-only,
+  # or the workflow will skip planning and then hit no-op commit/version-bump steps.
+  echo "Full pipeline: branch has no diff vs ${DEFAULT_BRANCH}; running plan."
+  echo "CSA_VAR:FAST_PATH=false"
+elif [ "${CODE_FILES}" -eq 0 ] && [ "${TOTAL_INSERTIONS:-0}" -lt 100 ]; then
   echo "FAST_PATH: docs/config-only changes detected. Skipping mktd/mktsk."
   echo "CSA_VAR:FAST_PATH=true"
 else
@@ -162,6 +170,8 @@ LIGHT_THRESHOLD_FILES="${PLANNING_LIGHT_THRESHOLD_FILES:-2}"
 LIGHT_THRESHOLD_LINES="${PLANNING_LIGHT_THRESHOLD_LINES:-50}"
 PLAN_CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
 PLAN_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
+# Audit note: empty diff also lands in "light", but that is fine here because this
+# block only chooses mktd intensity after Step 2 has already forced the full plan path.
 if [ "${PLAN_CODE_FILES}" -le "${LIGHT_THRESHOLD_FILES}" ] && [ "${PLAN_INSERTIONS:-0}" -lt "${LIGHT_THRESHOLD_LINES}" ]; then
   MKTD_INTENSITY="light"
   echo "Planning intensity: light (${PLAN_CODE_FILES} code files, ${PLAN_INSERTIONS} insertions)"

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -163,8 +163,14 @@ skip mktd/mktsk/debate but keep L1/L2 quality checks.
 ```bash
 set -euo pipefail
 CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
+TOTAL_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -c . || true)"
 TOTAL_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
-if [ "${CODE_FILES}" -eq 0 ] && [ "${TOTAL_INSERTIONS:-0}" -lt 100 ]; then
+if [ "${TOTAL_FILES}" -eq 0 ]; then
+  # Empty diff means HEAD matches the base branch; do not treat that as docs-only,
+  # or the workflow will skip planning and then hit no-op commit/version-bump steps.
+  echo "Full pipeline: branch has no diff vs ${DEFAULT_BRANCH}; running plan."
+  echo "CSA_VAR:FAST_PATH=false"
+elif [ "${CODE_FILES}" -eq 0 ] && [ "${TOTAL_INSERTIONS:-0}" -lt 100 ]; then
   echo "FAST_PATH: docs/config-only changes detected. Skipping mktd/mktsk."
   echo "CSA_VAR:FAST_PATH=true"
 else
@@ -271,6 +277,8 @@ LIGHT_THRESHOLD_FILES="${PLANNING_LIGHT_THRESHOLD_FILES:-2}"
 LIGHT_THRESHOLD_LINES="${PLANNING_LIGHT_THRESHOLD_LINES:-50}"
 PLAN_CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
 PLAN_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
+# Audit note: empty diff also lands in "light", but that is fine here because this
+# block only chooses mktd intensity after Step 2 has already forced the full plan path.
 if [ "${PLAN_CODE_FILES}" -le "${LIGHT_THRESHOLD_FILES}" ] && [ "${PLAN_INSERTIONS:-0}" -lt "${LIGHT_THRESHOLD_LINES}" ]; then
   MKTD_INTENSITY="light"
   echo "Planning intensity: light (${PLAN_CODE_FILES} code files, ${PLAN_INSERTIONS} insertions)"


### PR DESCRIPTION
## Summary
- FAST_PATH detection previously marked empty-diff branches (HEAD==main) as docs-only, skipping mktd/mktsk and collapsing the entire pipeline to no-op commit/version-bump steps.
- Fix distinguishes three cases in Step 2: empty diff → FAST_PATH=false, docs-only → FAST_PATH=true, code diff → FAST_PATH=false.
- PATTERN.md synced with workflow.toml per Rule 027.
- Version bumped to 0.1.288.

## Context
Discovered when starting Q1 dev2merge on a freshly-created feature branch. Step 2 emitted `docs/config-only changes detected. Skipping mktd/mktsk.` on a zero-diff branch, then FAST_PATH Commit would commit nothing and the pipeline proceeded to version-bump + no-op review. This is exactly the case where planning is most needed, so silently skipping it is a workflow-killer.

## Test plan
- [x] `just fmt` / `just clippy` / `just test` pass
- [x] Pre-commit `csa review --diff` PASS (iter 2, after Rule 027 PATTERN.md sync)
- [x] Pre-push `csa review --range main...HEAD` PASS (iter 3)
- [ ] Manually verify: empty branch (HEAD==main) → FAST_PATH=false
- [ ] Manually verify: branch with only *.md diff → FAST_PATH=true
- [ ] Manually verify: branch with any *.rs diff → FAST_PATH=false
- [ ] PATTERN.md bash block byte-identical to workflow.toml per Rule 027

🤖 Generated with [Claude Code](https://claude.com/claude-code)