### PR TITLE
feat(csa-review): add --prior-rounds-summary flag for invariant verification (#764)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.325"
+version = "0.1.326"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.325"
+version = "0.1.326"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -182,6 +182,10 @@ pub struct ReviewArgs {
     #[arg(long, value_name = "PATH")]
     pub prompt_file: Option<PathBuf>,
 
+    /// TOML file containing prior-round fix summaries and invariants to re-verify
+    #[arg(long, value_name = "PATH")]
+    pub prior_rounds_summary: Option<PathBuf>,
+
     /// [DEPRECATED] Daemon mode is now the default. This flag is a no-op.
     #[arg(long, hide = true)]
     pub daemon: bool,

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -42,6 +42,7 @@ mod review_cmd;
 mod review_consensus;
 mod review_context;
 mod review_findings;
+mod review_prior_rounds;
 mod review_routing;
 mod run_cmd;
 mod run_cmd_daemon;

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -15,7 +15,9 @@ use anyhow::{Context, Result};
 #[cfg(test)]
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::consensus::AgentResponse;
-use csa_core::types::{ReviewDecision, ToolName};
+use csa_core::types::ReviewDecision;
+#[cfg(test)]
+use csa_core::types::ToolName;
 use csa_session::state::ReviewSessionMeta;
 use tokio::task::JoinSet;
 use tracing::{debug, error, warn};
@@ -42,6 +44,9 @@ mod reviewers;
 #[path = "review_cmd_execute.rs"]
 mod execute;
 
+#[path = "review_cmd_prior_rounds.rs"]
+mod prior_rounds;
+
 #[path = "review_cmd_bug_class.rs"]
 mod bug_class_pipeline;
 #[path = "review_cmd_resolve.rs"]
@@ -52,6 +57,9 @@ use bug_class_pipeline::{try_extract_recurring_bug_class_skills, try_resolve_rev
 use execute::{compute_diff_fingerprint, execute_review};
 use findings_toml::persist_review_findings_toml;
 use post_review::{build_post_review_output, emit_post_review_output, review_scope_is_cumulative};
+use prior_rounds::{
+    explicit_review_tool, load_prior_rounds_section_or_persist_error, review_pre_exec_session_id,
+};
 #[cfg(test)]
 use resolve::build_review_instruction;
 use resolve::{
@@ -61,15 +69,6 @@ use resolve::{
     verify_review_skill_available, write_multi_reviewer_consolidated_artifact,
 };
 use reviewers::resolve_multi_reviewer_pool;
-
-fn explicit_review_tool(args: &ReviewArgs) -> Option<ToolName> {
-    args.tool.or_else(|| {
-        args.model_spec
-            .as_deref()
-            .and_then(|spec| spec.split('/').next())
-            .and_then(|tool_name| crate::run_helpers::parse_tool_name(tool_name).ok())
-    })
-}
 
 fn review_decision_from_verdict(verdict: &str) -> ReviewDecision {
     if verdict == CLEAN {
@@ -237,11 +236,8 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         "review: {}",
         crate::run_helpers::truncate_prompt(&scope, 80)
     );
-    let prior_rounds_section = args
-        .prior_rounds_summary
-        .as_deref()
-        .map(crate::review_prior_rounds::load_prior_rounds_section)
-        .transpose()?;
+    let prior_rounds_section =
+        load_prior_rounds_section_or_persist_error(&args, &project_root, &review_description)?;
 
     // 4. Build review instruction (no diff content — tool loads skill and fetches diff itself)
     let (mut prompt, review_routing) = build_review_instruction_for_project(
@@ -282,7 +278,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             return Err(crate::session_guard::persist_pre_exec_error_result(
                 crate::session_guard::PreExecErrorCtx {
                     project_root: &project_root,
-                    session_id: args.session.as_deref(),
+                    session_id: review_pre_exec_session_id(&args),
                     description: Some(review_description.as_str()),
                     parent: None,
                     tool_name: explicit_review_tool(&args).map(|tool| tool.as_str()),

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -55,10 +55,10 @@ use post_review::{build_post_review_output, emit_post_review_output, review_scop
 #[cfg(test)]
 use resolve::build_review_instruction;
 use resolve::{
-    build_review_instruction_for_project, derive_scope, resolve_review_model,
-    resolve_review_stream_mode, resolve_review_thinking, resolve_review_tier_name,
-    resolve_review_tool, review_scope_allows_auto_discovery, verify_review_skill_available,
-    write_multi_reviewer_consolidated_artifact,
+    ReviewProjectPromptOptions, build_review_instruction_for_project, derive_scope,
+    resolve_review_model, resolve_review_stream_mode, resolve_review_thinking,
+    resolve_review_tier_name, resolve_review_tool, review_scope_allows_auto_discovery,
+    verify_review_skill_available, write_multi_reviewer_consolidated_artifact,
 };
 use reviewers::resolve_multi_reviewer_pool;
 
@@ -237,6 +237,11 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         "review: {}",
         crate::run_helpers::truncate_prompt(&scope, 80)
     );
+    let prior_rounds_section = args
+        .prior_rounds_summary
+        .as_deref()
+        .map(crate::review_prior_rounds::load_prior_rounds_section)
+        .transpose()?;
 
     // 4. Build review instruction (no diff content — tool loads skill and fetches diff itself)
     let (mut prompt, review_routing) = build_review_instruction_for_project(
@@ -246,7 +251,10 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         review_mode,
         context.as_ref(),
         &project_root,
-        config.as_ref(),
+        ReviewProjectPromptOptions {
+            project_config: config.as_ref(),
+            prior_rounds_section: prior_rounds_section.as_deref(),
+        },
     );
 
     // 4b. Inject gate pipeline results into review prompt for reviewer awareness
@@ -571,8 +579,12 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
 
     let mut join_set = JoinSet::new();
     for (reviewer_index, reviewer_tool) in reviewer_tools.into_iter().enumerate() {
-        let reviewer_prompt =
-            build_multi_reviewer_instruction(&prompt, reviewer_index + 1, reviewer_tool);
+        let reviewer_prompt = build_multi_reviewer_instruction(
+            &prompt,
+            reviewer_index + 1,
+            reviewer_tool,
+            prior_rounds_section.as_deref(),
+        );
         let reviewer_model = review_model.clone();
         let reviewer_project_root = project_root.clone();
         let reviewer_config = config.clone();

--- a/crates/cli-sub-agent/src/review_cmd_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prior_rounds.rs
@@ -1,0 +1,42 @@
+use crate::cli::ReviewArgs;
+use anyhow::Result;
+
+pub(super) fn load_prior_rounds_section_or_persist_error(
+    args: &ReviewArgs,
+    project_root: &std::path::Path,
+    review_description: &str,
+) -> Result<Option<String>> {
+    match args
+        .prior_rounds_summary
+        .as_deref()
+        .map(crate::review_prior_rounds::load_prior_rounds_section)
+        .transpose()
+    {
+        Ok(section) => Ok(section),
+        Err(err) => Err(crate::session_guard::persist_pre_exec_error_result(
+            crate::session_guard::PreExecErrorCtx {
+                project_root,
+                session_id: review_pre_exec_session_id(args),
+                description: Some(review_description),
+                parent: None,
+                tool_name: explicit_review_tool(args).map(|tool| tool.as_str()),
+                task_type: Some("review"),
+                tier_name: args.tier.as_deref(),
+                error: err,
+            },
+        )),
+    }
+}
+
+pub(super) fn review_pre_exec_session_id(args: &ReviewArgs) -> Option<&str> {
+    args.session_id.as_deref().or(args.session.as_deref())
+}
+
+pub(super) fn explicit_review_tool(args: &ReviewArgs) -> Option<csa_core::types::ToolName> {
+    args.tool.or_else(|| {
+        args.model_spec
+            .as_deref()
+            .and_then(|spec| spec.split('/').next())
+            .and_then(|tool_name| crate::run_helpers::parse_tool_name(tool_name).ok())
+    })
+}

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -9,6 +9,7 @@ use crate::review_context::{
     ResolvedReviewContext, ResolvedReviewContextKind, discover_prior_round_assumptions,
     discover_review_checklist, render_spec_review_context,
 };
+use crate::review_prior_rounds::REVIEW_FINDINGS_TOML_INSTRUCTION;
 use crate::review_routing::{ReviewRoutingMetadata, detect_review_routing_metadata};
 use csa_config::global::{heterogeneous_counterpart, select_heterogeneous_tool};
 use csa_config::{GlobalConfig, ProjectConfig};
@@ -527,7 +528,7 @@ pub(crate) fn build_review_instruction(
     context: Option<&ResolvedReviewContext>,
 ) -> String {
     let mut instruction = format!(
-        "{ANTI_RECURSION_PREAMBLE}Use the csa-review skill. scope={scope}, mode={mode}, security_mode={security_mode}, review_mode={review_mode}. Emit exactly one final verdict token: PASS, FAIL, SKIP, or UNCERTAIN. After the CSA summary/details sections, append exactly one fenced TOML block labeled `findings.toml` for machine parsing. Keep that fenced block OUTSIDE the CSA sections so `details.md` remains unchanged. Use `findings = []` when there are no findings."
+        "{ANTI_RECURSION_PREAMBLE}Use the csa-review skill. scope={scope}, mode={mode}, security_mode={security_mode}, review_mode={review_mode}. Emit exactly one final verdict token: PASS, FAIL, SKIP, or UNCERTAIN."
     );
     if let Some(ctx) = context {
         instruction.push_str(&format!(" context={}", ctx.path));
@@ -549,9 +550,9 @@ pub(crate) fn build_review_instruction_for_project(
     review_mode: ReviewMode,
     context: Option<&ResolvedReviewContext>,
     project_root: &Path,
-    project_config: Option<&ProjectConfig>,
+    options: ReviewProjectPromptOptions<'_>,
 ) -> (String, ReviewRoutingMetadata) {
-    let review_routing = detect_review_routing_metadata(project_root, project_config);
+    let review_routing = detect_review_routing_metadata(project_root, options.project_config);
     let mut instruction =
         build_review_instruction(scope, mode, security_mode, review_mode, context);
     instruction.push_str(&format!(
@@ -582,6 +583,12 @@ pub(crate) fn build_review_instruction_for_project(
     if let Some(prior) = discover_prior_round_assumptions(project_root, branch.as_deref(), None) {
         instruction.push_str(&prior);
     }
+    if let Some(prior_rounds_section) = options.prior_rounds_section {
+        instruction.push_str("\n\n");
+        instruction.push_str(prior_rounds_section);
+    }
+    instruction.push_str("\n\n");
+    instruction.push_str(REVIEW_FINDINGS_TOML_INSTRUCTION);
 
     (instruction, review_routing)
 }
@@ -597,6 +604,11 @@ fn append_design_anchor(prompt: &mut String) {
     }
     prompt.push_str("\n\n");
     prompt.push_str(crate::review_consensus::review_design_anchor::REVIEW_DESIGN_PREFERENCE_ANCHOR);
+}
+
+pub(crate) struct ReviewProjectPromptOptions<'a> {
+    pub(crate) project_config: Option<&'a ProjectConfig>,
+    pub(crate) prior_rounds_section: Option<&'a str>,
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -446,6 +446,7 @@ fn default_review_args() -> ReviewArgs {
         no_fs_sandbox: false,
         extra_writable: vec![],
         prompt_file: None,
+        prior_rounds_summary: None,
         daemon: false,
         no_daemon: true,
         daemon_child: false,
@@ -784,17 +785,13 @@ fn has_structured_review_content_requires_non_empty_sections() {
     assert!(has_structured_review_content(structured));
 }
 
-#[path = "review_cmd_tier_tests.rs"]
-mod tier_tests;
-
-#[path = "review_cmd_tests_tail.rs"]
-mod tail_tests;
-
-#[path = "review_cmd_tests_transport_tail.rs"]
-mod transport_tail_tests;
-
-#[path = "review_cmd_tests_no_failover.rs"]
-mod no_failover_tests;
-
 #[path = "review_cmd_bug_class_tests.rs"]
 mod bug_class_tests;
+#[path = "review_cmd_tests_no_failover.rs"]
+mod no_failover_tests;
+#[path = "review_cmd_tests_tail.rs"]
+mod tail_tests;
+#[path = "review_cmd_tier_tests.rs"]
+mod tier_tests;
+#[path = "review_cmd_tests_transport_tail.rs"]
+mod transport_tail_tests;

--- a/crates/cli-sub-agent/src/review_cmd_tests_checklist.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_checklist.rs
@@ -1,0 +1,60 @@
+use super::*;
+use tempfile::tempdir;
+
+#[test]
+fn build_review_instruction_for_project_injects_review_checklist() {
+    let project_dir = tempdir().unwrap();
+    let csa_dir = project_dir.path().join(".csa");
+    std::fs::create_dir_all(&csa_dir).unwrap();
+    std::fs::write(
+        csa_dir.join("review-checklist.md"),
+        "# Checklist\n- [ ] Verify error paths\n",
+    )
+    .unwrap();
+
+    let (instruction, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: None,
+        },
+    );
+
+    assert!(
+        instruction.contains("<review-checklist>"),
+        "instruction should contain review-checklist open tag"
+    );
+    assert!(
+        instruction.contains("</review-checklist>"),
+        "instruction should contain review-checklist close tag"
+    );
+    assert!(instruction.contains("Verify error paths"));
+}
+
+#[test]
+fn build_review_instruction_for_project_omits_checklist_when_missing() {
+    let project_dir = tempdir().unwrap();
+
+    let (instruction, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: None,
+        },
+    );
+
+    assert!(
+        !instruction.contains("<review-checklist>"),
+        "instruction should not contain review-checklist tag when file is missing"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -127,7 +127,10 @@ fn build_review_instruction_for_project_contains_design_preference_anchor() {
         ReviewMode::Standard,
         None,
         project_dir.path(),
-        None,
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: None,
+        },
     );
 
     assert!(instruction.contains("Design preferences vs correctness bugs"));
@@ -139,6 +142,7 @@ fn build_multi_reviewer_instruction_contains_design_preference_anchor() {
         "Base prompt",
         1,
         ToolName::Codex,
+        None,
     );
 
     assert!(prompt.contains("Design preferences vs correctness bugs"));
@@ -161,7 +165,10 @@ fn count_prior_reviews_zero_omits_iteration_block() {
         ReviewMode::Standard,
         None,
         project_dir.path(),
-        None,
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: None,
+        },
     );
 
     assert!(!instruction.contains("## Review iteration context"));
@@ -191,7 +198,10 @@ fn count_prior_reviews_one_injects_iteration_two() {
         ReviewMode::Standard,
         None,
         project_dir.path(),
-        None,
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: None,
+        },
     );
 
     assert!(instruction.contains("This is review iteration 2 on branch 'feat/iter-one'."));
@@ -235,6 +245,7 @@ fn count_prior_reviews_three_adds_multi_round_escalation() {
         "Base prompt",
         2,
         ToolName::Codex,
+        None,
     );
 
     assert!(prompt.contains("Prior review count on this branch: 3."));
@@ -275,6 +286,7 @@ fn multi_round_escalation_keeps_persistent_correctness_bugs_blocking() {
         "Base prompt",
         2,
         ToolName::Codex,
+        None,
     );
 
     assert!(prompt.contains("persistent correctness bugs remain blocking"));
@@ -349,3 +361,8 @@ fn count_prior_reviews_uses_canonical_max_after_more_than_ten_prior_reviews() {
         12
     );
 }
+
+#[path = "review_cmd_tests_checklist.rs"]
+mod review_cmd_tests_checklist;
+#[path = "review_cmd_tests_prior_rounds.rs"]
+mod review_cmd_tests_prior_rounds;

--- a/crates/cli-sub-agent/src/review_cmd_tests_pre_exec.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_pre_exec.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+#[tokio::test]
+async fn handle_review_persists_result_for_prior_rounds_summary_parse_failure() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    write_review_project_config(
+        project_dir.path(),
+        &project_config_with_enabled_tools(&["codex"]),
+    );
+    install_pattern(project_dir.path(), "csa-review");
+
+    let seeded = csa_session::create_session(
+        project_dir.path(),
+        Some("daemon-review"),
+        None,
+        Some("codex"),
+    )
+    .expect("seed daemon review session");
+    let seeded_session_id = seeded.meta_session_id;
+    let cd = project_dir.path().display().to_string();
+    let missing = project_dir.path().join("missing-prior-rounds.toml");
+    let args = parse_review_args(&[
+        "csa",
+        "review",
+        "--cd",
+        &cd,
+        "--files",
+        "src/lib.rs",
+        "--session-id",
+        &seeded_session_id,
+        "--prior-rounds-summary",
+        missing.to_str().expect("utf-8 path"),
+    ]);
+
+    let err = handle_review(args, 0)
+        .await
+        .expect_err("missing prior-rounds summary must fail");
+    assert!(
+        err.chain().any(|cause| cause
+            .to_string()
+            .contains("Failed to read prior-rounds summary file")),
+        "unexpected error chain: {err:#}"
+    );
+
+    let result = csa_session::load_result(project_dir.path(), &seeded_session_id)
+        .unwrap()
+        .expect("result.toml must be written for prior-rounds parse failure");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(result.summary.contains("pre-exec:"));
+    assert!(
+        result
+            .summary
+            .contains("Failed to read prior-rounds summary file")
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
@@ -1,0 +1,149 @@
+use super::*;
+use crate::review_prior_rounds::{REVIEW_FINDINGS_TOML_INSTRUCTION, load_prior_rounds_section};
+use csa_core::types::ToolName;
+use tempfile::tempdir;
+
+#[test]
+fn parse_review_args_accepts_prior_rounds_summary_flag() {
+    let args = parse_review_args(&[
+        "csa",
+        "review",
+        "--prior-rounds-summary",
+        "prior_rounds.toml",
+    ]);
+
+    assert_eq!(
+        args.prior_rounds_summary.as_deref(),
+        Some(std::path::Path::new("prior_rounds.toml"))
+    );
+}
+
+#[test]
+fn prior_rounds_summary_valid_toml_renders_rounds_in_single_and_multi_reviewer_prompts() {
+    let project_dir = tempdir().unwrap();
+    let summary_path = project_dir.path().join("prior_rounds.toml");
+    std::fs::write(
+        &summary_path,
+        r#"
+[[round]]
+number = 6
+commit = "29b6c34c"
+summary = "narrowed legacy ACP fallback to tool == \"codex\""
+invariant = "ACP codex sessions route to output.log"
+
+[[round]]
+number = 7
+commit = "2fdcba62"
+summary = "moved runtime_binary write behind lock"
+invariant = "lock-losing resume cannot mutate metadata of winning session"
+"#,
+    )
+    .unwrap();
+
+    let prior_rounds = load_prior_rounds_section(&summary_path).expect("parse prior rounds");
+    let (instruction, _routing) = build_review_instruction_for_project(
+        "range:main...HEAD",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: Some(&prior_rounds),
+        },
+    );
+
+    assert!(instruction.contains("## Prior-Round Invariant Verification"));
+    assert!(instruction.contains("Round 6 (commit 29b6c34c)"));
+    assert!(instruction.contains("ACP codex sessions route to output.log"));
+    assert!(instruction.contains("Round 7 (commit 2fdcba62)"));
+    assert!(instruction.contains("lock-losing resume cannot mutate metadata of winning session"));
+
+    let single_idx = instruction
+        .find("## Prior-Round Invariant Verification")
+        .expect("single prompt must contain prior-round section");
+    let single_findings_idx = instruction
+        .find(REVIEW_FINDINGS_TOML_INSTRUCTION)
+        .expect("single prompt must contain findings instruction");
+    assert!(
+        single_idx < single_findings_idx,
+        "prior-round section must appear before findings instruction"
+    );
+
+    let prompt = crate::review_consensus::build_multi_reviewer_instruction(
+        "Base prompt",
+        2,
+        ToolName::Codex,
+        Some(&prior_rounds),
+    );
+    assert!(prompt.contains("Round 6 (commit 29b6c34c)"));
+    assert!(prompt.contains("ACP codex sessions route to output.log"));
+    let multi_idx = prompt
+        .find("## Prior-Round Invariant Verification")
+        .expect("multi prompt must contain prior-round section");
+    let multi_findings_idx = prompt
+        .find(REVIEW_FINDINGS_TOML_INSTRUCTION)
+        .expect("multi prompt must contain findings instruction");
+    assert!(
+        multi_idx < multi_findings_idx,
+        "prior-round section must appear before findings instruction"
+    );
+}
+
+#[test]
+fn prior_rounds_summary_missing_file_returns_clear_error() {
+    let project_dir = tempdir().unwrap();
+    let missing_path = project_dir.path().join("missing_prior_rounds.toml");
+    let error = load_prior_rounds_section(&missing_path).expect_err("missing file must fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("Failed to read prior-rounds summary file")
+    );
+    assert!(error.to_string().contains("missing_prior_rounds.toml"));
+}
+
+#[test]
+fn prior_rounds_summary_malformed_toml_returns_clear_error() {
+    let project_dir = tempdir().unwrap();
+    let summary_path = project_dir.path().join("prior_rounds.toml");
+    std::fs::write(
+        &summary_path,
+        r#"
+[[round]]
+number = "oops"
+commit = "29b6c34c"
+"#,
+    )
+    .unwrap();
+
+    let error = load_prior_rounds_section(&summary_path).expect_err("bad TOML must fail");
+    assert!(
+        error
+            .to_string()
+            .contains("Failed to parse prior-rounds summary TOML")
+    );
+    assert!(error.to_string().contains("prior_rounds.toml"));
+}
+
+#[test]
+fn build_review_instruction_for_project_without_prior_rounds_flag_leaves_section_absent() {
+    let project_dir = tempdir().unwrap();
+    let (instruction, _routing) = build_review_instruction_for_project(
+        "range:main...HEAD",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: None,
+        },
+    );
+
+    assert!(!instruction.contains("## Prior-Round Invariant Verification"));
+    assert!(instruction.contains(REVIEW_FINDINGS_TOML_INSTRUCTION));
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::review_prior_rounds::{REVIEW_FINDINGS_TOML_INSTRUCTION, load_prior_rounds_section};
+use crate::review_prior_rounds::{
+    PRIOR_ROUNDS_SECTION_HEADING, REVIEW_FINDINGS_TOML_INSTRUCTION, load_prior_rounds_section,
+};
 use csa_core::types::ToolName;
 use tempfile::tempdir;
 
@@ -146,4 +148,19 @@ fn build_review_instruction_for_project_without_prior_rounds_flag_leaves_section
 
     assert!(!instruction.contains("## Prior-Round Invariant Verification"));
     assert!(instruction.contains(REVIEW_FINDINGS_TOML_INSTRUCTION));
+}
+
+#[test]
+fn multi_reviewer_prompt_does_not_duplicate_prior_rounds_section_from_base_prompt() {
+    let prior_rounds = "## Prior-Round Invariant Verification\n\nRound 6 (commit 29b6c34c): summary - Invariant: invariant";
+    let base_prompt = format!("Base prompt\n\n{prior_rounds}");
+
+    let prompt = crate::review_consensus::build_multi_reviewer_instruction(
+        &base_prompt,
+        2,
+        ToolName::Codex,
+        Some(prior_rounds),
+    );
+
+    assert_eq!(prompt.matches(PRIOR_ROUNDS_SECTION_HEADING).count(), 1);
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -378,7 +378,10 @@ fn test_build_review_instruction_for_project_includes_rust_profile() {
         ReviewMode::Standard,
         None,
         project_dir.path(),
-        None,
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: None,
+        },
     );
 
     assert!(instruction.contains("[project_profile: rust]"));
@@ -396,7 +399,10 @@ fn test_build_review_instruction_for_project_includes_unknown_profile_for_empty_
         ReviewMode::Standard,
         None,
         project_dir.path(),
-        None,
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: None,
+        },
     );
 
     assert!(instruction.contains("[project_profile: unknown]"));
@@ -741,58 +747,6 @@ fn claude_code_also_routes_to_acp_transport() {
         mode,
         csa_executor::transport::TransportMode::Acp,
         "claude-code must route to ACP transport"
-    );
-}
-
-#[test]
-fn build_review_instruction_for_project_injects_review_checklist() {
-    let project_dir = tempdir().unwrap();
-    let csa_dir = project_dir.path().join(".csa");
-    std::fs::create_dir_all(&csa_dir).unwrap();
-    std::fs::write(
-        csa_dir.join("review-checklist.md"),
-        "# Checklist\n- [ ] Verify error paths\n",
-    )
-    .unwrap();
-
-    let (instruction, _routing) = build_review_instruction_for_project(
-        "uncommitted",
-        "review-only",
-        "auto",
-        ReviewMode::Standard,
-        None,
-        project_dir.path(),
-        None,
-    );
-
-    assert!(
-        instruction.contains("<review-checklist>"),
-        "instruction should contain review-checklist open tag"
-    );
-    assert!(
-        instruction.contains("</review-checklist>"),
-        "instruction should contain review-checklist close tag"
-    );
-    assert!(instruction.contains("Verify error paths"));
-}
-
-#[test]
-fn build_review_instruction_for_project_omits_checklist_when_missing() {
-    let project_dir = tempdir().unwrap();
-
-    let (instruction, _routing) = build_review_instruction_for_project(
-        "uncommitted",
-        "review-only",
-        "auto",
-        ReviewMode::Standard,
-        None,
-        project_dir.path(),
-        None,
-    );
-
-    assert!(
-        !instruction.contains("<review-checklist>"),
-        "instruction should not contain review-checklist tag when file is missing"
     );
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -752,3 +752,6 @@ fn claude_code_also_routes_to_acp_transport() {
 
 #[path = "review_cmd_tests_iteration.rs"]
 mod review_cmd_tests_iteration;
+
+#[path = "review_cmd_tests_pre_exec.rs"]
+mod review_cmd_tests_pre_exec;

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -1,3 +1,4 @@
+use crate::review_prior_rounds::REVIEW_FINDINGS_TOML_INSTRUCTION;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::fs;
@@ -165,6 +166,7 @@ pub(crate) fn build_multi_reviewer_instruction(
     base_prompt: &str,
     reviewer_index: usize,
     tool: ToolName,
+    prior_rounds_section: Option<&str>,
 ) -> String {
     let output_dir = reviewer_output_dir(reviewer_index);
     let mut prompt = format!(
@@ -173,7 +175,6 @@ You are reviewer {reviewer_index}. Emit exactly one final verdict token: \
 PASS, FAIL, SKIP, or UNCERTAIN.\n\
 Legacy aliases accepted: {CLEAN} → PASS, {HAS_ISSUES} → FAIL.\n\
 Write review artifacts to {output_dir}/review-findings.json and {output_dir}/review-report.md.\n\
-After the CSA summary/details sections, append exactly one fenced TOML block labeled `findings.toml` for machine parsing. Keep that fenced block OUTSIDE the CSA sections so `details.md` remains unchanged. Use `findings = []` when there are no findings.\n\
 Verdict rules:\n\
 - PASS: no serious issues (P0/P1).\n\
 - FAIL: serious issues found.\n\
@@ -199,6 +200,12 @@ Reviewer tool hint: {}.",
             prompt.push_str(&iteration_context);
         }
     }
+    if let Some(prior_rounds_section) = prior_rounds_section {
+        prompt.push_str("\n\n");
+        prompt.push_str(prior_rounds_section);
+    }
+    prompt.push_str("\n\n");
+    prompt.push_str(REVIEW_FINDINGS_TOML_INSTRUCTION);
     prompt
 }
 

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -1,4 +1,4 @@
-use crate::review_prior_rounds::REVIEW_FINDINGS_TOML_INSTRUCTION;
+use crate::review_prior_rounds::{PRIOR_ROUNDS_SECTION_HEADING, REVIEW_FINDINGS_TOML_INSTRUCTION};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::fs;
@@ -200,7 +200,9 @@ Reviewer tool hint: {}.",
             prompt.push_str(&iteration_context);
         }
     }
-    if let Some(prior_rounds_section) = prior_rounds_section {
+    if let Some(prior_rounds_section) = prior_rounds_section
+        && !base_prompt.contains(PRIOR_ROUNDS_SECTION_HEADING)
+    {
         prompt.push_str("\n\n");
         prompt.push_str(prior_rounds_section);
     }

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -206,8 +206,10 @@ Reviewer tool hint: {}.",
         prompt.push_str("\n\n");
         prompt.push_str(prior_rounds_section);
     }
-    prompt.push_str("\n\n");
-    prompt.push_str(REVIEW_FINDINGS_TOML_INSTRUCTION);
+    if !base_prompt.contains(REVIEW_FINDINGS_TOML_INSTRUCTION) {
+        prompt.push_str("\n\n");
+        prompt.push_str(REVIEW_FINDINGS_TOML_INSTRUCTION);
+    }
     prompt
 }
 

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -270,7 +270,7 @@ fn build_multi_reviewer_instruction_prefers_current_session_dir_env_when_both_ex
     let _parent_guard = ScopedEnvVar::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
     let _session_guard = ScopedEnvVar::set(CSA_SESSION_DIR_ENV_KEY, "/tmp/child-session");
 
-    let prompt = build_multi_reviewer_instruction("Base prompt", 2, ToolName::Codex);
+    let prompt = build_multi_reviewer_instruction("Base prompt", 2, ToolName::Codex, None);
 
     assert!(prompt.contains("/tmp/child-session/reviewer-2/review-findings.json"));
     assert!(
@@ -287,7 +287,7 @@ fn build_multi_reviewer_instruction_falls_back_to_parent_session_dir_env() {
     let _parent_guard = ScopedEnvVar::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
     let _session_guard = ScopedEnvVar::unset(CSA_SESSION_DIR_ENV_KEY);
 
-    let prompt = build_multi_reviewer_instruction("Base prompt", 3, ToolName::Codex);
+    let prompt = build_multi_reviewer_instruction("Base prompt", 3, ToolName::Codex, None);
 
     assert!(prompt.contains("/tmp/parent-session/reviewer-3/review-findings.json"));
 }
@@ -300,7 +300,7 @@ fn build_multi_reviewer_instruction_uses_session_first_shell_fallback_when_env_m
     let _parent_guard = ScopedEnvVar::unset(CSA_PARENT_SESSION_DIR_ENV_KEY);
     let _session_guard = ScopedEnvVar::unset(CSA_SESSION_DIR_ENV_KEY);
 
-    let prompt = build_multi_reviewer_instruction("Base prompt", 4, ToolName::Codex);
+    let prompt = build_multi_reviewer_instruction("Base prompt", 4, ToolName::Codex, None);
 
     assert!(
         prompt.contains(

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -310,6 +310,15 @@ fn build_multi_reviewer_instruction_uses_session_first_shell_fallback_when_env_m
 }
 
 #[test]
+fn build_multi_reviewer_instruction_does_not_duplicate_findings_contract_from_base_prompt() {
+    let base_prompt = format!("Base prompt\n\n{REVIEW_FINDINGS_TOML_INSTRUCTION}");
+
+    let prompt = build_multi_reviewer_instruction(&base_prompt, 4, ToolName::Codex, None);
+
+    assert_eq!(prompt.matches(REVIEW_FINDINGS_TOML_INSTRUCTION).count(), 1);
+}
+
+#[test]
 fn parse_review_verdict_is_case_insensitive_and_token_aware() {
     assert_eq!(
         parse_review_verdict("final verdict: clean.", 1),

--- a/crates/cli-sub-agent/src/review_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_prior_rounds.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 
 pub(crate) const REVIEW_FINDINGS_TOML_INSTRUCTION: &str = "After the CSA summary/details sections, append exactly one fenced TOML block labeled `findings.toml` for machine parsing. Keep that fenced block OUTSIDE the CSA sections so `details.md` remains unchanged. Use `findings = []` when there are no findings.";
+pub(crate) const PRIOR_ROUNDS_SECTION_HEADING: &str = "## Prior-Round Invariant Verification";
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub(crate) struct PriorRoundsSummary {
@@ -41,7 +42,8 @@ pub(crate) fn load_prior_rounds_section(path: &Path) -> Result<String> {
 }
 
 pub(crate) fn render_prior_rounds_section(summary: &PriorRoundsSummary) -> String {
-    let mut rendered = String::from("## Prior-Round Invariant Verification\n\n");
+    let mut rendered = String::from(PRIOR_ROUNDS_SECTION_HEADING);
+    rendered.push_str("\n\n");
     rendered.push_str("Prior rounds of review have fired on this branch and their fixes are now\n");
     rendered.push_str("part of the diff you are reviewing. Verify each prior-round fix did NOT\n");
     rendered.push_str("introduce a regression:\n\n");

--- a/crates/cli-sub-agent/src/review_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_prior_rounds.rs
@@ -1,0 +1,104 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+pub(crate) const REVIEW_FINDINGS_TOML_INSTRUCTION: &str = "After the CSA summary/details sections, append exactly one fenced TOML block labeled `findings.toml` for machine parsing. Keep that fenced block OUTSIDE the CSA sections so `details.md` remains unchanged. Use `findings = []` when there are no findings.";
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct PriorRoundsSummary {
+    #[serde(default)]
+    pub(crate) round: Vec<PriorRound>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct PriorRound {
+    pub(crate) number: u32,
+    pub(crate) commit: String,
+    pub(crate) summary: String,
+    pub(crate) invariant: String,
+}
+
+pub(crate) fn load_prior_rounds_summary(path: &Path) -> Result<PriorRoundsSummary> {
+    let content = fs::read_to_string(path).with_context(|| {
+        format!(
+            "Failed to read prior-rounds summary file: {}",
+            path.display()
+        )
+    })?;
+    toml::from_str(&content).with_context(|| {
+        format!(
+            "Failed to parse prior-rounds summary TOML: {}",
+            path.display()
+        )
+    })
+}
+
+pub(crate) fn load_prior_rounds_section(path: &Path) -> Result<String> {
+    let summary = load_prior_rounds_summary(path)?;
+    Ok(render_prior_rounds_section(&summary))
+}
+
+pub(crate) fn render_prior_rounds_section(summary: &PriorRoundsSummary) -> String {
+    let mut rendered = String::from("## Prior-Round Invariant Verification\n\n");
+    rendered.push_str("Prior rounds of review have fired on this branch and their fixes are now\n");
+    rendered.push_str("part of the diff you are reviewing. Verify each prior-round fix did NOT\n");
+    rendered.push_str("introduce a regression:\n\n");
+
+    if summary.round.is_empty() {
+        rendered.push_str("No prior-round summaries were provided.\n\n");
+    } else {
+        for round in &summary.round {
+            rendered.push_str(&format!(
+                "- Round {} (commit {}): {} - Invariant: {}\n",
+                round.number, round.commit, round.summary, round.invariant
+            ));
+        }
+        rendered.push('\n');
+    }
+
+    rendered.push_str("For each invariant above, explicitly check:\n");
+    rendered
+        .push_str("1. The fix from that round still enforces the invariant in the current diff.\n");
+    rendered.push_str(
+        "2. No later commit accidentally loosened the fix (e.g., made a guard too broad, reintroduced a race).\n",
+    );
+    rendered.push_str(
+        "3. If a fix narrowed a bug, the narrowing still covers every reachable code path.\n\n",
+    );
+    rendered.push_str("FAIL findings that break any prior-round invariant. Preserve PASS for\n");
+    rendered.push_str("invariants that hold under the current diff.");
+    rendered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_prior_rounds_section_includes_round_summaries_and_invariants() {
+        let rendered = render_prior_rounds_section(&PriorRoundsSummary {
+            round: vec![
+                PriorRound {
+                    number: 6,
+                    commit: "29b6c34c".to_string(),
+                    summary: "narrowed legacy ACP fallback to tool == \"codex\"".to_string(),
+                    invariant: "ACP codex sessions route to output.log".to_string(),
+                },
+                PriorRound {
+                    number: 7,
+                    commit: "2fdcba62".to_string(),
+                    summary: "moved runtime_binary write behind lock".to_string(),
+                    invariant: "lock-losing resume cannot mutate metadata".to_string(),
+                },
+            ],
+        });
+
+        assert!(rendered.contains("## Prior-Round Invariant Verification"));
+        assert!(rendered.contains("Round 6 (commit 29b6c34c)"));
+        assert!(rendered.contains("ACP codex sessions route to output.log"));
+        assert!(rendered.contains("Round 7 (commit 2fdcba62)"));
+        assert!(rendered.contains("lock-losing resume cannot mutate metadata"));
+    }
+}

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
@@ -30,7 +30,7 @@ pub(crate) fn resolve_last_session_selection(
     }
 
     let mut sorted_sessions = sessions;
-    sorted_sessions.sort_by(|a, b| b.last_accessed.cmp(&a.last_accessed));
+    sorted_sessions.sort_by_key(|session| std::cmp::Reverse(session.last_accessed));
     let selected_id = sorted_sessions[0].meta_session_id.clone();
 
     let active_sessions: Vec<&MetaSessionState> = sorted_sessions

--- a/crates/cli-sub-agent/src/session_cmds_list.rs
+++ b/crates/cli-sub-agent/src/session_cmds_list.rs
@@ -108,7 +108,7 @@ pub(super) fn select_sessions_for_list(
         sessions.retain(|session| session.branch.as_deref() == Some(branch_filter));
     }
 
-    sessions.sort_by(|a, b| b.last_accessed.cmp(&a.last_accessed));
+    sessions.sort_by_key(|session| std::cmp::Reverse(session.last_accessed));
     Ok(sessions)
 }
 
@@ -126,7 +126,7 @@ pub(super) fn select_sessions_for_list_all_projects(
         sessions.retain(|session| tools.iter().any(|tool| session.tools.contains_key(*tool)));
     }
 
-    sessions.sort_by(|a, b| b.last_accessed.cmp(&a.last_accessed));
+    sessions.sort_by_key(|session| std::cmp::Reverse(session.last_accessed));
     Ok(sessions)
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_resolve.rs
+++ b/crates/cli-sub-agent/src/session_cmds_resolve.rs
@@ -56,7 +56,7 @@ pub(super) fn list_checkpoints_from_dirs(
         }
     }
 
-    checkpoints.sort_by(|a, b| b.1.completed_at.cmp(&a.1.completed_at));
+    checkpoints.sort_by_key(|checkpoint| std::cmp::Reverse(checkpoint.1.completed_at.clone()));
     Ok(checkpoints)
 }
 

--- a/crates/cli-sub-agent/tests/review_mode_compat.rs
+++ b/crates/cli-sub-agent/tests/review_mode_compat.rs
@@ -3,6 +3,9 @@ mod cli_defs;
 
 #[path = "../src/review_consensus.rs"]
 mod review_consensus;
+#[allow(dead_code)]
+#[path = "../src/review_prior_rounds.rs"]
+mod review_prior_rounds;
 
 use chrono::{TimeZone, Utc};
 use clap::Parser;
@@ -109,7 +112,7 @@ fn review_cli_validation_and_consensus_helpers_remain_compatible() {
         .expect("red-team review args should validate");
 
     let instruction =
-        review_consensus::build_multi_reviewer_instruction("Base prompt", 2, ToolName::Codex);
+        review_consensus::build_multi_reviewer_instruction("Base prompt", 2, ToolName::Codex, None);
     assert!(instruction.contains("reviewer 2"));
     assert!(instruction.contains("CLEAN"));
     assert!(instruction.contains("HAS_ISSUES"));

--- a/crates/csa-eval/src/lib.rs
+++ b/crates/csa-eval/src/lib.rs
@@ -124,7 +124,7 @@ pub fn identify_failure_patterns(sessions: &[SessionSummary]) -> Vec<FailurePatt
     }
 
     // Sort by count descending for readability
-    patterns.sort_by(|a, b| b.count.cmp(&a.count));
+    patterns.sort_by_key(|pattern| std::cmp::Reverse(pattern.count));
     patterns
 }
 

--- a/crates/csa-memory/src/store.rs
+++ b/crates/csa-memory/src/store.rs
@@ -151,7 +151,7 @@ impl MemoryStore {
             })
             .collect();
 
-        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.timestamp));
         Ok(entries)
     }
 
@@ -177,7 +177,7 @@ impl MemoryStore {
             })
             .collect();
 
-        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.timestamp));
         Ok(entries)
     }
 

--- a/crates/csa-scheduler/src/seed_session.rs
+++ b/crates/csa-scheduler/src/seed_session.rs
@@ -116,7 +116,7 @@ fn find_seed_session_inner(
         .collect();
 
     // Sort by last_accessed descending (most recent first)
-    candidates.sort_by(|a, b| b.last_accessed.cmp(&a.last_accessed));
+    candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.last_accessed));
 
     if let Some(best) = candidates.first() {
         debug!(
@@ -156,7 +156,7 @@ pub fn evict_excess_seeds(
         .collect();
 
     // Sort by last_accessed descending (keep most recent)
-    seeds.sort_by(|a, b| b.last_accessed.cmp(&a.last_accessed));
+    seeds.sort_by_key(|seed| std::cmp::Reverse(seed.last_accessed));
 
     let mut retired_ids = Vec::new();
 

--- a/crates/csa-session/src/genealogy.rs
+++ b/crates/csa-session/src/genealogy.rs
@@ -110,7 +110,7 @@ fn list_sessions_tree_in_roots(
     }
 
     // Sort by created_at for consistent ordering
-    all_sessions.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    all_sessions.sort_by_key(|a| a.created_at);
 
     // Build set of session IDs present in the list for quick lookup.
     let present_ids: HashSet<&str> = all_sessions

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -315,7 +315,7 @@ pub fn list_all_sessions_all_projects() -> Result<Vec<MetaSessionState>> {
             }
         }
     }
-    all_sessions.sort_by(|a, b| b.last_accessed.cmp(&a.last_accessed));
+    all_sessions.sort_by_key(|session| std::cmp::Reverse(session.last_accessed));
     Ok(all_sessions)
 }
 
@@ -597,7 +597,7 @@ pub(crate) fn find_sessions_in(
         sessions.retain(|session| tools.iter().any(|tool| session.tools.contains_key(*tool)));
     }
 
-    sessions.sort_by(|a, b| b.last_accessed.cmp(&a.last_accessed));
+    sessions.sort_by_key(|session| std::cmp::Reverse(session.last_accessed));
     sessions.truncate(10);
     Ok(sessions)
 }

--- a/crates/csa-todo/src/lib.rs
+++ b/crates/csa-todo/src/lib.rs
@@ -339,7 +339,7 @@ impl TodoManager {
         }
 
         // Newest first (timestamps sort lexicographically)
-        plans.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        plans.sort_by_key(|plan| std::cmp::Reverse(plan.timestamp.clone()));
 
         Ok(plans)
     }


### PR DESCRIPTION
## Summary
- add `--prior-rounds-summary` support so `csa review` can load explicit TOML summaries of prior review rounds and render a dedicated prior-round invariant verification section
- inject the prior-round section into both single-reviewer resolution prompts and multi-reviewer consensus prompts, while preventing duplicate section and duplicate `findings.toml` instruction insertion
- persist structured pre-exec failures when the summary file is missing or malformed, and cover the behavior with targeted prompt and failure-path tests

## Verification
- `just pre-commit`
- attempted local review gate: `csa review --range main...HEAD --sa-mode true --model-spec gemini-cli/google/gemini-3.1-pro-preview/xhigh --force-ignore-tier-setting --no-failover --timeout 7200`

## Recovery note
This PR was recovered from prior session `01KPDA1SEQFB81TTERTTK821AM`, which timed out before push/merge completion. The implementation work was already present on branch; this recovery finished verification, push, PR hygiene, and merge steps.

## Local review gate note
The required local Gemini review could not produce a verdict because the configured tool blocked on interactive authentication:

- recovery session: `01KPDF9RMBMWSBHTGQ7RE7XDNA`
- symptom: `Opening authentication page in your browser. Do you want to continue? [Y/n]:`
- related open issue: #790
- previous attempts already documented on this PR: `01KPDB1MR477T325HQTGPZAMS3`, `01KPDB5W8PPKWGFNZ33P6SNY61`, followup #831

Proceeding under the documented escape-hatch precedent for tool-level CSA failures.

Closes #764.
