### PR TITLE
feat(csa-review): auto-select heterogeneous reviewers on multi-tool tier (#765)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.326"
+version = "0.1.327"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.326"
+version = "0.1.327"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -114,9 +114,15 @@ pub struct ReviewArgs {
     #[arg(long)]
     pub context: Option<String>,
 
-    /// Number of reviewers to run in parallel (default: 1)
-    #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u32).range(1..))]
-    pub reviewers: u32,
+    /// Number of reviewers to run in parallel (default: 1).
+    /// `--range` auto-selects up to 3 heterogeneous reviewers from a multi-tool tier
+    /// unless `--reviewers`, `--single`, `--tool`, or `--model-spec` overrides it.
+    #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
+    pub reviewers: Option<u32>,
+
+    /// Force single-reviewer mode even when `--range` would auto-select heterogeneous reviewers.
+    #[arg(long)]
+    pub single: bool,
 
     /// Consensus strategy for multi-reviewer mode
     #[arg(
@@ -204,6 +210,10 @@ pub struct ReviewArgs {
 }
 
 impl ReviewArgs {
+    pub fn requested_reviewers(&self) -> u32 {
+        self.reviewers.unwrap_or(1)
+    }
+
     pub fn effective_review_mode(&self) -> ReviewMode {
         if self.red_team {
             ReviewMode::RedTeam
@@ -241,6 +251,13 @@ pub fn validate_review_args(args: &ReviewArgs) -> std::result::Result<(), clap::
         return Err(clap::Error::raw(
             clap::error::ErrorKind::ArgumentConflict,
             format!("{mode_flag} conflicts with --security-mode off"),
+        ));
+    }
+
+    if args.single && args.requested_reviewers() > 1 {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::ArgumentConflict,
+            "--single conflicts with --reviewers > 1",
         ));
     }
 

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -344,6 +344,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
     let requested_reviewers = args.requested_reviewers() as usize;
     let reviewers = resolve_effective_reviewer_count(&AutoReviewerRequest {
         requested_reviewers,
+        explicit_reviewer_count: args.reviewers.is_some(),
         single: args.single,
         scope_is_range: args.range.is_some(),
         explicit_tool: explicit_review_tool(&args),

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -68,7 +68,9 @@ use resolve::{
     resolve_review_tier_name, resolve_review_tool, review_scope_allows_auto_discovery,
     verify_review_skill_available, write_multi_reviewer_consolidated_artifact,
 };
-use reviewers::resolve_multi_reviewer_pool;
+use reviewers::{
+    AutoReviewerRequest, resolve_effective_reviewer_count, resolve_multi_reviewer_pool,
+};
 
 fn review_decision_from_verdict(verdict: &str) -> ReviewDecision {
     if verdict == CLEAN {
@@ -339,7 +341,20 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
     // Resolve readonly_project_root from config (default: false).
     let readonly_project_root = global_config.review.readonly_sandbox.unwrap_or(false);
 
-    if args.reviewers == 1 {
+    let requested_reviewers = args.requested_reviewers() as usize;
+    let reviewers = resolve_effective_reviewer_count(&AutoReviewerRequest {
+        requested_reviewers,
+        single: args.single,
+        scope_is_range: args.range.is_some(),
+        explicit_tool: explicit_review_tool(&args),
+        explicit_model_spec: args.model_spec.as_deref(),
+        primary_tool: tool,
+        resolved_tier_name: resolved_tier_name.as_deref(),
+        config: config.as_ref(),
+        global_config: &global_config,
+    });
+
+    if reviewers == 1 {
         // Single-reviewer path (with optional --fix loop).
         let review_future = execute_review(
             tool,
@@ -560,7 +575,6 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         anyhow::bail!("--session is only supported when --reviewers=1");
     }
 
-    let reviewers = args.reviewers as usize;
     let consensus_strategy = parse_consensus_strategy(&args.consensus)?;
     let reviewer_pool = resolve_multi_reviewer_pool(
         reviewers,

--- a/crates/cli-sub-agent/src/review_cmd_reviewers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers.rs
@@ -1,24 +1,40 @@
 use anyhow::Result;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::review_consensus::{build_reviewer_tools, validate_multi_reviewer_tier_pool};
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::ToolName;
+
+const MAX_AUTO_HETEROGENEOUS_REVIEWERS: usize = 3;
+
+pub(crate) struct AutoReviewerSelection {
+    pub(crate) reviewers: usize,
+    pub(crate) selected_tools: Vec<ToolName>,
+}
+
+pub(crate) struct AutoReviewerRequest<'a> {
+    pub(crate) requested_reviewers: usize,
+    pub(crate) single: bool,
+    pub(crate) scope_is_range: bool,
+    pub(crate) explicit_tool: Option<ToolName>,
+    pub(crate) explicit_model_spec: Option<&'a str>,
+    pub(crate) primary_tool: ToolName,
+    pub(crate) resolved_tier_name: Option<&'a str>,
+    pub(crate) config: Option<&'a ProjectConfig>,
+    pub(crate) global_config: &'a GlobalConfig,
+}
 
 pub(crate) struct MultiReviewerPool {
     pub(crate) reviewer_tools: Vec<ToolName>,
     pub(crate) tier_reviewer_specs: Vec<crate::run_helpers::TierToolResolution>,
 }
 
-pub(crate) fn resolve_multi_reviewer_pool(
-    reviewers: usize,
-    explicit_tool: Option<ToolName>,
-    primary_tool: ToolName,
+fn collect_tier_reviewer_specs(
     resolved_tier_name: Option<&str>,
     config: Option<&ProjectConfig>,
     global_config: &GlobalConfig,
-) -> Result<MultiReviewerPool> {
-    let tier_reviewer_specs = resolved_tier_name
+) -> Vec<crate::run_helpers::TierToolResolution> {
+    resolved_tier_name
         .and_then(|tier_name| {
             config.map(|cfg| {
                 let effective_selection = cfg
@@ -34,14 +50,98 @@ pub(crate) fn resolve_multi_reviewer_pool(
                 )
             })
         })
-        .unwrap_or_default();
+        .unwrap_or_default()
+}
 
+fn collect_unique_tier_tools(
+    tier_reviewer_specs: &[crate::run_helpers::TierToolResolution],
+) -> Vec<ToolName> {
     let mut tier_reviewer_tools = Vec::new();
-    for resolution in &tier_reviewer_specs {
+    for resolution in tier_reviewer_specs {
         if !tier_reviewer_tools.contains(&resolution.tool) {
             tier_reviewer_tools.push(resolution.tool);
         }
     }
+    tier_reviewer_tools
+}
+
+fn build_selected_tool_subset(
+    primary_tool: ToolName,
+    tier_reviewer_tools: &[ToolName],
+    reviewers: usize,
+) -> Vec<ToolName> {
+    let mut selected = vec![primary_tool];
+    for tool in tier_reviewer_tools {
+        if !selected.contains(tool) {
+            selected.push(*tool);
+        }
+    }
+    selected.truncate(reviewers);
+    selected
+}
+
+pub(crate) fn resolve_auto_reviewer_selection(
+    request: &AutoReviewerRequest<'_>,
+) -> Option<AutoReviewerSelection> {
+    if request.requested_reviewers != 1
+        || request.single
+        || !request.scope_is_range
+        || request.explicit_tool.is_some()
+        || request.explicit_model_spec.is_some()
+    {
+        return None;
+    }
+
+    let tier_reviewer_specs = collect_tier_reviewer_specs(
+        request.resolved_tier_name,
+        request.config,
+        request.global_config,
+    );
+    let tier_reviewer_tools = collect_unique_tier_tools(&tier_reviewer_specs);
+    let unique_pool = build_selected_tool_subset(
+        request.primary_tool,
+        &tier_reviewer_tools,
+        MAX_AUTO_HETEROGENEOUS_REVIEWERS,
+    );
+
+    (unique_pool.len() >= 2).then_some(AutoReviewerSelection {
+        reviewers: unique_pool.len(),
+        selected_tools: unique_pool,
+    })
+}
+
+pub(crate) fn resolve_effective_reviewer_count(request: &AutoReviewerRequest<'_>) -> usize {
+    let auto_reviewer_selection = resolve_auto_reviewer_selection(request);
+    if let Some(selection) = auto_reviewer_selection {
+        let tool_list = selection
+            .selected_tools
+            .iter()
+            .map(|tool| tool.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        info!(
+            "Auto-selected {} heterogeneous reviewers from tier '{}': {}",
+            selection.reviewers,
+            request.resolved_tier_name.unwrap_or("unknown"),
+            tool_list
+        );
+        selection.reviewers
+    } else {
+        request.requested_reviewers
+    }
+}
+
+pub(crate) fn resolve_multi_reviewer_pool(
+    reviewers: usize,
+    explicit_tool: Option<ToolName>,
+    primary_tool: ToolName,
+    resolved_tier_name: Option<&str>,
+    config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+) -> Result<MultiReviewerPool> {
+    let tier_reviewer_specs =
+        collect_tier_reviewer_specs(resolved_tier_name, config, global_config);
+    let tier_reviewer_tools = collect_unique_tier_tools(&tier_reviewer_specs);
 
     if let Some(tier_name) = resolved_tier_name {
         let unique_reviewer_tools = validate_multi_reviewer_tier_pool(
@@ -73,4 +173,259 @@ pub(crate) fn resolve_multi_reviewer_pool(
         reviewer_tools,
         tier_reviewer_specs,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AutoReviewerRequest, resolve_auto_reviewer_selection};
+    use crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV;
+    use crate::test_env_lock::TEST_ENV_LOCK;
+    use csa_config::config::TierConfig;
+    use csa_config::{
+        GlobalConfig, ProjectConfig, ProjectMeta, ResourcesConfig, TierStrategy, ToolConfig,
+    };
+    use csa_core::types::ToolName;
+    use std::collections::HashMap;
+
+    struct ScopedEnvVarRestore {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl ScopedEnvVarRestore {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for ScopedEnvVarRestore {
+        fn drop(&mut self) {
+            // SAFETY: restoration of test-scoped env mutation.
+            unsafe {
+                match self.original.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    fn assume_review_tools_available() -> (std::sync::MutexGuard<'static, ()>, ScopedEnvVarRestore)
+    {
+        (
+            TEST_ENV_LOCK.lock().expect("review env lock poisoned"),
+            ScopedEnvVarRestore::set(TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1"),
+        )
+    }
+
+    fn project_config_with_tier(models: &[&str]) -> ProjectConfig {
+        let mut tool_map = HashMap::new();
+        for tool in csa_config::global::all_known_tools() {
+            tool_map.insert(
+                tool.as_str().to_string(),
+                ToolConfig {
+                    enabled: false,
+                    restrictions: None,
+                    suppress_notify: true,
+                    ..Default::default()
+                },
+            );
+        }
+
+        for tool_name in models.iter().filter_map(|model| model.split('/').next()) {
+            tool_map.insert(
+                tool_name.to_string(),
+                ToolConfig {
+                    enabled: true,
+                    restrictions: None,
+                    suppress_notify: true,
+                    ..Default::default()
+                },
+            );
+        }
+
+        let mut tiers = HashMap::new();
+        tiers.insert(
+            "quality".to_string(),
+            TierConfig {
+                description: "Test tier".to_string(),
+                models: models.iter().map(|model| (*model).to_string()).collect(),
+                strategy: TierStrategy::default(),
+                token_budget: None,
+                max_turns: None,
+            },
+        );
+
+        ProjectConfig {
+            schema_version: 1,
+            project: ProjectMeta::default(),
+            resources: ResourcesConfig::default(),
+            acp: Default::default(),
+            tools: tool_map,
+            review: None,
+            debate: None,
+            tiers,
+            tier_mapping: HashMap::new(),
+            aliases: HashMap::new(),
+            tool_aliases: HashMap::new(),
+            preferences: None,
+            session: Default::default(),
+            memory: Default::default(),
+            hooks: Default::default(),
+            execution: Default::default(),
+            vcs: Default::default(),
+            filesystem_sandbox: Default::default(),
+        }
+    }
+
+    #[test]
+    fn auto_reviewer_selection_skips_single_tool_tier() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier(&["codex/openai/gpt-5.4/high"]);
+        let global = GlobalConfig::default();
+
+        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+            requested_reviewers: 1,
+            single: false,
+            scope_is_range: true,
+            explicit_tool: None,
+            explicit_model_spec: None,
+            primary_tool: ToolName::Codex,
+            resolved_tier_name: Some("quality"),
+            config: Some(&config),
+            global_config: &global,
+        });
+
+        assert!(selection.is_none());
+    }
+
+    #[test]
+    fn auto_reviewer_selection_uses_all_distinct_tier_tools_up_to_cap() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier(&[
+            "codex/openai/gpt-5.4/high",
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "opencode/openrouter/sonnet/high",
+            "claude-code/anthropic/sonnet/xhigh",
+        ]);
+        let global = GlobalConfig::default();
+
+        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+            requested_reviewers: 1,
+            single: false,
+            scope_is_range: true,
+            explicit_tool: None,
+            explicit_model_spec: None,
+            primary_tool: ToolName::GeminiCli,
+            resolved_tier_name: Some("quality"),
+            config: Some(&config),
+            global_config: &global,
+        })
+        .expect("multi-tool tier should auto-select reviewers");
+
+        assert_eq!(selection.reviewers, 3);
+        assert_eq!(
+            selection.selected_tools,
+            vec![ToolName::GeminiCli, ToolName::Codex, ToolName::Opencode]
+        );
+    }
+
+    #[test]
+    fn auto_reviewer_selection_respects_single_flag() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier(&[
+            "codex/openai/gpt-5.4/high",
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        ]);
+        let global = GlobalConfig::default();
+
+        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+            requested_reviewers: 1,
+            single: true,
+            scope_is_range: true,
+            explicit_tool: None,
+            explicit_model_spec: None,
+            primary_tool: ToolName::Codex,
+            resolved_tier_name: Some("quality"),
+            config: Some(&config),
+            global_config: &global,
+        });
+
+        assert!(selection.is_none());
+    }
+
+    #[test]
+    fn auto_reviewer_selection_respects_explicit_reviewer_override() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier(&[
+            "codex/openai/gpt-5.4/high",
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        ]);
+        let global = GlobalConfig::default();
+
+        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+            requested_reviewers: 5,
+            single: false,
+            scope_is_range: true,
+            explicit_tool: None,
+            explicit_model_spec: None,
+            primary_tool: ToolName::Codex,
+            resolved_tier_name: Some("quality"),
+            config: Some(&config),
+            global_config: &global,
+        });
+
+        assert!(selection.is_none());
+    }
+
+    #[test]
+    fn auto_reviewer_selection_respects_explicit_tool_override() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier(&[
+            "codex/openai/gpt-5.4/high",
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        ]);
+        let global = GlobalConfig::default();
+
+        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+            requested_reviewers: 1,
+            single: false,
+            scope_is_range: true,
+            explicit_tool: Some(ToolName::Codex),
+            explicit_model_spec: None,
+            primary_tool: ToolName::Codex,
+            resolved_tier_name: Some("quality"),
+            config: Some(&config),
+            global_config: &global,
+        });
+
+        assert!(selection.is_none());
+    }
+
+    #[test]
+    fn auto_reviewer_selection_skips_non_range_scope() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier(&[
+            "codex/openai/gpt-5.4/high",
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        ]);
+        let global = GlobalConfig::default();
+
+        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+            requested_reviewers: 1,
+            single: false,
+            scope_is_range: false,
+            explicit_tool: None,
+            explicit_model_spec: None,
+            primary_tool: ToolName::Codex,
+            resolved_tier_name: Some("quality"),
+            config: Some(&config),
+            global_config: &global,
+        });
+
+        assert!(selection.is_none());
+    }
 }

--- a/crates/cli-sub-agent/src/review_cmd_reviewers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers.rs
@@ -14,6 +14,7 @@ pub(crate) struct AutoReviewerSelection {
 
 pub(crate) struct AutoReviewerRequest<'a> {
     pub(crate) requested_reviewers: usize,
+    pub(crate) explicit_reviewer_count: bool,
     pub(crate) single: bool,
     pub(crate) scope_is_range: bool,
     pub(crate) explicit_tool: Option<ToolName>,
@@ -84,6 +85,7 @@ pub(crate) fn resolve_auto_reviewer_selection(
     request: &AutoReviewerRequest<'_>,
 ) -> Option<AutoReviewerSelection> {
     if request.requested_reviewers != 1
+        || request.explicit_reviewer_count
         || request.single
         || !request.scope_is_range
         || request.explicit_tool.is_some()
@@ -289,6 +291,7 @@ mod tests {
 
         let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
             requested_reviewers: 1,
+            explicit_reviewer_count: false,
             single: false,
             scope_is_range: true,
             explicit_tool: None,
@@ -315,6 +318,7 @@ mod tests {
 
         let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
             requested_reviewers: 1,
+            explicit_reviewer_count: false,
             single: false,
             scope_is_range: true,
             explicit_tool: None,
@@ -344,6 +348,7 @@ mod tests {
 
         let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
             requested_reviewers: 1,
+            explicit_reviewer_count: false,
             single: true,
             scope_is_range: true,
             explicit_tool: None,
@@ -367,11 +372,37 @@ mod tests {
         let global = GlobalConfig::default();
 
         let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
-            requested_reviewers: 5,
+            requested_reviewers: 1,
+            explicit_reviewer_count: true,
             single: false,
             scope_is_range: true,
             explicit_tool: None,
             explicit_model_spec: None,
+            primary_tool: ToolName::Codex,
+            resolved_tier_name: Some("quality"),
+            config: Some(&config),
+            global_config: &global,
+        });
+
+        assert!(selection.is_none());
+    }
+
+    #[test]
+    fn auto_reviewer_selection_respects_explicit_model_spec_override() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier(&[
+            "codex/openai/gpt-5.4/high",
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        ]);
+        let global = GlobalConfig::default();
+
+        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+            requested_reviewers: 1,
+            explicit_reviewer_count: false,
+            single: false,
+            scope_is_range: true,
+            explicit_tool: None,
+            explicit_model_spec: Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
             primary_tool: ToolName::Codex,
             resolved_tier_name: Some("quality"),
             config: Some(&config),
@@ -392,6 +423,7 @@ mod tests {
 
         let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
             requested_reviewers: 1,
+            explicit_reviewer_count: false,
             single: false,
             scope_is_range: true,
             explicit_tool: Some(ToolName::Codex),
@@ -416,6 +448,7 @@ mod tests {
 
         let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
             requested_reviewers: 1,
+            explicit_reviewer_count: false,
             single: false,
             scope_is_range: false,
             explicit_tool: None,

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -430,7 +430,8 @@ fn default_review_args() -> ReviewArgs {
         red_team: false,
         security_mode: "auto".to_string(),
         context: None,
-        reviewers: 1,
+        reviewers: None,
+        single: false,
         consensus: "majority".to_string(),
         cd: None,
         timeout: None,
@@ -607,7 +608,7 @@ fn review_cli_parses_range_scope_with_multiple_reviewers() {
         "3",
     ]);
 
-    assert_eq!(args.reviewers, 3);
+    assert_eq!(args.reviewers, Some(3));
     assert_eq!(derive_scope(&args), "range:main...HEAD");
 }
 
@@ -641,7 +642,7 @@ fn review_cli_builds_multi_reviewer_config_from_args() {
     ]);
 
     let strategy = parse_consensus_strategy(&args.consensus).unwrap();
-    let reviewers = args.reviewers as usize;
+    let reviewers = args.requested_reviewers() as usize;
     let reviewer_tools =
         build_reviewer_tools(args.tool, ToolName::Codex, None, None, None, reviewers);
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -150,6 +150,7 @@ fn build_multi_reviewer_instruction_contains_design_preference_anchor() {
 
 #[test]
 fn count_prior_reviews_zero_omits_iteration_block() {
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-zero");
 
@@ -176,6 +177,7 @@ fn count_prior_reviews_zero_omits_iteration_block() {
 
 #[test]
 fn count_prior_reviews_one_injects_iteration_two() {
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-one");
     create_mock_review_session(
@@ -294,6 +296,7 @@ fn multi_round_escalation_keeps_persistent_correctness_bugs_blocking() {
 
 #[test]
 fn count_prior_reviews_does_not_pull_reviews_from_other_branches() {
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-current");
     create_mock_review_session(
@@ -319,6 +322,7 @@ fn count_prior_reviews_does_not_pull_reviews_from_other_branches() {
 
 #[test]
 fn count_prior_reviews_branch_unknown_returns_safe_zero() {
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-unknown");
     create_mock_review_session(
@@ -343,6 +347,7 @@ fn count_prior_reviews_branch_unknown_returns_safe_zero() {
 
 #[test]
 fn count_prior_reviews_uses_canonical_max_after_more_than_ten_prior_reviews() {
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-many");
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -150,7 +150,6 @@ fn build_multi_reviewer_instruction_contains_design_preference_anchor() {
 
 #[test]
 fn count_prior_reviews_zero_omits_iteration_block() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-zero");
 
@@ -177,7 +176,6 @@ fn count_prior_reviews_zero_omits_iteration_block() {
 
 #[test]
 fn count_prior_reviews_one_injects_iteration_two() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-one");
     create_mock_review_session(
@@ -296,7 +294,6 @@ fn multi_round_escalation_keeps_persistent_correctness_bugs_blocking() {
 
 #[test]
 fn count_prior_reviews_does_not_pull_reviews_from_other_branches() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-current");
     create_mock_review_session(
@@ -322,7 +319,6 @@ fn count_prior_reviews_does_not_pull_reviews_from_other_branches() {
 
 #[test]
 fn count_prior_reviews_branch_unknown_returns_safe_zero() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-unknown");
     create_mock_review_session(
@@ -347,7 +343,6 @@ fn count_prior_reviews_branch_unknown_returns_safe_zero() {
 
 #[test]
 fn count_prior_reviews_uses_canonical_max_after_more_than_ten_prior_reviews() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-many");
 

--- a/crates/cli-sub-agent/tests/review_mode_compat.rs
+++ b/crates/cli-sub-agent/tests/review_mode_compat.rs
@@ -8,7 +8,7 @@ mod review_consensus;
 mod review_prior_rounds;
 
 use chrono::{TimeZone, Utc};
-use clap::Parser;
+use clap::{Parser, error::ErrorKind};
 use cli_defs::{Cli, Commands, ReviewMode};
 use csa_core::{consensus::ConsensusStrategy, types::ToolName};
 use csa_session::review_artifact::{ReviewArtifact, SeveritySummary};
@@ -122,4 +122,18 @@ fn review_cli_validation_and_consensus_helpers_remain_compatible() {
         review_consensus::consensus_strategy_label(ConsensusStrategy::Majority),
         "majority"
     );
+}
+
+#[test]
+fn review_cli_validation_rejects_single_with_multiple_reviewers() {
+    let cli = Cli::try_parse_from(["csa", "review", "--diff", "--single", "--reviewers", "2"])
+        .expect("single flag should parse before validation");
+    let err = match cli.command {
+        Commands::Review(args) => {
+            cli_defs::validate_review_args(&args).expect_err("validation should reject conflict")
+        }
+        _ => panic!("expected review command"),
+    };
+
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 }

--- a/crates/csa-config/src/global_tests.rs
+++ b/crates/csa-config/src/global_tests.rs
@@ -161,7 +161,9 @@ frequent_poll_seconds = 45
 fn test_resolve_session_wait_long_poll_seconds_uses_legacy_config_dir_fallback() {
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
-    let legacy_dir = config_root.join("csa");
+    let _home_guard = EnvVarGuard::set("HOME", dir.path());
+    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+    let legacy_dir = crate::paths::legacy_config_dir().expect("legacy config dir");
     std::fs::create_dir_all(&legacy_dir).unwrap();
     std::fs::write(
         legacy_dir.join("config.toml"),
@@ -171,9 +173,6 @@ long_poll_seconds = 3000
 "#,
     )
     .unwrap();
-
-    let _home_guard = EnvVarGuard::set("HOME", dir.path());
-    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
     let config_dir = crate::paths::config_dir();
     assert_eq!(

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -487,7 +487,10 @@ fn prepare_gemini_acp_runtime_resolves_mise_shims_via_mise_which() {
     )
     .expect("prepare runtime");
 
-    assert_eq!(launch.command, node_dir.join("node").to_string_lossy());
+    assert_eq!(
+        canonicalize_if_exists(Path::new(&launch.command)),
+        canonicalize_if_exists(&node_dir.join("node"))
+    );
     assert_eq!(launch.args[1], real_script.to_string_lossy());
     let prepared_path = env.get("PATH").expect("prepared path");
     assert_eq!(
@@ -574,7 +577,10 @@ fn prepare_gemini_acp_runtime_passes_project_dir_to_mise_which() {
     )
     .expect("prepare runtime");
 
-    assert_eq!(launch.command, node_dir.join("node").to_string_lossy());
+    assert_eq!(
+        canonicalize_if_exists(Path::new(&launch.command)),
+        canonicalize_if_exists(&node_dir.join("node"))
+    );
     assert_eq!(env.get("TMPDIR"), Some(&runtime_tmp.to_string_lossy().into_owned()));
 }
 
@@ -681,4 +687,9 @@ fn resolve_first_path_entry(name: &str, path_env: &str) -> Option<PathBuf> {
     std::env::split_paths(OsStr::new(path_env))
         .map(|directory| directory.join(name))
         .find(|candidate| candidate.is_file())
+        .map(|candidate| canonicalize_if_exists(&candidate))
+}
+
+fn canonicalize_if_exists(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -86,9 +86,15 @@ fn prepare_gemini_acp_runtime_sets_runtime_home_and_resolves_direct_launch() {
     )
     .expect("prepare runtime");
 
-    assert_eq!(launch.command, node_path.to_string_lossy());
+    assert_eq!(
+        canonicalize_if_exists(Path::new(&launch.command)),
+        canonicalize_if_exists(&node_path)
+    );
     assert_eq!(launch.args[0], "--no-warnings=DEP0040");
-    assert_eq!(launch.args[1], real_script.to_string_lossy());
+    assert_eq!(
+        canonicalize_if_exists(Path::new(&launch.args[1])),
+        canonicalize_if_exists(&real_script)
+    );
     assert_eq!(launch.args[2], "--acp");
 
     let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
@@ -491,7 +497,10 @@ fn prepare_gemini_acp_runtime_resolves_mise_shims_via_mise_which() {
         canonicalize_if_exists(Path::new(&launch.command)),
         canonicalize_if_exists(&node_dir.join("node"))
     );
-    assert_eq!(launch.args[1], real_script.to_string_lossy());
+    assert_eq!(
+        canonicalize_if_exists(Path::new(&launch.args[1])),
+        canonicalize_if_exists(&real_script)
+    );
     let prepared_path = env.get("PATH").expect("prepared path");
     assert_eq!(
         resolve_first_path_entry("node", prepared_path),

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -413,12 +413,12 @@ fn prepare_gemini_acp_runtime_pins_non_shim_runtime_bins_on_path() {
     let prepared_path = env.get("PATH").expect("prepared path");
     assert_eq!(
         resolve_first_path_entry("node", prepared_path),
-        Some(node_dir.join("node")),
+        Some(canonicalize_if_exists(&node_dir.join("node"))),
         "nested yarn/node launches must hit the real node binary before any shim"
     );
     assert_eq!(
         resolve_first_path_entry("yarn", prepared_path),
-        Some(yarn_dir.join("yarn")),
+        Some(canonicalize_if_exists(&yarn_dir.join("yarn"))),
         "runtime PATH should preserve direct yarn binaries ahead of shim-only entries"
     );
     assert_eq!(env.get("MISE_SHIM"), Some(&String::new()));
@@ -495,12 +495,12 @@ fn prepare_gemini_acp_runtime_resolves_mise_shims_via_mise_which() {
     let prepared_path = env.get("PATH").expect("prepared path");
     assert_eq!(
         resolve_first_path_entry("node", prepared_path),
-        Some(node_dir.join("node")),
+        Some(canonicalize_if_exists(&node_dir.join("node"))),
         "mise-which fallback should pin the real node binary ahead of shim-only PATH entries"
     );
     assert_eq!(
         resolve_first_path_entry("yarn", prepared_path),
-        Some(yarn_dir.join("yarn")),
+        Some(canonicalize_if_exists(&yarn_dir.join("yarn"))),
         "mise-which fallback should pin the real yarn binary ahead of shim-only PATH entries"
     );
 }

--- a/crates/csa-hooks/src/audit.rs
+++ b/crates/csa-hooks/src/audit.rs
@@ -102,7 +102,6 @@ mod tests {
     /// the original value on drop.
     struct ScopedXdgOverride {
         orig: Option<String>,
-        orig_home: Option<String>,
         _lock: std::sync::MutexGuard<'static, ()>,
     }
 
@@ -110,19 +109,11 @@ mod tests {
         fn new(tmp: &tempfile::TempDir) -> Self {
             let lock = ENV_LOCK.lock().expect("env lock poisoned");
             let orig = std::env::var("XDG_STATE_HOME").ok();
-            let orig_home = std::env::var("HOME").ok();
-            let home = tmp.path().join("home");
-            fs::create_dir_all(&home).expect("create isolated HOME for audit tests");
             // SAFETY: test-scoped env mutation protected by AUDIT_ENV_LOCK.
             unsafe {
                 std::env::set_var("XDG_STATE_HOME", tmp.path().join("state").to_str().unwrap());
-                std::env::set_var("HOME", home.to_str().unwrap());
             }
-            Self {
-                orig,
-                orig_home,
-                _lock: lock,
-            }
+            Self { orig, _lock: lock }
         }
     }
 
@@ -133,10 +124,6 @@ mod tests {
                 match &self.orig {
                     Some(v) => std::env::set_var("XDG_STATE_HOME", v),
                     None => std::env::remove_var("XDG_STATE_HOME"),
-                }
-                match &self.orig_home {
-                    Some(v) => std::env::set_var("HOME", v),
-                    None => std::env::remove_var("HOME"),
                 }
             }
         }

--- a/crates/csa-hooks/src/audit.rs
+++ b/crates/csa-hooks/src/audit.rs
@@ -96,10 +96,7 @@ pub fn audit_log_path() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{LazyLock, Mutex};
-
-    /// Process-wide lock for tests that mutate `XDG_STATE_HOME`.
-    static AUDIT_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    use crate::test_support::ENV_LOCK;
 
     /// RAII guard that sets `XDG_STATE_HOME` to a temp path and restores
     /// the original value on drop.
@@ -110,7 +107,7 @@ mod tests {
 
     impl ScopedXdgOverride {
         fn new(tmp: &tempfile::TempDir) -> Self {
-            let lock = AUDIT_ENV_LOCK.lock().expect("env lock poisoned");
+            let lock = ENV_LOCK.lock().expect("env lock poisoned");
             let orig = std::env::var("XDG_STATE_HOME").ok();
             // SAFETY: test-scoped env mutation protected by AUDIT_ENV_LOCK.
             unsafe {
@@ -143,9 +140,9 @@ mod tests {
             Path::new("/tmp/markers/owner_repo/42-abc123def.done"),
         );
 
-        let log_path = tmp
-            .path()
-            .join("state/cli-sub-agent/events/merge-guard.jsonl");
+        let log_path = csa_config::paths::state_dir()
+            .expect("state dir")
+            .join("events/merge-guard.jsonl");
         assert!(log_path.exists(), "audit log should be created");
 
         let content = fs::read_to_string(&log_path).unwrap();
@@ -167,9 +164,9 @@ mod tests {
         emit_merge_completed_event(1, "sha1", Path::new("/tmp/m1.done"));
         emit_merge_completed_event(2, "sha2", Path::new("/tmp/m2.done"));
 
-        let log_path = tmp
-            .path()
-            .join("state/cli-sub-agent/events/merge-guard.jsonl");
+        let log_path = csa_config::paths::state_dir()
+            .expect("state dir")
+            .join("events/merge-guard.jsonl");
         let content = fs::read_to_string(&log_path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
         assert_eq!(lines.len(), 2, "should have two event lines");

--- a/crates/csa-hooks/src/audit.rs
+++ b/crates/csa-hooks/src/audit.rs
@@ -102,6 +102,7 @@ mod tests {
     /// the original value on drop.
     struct ScopedXdgOverride {
         orig: Option<String>,
+        orig_home: Option<String>,
         _lock: std::sync::MutexGuard<'static, ()>,
     }
 
@@ -109,11 +110,19 @@ mod tests {
         fn new(tmp: &tempfile::TempDir) -> Self {
             let lock = ENV_LOCK.lock().expect("env lock poisoned");
             let orig = std::env::var("XDG_STATE_HOME").ok();
+            let orig_home = std::env::var("HOME").ok();
+            let home = tmp.path().join("home");
+            fs::create_dir_all(&home).expect("create isolated HOME for audit tests");
             // SAFETY: test-scoped env mutation protected by AUDIT_ENV_LOCK.
             unsafe {
                 std::env::set_var("XDG_STATE_HOME", tmp.path().join("state").to_str().unwrap());
+                std::env::set_var("HOME", home.to_str().unwrap());
             }
-            Self { orig, _lock: lock }
+            Self {
+                orig,
+                orig_home,
+                _lock: lock,
+            }
         }
     }
 
@@ -124,6 +133,10 @@ mod tests {
                 match &self.orig {
                     Some(v) => std::env::set_var("XDG_STATE_HOME", v),
                     None => std::env::remove_var("XDG_STATE_HOME"),
+                }
+                match &self.orig_home {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
                 }
             }
         }

--- a/crates/csa-hooks/src/lib.rs
+++ b/crates/csa-hooks/src/lib.rs
@@ -54,6 +54,14 @@ pub mod policy;
 pub mod runner;
 pub mod waiver;
 
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::{LazyLock, Mutex};
+
+    /// Process-wide lock for tests that mutate shared process environment.
+    pub(crate) static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+}
+
 // Re-export key types
 pub use audit::{MergeAuditEvent, audit_log_path, emit_merge_completed_event};
 pub use config::{HookConfig, HooksConfig, global_hooks_path, load_hooks_config};

--- a/crates/csa-hooks/src/merge_guard/tests.rs
+++ b/crates/csa-hooks/src/merge_guard/tests.rs
@@ -1,10 +1,7 @@
 use super::*;
+use crate::test_support::ENV_LOCK;
 use std::io::Write as _;
-use std::sync::{LazyLock, Mutex};
 use tempfile::NamedTempFile;
-
-/// Process-wide lock for tests that mutate `XDG_STATE_HOME`.
-static GUARD_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 /// RAII guard that sets `XDG_STATE_HOME` to a temp path and restores
 /// the original value on drop — even if the test panics.
@@ -15,7 +12,7 @@ struct ScopedXdgOverride {
 
 impl ScopedXdgOverride {
     fn new(tmp: &tempfile::TempDir) -> Self {
-        let lock = GUARD_ENV_LOCK.lock().expect("env lock poisoned");
+        let lock = ENV_LOCK.lock().expect("env lock poisoned");
         let orig = std::env::var("XDG_STATE_HOME").ok();
         // SAFETY: test-scoped env mutation protected by GUARD_ENV_LOCK.
         unsafe {

--- a/crates/csa-hooks/src/merge_guard/tests.rs
+++ b/crates/csa-hooks/src/merge_guard/tests.rs
@@ -7,6 +7,7 @@ use tempfile::NamedTempFile;
 /// the original value on drop — even if the test panics.
 struct ScopedXdgOverride {
     orig: Option<String>,
+    orig_home: Option<String>,
     _lock: std::sync::MutexGuard<'static, ()>,
 }
 
@@ -14,11 +15,19 @@ impl ScopedXdgOverride {
     fn new(tmp: &tempfile::TempDir) -> Self {
         let lock = ENV_LOCK.lock().expect("env lock poisoned");
         let orig = std::env::var("XDG_STATE_HOME").ok();
+        let orig_home = std::env::var("HOME").ok();
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).expect("create isolated HOME for merge guard tests");
         // SAFETY: test-scoped env mutation protected by GUARD_ENV_LOCK.
         unsafe {
             std::env::set_var("XDG_STATE_HOME", tmp.path().join("state").to_str().unwrap());
+            std::env::set_var("HOME", home.to_str().unwrap());
         }
-        Self { orig, _lock: lock }
+        Self {
+            orig,
+            orig_home,
+            _lock: lock,
+        }
     }
 }
 
@@ -29,6 +38,10 @@ impl Drop for ScopedXdgOverride {
             match &self.orig {
                 Some(v) => std::env::set_var("XDG_STATE_HOME", v),
                 None => std::env::remove_var("XDG_STATE_HOME"),
+            }
+            match &self.orig_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
             }
         }
     }

--- a/crates/csa-hooks/src/merge_guard/tests.rs
+++ b/crates/csa-hooks/src/merge_guard/tests.rs
@@ -7,7 +7,6 @@ use tempfile::NamedTempFile;
 /// the original value on drop — even if the test panics.
 struct ScopedXdgOverride {
     orig: Option<String>,
-    orig_home: Option<String>,
     _lock: std::sync::MutexGuard<'static, ()>,
 }
 
@@ -15,19 +14,11 @@ impl ScopedXdgOverride {
     fn new(tmp: &tempfile::TempDir) -> Self {
         let lock = ENV_LOCK.lock().expect("env lock poisoned");
         let orig = std::env::var("XDG_STATE_HOME").ok();
-        let orig_home = std::env::var("HOME").ok();
-        let home = tmp.path().join("home");
-        fs::create_dir_all(&home).expect("create isolated HOME for merge guard tests");
         // SAFETY: test-scoped env mutation protected by GUARD_ENV_LOCK.
         unsafe {
             std::env::set_var("XDG_STATE_HOME", tmp.path().join("state").to_str().unwrap());
-            std::env::set_var("HOME", home.to_str().unwrap());
         }
-        Self {
-            orig,
-            orig_home,
-            _lock: lock,
-        }
+        Self { orig, _lock: lock }
     }
 }
 
@@ -38,10 +29,6 @@ impl Drop for ScopedXdgOverride {
             match &self.orig {
                 Some(v) => std::env::set_var("XDG_STATE_HOME", v),
                 None => std::env::remove_var("XDG_STATE_HOME"),
-            }
-            match &self.orig_home {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `csa review --single` as an explicit opt-out for heterogeneous multi-reviewer auto-selection
- make `csa review --range` auto-select up to 3 heterogeneous reviewers from the resolved multi-tool tier when reviewer count is still at its default and no explicit tool/model pin is present
- log when heterogeneous auto-selection activates, update CLI docs, add coverage for range/single/override/scope-guard cases, and bump the workspace version to 0.1.327

## Why
Issue #765 reported that cumulative `csa review --range` wastes cognitive diversity on multi-tool tiers by defaulting to a single reviewer. The new default preserves existing explicit overrides while making the cumulative range workflow heterogeneous by default.

## Validation
- `cargo test -p cli-sub-agent auto_reviewer_selection`
- `cargo test -p cli-sub-agent review_cli_`
- `cargo test -p cli-sub-agent review_cli_validation_rejects_single_with_multiple_reviewers`
- `just pre-commit`

## Review Gate Notes
- attempted required Gemini review gate via `./target/release/csa review --range main...HEAD --sa-mode true --model-spec gemini-cli/google/gemini-3.1-pro-preview/xhigh --force-ignore-tier-setting --no-failover --timeout 7200`, but it blocked on the known OAuth browser prompt issue tracked in #790
- recorded codex fallback review session for this exact HEAD: `01KPDM9ZY1AAETB8TH0KQ89ERB`
