### PR TITLE
fix(csa-session): fix ACP attach routing + proptest coverage (#762)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ strix_runs
 # Review artifacts
 result.toml
 .letta/
+proptest-regressions/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3046,7 +3046,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -3096,7 +3096,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3121,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.310"
+version = "0.1.311"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.310"
+version = "0.1.311"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -779,21 +779,22 @@ pub(crate) fn handle_session_kill(session: String, cd: Option<String>) -> Result
         let err = std::io::Error::last_os_error();
         eprintln!("Warning: SIGKILL failed for PID {pid}: {err}");
     }
-
     // Wait for reaping.
     std::thread::sleep(std::time::Duration::from_millis(500));
     if is_pid_alive(pid) {
         anyhow::bail!(
             "Failed to kill session {} (PID {})",
             resolved.session_id,
-            pid,
+            pid
         );
     }
-
     eprintln!("Session {} killed", resolved.session_id);
     Ok(())
 }
 
+#[cfg(test)]
+#[path = "session_cmds_daemon_routing_proptest.rs"]
+mod session_cmds_daemon_routing_proptest;
 #[cfg(test)]
 #[path = "session_cmds_daemon_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
@@ -16,9 +16,22 @@ const ATTACH_ROUTE_POLL_INTERVAL: std::time::Duration = std::time::Duration::fro
 const ATTACH_METADATA_RETRY_MAX_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
 const ATTACH_STDOUT_LIVE_WINDOW: std::time::Duration = std::time::Duration::from_secs(3);
 
+fn runtime_binary_file_name(runtime_binary: &str) -> Option<&str> {
+    std::path::Path::new(runtime_binary)
+        .file_name()
+        .and_then(|name| name.to_str())
+}
+
+fn runtime_binary_indicates_codex_acp(runtime_binary: &str) -> bool {
+    runtime_binary_file_name(runtime_binary).is_some_and(|name| name.contains("codex-acp"))
+}
+
 fn routes_session_output_to_output_log(metadata: &csa_session::metadata::SessionMetadata) -> bool {
-    if metadata.runtime_binary.as_deref() == Some("codex-acp") {
-        return true;
+    if metadata.tool == "codex" {
+        return metadata
+            .runtime_binary
+            .as_deref()
+            .is_some_and(runtime_binary_indicates_codex_acp);
     }
     matches!(
         TransportFactory::mode_for_tool(&metadata.tool),
@@ -72,10 +85,11 @@ fn attach_primary_output_from_metadata_fragment(
     let runtime_binary = metadata_fragment_value(contents, "runtime_binary");
     let tool = metadata_fragment_value(contents, "tool").or_else(|| {
         let binary = runtime_binary.as_deref()?;
-        if binary == "codex" || binary == "codex-acp" {
+        let file_name = runtime_binary_file_name(binary).unwrap_or(binary);
+        if file_name == "codex" || runtime_binary_indicates_codex_acp(binary) {
             return Some("codex".to_string());
         }
-        binary
+        file_name
             .strip_suffix("-acp")
             .map(std::string::ToString::to_string)
     })?;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_routing_proptest.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_routing_proptest.rs
@@ -1,0 +1,130 @@
+use super::*;
+
+#[test]
+fn attach_primary_output_for_session_routes_expected_primary_log() {
+    for tool in attach_tool_cases() {
+        for runtime_binary in attach_runtime_binary_cases() {
+            for output_log_exists in [false, true] {
+                for stdout_log_exists in [false, true] {
+                    let route = attach_route_for_session(
+                        tool,
+                        runtime_binary,
+                        output_log_exists,
+                        stdout_log_exists,
+                        true,
+                    );
+
+                    if codex_routes_to_output_log(tool, runtime_binary) {
+                        assert_eq!(
+                            route,
+                            AttachPrimaryOutput::OutputLog,
+                            "codex ACP sessions must route to output.log: tool={tool} runtime_binary={runtime_binary:?} output_log_exists={output_log_exists} stdout_log_exists={stdout_log_exists}"
+                        );
+                    }
+
+                    if routes_to_output_log_independent_of_files(tool, runtime_binary) {
+                        assert_eq!(
+                            route,
+                            AttachPrimaryOutput::OutputLog,
+                            "ACP sessions must not pin to stdout.log: tool={tool} runtime_binary={runtime_binary:?} output_log_exists={output_log_exists} stdout_log_exists={stdout_log_exists}"
+                        );
+
+                        let flipped_route = attach_route_for_session(
+                            tool,
+                            runtime_binary,
+                            !output_log_exists,
+                            !stdout_log_exists,
+                            true,
+                        );
+                        assert_eq!(
+                            flipped_route, route,
+                            "ACP routing must not depend on log file existence: tool={tool} runtime_binary={runtime_binary:?}"
+                        );
+                    }
+
+                    if matches!(tool, "gemini-cli" | "opencode") {
+                        assert_eq!(
+                            route,
+                            AttachPrimaryOutput::StdoutLog,
+                            "legacy non-ACP tools may fall back to stdout.log: tool={tool} runtime_binary={runtime_binary:?} output_log_exists={output_log_exists} stdout_log_exists={stdout_log_exists}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn attach_route_for_session(
+    tool: &str,
+    runtime_binary: Option<&str>,
+    output_log_exists: bool,
+    stdout_log_exists: bool,
+    session_active: bool,
+) -> AttachPrimaryOutput {
+    let td = tempfile::tempdir().expect("tempdir");
+    let metadata = csa_session::metadata::SessionMetadata {
+        tool: tool.to_string(),
+        tool_locked: true,
+        runtime_binary: runtime_binary.map(std::string::ToString::to_string),
+    };
+    let metadata_toml = toml::to_string_pretty(&metadata).expect("metadata toml");
+    std::fs::write(
+        td.path().join(csa_session::metadata::METADATA_FILE_NAME),
+        metadata_toml,
+    )
+    .expect("write metadata");
+
+    if output_log_exists {
+        std::fs::write(td.path().join("output.log"), "output").expect("write output log");
+    }
+    if stdout_log_exists {
+        std::fs::write(td.path().join("stdout.log"), "stdout").expect("write stdout log");
+    }
+
+    if session_active {
+        let lock_name = match tool {
+            "codex" => "codex.lock",
+            "claude-code" => "claude-code.lock",
+            "gemini-cli" => "gemini-cli.lock",
+            "opencode" => "opencode.lock",
+            other => panic!("unsupported tool {other}"),
+        };
+        std::fs::create_dir_all(td.path().join("locks")).expect("create locks dir");
+        std::fs::write(
+            td.path().join("locks").join(lock_name),
+            format!("{{\"pid\":{}}}", std::process::id()),
+        )
+        .expect("write lock");
+    }
+
+    attach_primary_output_for_session(td.path())
+}
+
+fn attach_runtime_binary_cases() -> [Option<&'static str>; 4] {
+    [
+        None,
+        Some("/opt/csa/bin/codex"),
+        Some("/opt/csa/bin/codex-acp"),
+        Some("/opt/csa/bin/claude-code"),
+    ]
+}
+
+fn attach_tool_cases() -> [&'static str; 4] {
+    ["codex", "claude-code", "gemini-cli", "opencode"]
+}
+
+fn codex_routes_to_output_log(tool: &str, runtime_binary: Option<&str>) -> bool {
+    tool == "codex" && runtime_binary.is_none_or(runtime_binary_indicates_codex_acp)
+}
+
+fn routes_to_output_log_independent_of_files(tool: &str, runtime_binary: Option<&str>) -> bool {
+    tool == "claude-code" || codex_routes_to_output_log(tool, runtime_binary)
+}
+
+fn runtime_binary_indicates_codex_acp(runtime_binary: &str) -> bool {
+    std::path::Path::new(runtime_binary)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.contains("codex-acp"))
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
@@ -623,7 +623,7 @@ proptest::proptest! {
         session_active in proptest::prelude::any::<bool>(),
     ) {
         let result = attach_route_for(tool, runtime_binary, output_log_exists, session_active);
-        if runtime_binary == Some("codex-acp") {
+        if tool == "codex" && runtime_binary == Some("codex-acp") {
             proptest::prop_assert_eq!(
                 result,
                 AttachPrimaryOutput::OutputLog,

--- a/crates/cli-sub-agent/tests/config_get_global_warning_e2e.rs
+++ b/crates/cli-sub-agent/tests/config_get_global_warning_e2e.rs
@@ -50,7 +50,7 @@ fn config_get_global_warns_when_falling_back_to_raw_invalid_global_config() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let global_config_path = global_config_path(tmp.path());
     let global_dir = global_config_path.parent().expect("global config dir");
-    std::fs::create_dir_all(&global_dir).expect("create global config dir");
+    std::fs::create_dir_all(global_dir).expect("create global config dir");
     std::fs::write(
         &global_config_path,
         r#"

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -361,7 +361,7 @@ fn config_get_prefers_effective_tool_state_over_raw_project_value() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let global_config_path = global_config_path(tmp.path());
     let global_dir = global_config_path.parent().expect("global config dir");
-    std::fs::create_dir_all(&global_dir).expect("create global config dir");
+    std::fs::create_dir_all(global_dir).expect("create global config dir");
     std::fs::write(
         &global_config_path,
         r#"
@@ -398,7 +398,7 @@ fn config_get_redacts_global_memory_api_keys_in_project_scoped_lookups() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let global_config_path = global_config_path(tmp.path());
     let global_dir = global_config_path.parent().expect("global config dir");
-    std::fs::create_dir_all(&global_dir).expect("create global config dir");
+    std::fs::create_dir_all(global_dir).expect("create global config dir");
     std::fs::write(
         &global_config_path,
         r#"
@@ -444,7 +444,7 @@ fn config_get_falls_back_to_raw_project_value_when_global_config_is_invalid() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let global_config_path = global_config_path(tmp.path());
     let global_dir = global_config_path.parent().expect("global config dir");
-    std::fs::create_dir_all(&global_dir).expect("create global config dir");
+    std::fs::create_dir_all(global_dir).expect("create global config dir");
     std::fs::write(&global_config_path, "{{invalid toml").expect("write invalid global config");
 
     let config_path = csa_config::ProjectConfig::config_path(tmp.path());

--- a/crates/csa-config/src/config_merge_tests_tail.rs
+++ b/crates/csa-config/src/config_merge_tests_tail.rs
@@ -176,9 +176,10 @@ fn test_execution_config_is_not_default_with_custom_value() {
 
 #[test]
 fn test_execution_config_resolved_acp_crash_max_attempts_clamps() {
-    let mut exec = crate::config::ExecutionConfig::default();
-
-    exec.acp_crash_max_attempts = 0;
+    let mut exec = crate::config::ExecutionConfig {
+        acp_crash_max_attempts: 0,
+        ..Default::default()
+    };
     assert_eq!(exec.resolved_acp_crash_max_attempts(), 1);
 
     exec.acp_crash_max_attempts = 2;

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,10 @@ ignore = [
     # Transitive from cc-sdk -> reqwest -> rustls. CRL revocation check bug.
     # Safe default (UnknownStatusPolicy::Deny) mitigates impact.
     "RUSTSEC-2026-0049",
+    # Transitive from rustls-webpki 0.101.7 (old chain). URI name constraints bypass.
+    "RUSTSEC-2026-0098",
+    # Transitive from rustls-webpki 0.101.7 (old chain). Wildcard name constraints bypass.
+    "RUSTSEC-2026-0099",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

- Fixes ACP attach routing: `attach_primary_output_for_session` now routes codex ACP sessions to `OutputLog` regardless of file existence, eliminating the TOCTOU race from #753 round 8.
- Adds property-based regression test covering all 64 input combinations (tool × runtime_binary × output_log_exists × stdout_log_exists) against 4 invariants.
- Drive-by: 4 pre-existing clippy warnings in test modules, rustls-webpki 0.103.10→0.103.12 (GHSA-xgp8-3hg3-c2mh), and deny.toml ignores for two transitive advisories (RUSTSEC-2026-0098/0099) in the unavoidable 0.101.7 chain.

## Test plan

- [x] `cargo test` — full suite green (including new proptest)
- [x] `cargo clippy` — clean
- [x] `cargo deny check` — passes with updated ignore list
- [x] `csa review --range main...HEAD` — Pass (session 01KPCF8VJ7XAXVXVDAER2VHAW3)
- [ ] pr-bot cloud review

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)