### PR TITLE
fix(csa-review): deterministic prior-review-session selection via session_id tie-break (#794)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.304"
+version = "0.1.305"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.304"
+version = "0.1.305"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -220,7 +220,11 @@ fn find_latest_branch_review_meta(
             let meta = load_review_meta(project_root, &candidate.meta_session_id)?;
             Some((candidate.meta_session_id, meta))
         })
-        .max_by(|a, b| a.1.timestamp.cmp(&b.1.timestamp))
+        .max_by(|a, b| {
+            a.1.timestamp
+                .cmp(&b.1.timestamp)
+                .then_with(|| a.0.cmp(&b.0))
+        })
 }
 
 fn load_review_meta(project_root: &Path, session_id: &str) -> Option<ReviewSessionMeta> {
@@ -693,6 +697,46 @@ mod tests {
         assert!(rendered.contains("[high]"));
         assert!(rendered.contains("src/lib.rs:42"));
         assert!(rendered.contains("no unwrap"));
+    }
+
+    #[test]
+    fn find_latest_branch_review_meta_breaks_timestamp_ties_by_session_id() {
+        use crate::test_session_sandbox::ScopedSessionSandbox;
+        use csa_session::{create_session, get_session_dir, write_review_meta};
+
+        let project = setup_git_repo_with_branch("feat/tie-break");
+        let _sandbox = ScopedSessionSandbox::new(&project);
+        let shared_timestamp = chrono::Utc::now();
+
+        let session_a = create_session(project.path(), Some("review-a"), None, Some("codex"))
+            .expect("session a created");
+        let session_b = create_session(project.path(), Some("review-b"), None, Some("codex"))
+            .expect("session b created");
+
+        let session_a_dir = get_session_dir(project.path(), &session_a.meta_session_id).unwrap();
+        let session_b_dir = get_session_dir(project.path(), &session_b.meta_session_id).unwrap();
+
+        let mut meta_a = make_review_meta(&session_a.meta_session_id, "fail", 1);
+        meta_a.timestamp = shared_timestamp;
+        let mut meta_b = make_review_meta(&session_b.meta_session_id, "pass", 2);
+        meta_b.timestamp = shared_timestamp;
+
+        write_review_meta(&session_a_dir, &meta_a).expect("write session a review meta");
+        write_review_meta(&session_b_dir, &meta_b).expect("write session b review meta");
+
+        let expected_session_id = std::cmp::max(
+            session_a.meta_session_id.clone(),
+            session_b.meta_session_id.clone(),
+        );
+
+        for _ in 0..5 {
+            let (selected_session_id, selected_meta) =
+                find_latest_branch_review_meta(project.path(), "feat/tie-break", None)
+                    .expect("latest prior review session");
+            assert_eq!(selected_session_id, expected_session_id);
+            assert_eq!(selected_meta.session_id, expected_session_id);
+            assert_eq!(selected_meta.timestamp, shared_timestamp);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Multi-reviewer cumulative runs persist the same `review_meta_timestamp` across every reviewer session, so the prior-round "latest" picker's `sort_by_key(|s| s.timestamp)` in `review_context.rs:223` selected non-deterministically on ties (varies by filesystem iteration order). Prior-round assumption injection became unstable across identical runs.

This PR replaces the single-key sort with a stable tie-break on `session_id` (ULID, monotonically increasing). Ties between equal-timestamp sessions are now broken consistently.

## Changes

- `crates/cli-sub-agent/src/review_context.rs` — tie-break sort on `session_id`
- Regression test: identical timestamps, different session_id → deterministic latest

## Test plan

- [x] `cargo test -p cli-sub-agent review_context`
- [x] `just pre-commit`

Refs #794. Related to #791, #793 (same multi-reviewer subsystem — separate PRs to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)