### PR TITLE
fix(csa-review): respect user-configured ./target for review CARGO_TARGET_DIR (#843)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.329"
+version = "0.1.330"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.329"
+version = "0.1.330"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_env.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use csa_config::ProjectConfig;
+use tracing::info;
 
 /// Read the current CSA recursion depth from the environment.
 pub(crate) fn current_csa_depth() -> u32 {
@@ -62,9 +64,37 @@ pub(crate) fn apply_review_target_dir(
     merged_env: &mut HashMap<String, String>,
 ) {
     if matches!(task_type, Some("review")) {
+        let project_root = resolve_review_project_root(session_dir)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        let repo_target_dir = project_root.join("target");
+        let user_configured_target = std::fs::symlink_metadata(&repo_target_dir)
+            .map(|metadata| metadata.is_dir() || metadata.file_type().is_symlink())
+            .unwrap_or(false);
+
+        if user_configured_target {
+            info!(
+                project_target = %repo_target_dir.display(),
+                "Review session: ./target already configured by user (detected symlink/dir), leaving CARGO_TARGET_DIR untouched"
+            );
+            return;
+        }
+
+        let review_target_dir = session_dir.join("target");
+        info!(
+            "Review session: no user-configured ./target, routing CARGO_TARGET_DIR to {}",
+            review_target_dir.display()
+        );
         merged_env.insert(
             "CARGO_TARGET_DIR".to_string(),
-            session_dir.join("target").display().to_string(),
+            review_target_dir.display().to_string(),
         );
     }
+}
+
+fn resolve_review_project_root(session_dir: &Path) -> Option<PathBuf> {
+    let state_path = session_dir.join("state.toml");
+    let state_contents = std::fs::read_to_string(state_path).ok()?;
+    let state_value: toml::Value = toml::from_str(&state_contents).ok()?;
+    let project_path = state_value.get("project_path")?.as_str()?;
+    Some(PathBuf::from(project_path))
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_review_target.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_review_target.rs
@@ -1,32 +1,139 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use tempfile::tempdir;
+
+fn current_dir_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct CurrentDirGuard {
+    original: PathBuf,
+}
+
+impl CurrentDirGuard {
+    fn enter(path: &Path) -> Self {
+        let original = std::env::current_dir().expect("read current dir");
+        std::env::set_current_dir(path).expect("set current dir");
+        Self { original }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.original).expect("restore current dir");
+    }
+}
 
 #[test]
-fn apply_review_target_dir_routes_review_sessions_off_repo() {
-    let session_dir = std::path::Path::new("/tmp/csa-state/sessions/01TEST");
+fn apply_review_target_dir_leaves_existing_directory_target_untouched() {
+    let _lock = current_dir_lock().lock().expect("current dir lock");
+    let project = tempdir().expect("tempdir");
+    let _cwd = CurrentDirGuard::enter(project.path());
+    std::fs::create_dir(project.path().join("target")).expect("create target dir");
+    let session_dir = project.path().join("session");
     let mut env = HashMap::new();
     env.insert(
         "CARGO_TARGET_DIR".to_string(),
         "/repo/legacy-review-target".to_string(),
     );
 
-    crate::pipeline_env::apply_review_target_dir(Some("review"), session_dir, &mut env);
+    crate::pipeline_env::apply_review_target_dir(Some("review"), &session_dir, &mut env);
 
     assert_eq!(
         env.get("CARGO_TARGET_DIR").map(String::as_str),
-        Some("/tmp/csa-state/sessions/01TEST/target")
+        Some("/repo/legacy-review-target")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn apply_review_target_dir_leaves_broken_target_symlink_untouched() {
+    use std::os::unix::fs::symlink;
+
+    let _lock = current_dir_lock().lock().expect("current dir lock");
+    let project = tempdir().expect("tempdir");
+    let _cwd = CurrentDirGuard::enter(project.path());
+    symlink("missing-mount/target", project.path().join("target"))
+        .expect("create broken target symlink");
+    let session_dir = project.path().join("session");
+    let mut env = HashMap::new();
+    env.insert(
+        "CARGO_TARGET_DIR".to_string(),
+        "/repo/legacy-review-target".to_string(),
+    );
+
+    crate::pipeline_env::apply_review_target_dir(Some("review"), &session_dir, &mut env);
+
+    assert_eq!(
+        env.get("CARGO_TARGET_DIR").map(String::as_str),
+        Some("/repo/legacy-review-target")
+    );
+}
+
+#[test]
+fn apply_review_target_dir_prefers_project_path_from_session_state() {
+    let _lock = current_dir_lock().lock().expect("current dir lock");
+    let project = tempdir().expect("project tempdir");
+    let unrelated_cwd = tempdir().expect("cwd tempdir");
+    let _cwd = CurrentDirGuard::enter(unrelated_cwd.path());
+    std::fs::create_dir(project.path().join("target")).expect("create target dir");
+    let session_dir = project.path().join("session");
+    std::fs::create_dir_all(&session_dir).expect("create session dir");
+    std::fs::write(
+        session_dir.join("state.toml"),
+        format!("project_path = {:?}\n", project.path()),
+    )
+    .expect("write state file");
+    let mut env = HashMap::new();
+    env.insert(
+        "CARGO_TARGET_DIR".to_string(),
+        "/repo/legacy-review-target".to_string(),
+    );
+
+    crate::pipeline_env::apply_review_target_dir(Some("review"), &session_dir, &mut env);
+
+    assert_eq!(
+        env.get("CARGO_TARGET_DIR").map(String::as_str),
+        Some("/repo/legacy-review-target")
+    );
+}
+
+#[test]
+fn apply_review_target_dir_routes_review_sessions_when_repo_target_missing() {
+    let _lock = current_dir_lock().lock().expect("current dir lock");
+    let project = tempdir().expect("tempdir");
+    let _cwd = CurrentDirGuard::enter(project.path());
+    let session_dir = project.path().join("session");
+    let mut env = HashMap::new();
+    env.insert(
+        "CARGO_TARGET_DIR".to_string(),
+        "/repo/legacy-review-target".to_string(),
+    );
+
+    crate::pipeline_env::apply_review_target_dir(Some("review"), &session_dir, &mut env);
+
+    assert_eq!(
+        env.get("CARGO_TARGET_DIR").map(String::as_str),
+        Some(session_dir.join("target").to_string_lossy().as_ref())
     );
 }
 
 #[test]
 fn apply_review_target_dir_leaves_non_review_sessions_unchanged() {
-    let session_dir = std::path::Path::new("/tmp/csa-state/sessions/01TEST");
+    let _lock = current_dir_lock().lock().expect("current dir lock");
+    let project = tempdir().expect("tempdir");
+    let _cwd = CurrentDirGuard::enter(project.path());
+    let session_dir = project.path().join("session");
     let mut env = HashMap::new();
     env.insert(
         "CARGO_TARGET_DIR".to_string(),
         "/repo/legacy-review-target".to_string(),
     );
 
-    crate::pipeline_env::apply_review_target_dir(Some("run"), session_dir, &mut env);
+    crate::pipeline_env::apply_review_target_dir(Some("run"), &session_dir, &mut env);
 
     assert_eq!(
         env.get("CARGO_TARGET_DIR").map(String::as_str),

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -13,6 +13,8 @@ use csa_session::{
 };
 
 use crate::plan_cmd::shell_escape_for_command;
+#[path = "session_cmds_reconcile_cleanup.rs"]
+mod reconcile_cleanup;
 
 type PersistSessionFn<'a> = dyn Fn(&Path, &MetaSessionState) -> Result<()> + 'a;
 const UNPUSHED_COMMITS_SIDECAR_PATH: &str = "output/unpushed_commits.json";
@@ -521,6 +523,7 @@ fn retire_if_dead_with_result_impl(
         .get_or_insert_with(|| "completed".to_string());
     persist_session(session_dir, &session)
         .with_context(|| format!("Failed to persist retired session state for {session_id}"))?;
+    reconcile_cleanup::cleanup_retired_session_target_dir(session_dir)?;
     info!(
         session_id = %session_id,
         trigger = %trigger,

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_cleanup.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_cleanup.rs
@@ -1,0 +1,74 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
+use tracing::info;
+
+pub(crate) fn cleanup_retired_session_target_dir(session_dir: &Path) -> Result<()> {
+    let target_dir = session_dir.join("target");
+    let metadata = match fs::symlink_metadata(&target_dir) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!(
+                    "Failed to inspect retired session target directory {}",
+                    target_dir.display()
+                )
+            });
+        }
+    };
+
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Ok(());
+    }
+
+    let size_bytes = measure_directory_size_bytes(&target_dir).with_context(|| {
+        format!(
+            "Failed to measure retired session target directory {}",
+            target_dir.display()
+        )
+    })?;
+    fs::remove_dir_all(&target_dir).with_context(|| {
+        format!(
+            "Failed to remove retired session target directory {}",
+            target_dir.display()
+        )
+    })?;
+    info!(
+        "Retiring session: removed {} ({})",
+        target_dir.display(),
+        format_bytes(size_bytes)
+    );
+    Ok(())
+}
+
+fn measure_directory_size_bytes(path: &Path) -> std::io::Result<u64> {
+    let mut total = 0u64;
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let entry_path = entry.path();
+        let metadata = fs::symlink_metadata(&entry_path)?;
+        if metadata.is_dir() {
+            total = total.saturating_add(measure_directory_size_bytes(&entry_path)?);
+        } else if metadata.is_file() {
+            total = total.saturating_add(metadata.len());
+        }
+    }
+    Ok(total)
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0usize;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} {}", UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -1,9 +1,7 @@
 use super::*;
 use crate::test_env_lock::TEST_ENV_LOCK;
-#[cfg(unix)]
 use chrono::Utc;
-use csa_session::{create_session, get_session_dir, load_result};
-#[cfg(unix)]
+use csa_session::{SessionResult, create_session, get_session_dir, load_result};
 use csa_session::{load_session, save_result};
 #[cfg(unix)]
 use std::ffi::CString;
@@ -56,6 +54,21 @@ impl SessionTestEnv {
             _home_guard: home_guard,
             _state_guard: state_guard,
         }
+    }
+}
+
+fn make_result(status: &str, exit_code: i32) -> SessionResult {
+    let now = Utc::now();
+    SessionResult {
+        status: status.to_string(),
+        exit_code,
+        summary: "summary".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
     }
 }
 
@@ -241,6 +254,38 @@ fn ensure_terminal_result_for_dead_active_session_shell_escapes_recovery_command
         parsed.cmd.as_deref(),
         Some("git push -u origin 'feat/$(touch-pwn)'")
     );
+}
+
+#[test]
+fn retire_if_dead_with_result_removes_session_target_dir() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(project, Some("retire-cleans-target"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    save_result(project, &session_id, &make_result("success", 0)).unwrap();
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    let target_dir = session_dir.join("target");
+    std::fs::create_dir_all(target_dir.join("debug")).unwrap();
+    std::fs::write(target_dir.join("debug").join("artifact.bin"), b"payload").unwrap();
+
+    let retired = retire_if_dead_with_result_impl(
+        project,
+        &session_id,
+        "session list",
+        &session_dir,
+        &persist_session_state_atomically,
+    )
+    .unwrap();
+
+    assert!(retired, "session should retire");
+    assert!(
+        !target_dir.exists(),
+        "retired session target directory should be removed"
+    );
+    let persisted = load_session(project, &session_id).unwrap();
+    assert_eq!(persisted.phase, SessionPhase::Retired);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- respect an existing user-configured `./target` directory or symlink before applying the review-only `CARGO_TARGET_DIR` fallback introduced by #742
- keep #742's fallback only when the project has no `./target` entry at all
- remove retired session-local `target/` directories during Active -> Retired reconciliation

## Why
Issue #843 reports that #742 routed review-session cargo artifacts into per-session state even when the user had already configured `./target` as a symlink to a larger secondary disk. That behavior violates the new Rule 041 expectation against autonomous fallback path selection, and retroactively exposed the Rule 037 problem that #742 caused by bypassing the user's chosen target location.

This PR is the minimal fix:
- if `<project_root>/target` already exists as a directory or symlink, leave `CARGO_TARGET_DIR` untouched and let Cargo honor the user's configuration
- if it does not exist, keep the existing review-only fallback from #742
- when a review session retires, delete its own `<session_dir>/target/` directory if one was created

## Scope
Included:
- review-session detection guard
- retired-session cleanup for session-local `target/`
- observability logs for both branches and cleanup
- regression tests covering directory, symlink, missing-target, and retire cleanup cases

Deferred:
- shared target reuse across review sessions
- `CARGO_HOME` / registry override detection
- any fallback-path redesign beyond the current minimal behavior
