### PR TITLE
fix(csa-executor): classify gemini-cli ACP init failure (#778, #755)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.328"
+version = "0.1.329"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.328"
+version = "0.1.329"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -143,7 +143,13 @@ impl AcpConnection {
 
         match result {
             Some(Ok(_response)) => Ok(()),
-            Some(Err(err)) => Err(AcpError::InitializationFailed(err.to_string())),
+            Some(Err(err)) => {
+                let stderr = self.stderr();
+                Err(AcpError::InitializationFailed(format!(
+                    "{err}{}",
+                    Self::format_stderr(&stderr)
+                )))
+            }
             None => {
                 let stderr = self.stderr();
                 let _ = self.kill().await;
@@ -185,7 +191,13 @@ impl AcpConnection {
 
         match result {
             Some(Ok(response)) => Ok(response.session_id.0.to_string()),
-            Some(Err(err)) => Err(AcpError::SessionFailed(err.to_string())),
+            Some(Err(err)) => {
+                let stderr = self.stderr();
+                Err(AcpError::SessionFailed(format!(
+                    "{err}{}",
+                    Self::format_stderr(&stderr)
+                )))
+            }
             None => {
                 let stderr = self.stderr();
                 let _ = self.kill().await;
@@ -222,7 +234,13 @@ impl AcpConnection {
 
         match result {
             Some(Ok(_response)) => Ok(session_id.to_string()),
-            Some(Err(err)) => Err(AcpError::SessionFailed(err.to_string())),
+            Some(Err(err)) => {
+                let stderr = self.stderr();
+                Err(AcpError::SessionFailed(format!(
+                    "{err}{}",
+                    Self::format_stderr(&stderr)
+                )))
+            }
             None => {
                 // Unlike initialize/new_session, do NOT kill the process here.
                 // load_session is an optional optimisation (resume vs create new).
@@ -603,15 +621,10 @@ fn maybe_emit_heartbeat(
     *last_heartbeat = now;
 }
 
-/// Maximum bytes a line buffer may hold before being force-flushed.
-/// Prevents unbounded memory growth on long non-newline output (base64,
-/// minified JSON, etc.).
+/// Maximum bytes buffered before a newline-free chunk is force-flushed.
 pub(crate) const LINE_BUF_CAP: usize = 64 * 1024;
 
-/// Flush complete lines (terminated by `\n`) from `buf`, each prefixed with
-/// `prefix`.  Incomplete trailing content stays in `buf` for the next call,
-/// unless the buffer exceeds [`LINE_BUF_CAP`], in which case the entire
-/// remainder is force-flushed.
+/// Flush complete lines; keep incomplete tails unless the buffer exceeds [`LINE_BUF_CAP`].
 fn flush_complete_lines(buf: &mut String, prefix: &str) {
     while let Some(pos) = buf.find('\n') {
         let line: String = buf.drain(..=pos).collect();
@@ -624,8 +637,7 @@ fn flush_complete_lines(buf: &mut String, prefix: &str) {
     }
 }
 
-/// Flush any remaining content from `buf` (for end-of-stream or stream-type
-/// switch).  Appends a newline so the log entry is properly terminated.
+/// Flush any remaining buffered content, appending a terminating newline.
 fn flush_remaining_buf(buf: &mut String, prefix: &str) {
     if !buf.is_empty() {
         let remainder = std::mem::take(buf);
@@ -642,10 +654,7 @@ fn stream_new_agent_messages(
     stdout_line_buf: &mut String,
     thought_line_buf: &mut String,
 ) {
-    // Iterate new retained events by total event count.  Older events may be
-    // dropped from the front once retention reaches `MAX_RETAINED_EVENTS`, so
-    // the processing cursor is tracked against the total number of events seen
-    // rather than the retained deque length.
+    // Track progress against total seen events because the retained deque can evict old entries.
     let events_ref = events.borrow();
     metadata.sync_from_store(&events_ref);
     if *processed_event_count >= events_ref.total_events_count() {
@@ -661,8 +670,7 @@ fn stream_new_agent_messages(
             processed = *processed_event_count,
             "ACP event ring buffer overrun: {skipped} events were evicted before being streamed to spool/stderr"
         );
-        // Clear partial line buffers so we don't splice stale content with
-        // the first retained chunk after the gap (PR #440 P3).
+        // Avoid splicing pre-overrun partial lines with the first retained chunk.
         stdout_line_buf.clear();
         thought_line_buf.clear();
     }
@@ -672,7 +680,6 @@ fn stream_new_agent_messages(
         match event {
             SessionEvent::AgentMessage(chunk) => {
                 if stream_stdout_to_stderr {
-                    // Flush thought buffer on stream-type switch.
                     flush_remaining_buf(thought_line_buf, "[thought] ");
                     stdout_line_buf.push_str(chunk);
                     flush_complete_lines(stdout_line_buf, "[stdout] ");
@@ -682,7 +689,6 @@ fn stream_new_agent_messages(
             }
             SessionEvent::AgentThought(chunk) => {
                 if stream_stdout_to_stderr {
-                    // Flush stdout buffer on stream-type switch.
                     flush_remaining_buf(stdout_line_buf, "[stdout] ");
                     thought_line_buf.push_str(chunk);
                     flush_complete_lines(thought_line_buf, "[thought] ");
@@ -731,10 +737,7 @@ fn stream_new_agent_messages(
         }
     }
 
-    // Debounce: flush any accumulated partial line at the end of each poll
-    // cycle to maintain progressive output visibility.  This ensures one
-    // coalesced [stdout] tag per ~200ms poll instead of per-token, while
-    // still showing progress for newline-free output (PR #440 P2).
+    // Flush partial lines once per poll so newline-free output still streams progressively.
     if stream_stdout_to_stderr {
         flush_remaining_buf(stdout_line_buf, "[stdout] ");
         flush_remaining_buf(thought_line_buf, "[thought] ");
@@ -747,24 +750,11 @@ fn spool_chunk(spool: &mut Option<SpoolRotator>, bytes: &[u8], metadata: &mut St
     if let Some(writer) = spool {
         let _ = writer.write(bytes);
         metadata.spool_bytes_written = writer.bytes_written();
-        // BufWriter flushes automatically when the buffer fills (64 KiB).
-        // No per-chunk flush — the final flush happens on drop or when the
-        // prompt_with_io loop ends.
-        //
-        // Note: no size cap on the spool file.  Disk usage is managed by
-        // `csa gc`, not here.  A HEAD-only cap would truncate tail markers
-        // (e.g. return-packet), breaking fork call chains.  RAM is bounded
-        // by the StreamingMetadata tail buffer instead.
+        // Let BufWriter flush on capacity/drop; spool retention is managed by `csa gc`.
     }
 }
 
-/// Collect agent output for the caller (stdout / summary extraction).
-///
-/// Prefers `message_text` (actual agent output).  When no message text was
-/// produced but thought text exists, falls back to thought text with a
-/// `[thought-fallback]` prefix so callers know the output is derived from
-/// internal reasoning rather than visible agent messages.  This handles
-/// models (e.g. gemini) that produce thoughts but no visible message content.
+/// Collect agent-visible output, falling back to thought text when no message text exists.
 fn collect_agent_output(metadata: &mut StreamingMetadata) -> String {
     let message = metadata.message_text.trim();
     if !message.is_empty() {
@@ -777,8 +767,7 @@ fn collect_agent_output(metadata: &mut StreamingMetadata) -> String {
             thought_bytes = metadata.thought_text.len(),
             "agent produced no message output; falling back to thought text"
         );
-        // Put the marker on its own line so CSA section markers
-        // (<!-- CSA:SECTION:... -->) in the thought text remain parseable.
+        // Keep the marker on its own line so CSA section markers remain parseable.
         return format!("[thought-fallback]\n{}", metadata.thought_text);
     }
     String::new()

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -32,9 +32,9 @@ mod transport_gemini_helpers;
 use transport_gemini_helpers::format_gemini_retry_report;
 use transport_gemini_helpers::{
     GeminiRetryPhase, annotate_gemini_retry_error, append_gemini_retry_report,
-    apply_gemini_sandbox_runtime_env_overrides, classify_join_error,
-    ensure_gemini_runtime_home_writable_path, gemini_phase_desc,
-    gemini_sandbox_runtime_env_overrides,
+    apply_gemini_sandbox_runtime_env_overrides, classify_gemini_acp_init_failure,
+    classify_join_error, ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure,
+    gemini_phase_desc, gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure,
 };
 
 #[path = "transport_gemini_acp_runtime.rs"]
@@ -431,6 +431,15 @@ impl AcpTransport {
         }
         let gemini_sandbox_env_overrides =
             (self.tool_name == "gemini-cli").then(|| gemini_sandbox_runtime_env_overrides(&env));
+        let gemini_env_allowlist_applied = gemini_sandbox_env_overrides
+            .as_ref()
+            .map(|overrides| {
+                let mut keys = overrides.keys().cloned().collect::<Vec<_>>();
+                keys.sort();
+                keys.join(",")
+            })
+            .unwrap_or_else(|| "none".to_string());
+        let gemini_classification_env = (self.tool_name == "gemini-cli").then(|| env.clone());
 
         let sandbox_plan = options.sandbox.map(|s| {
             let mut isolation_plan = s.isolation_plan.clone();
@@ -588,6 +597,32 @@ impl AcpTransport {
             .await
             .map_err(classify_join_error)?
             .map_err(|error| {
+                if self.tool_name == "gemini-cli" {
+                    let error_display = format!("{error:#}");
+                    if is_gemini_acp_init_failure(&error_display) {
+                        let memory_max_mb = options
+                            .sandbox
+                            .and_then(|sandbox| sandbox.isolation_plan.memory_max_mb);
+                        let classification = classify_gemini_acp_init_failure(
+                            &error_display,
+                            gemini_classification_env
+                                .as_ref()
+                                .expect("gemini classification env"),
+                        );
+                        tracing::warn!(
+                            classified_reason = classification.code,
+                            memory_max_mb,
+                            env_allowlist_applied = %gemini_env_allowlist_applied,
+                            missing_env_vars = %classification.missing_env_vars.join(","),
+                            "classified gemini ACP initialization failure"
+                        );
+                        return format_gemini_acp_init_failure(
+                            &classification,
+                            error,
+                            memory_max_mb,
+                        );
+                    }
+                }
                 if let Some(path) = acp_payload_debug_path.as_deref() {
                     error.context(format!(
                         "ACP payload debug written to {}",
@@ -627,6 +662,7 @@ mod tests {
     include!("transport_tests_tail.rs");
     include!("transport_tests_ephemeral.rs");
     include!("transport_tests_gemini_fallback.rs");
+    include!("transport_tests_gemini_init_classification.rs");
     include!("transport_tests_extra.rs");
 }
 

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -178,6 +178,123 @@ pub(super) fn classify_join_error(e: tokio::task::JoinError) -> anyhow::Error {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct GeminiAcpInitFailureClassification {
+    pub(super) code: &'static str,
+    pub(super) missing_env_vars: Vec<&'static str>,
+}
+
+pub(super) fn is_gemini_acp_init_failure(error: &str) -> bool {
+    let error_lower = error.to_ascii_lowercase();
+    error_lower.contains("acp initialization failed")
+        || error_lower.contains("sandboxed acp: acp initialization failed")
+}
+
+pub(super) fn classify_gemini_acp_init_failure(
+    error: &str,
+    execution_env: &HashMap<String, String>,
+) -> GeminiAcpInitFailureClassification {
+    let error_lower = error.to_ascii_lowercase();
+    let missing_env_vars = missing_gemini_auth_env_vars(execution_env);
+
+    let code = if is_gemini_init_oom(&error_lower) {
+        "gemini_acp_init_oom"
+    } else if is_gemini_init_mcp_extension(&error_lower) {
+        "gemini_acp_init_mcp_extension"
+    } else if !missing_env_vars.is_empty() && is_gemini_init_auth_env(&error_lower) {
+        "gemini_acp_init_auth_env"
+    } else {
+        "gemini_acp_init_handshake_timeout"
+    };
+
+    GeminiAcpInitFailureClassification {
+        code,
+        missing_env_vars,
+    }
+}
+
+pub(super) fn format_gemini_acp_init_failure(
+    classification: &GeminiAcpInitFailureClassification,
+    error: anyhow::Error,
+    memory_max_mb: Option<u64>,
+) -> anyhow::Error {
+    let current_limit = match memory_max_mb {
+        Some(limit_mb) => format!("{limit_mb}MB"),
+        None => "(no explicit limit set — using system default)".to_string(),
+    };
+
+    let detail = match classification.code {
+        "gemini_acp_init_oom" => format!(
+            "Gemini ACP child died before handshake and looks memory-constrained. Current limit: {current_limit} ([tools.gemini-cli].memory_max_mb)."
+        ),
+        "gemini_acp_init_auth_env" => format!(
+            "Gemini ACP child died before handshake and auth/routing env may have been stripped: {}.",
+            classification.missing_env_vars.join(", ")
+        ),
+        "gemini_acp_init_mcp_extension" => {
+            "Gemini ACP child died before handshake while starting a Gemini MCP extension."
+                .to_string()
+        }
+        _ => {
+            "Gemini ACP child died before handshake or initialization never completed.".to_string()
+        }
+    };
+
+    anyhow!(
+        "{code}: {detail}\nOriginal error: {error:#}",
+        code = classification.code
+    )
+}
+
+fn missing_gemini_auth_env_vars(execution_env: &HashMap<String, String>) -> Vec<&'static str> {
+    [
+        csa_core::gemini::API_KEY_ENV,
+        csa_core::gemini::BASE_URL_ENV,
+    ]
+    .into_iter()
+    .filter(|key| {
+        std::env::var_os(key).is_some()
+            && execution_env
+                .get(*key)
+                .is_none_or(|value| value.trim().is_empty())
+    })
+    .collect()
+}
+
+fn is_gemini_init_oom(error_lower: &str) -> bool {
+    error_lower.contains("oom detected")
+        || error_lower.contains("out of memory")
+        || error_lower.contains("killed by signal 9")
+        || error_lower.contains("memory limit")
+}
+
+fn is_gemini_init_auth_env(error_lower: &str) -> bool {
+    [
+        "auth",
+        "oauth",
+        "credential",
+        "api key",
+        "unauthorized",
+        "forbidden",
+        "permission denied",
+        "login",
+        "401",
+        "403",
+    ]
+    .iter()
+    .any(|pattern| error_lower.contains(pattern))
+}
+
+fn is_gemini_init_mcp_extension(error_lower: &str) -> bool {
+    error_lower.contains("mcp-server")
+        || error_lower.contains("gemini-cli-security")
+        || error_lower.contains("/extensions/")
+        || (error_lower.contains("extension")
+            && ["enoent", "eacces", "spawn", "failed to start"]
+                .iter()
+                .any(|pattern| error_lower.contains(pattern)))
+}
+
 pub(super) fn format_gemini_retry_report(phases: &[GeminiRetryPhase]) -> String {
     phases
         .iter()

--- a/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
@@ -1,0 +1,113 @@
+#[test]
+fn test_classify_gemini_acp_init_failure_detects_oom() {
+    let env = HashMap::new();
+    let classification = classify_gemini_acp_init_failure(
+        "sandboxed ACP: ACP initialization failed: killed by signal 9 (SIGKILL)",
+        &env,
+    );
+    assert_eq!(classification.code, "gemini_acp_init_oom");
+}
+
+#[test]
+fn test_classify_gemini_acp_init_failure_detects_auth_env() {
+    let original_api_key = std::env::var(csa_core::gemini::API_KEY_ENV).ok();
+    let original_base_url = std::env::var(csa_core::gemini::BASE_URL_ENV).ok();
+    unsafe {
+        std::env::set_var(csa_core::gemini::API_KEY_ENV, "test-key");
+        std::env::set_var(csa_core::gemini::BASE_URL_ENV, "http://127.0.0.1:8317");
+    }
+
+    let env = HashMap::new();
+    let classification = classify_gemini_acp_init_failure(
+        "ACP initialization failed: authentication failed: missing credentials",
+        &env,
+    );
+
+    match original_api_key {
+        Some(value) => unsafe { std::env::set_var(csa_core::gemini::API_KEY_ENV, value) },
+        None => unsafe { std::env::remove_var(csa_core::gemini::API_KEY_ENV) },
+    }
+    match original_base_url {
+        Some(value) => unsafe { std::env::set_var(csa_core::gemini::BASE_URL_ENV, value) },
+        None => unsafe { std::env::remove_var(csa_core::gemini::BASE_URL_ENV) },
+    }
+
+    assert_eq!(classification.code, "gemini_acp_init_auth_env");
+    assert_eq!(
+        classification.missing_env_vars,
+        vec![
+            csa_core::gemini::API_KEY_ENV,
+            csa_core::gemini::BASE_URL_ENV
+        ]
+    );
+}
+
+#[test]
+fn test_classify_gemini_acp_init_failure_detects_mcp_extension() {
+    let env = HashMap::new();
+    let classification = classify_gemini_acp_init_failure(
+        "ACP initialization failed: spawn /home/obj/.gemini/extensions/gemini-cli-security/mcp-server ENOENT",
+        &env,
+    );
+    assert_eq!(classification.code, "gemini_acp_init_mcp_extension");
+}
+
+#[test]
+fn test_classify_gemini_acp_init_failure_defaults_to_handshake_timeout() {
+    let env = HashMap::new();
+    let classification = classify_gemini_acp_init_failure(
+        "ACP initialization failed: Internal error: \"server shut down unexpectedly\"",
+        &env,
+    );
+    assert_eq!(classification.code, "gemini_acp_init_handshake_timeout");
+}
+
+#[tokio::test]
+async fn test_execute_in_classifies_pre_handshake_gemini_failure_with_child_stderr() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script_path = temp.path().join("gemini");
+    std::fs::write(
+        &script_path,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+echo "spawn /home/obj/.gemini/extensions/gemini-cli-security/mcp-server ENOENT" >&2
+exit 1
+"#,
+    )
+    .expect("write fake gemini");
+    let mut perms = std::fs::metadata(&script_path)
+        .expect("metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script_path, perms).expect("chmod +x");
+
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let env = HashMap::from([(
+        "PATH".to_string(),
+        format!("{}:{old_path}", temp.path().display()),
+    )]);
+
+    let transport = AcpTransport::new("gemini-cli", None);
+    let error = transport
+        .execute_in(
+            "test pre-handshake failure",
+            temp.path(),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+        )
+        .await
+        .expect_err("fake gemini should fail before ACP handshake");
+
+    let error_text = format!("{error:#}");
+    assert!(
+        error_text.contains("gemini_acp_init_mcp_extension"),
+        "expected classified init failure, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("gemini-cli-security/mcp-server ENOENT"),
+        "expected child stderr in error text, got: {error_text}"
+    );
+}

--- a/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
@@ -1,3 +1,32 @@
+static GEMINI_INIT_ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
+struct GeminiInitScopedEnvVar {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl GeminiInitScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by GEMINI_INIT_ENV_LOCK.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for GeminiInitScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by GEMINI_INIT_ENV_LOCK.
+        unsafe {
+            match self.original.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 #[test]
 fn test_classify_gemini_acp_init_failure_detects_oom() {
     let env = HashMap::new();
@@ -10,27 +39,18 @@ fn test_classify_gemini_acp_init_failure_detects_oom() {
 
 #[test]
 fn test_classify_gemini_acp_init_failure_detects_auth_env() {
-    let original_api_key = std::env::var(csa_core::gemini::API_KEY_ENV).ok();
-    let original_base_url = std::env::var(csa_core::gemini::BASE_URL_ENV).ok();
-    unsafe {
-        std::env::set_var(csa_core::gemini::API_KEY_ENV, "test-key");
-        std::env::set_var(csa_core::gemini::BASE_URL_ENV, "http://127.0.0.1:8317");
-    }
+    let _env_lock = GEMINI_INIT_ENV_LOCK
+        .lock()
+        .expect("gemini init env lock poisoned");
+    let _api_key = GeminiInitScopedEnvVar::set(csa_core::gemini::API_KEY_ENV, "test-key");
+    let _base_url =
+        GeminiInitScopedEnvVar::set(csa_core::gemini::BASE_URL_ENV, "http://127.0.0.1:8317");
 
     let env = HashMap::new();
     let classification = classify_gemini_acp_init_failure(
         "ACP initialization failed: authentication failed: missing credentials",
         &env,
     );
-
-    match original_api_key {
-        Some(value) => unsafe { std::env::set_var(csa_core::gemini::API_KEY_ENV, value) },
-        None => unsafe { std::env::remove_var(csa_core::gemini::API_KEY_ENV) },
-    }
-    match original_base_url {
-        Some(value) => unsafe { std::env::set_var(csa_core::gemini::BASE_URL_ENV, value) },
-        None => unsafe { std::env::remove_var(csa_core::gemini::BASE_URL_ENV) },
-    }
 
     assert_eq!(classification.code, "gemini_acp_init_auth_env");
     assert_eq!(


### PR DESCRIPTION
## Summary
- surface child stderr when the Gemini ACP child dies before the first handshake
- classify Gemini init failures into actionable buckets in session summaries and logs
- add focused regression coverage for OOM, auth-env, MCP extension, timeout, and pre-handshake child-stderr propagation

## What changed
- `csa-acp` now appends captured child stderr on `initialize`, `new_session`, and `load_session` failures instead of returning only the generic ACP wrapper error.
- `csa-executor` now classifies Gemini pre-handshake failures as one of:
  - `gemini_acp_init_oom`
  - `gemini_acp_init_auth_env`
  - `gemini_acp_init_mcp_extension`
  - `gemini_acp_init_handshake_timeout`
- classification emits `tracing::warn!` with the classified reason, current `memory_max_mb`, and the Gemini env allowlist applied.
- test coverage includes a fake pre-handshake Gemini child that emits MCP-extension stderr and exits before ACP roundtrip 1.

## Verification
- `just pre-commit`
- `cargo test -p csa-executor test_classify_gemini_acp_init_failure_detects_auth_env -- --nocapture`
- `cargo test -p csa-executor test_execute_in_classifies_pre_handshake_gemini_failure_with_child_stderr -- --nocapture`
- local review gate:
  - gemini-cli attempted twice, both exited 137 with `initial_response_timeout: no stdout output for 120s; process killed immediately (no liveness polling)` and were logged to #831
  - codex fallback review session `01KPE1QNPDM65W4TYM5DTDSK8C` passed

## Issue status
- Partial fix for #778
- Partial fix for #755
- follow-up root-cause issue: #840

## Notes
This PR intentionally ships the diagnostics/classification layer even though the host-specific runtime root cause is not yet proven. That turns the current black-box Gemini startup crash into an actionable failure mode without blocking on a riskier sandbox/runtime change.
