### PR TITLE
fix(csa-review): synthesize review result.toml on execution failure (#795)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.309"
+version = "0.1.310"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.309"
+version = "0.1.310"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -1,11 +1,15 @@
 //! Review execution helpers extracted from `review_cmd.rs`.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use csa_config::{ExecutionEnvOptions, GlobalConfig, ProjectConfig};
 use csa_core::types::{OutputFormat, ToolName};
-use csa_session::{SessionResult, load_result, load_session, save_result, save_session};
+use csa_session::{
+    SessionResult, get_session_dir, load_result, load_session, save_result, save_session,
+};
 use tracing::{info, warn};
 
 use crate::review_routing::{ReviewRoutingMetadata, persist_review_routing_artifact};
@@ -48,6 +52,7 @@ pub(super) async fn execute_review(
     readonly_project_root: bool,
     extra_writable: &[PathBuf],
 ) -> Result<crate::pipeline::SessionExecutionResult> {
+    let execution_started_at = Utc::now();
     let enforce_tier =
         tier_name.is_some() && tier_model_spec.is_some() && !force_ignore_tier_setting;
     let executor = crate::pipeline::build_and_validate_executor(
@@ -101,7 +106,7 @@ pub(super) async fn execute_review(
         effective_prompt = format!("{guard}\n\n{effective_prompt}");
     }
 
-    let mut execution = crate::pipeline::execute_with_session_and_meta_with_parent_source(
+    let mut execution = match crate::pipeline::execute_with_session_and_meta_with_parent_source(
         &executor,
         &tool,
         &effective_prompt,
@@ -127,12 +132,155 @@ pub(super) async fn execute_review(
         readonly_project_root,
         extra_writable,
     )
-    .await?;
+    .await
+    {
+        Ok(execution) => execution,
+        Err(err) => {
+            maybe_synthesize_missing_review_result(project_root, tool, execution_started_at, &err);
+            return Err(err);
+        }
+    };
 
     persist_review_routing_artifact(project_root, &execution.meta_session_id, &review_routing);
     repair_completed_review_restriction_result(project_root, tool, &mut execution)?;
 
     Ok(execution)
+}
+
+fn maybe_synthesize_missing_review_result(
+    project_root: &Path,
+    tool: ToolName,
+    started_at: DateTime<Utc>,
+    error: &anyhow::Error,
+) {
+    let Some(session_id) = extract_meta_session_id_from_error(error) else {
+        return;
+    };
+
+    match load_result(project_root, &session_id) {
+        Ok(Some(_)) => return,
+        Ok(None) => {}
+        Err(load_err) => {
+            warn!(
+                session_id = %session_id,
+                error = %load_err,
+                "Failed to check for existing review result.toml before fallback synthesis"
+            );
+        }
+    }
+
+    let session_dir = match get_session_dir(project_root, &session_id) {
+        Ok(path) => path,
+        Err(session_dir_err) => {
+            warn!(
+                session_id = %session_id,
+                error = %session_dir_err,
+                "Failed to resolve review session dir for fallback result synthesis"
+            );
+            return;
+        }
+    };
+
+    let stderr_excerpt = read_review_failure_excerpt(&session_dir)
+        .unwrap_or_else(|| truncate_for_summary(&format!("{error:#}"), 500));
+    let (status, exit_code, error_kind) = classify_review_failure(error, &stderr_excerpt);
+    let summary = truncate_for_summary(
+        &format!("review {error_kind}: {}", stderr_excerpt.trim()),
+        200,
+    );
+    let completed_at = Utc::now();
+    let fallback_result = SessionResult {
+        status: status.to_string(),
+        exit_code,
+        summary,
+        tool: tool.to_string(),
+        started_at,
+        completed_at,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+    };
+
+    if let Err(save_err) = save_result(project_root, &session_id, &fallback_result) {
+        warn!(
+            session_id = %session_id,
+            error = %save_err,
+            "Failed to synthesize missing review result.toml"
+        );
+        return;
+    }
+
+    csa_session::write_cooldown_marker_for_project(project_root, &session_id, completed_at);
+    warn!(
+        session_id = %session_id,
+        error_kind,
+        "Synthesized missing review result.toml after execution error"
+    );
+}
+
+fn extract_meta_session_id_from_error(error: &anyhow::Error) -> Option<String> {
+    const MARKER: &str = "meta_session_id=";
+    for cause in error.chain() {
+        let message = cause.to_string();
+        let Some(idx) = message.find(MARKER) else {
+            continue;
+        };
+        let suffix = &message[idx + MARKER.len()..];
+        let session_id: String = suffix
+            .chars()
+            .take_while(|ch| ch.is_ascii_alphanumeric())
+            .collect();
+        if !session_id.is_empty() {
+            return Some(session_id);
+        }
+    }
+    None
+}
+
+fn read_review_failure_excerpt(session_dir: &Path) -> Option<String> {
+    let stderr_path = session_dir.join("stderr.log");
+    let contents = fs::read_to_string(stderr_path).ok()?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(truncate_for_summary(trimmed, 500))
+}
+
+fn classify_review_failure(
+    error: &anyhow::Error,
+    excerpt: &str,
+) -> (&'static str, i32, &'static str) {
+    let mut combined = excerpt.to_ascii_lowercase();
+    for cause in error.chain() {
+        combined.push('\n');
+        combined.push_str(&cause.to_string().to_ascii_lowercase());
+    }
+
+    if combined.contains("initial_response_timeout")
+        || combined.contains("timed out")
+        || combined.contains("timeout")
+    {
+        ("timeout", 124, "timeout")
+    } else if combined.contains("sigkill")
+        || combined.contains("sigterm")
+        || combined.contains("killed")
+        || combined.contains("terminated by signal")
+    {
+        ("signal", 137, "signal")
+    } else if combined.contains("fork")
+        || combined.contains("spawn")
+        || combined.contains("provider_session_id")
+    {
+        ("failure", 1, "spawn_fail")
+    } else {
+        ("failure", 1, "tool_crash")
+    }
+}
+
+fn truncate_for_summary(text: &str, max_chars: usize) -> String {
+    let truncated: String = text.chars().take(max_chars).collect();
+    truncated.trim().replace('\n', " ")
 }
 
 fn repair_completed_review_restriction_result(
@@ -245,6 +393,7 @@ mod tests {
     use crate::review_cmd::tests::{
         ScopedEnvVarRestore, project_config_with_enabled_tools, setup_git_repo,
     };
+    use crate::session_cmds_result::{StructuredOutputOpts, handle_session_result};
     use crate::test_session_sandbox::ScopedSessionSandbox;
     use csa_config::{GlobalConfig, ProjectProfile, ToolRestrictions};
     use csa_core::types::ToolName;
@@ -428,5 +577,48 @@ printf '%s\\n' \
             "expected structured review output, got: {}",
             result.execution.output
         );
+    }
+
+    #[test]
+    fn synthesize_missing_review_result_makes_session_result_readable() {
+        let td = tempfile::tempdir().unwrap();
+        let _sandbox = ScopedSessionSandbox::new(&td);
+        let project_root = td.path();
+
+        let session =
+            csa_session::create_session(project_root, Some("review-failure"), None, Some("codex"))
+                .expect("session creation");
+        let session_id = session.meta_session_id.clone();
+        let session_dir = csa_session::get_session_dir(project_root, &session_id).unwrap();
+        std::fs::write(
+            session_dir.join("stderr.log"),
+            "codex daemon fork-from failed: provider session bootstrap failed",
+        )
+        .unwrap();
+
+        let started_at = Utc::now();
+        let err = anyhow::anyhow!("codex daemon fork-from failed")
+            .context(format!("meta_session_id={session_id}"));
+
+        maybe_synthesize_missing_review_result(project_root, ToolName::Codex, started_at, &err);
+
+        let result = csa_session::load_result(project_root, &session.meta_session_id)
+            .unwrap()
+            .expect("synthetic result.toml should exist");
+        assert_eq!(result.status, "failure");
+        assert_eq!(result.exit_code, 1);
+        assert!(
+            result.summary.contains("spawn_fail"),
+            "expected classified summary, got: {}",
+            result.summary
+        );
+
+        handle_session_result(
+            session.meta_session_id,
+            false,
+            Some(project_root.to_string_lossy().into_owned()),
+            StructuredOutputOpts::default(),
+        )
+        .expect("session result should read the synthetic review failure");
     }
 }

--- a/output/fix-795-scoping-decision.md
+++ b/output/fix-795-scoping-decision.md
@@ -1,0 +1,31 @@
+## Scoping Decision
+
+Selected fix: Option A, but scoped to the `csa review` execution boundary only.
+
+Why this option:
+- The user-facing failure is specifically `csa review --range main...HEAD` leaving no `result.toml`, which blocks SA-guard callers.
+- Existing code already synthesizes or persists terminal results in several generic paths:
+  - pre-exec failures in `session_guard.rs`
+  - transport failures in `pipeline_execute.rs`
+  - post-exec failures in `pipeline_post_exec.rs`
+  - dead-daemon reconciliation in `session_cmds_reconcile.rs`
+- The remaining gap appears to be review-layer error propagation where a session ID exists in the error chain but no terminal `result.toml` was persisted.
+
+Why not full global Option A in this change:
+- A fully generic implementation would likely require broadening the shared session result schema and/or reconciliation surface across more than 3 files.
+- That exceeds the requested tight-scope change discipline for this task.
+
+Planned implementation:
+- In `review_cmd_execute.rs`, if review execution returns an error with `meta_session_id=...` and the session has no `result.toml`, synthesize a minimal failure result there.
+- The synthetic result will use the existing standard `SessionResult` schema so `csa session result` can read it immediately.
+- The summary will include a compact classified failure reason plus a short stderr excerpt when available.
+
+Expected touch surface:
+- `crates/cli-sub-agent/src/review_cmd_execute.rs`
+- `crates/cli-sub-agent/src/review_cmd_tests_tail.rs`
+- `output/fix-795-summary.md`
+
+Non-goals:
+- No new config keys.
+- No changes to generic session result rendering.
+- No attempt to solve all non-review commands in this commit.

--- a/output/fix-795-summary.md
+++ b/output/fix-795-summary.md
@@ -1,0 +1,29 @@
+## Fix #795 Summary
+
+Selected sub-fix: scoped Option A for `csa review`.
+
+What changed:
+- Added a review-layer fallback in `crates/cli-sub-agent/src/review_cmd_execute.rs`.
+- When review execution fails with a `meta_session_id` but no persisted `result.toml`, CSA now synthesizes a minimal terminal `SessionResult`.
+- The fallback classifies the failure into:
+  - `timeout`
+  - `signal`
+  - `spawn_fail`
+  - `tool_crash`
+- The synthesized summary prefers a short `stderr.log` excerpt so SA-guard callers get structured failure output without reading raw logs directly.
+
+Why this scope:
+- The generic pipeline already handles many pre-exec, transport, post-exec, and dead-daemon reconciliation cases.
+- The remaining user-visible gap was review-specific error propagation that could escape without a terminal result file.
+- This keeps the fix tight while directly addressing the blocked `csa review --range main...HEAD` caller flow from #795.
+
+Regression coverage:
+- Added a test that creates a review session with no `result.toml`, injects a review failure carrying `meta_session_id=...`, synthesizes the fallback result, and verifies `handle_session_result(...)` can read it.
+
+Verification run:
+- `cargo test -p cli-sub-agent synthesize_missing_review_result_makes_session_result_readable`
+- `cargo test -p cli-sub-agent review_cmd::execute::tests`
+- `cargo test -p csa-session`
+- `cargo test -p csa-executor`
+- `cargo fmt --all`
+- `just pre-commit`


### PR DESCRIPTION
## Summary

`csa review` can terminate without producing a `result.toml` (tool timeout, spawn failure, tool crash, SIGKILL). SA-guard-compliant callers are forbidden from reading raw stdout.log/stderr.log, so they get stuck with no structured error.

This fix adds a review-layer fallback in `review_cmd_execute.rs`: when execution fails with a `meta_session_id` but no persisted `result.toml`, CSA synthesizes a minimal terminal `SessionResult` classifying the failure (timeout/signal/spawn_fail/tool_crash) and excerpting stderr.log into the summary field.

`csa session result` then renders this synthetic result.toml like any other — callers consume uniformly.

Closes #795.

## Scope

Option A per issue analysis. Does NOT include:
- Configurable `initial_response_timeout_seconds` (#795 Ask 2, future PR).
- Deeper root-cause investigation of `tools=-` spawn-phase failures (#795 Ask 3).

## Test plan

- [x] Regression test: session with no `result.toml` + injected review failure with `meta_session_id` → synthesized result → `handle_session_result()` reads it.
- [x] `just pre-commit` exit 0.