### PR TITLE
fix: commit/session lifecycle robustness (#738 #747 #782)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.299"
+version = "0.1.300"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.299"
+version = "0.1.300"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -40,6 +40,7 @@ mod plan_cmd_flow;
 
 #[path = "plan_cmd_steps.rs"]
 mod plan_cmd_steps;
+pub(crate) use plan_cmd_flow::shell_escape_for_command;
 use plan_cmd_steps::{PlanRunContext, execute_plan_with_journal};
 pub(crate) use plan_cmd_steps::{StepResult, StepTarget, resolve_step_tool};
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/plan_cmd_flow.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_flow.rs
@@ -8,7 +8,7 @@ pub(super) enum OrchestratorHandoff {
     AwaitUser,
 }
 
-fn shell_escape_for_command(value: &str) -> String {
+pub(crate) fn shell_escape_for_command(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
@@ -42,6 +42,18 @@ fn workspace_root() -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
 }
 
+fn extract_bash_block(prompt: &str) -> String {
+    let start = prompt
+        .find("```bash\n")
+        .expect("prompt should contain opening bash fence")
+        + "```bash\n".len();
+    let rest = &prompt[start..];
+    let end = rest
+        .find("\n```")
+        .expect("prompt should contain closing fence");
+    rest[..end].to_string()
+}
+
 #[test]
 fn commit_workflow_csa_dispatch_steps_have_non_empty_prompts() {
     let workflow_path = workspace_root().join("patterns/commit/workflow.toml");
@@ -131,5 +143,67 @@ async fn execute_step_csa_nested_plan_uses_fresh_child_session() {
         child.genealogy.parent_session_id.as_deref(),
         Some(parent.meta_session_id.as_str()),
         "fresh plan child session should point back to the plan runner session"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn commit_workflow_auto_pr_step_exits_before_push_in_executor_mode() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let workflow_path = workspace_root().join("patterns/commit/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+    let auto_pr_step = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Auto PR Transaction")
+        .expect("missing Auto PR Transaction step");
+    let script = extract_bash_block(&auto_pr_step.prompt);
+
+    let td = tempfile::tempdir().unwrap();
+    let bin_dir = td.path().join("bin");
+    let log_path = td.path().join("command.log");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+
+    for tool in ["git", "gh"] {
+        let tool_path = bin_dir.join(tool);
+        std::fs::write(
+            &tool_path,
+            format!(
+                "#!/bin/sh\nprintf '%s %s\\n' \"{tool}\" \"$*\" >> '{}'\nexit 99\n",
+                log_path.display()
+            ),
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&tool_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&tool_path, perms).unwrap();
+    }
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+    let status = Command::new("bash")
+        .arg("-ceu")
+        .arg(script)
+        .current_dir(td.path())
+        .env("PATH", patched_path)
+        .env(
+            "COMMIT_SUBJECT",
+            "fix(cli-sub-agent): guard executor publish (#782)",
+        )
+        .env("BRANCH", "fix/executor-guard")
+        .env("PR_BODY", "body")
+        .env("CSA_DEPTH", "1")
+        .env("CSA_INTERNAL_INVOCATION", "1")
+        .status()
+        .unwrap();
+
+    assert!(status.success(), "executor-mode guard should exit cleanly");
+    let log_contents = std::fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        log_contents.trim().is_empty(),
+        "executor-mode auto PR step must exit before invoking git/gh, got: {log_contents}"
     );
 }

--- a/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
@@ -207,3 +207,18 @@ fn commit_workflow_auto_pr_step_exits_before_push_in_executor_mode() {
         "executor-mode auto PR step must exit before invoking git/gh, got: {log_contents}"
     );
 }
+
+#[test]
+fn commit_pattern_step1_bridges_csa_skip_publish_to_skip_publish() {
+    let pattern_path = workspace_root().join("patterns/commit/PATTERN.md");
+    let pattern = std::fs::read_to_string(&pattern_path).unwrap();
+
+    assert!(
+        pattern.contains(": \"${FILES}\" \"${SCOPE}\" \"${BRANCH}\" \"${COMMIT_SUBJECT}\" \"${COMMIT_BODY}\" \"${COMMIT_MESSAGE_FILE}\" \"${IS_MILESTONE}\" \"${ENABLE_REVIEW_LOOP}\" \"${AUDIT_FAIL}\" \"${AUDIT_PASS_DEFERRED}\" \"${REVIEW_HAS_ISSUES}\" \"${PR_BODY}\" \"${SKIP_PUBLISH}\""),
+        "PATTERN.md Step 1 must initialize SKIP_PUBLISH alongside the other mirrored workflow variables"
+    );
+    assert!(
+        pattern.contains("if [ \"${CSA_SKIP_PUBLISH:-}\" = \"true\" ]; then\n  SKIP_PUBLISH=true"),
+        "PATTERN.md Step 1 must bridge CSA_SKIP_PUBLISH=true into SKIP_PUBLISH=true"
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -168,19 +168,50 @@ where
         if let Some(completion) = load_daemon_completion_packet(&session_dir)?
             && !session_has_terminal_process(&session_dir)
         {
-            let _ = refresh_result_for_wait(
+            let refreshed_result = refresh_result_for_wait(
                 effective_root,
                 &resolved.session_id,
                 &session_dir,
                 is_cross_project,
             );
+            if let Err(err) = &refreshed_result {
+                tracing::debug!(
+                    session_id = %resolved.session_id,
+                    error = %err,
+                    "Failed to refresh result after daemon completion packet"
+                );
+            }
+            let refreshed_result = refreshed_result.ok().flatten();
+            let mut synthetic = false;
+            if refreshed_result.is_some() {
+                let _ = crate::session_cmds::retire_if_dead_with_result(
+                    effective_root,
+                    &resolved.session_id,
+                    "session wait",
+                );
+            } else {
+                let reconciled = reconcile_dead_active_session(
+                    effective_root,
+                    &resolved.session_id,
+                    "session wait",
+                )?;
+                synthetic = reconciled.synthetic;
+                if reconciled.result_became_available {
+                    let _ = load_completed_daemon_result_adaptive(
+                        effective_root,
+                        &resolved.session_id,
+                        &session_dir,
+                        is_cross_project,
+                    )?;
+                }
+            }
             let streamed_output = stream_wait_output(&session_dir)?;
             emit_wait_next_step_if_needed(&session_dir)?;
             emit_completion_signal(
                 &resolved.session_id,
                 &completion.status,
                 completion.exit_code,
-                false,
+                synthetic,
                 !streamed_output,
             );
             return Ok(completion.exit_code);

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -1,5 +1,6 @@
 //! Daemon-specific session commands extracted from `session_cmds.rs`.
 
+use std::borrow::Cow;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -188,7 +189,7 @@ where
             }
             let refreshed_result = refreshed_result.ok().flatten();
             let mut synthetic = false;
-            let mut completion_status = completion.status.as_str();
+            let mut completion_status = Cow::Borrowed(completion.status.as_str());
             let mut exit_code = completion.exit_code;
             if refreshed_result.is_some() {
                 let _ = crate::session_cmds::retire_if_dead_with_result(
@@ -203,24 +204,31 @@ where
                     "session wait",
                 )?;
                 synthetic = reconciled.synthetic;
+                let mut loaded_result = None;
                 if reconciled.synthetic {
-                    completion_status = "failure";
+                    completion_status = Cow::Borrowed("failure");
                     exit_code = 1;
                 }
                 if reconciled.result_became_available {
-                    let _ = load_completed_daemon_result_adaptive(
+                    loaded_result = load_completed_daemon_result_adaptive(
                         effective_root,
                         &resolved.session_id,
                         &session_dir,
                         is_cross_project,
                     )?;
                 }
+                if !reconciled.synthetic
+                    && let Some(result) = loaded_result
+                {
+                    completion_status = Cow::Owned(result.status);
+                    exit_code = result.exit_code;
+                }
             }
             let streamed_output = stream_wait_output(&session_dir)?;
             emit_wait_next_step_if_needed(&session_dir)?;
             emit_completion_signal(
                 &resolved.session_id,
-                completion_status,
+                completion_status.as_ref(),
                 exit_code,
                 synthetic,
                 !streamed_output,

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -39,6 +39,11 @@ struct DaemonCompletionPacket {
     status: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UnpushedCommitsRecoveryPacket {
+    recovery_command: String,
+}
+
 impl DaemonCompletionPacket {
     fn from_exit_code(exit_code: i32) -> Self {
         Self {
@@ -351,6 +356,18 @@ pub(crate) fn synthesized_wait_next_step(session_dir: &Path) -> Result<Option<St
         && csa_hooks::parse_next_step_directive(&stdout).is_some()
     {
         return Ok(None);
+    }
+
+    let unpushed_commits_path = session_dir.join("output").join("unpushed_commits.json");
+    if unpushed_commits_path.is_file() {
+        let recovery: UnpushedCommitsRecoveryPacket =
+            serde_json::from_str(&fs::read_to_string(unpushed_commits_path)?)?;
+        if !recovery.recovery_command.trim().is_empty() {
+            return Ok(Some(csa_hooks::format_next_step_directive(
+                &recovery.recovery_command,
+                true,
+            )));
+        }
     }
 
     let review_meta_path = session_dir.join("review_meta.json");

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -189,9 +189,22 @@ where
             }
             let refreshed_result = refreshed_result.ok().flatten();
             let mut synthetic = false;
-            let mut completion_status = Cow::Borrowed(completion.status.as_str());
-            let mut exit_code = completion.exit_code;
-            if refreshed_result.is_some() {
+            let refreshed_result_available = refreshed_result.is_some();
+            #[rustfmt::skip]
+            let refreshed_result_newer_than_completion = matches!(
+                (
+                    fs::metadata(session_dir.join(csa_session::result::RESULT_FILE_NAME))
+                        .ok()
+                        .and_then(|metadata| metadata.modified().ok()),
+                    fs::metadata(daemon_completion_path(&session_dir))
+                        .ok()
+                        .and_then(|metadata| metadata.modified().ok())
+                ),
+                (Some(result_modified), Some(completion_modified)) if result_modified > completion_modified
+            );
+            let mut loaded_result =
+                refreshed_result.filter(|_| refreshed_result_newer_than_completion);
+            if refreshed_result_available {
                 let _ = crate::session_cmds::retire_if_dead_with_result(
                     effective_root,
                     &resolved.session_id,
@@ -204,11 +217,6 @@ where
                     "session wait",
                 )?;
                 synthetic = reconciled.synthetic;
-                let mut loaded_result = None;
-                if reconciled.synthetic {
-                    completion_status = Cow::Borrowed("failure");
-                    exit_code = 1;
-                }
                 if reconciled.result_became_available {
                     loaded_result = load_completed_daemon_result_adaptive(
                         effective_root,
@@ -217,15 +225,11 @@ where
                         is_cross_project,
                     )?;
                 }
-                if !reconciled.synthetic
-                    && let Some(result) = loaded_result
-                {
-                    completion_status = Cow::Owned(result.status);
-                    exit_code = result.exit_code;
-                }
             }
             let streamed_output = stream_wait_output(&session_dir)?;
             emit_wait_next_step_if_needed(&session_dir)?;
+            #[rustfmt::skip]
+            let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(completion.status.as_str(), completion.exit_code, synthetic, loaded_result.as_ref());
             emit_completion_signal(
                 &resolved.session_id,
                 completion_status.as_ref(),
@@ -244,14 +248,16 @@ where
         )? {
             let streamed_output = stream_wait_output(&session_dir)?;
             emit_wait_next_step_if_needed(&session_dir)?;
+            #[rustfmt::skip]
+            let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, false, Some(&result));
             emit_completion_signal(
                 &resolved.session_id,
-                &result.status,
-                result.exit_code,
+                completion_status.as_ref(),
+                exit_code,
                 false,
                 !streamed_output,
             );
-            return Ok(result.exit_code);
+            return Ok(exit_code);
         }
 
         // Synthesize terminal result for dead Active sessions.
@@ -267,10 +273,12 @@ where
         {
             let streamed_output = stream_wait_output(&session_dir)?;
             emit_wait_next_step_if_needed(&session_dir)?;
+            #[rustfmt::skip]
+            let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, reconciled.synthetic, Some(&result));
             emit_completion_signal(
                 &resolved.session_id,
-                &result.status,
-                result.exit_code,
+                completion_status.as_ref(),
+                exit_code,
                 reconciled.synthetic,
                 !streamed_output,
             );
@@ -280,7 +288,7 @@ where
                     resolved.session_id,
                 );
             }
-            return Ok(result.exit_code);
+            return Ok(exit_code);
         }
 
         if !session_has_terminal_process(&session_dir) {
@@ -292,14 +300,16 @@ where
             )? {
                 let streamed_output = stream_wait_output(&session_dir)?;
                 emit_wait_next_step_if_needed(&session_dir)?;
+                #[rustfmt::skip]
+                let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, false, Some(&result));
                 emit_completion_signal(
                     &resolved.session_id,
-                    &result.status,
-                    result.exit_code,
+                    completion_status.as_ref(),
+                    exit_code,
                     false,
                     !streamed_output,
                 );
-                return Ok(result.exit_code);
+                return Ok(exit_code);
             }
             eprintln!(
                 "Session {} has no live daemon process and no terminal result packet.",
@@ -428,6 +438,21 @@ fn emit_wait_next_step_if_needed(session_dir: &Path) -> Result<()> {
         println!("{directive}");
     }
     Ok(())
+}
+
+fn resolve_wait_completion_status_and_exit<'a>(
+    fallback_status: &'a str,
+    fallback_exit_code: i32,
+    synthetic: bool,
+    real_result: Option<&'a csa_session::SessionResult>,
+) -> (Cow<'a, str>, i32) {
+    if synthetic {
+        return (Cow::Borrowed("failure"), 1);
+    }
+    real_result.map_or_else(
+        || (Cow::Borrowed(fallback_status), fallback_exit_code),
+        |result| (Cow::Borrowed(result.status.as_str()), result.exit_code),
+    )
 }
 
 fn load_completed_daemon_result(

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -188,6 +188,7 @@ where
             }
             let refreshed_result = refreshed_result.ok().flatten();
             let mut synthetic = false;
+            let mut completion_status = completion.status.as_str();
             let mut exit_code = completion.exit_code;
             if refreshed_result.is_some() {
                 let _ = crate::session_cmds::retire_if_dead_with_result(
@@ -203,6 +204,7 @@ where
                 )?;
                 synthetic = reconciled.synthetic;
                 if reconciled.synthetic {
+                    completion_status = "failure";
                     exit_code = 1;
                 }
                 if reconciled.result_became_available {
@@ -218,7 +220,7 @@ where
             emit_wait_next_step_if_needed(&session_dir)?;
             emit_completion_signal(
                 &resolved.session_id,
-                &completion.status,
+                completion_status,
                 exit_code,
                 synthetic,
                 !streamed_output,

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -205,11 +205,11 @@ where
             let mut loaded_result =
                 refreshed_result.filter(|_| refreshed_result_newer_than_completion);
             if refreshed_result_available {
-                let _ = crate::session_cmds::retire_if_dead_with_result(
+                crate::session_cmds::retire_if_dead_with_result(
                     effective_root,
                     &resolved.session_id,
                     "session wait",
-                );
+                )?;
             } else {
                 let reconciled = reconcile_dead_active_session(
                     effective_root,

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -190,20 +190,28 @@ where
             let refreshed_result = refreshed_result.ok().flatten();
             let mut synthetic = false;
             let refreshed_result_available = refreshed_result.is_some();
-            #[rustfmt::skip]
-            let refreshed_result_newer_than_completion = matches!(
-                (
+            let mut loaded_result = refreshed_result.filter(|result| {
+                match (
                     fs::metadata(session_dir.join(csa_session::result::RESULT_FILE_NAME))
                         .ok()
                         .and_then(|metadata| metadata.modified().ok()),
                     fs::metadata(daemon_completion_path(&session_dir))
                         .ok()
-                        .and_then(|metadata| metadata.modified().ok())
-                ),
-                (Some(result_modified), Some(completion_modified)) if result_modified > completion_modified
-            );
-            let mut loaded_result =
-                refreshed_result.filter(|_| refreshed_result_newer_than_completion);
+                        .and_then(|metadata| metadata.modified().ok()),
+                ) {
+                    (Some(result_modified), Some(completion_modified))
+                        if result_modified > completion_modified =>
+                    {
+                        true
+                    }
+                    (Some(result_modified), Some(completion_modified))
+                        if result_modified == completion_modified =>
+                    {
+                        completion.exit_code == 0 && result.exit_code != 0
+                    }
+                    _ => false,
+                }
+            });
             if refreshed_result_available {
                 crate::session_cmds::retire_if_dead_with_result(
                     effective_root,
@@ -439,7 +447,6 @@ fn emit_wait_next_step_if_needed(session_dir: &Path) -> Result<()> {
     }
     Ok(())
 }
-
 fn resolve_wait_completion_status_and_exit<'a>(
     fallback_status: &'a str,
     fallback_exit_code: i32,
@@ -454,7 +461,6 @@ fn resolve_wait_completion_status_and_exit<'a>(
         |result| (Cow::Borrowed(result.status.as_str()), result.exit_code),
     )
 }
-
 fn load_completed_daemon_result(
     project_root: &std::path::Path,
     session_id: &str,
@@ -479,7 +485,6 @@ fn load_completed_daemon_result(
     if session_has_terminal_process(session_dir) {
         return Ok(None);
     }
-
     Ok(Some(result))
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -188,6 +188,7 @@ where
             }
             let refreshed_result = refreshed_result.ok().flatten();
             let mut synthetic = false;
+            let mut exit_code = completion.exit_code;
             if refreshed_result.is_some() {
                 let _ = crate::session_cmds::retire_if_dead_with_result(
                     effective_root,
@@ -201,6 +202,9 @@ where
                     "session wait",
                 )?;
                 synthetic = reconciled.synthetic;
+                if reconciled.synthetic {
+                    exit_code = 1;
+                }
                 if reconciled.result_became_available {
                     let _ = load_completed_daemon_result_adaptive(
                         effective_root,
@@ -215,11 +219,11 @@ where
             emit_completion_signal(
                 &resolved.session_id,
                 &completion.status,
-                completion.exit_code,
+                exit_code,
                 synthetic,
                 !streamed_output,
             );
-            return Ok(completion.exit_code);
+            return Ok(exit_code);
         }
 
         if let Some(result) = load_completed_daemon_result_adaptive(

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -366,13 +366,32 @@ pub(crate) fn synthesized_wait_next_step(session_dir: &Path) -> Result<Option<St
 
     let unpushed_commits_path = session_dir.join("output").join("unpushed_commits.json");
     if unpushed_commits_path.is_file() {
-        let recovery: UnpushedCommitsRecoveryPacket =
-            serde_json::from_str(&fs::read_to_string(unpushed_commits_path)?)?;
-        if !recovery.recovery_command.trim().is_empty() {
-            return Ok(Some(csa_hooks::format_next_step_directive(
-                &recovery.recovery_command,
-                true,
-            )));
+        match fs::read_to_string(&unpushed_commits_path) {
+            Ok(contents) => {
+                match serde_json::from_str::<UnpushedCommitsRecoveryPacket>(&contents) {
+                    Ok(recovery) if !recovery.recovery_command.trim().is_empty() => {
+                        return Ok(Some(csa_hooks::format_next_step_directive(
+                            &recovery.recovery_command,
+                            true,
+                        )));
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        tracing::warn!(
+                            sidecar_path = %unpushed_commits_path.display(),
+                            error = %err,
+                            "Ignoring malformed unpushed commit recovery sidecar while synthesizing wait next-step"
+                        );
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::debug!(
+                    sidecar_path = %unpushed_commits_path.display(),
+                    error = %err,
+                    "Ignoring unreadable unpushed commit recovery sidecar while synthesizing wait next-step"
+                );
+            }
         }
     }
 

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -334,7 +334,6 @@ where
         }
         Err(err) => return Err(err),
     }
-
     let now = chrono::Utc::now();
     let tool_name = session
         .tools
@@ -342,21 +341,21 @@ where
         .max_by_key(|(_, state)| state.updated_at)
         .map(|(tool, _)| tool.clone())
         .unwrap_or_else(|| "unknown".to_string());
-    let sidecar_rollback_guard =
-        match persist_unpushed_commits_sidecar(project_root, &session, session_dir) {
-            Ok(rollback_guard) => rollback_guard,
-            Err(err) => {
-                warn!(
-                    session_id = %session_id,
-                    trigger = %trigger,
-                    error = %err,
-                    "Failed to persist unpushed commit recovery sidecar"
-                );
-                None
-            }
-        };
-    let artifacts =
-        crate::pipeline_post_exec::collect_fallback_result_artifacts(project_root, session_id);
+    #[rustfmt::skip]
+    let sidecar_rollback_guard = match persist_unpushed_commits_sidecar(project_root, &session, session_dir) {
+        Ok(rollback_guard) => rollback_guard,
+        Err(err) => {
+            warn!(
+                session_id = %session_id,
+                trigger = %trigger,
+                error = %err,
+                "Failed to persist unpushed commit recovery sidecar"
+            );
+            None
+        }
+    };
+    #[rustfmt::skip]
+    let artifacts = crate::pipeline_post_exec::collect_fallback_result_artifacts(project_root, session_id);
     let output_log_mtime = format_optional_file_mtime(&session_dir.join("output.log"));
     let summary_prefix = format!(
         "synthetic failure by {trigger}: process dead, result.toml missing (reconciliation_reason=true_missing_result, output_log_mtime={})",
@@ -376,10 +375,19 @@ where
         artifacts,
         peak_memory_mb: None,
     };
-    let result_contents = toml::to_string_pretty(&fallback)
-        .map_err(|err| anyhow!("Failed to serialize synthetic result for {session_id}: {err}"))?;
+    #[rustfmt::skip]
+    let result_contents = toml::to_string_pretty(&fallback).map_err(|err| anyhow!("Failed to serialize synthetic result for {session_id}: {err}"))?;
     match persist_new_result_file(&result_path, &result_contents, before_write)? {
         SyntheticResultPersistOutcome::AlreadyExists => {
+            if let Err(err) = remove_created_sidecar_if_unchanged(sidecar_rollback_guard.as_ref()) {
+                warn!(
+                    session_id = %session_id,
+                    trigger = %trigger,
+                    reconciliation_reason = "late_result_write_sidecar_cleanup_failed",
+                    error = %err,
+                    "Failed to clean up reconcile-owned unpushed commit sidecar after late result.toml write"
+                );
+            }
             let retired = retire_if_dead_with_result_impl(
                 project_root,
                 session_id,
@@ -572,12 +580,10 @@ fn persist_session_state_atomically(session_dir: &Path, session: &MetaSessionSta
     })?;
     Ok(())
 }
-
 #[rustfmt::skip]
 fn remove_synthetic_result_if_unchanged(result_path: &Path, expected_contents: &[u8]) -> std::io::Result<()> {
     remove_artifact_if_unchanged(result_path, expected_contents, ArtifactRollbackLabels { removed_cleanup: "removed_synthetic_result", missing_after_match_cleanup: "result_missing_after_match", remove_failed_cleanup: "remove_failed", preserved_cleanup: "late_real_result_preserved", missing_cleanup: "result_missing", read_failed_cleanup: "read_failed", artifact_label: "synthetic result.toml" })
 }
-
 #[rustfmt::skip]
 fn remove_created_sidecar_if_unchanged(rollback_guard: Option<&CreatedArtifactRollbackGuard>) -> std::io::Result<()> {
     let Some(rollback_guard) = rollback_guard else {
@@ -585,13 +591,11 @@ fn remove_created_sidecar_if_unchanged(rollback_guard: Option<&CreatedArtifactRo
     };
     remove_artifact_if_unchanged(&rollback_guard.artifact_path, rollback_guard.expected_contents.as_slice(), ArtifactRollbackLabels { removed_cleanup: "removed_unpushed_commits_sidecar", missing_after_match_cleanup: "sidecar_missing_after_match", remove_failed_cleanup: "sidecar_remove_failed", preserved_cleanup: "preexisting_sidecar_preserved", missing_cleanup: "sidecar_missing", read_failed_cleanup: "sidecar_read_failed", artifact_label: "unpushed_commits.json sidecar" })
 }
-
 #[rustfmt::skip]
 fn rollback_reconciliation_artifacts(result_path: &Path, result_contents: &[u8], sidecar_rollback_guard: Option<&CreatedArtifactRollbackGuard>) -> std::io::Result<()> {
     remove_synthetic_result_if_unchanged(result_path, result_contents)?;
     remove_created_sidecar_if_unchanged(sidecar_rollback_guard)
 }
-
 fn remove_artifact_if_unchanged(
     artifact_path: &Path,
     expected_contents: &[u8],

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -17,26 +17,21 @@ use crate::plan_cmd::shell_escape_for_command;
 type PersistSessionFn<'a> = dyn Fn(&Path, &MetaSessionState) -> Result<()> + 'a;
 const UNPUSHED_COMMITS_SIDECAR_PATH: &str = "output/unpushed_commits.json";
 
+#[rustfmt::skip]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct UnpushedCommitRecord {
-    sha: String,
-    subject: String,
-}
+struct UnpushedCommitRecord { sha: String, subject: String }
 
+#[rustfmt::skip]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct UnpushedCommitsSidecar {
-    branch: String,
-    remote_ref: Option<String>,
-    commits_ahead: u64,
-    commits: Vec<UnpushedCommitRecord>,
-    recovery_command: String,
-}
+struct UnpushedCommitsSidecar { branch: String, remote_ref: Option<String>, commits_ahead: u64, commits: Vec<UnpushedCommitRecord>, recovery_command: String }
 
+#[rustfmt::skip]
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct CreatedArtifactRollbackGuard {
-    artifact_path: PathBuf,
-    expected_contents: Vec<u8>,
-}
+struct ArtifactRollbackGuard { artifact_path: PathBuf, expected_contents: Vec<u8>, rollback_action: ArtifactRollbackAction }
+
+#[rustfmt::skip]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ArtifactRollbackAction { RemoveIfContentsMatch, RestoreOriginal(Vec<u8>) }
 
 #[rustfmt::skip]
 struct ArtifactRollbackLabels<'a> { removed_cleanup: &'a str, missing_after_match_cleanup: &'a str, remove_failed_cleanup: &'a str, preserved_cleanup: &'a str, missing_cleanup: &'a str, read_failed_cleanup: &'a str, artifact_label: &'a str }
@@ -174,27 +169,16 @@ fn inspect_unpushed_commits(
     }))
 }
 
-fn persist_unpushed_commits_sidecar(
-    project_root: &Path,
-    session: &MetaSessionState,
-    session_dir: &Path,
-) -> Result<Option<CreatedArtifactRollbackGuard>> {
-    if session.resolved_identity().vcs_kind != VcsKind::Git {
-        return Ok(None);
-    }
-    let Some(branch) = session.branch.as_deref() else {
-        return Ok(None);
-    };
-    let Some(sidecar) = inspect_unpushed_commits(project_root, branch)? else {
-        return Ok(None);
-    };
-    let output_dir = session_dir.join("output");
-    fs::create_dir_all(&output_dir)?;
+#[rustfmt::skip]
+fn persist_unpushed_commits_sidecar(project_root: &Path, session: &MetaSessionState, session_dir: &Path) -> Result<Option<ArtifactRollbackGuard>> {
+    if session.resolved_identity().vcs_kind != VcsKind::Git { return Ok(None); }
+    let Some(branch) = session.branch.as_deref() else { return Ok(None); };
+    let Some(sidecar) = inspect_unpushed_commits(project_root, branch)? else { return Ok(None); };
+    fs::create_dir_all(session_dir.join("output"))?;
     let sidecar_path = session_dir.join(UNPUSHED_COMMITS_SIDECAR_PATH);
     let sidecar_contents = serde_json::to_vec_pretty(&sidecar)?;
-    let rollback_guard =
-        created_artifact_rollback_guard(&sidecar_path, sidecar_contents.as_slice())?;
-    fs::write(&sidecar_path, &sidecar_contents)?;
+    let rollback_guard = artifact_rollback_guard(&sidecar_path, sidecar_contents.as_slice())?;
+    write_sidecar_atomically(&sidecar_path, &sidecar_contents)?;
     Ok(rollback_guard)
 }
 
@@ -379,7 +363,7 @@ where
     let result_contents = toml::to_string_pretty(&fallback).map_err(|err| anyhow!("Failed to serialize synthetic result for {session_id}: {err}"))?;
     match persist_new_result_file(&result_path, &result_contents, before_write)? {
         SyntheticResultPersistOutcome::AlreadyExists => {
-            if let Err(err) = remove_created_sidecar_if_unchanged(sidecar_rollback_guard.as_ref()) {
+            if let Err(err) = rollback_sidecar(sidecar_rollback_guard.as_ref()) {
                 warn!(
                     session_id = %session_id,
                     trigger = %trigger,
@@ -585,104 +569,71 @@ fn remove_synthetic_result_if_unchanged(result_path: &Path, expected_contents: &
     remove_artifact_if_unchanged(result_path, expected_contents, ArtifactRollbackLabels { removed_cleanup: "removed_synthetic_result", missing_after_match_cleanup: "result_missing_after_match", remove_failed_cleanup: "remove_failed", preserved_cleanup: "late_real_result_preserved", missing_cleanup: "result_missing", read_failed_cleanup: "read_failed", artifact_label: "synthetic result.toml" })
 }
 #[rustfmt::skip]
-fn remove_created_sidecar_if_unchanged(rollback_guard: Option<&CreatedArtifactRollbackGuard>) -> std::io::Result<()> {
-    let Some(rollback_guard) = rollback_guard else {
-        return Ok(());
-    };
-    remove_artifact_if_unchanged(&rollback_guard.artifact_path, rollback_guard.expected_contents.as_slice(), ArtifactRollbackLabels { removed_cleanup: "removed_unpushed_commits_sidecar", missing_after_match_cleanup: "sidecar_missing_after_match", remove_failed_cleanup: "sidecar_remove_failed", preserved_cleanup: "preexisting_sidecar_preserved", missing_cleanup: "sidecar_missing", read_failed_cleanup: "sidecar_read_failed", artifact_label: "unpushed_commits.json sidecar" })
+fn rollback_sidecar(rollback_guard: Option<&ArtifactRollbackGuard>) -> std::io::Result<()> {
+    let Some(rollback_guard) = rollback_guard else { return Ok(()); };
+    match &rollback_guard.rollback_action {
+        ArtifactRollbackAction::RemoveIfContentsMatch => remove_artifact_if_unchanged(&rollback_guard.artifact_path, rollback_guard.expected_contents.as_slice(), ArtifactRollbackLabels { removed_cleanup: "removed_unpushed_commits_sidecar", missing_after_match_cleanup: "sidecar_missing_after_match", remove_failed_cleanup: "sidecar_remove_failed", preserved_cleanup: "preexisting_sidecar_preserved", missing_cleanup: "sidecar_missing", read_failed_cleanup: "sidecar_read_failed", artifact_label: "unpushed_commits.json sidecar" }),
+        ArtifactRollbackAction::RestoreOriginal(original_contents) => match fs::read(&rollback_guard.artifact_path) {
+            Ok(current_contents) if current_contents == rollback_guard.expected_contents => { fs::write(&rollback_guard.artifact_path, original_contents)?; warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "restored_preexisting_unpushed_commits_sidecar", "Rollback restored preexisting unpushed_commits.json sidecar after reconciliation failure"); Ok(()) }
+            Ok(_) => { warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "preexisting_sidecar_preserved", "Rollback preserved unpushed_commits.json sidecar because contents changed after reconciliation failure"); Ok(()) }
+            Err(err) if err.kind() == ErrorKind::NotFound => { warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "sidecar_missing", "Rollback found no unpushed_commits.json sidecar to restore after reconciliation failure"); Ok(()) }
+            Err(err) => { warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "sidecar_read_failed", error = %err, "Rollback failed to read unpushed_commits.json sidecar for content-aware restore after reconciliation failure"); Ok(()) }
+        },
+    }
 }
 #[rustfmt::skip]
-fn rollback_reconciliation_artifacts(result_path: &Path, result_contents: &[u8], sidecar_rollback_guard: Option<&CreatedArtifactRollbackGuard>) -> std::io::Result<()> {
+fn rollback_reconciliation_artifacts(result_path: &Path, result_contents: &[u8], sidecar_rollback_guard: Option<&ArtifactRollbackGuard>) -> std::io::Result<()> {
     remove_synthetic_result_if_unchanged(result_path, result_contents)?;
-    remove_created_sidecar_if_unchanged(sidecar_rollback_guard)
+    rollback_sidecar(sidecar_rollback_guard)
 }
-fn remove_artifact_if_unchanged(
-    artifact_path: &Path,
-    expected_contents: &[u8],
-    labels: ArtifactRollbackLabels<'_>,
-) -> std::io::Result<()> {
+#[rustfmt::skip]
+fn remove_artifact_if_unchanged(artifact_path: &Path, expected_contents: &[u8], labels: ArtifactRollbackLabels<'_>) -> std::io::Result<()> {
     match fs::read(artifact_path) {
-        Ok(current_contents) if current_contents == expected_contents => {
-            match fs::remove_file(artifact_path) {
-                Ok(()) => {
-                    warn!(
-                        artifact_path = %artifact_path.display(),
-                        rollback_cleanup = labels.removed_cleanup,
-                        "Rollback removed matching {} after reconciliation failure",
-                        labels.artifact_label
-                    );
-                    Ok(())
-                }
-                Err(err) if err.kind() == ErrorKind::NotFound => {
-                    warn!(
-                        artifact_path = %artifact_path.display(),
-                        rollback_cleanup = labels.missing_after_match_cleanup,
-                        "Rollback matching {} was already absent after reconciliation failure",
-                        labels.artifact_label
-                    );
-                    Ok(())
-                }
-                Err(err) => {
-                    warn!(
-                        artifact_path = %artifact_path.display(),
-                        rollback_cleanup = labels.remove_failed_cleanup,
-                        error = %err,
-                        "Rollback failed to remove matching {} after reconciliation failure",
-                        labels.artifact_label
-                    );
-                    Err(err)
-                }
-            }
-        }
-        Ok(_) => {
-            if labels.preserved_cleanup == "late_real_result_preserved" {
-                warn!(
-                    artifact_path = %artifact_path.display(),
-                    rollback_cleanup = labels.preserved_cleanup,
-                    "Rollback detected late real result.toml and left it in place"
-                );
-            } else {
-                warn!(
-                    artifact_path = %artifact_path.display(),
-                    rollback_cleanup = labels.preserved_cleanup,
-                    "Rollback preserved {} because contents changed after reconciliation failure",
-                    labels.artifact_label
-                );
-            }
-            Ok(())
-        }
-        Err(err) if err.kind() == ErrorKind::NotFound => {
-            warn!(
-                artifact_path = %artifact_path.display(),
-                rollback_cleanup = labels.missing_cleanup,
-                "Rollback found no {} to clean up after reconciliation failure",
-                labels.artifact_label
-            );
-            Ok(())
-        }
-        Err(err) => {
-            warn!(
-                artifact_path = %artifact_path.display(),
-                rollback_cleanup = labels.read_failed_cleanup,
-                error = %err,
-                "Rollback failed to read {} for content-aware cleanup after reconciliation failure",
-                labels.artifact_label
-            );
-            Ok(())
-        }
+        Ok(current_contents) if current_contents == expected_contents => match fs::remove_file(artifact_path) {
+            Ok(()) => { warn!(artifact_path = %artifact_path.display(), rollback_cleanup = labels.removed_cleanup, "Rollback removed matching {} after reconciliation failure", labels.artifact_label); Ok(()) }
+            Err(err) if err.kind() == ErrorKind::NotFound => { warn!(artifact_path = %artifact_path.display(), rollback_cleanup = labels.missing_after_match_cleanup, "Rollback matching {} was already absent after reconciliation failure", labels.artifact_label); Ok(()) }
+            Err(err) => { warn!(artifact_path = %artifact_path.display(), rollback_cleanup = labels.remove_failed_cleanup, error = %err, "Rollback failed to remove matching {} after reconciliation failure", labels.artifact_label); Err(err) }
+        },
+        Ok(_) if labels.preserved_cleanup == "late_real_result_preserved" => { warn!(artifact_path = %artifact_path.display(), rollback_cleanup = labels.preserved_cleanup, "Rollback detected late real result.toml and left it in place"); Ok(()) }
+        Ok(_) => { warn!(artifact_path = %artifact_path.display(), rollback_cleanup = labels.preserved_cleanup, "Rollback preserved {} because contents changed after reconciliation failure", labels.artifact_label); Ok(()) }
+        Err(err) if err.kind() == ErrorKind::NotFound => { warn!(artifact_path = %artifact_path.display(), rollback_cleanup = labels.missing_cleanup, "Rollback found no {} to clean up after reconciliation failure", labels.artifact_label); Ok(()) }
+        Err(err) => { warn!(artifact_path = %artifact_path.display(), rollback_cleanup = labels.read_failed_cleanup, error = %err, "Rollback failed to read {} for content-aware cleanup after reconciliation failure", labels.artifact_label); Ok(()) }
     }
 }
 
 #[rustfmt::skip]
-fn created_artifact_rollback_guard(artifact_path: &Path, expected_contents: &[u8]) -> std::io::Result<Option<CreatedArtifactRollbackGuard>> {
+fn artifact_rollback_guard(artifact_path: &Path, expected_contents: &[u8]) -> std::io::Result<Option<ArtifactRollbackGuard>> {
     match fs::read(artifact_path) {
-        Ok(_) => Ok(None),
-        Err(err) if err.kind() == ErrorKind::NotFound => Ok(Some(CreatedArtifactRollbackGuard {
+        Ok(current_contents) if current_contents == expected_contents => Ok(None),
+        Ok(current_contents) => Ok(Some(ArtifactRollbackGuard {
             artifact_path: artifact_path.to_path_buf(),
             expected_contents: expected_contents.to_vec(),
+            rollback_action: ArtifactRollbackAction::RestoreOriginal(current_contents),
+        })),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(Some(ArtifactRollbackGuard {
+            artifact_path: artifact_path.to_path_buf(),
+            expected_contents: expected_contents.to_vec(),
+            rollback_action: ArtifactRollbackAction::RemoveIfContentsMatch,
         })),
         Err(err) => Err(err),
     }
+}
+
+#[rustfmt::skip]
+fn write_sidecar_atomically(sidecar_path: &Path, contents: &[u8]) -> Result<()> {
+    let sidecar_dir = sidecar_path.parent().ok_or_else(|| anyhow!("Unpushed commit sidecar path has no parent: {}", sidecar_path.display()))?;
+    let temp_path = sidecar_dir.join(format!("{}.tmp.{}", sidecar_path.file_name().and_then(|name| name.to_str()).unwrap_or("unpushed_commits.json"), std::process::id()));
+    let write_result = (|| -> Result<()> {
+        let mut temp_file = OpenOptions::new().write(true).create_new(true).open(&temp_path).with_context(|| format!("Failed to create temporary unpushed commit sidecar: {}", temp_path.display()))?;
+        temp_file.write_all(contents).with_context(|| format!("Failed to write temporary unpushed commit sidecar: {}", temp_path.display()))?;
+        temp_file.sync_all().with_context(|| format!("Failed to sync temporary unpushed commit sidecar: {}", temp_path.display()))?;
+        preserve_existing_permissions_if_present(&mut temp_file, sidecar_path, "unpushed commit sidecar")?;
+        drop(temp_file);
+        fs::rename(&temp_path, sidecar_path).with_context(|| format!("Failed to publish unpushed commit sidecar {} from {}", sidecar_path.display(), temp_path.display()))?;
+        Ok(())
+    })();
+    if write_result.is_err() { let _ = fs::remove_file(&temp_path); }
+    write_result
 }
 
 #[rustfmt::skip]

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -495,14 +495,6 @@ fn retire_if_dead_with_result_impl(
     {
         return Ok(false);
     }
-    if let Err(err) = persist_unpushed_commits_sidecar(project_root, &session, session_dir) {
-        warn!(
-            session_id = %session_id,
-            trigger = %trigger,
-            error = %err,
-            "Failed to persist unpushed commit recovery sidecar"
-        );
-    }
     if session
         .apply_phase_event(csa_session::PhaseEvent::Retired)
         .is_err()

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -1,7 +1,10 @@
 use anyhow::{Context, Result, anyhow};
+use csa_core::vcs::VcsKind;
+use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Write};
 use std::path::Path;
+use std::process::Command;
 use tracing::{info, warn};
 
 use csa_process::ToolLiveness;
@@ -10,6 +13,22 @@ use csa_session::{
 };
 
 type PersistSessionFn<'a> = dyn Fn(&Path, &MetaSessionState) -> Result<()> + 'a;
+const UNPUSHED_COMMITS_SIDECAR_PATH: &str = "output/unpushed_commits.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct UnpushedCommitRecord {
+    sha: String,
+    subject: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct UnpushedCommitsSidecar {
+    branch: String,
+    remote_ref: Option<String>,
+    commits_ahead: u64,
+    commits: Vec<UnpushedCommitRecord>,
+    recovery_command: String,
+}
 
 struct SyntheticResultHooks<'a> {
     before_write: &'a dyn Fn(&Path),
@@ -56,6 +75,113 @@ fn with_reconcile_lock<R>(
 }
 
 fn noop_path(_: &Path) {}
+
+fn git_output(project_root: &Path, args: &[&str]) -> Result<std::process::Output> {
+    Command::new("git")
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .with_context(|| format!("Failed to run git {:?}", args))
+}
+
+fn git_success(project_root: &Path, args: &[&str]) -> bool {
+    git_output(project_root, args)
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn inspect_unpushed_commits(
+    project_root: &Path,
+    branch: &str,
+) -> Result<Option<UnpushedCommitsSidecar>> {
+    let range = if git_success(
+        project_root,
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/remotes/origin/{branch}"),
+        ],
+    ) {
+        (
+            Some(format!("origin/{branch}")),
+            format!("origin/{branch}..HEAD"),
+        )
+    } else if git_success(
+        project_root,
+        &["rev-parse", "--verify", "--quiet", "refs/heads/main"],
+    ) {
+        (None, "main..HEAD".to_string())
+    } else if git_success(
+        project_root,
+        &["rev-parse", "--verify", "--quiet", "refs/heads/master"],
+    ) {
+        (None, "master..HEAD".to_string())
+    } else {
+        return Ok(None);
+    };
+    let (remote_ref, rev_range) = range;
+
+    let count_output = git_output(project_root, &["rev-list", "--count", &rev_range])?;
+    if !count_output.status.success() {
+        return Ok(None);
+    }
+    let commits_ahead = String::from_utf8_lossy(&count_output.stdout)
+        .trim()
+        .parse::<u64>()
+        .unwrap_or(0);
+    if commits_ahead == 0 {
+        return Ok(None);
+    }
+
+    let log_output = git_output(project_root, &["log", "--format=%H%x09%s", &rev_range])?;
+    if !log_output.status.success() {
+        return Ok(None);
+    }
+
+    let commits = String::from_utf8_lossy(&log_output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (sha, subject) = line.split_once('\t')?;
+            Some(UnpushedCommitRecord {
+                sha: sha.to_string(),
+                subject: subject.to_string(),
+            })
+        })
+        .collect::<Vec<_>>();
+    if commits.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(UnpushedCommitsSidecar {
+        branch: branch.to_string(),
+        remote_ref,
+        commits_ahead,
+        commits,
+        recovery_command: format!("git push -u origin {branch}"),
+    }))
+}
+
+fn persist_unpushed_commits_sidecar(
+    project_root: &Path,
+    session: &MetaSessionState,
+    session_dir: &Path,
+) -> Result<Option<UnpushedCommitsSidecar>> {
+    if session.resolved_identity().vcs_kind != VcsKind::Git {
+        return Ok(None);
+    }
+    let Some(branch) = session.branch.as_deref() else {
+        return Ok(None);
+    };
+    let Some(sidecar) = inspect_unpushed_commits(project_root, branch)? else {
+        return Ok(None);
+    };
+    let output_dir = session_dir.join("output");
+    fs::create_dir_all(&output_dir)?;
+    let sidecar_path = session_dir.join(UNPUSHED_COMMITS_SIDECAR_PATH);
+    fs::write(&sidecar_path, serde_json::to_string_pretty(&sidecar)?)?;
+    Ok(Some(sidecar))
+}
 
 fn session_has_terminal_process(session_dir: &Path) -> bool {
     ToolLiveness::has_live_process(session_dir) || ToolLiveness::daemon_pid_is_alive(session_dir)
@@ -201,6 +327,14 @@ where
         .max_by_key(|(_, state)| state.updated_at)
         .map(|(tool, _)| tool.clone())
         .unwrap_or_else(|| "unknown".to_string());
+    if let Err(err) = persist_unpushed_commits_sidecar(project_root, &session, session_dir) {
+        warn!(
+            session_id = %session_id,
+            trigger = %trigger,
+            error = %err,
+            "Failed to persist unpushed commit recovery sidecar"
+        );
+    }
     let artifacts =
         crate::pipeline_post_exec::collect_fallback_result_artifacts(project_root, session_id);
     let output_log_mtime = format_optional_file_mtime(&session_dir.join("output.log"));
@@ -359,6 +493,14 @@ fn retire_if_dead_with_result_impl(
     if session_has_terminal_process(session_dir) || load_result(project_root, session_id)?.is_none()
     {
         return Ok(false);
+    }
+    if let Err(err) = persist_unpushed_commits_sidecar(project_root, &session, session_dir) {
+        warn!(
+            session_id = %session_id,
+            trigger = %trigger,
+            error = %err,
+            "Failed to persist unpushed commit recovery sidecar"
+        );
     }
     if session
         .apply_phase_event(csa_session::PhaseEvent::Retired)
@@ -574,3 +716,7 @@ fn format_optional_file_mtime(path: &Path) -> Option<String> {
 #[cfg(test)]
 #[path = "session_cmds_reconcile_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "session_cmds_reconcile_tests_tail.rs"]
+mod tail_tests;

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -3,7 +3,7 @@ use csa_core::vcs::VcsKind;
 use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tracing::{info, warn};
 
@@ -11,6 +11,8 @@ use csa_process::ToolLiveness;
 use csa_session::{
     MetaSessionState, SessionPhase, SessionResult, get_session_dir, load_result, load_session,
 };
+
+use crate::plan_cmd::shell_escape_for_command;
 
 type PersistSessionFn<'a> = dyn Fn(&Path, &MetaSessionState) -> Result<()> + 'a;
 const UNPUSHED_COMMITS_SIDECAR_PATH: &str = "output/unpushed_commits.json";
@@ -29,6 +31,15 @@ struct UnpushedCommitsSidecar {
     commits: Vec<UnpushedCommitRecord>,
     recovery_command: String,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CreatedArtifactRollbackGuard {
+    artifact_path: PathBuf,
+    expected_contents: Vec<u8>,
+}
+
+#[rustfmt::skip]
+struct ArtifactRollbackLabels<'a> { removed_cleanup: &'a str, missing_after_match_cleanup: &'a str, remove_failed_cleanup: &'a str, preserved_cleanup: &'a str, missing_cleanup: &'a str, read_failed_cleanup: &'a str, artifact_label: &'a str }
 
 struct SyntheticResultHooks<'a> {
     before_write: &'a dyn Fn(&Path),
@@ -159,7 +170,7 @@ fn inspect_unpushed_commits(
         remote_ref,
         commits_ahead,
         commits,
-        recovery_command: format!("git push -u origin {branch}"),
+        recovery_command: format_git_push_recovery_command(branch),
     }))
 }
 
@@ -167,7 +178,7 @@ fn persist_unpushed_commits_sidecar(
     project_root: &Path,
     session: &MetaSessionState,
     session_dir: &Path,
-) -> Result<Option<UnpushedCommitsSidecar>> {
+) -> Result<Option<CreatedArtifactRollbackGuard>> {
     if session.resolved_identity().vcs_kind != VcsKind::Git {
         return Ok(None);
     }
@@ -180,8 +191,11 @@ fn persist_unpushed_commits_sidecar(
     let output_dir = session_dir.join("output");
     fs::create_dir_all(&output_dir)?;
     let sidecar_path = session_dir.join(UNPUSHED_COMMITS_SIDECAR_PATH);
-    fs::write(&sidecar_path, serde_json::to_string_pretty(&sidecar)?)?;
-    Ok(Some(sidecar))
+    let sidecar_contents = serde_json::to_vec_pretty(&sidecar)?;
+    let rollback_guard =
+        created_artifact_rollback_guard(&sidecar_path, sidecar_contents.as_slice())?;
+    fs::write(&sidecar_path, &sidecar_contents)?;
+    Ok(rollback_guard)
 }
 
 fn session_has_terminal_process(session_dir: &Path) -> bool {
@@ -328,14 +342,19 @@ where
         .max_by_key(|(_, state)| state.updated_at)
         .map(|(tool, _)| tool.clone())
         .unwrap_or_else(|| "unknown".to_string());
-    if let Err(err) = persist_unpushed_commits_sidecar(project_root, &session, session_dir) {
-        warn!(
-            session_id = %session_id,
-            trigger = %trigger,
-            error = %err,
-            "Failed to persist unpushed commit recovery sidecar"
-        );
-    }
+    let sidecar_rollback_guard =
+        match persist_unpushed_commits_sidecar(project_root, &session, session_dir) {
+            Ok(rollback_guard) => rollback_guard,
+            Err(err) => {
+                warn!(
+                    session_id = %session_id,
+                    trigger = %trigger,
+                    error = %err,
+                    "Failed to persist unpushed commit recovery sidecar"
+                );
+                None
+            }
+        };
     let artifacts =
         crate::pipeline_post_exec::collect_fallback_result_artifacts(project_root, session_id);
     let output_log_mtime = format_optional_file_mtime(&session_dir.join("output.log"));
@@ -395,14 +414,16 @@ where
             error = %err,
             "Failed to transition orphaned session to Retired phase during reconciliation; removing synthetic result and leaving session state unchanged"
         );
-        remove_synthetic_result_if_unchanged(&result_path, result_contents.as_bytes()).map_err(
-            |cleanup_err| {
+        rollback_reconciliation_artifacts(
+            &result_path,
+            result_contents.as_bytes(),
+            sidecar_rollback_guard.as_ref(),
+        )
+        .map_err(|cleanup_err| {
             anyhow!(
-                "Failed to transition orphaned session to Retired phase during reconciliation for {session_id}: {err}; additionally failed to remove synthetic result {}: {cleanup_err}",
-                result_path.display()
+                "Failed to transition orphaned session to Retired phase during reconciliation for {session_id}: {err}; additionally failed to remove synthetic artifacts: {cleanup_err}"
             )
-        },
-        )?;
+        })?;
         return Err(anyhow!(
             "Failed to transition orphaned session to Retired phase during reconciliation for {session_id}: {err}"
         ));
@@ -416,14 +437,16 @@ where
             error = %err,
             "Failed to persist retired orphaned session state during reconciliation; removing synthetic result and leaving session state unchanged"
         );
-        remove_synthetic_result_if_unchanged(&result_path, result_contents.as_bytes()).map_err(
-            |cleanup_err| {
+        rollback_reconciliation_artifacts(
+            &result_path,
+            result_contents.as_bytes(),
+            sidecar_rollback_guard.as_ref(),
+        )
+        .map_err(|cleanup_err| {
             anyhow!(
-                "Failed to persist retired orphaned session state for {session_id}: {err}; additionally failed to remove synthetic result {}: {cleanup_err}",
-                result_path.display()
+                "Failed to persist retired orphaned session state for {session_id}: {err}; additionally failed to remove synthetic artifacts: {cleanup_err}"
             )
-        },
-        )?;
+        })?;
         return Err(anyhow!(
             "Failed to persist retired orphaned session state for {session_id}: {err}"
         ));
@@ -550,67 +573,125 @@ fn persist_session_state_atomically(session_dir: &Path, session: &MetaSessionSta
     Ok(())
 }
 
-fn remove_synthetic_result_if_unchanged(
-    result_path: &Path,
+#[rustfmt::skip]
+fn remove_synthetic_result_if_unchanged(result_path: &Path, expected_contents: &[u8]) -> std::io::Result<()> {
+    remove_artifact_if_unchanged(result_path, expected_contents, ArtifactRollbackLabels { removed_cleanup: "removed_synthetic_result", missing_after_match_cleanup: "result_missing_after_match", remove_failed_cleanup: "remove_failed", preserved_cleanup: "late_real_result_preserved", missing_cleanup: "result_missing", read_failed_cleanup: "read_failed", artifact_label: "synthetic result.toml" })
+}
+
+#[rustfmt::skip]
+fn remove_created_sidecar_if_unchanged(rollback_guard: Option<&CreatedArtifactRollbackGuard>) -> std::io::Result<()> {
+    let Some(rollback_guard) = rollback_guard else {
+        return Ok(());
+    };
+    remove_artifact_if_unchanged(&rollback_guard.artifact_path, rollback_guard.expected_contents.as_slice(), ArtifactRollbackLabels { removed_cleanup: "removed_unpushed_commits_sidecar", missing_after_match_cleanup: "sidecar_missing_after_match", remove_failed_cleanup: "sidecar_remove_failed", preserved_cleanup: "preexisting_sidecar_preserved", missing_cleanup: "sidecar_missing", read_failed_cleanup: "sidecar_read_failed", artifact_label: "unpushed_commits.json sidecar" })
+}
+
+#[rustfmt::skip]
+fn rollback_reconciliation_artifacts(result_path: &Path, result_contents: &[u8], sidecar_rollback_guard: Option<&CreatedArtifactRollbackGuard>) -> std::io::Result<()> {
+    remove_synthetic_result_if_unchanged(result_path, result_contents)?;
+    remove_created_sidecar_if_unchanged(sidecar_rollback_guard)
+}
+
+fn remove_artifact_if_unchanged(
+    artifact_path: &Path,
     expected_contents: &[u8],
+    labels: ArtifactRollbackLabels<'_>,
 ) -> std::io::Result<()> {
-    match fs::read(result_path) {
+    match fs::read(artifact_path) {
         Ok(current_contents) if current_contents == expected_contents => {
-            match fs::remove_file(result_path) {
+            match fs::remove_file(artifact_path) {
                 Ok(()) => {
                     warn!(
-                        result_path = %result_path.display(),
-                        rollback_cleanup = "removed_synthetic_result",
-                        "Rollback removed synthetic result.toml after reconciliation failure"
+                        artifact_path = %artifact_path.display(),
+                        rollback_cleanup = labels.removed_cleanup,
+                        "Rollback removed matching {} after reconciliation failure",
+                        labels.artifact_label
                     );
                     Ok(())
                 }
                 Err(err) if err.kind() == ErrorKind::NotFound => {
                     warn!(
-                        result_path = %result_path.display(),
-                        rollback_cleanup = "result_missing_after_match",
-                        "Rollback synthetic result.toml was already absent after reconciliation failure"
+                        artifact_path = %artifact_path.display(),
+                        rollback_cleanup = labels.missing_after_match_cleanup,
+                        "Rollback matching {} was already absent after reconciliation failure",
+                        labels.artifact_label
                     );
                     Ok(())
                 }
                 Err(err) => {
                     warn!(
-                        result_path = %result_path.display(),
-                        rollback_cleanup = "remove_failed",
+                        artifact_path = %artifact_path.display(),
+                        rollback_cleanup = labels.remove_failed_cleanup,
                         error = %err,
-                        "Rollback failed to remove matching synthetic result.toml after reconciliation failure"
+                        "Rollback failed to remove matching {} after reconciliation failure",
+                        labels.artifact_label
                     );
                     Err(err)
                 }
             }
         }
         Ok(_) => {
-            warn!(
-                result_path = %result_path.display(),
-                rollback_cleanup = "late_real_result_preserved",
-                "Rollback detected late real result.toml and left it in place"
-            );
+            if labels.preserved_cleanup == "late_real_result_preserved" {
+                warn!(
+                    artifact_path = %artifact_path.display(),
+                    rollback_cleanup = labels.preserved_cleanup,
+                    "Rollback detected late real result.toml and left it in place"
+                );
+            } else {
+                warn!(
+                    artifact_path = %artifact_path.display(),
+                    rollback_cleanup = labels.preserved_cleanup,
+                    "Rollback preserved {} because contents changed after reconciliation failure",
+                    labels.artifact_label
+                );
+            }
             Ok(())
         }
         Err(err) if err.kind() == ErrorKind::NotFound => {
             warn!(
-                result_path = %result_path.display(),
-                rollback_cleanup = "result_missing",
-                "Rollback found no result.toml to clean up after reconciliation failure"
+                artifact_path = %artifact_path.display(),
+                rollback_cleanup = labels.missing_cleanup,
+                "Rollback found no {} to clean up after reconciliation failure",
+                labels.artifact_label
             );
             Ok(())
         }
         Err(err) => {
             warn!(
-                result_path = %result_path.display(),
-                rollback_cleanup = "read_failed",
+                artifact_path = %artifact_path.display(),
+                rollback_cleanup = labels.read_failed_cleanup,
                 error = %err,
-                "Rollback failed to read result.toml for content-aware cleanup after reconciliation failure"
+                "Rollback failed to read {} for content-aware cleanup after reconciliation failure",
+                labels.artifact_label
             );
             Ok(())
         }
     }
 }
+
+#[rustfmt::skip]
+fn created_artifact_rollback_guard(artifact_path: &Path, expected_contents: &[u8]) -> std::io::Result<Option<CreatedArtifactRollbackGuard>> {
+    match fs::read(artifact_path) {
+        Ok(_) => Ok(None),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(Some(CreatedArtifactRollbackGuard {
+            artifact_path: artifact_path.to_path_buf(),
+            expected_contents: expected_contents.to_vec(),
+        })),
+        Err(err) => Err(err),
+    }
+}
+
+#[rustfmt::skip]
+fn format_git_push_recovery_command(branch: &str) -> String {
+    if branch_is_shell_word_safe(branch) {
+        format!("git push -u origin {branch}")
+    } else {
+        format!("git push -u origin {}", shell_escape_for_command(branch))
+    }
+}
+
+#[rustfmt::skip]
+fn branch_is_shell_word_safe(branch: &str) -> bool { branch.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-')) }
 
 fn persist_new_result_file<F>(
     result_path: &Path,

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -622,18 +622,12 @@ fn artifact_rollback_guard(artifact_path: &Path, expected_contents: &[u8]) -> st
 #[rustfmt::skip]
 fn write_sidecar_atomically(sidecar_path: &Path, contents: &[u8]) -> Result<()> {
     let sidecar_dir = sidecar_path.parent().ok_or_else(|| anyhow!("Unpushed commit sidecar path has no parent: {}", sidecar_path.display()))?;
-    let temp_path = sidecar_dir.join(format!("{}.tmp.{}", sidecar_path.file_name().and_then(|name| name.to_str()).unwrap_or("unpushed_commits.json"), std::process::id()));
-    let write_result = (|| -> Result<()> {
-        let mut temp_file = OpenOptions::new().write(true).create_new(true).open(&temp_path).with_context(|| format!("Failed to create temporary unpushed commit sidecar: {}", temp_path.display()))?;
-        temp_file.write_all(contents).with_context(|| format!("Failed to write temporary unpushed commit sidecar: {}", temp_path.display()))?;
-        temp_file.sync_all().with_context(|| format!("Failed to sync temporary unpushed commit sidecar: {}", temp_path.display()))?;
-        preserve_existing_permissions_if_present(&mut temp_file, sidecar_path, "unpushed commit sidecar")?;
-        drop(temp_file);
-        fs::rename(&temp_path, sidecar_path).with_context(|| format!("Failed to publish unpushed commit sidecar {} from {}", sidecar_path.display(), temp_path.display()))?;
-        Ok(())
-    })();
-    if write_result.is_err() { let _ = fs::remove_file(&temp_path); }
-    write_result
+    let mut temp_file = tempfile::NamedTempFile::new_in(sidecar_dir).with_context(|| format!("Failed to create temporary unpushed commit sidecar in {}", sidecar_dir.display()))?;
+    temp_file.as_file_mut().write_all(contents).with_context(|| format!("Failed to write temporary unpushed commit sidecar for {}", sidecar_path.display()))?;
+    temp_file.as_file_mut().sync_all().with_context(|| format!("Failed to sync temporary unpushed commit sidecar for {}", sidecar_path.display()))?;
+    preserve_existing_permissions_if_present(temp_file.as_file_mut(), sidecar_path, "unpushed commit sidecar")?;
+    temp_file.persist(sidecar_path).map_err(|err| anyhow!("Failed to publish unpushed commit sidecar {}: {}", sidecar_path.display(), err.error))?;
+    Ok(())
 }
 
 #[rustfmt::skip]

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -94,6 +94,7 @@ fn inspect_unpushed_commits(
     project_root: &Path,
     branch: &str,
 ) -> Result<Option<UnpushedCommitsSidecar>> {
+    let session_branch_ref = format!("refs/heads/{branch}");
     let range = if git_success(
         project_root,
         &[
@@ -105,18 +106,18 @@ fn inspect_unpushed_commits(
     ) {
         (
             Some(format!("origin/{branch}")),
-            format!("origin/{branch}..HEAD"),
+            format!("origin/{branch}..{session_branch_ref}"),
         )
     } else if git_success(
         project_root,
         &["rev-parse", "--verify", "--quiet", "refs/heads/main"],
     ) {
-        (None, "main..HEAD".to_string())
+        (None, format!("main..{session_branch_ref}"))
     } else if git_success(
         project_root,
         &["rev-parse", "--verify", "--quiet", "refs/heads/master"],
     ) {
-        (None, "master..HEAD".to_string())
+        (None, format!("master..{session_branch_ref}"))
     } else {
         return Ok(None);
     };

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -303,6 +303,102 @@ fn reconcile_failure_rolls_back_new_unpushed_commit_sidecar() {
     );
 }
 
+#[test]
+fn late_real_result_already_exists_cleans_up_reconcile_owned_sidecar() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path().join("project");
+    let origin = td.path().join("origin.git");
+    fs::create_dir_all(&project).unwrap();
+
+    run_git(&project, &["init", "--initial-branch", "main"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test User"]);
+    fs::write(project.join("README.md"), "base\n").unwrap();
+    run_git(&project, &["add", "README.md"]);
+    run_git(&project, &["commit", "-m", "init"]);
+
+    run_git(td.path(), &["init", "--bare", origin.to_str().unwrap()]);
+    run_git(
+        &project,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+    run_git(&project, &["push", "-u", "origin", "main"]);
+
+    run_git(&project, &["checkout", "-b", "fix/session-progress"]);
+    fs::write(project.join("progress.txt"), "first\n").unwrap();
+    run_git(&project, &["add", "progress.txt"]);
+    run_git(&project, &["commit", "-m", "feat: first progress"]);
+
+    let session = create_session(
+        &project,
+        Some("late-result-sidecar-cleanup"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(&project, &session_id).unwrap();
+    tail_backdate_tree(&session_dir, 120);
+
+    let now = chrono::Utc::now();
+    csa_session::write_review_meta(
+        &session_dir,
+        &csa_session::ReviewSessionMeta {
+            session_id: session_id.clone(),
+            head_sha: "deadbeef".to_string(),
+            decision: "pass".to_string(),
+            verdict: "CLEAN".to_string(),
+            tool: "codex".to_string(),
+            scope: "range:main...HEAD".to_string(),
+            exit_code: 0,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 1,
+            timestamp: now,
+            diff_fingerprint: None,
+        },
+    )
+    .unwrap();
+
+    let real_result = toml::to_string_pretty(&csa_session::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "real terminal result".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+    })
+    .unwrap();
+
+    let reconciled = ensure_terminal_result_for_dead_active_session_with_before_write(
+        &project,
+        &session_id,
+        "session wait",
+        |result_path| fs::write(result_path, &real_result).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::LateResultRetired
+    );
+    assert!(
+        !session_dir
+            .join("output")
+            .join("unpushed_commits.json")
+            .exists(),
+        "late real result should clean up the sidecar created by this reconcile attempt"
+    );
+
+    let directive = crate::session_cmds_daemon::synthesized_wait_next_step(&session_dir)
+        .unwrap()
+        .expect("review handoff should still synthesize a next-step directive");
+    assert!(directive.contains("pr-bot"));
+}
+
 #[cfg(unix)]
 #[test]
 fn retire_if_dead_with_result_preserves_pr_bot_handoff_for_real_results() {

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -1,0 +1,177 @@
+use super::*;
+use crate::test_env_lock::TEST_ENV_LOCK;
+use csa_session::{create_session, get_session_dir, load_result};
+use std::ffi::CString;
+use std::fs;
+use std::os::unix::ffi::OsStrExt;
+use tempfile::tempdir;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+struct SessionTestEnv {
+    _env_lock: std::sync::MutexGuard<'static, ()>,
+    _home_guard: EnvVarGuard,
+    _state_guard: EnvVarGuard,
+}
+
+impl SessionTestEnv {
+    fn new(td: &tempfile::TempDir) -> Self {
+        let env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+        let state_home = td.path().join("xdg-state");
+        fs::create_dir_all(&state_home).expect("create state home");
+        let home_guard = EnvVarGuard::set("HOME", td.path());
+        let state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+        Self {
+            _env_lock: env_lock,
+            _home_guard: home_guard,
+            _state_guard: state_guard,
+        }
+    }
+}
+
+fn run_git(dir: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+fn tail_set_file_mtime_seconds_ago(path: &std::path::Path, seconds_ago: u64) {
+    let target = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(seconds_ago))
+        .expect("target time before unix epoch")
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before unix epoch");
+    let tv_sec = libc::time_t::try_from(target.as_secs()).expect("mtime seconds fit in time_t");
+    let tv_nsec = target.subsec_nanos() as libc::c_long;
+    let times = [
+        libc::timespec { tv_sec, tv_nsec },
+        libc::timespec { tv_sec, tv_nsec },
+    ];
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("path contains NUL");
+    // SAFETY: `utimensat` receives a valid C path pointer and valid timespec array.
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    assert_eq!(rc, 0, "utimensat failed for {}", path.display());
+}
+
+#[cfg(unix)]
+fn tail_backdate_tree(path: &std::path::Path, seconds_ago: u64) {
+    if path.is_dir() {
+        for entry in std::fs::read_dir(path).expect("read_dir") {
+            let entry = entry.expect("dir entry");
+            tail_backdate_tree(&entry.path(), seconds_ago);
+        }
+    }
+    tail_set_file_mtime_seconds_ago(path, seconds_ago);
+}
+
+#[test]
+fn ensure_terminal_result_for_dead_active_session_writes_unpushed_commit_sidecar() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path().join("project");
+    let origin = td.path().join("origin.git");
+    fs::create_dir_all(&project).unwrap();
+
+    run_git(&project, &["init", "--initial-branch", "main"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test User"]);
+    fs::write(project.join("README.md"), "base\n").unwrap();
+    run_git(&project, &["add", "README.md"]);
+    run_git(&project, &["commit", "-m", "init"]);
+
+    run_git(td.path(), &["init", "--bare", origin.to_str().unwrap()]);
+    run_git(
+        &project,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+    run_git(&project, &["push", "-u", "origin", "main"]);
+
+    run_git(&project, &["checkout", "-b", "fix/session-progress"]);
+    fs::write(project.join("progress-1.txt"), "first\n").unwrap();
+    run_git(&project, &["add", "progress-1.txt"]);
+    run_git(&project, &["commit", "-m", "feat: first progress"]);
+    fs::write(project.join("progress-2.txt"), "second\n").unwrap();
+    run_git(&project, &["add", "progress-2.txt"]);
+    run_git(&project, &["commit", "-m", "fix: second progress"]);
+
+    let session = create_session(&project, Some("unpushed-progress"), None, Some("codex")).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(&project, &session_id).unwrap();
+    tail_backdate_tree(&session_dir, 120);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(&project, &session_id, "session wait")
+            .unwrap();
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
+
+    let sidecar_path = session_dir.join("output").join("unpushed_commits.json");
+    let sidecar: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&sidecar_path).unwrap()).unwrap();
+    assert_eq!(sidecar["branch"], "fix/session-progress");
+    assert_eq!(sidecar["commits_ahead"], 2);
+    assert_eq!(
+        sidecar["recovery_command"],
+        "git push -u origin fix/session-progress"
+    );
+    assert_eq!(sidecar["commits"].as_array().unwrap().len(), 2);
+    assert!(
+        sidecar["commits"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["subject"] == "feat: first progress")
+    );
+    assert!(
+        sidecar["commits"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["subject"] == "fix: second progress")
+    );
+
+    let result = load_result(&project, &session_id).unwrap().unwrap();
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "output/unpushed_commits.json"),
+        "synthetic result should advertise the recovery sidecar"
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -1,8 +1,14 @@
 use super::*;
 use crate::test_env_lock::TEST_ENV_LOCK;
+#[cfg(unix)]
+use chrono::Utc;
 use csa_session::{create_session, get_session_dir, load_result};
+#[cfg(unix)]
+use csa_session::{load_session, save_result};
+#[cfg(unix)]
 use std::ffi::CString;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 use tempfile::tempdir;
 
@@ -174,6 +180,83 @@ fn ensure_terminal_result_for_dead_active_session_writes_unpushed_commit_sidecar
             .any(|artifact| artifact.path == "output/unpushed_commits.json"),
         "synthetic result should advertise the recovery sidecar"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn retire_if_dead_with_result_preserves_pr_bot_handoff_for_real_results() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(project, Some("late-real-result"), None, Some("codex")).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    tail_backdate_tree(&session_dir, 120);
+
+    let now = Utc::now();
+    save_result(
+        project,
+        &session_id,
+        &csa_session::SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "real terminal result".to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: Vec::new(),
+            peak_memory_mb: None,
+        },
+    )
+    .unwrap();
+
+    csa_session::write_review_meta(
+        &session_dir,
+        &csa_session::ReviewSessionMeta {
+            session_id: session_id.clone(),
+            head_sha: "deadbeef".to_string(),
+            decision: "pass".to_string(),
+            verdict: "CLEAN".to_string(),
+            tool: "codex".to_string(),
+            scope: "range:main...HEAD".to_string(),
+            exit_code: 0,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 1,
+            timestamp: now,
+            diff_fingerprint: None,
+        },
+    )
+    .unwrap();
+
+    let retired = retire_if_dead_with_result_impl(
+        project,
+        &session_id,
+        "session wait",
+        &session_dir,
+        &persist_session_state_atomically,
+    )
+    .unwrap();
+    assert!(retired);
+    assert!(
+        !session_dir
+            .join("output")
+            .join("unpushed_commits.json")
+            .exists(),
+        "real-result retirement must not leave an unpushed-commit recovery sidecar"
+    );
+
+    let directive = crate::session_cmds_daemon::synthesized_wait_next_step(&session_dir)
+        .unwrap()
+        .expect("cumulative review should still synthesize a next-step directive");
+    assert!(directive.contains("CSA:NEXT_STEP"));
+    assert!(directive.contains("pr-bot"));
+
+    let persisted = load_session(project, &session_id).unwrap();
+    assert_eq!(persisted.phase, csa_session::SessionPhase::Retired);
+    assert_eq!(persisted.termination_reason.as_deref(), Some("completed"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -182,6 +182,127 @@ fn ensure_terminal_result_for_dead_active_session_writes_unpushed_commit_sidecar
     );
 }
 
+#[test]
+fn ensure_terminal_result_for_dead_active_session_shell_escapes_recovery_command() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path().join("project");
+    let origin = td.path().join("origin.git");
+    fs::create_dir_all(&project).unwrap();
+
+    run_git(&project, &["init", "--initial-branch", "main"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test User"]);
+    fs::write(project.join("README.md"), "base\n").unwrap();
+    run_git(&project, &["add", "README.md"]);
+    run_git(&project, &["commit", "-m", "init"]);
+
+    run_git(td.path(), &["init", "--bare", origin.to_str().unwrap()]);
+    run_git(
+        &project,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+    run_git(&project, &["push", "-u", "origin", "main"]);
+
+    let branch = "feat/$(touch-pwn)";
+    run_git(&project, &["checkout", "-b", branch]);
+    fs::write(project.join("progress.txt"), "first\n").unwrap();
+    run_git(&project, &["add", "progress.txt"]);
+    run_git(&project, &["commit", "-m", "feat: adversarial progress"]);
+
+    let session = create_session(&project, Some("escaped-recovery"), None, Some("codex")).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(&project, &session_id).unwrap();
+    tail_backdate_tree(&session_dir, 120);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(&project, &session_id, "session wait")
+            .unwrap();
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
+
+    let sidecar_path = session_dir.join("output").join("unpushed_commits.json");
+    let sidecar: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&sidecar_path).unwrap()).unwrap();
+    assert_eq!(
+        sidecar["recovery_command"],
+        "git push -u origin 'feat/$(touch-pwn)'"
+    );
+
+    let directive = crate::session_cmds_daemon::synthesized_wait_next_step(&session_dir)
+        .unwrap()
+        .expect("recovery next-step directive should be synthesized");
+    let parsed = csa_hooks::parse_next_step_directive(&directive)
+        .expect("directive should parse into a next-step command");
+    assert_eq!(
+        parsed.cmd.as_deref(),
+        Some("git push -u origin 'feat/$(touch-pwn)'")
+    );
+}
+
+#[test]
+fn reconcile_failure_rolls_back_new_unpushed_commit_sidecar() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path().join("project");
+    let origin = td.path().join("origin.git");
+    fs::create_dir_all(&project).unwrap();
+
+    run_git(&project, &["init", "--initial-branch", "main"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test User"]);
+    fs::write(project.join("README.md"), "base\n").unwrap();
+    run_git(&project, &["add", "README.md"]);
+    run_git(&project, &["commit", "-m", "init"]);
+
+    run_git(td.path(), &["init", "--bare", origin.to_str().unwrap()]);
+    run_git(
+        &project,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+    run_git(&project, &["push", "-u", "origin", "main"]);
+
+    run_git(&project, &["checkout", "-b", "fix/session-progress"]);
+    fs::write(project.join("progress.txt"), "first\n").unwrap();
+    run_git(&project, &["add", "progress.txt"]);
+    run_git(&project, &["commit", "-m", "feat: first progress"]);
+
+    let session = create_session(&project, Some("rollback-sidecar"), None, Some("codex")).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(&project, &session_id).unwrap();
+    tail_backdate_tree(&session_dir, 120);
+
+    let err = ensure_terminal_result_for_dead_active_session_impl(
+        &project,
+        &session_id,
+        "session wait",
+        &session_dir,
+        SyntheticResultHooks {
+            before_write: &noop_path,
+            after_publish: &noop_path,
+        },
+        |_| {},
+        &|_, _| Err(anyhow::anyhow!("persist session failed")),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("persist session failed"));
+    assert!(
+        !session_dir
+            .join("output")
+            .join("unpushed_commits.json")
+            .exists(),
+        "rollback should remove a sidecar created by this reconcile attempt"
+    );
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "rollback should remove the synthetic result when session persistence fails"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn retire_if_dead_with_result_preserves_pr_bot_handoff_for_real_results() {

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -182,6 +182,7 @@ fn ensure_terminal_result_for_dead_active_session_writes_unpushed_commit_sidecar
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn ensure_terminal_result_for_dead_active_session_shell_escapes_recovery_command() {
     let td = tempdir().expect("tempdir");
@@ -242,6 +243,7 @@ fn ensure_terminal_result_for_dead_active_session_shell_escapes_recovery_command
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn reconcile_failure_rolls_back_new_unpushed_commit_sidecar() {
     let td = tempdir().expect("tempdir");
@@ -303,6 +305,7 @@ fn reconcile_failure_rolls_back_new_unpushed_commit_sidecar() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn reconcile_failure_restores_preexisting_unpushed_commit_sidecar() {
     let td = tempdir().expect("tempdir");
@@ -369,6 +372,7 @@ fn reconcile_failure_restores_preexisting_unpushed_commit_sidecar() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn late_real_result_already_exists_cleans_up_reconcile_owned_sidecar() {
     let td = tempdir().expect("tempdir");
@@ -542,6 +546,24 @@ fn retire_if_dead_with_result_preserves_pr_bot_handoff_for_real_results() {
     assert_eq!(persisted.termination_reason.as_deref(), Some("completed"));
 }
 
+#[test]
+fn write_sidecar_atomically_replaces_preexisting_contents() {
+    let td = tempdir().expect("tempdir");
+    let sidecar_path = td.path().join("output").join("unpushed_commits.json");
+    fs::create_dir_all(sidecar_path.parent().expect("sidecar parent"))
+        .expect("create sidecar parent");
+
+    let first = br#"{"recovery_command":"git push -u origin fix/first"}"#;
+    let second = br#"{"recovery_command":"git push -u origin fix/second"}"#;
+
+    write_sidecar_atomically(&sidecar_path, first).expect("first sidecar write succeeds");
+    write_sidecar_atomically(&sidecar_path, second)
+        .expect("second sidecar write replaces preexisting file");
+
+    assert_eq!(fs::read(&sidecar_path).expect("read final sidecar"), second);
+}
+
+#[cfg(unix)]
 #[test]
 fn inspect_unpushed_commits_uses_session_branch_not_checked_out_head() {
     let td = tempdir().expect("tempdir");

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -304,6 +304,72 @@ fn reconcile_failure_rolls_back_new_unpushed_commit_sidecar() {
 }
 
 #[test]
+fn reconcile_failure_restores_preexisting_unpushed_commit_sidecar() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path().join("project");
+    let origin = td.path().join("origin.git");
+    fs::create_dir_all(&project).unwrap();
+
+    run_git(&project, &["init", "--initial-branch", "main"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test User"]);
+    fs::write(project.join("README.md"), "base\n").unwrap();
+    run_git(&project, &["add", "README.md"]);
+    run_git(&project, &["commit", "-m", "init"]);
+
+    run_git(td.path(), &["init", "--bare", origin.to_str().unwrap()]);
+    run_git(
+        &project,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+    run_git(&project, &["push", "-u", "origin", "main"]);
+
+    run_git(&project, &["checkout", "-b", "fix/session-progress"]);
+    fs::write(project.join("progress.txt"), "first\n").unwrap();
+    run_git(&project, &["add", "progress.txt"]);
+    run_git(&project, &["commit", "-m", "feat: first progress"]);
+
+    let session = create_session(
+        &project,
+        Some("rollback-preexisting-sidecar"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(&project, &session_id).unwrap();
+    tail_backdate_tree(&session_dir, 120);
+
+    let sidecar_path = session_dir.join("output").join("unpushed_commits.json");
+    fs::create_dir_all(sidecar_path.parent().unwrap()).unwrap();
+    let original_contents = br#"{"recovery_command":"git push -u origin fix/original-sidecar"}"#;
+    fs::write(&sidecar_path, original_contents).unwrap();
+
+    let err = ensure_terminal_result_for_dead_active_session_impl(
+        &project,
+        &session_id,
+        "session wait",
+        &session_dir,
+        SyntheticResultHooks {
+            before_write: &noop_path,
+            after_publish: &noop_path,
+        },
+        |_| {},
+        &|_, _| Err(anyhow::anyhow!("persist session failed")),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("persist session failed"));
+    assert_eq!(fs::read(&sidecar_path).unwrap(), original_contents);
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "rollback should remove the synthetic result when session persistence fails"
+    );
+}
+
+#[test]
 fn late_real_result_already_exists_cleans_up_reconcile_owned_sidecar() {
     let td = tempdir().expect("tempdir");
     let _env = SessionTestEnv::new(&td);

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -175,3 +175,75 @@ fn ensure_terminal_result_for_dead_active_session_writes_unpushed_commit_sidecar
         "synthetic result should advertise the recovery sidecar"
     );
 }
+
+#[test]
+fn inspect_unpushed_commits_uses_session_branch_not_checked_out_head() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path().join("project");
+    let origin = td.path().join("origin.git");
+    fs::create_dir_all(&project).unwrap();
+
+    run_git(&project, &["init", "--initial-branch", "main"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test User"]);
+    fs::write(project.join("README.md"), "base\n").unwrap();
+    run_git(&project, &["add", "README.md"]);
+    run_git(&project, &["commit", "-m", "init"]);
+
+    run_git(td.path(), &["init", "--bare", origin.to_str().unwrap()]);
+    run_git(
+        &project,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+    run_git(&project, &["push", "-u", "origin", "main"]);
+
+    run_git(&project, &["checkout", "-b", "fix/session-progress"]);
+    fs::write(project.join("progress-1.txt"), "first\n").unwrap();
+    run_git(&project, &["add", "progress-1.txt"]);
+    run_git(&project, &["commit", "-m", "feat: first progress"]);
+    fs::write(project.join("progress-2.txt"), "second\n").unwrap();
+    run_git(&project, &["add", "progress-2.txt"]);
+    run_git(&project, &["commit", "-m", "fix: second progress"]);
+
+    let session = create_session(&project, Some("unpushed-progress"), None, Some("codex")).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(&project, &session_id).unwrap();
+    tail_backdate_tree(&session_dir, 120);
+
+    run_git(&project, &["checkout", "main"]);
+    run_git(&project, &["checkout", "-b", "operator/other-work"]);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(&project, &session_id, "session wait")
+            .unwrap();
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
+
+    let sidecar_path = session_dir.join("output").join("unpushed_commits.json");
+    let sidecar: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&sidecar_path).unwrap()).unwrap();
+    assert_eq!(sidecar["branch"], "fix/session-progress");
+    assert_eq!(sidecar["commits_ahead"], 2);
+    assert_eq!(
+        sidecar["recovery_command"],
+        "git push -u origin fix/session-progress"
+    );
+    assert_eq!(sidecar["commits"].as_array().unwrap().len(), 2);
+    assert!(
+        sidecar["commits"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["subject"] == "feat: first progress")
+    );
+    assert!(
+        sidecar["commits"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["subject"] == "fix: second progress")
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -789,8 +789,9 @@ fn session_to_json_includes_depth_and_parent() {
     assert_eq!(value.get("depth").and_then(|v| v.as_u64()), Some(2));
 }
 
-#[path = "session_cmds_tests_tail.rs"]
-mod tail_tests;
-
 #[path = "session_cmds_tests_daemon_pid_tail.rs"]
 mod daemon_pid_tail_tests;
+#[path = "session_cmds_tests_tail.rs"]
+mod tail_tests;
+#[path = "session_cmds_tests_tail_wait.rs"]
+mod tail_tests_wait;

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -793,5 +793,7 @@ fn session_to_json_includes_depth_and_parent() {
 mod daemon_pid_tail_tests;
 #[path = "session_cmds_tests_tail.rs"]
 mod tail_tests;
+#[path = "session_cmds_tests_tail_recovery.rs"]
+mod tail_tests_recovery;
 #[path = "session_cmds_tests_tail_wait.rs"]
 mod tail_tests_wait;

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -697,22 +697,12 @@ fn persist_daemon_completion_from_env_writes_packet_for_seeded_session() {
     assert!(packet.contains("status = \"failure\""));
 }
 
+#[rustfmt::skip]
 #[cfg(unix)]
 #[test]
 fn synthesized_wait_next_step_returns_directive_for_clean_cumulative_review() {
-    let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
-    let state_home = td.path().join("xdg-state");
-    std::fs::create_dir_all(&state_home).unwrap();
-    let _home_guard = EnvVarGuard::set("HOME", td.path());
-    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
-    let project = td.path();
-    let session = create_session(project, Some("wait-next-step"), None, Some("codex")).unwrap();
-    let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
-
-    std::fs::write(
-        session_dir.join("review_meta.json"),
-        r#"{
+    let td = tempdir().unwrap(); let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned"); let state_home = td.path().join("xdg-state"); std::fs::create_dir_all(&state_home).unwrap(); let _home_guard = EnvVarGuard::set("HOME", td.path()); let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home); let project = td.path(); let session = create_session(project, Some("wait-next-step"), None, Some("codex")).unwrap(); let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
+    std::fs::write(session_dir.join("review_meta.json"), r#"{
   "session_id": "01TEST",
   "head_sha": "deadbeef",
   "decision": "pass",
@@ -723,34 +713,16 @@ fn synthesized_wait_next_step_returns_directive_for_clean_cumulative_review() {
   "fix_attempted": false,
   "fix_rounds": 0,
   "timestamp": "2026-04-01T00:00:00Z"
-}"#,
-    )
-    .unwrap();
-
-    let directive = synthesized_wait_next_step(&session_dir)
-        .unwrap()
-        .expect("directive should be synthesized");
-    assert!(directive.contains("CSA:NEXT_STEP"));
-    assert!(directive.contains("pr-bot"));
+}"#).unwrap();
+    let directive = synthesized_wait_next_step(&session_dir).unwrap().expect("directive should be synthesized"); assert!(directive.contains("CSA:NEXT_STEP")); assert!(directive.contains("pr-bot"));
 }
 
+#[rustfmt::skip]
 #[cfg(unix)]
 #[test]
 fn synthesized_wait_next_step_skips_non_cumulative_or_existing_directive() {
-    let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
-    let state_home = td.path().join("xdg-state");
-    std::fs::create_dir_all(&state_home).unwrap();
-    let _home_guard = EnvVarGuard::set("HOME", td.path());
-    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
-    let project = td.path();
-    let session =
-        create_session(project, Some("wait-next-step-skip"), None, Some("codex")).unwrap();
-    let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
-
-    std::fs::write(
-        session_dir.join("review_meta.json"),
-        r#"{
+    let td = tempdir().unwrap(); let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned"); let state_home = td.path().join("xdg-state"); std::fs::create_dir_all(&state_home).unwrap(); let _home_guard = EnvVarGuard::set("HOME", td.path()); let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home); let project = td.path(); let session = create_session(project, Some("wait-next-step-skip"), None, Some("codex")).unwrap(); let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
+    std::fs::write(session_dir.join("review_meta.json"), r#"{
   "session_id": "01TEST",
   "head_sha": "deadbeef",
   "decision": "pass",
@@ -761,14 +733,9 @@ fn synthesized_wait_next_step_skips_non_cumulative_or_existing_directive() {
   "fix_attempted": false,
   "fix_rounds": 0,
   "timestamp": "2026-04-01T00:00:00Z"
-}"#,
-    )
-    .unwrap();
+}"#).unwrap();
     assert!(synthesized_wait_next_step(&session_dir).unwrap().is_none());
-
-    std::fs::write(
-        session_dir.join("review_meta.json"),
-        r#"{
+    std::fs::write(session_dir.join("review_meta.json"), r#"{
   "session_id": "01TEST",
   "head_sha": "deadbeef",
   "decision": "pass",
@@ -779,13 +746,27 @@ fn synthesized_wait_next_step_skips_non_cumulative_or_existing_directive() {
   "fix_attempted": false,
   "fix_rounds": 0,
   "timestamp": "2026-04-01T00:00:00Z"
-}"#,
-    )
-    .unwrap();
-    std::fs::write(
-        session_dir.join("stdout.log"),
-        "<!-- CSA:NEXT_STEP cmd=\"custom\" required=false -->\n",
-    )
-    .unwrap();
-    assert!(synthesized_wait_next_step(&session_dir).unwrap().is_none());
+}"#).unwrap();
+    std::fs::write(session_dir.join("stdout.log"), "<!-- CSA:NEXT_STEP cmd=\"custom\" required=false -->\n").unwrap(); assert!(synthesized_wait_next_step(&session_dir).unwrap().is_none());
+}
+
+#[rustfmt::skip]
+#[cfg(unix)]
+#[test]
+fn synthesized_wait_next_step_ignores_malformed_unpushed_commit_sidecar() {
+    let td = tempdir().unwrap(); let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned"); let state_home = td.path().join("xdg-state"); std::fs::create_dir_all(&state_home).unwrap(); let _home_guard = EnvVarGuard::set("HOME", td.path()); let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home); let project = td.path(); let session = create_session(project, Some("wait-next-step-malformed-sidecar"), None, Some("codex")).unwrap(); let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
+    std::fs::write(session_dir.join("review_meta.json"), r#"{
+  "session_id": "01TEST",
+  "head_sha": "deadbeef",
+  "decision": "pass",
+  "verdict": "CLEAN",
+  "tool": "codex",
+  "scope": "range:main...HEAD",
+  "exit_code": 0,
+  "fix_attempted": false,
+  "fix_rounds": 0,
+  "timestamp": "2026-04-01T00:00:00Z"
+}"#).unwrap();
+    std::fs::create_dir_all(session_dir.join("output")).unwrap(); std::fs::write(session_dir.join("output").join("unpushed_commits.json"), "{\"recovery_command\":").unwrap();
+    let directive = synthesized_wait_next_step(&session_dir).unwrap().expect("malformed sidecar should fall back to review handoff"); assert!(directive.contains("CSA:NEXT_STEP")); assert!(directive.contains("pr-bot"));
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_recovery.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_recovery.rs
@@ -1,0 +1,71 @@
+use super::*;
+use crate::test_env_lock::TEST_ENV_LOCK;
+use tempfile::tempdir;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn synthesized_wait_next_step_returns_directive_for_unpushed_commit_recovery() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+    let session = create_session(
+        project,
+        Some("wait-next-step-unpushed"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
+    std::fs::create_dir_all(session_dir.join("output")).unwrap();
+
+    std::fs::write(
+        session_dir.join("output").join("unpushed_commits.json"),
+        r#"{
+  "branch": "fix/session-progress",
+  "remote_ref": null,
+  "commits_ahead": 2,
+  "commits": [
+    {"sha": "abc123", "subject": "feat: first progress"},
+    {"sha": "def456", "subject": "fix: second progress"}
+  ],
+  "recovery_command": "git push -u origin fix/session-progress"
+}"#,
+    )
+    .unwrap();
+
+    let directive = synthesized_wait_next_step(&session_dir)
+        .unwrap()
+        .expect("directive should be synthesized");
+    assert!(directive.contains("CSA:NEXT_STEP"));
+    assert!(directive.contains("git push -u origin fix/session-progress"));
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
@@ -244,6 +244,87 @@ fn handle_session_wait_prefers_refreshed_real_result_status_and_exit_code_over_c
 
 #[cfg(unix)]
 #[test]
+fn handle_session_wait_prefers_refreshed_real_result_on_equal_mtime_with_completion_packet() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-refresh-real-result-equal-mtime"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let completion_path = session_dir.join("daemon-completion.toml");
+    std::fs::write(&completion_path, "exit_code = 0\nstatus = \"success\"\n")
+        .expect("write completion packet");
+
+    let refreshed_result = SessionResult {
+        summary: "refreshed real terminal result with equal mtime".to_string(),
+        ..make_result("failure", 7)
+    };
+    save_result(project, &session_id, &refreshed_result).expect("save refreshed result");
+
+    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
+    let same_second_time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+    for path in [completion_path.as_path(), result_path.as_path()] {
+        let file = std::fs::File::options()
+            .write(true)
+            .open(path)
+            .expect("open file for mtime update");
+        file.set_times(std::fs::FileTimes::new().set_modified(same_second_time))
+            .expect("set mtime");
+    }
+
+    let completion_modified = std::fs::metadata(&completion_path)
+        .expect("completion metadata")
+        .modified()
+        .expect("completion modified time");
+    let result_modified = std::fs::metadata(&result_path)
+        .expect("result metadata")
+        .modified()
+        .expect("result modified time");
+    assert_eq!(
+        result_modified, completion_modified,
+        "test setup requires equal mtimes"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+        |_project_root, _current_session_id, _trigger| {
+            panic!("refresh_result_for_wait should short-circuit before reconcile");
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should succeed");
+
+    assert_eq!(exit_code, 7);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id.clone(), "failure".to_string(), 7, false))
+    );
+
+    let persisted = load_result(project, &session_id)
+        .expect("load result")
+        .expect("refreshed real result should persist");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 7);
+}
+
+#[cfg(unix)]
+#[test]
 fn handle_session_wait_errors_when_refresh_branch_cannot_persist_retired_phase() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
@@ -241,3 +241,75 @@ fn handle_session_wait_prefers_refreshed_real_result_status_and_exit_code_over_c
     assert_eq!(persisted.status, "failure");
     assert_eq!(persisted.exit_code, 7);
 }
+
+#[cfg(unix)]
+#[test]
+fn handle_session_wait_errors_when_refresh_branch_cannot_persist_retired_phase() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-refresh-retire-save-failure"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write completion packet");
+    set_file_mtime_seconds_ago(&session_dir.join("daemon-completion.toml"), 2);
+
+    let refreshed_result = SessionResult {
+        summary: "refreshed real terminal result".to_string(),
+        ..make_result("failure", 7)
+    };
+    save_result(project, &session_id, &refreshed_result).expect("save refreshed result");
+
+    let lock_path = session_dir.join(".reconcile.lock");
+    std::fs::create_dir(&lock_path).expect("poison reconcile lock path with a directory");
+
+    let mut emitted_completion = false;
+    let wait_err = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+        |_project_root, _current_session_id, _trigger| {
+            panic!("refresh_result_for_wait should short-circuit before reconcile");
+        },
+        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {
+            emitted_completion = true;
+        },
+    )
+    .expect_err("wait should fail when retire persistence fails");
+
+    assert!(
+        wait_err
+            .to_string()
+            .contains("Failed to open reconciliation lock file"),
+        "unexpected error: {wait_err:#}"
+    );
+    assert!(
+        !emitted_completion,
+        "wait should not emit completion when retire persistence fails"
+    );
+
+    let persisted = load_session(project, &session_id).expect("load session");
+    assert_eq!(persisted.phase, SessionPhase::Active);
+    assert_eq!(persisted.termination_reason, None);
+
+    let result = load_result(project, &session_id)
+        .expect("load result")
+        .expect("refreshed real result should still exist");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 7);
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::session_cmds_daemon::{WaitReconciliationOutcome, handle_session_wait_with_hooks};
 use crate::test_env_lock::TEST_ENV_LOCK;
 use tempfile::tempdir;
 
@@ -73,5 +74,54 @@ fn handle_session_wait_retires_active_session_after_dead_failure_completion_pack
     assert_eq!(
         persisted.termination_reason.as_deref(),
         Some("orphaned_process")
+    );
+}
+
+#[test]
+fn handle_session_wait_prefers_synthetic_failure_exit_code_over_completion_packet() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-synthetic-exit-code"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write completion packet");
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: true,
+                synthetic: true,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should succeed");
+
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "success".to_string(), 1, true))
     );
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
@@ -181,3 +181,63 @@ fn handle_session_wait_prefers_late_real_result_status_and_exit_code_over_comple
     assert_eq!(persisted.status, "failure");
     assert_eq!(persisted.exit_code, 7);
 }
+
+#[test]
+fn handle_session_wait_prefers_refreshed_real_result_status_and_exit_code_over_completion_packet() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-refresh-real-result"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write completion packet");
+    #[cfg(unix)]
+    set_file_mtime_seconds_ago(&session_dir.join("daemon-completion.toml"), 2);
+
+    let refreshed_result = SessionResult {
+        summary: "refreshed real terminal result".to_string(),
+        ..make_result("failure", 7)
+    };
+    save_result(project, &session_id, &refreshed_result).expect("save refreshed result");
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+        |_project_root, _current_session_id, _trigger| {
+            panic!("refresh_result_for_wait should short-circuit before reconcile");
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should succeed");
+
+    assert_eq!(exit_code, 7);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id.clone(), "failure".to_string(), 7, false))
+    );
+
+    let persisted = load_result(project, &session_id)
+        .expect("load result")
+        .expect("refreshed real result should persist");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 7);
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
@@ -1,0 +1,77 @@
+use super::*;
+use crate::test_env_lock::TEST_ENV_LOCK;
+use tempfile::tempdir;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_wait_retires_active_session_after_dead_failure_completion_packet() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-retire-dead-completion-packet"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+
+    let exit_code = handle_session_wait(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(exit_code, 1);
+
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("wait should synthesize a terminal result for a dead active session");
+    assert_eq!(result.status, "failure");
+
+    let persisted = load_session(project, &session_id).unwrap();
+    assert_eq!(persisted.phase, SessionPhase::Retired);
+    assert_eq!(
+        persisted.termination_reason.as_deref(),
+        Some("orphaned_process")
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
@@ -125,3 +125,59 @@ fn handle_session_wait_prefers_synthetic_failure_status_and_exit_code_over_compl
         Some((session_id, "failure".to_string(), 1, true))
     );
 }
+
+#[test]
+fn handle_session_wait_prefers_late_real_result_status_and_exit_code_over_completion_packet() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(project, Some("wait-late-real-result"), None, Some("codex"))
+        .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write completion packet");
+
+    let late_result = SessionResult {
+        summary: "late real terminal result".to_string(),
+        ..make_result("failure", 7)
+    };
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+        |project_root, current_session_id, _trigger| {
+            save_result(project_root, current_session_id, &late_result).expect("save late result");
+            Ok(WaitReconciliationOutcome {
+                result_became_available: true,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should succeed");
+
+    assert_eq!(exit_code, 7);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id.clone(), "failure".to_string(), 7, false))
+    );
+
+    let persisted = load_result(project, &session_id)
+        .expect("load result")
+        .expect("late real result should persist");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 7);
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
@@ -78,7 +78,7 @@ fn handle_session_wait_retires_active_session_after_dead_failure_completion_pack
 }
 
 #[test]
-fn handle_session_wait_prefers_synthetic_failure_exit_code_over_completion_packet() {
+fn handle_session_wait_prefers_synthetic_failure_status_and_exit_code_over_completion_packet() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
     let state_home = td.path().join("xdg-state");
@@ -122,6 +122,6 @@ fn handle_session_wait_prefers_synthetic_failure_exit_code_over_completion_packe
     assert_eq!(exit_code, 1);
     assert_eq!(
         emitted_completion,
-        Some((session_id, "success".to_string(), 1, true))
+        Some((session_id, "failure".to_string(), 1, true))
     );
 }

--- a/output/summary.md
+++ b/output/summary.md
@@ -1,0 +1,30 @@
+# Batch 1 Summary
+
+## Commits
+- `754c3cc3` fix(csa-session): retire dead active wait sessions (#738)
+- `0c73b885` fix(csa-session): surface unpushed session recovery steps (#747)
+- `b2514cf1` fix(cli-sub-agent): skip executor publish transactions (#782)
+
+## Per-issue detail
+
+### #738
+- **Root cause**: `csa session wait` could observe a dead session's `daemon-completion.toml` without reconciling the result into a terminal phase, leaving the session stuck in `Active`.
+- **Fix**: `session wait` now refreshes or synthesizes the result on daemon completion and retires the dead session before returning failure.
+- **Files touched**: `crates/cli-sub-agent/src/session_cmds_daemon.rs`, `crates/cli-sub-agent/src/session_cmds_tests.rs`, `crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs`
+- **Regression tests**: `cargo test -p cli-sub-agent handle_session_wait_retires_active_session_after_dead_failure_completion_packet`
+
+### #747
+- **Root cause**: dead-session reconciliation discarded the fact that a session branch could already be ahead of origin, so Layer 0 had no durable hint that partial progress still needed publishing.
+- **Fix**: reconciliation now writes `output/unpushed_commits.json` for ahead branches, and `session wait` emits a `CSA:NEXT_STEP` directive using that recovery command.
+- **Files touched**: `crates/cli-sub-agent/src/session_cmds_reconcile.rs`, `crates/cli-sub-agent/src/session_cmds_daemon.rs`, `crates/cli-sub-agent/src/session_cmds_tests.rs`, `crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs`, `crates/cli-sub-agent/src/session_cmds_tests_tail_recovery.rs`
+- **Regression tests**: `cargo test -p cli-sub-agent ensure_terminal_result_for_dead_active_session_writes_unpushed_commit_sidecar`; `cargo test -p cli-sub-agent synthesized_wait_next_step_returns_directive_for_unpushed_commit_recovery`
+
+### #782
+- **Root cause**: executor-mode commit workflows did not fully short-circuit the publish transaction, so internal sessions could still reach `git push` paths that depend on outer-layer review state.
+- **Fix**: the commit workflow now gates both publish-variable bridging and the auto-PR transaction on executor-mode env detection, with docs and a shell regression test kept in sync.
+- **Files touched**: `patterns/commit/PATTERN.md`, `patterns/commit/skills/commit/SKILL.md`, `patterns/commit/workflow.toml`, `crates/cli-sub-agent/src/plan_cmd_tests_commit.rs`, `Cargo.toml`, `Cargo.lock`, `weave.lock`, `output/summary.md`
+- **Regression tests**: `cargo test -p cli-sub-agent commit_workflow_auto_pr_step_exits_before_push_in_executor_mode`
+
+## Blockers encountered
+- Repository pre-commit auto-stages tracked Rust files after `cargo fmt`, so issue-scoped commits required temporarily stashing unrelated tracked `.rs` changes before each commit.
+- Workspace version bump files (`Cargo.toml`, `Cargo.lock`, `weave.lock`) were required by the repository gate `just check-version-bumped`; they were included with `#782` so the branch stays gate-clean.

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -33,7 +33,23 @@ Initialize and declare workflow variables.
 
 ```bash
 # Force weave to pick up these variables
-: "${FILES}" "${SCOPE}" "${BRANCH}" "${COMMIT_SUBJECT}" "${COMMIT_BODY}" "${COMMIT_MESSAGE_FILE}" "${IS_MILESTONE}" "${ENABLE_REVIEW_LOOP}" "${AUDIT_FAIL}" "${AUDIT_PASS_DEFERRED}" "${REVIEW_HAS_ISSUES}" "${PR_BODY}"
+: "${FILES}" "${SCOPE}" "${BRANCH}" "${COMMIT_SUBJECT}" "${COMMIT_BODY}" "${COMMIT_MESSAGE_FILE}" "${IS_MILESTONE}" "${ENABLE_REVIEW_LOOP}" "${AUDIT_FAIL}" "${AUDIT_PASS_DEFERRED}" "${REVIEW_HAS_ISSUES}" "${PR_BODY}" "${SKIP_PUBLISH}"
+
+# Bridge CSA_SKIP_PUBLISH env var to workflow variable.
+# When parent workflow (mktsk/dev2merge) sets CSA_SKIP_PUBLISH=true, auto-PR is skipped.
+# When standalone, CSA_SKIP_PUBLISH is unset → auto-PR runs after commit.
+# Also auto-skip in executor mode (`CSA_DEPTH>0` + `CSA_INTERNAL_INVOCATION=1`) —
+# the Layer 0 orchestrator owns publish/pr-bot. Letting an employee session
+# invoke /pr-bot nests another `csa plan run` and can trip the recursion-ceiling
+# guard or leak grandchild processes if the chain fails mid-flight (see #752 Bug 4).
+if [ "${CSA_SKIP_PUBLISH:-}" = "true" ]; then
+  SKIP_PUBLISH=true
+elif [ "${CSA_DEPTH:-0}" != "0" ] && [ -n "${CSA_DEPTH:-}" ] && \
+     { [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ] || [ "${CSA_INTERNAL_INVOCATION:-}" = "true" ]; }; then
+  SKIP_PUBLISH=true
+else
+  : "${SKIP_PUBLISH:=false}"
+fi
 echo "Variables initialized."
 ```
 

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -24,7 +24,7 @@ Initialize and declare workflow variables.
 - `${COMMIT_SUBJECT}`: Generated or provided commit subject
 - `${COMMIT_BODY}`: Generated or provided commit body
 - `${COMMIT_MESSAGE_FILE}`: Path to temporary commit message file
-- `${SKIP_PUBLISH}`: Set to `"true"` to skip auto-PR (parent workflow handles publish). Workflow auto-activates this when `CSA_SKIP_PUBLISH=true` or when running inside a CSA session (`CSA_DEPTH` set and non-zero) to keep employee sessions orchestration-pure — the Layer 0 orchestrator owns publish/pr-bot (#752 Bug 4).
+- `${SKIP_PUBLISH}`: Set to `"true"` to skip auto-PR (parent workflow handles publish). Workflow auto-activates this when `CSA_SKIP_PUBLISH=true` or in executor mode (`CSA_DEPTH` set and non-zero plus `CSA_INTERNAL_INVOCATION=1`) to keep employee sessions orchestration-pure — the Layer 0 orchestrator owns publish/pr-bot (#752 Bug 4, #782).
 - `${ENABLE_REVIEW_LOOP}`: Set to `"true"` to run iterative review loop
 - `${AUDIT_FAIL}`: Set by `security-audit` if blocking issues found
 - `${AUDIT_PASS_DEFERRED}`: Set by `security-audit` if non-blocking issues found
@@ -432,12 +432,18 @@ OnFail: abort
 Push, create or reuse the PR, then synchronously run the post-create helper.
 This makes PR creation + pr-bot a single shell-enforced transaction.
 Runs by default when standalone. Skipped when parent workflow sets
-`CSA_SKIP_PUBLISH=true`, or automatically when invoked from inside a CSA
-session (`CSA_DEPTH` set and non-zero) — the Layer 0 orchestrator owns the
-publish/pr-bot transaction in that case.
+`CSA_SKIP_PUBLISH=true`, or automatically in executor mode
+(`CSA_DEPTH` set and non-zero plus `CSA_INTERNAL_INVOCATION=1`) — the Layer 0
+orchestrator owns the publish/pr-bot transaction in that case.
 
 ```bash
 set -euo pipefail
+if [ "${CSA_DEPTH:-0}" != "0" ] && [ -n "${CSA_DEPTH:-}" ] && \
+   { [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ] || [ "${CSA_INTERNAL_INVOCATION:-}" = "true" ]; }; then
+  echo "INFO: Executor mode detected; skipping push/PR transaction."
+  exit 0
+fi
+
 if [ -z "${COMMIT_SUBJECT:-}" ]; then
   echo "ERROR: PR title is empty." >&2
   exit 1

--- a/patterns/commit/skills/commit/SKILL.md
+++ b/patterns/commit/skills/commit/SKILL.md
@@ -78,10 +78,10 @@ breaks prompt-guard propagation.
 8. **Commit**: `git commit -m "${COMMIT_MSG}"`.
 9. **Auto PR** (standalone by default): Push branch, create PR targeting main, invoke `/pr-bot`.
    Runs automatically when commit is standalone. Skipped when parent workflow
-   (mktsk/dev2merge) sets `CSA_SKIP_PUBLISH=true`, or automatically when
-   invoked from inside a CSA session (`CSA_DEPTH` set and non-zero) so that
-   employee sessions stay orchestration-pure and only the Layer 0 orchestrator
-   runs the PR + pr-bot transaction (#752 Bug 4).
+   (mktsk/dev2merge) sets `CSA_SKIP_PUBLISH=true`, or automatically in
+   executor mode (`CSA_DEPTH` set and non-zero plus `CSA_INTERNAL_INVOCATION=1`)
+   so that employee sessions stay orchestration-pure and only the Layer 0
+   orchestrator runs the push + PR + pr-bot transaction (#752 Bug 4, #782).
    - **NOTE**: `/pr-bot` internally runs a **separate cumulative review** (`csa review --range main...HEAD`) covering ALL commits on the branch before push. This is distinct from Step 6's per-commit review (`csa review --diff`). Do NOT skip pr-bot's internal review even if Step 6 passed.
 
 ## Two-Layer Review Architecture

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -110,15 +110,16 @@ Initialize and declare workflow variables.
 # Bridge CSA_SKIP_PUBLISH env var to workflow variable.
 # When parent workflow (mktsk/dev2merge) sets CSA_SKIP_PUBLISH=true, auto-PR is skipped.
 # When standalone, CSA_SKIP_PUBLISH is unset → auto-PR runs after commit.
-# Also auto-skip when running inside a CSA session (CSA_DEPTH>0) — the Layer 0
-# orchestrator owns publish/pr-bot. Letting an employee session invoke /pr-bot
-# nests another `csa plan run` and can trip the recursion-ceiling guard or leak
-# grandchild processes if the chain fails mid-flight (see #752 Bug 4).
+# Also auto-skip in executor mode (`CSA_DEPTH>0` + `CSA_INTERNAL_INVOCATION=1`) —
+# the Layer 0 orchestrator owns publish/pr-bot. Letting an employee session
+# invoke /pr-bot nests another `csa plan run` and can trip the recursion-ceiling
+# guard or leak grandchild processes if the chain fails mid-flight (see #752 Bug 4).
 if [ "${CSA_SKIP_PUBLISH:-}" = "true" ]; then
   echo "CSA_VAR:SKIP_PUBLISH=true"
-elif [ "${CSA_DEPTH:-0}" != "0" ] && [ -n "${CSA_DEPTH:-}" ]; then
+elif [ "${CSA_DEPTH:-0}" != "0" ] && [ -n "${CSA_DEPTH:-}" ] && \
+     { [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ] || [ "${CSA_INTERNAL_INVOCATION:-}" = "true" ]; }; then
   echo "CSA_VAR:SKIP_PUBLISH=true"
-  echo "INFO: Detected CSA_DEPTH=${CSA_DEPTH}; auto-skipping pr-bot to keep employee sessions orchestration-pure."
+  echo "INFO: Detected executor mode (CSA_DEPTH=${CSA_DEPTH}, CSA_INTERNAL_INVOCATION=${CSA_INTERNAL_INVOCATION:-0}); auto-skipping push/PR to keep employee sessions orchestration-pure."
 else
   echo "CSA_VAR:SKIP_PUBLISH=${SKIP_PUBLISH:-false}"
 fi
@@ -519,6 +520,12 @@ Runs by default when commit is standalone. Skipped when parent workflow
 
 ```bash
 set -euo pipefail
+if [ "${CSA_DEPTH:-0}" != "0" ] && [ -n "${CSA_DEPTH:-}" ] && \
+   { [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ] || [ "${CSA_INTERNAL_INVOCATION:-}" = "true" ]; }; then
+  echo "INFO: Executor mode detected; skipping push/PR transaction."
+  exit 0
+fi
+
 if [ -z "${COMMIT_SUBJECT:-}" ]; then
   echo "ERROR: PR title is empty." >&2
   exit 1

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.299"
-weave = "0.1.299"
+csa = "0.1.300"
+weave = "0.1.300"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.286"
-weave = "0.1.286"
+csa = "0.1.299"
+weave = "0.1.299"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Batch 1 of Q1 review-pattern-quality follow-up sprint. Addresses three commit/session lifecycle bugs in one PR (Quality-tier priority per autonomous burn-down plan).

- **#738** Retire dead active wait sessions — `csa session wait` now reconciles stale `Active` phase when the daemon is dead + has written a completion packet, so wait no longer hangs forever.
- **#747** Surface unpushed session recovery steps — synthetic failure reconciliation writes `output/unpushed_commits.json` and emits a `CSA:NEXT_STEP` directive so Layer 0 can safely resume a crashed session's unpublished commits.
- **#782** Executor-mode short-circuit — commit auto-publish now skips push/PR when `CSA_DEPTH > 0` + `CSA_INTERNAL_INVOCATION = 1`, keeping the pre-push review-check bootstrap deadlock from triggering.

## Closes

- Closes #738
- Closes #747
- Closes #782

## Test plan

- [x] `cargo test -p cli-sub-agent handle_session_wait_retires_active_session_after_dead_failure_completion_packet`
- [x] `cargo test -p cli-sub-agent ensure_terminal_result_for_dead_active_session_writes_unpushed_commit_sidecar`
- [x] `cargo test -p cli-sub-agent synthesized_wait_next_step_returns_directive_for_unpushed_commit_recovery`
- [x] `cargo test -p cli-sub-agent commit_workflow_auto_pr_step_exits_before_push_in_executor_mode`
- [x] `just pre-commit` passes
- [x] Local cumulative review session `01KP6R909W02Y1J0Q993Y8MEM4` (gemini-cli xhigh) — decision=pass, severity counts all zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)