### PR TITLE
fix(cli-sub-agent): honor project target in review dispatch (#850)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.333"
+version = "0.1.334"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.333"
+version = "0.1.334"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_env.rs
@@ -61,32 +61,24 @@ pub(crate) fn build_merged_env(
 pub(crate) fn apply_review_target_dir(
     task_type: Option<&str>,
     session_dir: &std::path::Path,
-    merged_env: &mut HashMap<String, String>,
+    _merged_env: &mut HashMap<String, String>,
 ) {
     if matches!(task_type, Some("review")) {
         let project_root = resolve_review_project_root(session_dir)
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
         let repo_target_dir = project_root.join("target");
-        let user_configured_target = std::fs::symlink_metadata(&repo_target_dir)
-            .map(|metadata| metadata.is_dir() || metadata.file_type().is_symlink())
-            .unwrap_or(false);
-
-        if user_configured_target {
+        if let Some(target_kind) = detect_project_target_kind(&repo_target_dir) {
             info!(
                 project_target = %repo_target_dir.display(),
-                "Review session: ./target already configured by user (detected symlink/dir), leaving CARGO_TARGET_DIR untouched"
+                target_kind,
+                "honoring user ./target ({target_kind}), CARGO_TARGET_DIR untouched"
             );
             return;
         }
 
-        let review_target_dir = session_dir.join("target");
         info!(
-            "Review session: no user-configured ./target, routing CARGO_TARGET_DIR to {}",
-            review_target_dir.display()
-        );
-        merged_env.insert(
-            "CARGO_TARGET_DIR".to_string(),
-            review_target_dir.display().to_string(),
+            project_target = %repo_target_dir.display(),
+            "no ./target present, CARGO_TARGET_DIR left at codex/cargo default"
         );
     }
 }
@@ -135,4 +127,15 @@ fn resolve_review_project_root(session_dir: &Path) -> Option<PathBuf> {
     let state_value: toml::Value = toml::from_str(&state_contents).ok()?;
     let project_path = state_value.get("project_path")?.as_str()?;
     Some(PathBuf::from(project_path))
+}
+
+fn detect_project_target_kind(repo_target_dir: &Path) -> Option<&'static str> {
+    let metadata = std::fs::symlink_metadata(repo_target_dir).ok()?;
+    if metadata.file_type().is_symlink() {
+        return Some("symlink");
+    }
+    if metadata.is_dir() {
+        return Some("dir");
+    }
+    None
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_review_target.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_review_target.rs
@@ -102,23 +102,16 @@ fn apply_review_target_dir_prefers_project_path_from_session_state() {
 }
 
 #[test]
-fn apply_review_target_dir_routes_review_sessions_when_repo_target_missing() {
+fn apply_review_target_dir_leaves_default_behavior_when_repo_target_missing() {
     let _lock = current_dir_lock().lock().expect("current dir lock");
     let project = tempdir().expect("tempdir");
     let _cwd = CurrentDirGuard::enter(project.path());
     let session_dir = project.path().join("session");
     let mut env = HashMap::new();
-    env.insert(
-        "CARGO_TARGET_DIR".to_string(),
-        "/repo/legacy-review-target".to_string(),
-    );
 
     crate::pipeline_env::apply_review_target_dir(Some("review"), &session_dir, &mut env);
 
-    assert_eq!(
-        env.get("CARGO_TARGET_DIR").map(String::as_str),
-        Some(session_dir.join("target").to_string_lossy().as_ref())
-    );
+    assert_eq!(env.get("CARGO_TARGET_DIR").map(String::as_str), None);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
@@ -107,6 +107,93 @@ printf 'tool mutation\\n' >> tracked.txt\n",
 
 #[cfg(unix)]
 #[tokio::test]
+async fn execute_review_preserves_codex_default_target_when_project_target_exists() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let project_dir = setup_git_repo();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let target_mount = project_dir.path().join("ssd-target");
+    std::fs::create_dir_all(&target_mount).unwrap();
+    symlink(&target_mount, project_dir.path().join("target")).unwrap();
+
+    let bin_dir = project_dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let fake_codex = bin_dir.join("codex");
+    let cargo_target_log = project_dir.path().join("cargo-target-dir.log");
+    std::fs::write(
+        &fake_codex,
+        format!(
+            "#!/bin/sh\n\
+printf '%s' \"${{CARGO_TARGET_DIR:-}}\" > \"{}\"\n\
+printf '%s\\n' \
+'<!-- CSA:SECTION:summary -->' \
+'PASS' \
+'<!-- CSA:SECTION:summary:END -->' \
+'' \
+'<!-- CSA:SECTION:details -->' \
+'Review used default cargo target behavior.' \
+'<!-- CSA:SECTION:details:END -->'\n",
+            cargo_target_log.display()
+        ),
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&fake_codex).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&fake_codex, perms).unwrap();
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+    let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
+
+    let config = project_config_with_enabled_tools(&["codex"]);
+    let global = GlobalConfig::default();
+    let result = execute_review(
+        ToolName::Codex,
+        "scope=range:main...HEAD mode=review-only security=auto".to_string(),
+        None,
+        None,
+        Some("codex/openai/gpt-5.4/medium".to_string()),
+        None,
+        None,
+        "review: codex-target-default".to_string(),
+        project_dir.path(),
+        Some(&config),
+        &global,
+        ReviewRoutingMetadata {
+            project_profile: ProjectProfile::Unknown,
+            detection_method: "auto",
+        },
+        csa_process::StreamMode::BufferOnly,
+        crate::pipeline::DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        false,
+        true,
+        true,
+        false,
+        false,
+        &[],
+    )
+    .await
+    .expect("codex review should honor project target");
+
+    assert_eq!(result.execution.execution.exit_code, 0);
+    let session_dir =
+        csa_session::get_session_dir(project_dir.path(), &result.execution.meta_session_id)
+            .unwrap();
+    let observed_target_dir = std::fs::read_to_string(cargo_target_log).unwrap();
+    assert_ne!(
+        observed_target_dir,
+        session_dir.join("target").display().to_string(),
+        "review dispatch must not override CARGO_TARGET_DIR to the session-local target dir"
+    );
+    assert!(
+        !session_dir.join("target").exists(),
+        "review session should not create a session-local target dir"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn execute_review_model_spec_bypasses_tier_enforcement_without_active_tier() {
     use std::os::unix::fs::PermissionsExt;
 

--- a/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
@@ -144,6 +144,7 @@ printf '%s\\n' \
     let inherited_path = std::env::var("PATH").unwrap_or_default();
     let patched_path = format!("{}:{inherited_path}", bin_dir.display());
     let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
+    let _bwrap_preflight_guard = ScopedEnvVarRestore::set("CSA_SKIP_BWRAP_PREFLIGHT", "1");
 
     let config = project_config_with_enabled_tools(&["codex"]);
     let global = GlobalConfig::default();


### PR DESCRIPTION
## Summary

Closes #850 — URGENT regression where `csa review --range main...HEAD` still overrode `CARGO_TARGET_DIR` to the session state dir, leaking 12.3 GB on 2026-04-17 despite PR #844 (#843 fix) and PR #846 (#715 fix) shipping.

**Root cause**: The actual bypass path was `review_cmd::execute_review → pipeline_session_exec::execute_with_session_and_meta_with_parent_source → pipeline_env::apply_review_target_dir`, which had an old fallback branch routing `CARGO_TARGET_DIR` to `session_dir/target` when `./target` was absent. This violated **Rule 041** (no autonomous write-path fallback).

**Fix**: Removed the fallback. `apply_review_target_dir` now only:
- Detects `./target` as dir or symlink → log `honoring user ./target (symlink|dir), CARGO_TARGET_DIR untouched` and leave env untouched
- Absent → log `no ./target present, CARGO_TARGET_DIR left at codex/cargo default` and leave env untouched

No fallback branch. No new path. No change to `pipeline_env.rs` for the `csa run` path (already fixed by #846).

## Verification

- `cargo test -p cli-sub-agent apply_review_target_dir` ✓
- `cargo test -p cli-sub-agent execute_review_preserves_codex_default_target_when_project_target_exists` ✓ (new regression test)
- `just pre-commit` ✓
- **Live dry-run**: one `csa review` session on reverted HEAD produced zero `sessions/<ULID>/target/` directories — confirmed by `find ~/.local/state/cli-sub-agent -maxdepth 6 -type d -name target` both before and after the dispatch returning empty.

## Test plan
- [x] Unit: `apply_review_target_dir` test asserts no override when `./target` exists as symlink
- [x] Integration: `execute_review_preserves_codex_default_target_when_project_target_exists` walks the real spawn path with tempdir `./target` symlink fixture
- [x] Live: dry-run review session produces zero leaked target dirs

## Version

0.1.333 → 0.1.334

🤖 Generated with [Claude Code](https://claude.com/claude-code)