### PR TITLE
fix(workflow): require regression tests for timing guidance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.324"
+version = "0.1.325"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.324"
+version = "0.1.325"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
@@ -222,3 +222,61 @@ fn commit_pattern_step1_bridges_csa_skip_publish_to_skip_publish() {
         "PATTERN.md Step 1 must bridge CSA_SKIP_PUBLISH=true into SKIP_PUBLISH=true"
     );
 }
+
+#[test]
+fn commit_reviewer_guidance_schema_requires_regression_tests_for_timing_scenarios() {
+    let commit_pattern =
+        std::fs::read_to_string(workspace_root().join("patterns/commit/PATTERN.md")).unwrap();
+    let commit_workflow =
+        std::fs::read_to_string(workspace_root().join("patterns/commit/workflow.toml")).unwrap();
+    let commit_skill =
+        std::fs::read_to_string(workspace_root().join("patterns/commit/skills/commit/SKILL.md"))
+            .unwrap();
+    let review_pattern =
+        std::fs::read_to_string(workspace_root().join("patterns/ai-reviewed-commit/PATTERN.md"))
+            .unwrap();
+    let review_workflow =
+        std::fs::read_to_string(workspace_root().join("patterns/ai-reviewed-commit/workflow.toml"))
+            .unwrap();
+    let review_skill = std::fs::read_to_string(
+        workspace_root().join("patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md"),
+    )
+    .unwrap();
+    let commit_msg_script =
+        std::fs::read_to_string(workspace_root().join("scripts/gen_commit_msg.sh")).unwrap();
+
+    for content in [
+        &commit_pattern,
+        &commit_workflow,
+        &commit_skill,
+        &review_pattern,
+        &review_workflow,
+        &review_skill,
+        &commit_msg_script,
+    ] {
+        assert!(
+            content.contains("Regression Tests Added"),
+            "updated reviewer-guidance schema must mention Regression Tests Added"
+        );
+    }
+
+    for content in [&commit_pattern, &commit_workflow] {
+        assert!(
+            content.contains("Regression Tests Added must list concrete test names when Timing/Race Scenarios is not 'none'."),
+            "commit gate must reject timing/race guidance without named regression tests"
+        );
+    }
+
+    for content in [&review_pattern, &review_workflow, &review_skill] {
+        assert!(
+            content.contains("matching regression tests exist")
+                && content.contains("Regression Tests Added"),
+            "ai-reviewed-commit review guidance must require matching regression tests"
+        );
+    }
+
+    assert!(
+        !commit_pattern.contains("Risk Areas:") && !commit_workflow.contains("Risk Areas:"),
+        "commit pattern/workflow should no longer require the old Risk Areas reviewer-guidance field"
+    );
+}

--- a/patterns/ai-reviewed-commit/PATTERN.md
+++ b/patterns/ai-reviewed-commit/PATTERN.md
@@ -13,7 +13,7 @@ Automated fix-and-retry loop: review → fix → re-review → repeat until clea
 Maximum 3 iterations.
 Because this pattern invokes the downstream `commit` skill, the AI reviewer should verify the
 `Reviewer Guidance` schema required there, including `Timing/Race Scenarios`, `Boundary Cases`,
-and `Risk Areas`.
+and `Regression Tests Added`.
 
 ## Step 1: Stage Changes
 
@@ -101,6 +101,9 @@ bash scripts/csa/session-wait-until-done.sh "$SID"
 The review MUST include AGENTS.md compliance checklist:
 - Discover AGENTS.md chain (root-to-leaf) for each staged file
 - Check every applicable rule
+- If the staged diff or generated commit body lists concrete `Timing/Race Scenarios`, verify that
+  matching regression tests exist and are named under `Regression Tests Added`. Missing or
+  mismatched tests are a blocking review failure.
 - If staged diff touches `PATTERN.md` or `workflow.toml`, MUST check rule 027 `pattern-workflow-sync`
 - If staged diff touches process spawning/lifecycle code, MUST check Rust rule 015 `subprocess-lifecycle`
 - Zero unchecked items before proceeding to commit

--- a/patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md
+++ b/patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md
@@ -58,7 +58,7 @@ breaks prompt-guard propagation.
    - Self-authored: `csa debate "Review my staged changes for correctness, security, and test gaps. Run 'git diff --staged' yourself."`
    - Other-authored: `csa review --diff --allow-fallback`
 5. **Fix loop** (if issues found, max 3 rounds): Dispatch sub-agent to fix issues, re-stage, re-review. Preserve original code intent -- do NOT delete code to silence warnings.
-6. **AGENTS.md compliance**: Discover AGENTS.md chain for each staged file. Check every applicable rule. Zero unchecked items before proceeding.
+6. **AGENTS.md compliance**: Discover AGENTS.md chain for each staged file. Check every applicable rule. If the staged diff or generated commit body lists concrete `Timing/Race Scenarios`, verify that matching regression tests exist and are named under `Regression Tests Added`; missing or mismatched tests are a blocking failure. Zero unchecked items before proceeding.
 7. **Generate commit message**: `csa run "Run 'git diff --staged' and generate a Conventional Commits message"` (tier-1).
 8. **Commit**: `git commit -m "${COMMIT_MSG}"`.
 

--- a/patterns/ai-reviewed-commit/workflow.toml
+++ b/patterns/ai-reviewed-commit/workflow.toml
@@ -120,6 +120,9 @@ prompt = """
 The review MUST include AGENTS.md compliance checklist:
 - Discover AGENTS.md chain (root-to-leaf) for each staged file
 - Check every applicable rule
+- If the staged diff or generated commit body lists concrete `Timing/Race Scenarios`, verify that
+  matching regression tests exist and are named under `Regression Tests Added`. Missing or
+  mismatched tests are a blocking review failure.
 - If staged diff touches `PATTERN.md` or `workflow.toml`, MUST check rule 027 `pattern-workflow-sync`
 - If staged diff touches process spawning/lifecycle code, MUST check Rust rule 015 `subprocess-lifecycle`
 - Zero unchecked items before proceeding to commit"""

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -197,6 +197,11 @@ Run the staged-diff review directly in this CSA step.
   - Other-authored changes: review with the `csa review --diff --allow-fallback` standard.
 - Check the applicable AGENTS.md chain for every staged file.
 - Explicitly check rule 009 (error handling), rule 014 (security), and rule 016 (testing).
+- Enforce the `Reviewer Guidance` schema in the generated commit body:
+  - `Timing/Race Scenarios`, `Boundary Cases`, and `Regression Tests Added` must all be present.
+  - If `Timing/Race Scenarios` is not `none`, `Regression Tests Added` must list concrete test names.
+  - Missing tests, empty test lists, or tests that do not match the stated timing/race scenarios are
+    blocking review failures.
 - If staged changes touch `PATTERN.md` or `workflow.toml`, check rule 027 `pattern-workflow-sync`.
 - If staged changes touch process spawning or lifecycle code, check Rust rule 015 `subprocess-lifecycle`.
 - If the implementation session is available, you may optionally use fork-based self-review guidance such as `csa review --fork-from <impl-session-id> --diff` for zero-cost context reuse.
@@ -212,6 +217,8 @@ Verify changes comply with all applicable AGENTS.md rules for this task.
 If staged diff touches `PATTERN.md` or `workflow.toml`, MUST check rule 027 `pattern-workflow-sync`.
 If staged diff touches process spawning/lifecycle code, MUST check Rust rule 015 `subprocess-lifecycle`.
 Explicitly check: error handling (009), security (014), testing (016).
+If `Reviewer Guidance` lists concrete `Timing/Race Scenarios`, the review MUST verify matching
+tests exist and are named in `Regression Tests Added`; otherwise the review MUST fail.
 Fix-and-retry loop (max 3 rounds).
 
 ### Fork-Based Self-Review (Optional)
@@ -306,12 +313,27 @@ do
   fi
 done
 
-for required_guidance in 'Timing/Race Scenarios:' 'Boundary Cases:' 'Risk Areas:'; do
+for required_guidance in 'Timing/Race Scenarios:' 'Boundary Cases:' 'Regression Tests Added:'; do
   if ! printf '%s\n' "${COMMIT_BODY_LOCAL}" | grep -Fq -- "${required_guidance}"; then
     echo "ERROR: Commit body Reviewer Guidance must include the required '${required_guidance}' sub-field." >&2
     exit 1
   fi
 done
+
+timing_guidance="$(printf '%s\n' "${COMMIT_BODY_LOCAL}" | sed -n 's/^  - \*\*Timing\/Race Scenarios\*\*: //p' | head -n1)"
+regression_tests_guidance="$(printf '%s\n' "${COMMIT_BODY_LOCAL}" | sed -n 's/^  - \*\*Regression Tests Added\*\*: //p' | head -n1)"
+
+if [ -z "${timing_guidance}" ] || [ -z "${regression_tests_guidance}" ]; then
+  echo "ERROR: Commit body Reviewer Guidance must populate both Timing/Race Scenarios and Regression Tests Added." >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "${timing_guidance}" | grep -Eiq '^(none|n/a|na|not applicable)([[:space:][:punct:]].*)?$'; then
+  if printf '%s\n' "${regression_tests_guidance}" | grep -Eiq '^(none|n/a|na|not applicable)([[:space:][:punct:]].*)?$'; then
+    echo "ERROR: Regression Tests Added must list concrete test names when Timing/Race Scenarios is not 'none'." >&2
+    exit 1
+  fi
+fi
 
 if ! printf '%s\n' "${COMMIT_BODY_LOCAL}" | awk '
   BEGIN { found = 0; has_summary = 0 }

--- a/patterns/commit/skills/commit/SKILL.md
+++ b/patterns/commit/skills/commit/SKILL.md
@@ -106,9 +106,9 @@ All commits created by this workflow must use:
 - **Design Intent**: <Why this change was made, what problem it solves. Context not obvious from the diff.>
 - **Key Decisions**: <Significant architectural or implementation choices made during the task.>
 - **Reviewer Guidance**: List areas needing careful review, with REQUIRED sub-fields:
-  - **Timing/Race Scenarios**: any timing-sensitive ordering, concurrency race, file-system race, or async ordering the change must survive. Cite the scenario + the test that exercises it.
-  - **Boundary Cases**: null/empty/max/min/off-by-one inputs, and the test(s) that cover them.
-  - **Risk Areas**: the parts of the change that, if wrong, would not be caught by compile + unit tests.
+  - **Timing/Race Scenarios**: any timing-sensitive ordering, concurrency race, file-system race, or async ordering the change must survive. List the concrete input/orderings to verify. Use `none` when not applicable.
+  - **Boundary Cases**: null/empty/max/min/off-by-one inputs and other edge conditions that require explicit checking. Use `none` when not applicable.
+  - **Regression Tests Added**: list the concrete test names that cover the timing/race and boundary guidance above. This field is REQUIRED. If `Timing/Race Scenarios` is not `none`, this list MUST be non-empty and the pre-commit review MUST fail when matching tests are missing.
 ```
 
 ## Example Usage

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -283,6 +283,11 @@ Run the staged-diff review directly in this CSA step.
   - Other-authored changes: review with the `csa review --diff --allow-fallback` standard.
 - Check the applicable AGENTS.md chain for every staged file.
 - Explicitly check rule 009 (error handling), rule 014 (security), and rule 016 (testing).
+- Enforce the `Reviewer Guidance` schema in the generated commit body:
+  - `Timing/Race Scenarios`, `Boundary Cases`, and `Regression Tests Added` must all be present.
+  - If `Timing/Race Scenarios` is not `none`, `Regression Tests Added` must list concrete test names.
+  - Missing tests, empty test lists, or tests that do not match the stated timing/race scenarios are
+    blocking review failures.
 - If staged changes touch `PATTERN.md` or `workflow.toml`, check rule 027 `pattern-workflow-sync`.
 - If staged changes touch process spawning or lifecycle code, check Rust rule 015 `subprocess-lifecycle`.
 - If the implementation session is available, you may optionally use fork-based self-review guidance such as `csa review --fork-from <impl-session-id> --diff` for zero-cost context reuse.
@@ -379,12 +384,27 @@ do
   fi
 done
 
-for required_guidance in 'Timing/Race Scenarios:' 'Boundary Cases:' 'Risk Areas:'; do
+for required_guidance in 'Timing/Race Scenarios:' 'Boundary Cases:' 'Regression Tests Added:'; do
   if ! printf '%s\n' "${COMMIT_BODY_LOCAL}" | grep -Fq -- "${required_guidance}"; then
     echo "ERROR: Commit body Reviewer Guidance must include the required '${required_guidance}' sub-field." >&2
     exit 1
   fi
 done
+
+timing_guidance="$(printf '%s\n' "${COMMIT_BODY_LOCAL}" | sed -n 's/^  - \*\*Timing\/Race Scenarios\*\*: //p' | head -n1)"
+regression_tests_guidance="$(printf '%s\n' "${COMMIT_BODY_LOCAL}" | sed -n 's/^  - \*\*Regression Tests Added\*\*: //p' | head -n1)"
+
+if [ -z "${timing_guidance}" ] || [ -z "${regression_tests_guidance}" ]; then
+  echo "ERROR: Commit body Reviewer Guidance must populate both Timing/Race Scenarios and Regression Tests Added." >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "${timing_guidance}" | grep -Eiq '^(none|n/a|na|not applicable)([[:space:][:punct:]].*)?$'; then
+  if printf '%s\n' "${regression_tests_guidance}" | grep -Eiq '^(none|n/a|na|not applicable)([[:space:][:punct:]].*)?$'; then
+    echo "ERROR: Regression Tests Added must list concrete test names when Timing/Race Scenarios is not 'none'." >&2
+    exit 1
+  fi
+fi
 
 echo "CSA_VAR:COMMIT_SUBJECT=$COMMIT_SUBJECT_LOCAL"
 echo "CSA_VAR:COMMIT_BODY=$(printf '%s' "$COMMIT_BODY_LOCAL" | jq -Rs .)"

--- a/scripts/gen_commit_msg.sh
+++ b/scripts/gen_commit_msg.sh
@@ -117,8 +117,8 @@ ${summary}
 - **Key Decisions**: Derive this fallback from the staged file set and preserve the AI Reviewer Metadata scaffold required by the audited commit workflow.
 - **Reviewer Guidance**: Verify the staged diff still matches this generated summary and expand the metadata when the change needs task-specific rationale.
   - **Timing/Race Scenarios**: <none identified for this change>
-  - **Boundary Cases**: <describe or list "n/a">
-  - **Risk Areas**: <describe or list "n/a">
+  - **Boundary Cases**: <describe or list "none">
+  - **Regression Tests Added**: <list test names or "none">
 EOF
 }
 


### PR DESCRIPTION
## Summary
- tighten Reviewer Guidance so commits must include `Timing/Race Scenarios`, `Boundary Cases`, and `Regression Tests Added`
- make commit-pattern validation reject timing/race guidance without named regression tests
- sync ai-reviewed-commit docs/workflows and add a text-contract test covering the new schema
- bump workspace version to `0.1.325`

## Testing
- `cargo test -p cli-sub-agent commit_reviewer_guidance_schema_requires_regression_tests_for_timing_scenarios`
- `just pre-commit`

## Local review status
Attempted the required local cumulative review command twice:
- `01KPD9CWHG9HYYKFPYKHP9HC97` -> signal 137
- `01KPD9HVZSGFM1QYPS13S6S0JH` -> signal 137

Filed blockers:
- #826 commit workflow security-audit step exits 137 on text-only pattern changes
- #827 `csa review --range main...HEAD` exits 137 without verdict on a small text-only branch
