### PR TITLE
fix(csa-review): rename consolidated findings artifact to match reader (#791)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.305"
+version = "0.1.306"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.305"
+version = "0.1.306"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/bug_class.rs
+++ b/crates/cli-sub-agent/src/bug_class.rs
@@ -16,7 +16,7 @@ pub(crate) use sanitization::{
     SANITIZED_CONTENT_PLACEHOLDER, sanitize_code_for_skill, sanitize_text_for_skill,
 };
 
-const CONSOLIDATED_REVIEW_ARTIFACT_FILE: &str = "review-consolidated.json";
+const CONSOLIDATED_REVIEW_ARTIFACT_FILE: &str = "review-findings-consolidated.json";
 const SINGLE_REVIEW_ARTIFACT_FILE: &str = "review-findings.json";
 const REVIEW_DETAILS_CONTEXT_FILE: &str = "output/details.md";
 const BUG_CLASS_RECURRENCE_THRESHOLD: u32 = 2;

--- a/crates/cli-sub-agent/src/bug_class_tests.rs
+++ b/crates/cli-sub-agent/src/bug_class_tests.rs
@@ -213,7 +213,7 @@ fn loader_prefers_consolidated_artifacts_and_skips_sessions_without_reviews() {
     );
     write_review_artifact(
         &consolidated_dir,
-        "review-consolidated.json",
+        "review-findings-consolidated.json",
         &sample_artifact(
             &consolidated_session.meta_session_id,
             vec![sample_finding(

--- a/crates/cli-sub-agent/src/review_cmd_bug_class.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class.rs
@@ -11,7 +11,7 @@ use crate::bug_class::{
 };
 use crate::review_consensus::build_consolidated_artifact;
 
-const REVIEW_CONSOLIDATED_ARTIFACT_FILE: &str = "review-consolidated.json";
+const REVIEW_CONSOLIDATED_ARTIFACT_FILE: &str = "review-findings-consolidated.json";
 const REVIEW_FINDINGS_ARTIFACT_FILE: &str = "review-findings.json";
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -129,7 +129,7 @@ fn collapse_bug_class_review_artifacts(
     let mut grouped = BTreeMap::<ReviewArtifactGroupKey, Vec<GroupedReviewArtifact>>::new();
 
     for artifact in review_artifacts {
-        // Parent review-consolidated.json duplicates child reviewer findings but
+        // Parent review-findings-consolidated.json duplicates child reviewer findings but
         // does not carry review_meta.json. Skip only that parent artifact shape;
         // child reviewer sessions can legitimately have consolidated output too.
         if should_skip_bug_class_artifact(project_root, &artifact.session_id)? {

--- a/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::bug_class::classify_recurring_bug_classes;
 use crate::review_cmd::bug_class_pipeline::load_bug_class_review_artifacts;
+use crate::review_consensus::write_consolidated_artifact;
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_session::review_artifact::{Finding, ReviewArtifact, Severity, SeveritySummary};
 use csa_session::state::ReviewSessionMeta;
@@ -355,7 +356,7 @@ fn bug_class_loader_skips_parent_consolidated_artifact_to_avoid_false_promotion(
 
     write_review_artifact_file(
         &parent_dir,
-        "review-consolidated.json",
+        "review-findings-consolidated.json",
         &sample_review_artifact(&parent.meta_session_id, Severity::High, "rust/002"),
     );
     write_review_artifact(
@@ -421,7 +422,7 @@ fn bug_class_loader_keeps_sessions_with_review_meta_even_if_consolidated_exists(
 
     write_review_artifact_file(
         &child_dir,
-        "review-consolidated.json",
+        "review-findings-consolidated.json",
         &sample_review_artifact(&child.meta_session_id, Severity::High, "rust/002"),
     );
     write_review_meta(
@@ -448,4 +449,49 @@ fn bug_class_loader_keeps_sessions_with_review_meta_even_if_consolidated_exists(
 
     assert_eq!(review_artifacts.len(), 1);
     assert_eq!(review_artifacts[0].session_id, child.meta_session_id);
+}
+
+#[test]
+fn bug_class_loader_reads_exact_consolidated_path_written_by_consensus_writer() {
+    let temp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp);
+    let project_root = temp.path().join("project");
+    std::fs::create_dir_all(&project_root).unwrap();
+
+    let session = create_session(&project_root, Some("review session"), None, Some("codex"))
+        .expect("session should be created");
+    let session_dir = get_session_dir(&project_root, &session.meta_session_id).unwrap();
+    let artifact = sample_review_artifact(&session.meta_session_id, Severity::High, "rust/002");
+
+    write_consolidated_artifact(&artifact, &session_dir)
+        .expect("consensus writer should persist artifact");
+    write_review_meta(
+        &session_dir,
+        &ReviewSessionMeta {
+            session_id: session.meta_session_id.clone(),
+            head_sha: "deadbeef".to_string(),
+            decision: "fail".to_string(),
+            verdict: "HAS_ISSUES".to_string(),
+            tool: "codex".to_string(),
+            scope: "base:main".to_string(),
+            exit_code: 1,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 1,
+            timestamp: chrono::Utc::now(),
+            diff_fingerprint: Some("sha256:shared".to_string()),
+        },
+    )
+    .expect("review meta");
+
+    let writer_path = session_dir.join("review-findings-consolidated.json");
+    assert!(
+        writer_path.is_file(),
+        "writer should use consolidated findings path"
+    );
+
+    let loaded = load_bug_class_review_artifacts(&project_root)
+        .expect("bug-class loader should read consolidated artifact");
+
+    assert_eq!(loaded, vec![artifact]);
 }

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -444,7 +444,7 @@ pub(crate) fn write_consolidated_artifact(
     artifact: &ReviewArtifact,
     output_dir: &Path,
 ) -> Result<()> {
-    let artifact_path = output_dir.join("review-consolidated.json");
+    let artifact_path = output_dir.join("review-findings-consolidated.json");
     let payload = serde_json::to_string_pretty(artifact)
         .context("failed to serialize consolidated review artifact")?;
     fs::write(&artifact_path, payload).with_context(|| {

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -551,7 +551,7 @@ fn write_consolidated_artifact_creates_json_file_at_expected_path() {
 
     write_consolidated_artifact(&artifact, temp.path()).expect("artifact should be written");
 
-    let artifact_path = temp.path().join("review-consolidated.json");
+    let artifact_path = temp.path().join("review-findings-consolidated.json");
     assert!(artifact_path.exists());
     let contents = std::fs::read_to_string(&artifact_path).expect("json file should be readable");
     let parsed: ReviewArtifact =

--- a/output/fix-791-summary.md
+++ b/output/fix-791-summary.md
@@ -1,0 +1,16 @@
+# Fix 791 Summary
+
+- Renamed the consolidated review artifact from `review-consolidated.json` to
+  `review-findings-consolidated.json` so the multi-review writer matches the
+  reader's expected `review-findings-*` artifact family.
+- Updated the bug-class loader path and all affected tests to use the new
+  filename consistently.
+- Added a regression test proving the consensus writer emits the exact path that
+  the bug-class reader consumes.
+
+## Verification
+
+- `rg -n 'review-consolidated\.json' crates/`
+- `cargo test -p cli-sub-agent review_consensus`
+- `cargo test -p cli-sub-agent bug_class`
+- `just pre-commit`


### PR DESCRIPTION
## Summary

Writer emitted `review-consolidated.json` but the prior-round reader only looked for `review-findings-consolidated.json` / `review-findings.json`. Cumulative review's prior-round assumption feature silently dropped all consolidated findings in multi-reviewer mode.

This PR renames the writer output to `review-findings-consolidated.json`, bringing it into the `review-findings-*` naming family that the reader already expects.

## Changes

- `crates/cli-sub-agent/src/bug_class.rs` — `CONSOLIDATED_REVIEW_ARTIFACT_FILE` constant
- `crates/cli-sub-agent/src/review_consensus.rs` — writer output path
- Any other `.rs` file with the literal (bug_class loader included)
- Updated tests asserting the new filename

## Test plan

- [x] `cargo test -p cli-sub-agent review_consensus`
- [x] `just pre-commit`

Refs #791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)