### PR TITLE
fix(csa-session): flatten codex JSON transcripts before scanning CSA:SECTION markers (#776)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.302"
+version = "0.1.303"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.303"
+version = "0.1.304"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.303"
+version = "0.1.304"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.302"
+version = "0.1.303"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-session/src/output_parser/persist_streaming.rs
+++ b/crates/csa-session/src/output_parser/persist_streaming.rs
@@ -4,17 +4,18 @@
 //! multi-GB output files from long codex sessions.
 
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
+use tempfile::NamedTempFile;
 
 use crate::output_section::{OutputIndex, OutputSection};
 
 use super::{
     MARKER_END_SUFFIX, MARKER_PREFIX, MARKER_SUFFIX, Marker, deduplicate_file_paths,
-    estimate_tokens, id_to_title, persist_structured_output, sanitize_section_id,
+    estimate_tokens, id_to_title, sanitize_section_id,
 };
 
 /// Maximum number of sections to parse from a single output file.
@@ -48,12 +49,19 @@ pub fn persist_structured_output_from_file(
     session_dir: &Path,
     output_log_path: &Path,
 ) -> Result<OutputIndex> {
-    if let Some(flattened) = flatten_transcript_for_sections(output_log_path)? {
-        return persist_structured_output(session_dir, &flattened);
+    if let Some(flattened) = flatten_transcript_to_temp(session_dir, output_log_path)? {
+        return persist_structured_output_from_scan_path(session_dir, flattened.path());
     }
 
-    let file = fs::File::open(output_log_path)
-        .with_context(|| format!("Failed to open {}", output_log_path.display()))?;
+    persist_structured_output_from_scan_path(session_dir, output_log_path)
+}
+
+fn persist_structured_output_from_scan_path(
+    session_dir: &Path,
+    scan_path: &Path,
+) -> Result<OutputIndex> {
+    let file = fs::File::open(scan_path)
+        .with_context(|| format!("Failed to open {}", scan_path.display()))?;
     let reader = BufReader::new(file);
 
     // Pass 1: scan markers and count lines.
@@ -163,7 +171,7 @@ pub fn persist_structured_output_from_file(
     let output_dir = session_dir.join("output");
     fs::create_dir_all(&output_dir)?;
 
-    let file2 = fs::File::open(output_log_path)?;
+    let file2 = fs::File::open(scan_path)?;
     let reader2 = BufReader::new(file2);
 
     // Prepare writers for each section.
@@ -175,7 +183,7 @@ pub fn persist_structured_output_from_file(
             let path = output_dir.join(fp);
             let file = fs::File::create(&path)
                 .with_context(|| format!("Failed to create section file: {}", path.display()))?;
-            Some(std::io::BufWriter::new(file))
+            Some(BufWriter::new(file))
         } else {
             None
         };
@@ -195,7 +203,6 @@ pub fn persist_structured_output_from_file(
             }
             if line_num >= start && line_num <= end {
                 if let Some(ref mut writer) = section_writers[si] {
-                    use std::io::Write;
                     if line_num > start {
                         writeln!(writer)?;
                     }
@@ -208,7 +215,6 @@ pub fn persist_structured_output_from_file(
 
     // Flush all writers.
     for w in section_writers.iter_mut().flatten() {
-        use std::io::Write;
         w.flush()?;
     }
 
@@ -232,14 +238,19 @@ pub fn persist_structured_output_from_file(
     Ok(index)
 }
 
-fn flatten_transcript_for_sections(output_log_path: &Path) -> Result<Option<String>> {
+fn flatten_transcript_to_temp(
+    session_dir: &Path,
+    output_log_path: &Path,
+) -> Result<Option<NamedTempFile>> {
     let file = fs::File::open(output_log_path)
         .with_context(|| format!("Failed to open {}", output_log_path.display()))?;
     let reader = BufReader::new(file);
 
     let mut first_non_empty_line = None;
     let mut saw_json_line = false;
-    let mut flattened = String::new();
+    let mut flattened = NamedTempFile::new_in(session_dir)
+        .with_context(|| format!("Failed to create temp file in {}", session_dir.display()))?;
+    let mut wrote_text = false;
 
     for line_result in reader.lines() {
         let line = line_result
@@ -268,14 +279,19 @@ fn flatten_transcript_for_sections(output_log_path: &Path) -> Result<Option<Stri
             && item.item_type == "agent_message"
             && let Some(text) = item.text
         {
-            if !flattened.is_empty() {
-                flattened.push('\n');
+            if wrote_text {
+                writeln!(flattened)?;
             }
-            flattened.push_str(&text);
+            write!(flattened, "{text}")?;
+            wrote_text = true;
         }
     }
 
     if saw_json_line {
+        flattened
+            .as_file_mut()
+            .flush()
+            .context("Failed to flush flattened transcript temp file")?;
         Ok(Some(flattened))
     } else {
         Ok(None)
@@ -311,6 +327,26 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("output.log"), contents).unwrap();
         tmp
+    }
+
+    #[test]
+    fn flatten_transcript_to_temp_matches_round_1_flattened_text() {
+        let tmp = write_output_log(concat!(
+            r#"{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"line 1\nline 2"}}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"id":"item_2","type":"tool_result","text":"ignored"}}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"id":"item_3","type":"agent_message","text":"<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->"}}"#,
+        ));
+
+        let flattened =
+            flatten_transcript_to_temp(tmp.path(), &tmp.path().join("output.log")).unwrap();
+        let flattened = flattened.expect("json transcript should flatten");
+
+        assert_eq!(
+            fs::read_to_string(flattened.path()).unwrap(),
+            "line 1\nline 2\n<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->"
+        );
     }
 
     #[test]

--- a/crates/csa-session/src/output_parser/persist_streaming.rs
+++ b/crates/csa-session/src/output_parser/persist_streaming.rs
@@ -8,12 +8,13 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use serde::Deserialize;
 
 use crate::output_section::{OutputIndex, OutputSection};
 
 use super::{
     MARKER_END_SUFFIX, MARKER_PREFIX, MARKER_SUFFIX, Marker, deduplicate_file_paths,
-    estimate_tokens, id_to_title, sanitize_section_id,
+    estimate_tokens, id_to_title, persist_structured_output, sanitize_section_id,
 };
 
 /// Maximum number of sections to parse from a single output file.
@@ -21,6 +22,22 @@ use super::{
 /// Prevents file-descriptor exhaustion from malformed or adversarial output
 /// containing thousands of section markers.
 const MAX_SECTIONS: usize = 64;
+
+#[derive(Debug, Deserialize)]
+struct TranscriptEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    item: Option<TranscriptItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptItem {
+    #[serde(rename = "type")]
+    item_type: String,
+    #[serde(default)]
+    text: Option<String>,
+}
 
 /// Parse output.log from a file path using streaming reads.
 ///
@@ -31,6 +48,10 @@ pub fn persist_structured_output_from_file(
     session_dir: &Path,
     output_log_path: &Path,
 ) -> Result<OutputIndex> {
+    if let Some(flattened) = flatten_transcript_for_sections(output_log_path)? {
+        return persist_structured_output(session_dir, &flattened);
+    }
+
     let file = fs::File::open(output_log_path)
         .with_context(|| format!("Failed to open {}", output_log_path.display()))?;
     let reader = BufReader::new(file);
@@ -211,6 +232,56 @@ pub fn persist_structured_output_from_file(
     Ok(index)
 }
 
+fn flatten_transcript_for_sections(output_log_path: &Path) -> Result<Option<String>> {
+    let file = fs::File::open(output_log_path)
+        .with_context(|| format!("Failed to open {}", output_log_path.display()))?;
+    let reader = BufReader::new(file);
+
+    let mut first_non_empty_line = None;
+    let mut saw_json_line = false;
+    let mut flattened = String::new();
+
+    for line_result in reader.lines() {
+        let line = line_result
+            .with_context(|| format!("Failed to read line from {}", output_log_path.display()))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        if first_non_empty_line.is_none() {
+            first_non_empty_line = Some(line.clone());
+            if serde_json::from_str::<TranscriptEvent>(&line).is_err() {
+                return Ok(None);
+            }
+        }
+
+        let Ok(event) = serde_json::from_str::<TranscriptEvent>(&line) else {
+            return Ok(None);
+        };
+        saw_json_line = true;
+
+        let Some(item) = event.item else {
+            continue;
+        };
+
+        if event.event_type == "item.completed"
+            && item.item_type == "agent_message"
+            && let Some(text) = item.text
+        {
+            if !flattened.is_empty() {
+                flattened.push('\n');
+            }
+            flattened.push_str(&text);
+        }
+    }
+
+    if saw_json_line {
+        Ok(Some(flattened))
+    } else {
+        Ok(None)
+    }
+}
+
 /// Build an OutputSection without content (for streaming two-pass approach).
 fn build_section_no_content(id: &str, content_start: usize, content_end: usize) -> OutputSection {
     let safe_id = sanitize_section_id(id);
@@ -228,5 +299,92 @@ fn build_section_no_content(id: &str, content_start: usize, content_end: usize) 
         line_end,
         token_estimate: 0,
         file_path: Some(format!("{safe_id}.md")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_output_log(contents: &str) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("output.log"), contents).unwrap();
+        tmp
+    }
+
+    #[test]
+    fn persist_structured_output_from_file_extracts_summary_from_json_transcript() {
+        let tmp = write_output_log(
+            r#"{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->"}}"#,
+        );
+
+        let index = persist_structured_output_from_file(tmp.path(), &tmp.path().join("output.log"))
+            .unwrap();
+
+        assert_eq!(index.sections.len(), 1);
+        assert_eq!(index.sections[0].id, "summary");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("output/summary.md")).unwrap(),
+            "PASS"
+        );
+    }
+
+    #[test]
+    fn persist_structured_output_from_file_extracts_multiple_sections_from_json_transcript() {
+        let tmp = write_output_log(concat!(
+            r#"{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->"}}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"<!-- CSA:SECTION:details -->\nFound issue details\n<!-- CSA:SECTION:details:END -->"}}"#,
+        ));
+
+        let index = persist_structured_output_from_file(tmp.path(), &tmp.path().join("output.log"))
+            .unwrap();
+
+        assert_eq!(index.sections.len(), 2);
+        assert!(tmp.path().join("output/summary.md").exists());
+        assert!(tmp.path().join("output/details.md").exists());
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("output/summary.md")).unwrap(),
+            "PASS"
+        );
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("output/details.md")).unwrap(),
+            "Found issue details"
+        );
+    }
+
+    #[test]
+    fn persist_structured_output_from_file_keeps_plain_text_path() {
+        let tmp = write_output_log(
+            "<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n",
+        );
+
+        let index = persist_structured_output_from_file(tmp.path(), &tmp.path().join("output.log"))
+            .unwrap();
+
+        assert_eq!(index.sections.len(), 1);
+        assert_eq!(index.sections[0].id, "summary");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("output/summary.md")).unwrap(),
+            "PASS"
+        );
+    }
+
+    #[test]
+    fn persist_structured_output_from_file_falls_back_on_malformed_json_like_input() {
+        let tmp = write_output_log(
+            "{not valid json\n<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n",
+        );
+
+        let index = persist_structured_output_from_file(tmp.path(), &tmp.path().join("output.log"))
+            .unwrap();
+
+        assert_eq!(index.sections.len(), 1);
+        assert_eq!(index.sections[0].id, "summary");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("output/summary.md")).unwrap(),
+            "PASS"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`persist_structured_output_from_file` scanned `output.log` line-by-line for `<!-- CSA:SECTION:id -->` markers. Codex emits one JSON event per line, so the markers were embedded inside the JSON-escaped `text` field of `agent_message` events — invisible to the line-prefix scanner. Every codex-backed review session therefore persisted only a single `full` section, with `summary.md` / `details.md` missing despite the transcript containing explicit markers.

This PR detects JSON-per-line transcripts, extracts the concatenated `agent_message.text` content (same heuristic as `review_cmd_output::extract_review_text`), and feeds that flattened text to the existing section parser. Plain-text transcripts keep their fast path unchanged.

## Changes

- `crates/csa-session/src/output_parser/persist_streaming.rs` — `flatten_transcript_for_sections` helper + detection at top of `persist_structured_output_from_file`
- Regression tests: JSON single/multi section, plain-text preservation, malformed-JSON fallback

## Test plan

- [x] `cargo test -p csa-session`
- [x] `just pre-commit`

Refs #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)