### PR TITLE
fix(csa-review): codex review ping-pong mitigations (#821)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.319"
+version = "0.1.320"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.321"
+version = "0.1.322"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.311"
+version = "0.1.319"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.320"
+version = "0.1.321"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.322"
+version = "0.1.323"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.321"
+version = "0.1.322"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.320"
+version = "0.1.321"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.322"
+version = "0.1.323"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.319"
+version = "0.1.320"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.311"
+version = "0.1.319"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_bug_class.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use csa_session::ReviewSessionMeta;
 use csa_session::review_artifact::ReviewArtifact;
 use tracing::{info, warn};
 
@@ -10,6 +9,9 @@ use crate::bug_class::{
     SkillExtractor, classify_recurring_bug_classes, load_review_artifacts_for_project,
 };
 use crate::review_consensus::build_consolidated_artifact;
+use crate::review_consensus::review_iteration_resolver::{
+    load_review_meta, try_max_review_iterations_for_branch,
+};
 
 const REVIEW_CONSOLIDATED_ARTIFACT_FILE: &str = "review-findings-consolidated.json";
 const REVIEW_FINDINGS_ARTIFACT_FILE: &str = "review-findings.json";
@@ -243,39 +245,8 @@ pub(super) fn try_resolve_review_iterations(project_root: &Path, session_id: &st
         return Ok(1);
     };
 
-    let max_review_iterations = csa_session::list_sessions(project_root, None)?
-        .into_iter()
-        .filter(|candidate| candidate.meta_session_id != session_id)
-        .filter(|candidate| {
-            candidate.resolved_identity().ref_name.as_deref() == Some(branch.as_str())
-        })
-        .try_fold(0_u32, |max_review_iterations, candidate| {
-            let review_iterations =
-                load_review_iterations(project_root, &candidate.meta_session_id)?.unwrap_or(0);
-            Ok::<u32, anyhow::Error>(max_review_iterations.max(review_iterations))
-        })?;
+    let max_review_iterations =
+        try_max_review_iterations_for_branch(project_root, &branch, Some(session_id))?;
 
     Ok(std::cmp::max(1, max_review_iterations.saturating_add(1)))
-}
-
-fn load_review_iterations(project_root: &Path, session_id: &str) -> Result<Option<u32>> {
-    Ok(
-        load_review_meta(project_root, session_id)?
-            .map(|review_meta| review_meta.review_iterations),
-    )
-}
-
-fn load_review_meta(project_root: &Path, session_id: &str) -> Result<Option<ReviewSessionMeta>> {
-    let session_dir = csa_session::get_session_dir(project_root, session_id)
-        .with_context(|| format!("failed to resolve review session dir for {session_id}"))?;
-    let review_meta_path = session_dir.join("review_meta.json");
-    if !review_meta_path.is_file() {
-        return Ok(None);
-    }
-
-    let content = std::fs::read_to_string(&review_meta_path)
-        .with_context(|| format!("failed to read {}", review_meta_path.display()))?;
-    let review_meta: ReviewSessionMeta = serde_json::from_str(&content)
-        .with_context(|| format!("failed to parse {}", review_meta_path.display()))?;
-    Ok(Some(review_meta))
 }

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -538,6 +538,7 @@ pub(crate) fn build_review_instruction(
             instruction.push_str(&render_spec_review_context(spec));
         }
     }
+    append_design_anchor(&mut instruction);
     instruction
 }
 
@@ -568,6 +569,16 @@ pub(crate) fn build_review_instruction_for_project(
     // Inject prior-round assumptions when a previous review session exists on
     // the same branch (#764). Skipped on first-round reviews.
     let branch = current_git_branch_for_review(project_root);
+    if let Some(branch) = branch.as_deref()
+        && let Some(iteration_context) =
+            crate::review_consensus::review_iteration::render_review_iteration_context(
+                project_root,
+                branch,
+            )
+    {
+        instruction.push_str("\n\n");
+        instruction.push_str(&iteration_context);
+    }
     if let Some(prior) = discover_prior_round_assumptions(project_root, branch.as_deref(), None) {
         instruction.push_str(&prior);
     }
@@ -578,6 +589,14 @@ pub(crate) fn build_review_instruction_for_project(
 fn current_git_branch_for_review(project_root: &Path) -> Option<String> {
     let backend = csa_session::vcs_backends::create_vcs_backend(project_root);
     backend.current_branch(project_root).ok().flatten()
+}
+
+fn append_design_anchor(prompt: &mut String) {
+    if prompt.contains("## Design preferences vs correctness bugs") {
+        return;
+    }
+    prompt.push_str("\n\n");
+    prompt.push_str(crate::review_consensus::review_design_anchor::REVIEW_DESIGN_PREFERENCE_ANCHOR);
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -287,3 +287,24 @@ fn count_prior_reviews_branch_unknown_falls_back_to_recent_reviews() {
 
     assert_eq!(count_prior_reviews_for_branch(project_dir.path(), None), 2);
 }
+
+#[test]
+fn count_prior_reviews_uses_canonical_max_after_more_than_ten_prior_reviews() {
+    let project_dir = tempdir().unwrap();
+    init_git_repo_with_branch(project_dir.path(), "feat/iter-many");
+
+    for iteration in 1..=12 {
+        create_mock_review_session(
+            project_dir.path(),
+            &format!("01K7ER7A0E{:016}", iteration),
+            Some("feat/iter-many"),
+            "fail",
+            iteration,
+        );
+    }
+
+    assert_eq!(
+        count_prior_reviews_for_branch(project_dir.path(), Some("feat/iter-many")),
+        12
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -1,0 +1,182 @@
+use super::*;
+use crate::review_consensus::review_iteration::count_prior_reviews_for_branch;
+use crate::test_env_lock::TEST_ENV_LOCK;
+use chrono::Utc;
+use csa_core::types::ToolName;
+use csa_session::{ReviewSessionMeta, get_session_root, write_review_meta};
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+struct CurrentDirGuard {
+    original: std::path::PathBuf,
+}
+
+impl CurrentDirGuard {
+    fn change_to(path: &Path) -> Self {
+        let original = std::env::current_dir().expect("current dir");
+        std::env::set_current_dir(path).expect("set current dir");
+        Self { original }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.original);
+    }
+}
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .expect("spawn git");
+    assert!(
+        status.success(),
+        "git command failed: git {}",
+        args.join(" ")
+    );
+}
+
+fn init_git_repo_with_branch(dir: &Path, branch: &str) {
+    run_git(dir, &["init", "--initial-branch", branch]);
+    run_git(dir, &["config", "user.name", "Test User"]);
+    run_git(dir, &["config", "user.email", "test@example.com"]);
+    std::fs::write(dir.join("README.md"), "# test\n").expect("write README");
+    run_git(dir, &["add", "README.md"]);
+    run_git(dir, &["commit", "-m", "init"]);
+}
+
+fn make_review_meta(session_id: &str, decision: &str, review_iterations: u32) -> ReviewSessionMeta {
+    ReviewSessionMeta {
+        session_id: session_id.to_string(),
+        head_sha: "deadbeef".to_string(),
+        decision: decision.to_string(),
+        verdict: decision.to_ascii_uppercase(),
+        tool: "codex".to_string(),
+        scope: "uncommitted".to_string(),
+        exit_code: 0,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations,
+        timestamp: Utc::now(),
+        diff_fingerprint: None,
+    }
+}
+
+fn create_mock_review_session(
+    project_root: &Path,
+    session_id: &str,
+    decision: &str,
+    review_iterations: u32,
+) {
+    let session_root = get_session_root(project_root).expect("resolve session root");
+    let session_dir = session_root.join("sessions").join(session_id);
+    std::fs::create_dir_all(&session_dir).expect("create mock session dir");
+    write_review_meta(
+        &session_dir,
+        &make_review_meta(session_id, decision, review_iterations),
+    )
+    .expect("write review meta");
+}
+
+#[test]
+fn build_review_instruction_for_project_contains_design_preference_anchor() {
+    let project_dir = tempdir().unwrap();
+    let (instruction, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        None,
+    );
+
+    assert!(instruction.contains("Design preferences vs correctness bugs"));
+}
+
+#[test]
+fn build_multi_reviewer_instruction_contains_design_preference_anchor() {
+    let prompt = crate::review_consensus::build_multi_reviewer_instruction(
+        "Base prompt",
+        1,
+        ToolName::Codex,
+    );
+
+    assert!(prompt.contains("Design preferences vs correctness bugs"));
+}
+
+#[test]
+fn count_prior_reviews_zero_omits_iteration_block() {
+    let project_dir = tempdir().unwrap();
+    init_git_repo_with_branch(project_dir.path(), "feat/iter-zero");
+
+    assert_eq!(
+        count_prior_reviews_for_branch(project_dir.path(), "feat/iter-zero"),
+        0
+    );
+
+    let (instruction, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        None,
+    );
+
+    assert!(!instruction.contains("## Review iteration context"));
+}
+
+#[test]
+fn count_prior_reviews_one_injects_iteration_two() {
+    let project_dir = tempdir().unwrap();
+    init_git_repo_with_branch(project_dir.path(), "feat/iter-one");
+    create_mock_review_session(project_dir.path(), "01KITERONE0000000000000001", "fail", 1);
+
+    assert_eq!(
+        count_prior_reviews_for_branch(project_dir.path(), "feat/iter-one"),
+        1
+    );
+
+    let (instruction, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        None,
+    );
+
+    assert!(instruction.contains("This is review iteration 2 on branch 'feat/iter-one'."));
+    assert!(instruction.contains("Prior review count on this branch: 1."));
+}
+
+#[test]
+fn count_prior_reviews_three_adds_multi_round_escalation() {
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let project_dir = tempdir().unwrap();
+    init_git_repo_with_branch(project_dir.path(), "feat/iter-three");
+    create_mock_review_session(project_dir.path(), "01KITERTHREE00000000000001", "fail", 1);
+    create_mock_review_session(project_dir.path(), "01KITERTHREE00000000000002", "fail", 2);
+    create_mock_review_session(project_dir.path(), "01KITERTHREE00000000000003", "pass", 3);
+
+    assert_eq!(
+        count_prior_reviews_for_branch(project_dir.path(), "feat/iter-three"),
+        3
+    );
+
+    let _cwd = CurrentDirGuard::change_to(project_dir.path());
+    let prompt = crate::review_consensus::build_multi_reviewer_instruction(
+        "Base prompt",
+        2,
+        ToolName::Codex,
+    );
+
+    assert!(prompt.contains("Prior review count on this branch: 3."));
+    assert!(prompt.contains("Multiple prior rounds have fired on this branch."));
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -267,7 +267,7 @@ fn count_prior_reviews_does_not_pull_reviews_from_other_branches() {
 }
 
 #[test]
-fn count_prior_reviews_branch_unknown_falls_back_to_recent_reviews() {
+fn count_prior_reviews_branch_unknown_returns_safe_zero() {
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-unknown");
     create_mock_review_session(
@@ -285,7 +285,9 @@ fn count_prior_reviews_branch_unknown_falls_back_to_recent_reviews() {
         2,
     );
 
-    assert_eq!(count_prior_reviews_for_branch(project_dir.path(), None), 2);
+    // Branch-unknown must yield zero to avoid cross-branch contamination; mirror
+    // review_context.rs:187 behavior.
+    assert_eq!(count_prior_reviews_for_branch(project_dir.path(), None), 0);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -239,6 +239,45 @@ fn count_prior_reviews_three_adds_multi_round_escalation() {
 
     assert!(prompt.contains("Prior review count on this branch: 3."));
     assert!(prompt.contains("Multiple prior rounds have fired on this branch."));
+    assert!(prompt.contains("Oscillating DESIGN choices"));
+    assert!(prompt.contains("Still broken from last round is still broken."));
+}
+
+#[test]
+fn multi_round_escalation_keeps_persistent_correctness_bugs_blocking() {
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let project_dir = tempdir().unwrap();
+    init_git_repo_with_branch(project_dir.path(), "feat/iter-persistent-bug");
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000041",
+        Some("feat/iter-persistent-bug"),
+        "fail",
+        1,
+    );
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000042",
+        Some("feat/iter-persistent-bug"),
+        "fail",
+        2,
+    );
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000043",
+        Some("feat/iter-persistent-bug"),
+        "pass",
+        3,
+    );
+
+    let _cwd = CurrentDirGuard::change_to(project_dir.path());
+    let prompt = crate::review_consensus::build_multi_reviewer_instruction(
+        "Base prompt",
+        2,
+        ToolName::Codex,
+    );
+
+    assert!(prompt.contains("persistent correctness bugs remain blocking"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -3,7 +3,11 @@ use crate::review_consensus::review_iteration::count_prior_reviews_for_branch;
 use crate::test_env_lock::TEST_ENV_LOCK;
 use chrono::Utc;
 use csa_core::types::ToolName;
-use csa_session::{ReviewSessionMeta, get_session_root, write_review_meta};
+use csa_session::{
+    Genealogy, MetaSessionState, ReviewSessionMeta, SessionPhase, TaskContext, get_session_root,
+    save_session, write_review_meta,
+};
+use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
 use tempfile::tempdir;
@@ -68,12 +72,44 @@ fn make_review_meta(session_id: &str, decision: &str, review_iterations: u32) ->
 fn create_mock_review_session(
     project_root: &Path,
     session_id: &str,
+    branch: Option<&str>,
     decision: &str,
     review_iterations: u32,
 ) {
     let session_root = get_session_root(project_root).expect("resolve session root");
     let session_dir = session_root.join("sessions").join(session_id);
     std::fs::create_dir_all(&session_dir).expect("create mock session dir");
+    save_session(&MetaSessionState {
+        meta_session_id: session_id.to_string(),
+        description: None,
+        project_path: project_root.display().to_string(),
+        branch: branch.map(str::to_string),
+        created_at: Utc::now(),
+        last_accessed: Utc::now(),
+        genealogy: Genealogy {
+            parent_session_id: None,
+            depth: 0,
+            ..Default::default()
+        },
+        tools: HashMap::new(),
+        context_status: Default::default(),
+        total_token_usage: None,
+        phase: SessionPhase::Available,
+        task_context: TaskContext::default(),
+        turn_count: 0,
+        token_budget: None,
+        sandbox_info: None,
+        termination_reason: None,
+        is_seed_candidate: false,
+        git_head_at_creation: None,
+        last_return_packet: None,
+        change_id: None,
+        spec_id: None,
+        vcs_identity: None,
+        identity_version: 1,
+        fork_call_timestamps: Vec::new(),
+    })
+    .expect("write mock session state");
     write_review_meta(
         &session_dir,
         &make_review_meta(session_id, decision, review_iterations),
@@ -114,7 +150,7 @@ fn count_prior_reviews_zero_omits_iteration_block() {
     init_git_repo_with_branch(project_dir.path(), "feat/iter-zero");
 
     assert_eq!(
-        count_prior_reviews_for_branch(project_dir.path(), "feat/iter-zero"),
+        count_prior_reviews_for_branch(project_dir.path(), Some("feat/iter-zero")),
         0
     );
 
@@ -135,10 +171,16 @@ fn count_prior_reviews_zero_omits_iteration_block() {
 fn count_prior_reviews_one_injects_iteration_two() {
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-one");
-    create_mock_review_session(project_dir.path(), "01KITERONE0000000000000001", "fail", 1);
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000001",
+        Some("feat/iter-one"),
+        "fail",
+        1,
+    );
 
     assert_eq!(
-        count_prior_reviews_for_branch(project_dir.path(), "feat/iter-one"),
+        count_prior_reviews_for_branch(project_dir.path(), Some("feat/iter-one")),
         1
     );
 
@@ -161,12 +203,30 @@ fn count_prior_reviews_three_adds_multi_round_escalation() {
     let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-three");
-    create_mock_review_session(project_dir.path(), "01KITERTHREE00000000000001", "fail", 1);
-    create_mock_review_session(project_dir.path(), "01KITERTHREE00000000000002", "fail", 2);
-    create_mock_review_session(project_dir.path(), "01KITERTHREE00000000000003", "pass", 3);
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000011",
+        Some("feat/iter-three"),
+        "fail",
+        1,
+    );
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000012",
+        Some("feat/iter-three"),
+        "fail",
+        2,
+    );
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000013",
+        Some("feat/iter-three"),
+        "pass",
+        3,
+    );
 
     assert_eq!(
-        count_prior_reviews_for_branch(project_dir.path(), "feat/iter-three"),
+        count_prior_reviews_for_branch(project_dir.path(), Some("feat/iter-three")),
         3
     );
 
@@ -179,4 +239,51 @@ fn count_prior_reviews_three_adds_multi_round_escalation() {
 
     assert!(prompt.contains("Prior review count on this branch: 3."));
     assert!(prompt.contains("Multiple prior rounds have fired on this branch."));
+}
+
+#[test]
+fn count_prior_reviews_does_not_pull_reviews_from_other_branches() {
+    let project_dir = tempdir().unwrap();
+    init_git_repo_with_branch(project_dir.path(), "feat/iter-current");
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000021",
+        Some("feat/iter-other"),
+        "fail",
+        1,
+    );
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000022",
+        Some("feat/iter-other"),
+        "pass",
+        2,
+    );
+
+    assert_eq!(
+        count_prior_reviews_for_branch(project_dir.path(), Some("feat/iter-current")),
+        0
+    );
+}
+
+#[test]
+fn count_prior_reviews_branch_unknown_falls_back_to_recent_reviews() {
+    let project_dir = tempdir().unwrap();
+    init_git_repo_with_branch(project_dir.path(), "feat/iter-unknown");
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000031",
+        Some("feat/iter-a"),
+        "fail",
+        1,
+    );
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000032",
+        Some("feat/iter-b"),
+        "pass",
+        2,
+    );
+
+    assert_eq!(count_prior_reviews_for_branch(project_dir.path(), None), 2);
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -336,12 +336,13 @@ fn test_build_review_instruction_no_diff_content() {
         None,
     );
     assert!(
-        result.len() < 900,
-        "Instruction should be concise (preamble + params), got {} chars",
+        result.len() < 2200,
+        "Instruction should stay bounded even with the design anchor, got {} chars",
         result.len()
     );
     assert!(!result.contains("git diff"));
     assert!(!result.contains("Pass 1:"));
+    assert!(result.contains("Design preferences vs correctness bugs"));
 }
 
 #[test]
@@ -794,3 +795,6 @@ fn build_review_instruction_for_project_omits_checklist_when_missing() {
         "instruction should not contain review-checklist tag when file is missing"
     );
 }
+
+#[path = "review_cmd_tests_iteration.rs"]
+mod review_cmd_tests_iteration;

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -19,6 +19,11 @@ use csa_core::types::ToolName;
 use csa_executor::{CodexRuntimeMetadata, CodexTransport};
 use csa_session::review_artifact::{Finding, ReviewArtifact, SeveritySummary};
 
+#[path = "review_design_anchor.rs"]
+pub(crate) mod review_design_anchor;
+#[path = "review_iteration.rs"]
+pub(crate) mod review_iteration;
+
 pub(crate) const CLEAN: &str = "CLEAN";
 pub(crate) const HAS_ISSUES: &str = "HAS_ISSUES";
 
@@ -27,6 +32,14 @@ pub(crate) const HAS_ISSUES: &str = "HAS_ISSUES";
 pub(crate) const RULE_SPEC_DEVIATION: &str = "spec-deviation";
 pub(crate) const RULE_UNVERIFIED_CRITERION: &str = "unverified-criterion";
 pub(crate) const RULE_BOUNDARY_VIOLATION: &str = "boundary-violation";
+
+fn append_design_anchor(prompt: &mut String) {
+    if prompt.contains("## Design preferences vs correctness bugs") {
+        return;
+    }
+    prompt.push_str("\n\n");
+    prompt.push_str(review_design_anchor::REVIEW_DESIGN_PREFERENCE_ANCHOR);
+}
 
 #[cfg(test)]
 fn reviewer_tool_binary_available(_tool_name: &str, _config: Option<&ProjectConfig>) -> bool {
@@ -152,7 +165,7 @@ pub(crate) fn build_multi_reviewer_instruction(
     tool: ToolName,
 ) -> String {
     let output_dir = reviewer_output_dir(reviewer_index);
-    format!(
+    let mut prompt = format!(
         "{base_prompt}\n\
 You are reviewer {reviewer_index}. Emit exactly one final verdict token: \
 PASS, FAIL, SKIP, or UNCERTAIN.\n\
@@ -169,7 +182,21 @@ When spec/contract context is provided, use rule_id values: \
 '{RULE_BOUNDARY_VIOLATION}' (change exceeds spec scope).\n\
 Reviewer tool hint: {}.",
         tool.as_str()
-    )
+    );
+    append_design_anchor(&mut prompt);
+    if !prompt.contains("## Review iteration context")
+        && let Ok(project_root) = std::env::current_dir()
+    {
+        let backend = csa_session::vcs_backends::create_vcs_backend(&project_root);
+        if let Ok(Some(branch)) = backend.current_branch(&project_root)
+            && let Some(iteration_context) =
+                review_iteration::render_review_iteration_context(&project_root, &branch)
+        {
+            prompt.push_str("\n\n");
+            prompt.push_str(&iteration_context);
+        }
+    }
+    prompt
 }
 
 fn reviewer_output_dir(reviewer_index: usize) -> String {

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -23,6 +23,8 @@ use csa_session::review_artifact::{Finding, ReviewArtifact, SeveritySummary};
 pub(crate) mod review_design_anchor;
 #[path = "review_iteration.rs"]
 pub(crate) mod review_iteration;
+#[path = "review_iteration_resolver.rs"]
+pub(crate) mod review_iteration_resolver;
 
 pub(crate) const CLEAN: &str = "CLEAN";
 pub(crate) const HAS_ISSUES: &str = "HAS_ISSUES";

--- a/crates/cli-sub-agent/src/review_design_anchor.rs
+++ b/crates/cli-sub-agent/src/review_design_anchor.rs
@@ -1,0 +1,14 @@
+pub(crate) const REVIEW_DESIGN_PREFERENCE_ANCHOR: &str = r#"## Design preferences vs correctness bugs
+
+When reviewing diffs that touch design-level choices (preserve-vs-overwrite semantics, where to persist artifacts, API surface shapes, which lifecycle stages trigger which side-effects), treat the current choice as a DESIGN PREFERENCE if it has a coherent rationale, not as a correctness bug.
+
+Issue FAIL verdicts ONLY for:
+- Demonstrable data loss (e.g. unconditional delete of in-flight data, wrong write order that overwrites newer state)
+- Crash paths (unwrap on untrusted data, missing error handling that panics)
+- Contract violations (schema breakage, broken backward compatibility within a stable API)
+- Obvious security issues (injection, credential leakage, path traversal)
+
+Design preferences may have multiple valid answers. If the current choice works, is readable, and has a rationale documented in the commit message or the code itself, prefer PASS for that dimension. Surface design concerns as LOW-severity advisory notes, never as blocking FAIL findings.
+
+Rationale: review ping-pong on design preferences wastes iterations and does NOT converge to better code quality. A reviewer that flip-flops on the same design point across rounds is a stronger signal of design residual than of real bugs.
+"#;

--- a/crates/cli-sub-agent/src/review_iteration.rs
+++ b/crates/cli-sub-agent/src/review_iteration.rs
@@ -1,8 +1,5 @@
 use std::path::Path;
 
-use chrono::{Duration, Utc};
-use csa_session::{ReviewSessionMeta, get_session_root};
-
 use super::review_iteration_resolver::try_max_review_iterations_for_branch;
 
 const REVIEW_ITERATION_HEADER: &str = "## Review iteration context";
@@ -18,7 +15,7 @@ pub(crate) fn count_prior_reviews_for_branch(project_root: &Path, branch: Option
         )
         .map(|iterations| iterations as usize)
         .unwrap_or(0),
-        None => count_recent_reviews(project_root, current_session_id.as_deref()),
+        None => 0,
     }
 }
 
@@ -38,49 +35,4 @@ pub(crate) fn render_review_iteration_context(project_root: &Path, branch: &str)
         rendered.push('\n');
     }
     Some(rendered)
-}
-
-fn count_recent_reviews(project_root: &Path, exclude_session_id: Option<&str>) -> usize {
-    let cutoff = Utc::now() - Duration::hours(24);
-    let session_dirs = match list_session_dirs(project_root) {
-        Ok(session_dirs) => session_dirs,
-        Err(_) => return 0,
-    };
-
-    session_dirs
-        .into_iter()
-        .filter(|session_dir| {
-            exclude_session_id != session_dir.file_name().and_then(|name| name.to_str())
-        })
-        .filter_map(|session_dir| load_review_meta_from_dir(&session_dir))
-        .filter(|meta| meta.timestamp >= cutoff)
-        .count()
-}
-
-fn list_session_dirs(project_root: &Path) -> std::io::Result<Vec<std::path::PathBuf>> {
-    let session_root = get_session_root(project_root)
-        .map_err(std::io::Error::other)?
-        .join("sessions");
-    if !session_root.is_dir() {
-        return Ok(Vec::new());
-    }
-
-    let mut session_dirs = Vec::new();
-    for entry in std::fs::read_dir(session_root)? {
-        let entry = entry?;
-        if entry.file_type()?.is_dir() {
-            session_dirs.push(entry.path());
-        }
-    }
-    Ok(session_dirs)
-}
-
-fn load_review_meta_from_dir(session_dir: &Path) -> Option<ReviewSessionMeta> {
-    let review_meta_path = session_dir.join("review_meta.json");
-    if !review_meta_path.is_file() {
-        return None;
-    }
-
-    let content = std::fs::read_to_string(review_meta_path).ok()?;
-    serde_json::from_str(&content).ok()
 }

--- a/crates/cli-sub-agent/src/review_iteration.rs
+++ b/crates/cli-sub-agent/src/review_iteration.rs
@@ -1,47 +1,34 @@
 use std::path::Path;
 
 use chrono::{Duration, Utc};
-use csa_session::{
-    ReviewSessionMeta, find_sessions, get_session_dir, get_session_root, list_sessions,
-};
+use csa_session::{ReviewSessionMeta, find_sessions, get_session_dir, get_session_root};
 
 const REVIEW_ITERATION_HEADER: &str = "## Review iteration context";
 const MULTI_ROUND_ESCALATION: &str = "Multiple prior rounds have fired on this branch. Oscillating verdicts across rounds indicate design residuals, not bugs. Strongly prefer PASS for any finding that overlaps with prior rounds' concerns — FAIL only for NEW correctness bugs (crash, data loss, contract violation) not previously raised.";
 
-pub(crate) fn count_prior_reviews_for_branch(project_root: &Path, branch: &str) -> usize {
+pub(crate) fn count_prior_reviews_for_branch(project_root: &Path, branch: Option<&str>) -> usize {
     let current_session_id = std::env::var("CSA_SESSION_ID").ok();
-    let sessions = match find_sessions(project_root, Some(branch), None, None, None) {
-        Ok(sessions) => sessions,
-        Err(_) => return 0,
-    };
+    match branch {
+        Some(branch) => {
+            let sessions = match find_sessions(project_root, Some(branch), None, None, None) {
+                Ok(sessions) => sessions,
+                Err(_) => return 0,
+            };
 
-    if sessions.is_empty() {
-        let all_sessions = match list_sessions(project_root, None) {
-            Ok(sessions) => sessions,
-            Err(_) => return 0,
-        };
-        let saw_branch_metadata = all_sessions
-            .iter()
-            .any(|session| session.resolved_identity().ref_name.is_some());
-        if !saw_branch_metadata {
-            // Older session state may not persist branch/ref metadata reliably.
-            // Fall back to counting recent review sessions so repeated same-day
-            // review loops still receive anti-flip guidance instead of silently
-            // dropping all iteration context.
-            return count_recent_reviews(project_root, current_session_id.as_deref());
+            sessions
+                .into_iter()
+                .filter(|session| {
+                    current_session_id.as_deref() != Some(session.meta_session_id.as_str())
+                })
+                .filter_map(|session| load_review_meta(project_root, &session.meta_session_id))
+                .count()
         }
-        return count_recent_reviews(project_root, current_session_id.as_deref());
+        None => count_recent_reviews(project_root, current_session_id.as_deref()),
     }
-
-    sessions
-        .into_iter()
-        .filter(|session| current_session_id.as_deref() != Some(session.meta_session_id.as_str()))
-        .filter_map(|session| load_review_meta(project_root, &session.meta_session_id))
-        .count()
 }
 
 pub(crate) fn render_review_iteration_context(project_root: &Path, branch: &str) -> Option<String> {
-    let prior_count = count_prior_reviews_for_branch(project_root, branch);
+    let prior_count = count_prior_reviews_for_branch(project_root, Some(branch));
     if prior_count == 0 {
         return None;
     }

--- a/crates/cli-sub-agent/src/review_iteration.rs
+++ b/crates/cli-sub-agent/src/review_iteration.rs
@@ -1,0 +1,109 @@
+use std::path::Path;
+
+use chrono::{Duration, Utc};
+use csa_session::{
+    ReviewSessionMeta, find_sessions, get_session_dir, get_session_root, list_sessions,
+};
+
+const REVIEW_ITERATION_HEADER: &str = "## Review iteration context";
+const MULTI_ROUND_ESCALATION: &str = "Multiple prior rounds have fired on this branch. Oscillating verdicts across rounds indicate design residuals, not bugs. Strongly prefer PASS for any finding that overlaps with prior rounds' concerns — FAIL only for NEW correctness bugs (crash, data loss, contract violation) not previously raised.";
+
+pub(crate) fn count_prior_reviews_for_branch(project_root: &Path, branch: &str) -> usize {
+    let current_session_id = std::env::var("CSA_SESSION_ID").ok();
+    let sessions = match find_sessions(project_root, Some(branch), None, None, None) {
+        Ok(sessions) => sessions,
+        Err(_) => return 0,
+    };
+
+    if sessions.is_empty() {
+        let all_sessions = match list_sessions(project_root, None) {
+            Ok(sessions) => sessions,
+            Err(_) => return 0,
+        };
+        let saw_branch_metadata = all_sessions
+            .iter()
+            .any(|session| session.resolved_identity().ref_name.is_some());
+        if !saw_branch_metadata {
+            // Older session state may not persist branch/ref metadata reliably.
+            // Fall back to counting recent review sessions so repeated same-day
+            // review loops still receive anti-flip guidance instead of silently
+            // dropping all iteration context.
+            return count_recent_reviews(project_root, current_session_id.as_deref());
+        }
+        return count_recent_reviews(project_root, current_session_id.as_deref());
+    }
+
+    sessions
+        .into_iter()
+        .filter(|session| current_session_id.as_deref() != Some(session.meta_session_id.as_str()))
+        .filter_map(|session| load_review_meta(project_root, &session.meta_session_id))
+        .count()
+}
+
+pub(crate) fn render_review_iteration_context(project_root: &Path, branch: &str) -> Option<String> {
+    let prior_count = count_prior_reviews_for_branch(project_root, branch);
+    if prior_count == 0 {
+        return None;
+    }
+
+    let mut rendered = format!(
+        "{REVIEW_ITERATION_HEADER}\n\nThis is review iteration {} on branch '{branch}'. Prior review count on this branch: {prior_count}.\n",
+        prior_count + 1
+    );
+    if prior_count >= 3 {
+        rendered.push('\n');
+        rendered.push_str(MULTI_ROUND_ESCALATION);
+        rendered.push('\n');
+    }
+    Some(rendered)
+}
+
+fn count_recent_reviews(project_root: &Path, exclude_session_id: Option<&str>) -> usize {
+    let cutoff = Utc::now() - Duration::hours(24);
+    let session_dirs = match list_session_dirs(project_root) {
+        Ok(session_dirs) => session_dirs,
+        Err(_) => return 0,
+    };
+
+    session_dirs
+        .into_iter()
+        .filter(|session_dir| {
+            exclude_session_id != session_dir.file_name().and_then(|name| name.to_str())
+        })
+        .filter_map(|session_dir| load_review_meta_from_dir(&session_dir))
+        .filter(|meta| meta.timestamp >= cutoff)
+        .count()
+}
+
+fn list_session_dirs(project_root: &Path) -> std::io::Result<Vec<std::path::PathBuf>> {
+    let session_root = get_session_root(project_root)
+        .map_err(std::io::Error::other)?
+        .join("sessions");
+    if !session_root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut session_dirs = Vec::new();
+    for entry in std::fs::read_dir(session_root)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            session_dirs.push(entry.path());
+        }
+    }
+    Ok(session_dirs)
+}
+
+fn load_review_meta(project_root: &Path, session_id: &str) -> Option<ReviewSessionMeta> {
+    let session_dir = get_session_dir(project_root, session_id).ok()?;
+    load_review_meta_from_dir(&session_dir)
+}
+
+fn load_review_meta_from_dir(session_dir: &Path) -> Option<ReviewSessionMeta> {
+    let review_meta_path = session_dir.join("review_meta.json");
+    if !review_meta_path.is_file() {
+        return None;
+    }
+
+    let content = std::fs::read_to_string(review_meta_path).ok()?;
+    serde_json::from_str(&content).ok()
+}

--- a/crates/cli-sub-agent/src/review_iteration.rs
+++ b/crates/cli-sub-agent/src/review_iteration.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use super::review_iteration_resolver::try_max_review_iterations_for_branch;
 
 const REVIEW_ITERATION_HEADER: &str = "## Review iteration context";
-const MULTI_ROUND_ESCALATION: &str = "Multiple prior rounds have fired on this branch. Oscillating verdicts across rounds indicate design residuals, not bugs. Strongly prefer PASS for any finding that overlaps with prior rounds' concerns — FAIL only for NEW correctness bugs (crash, data loss, contract violation) not previously raised.";
+const MULTI_ROUND_ESCALATION: &str = "Multiple prior rounds have fired on this branch. Oscillating DESIGN choices (preserve-vs-overwrite semantics, where-to-persist artifacts, API surface shapes, which lifecycle stage triggers side-effects) across rounds indicate design residuals, not bugs — prefer PASS on those.\n\nHOWEVER: persistent correctness bugs remain blocking even if raised in a prior round. If a prior round flagged a crash path, data loss, contract violation, or security issue, and the current diff has NOT fixed it, FAIL on it — repetition does not convert a real bug into a design residual. Still broken from last round is still broken.\n\nOnly treat a finding as a design residual when prior rounds oscillated between contradictory fixes (A vs not-A) on a point of taste, AND the current choice has a coherent rationale.";
 
 pub(crate) fn count_prior_reviews_for_branch(project_root: &Path, branch: Option<&str>) -> usize {
     let current_session_id = std::env::var("CSA_SESSION_ID").ok();

--- a/crates/cli-sub-agent/src/review_iteration.rs
+++ b/crates/cli-sub-agent/src/review_iteration.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 
 use chrono::{Duration, Utc};
-use csa_session::{ReviewSessionMeta, find_sessions, get_session_dir, get_session_root};
+use csa_session::{ReviewSessionMeta, get_session_root};
+
+use super::review_iteration_resolver::try_max_review_iterations_for_branch;
 
 const REVIEW_ITERATION_HEADER: &str = "## Review iteration context";
 const MULTI_ROUND_ESCALATION: &str = "Multiple prior rounds have fired on this branch. Oscillating verdicts across rounds indicate design residuals, not bugs. Strongly prefer PASS for any finding that overlaps with prior rounds' concerns — FAIL only for NEW correctness bugs (crash, data loss, contract violation) not previously raised.";
@@ -9,20 +11,13 @@ const MULTI_ROUND_ESCALATION: &str = "Multiple prior rounds have fired on this b
 pub(crate) fn count_prior_reviews_for_branch(project_root: &Path, branch: Option<&str>) -> usize {
     let current_session_id = std::env::var("CSA_SESSION_ID").ok();
     match branch {
-        Some(branch) => {
-            let sessions = match find_sessions(project_root, Some(branch), None, None, None) {
-                Ok(sessions) => sessions,
-                Err(_) => return 0,
-            };
-
-            sessions
-                .into_iter()
-                .filter(|session| {
-                    current_session_id.as_deref() != Some(session.meta_session_id.as_str())
-                })
-                .filter_map(|session| load_review_meta(project_root, &session.meta_session_id))
-                .count()
-        }
+        Some(branch) => try_max_review_iterations_for_branch(
+            project_root,
+            branch,
+            current_session_id.as_deref(),
+        )
+        .map(|iterations| iterations as usize)
+        .unwrap_or(0),
         None => count_recent_reviews(project_root, current_session_id.as_deref()),
     }
 }
@@ -78,11 +73,6 @@ fn list_session_dirs(project_root: &Path) -> std::io::Result<Vec<std::path::Path
         }
     }
     Ok(session_dirs)
-}
-
-fn load_review_meta(project_root: &Path, session_id: &str) -> Option<ReviewSessionMeta> {
-    let session_dir = get_session_dir(project_root, session_id).ok()?;
-    load_review_meta_from_dir(&session_dir)
 }
 
 fn load_review_meta_from_dir(session_dir: &Path) -> Option<ReviewSessionMeta> {

--- a/crates/cli-sub-agent/src/review_iteration_resolver.rs
+++ b/crates/cli-sub-agent/src/review_iteration_resolver.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use csa_session::ReviewSessionMeta;
+
+pub(crate) fn try_max_review_iterations_for_branch(
+    project_root: &Path,
+    branch: &str,
+    exclude_session_id: Option<&str>,
+) -> Result<u32> {
+    csa_session::list_sessions(project_root, None)?
+        .into_iter()
+        .filter(|candidate| exclude_session_id != Some(candidate.meta_session_id.as_str()))
+        .filter(|candidate| candidate.resolved_identity().ref_name.as_deref() == Some(branch))
+        .try_fold(0_u32, |max_review_iterations, candidate| {
+            let review_iterations =
+                load_review_iterations(project_root, &candidate.meta_session_id)?.unwrap_or(0);
+            Ok::<u32, anyhow::Error>(max_review_iterations.max(review_iterations))
+        })
+}
+
+fn load_review_iterations(project_root: &Path, session_id: &str) -> Result<Option<u32>> {
+    Ok(
+        load_review_meta(project_root, session_id)?
+            .map(|review_meta| review_meta.review_iterations),
+    )
+}
+
+pub(crate) fn load_review_meta(
+    project_root: &Path,
+    session_id: &str,
+) -> Result<Option<ReviewSessionMeta>> {
+    let session_dir = csa_session::get_session_dir(project_root, session_id)
+        .with_context(|| format!("failed to resolve review session dir for {session_id}"))?;
+    let review_meta_path = session_dir.join("review_meta.json");
+    if !review_meta_path.is_file() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(&review_meta_path)
+        .with_context(|| format!("failed to read {}", review_meta_path.display()))?;
+    let review_meta: ReviewSessionMeta = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse {}", review_meta_path.display()))?;
+    Ok(Some(review_meta))
+}


### PR DESCRIPTION
## Summary

Implements two mitigations for codex review ping-pong (#821): a design-preference prompt anchor + iteration-count flip detection.

5 iterative rounds of narrow fixes, each addressing real HIGH-severity correctness findings from internal review:

- **Round 1** (0623bb46): design-preference anchor + iteration count feature
- **Round 2** (1e5eae73): bound iteration count to current branch (cross-branch contamination fix)
- **Round 3** (709ef716): align iteration counter with canonical resolver (10-entry truncation fix)
- **Round 4** (cc3417df): return zero when branch unknown (safe-zero consistency with review_context.rs:187)
- **Round 5** (77258127): narrow iteration escalation to design-only (persistent correctness bugs remain blocking)

## Test plan

- [x] `cargo test -p cli-sub-agent` passes (includes new iteration tests + regression tests for >10 reviews + cross-branch + persistent-bug-still-blocks)
- [x] `just pre-commit` exits 0 across all 5 rounds
- [x] Version bumped 0.1.318 → 0.1.323
- [ ] Cloud bot review (gemini-code-assist) via pr-bot

Addresses #821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)