### PR TITLE
fix(csa-run): respect user-configured ./target for codex run CARGO_TARGET_DIR (#715)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.330"
+version = "0.1.331"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.330"
+version = "0.1.331"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_env.rs
@@ -106,7 +106,7 @@ pub(crate) fn apply_run_target_dir_guard(
     task_type: Option<&str>,
     tool_name: &str,
     project_root: &Path,
-    merged_env: &mut HashMap<String, String>,
+    _merged_env: &mut HashMap<String, String>,
 ) {
     if !matches!(task_type, Some("run")) || tool_name != "codex" {
         return;
@@ -127,7 +127,6 @@ pub(crate) fn apply_run_target_dir_guard(
         project_target = %repo_target_dir.display(),
         "Run session: no user-configured ./target, leaving codex default CARGO_TARGET_DIR behavior (no CSA override)"
     );
-    merged_env.remove("CARGO_TARGET_DIR");
 }
 
 fn resolve_review_project_root(session_dir: &Path) -> Option<PathBuf> {

--- a/crates/cli-sub-agent/src/pipeline_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_env.rs
@@ -91,6 +91,45 @@ pub(crate) fn apply_review_target_dir(
     }
 }
 
+pub(crate) fn apply_task_target_dir_guards(
+    task_type: Option<&str>,
+    tool_name: &str,
+    project_root: &Path,
+    session_dir: &Path,
+    merged_env: &mut HashMap<String, String>,
+) {
+    apply_review_target_dir(task_type, session_dir, merged_env);
+    apply_run_target_dir_guard(task_type, tool_name, project_root, merged_env);
+}
+
+pub(crate) fn apply_run_target_dir_guard(
+    task_type: Option<&str>,
+    tool_name: &str,
+    project_root: &Path,
+    merged_env: &mut HashMap<String, String>,
+) {
+    if !matches!(task_type, Some("run")) || tool_name != "codex" {
+        return;
+    }
+
+    let repo_target_dir = project_root.join("target");
+    let user_configured_target = std::fs::symlink_metadata(&repo_target_dir).is_ok();
+
+    if user_configured_target {
+        info!(
+            project_target = %repo_target_dir.display(),
+            "Run session: ./target already configured by user (detected symlink/dir), leaving CARGO_TARGET_DIR untouched"
+        );
+        return;
+    }
+
+    info!(
+        project_target = %repo_target_dir.display(),
+        "Run session: no user-configured ./target, leaving codex default CARGO_TARGET_DIR behavior (no CSA override)"
+    );
+    merged_env.remove("CARGO_TARGET_DIR");
+}
+
 fn resolve_review_project_root(session_dir: &Path) -> Option<PathBuf> {
     let state_path = session_dir.join("state.toml");
     let state_contents = std::fs::read_to_string(state_path).ok()?;

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -279,7 +279,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         }
     };
 
-    // Acquire lock with truncated prompt as reason
     let lock_reason = truncate_prompt(prompt, 80);
     let _lock = match acquire_lock(&session_dir, executor.tool_name(), &lock_reason) {
         Ok(lock) => lock,
@@ -307,7 +306,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         })
     });
 
-    // Check resource availability
     if let Some(ref mut guard) = resource_guard
         && let Err(e) = guard.check_availability(executor.tool_name())
     {
@@ -329,7 +327,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             60,
         );
     }
-    // Token budget is observability-only (never a kill gate).
     if let Some(ref budget) = session.token_budget {
         if budget.is_hard_exceeded() {
             warn!(
@@ -435,7 +432,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         None
     };
 
-    // Resolve tool state for session resume.
     let tool_state = session
         .tools
         .get(executor.tool_name())
@@ -454,7 +450,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
 
     let result_file_cleared = clear_expected_result_artifacts_for_prompt(prompt, &session_dir);
     let execution_start_time = chrono::Utc::now();
-    // Build session config with MCP servers (if global config provided).
     let session_config = global_config.map(|gc| {
         let mcp_servers = resolve_mcp_servers(project_root, gc);
         if !mcp_servers.is_empty() {
@@ -473,7 +468,13 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
 
     let mut merged_env =
         crate::pipeline_env::build_merged_env(extra_env, config, executor.tool_name());
-    crate::pipeline_env::apply_review_target_dir(task_type, &session_dir, &mut merged_env);
+    crate::pipeline_env::apply_task_target_dir_guards(
+        task_type,
+        executor.tool_name(),
+        project_root,
+        &session_dir,
+        &mut merged_env,
+    );
     let merged_env_ref = if merged_env.is_empty() {
         None
     } else {
@@ -491,7 +492,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         global_hooks_path().as_deref(),
         project_hook_overrides.as_ref(),
     );
-    // PreRun hook: fires before tool execution starts.
     let sessions_root = session_dir
         .parent()
         .unwrap_or(&session_dir)

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -768,8 +768,6 @@ async fn build_and_validate_executor_enforce_tier_false_skips_model_name_check()
     )
     .await;
 
-    // Actual error fragment from enforce_tier_model_name (config.rs):
-    //   "is not configured in any tier"
     if let Err(e) = &result {
         let msg = e.to_string();
         assert!(
@@ -796,5 +794,7 @@ mod initial_response_tests;
 mod locking_tests;
 #[path = "pipeline_tests_review_target.rs"]
 mod review_target_tests;
+#[path = "pipeline_tests_run_target.rs"]
+mod run_target_tests;
 #[path = "pipeline_tests_tail.rs"]
 mod tail_tests;

--- a/crates/cli-sub-agent/src/pipeline_tests_run_target.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_run_target.rs
@@ -1,0 +1,106 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use tempfile::tempdir;
+
+fn current_dir_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct CurrentDirGuard {
+    original: PathBuf,
+}
+
+impl CurrentDirGuard {
+    fn enter(path: &std::path::Path) -> Self {
+        let original = std::env::current_dir().expect("read current dir");
+        std::env::set_current_dir(path).expect("set current dir");
+        Self { original }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.original).expect("restore current dir");
+    }
+}
+
+#[test]
+fn apply_run_target_dir_guard_leaves_existing_directory_target_untouched() {
+    let _lock = current_dir_lock().lock().expect("current dir lock");
+    let project = tempdir().expect("tempdir");
+    let _cwd = CurrentDirGuard::enter(project.path());
+    std::fs::create_dir(project.path().join("target")).expect("create target dir");
+    let mut env = HashMap::new();
+    env.insert(
+        "CARGO_TARGET_DIR".to_string(),
+        "/tmp/codex-session-target".to_string(),
+    );
+
+    crate::pipeline_env::apply_run_target_dir_guard(Some("run"), "codex", project.path(), &mut env);
+
+    assert_eq!(
+        env.get("CARGO_TARGET_DIR").map(String::as_str),
+        Some("/tmp/codex-session-target")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn apply_run_target_dir_guard_leaves_broken_target_symlink_untouched() {
+    use std::os::unix::fs::symlink;
+
+    let _lock = current_dir_lock().lock().expect("current dir lock");
+    let project = tempdir().expect("tempdir");
+    let _cwd = CurrentDirGuard::enter(project.path());
+    symlink("missing-mount/target", project.path().join("target"))
+        .expect("create broken target symlink");
+    let mut env = HashMap::new();
+    env.insert(
+        "CARGO_TARGET_DIR".to_string(),
+        "/tmp/codex-session-target".to_string(),
+    );
+
+    crate::pipeline_env::apply_run_target_dir_guard(Some("run"), "codex", project.path(), &mut env);
+
+    assert_eq!(
+        env.get("CARGO_TARGET_DIR").map(String::as_str),
+        Some("/tmp/codex-session-target")
+    );
+}
+
+#[test]
+fn apply_run_target_dir_guard_does_not_inject_override_when_repo_target_missing() {
+    let _lock = current_dir_lock().lock().expect("current dir lock");
+    let project = tempdir().expect("tempdir");
+    let _cwd = CurrentDirGuard::enter(project.path());
+    let mut env = HashMap::new();
+
+    crate::pipeline_env::apply_run_target_dir_guard(Some("run"), "codex", project.path(), &mut env);
+
+    assert!(
+        !env.contains_key("CARGO_TARGET_DIR"),
+        "run guard must not invent a CSA override when ./target is absent"
+    );
+}
+
+#[test]
+fn apply_run_target_dir_guard_removes_preexisting_override_when_repo_target_missing() {
+    let _lock = current_dir_lock().lock().expect("current dir lock");
+    let project = tempdir().expect("tempdir");
+    let _cwd = CurrentDirGuard::enter(project.path());
+    let mut env = HashMap::new();
+    env.insert(
+        "CARGO_TARGET_DIR".to_string(),
+        "/tmp/codex-session-target".to_string(),
+    );
+
+    crate::pipeline_env::apply_run_target_dir_guard(Some("run"), "codex", project.path(), &mut env);
+
+    assert!(
+        !env.contains_key("CARGO_TARGET_DIR"),
+        "run guard must preserve codex default behavior when ./target is absent"
+    );
+}

--- a/crates/cli-sub-agent/src/pipeline_tests_run_target.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_run_target.rs
@@ -87,7 +87,7 @@ fn apply_run_target_dir_guard_does_not_inject_override_when_repo_target_missing(
 }
 
 #[test]
-fn apply_run_target_dir_guard_removes_preexisting_override_when_repo_target_missing() {
+fn apply_run_target_dir_guard_preserves_existing_env_when_repo_target_missing() {
     let _lock = current_dir_lock().lock().expect("current dir lock");
     let project = tempdir().expect("tempdir");
     let _cwd = CurrentDirGuard::enter(project.path());
@@ -99,8 +99,8 @@ fn apply_run_target_dir_guard_removes_preexisting_override_when_repo_target_miss
 
     crate::pipeline_env::apply_run_target_dir_guard(Some("run"), "codex", project.path(), &mut env);
 
-    assert!(
-        !env.contains_key("CARGO_TARGET_DIR"),
-        "run guard must preserve codex default behavior when ./target is absent"
+    assert_eq!(
+        env.get("CARGO_TARGET_DIR").map(String::as_str),
+        Some("/tmp/codex-session-target")
     );
 }


### PR DESCRIPTION
## Summary
- mirror PR #844's `./target` detection guard onto the codex run path
- if `<project_root>/target` already exists (directory, symlink, including broken symlink), leave `CARGO_TARGET_DIR` untouched
- if `<project_root>/target` does not exist, leave codex's default behavior untouched and add no CSA fallback branch

## Why
Issue #715 reports that codex run / YOLO sessions still use `/tmp` for build artifacts even when the repo already has a user-configured `./target`.

PR #844 fixed the review path. This change applies the same respect-for-user-config intent to the run path.

## Rule 041
This change intentionally does **not** introduce any new alternate target path selection. Unlike #844, there is no pre-existing CSA-side run-path fallback to preserve here, so the absent-`./target` branch is a no-op with observability only.

## Validation
- `cargo test -p cli-sub-agent apply_run_target_dir_guard`
- `just pre-commit`
- `csa review --range main...HEAD ...` via codex fallback after gemini hit repeated exit 137 / initial response timeout

Closes #715.
