### PR TITLE
fix(csa-review): inject CSA_PARENT_SESSION_DIR for multi-reviewer (#793)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.307"
+version = "0.1.308"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.306"
+version = "0.1.307"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.307"
+version = "0.1.308"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.306"
+version = "0.1.307"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -579,3 +579,89 @@ fn current_git_branch_for_review(project_root: &Path) -> Option<String> {
     let backend = csa_session::vcs_backends::create_vcs_backend(project_root);
     backend.current_branch(project_root).ok().flatten()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::write_multi_reviewer_consolidated_artifact;
+    use csa_core::env::CSA_SESSION_DIR_ENV_KEY;
+    use csa_session::review_artifact::{Finding, ReviewArtifact, Severity, SeveritySummary};
+    use std::fs;
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    static REVIEW_RESOLVE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation guarded by REVIEW_RESOLVE_ENV_LOCK.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            // SAFETY: test-scoped env mutation guarded by REVIEW_RESOLVE_ENV_LOCK.
+            unsafe {
+                match self.original.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn write_multi_reviewer_consolidated_artifact_reads_parent_reviewer_dir() {
+        let _env_lock = REVIEW_RESOLVE_ENV_LOCK
+            .lock()
+            .expect("review resolve env lock poisoned");
+        let temp = tempdir().expect("tempdir should be created");
+        let session_dir = temp.path().display().to_string();
+        let _session_dir_guard = ScopedEnvVar::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
+        let _session_id_guard = ScopedEnvVar::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
+
+        let reviewer_dir = temp.path().join("reviewer-1");
+        fs::create_dir_all(&reviewer_dir).expect("reviewer dir should be created");
+        let findings = vec![Finding {
+            severity: Severity::High,
+            fid: "FID-1".to_string(),
+            file: "src/lib.rs".to_string(),
+            line: Some(7),
+            rule_id: "rule.review.parent-path".to_string(),
+            summary: "parent-path finding".to_string(),
+            engine: "reviewer".to_string(),
+        }];
+        let artifact = ReviewArtifact {
+            severity_summary: SeveritySummary::from_findings(&findings),
+            findings: findings.clone(),
+            review_mode: Some("diff".to_string()),
+            schema_version: "1.0".to_string(),
+            session_id: "01CHILDSESSION0000000000000".to_string(),
+            timestamp: chrono::Utc::now(),
+        };
+        fs::write(
+            reviewer_dir.join("review-findings.json"),
+            serde_json::to_vec_pretty(&artifact).expect("artifact should serialize"),
+        )
+        .expect("review artifact should be written");
+
+        write_multi_reviewer_consolidated_artifact(1)
+            .expect("consolidated artifact should be produced");
+
+        let consolidated_path = temp.path().join("review-findings-consolidated.json");
+        let consolidated: ReviewArtifact = serde_json::from_str(
+            &fs::read_to_string(&consolidated_path).expect("consolidated artifact should exist"),
+        )
+        .expect("consolidated artifact should parse");
+        assert_eq!(consolidated.findings.len(), 1);
+        assert_eq!(consolidated.findings[0].fid, "FID-1");
+        assert_eq!(consolidated.severity_summary.high, 1);
+    }
+}

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -13,6 +13,7 @@ use csa_core::consensus::{
     AgentResponse, ConsensusResult, ConsensusStrategy, resolve_majority, resolve_unanimous,
     resolve_weighted,
 };
+use csa_core::env::{CSA_PARENT_SESSION_DIR_ENV_KEY, CSA_SESSION_DIR_ENV_KEY};
 use csa_core::types::ToolName;
 #[cfg(not(test))]
 use csa_executor::{CodexRuntimeMetadata, CodexTransport};
@@ -150,7 +151,7 @@ pub(crate) fn build_multi_reviewer_instruction(
     reviewer_index: usize,
     tool: ToolName,
 ) -> String {
-    let output_dir = format!("$CSA_SESSION_DIR/reviewer-{reviewer_index}");
+    let output_dir = reviewer_output_dir(reviewer_index);
     format!(
         "{base_prompt}\n\
 You are reviewer {reviewer_index}. Emit exactly one final verdict token: \
@@ -169,6 +170,23 @@ When spec/contract context is provided, use rule_id values: \
 Reviewer tool hint: {}.",
         tool.as_str()
     )
+}
+
+fn reviewer_output_dir(reviewer_index: usize) -> String {
+    let reviewer_dir = format!("reviewer-{reviewer_index}");
+    std::env::var(CSA_PARENT_SESSION_DIR_ENV_KEY)
+        .or_else(|_| std::env::var(CSA_SESSION_DIR_ENV_KEY))
+        .map(|session_dir| {
+            Path::new(&session_dir)
+                .join(&reviewer_dir)
+                .display()
+                .to_string()
+        })
+        .unwrap_or_else(|_| {
+            format!(
+                "${{{CSA_PARENT_SESSION_DIR_ENV_KEY}:-${CSA_SESSION_DIR_ENV_KEY}}}/{reviewer_dir}"
+            )
+        })
 }
 
 pub(crate) fn parse_consensus_strategy(raw: &str) -> Result<ConsensusStrategy> {

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -174,8 +174,8 @@ Reviewer tool hint: {}.",
 
 fn reviewer_output_dir(reviewer_index: usize) -> String {
     let reviewer_dir = format!("reviewer-{reviewer_index}");
-    std::env::var(CSA_PARENT_SESSION_DIR_ENV_KEY)
-        .or_else(|_| std::env::var(CSA_SESSION_DIR_ENV_KEY))
+    std::env::var(CSA_SESSION_DIR_ENV_KEY)
+        .or_else(|_| std::env::var(CSA_PARENT_SESSION_DIR_ENV_KEY))
         .map(|session_dir| {
             Path::new(&session_dir)
                 .join(&reviewer_dir)
@@ -184,7 +184,7 @@ fn reviewer_output_dir(reviewer_index: usize) -> String {
         })
         .unwrap_or_else(|_| {
             format!(
-                "${{{CSA_PARENT_SESSION_DIR_ENV_KEY}:-${CSA_SESSION_DIR_ENV_KEY}}}/{reviewer_dir}"
+                "${{{CSA_SESSION_DIR_ENV_KEY}:-${CSA_PARENT_SESSION_DIR_ENV_KEY}}}/{reviewer_dir}"
             )
         })
 }

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -1,7 +1,44 @@
 use super::*;
 use csa_config::{GlobalConfig, ProjectMeta, ResourcesConfig, ToolConfig};
+use csa_core::env::{CSA_PARENT_SESSION_DIR_ENV_KEY, CSA_SESSION_DIR_ENV_KEY};
 use csa_session::review_artifact::{Finding, ReviewArtifact, Severity, SeveritySummary};
+use std::sync::Mutex;
 use tempfile::tempdir;
+
+static REVIEWER_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct ScopedEnvVar {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by REVIEWER_ENV_LOCK.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by REVIEWER_ENV_LOCK.
+        unsafe { std::env::remove_var(key) };
+        Self { key, original }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by REVIEWER_ENV_LOCK.
+        unsafe {
+            match self.original.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
 
 fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
     let mut tool_map = HashMap::new();
@@ -223,6 +260,36 @@ fn parse_review_verdict_accepts_clean_phrase_without_explicit_token() {
         parse_review_verdict("\u{672a}\u{53d1}\u{73b0}\u{95ee}\u{9898}\u{3002}", 0),
         CLEAN
     );
+}
+
+#[test]
+fn build_multi_reviewer_instruction_prefers_parent_session_dir_env() {
+    let _env_lock = REVIEWER_ENV_LOCK
+        .lock()
+        .expect("reviewer env lock poisoned");
+    let _parent_guard = ScopedEnvVar::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
+    let _session_guard = ScopedEnvVar::set(CSA_SESSION_DIR_ENV_KEY, "/tmp/child-session");
+
+    let prompt = build_multi_reviewer_instruction("Base prompt", 2, ToolName::Codex);
+
+    assert!(prompt.contains("/tmp/parent-session/reviewer-2/review-findings.json"));
+    assert!(
+        !prompt.contains("/tmp/child-session/reviewer-2/review-findings.json"),
+        "parent session dir should override child session dir when both exist"
+    );
+}
+
+#[test]
+fn build_multi_reviewer_instruction_falls_back_to_session_dir_env() {
+    let _env_lock = REVIEWER_ENV_LOCK
+        .lock()
+        .expect("reviewer env lock poisoned");
+    let _parent_guard = ScopedEnvVar::unset(CSA_PARENT_SESSION_DIR_ENV_KEY);
+    let _session_guard = ScopedEnvVar::set(CSA_SESSION_DIR_ENV_KEY, "/tmp/current-session");
+
+    let prompt = build_multi_reviewer_instruction("Base prompt", 3, ToolName::Codex);
+
+    assert!(prompt.contains("/tmp/current-session/reviewer-3/review-findings.json"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -263,7 +263,7 @@ fn parse_review_verdict_accepts_clean_phrase_without_explicit_token() {
 }
 
 #[test]
-fn build_multi_reviewer_instruction_prefers_parent_session_dir_env() {
+fn build_multi_reviewer_instruction_prefers_current_session_dir_env_when_both_exist() {
     let _env_lock = REVIEWER_ENV_LOCK
         .lock()
         .expect("reviewer env lock poisoned");
@@ -272,24 +272,41 @@ fn build_multi_reviewer_instruction_prefers_parent_session_dir_env() {
 
     let prompt = build_multi_reviewer_instruction("Base prompt", 2, ToolName::Codex);
 
-    assert!(prompt.contains("/tmp/parent-session/reviewer-2/review-findings.json"));
+    assert!(prompt.contains("/tmp/child-session/reviewer-2/review-findings.json"));
     assert!(
-        !prompt.contains("/tmp/child-session/reviewer-2/review-findings.json"),
-        "parent session dir should override child session dir when both exist"
+        !prompt.contains("/tmp/parent-session/reviewer-2/review-findings.json"),
+        "current session dir should override parent session dir when both exist"
     );
 }
 
 #[test]
-fn build_multi_reviewer_instruction_falls_back_to_session_dir_env() {
+fn build_multi_reviewer_instruction_falls_back_to_parent_session_dir_env() {
+    let _env_lock = REVIEWER_ENV_LOCK
+        .lock()
+        .expect("reviewer env lock poisoned");
+    let _parent_guard = ScopedEnvVar::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
+    let _session_guard = ScopedEnvVar::unset(CSA_SESSION_DIR_ENV_KEY);
+
+    let prompt = build_multi_reviewer_instruction("Base prompt", 3, ToolName::Codex);
+
+    assert!(prompt.contains("/tmp/parent-session/reviewer-3/review-findings.json"));
+}
+
+#[test]
+fn build_multi_reviewer_instruction_uses_session_first_shell_fallback_when_env_missing() {
     let _env_lock = REVIEWER_ENV_LOCK
         .lock()
         .expect("reviewer env lock poisoned");
     let _parent_guard = ScopedEnvVar::unset(CSA_PARENT_SESSION_DIR_ENV_KEY);
-    let _session_guard = ScopedEnvVar::set(CSA_SESSION_DIR_ENV_KEY, "/tmp/current-session");
+    let _session_guard = ScopedEnvVar::unset(CSA_SESSION_DIR_ENV_KEY);
 
-    let prompt = build_multi_reviewer_instruction("Base prompt", 3, ToolName::Codex);
+    let prompt = build_multi_reviewer_instruction("Base prompt", 4, ToolName::Codex);
 
-    assert!(prompt.contains("/tmp/current-session/reviewer-3/review-findings.json"));
+    assert!(
+        prompt.contains(
+            "${CSA_SESSION_DIR:-$CSA_PARENT_SESSION_DIR}/reviewer-4/review-findings.json"
+        )
+    );
 }
 
 #[test]

--- a/crates/csa-core/src/env.rs
+++ b/crates/csa-core/src/env.rs
@@ -1,2 +1,8 @@
 /// Reserved executor env var that disables automatic runtime failover/retry paths.
 pub const NO_FAILOVER_ENV_KEY: &str = "_CSA_NO_FAILOVER";
+
+/// Absolute path to the current session directory owned by this process.
+pub const CSA_SESSION_DIR_ENV_KEY: &str = "CSA_SESSION_DIR";
+
+/// Absolute path to the parent session directory when this process is a child session.
+pub const CSA_PARENT_SESSION_DIR_ENV_KEY: &str = "CSA_PARENT_SESSION_DIR";

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use csa_acp::SessionConfig;
+use csa_core::env::{CSA_PARENT_SESSION_DIR_ENV_KEY, CSA_SESSION_DIR_ENV_KEY};
 use csa_resource::isolation_plan::IsolationPlan;
 use csa_session::state::MetaSessionState;
 
@@ -22,7 +23,6 @@ const CSA_IS_SUBPROCESS_ENV: &str = "CSA_IS_SUBPROCESS";
 const CSA_PARENT_TOOL_ENV: &str = "CSA_PARENT_TOOL";
 const CSA_PARENT_SESSION_ENV: &str = "CSA_PARENT_SESSION";
 const CSA_FS_SANDBOXED_ENV: &str = "CSA_FS_SANDBOXED";
-const CSA_SESSION_DIR_ENV: &str = "CSA_SESSION_DIR";
 const CSA_OWNED_ENV_KEYS: &[&str] = &[
     CSA_SESSION_ID_ENV,
     CSA_DEPTH_ENV,
@@ -32,7 +32,8 @@ const CSA_OWNED_ENV_KEYS: &[&str] = &[
     CSA_PARENT_TOOL_ENV,
     CSA_PARENT_SESSION_ENV,
     CSA_FS_SANDBOXED_ENV,
-    CSA_SESSION_DIR_ENV,
+    CSA_SESSION_DIR_ENV_KEY,
+    CSA_PARENT_SESSION_DIR_ENV_KEY,
     csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
 ];
 
@@ -188,12 +189,12 @@ impl AcpTransport {
         env: &mut HashMap<String, String>,
         session: &MetaSessionState,
     ) {
-        if let Ok(dir) = csa_session::manager::get_session_dir(
-            Path::new(&session.project_path),
-            &session.meta_session_id,
-        ) {
+        let project_path = Path::new(&session.project_path);
+        if let Ok(dir) =
+            csa_session::manager::get_session_dir(project_path, &session.meta_session_id)
+        {
             env.insert(
-                CSA_SESSION_DIR_ENV.to_string(),
+                CSA_SESSION_DIR_ENV_KEY.to_string(),
                 dir.to_string_lossy().into_owned(),
             );
             env.insert(
@@ -204,6 +205,24 @@ impl AcpTransport {
             );
         } else {
             tracing::warn!("failed to compute CSA_SESSION_DIR for ACP env");
+        }
+
+        if let Some(parent_session_id) = session.genealogy.parent_session_id.as_deref() {
+            match csa_session::manager::get_session_dir(project_path, parent_session_id) {
+                Ok(parent_dir) => {
+                    env.insert(
+                        CSA_PARENT_SESSION_DIR_ENV_KEY.to_string(),
+                        parent_dir.to_string_lossy().into_owned(),
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        parent_session_id,
+                        error = %error,
+                        "failed to compute CSA_PARENT_SESSION_DIR for ACP env"
+                    );
+                }
+            }
         }
     }
 }
@@ -701,8 +720,12 @@ mod tests {
             ),
             (CSA_FS_SANDBOXED_ENV.to_string(), "0".to_string()),
             (
-                CSA_SESSION_DIR_ENV.to_string(),
+                CSA_SESSION_DIR_ENV_KEY.to_string(),
                 "/tmp/spoofed-session-dir".to_string(),
+            ),
+            (
+                CSA_PARENT_SESSION_DIR_ENV_KEY.to_string(),
+                "/tmp/spoofed-parent-session-dir".to_string(),
             ),
             (
                 csa_session::RESULT_TOML_PATH_CONTRACT_ENV.to_string(),
@@ -746,7 +769,7 @@ mod tests {
         );
 
         let session_dir = env
-            .get(CSA_SESSION_DIR_ENV)
+            .get(CSA_SESSION_DIR_ENV_KEY)
             .expect("CSA_SESSION_DIR should be present");
         assert!(
             session_dir.contains("/sessions/"),

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -440,3 +440,32 @@ async fn test_gemini_3phase_all_fail_returns_last_error() {
         "API key should be injected on attempts 2 and 3"
     );
 }
+
+#[test]
+fn test_acp_build_env_injects_parent_session_dir_for_child_sessions() {
+    let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
+    let _parent_tool_guard = ScopedEnvVar::set("CSA_TOOL", "parent-tool");
+    let transport = AcpTransport::new("claude-code", None);
+    let mut session = crate::transport::build_ephemeral_meta_session(std::path::Path::new(
+        "/tmp/test",
+    ));
+    session.meta_session_id = "01HTEST000000000000000000".to_string();
+    session.genealogy.parent_session_id = Some("01HPARENT000000000000000000".to_string());
+
+    let env = transport.build_env(&session, Some(&HashMap::from([(
+        csa_core::env::CSA_PARENT_SESSION_DIR_ENV_KEY.to_string(),
+        "/tmp/spoofed-parent-session-dir".to_string(),
+    )])));
+
+    let parent_session_dir = env
+        .get(csa_core::env::CSA_PARENT_SESSION_DIR_ENV_KEY)
+        .expect("CSA_PARENT_SESSION_DIR should be present for child sessions");
+    assert!(
+        parent_session_dir.contains("/sessions/"),
+        "CSA_PARENT_SESSION_DIR should be recomputed after merge, got: {parent_session_dir}"
+    );
+    assert!(
+        parent_session_dir.contains("01HPARENT000000000000000000"),
+        "CSA_PARENT_SESSION_DIR should include the parent session ID, got: {parent_session_dir}"
+    );
+}

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -220,6 +220,7 @@ fn test_acp_build_env_propagates_extra_env() {
     );
 }
 
+
 #[test]
 fn test_acp_build_env_includes_csa_session_dir() {
     let transport = AcpTransport::new("claude-code", None);


### PR DESCRIPTION
## Summary

- Inject `CSA_PARENT_SESSION_DIR` for child reviewer sessions when a parent session exists.
- Reviewer prompt in `review_consensus.rs` now writes findings to the parent path (falls back to `CSA_SESSION_DIR` in single-reviewer mode).
- Consolidator in `review_cmd_resolve.rs` now actually sees findings from child reviewers in multi-reviewer cumulative runs.

Closes #793.

## Test plan

- [x] Regression tests for env var injection (parent dir set → parent used; unset → child dir fallback).
- [x] Consolidator reads findings written by child using parent path.
- [x] `just pre-commit` exit 0.