### PR TITLE
fix(csa-policy): scope hook-bypass detector to command-prefix position (#799)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.301"
+version = "0.1.302"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.301"
+version = "0.1.302"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_shell.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell.rs
@@ -694,44 +694,50 @@ fn shell_script_contains_forbidden_lefthook_bypass(tokens: &[String]) -> bool {
 ///   - `export LEFTHOOK=0`
 ///   - `env LEFTHOOK=0 git ...`
 fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
-    let idx = skip_command_wrapper_tokens(tokens, 0);
-    let Some(first_token) = tokens.get(idx) else {
-        return false;
-    };
-    let token = first_token.as_str();
+    let mut idx = skip_command_wrapper_tokens(tokens, 0);
 
-    if is_env_assignment(token) {
-        return is_lefthook_env_assignment(token);
-    }
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
 
-    if token.eq_ignore_ascii_case("env") || token.ends_with("/env") {
-        let mut env_idx = idx + 1;
-        env_idx = skip_prefixed_command_options(tokens, env_idx, env_option_consumes_value);
-        while env_idx < tokens.len() {
-            let next = tokens[env_idx].as_str();
-            if !is_env_assignment(next) {
-                return false;
+        if token.eq_ignore_ascii_case("env") || token.ends_with("/env") {
+            idx += 1;
+            idx = skip_prefixed_command_options(tokens, idx, env_option_consumes_value);
+            while idx < tokens.len() {
+                let next = tokens[idx].as_str();
+                if !is_env_assignment(next) {
+                    return false;
+                }
+                if is_lefthook_env_assignment(next) {
+                    return true;
+                }
+                idx += 1;
             }
-            if is_lefthook_env_assignment(next) {
+            return false;
+        }
+
+        if token.eq_ignore_ascii_case("export") {
+            idx += 1;
+            while idx < tokens.len() {
+                let next = tokens[idx].as_str();
+                if !is_env_assignment(next) {
+                    return false;
+                }
+                if is_lefthook_env_assignment(next) {
+                    return true;
+                }
+                idx += 1;
+            }
+            return false;
+        }
+
+        if is_env_assignment(token) {
+            if is_lefthook_env_assignment(token) {
                 return true;
             }
-            env_idx += 1;
+            idx += 1;
+            continue;
         }
-        return false;
-    }
 
-    if token.eq_ignore_ascii_case("export") {
-        let mut export_idx = idx + 1;
-        while export_idx < tokens.len() {
-            let next = tokens[export_idx].as_str();
-            if !is_env_assignment(next) {
-                return false;
-            }
-            if is_lefthook_env_assignment(next) {
-                return true;
-            }
-            export_idx += 1;
-        }
         return false;
     }
 

--- a/crates/cli-sub-agent/src/run_cmd_shell.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell.rs
@@ -715,13 +715,11 @@ fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
         if token.eq_ignore_ascii_case("env") || token.ends_with("/env") {
             idx += 1;
             idx = skip_prefixed_command_options(tokens, idx, env_option_consumes_value);
-            let mut saw_separator = false;
             while idx < tokens.len() {
                 let next = tokens[idx].as_str();
                 if is_command_separator_token(next) {
                     idx += 1;
                     idx = skip_command_wrapper_tokens(tokens, idx);
-                    saw_separator = true;
                     break;
                 }
                 if !is_env_assignment(next) {
@@ -733,21 +731,16 @@ fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
                 }
                 idx += 1;
             }
-            if saw_separator {
-                continue;
-            }
-            return false;
+            continue;
         }
 
         if token.eq_ignore_ascii_case("export") {
             idx += 1;
-            let mut saw_separator = false;
             while idx < tokens.len() {
                 let next = tokens[idx].as_str();
                 if is_command_separator_token(next) {
                     idx += 1;
                     idx = skip_command_wrapper_tokens(tokens, idx);
-                    saw_separator = true;
                     break;
                 }
                 if !is_env_assignment(next) {
@@ -759,10 +752,7 @@ fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
                 }
                 idx += 1;
             }
-            if saw_separator {
-                continue;
-            }
-            return false;
+            continue;
         }
 
         if is_env_assignment(token) {

--- a/crates/cli-sub-agent/src/run_cmd_shell.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell.rs
@@ -401,10 +401,28 @@ fn is_command_separator_token(token: &str) -> bool {
         || token.ends_with('&')
 }
 
-fn skip_command_prefix_tokens(tokens: &[String], mut idx: usize) -> usize {
+fn skip_command_prefix_tokens(tokens: &[String], idx: usize) -> usize {
+    skip_command_prefix_tokens_with_mode(tokens, idx, PrefixSkipMode::FullCommandPrefix)
+}
+
+fn skip_command_wrapper_tokens(tokens: &[String], idx: usize) -> usize {
+    skip_command_prefix_tokens_with_mode(tokens, idx, PrefixSkipMode::WrapperOnly)
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum PrefixSkipMode {
+    FullCommandPrefix,
+    WrapperOnly,
+}
+
+fn skip_command_prefix_tokens_with_mode(
+    tokens: &[String],
+    mut idx: usize,
+    mode: PrefixSkipMode,
+) -> usize {
     while idx < tokens.len() {
         let token = tokens[idx].as_str();
-        if is_env_assignment(token) {
+        if mode == PrefixSkipMode::FullCommandPrefix && is_env_assignment(token) {
             idx += 1;
             continue;
         }
@@ -413,7 +431,9 @@ fn skip_command_prefix_tokens(tokens: &[String], mut idx: usize) -> usize {
             idx = skip_prefixed_command_options(tokens, idx, sudo_option_consumes_value);
             continue;
         }
-        if token.eq_ignore_ascii_case("env") || token.ends_with("/env") {
+        if mode == PrefixSkipMode::FullCommandPrefix
+            && (token.eq_ignore_ascii_case("env") || token.ends_with("/env"))
+        {
             idx += 1;
             idx = skip_prefixed_command_options(tokens, idx, env_option_consumes_value);
             while idx < tokens.len() && is_env_assignment(tokens[idx].as_str()) {
@@ -674,10 +694,10 @@ fn shell_script_contains_forbidden_lefthook_bypass(tokens: &[String]) -> bool {
 ///   - `export LEFTHOOK=0`
 ///   - `env LEFTHOOK=0 git ...`
 fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
-    let Some(first_token) = tokens.first() else {
+    let idx = skip_command_wrapper_tokens(tokens, 0);
+    let Some(first_token) = tokens.get(idx) else {
         return false;
     };
-    let mut idx = 0usize;
     let token = first_token.as_str();
 
     if is_env_assignment(token) {
@@ -685,31 +705,32 @@ fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
     }
 
     if token.eq_ignore_ascii_case("env") || token.ends_with("/env") {
-        idx += 1;
-        while idx < tokens.len() {
-            let next = tokens[idx].as_str();
+        let mut env_idx = idx + 1;
+        env_idx = skip_prefixed_command_options(tokens, env_idx, env_option_consumes_value);
+        while env_idx < tokens.len() {
+            let next = tokens[env_idx].as_str();
             if !is_env_assignment(next) {
                 return false;
             }
             if is_lefthook_env_assignment(next) {
                 return true;
             }
-            idx += 1;
+            env_idx += 1;
         }
         return false;
     }
 
     if token.eq_ignore_ascii_case("export") {
-        idx += 1;
-        while idx < tokens.len() {
-            let next = tokens[idx].as_str();
+        let mut export_idx = idx + 1;
+        while export_idx < tokens.len() {
+            let next = tokens[export_idx].as_str();
             if !is_env_assignment(next) {
                 return false;
             }
             if is_lefthook_env_assignment(next) {
                 return true;
             }
-            idx += 1;
+            export_idx += 1;
         }
         return false;
     }

--- a/crates/cli-sub-agent/src/run_cmd_shell.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell.rs
@@ -687,6 +687,13 @@ fn shell_script_contains_forbidden_lefthook_bypass(tokens: &[String]) -> bool {
     tokens_contain_lefthook_bypass(&script_tokens)
 }
 
+fn skip_to_next_command_boundary(tokens: &[String], mut idx: usize) -> usize {
+    while idx < tokens.len() && !is_command_separator_token(tokens[idx].as_str()) {
+        idx += 1;
+    }
+    idx
+}
+
 /// Scan a flat token list for any LEFTHOOK bypass env assignment.
 ///
 /// Handles:
@@ -699,33 +706,61 @@ fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
     while idx < tokens.len() {
         let token = tokens[idx].as_str();
 
+        if is_command_separator_token(token) {
+            idx += 1;
+            idx = skip_command_wrapper_tokens(tokens, idx);
+            continue;
+        }
+
         if token.eq_ignore_ascii_case("env") || token.ends_with("/env") {
             idx += 1;
             idx = skip_prefixed_command_options(tokens, idx, env_option_consumes_value);
+            let mut saw_separator = false;
             while idx < tokens.len() {
                 let next = tokens[idx].as_str();
+                if is_command_separator_token(next) {
+                    idx += 1;
+                    idx = skip_command_wrapper_tokens(tokens, idx);
+                    saw_separator = true;
+                    break;
+                }
                 if !is_env_assignment(next) {
-                    return false;
+                    idx = skip_to_next_command_boundary(tokens, idx + 1);
+                    break;
                 }
                 if is_lefthook_env_assignment(next) {
                     return true;
                 }
                 idx += 1;
             }
+            if saw_separator {
+                continue;
+            }
             return false;
         }
 
         if token.eq_ignore_ascii_case("export") {
             idx += 1;
+            let mut saw_separator = false;
             while idx < tokens.len() {
                 let next = tokens[idx].as_str();
+                if is_command_separator_token(next) {
+                    idx += 1;
+                    idx = skip_command_wrapper_tokens(tokens, idx);
+                    saw_separator = true;
+                    break;
+                }
                 if !is_env_assignment(next) {
-                    return false;
+                    idx = skip_to_next_command_boundary(tokens, idx + 1);
+                    break;
                 }
                 if is_lefthook_env_assignment(next) {
                     return true;
                 }
                 idx += 1;
+            }
+            if saw_separator {
+                continue;
             }
             return false;
         }
@@ -738,7 +773,7 @@ fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
             continue;
         }
 
-        return false;
+        idx = skip_to_next_command_boundary(tokens, idx + 1);
     }
 
     false

--- a/crates/cli-sub-agent/src/run_cmd_shell.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell.rs
@@ -633,7 +633,7 @@ fn long_option_is_message_like(token: &str) -> bool {
 /// Forbidden LEFTHOOK env var names that disable pre-commit hooks.
 const FORBIDDEN_LEFTHOOK_ENV_VARS: &[&str] = &["LEFTHOOK", "LEFTHOOK_SKIP"];
 
-fn command_contains_forbidden_lefthook_bypass(command: &str) -> bool {
+pub(crate) fn command_contains_forbidden_lefthook_bypass(command: &str) -> bool {
     split_shell_segments_preserving_quotes(command)
         .into_iter()
         .any(|segment| segment_contains_forbidden_lefthook_bypass(&segment))
@@ -646,7 +646,7 @@ fn command_contains_forbidden_lefthook_bypass(command: &str) -> bool {
 /// - `export LEFTHOOK=0`
 /// - `env LEFTHOOK=0 git commit ...`
 /// - `LEFTHOOK_SKIP=... git push ...`
-fn segment_contains_forbidden_lefthook_bypass(segment: &str) -> bool {
+pub(crate) fn segment_contains_forbidden_lefthook_bypass(segment: &str) -> bool {
     let tokens = tokenize_shell_tokens(segment);
     if tokens.is_empty() {
         return false;
@@ -674,28 +674,46 @@ fn shell_script_contains_forbidden_lefthook_bypass(tokens: &[String]) -> bool {
 ///   - `export LEFTHOOK=0`
 ///   - `env LEFTHOOK=0 git ...`
 fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
-    for (idx, token) in tokens.iter().enumerate() {
-        let t = token.as_str();
+    let Some(first_token) = tokens.first() else {
+        return false;
+    };
+    let mut idx = 0usize;
+    let token = first_token.as_str();
 
-        // Inline env assignment: `LEFTHOOK=0 cmd`, `LEFTHOOK_SKIP=... cmd`
-        if is_lefthook_env_assignment(t) {
-            return true;
-        }
-
-        // `export LEFTHOOK=0` / `export LEFTHOOK_SKIP=...`
-        if t.eq_ignore_ascii_case("export") {
-            for next in &tokens[idx + 1..] {
-                let n = next.as_str();
-                if is_lefthook_env_assignment(n) {
-                    return true;
-                }
-                // export can chain multiple assignments; stop at non-assignment
-                if !is_env_assignment(n) {
-                    break;
-                }
-            }
-        }
+    if is_env_assignment(token) {
+        return is_lefthook_env_assignment(token);
     }
+
+    if token.eq_ignore_ascii_case("env") || token.ends_with("/env") {
+        idx += 1;
+        while idx < tokens.len() {
+            let next = tokens[idx].as_str();
+            if !is_env_assignment(next) {
+                return false;
+            }
+            if is_lefthook_env_assignment(next) {
+                return true;
+            }
+            idx += 1;
+        }
+        return false;
+    }
+
+    if token.eq_ignore_ascii_case("export") {
+        idx += 1;
+        while idx < tokens.len() {
+            let next = tokens[idx].as_str();
+            if !is_env_assignment(next) {
+                return false;
+            }
+            if is_lefthook_env_assignment(next) {
+                return true;
+            }
+            idx += 1;
+        }
+        return false;
+    }
+
     false
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
@@ -222,6 +222,23 @@ fn command_contains_forbidden_lefthook_bypass_blocks_shell_wrapped_separator_res
 }
 
 #[test]
+fn command_contains_forbidden_lefthook_bypass_blocks_separator_resets_after_env_and_export_clauses()
+{
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "env FOO=1 cmd ; LEFTHOOK=0 other_cmd"
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "export FOO=1 BAR ; LEFTHOOK=0 other_cmd"
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "sh -c \"env FOO=1 cmd ; LEFTHOOK=0 other_cmd\""
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "sh -c \"export FOO=1 BAR ; LEFTHOOK=0 other_cmd\""
+    ));
+}
+
+#[test]
 fn command_contains_forbidden_lefthook_bypass_blocks_wrapper_prefixed_env_forms() {
     assert!(command_contains_forbidden_lefthook_bypass(
         "command env LEFTHOOK=0 git commit"
@@ -317,6 +334,23 @@ fn segment_contains_forbidden_lefthook_bypass_blocks_shell_wrapped_separator_res
     ));
     assert!(!segment_contains_forbidden_lefthook_bypass(
         "sh -c \"echo 'LEFTHOOK=0'; git commit\""
+    ));
+}
+
+#[test]
+fn segment_contains_forbidden_lefthook_bypass_blocks_separator_resets_after_env_and_export_clauses()
+{
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "env FOO=1 cmd ; LEFTHOOK=0 other_cmd"
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "export FOO=1 BAR ; LEFTHOOK=0 other_cmd"
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "sh -c \"env FOO=1 cmd ; LEFTHOOK=0 other_cmd\""
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "sh -c \"export FOO=1 BAR ; LEFTHOOK=0 other_cmd\""
     ));
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
@@ -194,6 +194,19 @@ fn command_contains_forbidden_lefthook_bypass_still_blocks_real_prefix_assignmen
 }
 
 #[test]
+fn command_contains_forbidden_lefthook_bypass_blocks_wrapper_prefixed_env_forms() {
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "command env LEFTHOOK=0 git commit"
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "time env LEFTHOOK=0 git commit"
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "sudo env LEFTHOOK=0 git commit"
+    ));
+}
+
+#[test]
 fn segment_contains_forbidden_lefthook_bypass_ignores_argument_mentions() {
     assert!(!segment_contains_forbidden_lefthook_bypass(
         "echo \"do not set LEFTHOOK=0\""
@@ -225,6 +238,19 @@ fn segment_contains_forbidden_lefthook_bypass_still_blocks_real_prefix_assignmen
     ));
     assert!(segment_contains_forbidden_lefthook_bypass(
         "sh -c \"export LEFTHOOK=0; git commit\""
+    ));
+}
+
+#[test]
+fn segment_contains_forbidden_lefthook_bypass_blocks_wrapper_prefixed_env_forms() {
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "command env LEFTHOOK=0 git commit"
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "time env LEFTHOOK=0 git commit"
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "sudo env LEFTHOOK=0 git commit"
     ));
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
@@ -203,6 +203,25 @@ fn command_contains_forbidden_lefthook_bypass_still_blocks_real_prefix_assignmen
 }
 
 #[test]
+fn command_contains_forbidden_lefthook_bypass_blocks_shell_wrapped_separator_resets() {
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "sh -c \"git status; LEFTHOOK=0 git commit\""
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "sh -c \"git rev-parse HEAD && LEFTHOOK=0 git commit\""
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "sh -c \"git commit && export LEFTHOOK=0\""
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "sh -c \"echo hello | LEFTHOOK=0 git commit\""
+    ));
+    assert!(!command_contains_forbidden_lefthook_bypass(
+        "sh -c \"echo 'LEFTHOOK=0'; git commit\""
+    ));
+}
+
+#[test]
 fn command_contains_forbidden_lefthook_bypass_blocks_wrapper_prefixed_env_forms() {
     assert!(command_contains_forbidden_lefthook_bypass(
         "command env LEFTHOOK=0 git commit"
@@ -279,6 +298,25 @@ fn segment_contains_forbidden_lefthook_bypass_blocks_wrapper_prefixed_env_forms(
 fn segment_contains_forbidden_lefthook_bypass_blocks_shell_wrapped_multi_assignment_prefixes() {
     assert!(segment_contains_forbidden_lefthook_bypass(
         "sh -c \"FOO=1 LEFTHOOK=0 git commit\""
+    ));
+}
+
+#[test]
+fn segment_contains_forbidden_lefthook_bypass_blocks_shell_wrapped_separator_resets() {
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "sh -c \"git status; LEFTHOOK=0 git commit\""
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "sh -c \"git rev-parse HEAD && LEFTHOOK=0 git commit\""
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "sh -c \"git commit && export LEFTHOOK=0\""
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "sh -c \"echo hello | LEFTHOOK=0 git commit\""
+    ));
+    assert!(!segment_contains_forbidden_lefthook_bypass(
+        "sh -c \"echo 'LEFTHOOK=0'; git commit\""
     ));
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
@@ -183,6 +183,12 @@ fn command_contains_forbidden_lefthook_bypass_still_blocks_real_prefix_assignmen
         "LEFTHOOK=0 git commit -m \"msg\""
     ));
     assert!(command_contains_forbidden_lefthook_bypass(
+        "FOO=1 LEFTHOOK=0 git commit -m \"msg\""
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "A=1 B=2 LEFTHOOK_SKIP=pre-commit git push"
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
         "env LEFTHOOK=0 git commit"
     ));
     assert!(command_contains_forbidden_lefthook_bypass(
@@ -191,12 +197,18 @@ fn command_contains_forbidden_lefthook_bypass_still_blocks_real_prefix_assignmen
     assert!(command_contains_forbidden_lefthook_bypass(
         "sh -c \"export LEFTHOOK=0; git commit\""
     ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "sh -c \"FOO=1 LEFTHOOK=0 git commit\""
+    ));
 }
 
 #[test]
 fn command_contains_forbidden_lefthook_bypass_blocks_wrapper_prefixed_env_forms() {
     assert!(command_contains_forbidden_lefthook_bypass(
         "command env LEFTHOOK=0 git commit"
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "command env A=1 LEFTHOOK=0 git commit"
     ));
     assert!(command_contains_forbidden_lefthook_bypass(
         "time env LEFTHOOK=0 git commit"
@@ -231,6 +243,12 @@ fn segment_contains_forbidden_lefthook_bypass_still_blocks_real_prefix_assignmen
         "LEFTHOOK=0 git commit -m \"msg\""
     ));
     assert!(segment_contains_forbidden_lefthook_bypass(
+        "FOO=1 LEFTHOOK=0 git commit -m \"msg\""
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "A=1 B=2 LEFTHOOK_SKIP=pre-commit git push"
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
         "env LEFTHOOK=0 git commit"
     ));
     assert!(segment_contains_forbidden_lefthook_bypass(
@@ -247,10 +265,20 @@ fn segment_contains_forbidden_lefthook_bypass_blocks_wrapper_prefixed_env_forms(
         "command env LEFTHOOK=0 git commit"
     ));
     assert!(segment_contains_forbidden_lefthook_bypass(
+        "command env A=1 LEFTHOOK=0 git commit"
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
         "time env LEFTHOOK=0 git commit"
     ));
     assert!(segment_contains_forbidden_lefthook_bypass(
         "sudo env LEFTHOOK=0 git commit"
+    ));
+}
+
+#[test]
+fn segment_contains_forbidden_lefthook_bypass_blocks_shell_wrapped_multi_assignment_prefixes() {
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "sh -c \"FOO=1 LEFTHOOK=0 git commit\""
     ));
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::run_cmd::shell::{
+    command_contains_forbidden_lefthook_bypass, segment_contains_forbidden_lefthook_bypass,
+};
 use csa_core::types::OutputFormat;
 
 #[test]
@@ -153,6 +156,76 @@ fn apply_lefthook_bypass_policy_blocks_export_in_shell_wrapper() {
         result.summary,
         "post-run policy blocked: forbidden LEFTHOOK=0/LEFTHOOK_SKIP bypass detected"
     );
+}
+
+#[test]
+fn command_contains_forbidden_lefthook_bypass_ignores_quoted_argument_mentions() {
+    assert!(!command_contains_forbidden_lefthook_bypass(
+        "echo \"do not set LEFTHOOK=0\""
+    ));
+    assert!(!command_contains_forbidden_lefthook_bypass(
+        "grep -r \"LEFTHOOK=0\" ."
+    ));
+    assert!(!command_contains_forbidden_lefthook_bypass(
+        "echo \"LEFTHOOK_SKIP is forbidden\""
+    ));
+    assert!(!command_contains_forbidden_lefthook_bypass(
+        "sed -i 's/LEFTHOOK=0//' file"
+    ));
+    assert!(!command_contains_forbidden_lefthook_bypass(
+        "echo 'cat <<EOF\nLEFTHOOK=0\nEOF'"
+    ));
+}
+
+#[test]
+fn command_contains_forbidden_lefthook_bypass_still_blocks_real_prefix_assignments() {
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "LEFTHOOK=0 git commit -m \"msg\""
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "env LEFTHOOK=0 git commit"
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "export LEFTHOOK=0"
+    ));
+    assert!(command_contains_forbidden_lefthook_bypass(
+        "sh -c \"export LEFTHOOK=0; git commit\""
+    ));
+}
+
+#[test]
+fn segment_contains_forbidden_lefthook_bypass_ignores_argument_mentions() {
+    assert!(!segment_contains_forbidden_lefthook_bypass(
+        "echo \"do not set LEFTHOOK=0\""
+    ));
+    assert!(!segment_contains_forbidden_lefthook_bypass(
+        "grep -r \"LEFTHOOK=0\" ."
+    ));
+    assert!(!segment_contains_forbidden_lefthook_bypass(
+        "echo \"LEFTHOOK_SKIP is forbidden\""
+    ));
+    assert!(!segment_contains_forbidden_lefthook_bypass(
+        "sed -i 's/LEFTHOOK=0//' file"
+    ));
+    assert!(!segment_contains_forbidden_lefthook_bypass(
+        "echo 'cat <<EOF\nLEFTHOOK=0\nEOF'"
+    ));
+}
+
+#[test]
+fn segment_contains_forbidden_lefthook_bypass_still_blocks_real_prefix_assignments() {
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "LEFTHOOK=0 git commit -m \"msg\""
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "env LEFTHOOK=0 git commit"
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "export LEFTHOOK=0"
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "sh -c \"export LEFTHOOK=0; git commit\""
+    ));
 }
 
 #[test]

--- a/output/fix-799-round4-summary.md
+++ b/output/fix-799-round4-summary.md
@@ -1,0 +1,28 @@
+<!-- CSA:SECTION:summary -->
+Round-4 HIGH fix implemented locally on top of `d1bda9df`.
+The bypass scanner now resets after shell separator tokens inside `sh -c` payloads, so later statements are scanned in command-prefix position again.
+Regression tests were added for `;`, `&&`, `|`, and post-command `export` forms, while preserving earlier false-positive guards.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+Scope:
+- `crates/cli-sub-agent/src/run_cmd_shell.rs`
+- `crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs`
+
+Implementation:
+- Kept the existing `Vec<String>` shell payload expansion shape.
+- Updated `tokens_contain_lefthook_bypass` so separator tokens restart prefix scanning instead of terminating the scan after the first command token.
+- Applied the same reset behavior while handling `env ...` and `export ...` prefix forms, so later statements in the same flattened payload are still checked.
+
+Regression coverage added:
+- `sh -c "git status; LEFTHOOK=0 git commit"` => blocked
+- `sh -c "git rev-parse HEAD && LEFTHOOK=0 git commit"` => blocked
+- `sh -c "git commit && export LEFTHOOK=0"` => blocked
+- `sh -c "echo hello | LEFTHOOK=0 git commit"` => blocked
+- `sh -c "echo 'LEFTHOOK=0'; git commit"` => allowed
+
+Pending at write time:
+- Focused `cargo test` runs
+- `just pre-commit`
+- commit + push
+<!-- CSA:SECTION:details:END -->


### PR DESCRIPTION
Closes #799.

## Summary

The CSA post-run hook-bypass detector was marking legitimate fix sessions as `Failed` whenever a transcript contained the literal substring of the guard env-var names (e.g. a prompt that warned "do NOT set these", or a grep over source files). The old scanner walked every token in every executed shell command and matched env-assignment syntax anywhere, so any quoted argument containing the substring tripped the guard.

This PR rewrites the scanner to respect shell grammar while preserving the guard's real purpose:

1. **Round 1** (19c085c2) — Treat env-assignment syntax as valid only at the command-prefix position. Args after the command name are no longer matched.
2. **Round 2** (8437674f) — Reuse `skip_command_prefix_tokens` (shared with the `--no-verify` scanner) so wrapper stacks like `command env`, `time env`, `sudo env` still trip.
3. **Round 3** (d1bda9df) — Walk ALL consecutive env assignments at the command-prefix position, not just the first (`FOO=1 LEFTHOOK=0 cmd`).
4. **Round 4** (1756b9e1) — Reset scanner on shell separators (`;`, `&&`, `||`, `|`, `&`) inside `sh -c` payloads so later statements are still scanned in command-prefix position.

## Test plan

- [x] Focused `cargo test -p cli-sub-agent apply_lefthook_bypass_policy` passes.
- [x] Focused `cargo test -p cli-sub-agent command_contains_forbidden_lefthook` passes.
- [x] Focused `cargo test -p cli-sub-agent segment_contains_forbidden_lefthook` passes.
- [x] Regression tests added for each round's edge case.
- [x] `just pre-commit` exits 0.
- [x] Cumulative `csa review --range main...HEAD` returned PASS (session `01KP7ECYVH8X2FCHTMR31BHB3W`).