### PR TITLE
fix(csa-executor): detect gemini OAuth prompt on both streams in legacy+ACP transports (#845)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.334"
+version = "0.1.335"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.334"
+version = "0.1.335"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -149,7 +149,11 @@ pub(super) async fn execute_review(
     repair_completed_review_restriction_result(project_root, tool, &mut execution)?;
 
     let mut status_reason = None;
-    if let Some(kind) = detect_tool_review_failure(tool, &execution.execution.output) {
+    if let Some(kind) = detect_tool_review_failure(
+        tool,
+        &execution.execution.output,
+        &execution.execution.stderr_output,
+    ) {
         let retry_env = (!no_failover)
             .then(|| build_gemini_api_key_retry_env(extra_env_owned.as_ref()))
             .flatten();
@@ -199,7 +203,11 @@ pub(super) async fn execute_review(
             );
             repair_completed_review_restriction_result(project_root, tool, &mut retried)?;
 
-            if let Some(retry_kind) = detect_tool_review_failure(tool, &retried.execution.output) {
+            if let Some(retry_kind) = detect_tool_review_failure(
+                tool,
+                &retried.execution.output,
+                &retried.execution.stderr_output,
+            ) {
                 classify_review_failure_result(project_root, tool, &mut retried, retry_kind)?;
                 status_reason = Some(retry_kind.status_reason().to_string());
                 execution = retried;

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -570,18 +570,26 @@ pub(super) fn detect_tool_diagnostic(stdout: &str, stderr: &str) -> Option<Strin
 pub(super) fn detect_tool_review_failure(
     tool: ToolName,
     stdout: &str,
+    stderr: &str,
 ) -> Option<ToolReviewFailureKind> {
     if tool != ToolName::GeminiCli {
         return None;
     }
+    let normalized_stdout = normalize_gemini_prompt_text(stdout);
+    let normalized_stderr = normalize_gemini_prompt_text(stderr);
+    let combined = if normalized_stderr.is_empty() {
+        normalized_stdout.clone()
+    } else if normalized_stdout.is_empty() {
+        normalized_stderr.clone()
+    } else {
+        format!("{normalized_stdout}\n{normalized_stderr}")
+    };
 
-    let has_oauth_prompt = stdout.contains("Opening authentication page")
-        || stdout.contains("Do you want to continue? [Y/n]");
-    if !has_oauth_prompt {
+    if !contains_gemini_oauth_prompt(&combined) {
         return None;
     }
 
-    let saw_turn_completed = stdout.lines().any(|line| {
+    let saw_turn_completed = combined.lines().any(|line| {
         line.contains("\"type\":\"turn.completed\"")
             || line.contains("\"type\": \"turn.completed\"")
             || line.trim() == "turn.completed"
@@ -590,17 +598,12 @@ pub(super) fn detect_tool_review_failure(
         return None;
     }
 
-    let output_tokens = crate::run_helpers::parse_token_usage(stdout)
+    let output_tokens = crate::run_helpers::parse_token_usage(&combined)
         .and_then(|usage| usage.output_tokens)
         .unwrap_or(0);
     if output_tokens != 0 {
         return None;
     }
-
-    if stdout.len() >= 200 {
-        return None;
-    }
-
     Some(ToolReviewFailureKind::GeminiAuthPromptDetected)
 }
 
@@ -661,6 +664,64 @@ fn strip_prompt_guards(text: &str) -> String {
         result.push('\n');
     }
     result
+}
+
+fn contains_gemini_oauth_prompt(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("opening authentication page in your browser")
+        || (lower.contains("opening authentication page")
+            && lower.contains("do you want to continue"))
+        || (lower.contains("authentication page in your browser")
+            && lower.contains("do you want to continue"))
+}
+
+fn normalize_gemini_prompt_text(text: &str) -> String {
+    let stripped = strip_prompt_guards(&strip_ansi_escape_sequences(text));
+    let mut cleaned = String::new();
+    let mut in_sa_guard = false;
+    for raw_line in stripped.lines() {
+        let trimmed = raw_line.trim();
+        if trimmed.starts_with("<csa-caller-sa-guard") {
+            in_sa_guard = true;
+            continue;
+        }
+        if trimmed.starts_with("</csa-caller-sa-guard>") {
+            in_sa_guard = false;
+            continue;
+        }
+        if in_sa_guard
+            || trimmed.is_empty()
+            || trimmed.starts_with("WARNING: weave.lock")
+            || trimmed.starts_with("csa run context:")
+            || trimmed.starts_with("Running scope as unit:")
+        {
+            continue;
+        }
+        let stripped = trimmed.strip_prefix("[stdout] ").unwrap_or(trimmed);
+        cleaned.push_str(stripped);
+        cleaned.push('\n');
+    }
+    cleaned
+}
+fn strip_ansi_escape_sequences(text: &str) -> String {
+    let mut stripped = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\u{1b}' {
+            stripped.push(ch);
+            continue;
+        }
+        if !matches!(chars.peek(), Some('[')) {
+            continue;
+        }
+        let _ = chars.next();
+        for next in chars.by_ref() {
+            if ('@'..='~').contains(&next) {
+                break;
+            }
+        }
+    }
+    stripped
 }
 
 fn truncate_review_result_summary(line: &str) -> String {

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -105,7 +105,7 @@ fn derive_decision_from_text_clean_phrase_without_skip_stays_pass() {
 #[test]
 fn detect_tool_review_failure_flags_gemini_oauth_prompt_without_real_turn() {
     let stdout = "Opening authentication page\nDo you want to continue? [Y/n]\n";
-    let detected = detect_tool_review_failure(ToolName::GeminiCli, stdout);
+    let detected = detect_tool_review_failure(ToolName::GeminiCli, stdout, "");
     assert_eq!(
         detected,
         Some(ToolReviewFailureKind::GeminiAuthPromptDetected)
@@ -119,13 +119,34 @@ fn detect_tool_review_failure_ignores_normal_review_output() {
         "<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n",
         "output_tokens: 12\n"
     );
-    assert!(detect_tool_review_failure(ToolName::GeminiCli, stdout).is_none());
+    assert!(detect_tool_review_failure(ToolName::GeminiCli, stdout, "").is_none());
 }
 
 #[test]
 fn detect_tool_review_failure_never_fires_for_non_gemini_tools() {
     let stdout = "Opening authentication page\nDo you want to continue? [Y/n]\n";
-    assert!(detect_tool_review_failure(ToolName::Codex, stdout).is_none());
+    assert!(detect_tool_review_failure(ToolName::Codex, stdout, "").is_none());
+}
+
+#[test]
+fn detect_tool_review_failure_handles_guarded_browser_prompt_variant() {
+    let stdout = concat!(
+        "<csa-caller-sa-guard>\n",
+        "SA MODE ACTIVE\n",
+        "</csa-caller-sa-guard>\n",
+        "\n",
+        "Opening authentication page in your browser. Do you want to continue? [Y/n]: ",
+        "<csa-caller-sa-guard>\n",
+        "SA MODE ACTIVE\n",
+        "</csa-caller-sa-guard>\n",
+    );
+    let stderr =
+        "[stdout] Opening authentication page in your browser. Do you want to continue? [Y/n]: \n";
+    let detected = detect_tool_review_failure(ToolName::GeminiCli, stdout, stderr);
+    assert_eq!(
+        detected,
+        Some(ToolReviewFailureKind::GeminiAuthPromptDetected)
+    );
 }
 
 #[test]

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -33,10 +33,11 @@ use transport_gemini_helpers::format_gemini_retry_report;
 use transport_gemini_helpers::{
     GeminiRetryPhase, annotate_gemini_retry_error, append_gemini_retry_report,
     apply_gemini_sandbox_runtime_env_overrides, classify_gemini_acp_init_failure,
-    classify_join_error, ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure,
-    gemini_phase_desc, gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure,
+    classify_gemini_oauth_prompt_result, classify_join_error,
+    ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure, gemini_phase_desc,
+    gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure,
+    is_gemini_oauth_prompt_result,
 };
-
 #[path = "transport_gemini_acp_runtime.rs"]
 mod transport_gemini_acp_runtime;
 use transport_gemini_acp_runtime::{gemini_runtime_home_from_env, prepare_gemini_acp_runtime};
@@ -781,16 +782,16 @@ include!("transport_acp_impl.rs");
 
 #[cfg(test)]
 mod tests {
-    use csa_acp::SessionConfig;
-    use csa_resource::isolation_plan::IsolationPlan;
-
     use super::*;
     use crate::transport_gemini_retry::*;
+    use csa_acp::SessionConfig;
+    use csa_resource::isolation_plan::IsolationPlan;
 
     include!("transport_tests_tail.rs");
     include!("transport_tests_ephemeral.rs");
     include!("transport_tests_gemini_fallback.rs");
     include!("transport_tests_gemini_init_classification.rs");
+    include!("transport_tests_gemini_oauth_prompt.rs");
     include!("transport_tests_extra.rs");
 }
 

--- a/crates/csa-executor/src/transport_acp_impl.rs
+++ b/crates/csa-executor/src/transport_acp_impl.rs
@@ -99,6 +99,48 @@ impl Transport for AcpTransport {
                 Err(e) => is_gemini_rate_limited_error(&format!("{e:#}")),
             };
 
+            if let Ok(mut transport_result) = result {
+                if is_gemini_oauth_prompt_result(&transport_result.execution) {
+                    if attempt == 1
+                        && gemini_inject_api_key_fallback(extra_env).is_some()
+                        && !crate::transport_gemini_retry::gemini_is_no_failover(extra_env)
+                    {
+                        tracing::warn!(
+                            attempt,
+                            "gemini-cli ACP OAuth browser prompt detected; retrying with API key"
+                        );
+                        attempt = attempt.saturating_add(1);
+                        continue;
+                    }
+
+                    classify_gemini_oauth_prompt_result(&mut transport_result.execution);
+                    append_gemini_retry_report(&mut transport_result.execution, &retry_phases);
+                    return Ok(transport_result);
+                }
+
+                if should_retry && attempt < max_attempts {
+                    tracing::info!(
+                        attempt,
+                        phase_desc = gemini_phase_desc(attempt),
+                        "gemini-cli ACP rate limited; advancing phase"
+                    );
+                    tokio::time::sleep(gemini_rate_limit_backoff(attempt)).await;
+                    attempt = attempt.saturating_add(1);
+                    continue;
+                }
+
+                if should_retry {
+                    tracing::warn!(
+                        attempt,
+                        max_attempts,
+                        "gemini-cli ACP: all retry phases exhausted, returning last result"
+                    );
+                }
+
+                append_gemini_retry_report(&mut transport_result.execution, &retry_phases);
+                return Ok(transport_result);
+            }
+
             if should_retry && attempt < max_attempts {
                 tracing::info!(
                     attempt,
@@ -118,13 +160,10 @@ impl Transport for AcpTransport {
                 );
             }
 
-            return match result {
-                Ok(mut transport_result) => {
-                    append_gemini_retry_report(&mut transport_result.execution, &retry_phases);
-                    Ok(transport_result)
-                }
-                Err(error) => Err(annotate_gemini_retry_error(error, &retry_phases)),
-            };
+            return Err(annotate_gemini_retry_error(
+                result.expect_err("only Err remains after Ok path handled"),
+                &retry_phases,
+            ));
         }
     }
 

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -8,6 +8,9 @@ use csa_resource::isolation_plan::IsolationPlan;
 
 use crate::transport_gemini_retry::{gemini_retry_model, gemini_should_use_api_key};
 
+pub(crate) const GEMINI_OAUTH_PROMPT_SUMMARY: &str =
+    "gemini-cli auth failure: OAuth browser prompt detected; no tool output produced";
+
 #[derive(Debug, Clone)]
 pub(super) struct GeminiRetryPhase {
     pub(super) attempt: u8,
@@ -151,6 +154,114 @@ pub(super) fn apply_gemini_sandbox_runtime_env_overrides(
             .iter()
             .map(|(key, value)| (key.clone(), value.clone())),
     );
+}
+
+pub(crate) fn is_gemini_oauth_prompt_result(execution: &ExecutionResult) -> bool {
+    let normalized_stdout = normalize_gemini_prompt_text(&execution.output);
+    let normalized_stderr = normalize_gemini_prompt_text(&execution.stderr_output);
+    let combined = if normalized_stderr.is_empty() {
+        normalized_stdout.clone()
+    } else if normalized_stdout.is_empty() {
+        normalized_stderr.clone()
+    } else {
+        format!("{normalized_stdout}\n{normalized_stderr}")
+    };
+
+    if !contains_gemini_oauth_prompt(&combined) {
+        return false;
+    }
+
+    !combined.lines().any(|line| {
+        line.contains("\"type\":\"turn.completed\"")
+            || line.contains("\"type\": \"turn.completed\"")
+            || line.trim() == "turn.completed"
+    })
+}
+
+pub(crate) fn classify_gemini_oauth_prompt_result(execution: &mut ExecutionResult) {
+    execution.exit_code = 1;
+    execution.summary = GEMINI_OAUTH_PROMPT_SUMMARY.to_string();
+    if execution.stderr_output.is_empty() {
+        execution.stderr_output = GEMINI_OAUTH_PROMPT_SUMMARY.to_string();
+    } else if !execution
+        .stderr_output
+        .contains(GEMINI_OAUTH_PROMPT_SUMMARY)
+    {
+        if !execution.stderr_output.ends_with('\n') {
+            execution.stderr_output.push('\n');
+        }
+        execution
+            .stderr_output
+            .push_str(GEMINI_OAUTH_PROMPT_SUMMARY);
+    }
+}
+
+fn contains_gemini_oauth_prompt(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("opening authentication page in your browser")
+        || (lower.contains("opening authentication page")
+            && lower.contains("do you want to continue"))
+        || (lower.contains("authentication page in your browser")
+            && lower.contains("do you want to continue"))
+}
+
+fn normalize_gemini_prompt_text(text: &str) -> String {
+    let mut cleaned = String::new();
+    let mut in_guard = false;
+    for raw_line in strip_ansi_escape_sequences(text).lines() {
+        let line = raw_line.trim_end_matches('\r');
+        let trimmed = line.trim();
+        if trimmed.starts_with("<csa-caller-sa-guard") {
+            in_guard = true;
+            continue;
+        }
+        if trimmed.starts_with("</csa-caller-sa-guard>") {
+            in_guard = false;
+            continue;
+        }
+        if trimmed.starts_with("<csa-caller-prompt-injection") {
+            in_guard = true;
+            continue;
+        }
+        if trimmed.starts_with("</csa-caller-prompt-injection>") {
+            in_guard = false;
+            continue;
+        }
+        if in_guard
+            || trimmed.is_empty()
+            || trimmed.starts_with("[csa-hook]")
+            || trimmed.starts_with("WARNING: weave.lock")
+            || trimmed.starts_with("csa run context:")
+            || trimmed.starts_with("Running scope as unit:")
+        {
+            continue;
+        }
+        let stripped = trimmed.strip_prefix("[stdout] ").unwrap_or(trimmed);
+        cleaned.push_str(stripped);
+        cleaned.push('\n');
+    }
+    cleaned
+}
+
+fn strip_ansi_escape_sequences(text: &str) -> String {
+    let mut stripped = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\u{1b}' {
+            stripped.push(ch);
+            continue;
+        }
+        if !matches!(chars.peek(), Some('[')) {
+            continue;
+        }
+        let _ = chars.next();
+        for next in chars.by_ref() {
+            if ('@'..='~').contains(&next) {
+                break;
+            }
+        }
+    }
+    stripped
 }
 
 /// Convert a `tokio::task::JoinError` into a descriptive `anyhow::Error`.

--- a/crates/csa-executor/src/transport_legacy_impl.rs
+++ b/crates/csa-executor/src/transport_legacy_impl.rs
@@ -35,6 +35,23 @@ impl Transport for LegacyTransport {
                     options.clone(),
                 )
                 .await?;
+            if is_gemini_oauth_prompt_result(&result.execution) {
+                if attempt == 1
+                    && gemini_inject_api_key_fallback(extra_env).is_some()
+                    && !crate::transport_gemini_retry::gemini_is_no_failover(extra_env)
+                {
+                    tracing::warn!(
+                        attempt,
+                        "gemini-cli legacy OAuth browser prompt detected; retrying with API key"
+                    );
+                    attempt = attempt.saturating_add(1);
+                    continue;
+                }
+
+                let mut result = result;
+                classify_gemini_oauth_prompt_result(&mut result.execution);
+                return Ok(result);
+            }
             if let Some(backoff) =
                 self.should_retry_gemini_rate_limited(&result.execution, attempt, extra_env)
             {

--- a/crates/csa-executor/src/transport_tests_gemini_oauth_prompt.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_oauth_prompt.rs
@@ -1,0 +1,27 @@
+#[test]
+fn test_detect_gemini_oauth_prompt_result_handles_guarded_browser_prompt_variant() {
+    let execution = ExecutionResult {
+        summary: "Opening authentication page in your browser. Do you want to continue? [Y/n]:"
+            .to_string(),
+        output: concat!(
+            "<csa-caller-sa-guard>\n",
+            "SA MODE ACTIVE — You are Layer 0 Manager (pure orchestrator).\n",
+            "</csa-caller-sa-guard>\n",
+            "\n",
+            "Opening authentication page in your browser. Do you want to continue? [Y/n]: ",
+            "<csa-caller-sa-guard>\n",
+            "SA MODE ACTIVE — You are Layer 0 Manager (pure orchestrator).\n",
+            "</csa-caller-sa-guard>\n",
+        )
+        .to_string(),
+        stderr_output: concat!(
+            "WARNING: weave.lock records stale version stamp(s)\n",
+            "[stdout] Opening authentication page in your browser. Do you want to continue? [Y/n]: \n",
+        )
+        .to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+    };
+
+    assert!(is_gemini_oauth_prompt_result(&execution));
+}


### PR DESCRIPTION
## Summary

Closes #845 — follow-up to #790 / PR #837. The OAuth browser-prompt detector shipped in v0.1.328 did **not** fire on session `01KPE5BK0KVJ83RAAYRYGFZESR` (v0.1.330 recon run), which exited with `status="success"` + `exit_code=0` while the payload was literally the OAuth prompt. This regressed the silent-failure guarantee #790 was meant to close.

**Root cause: (c) transport-path mismatch.** The detector existed only in the `cli-sub-agent` review-output classification layer, not in the `csa-executor` generic legacy/ACP transport path. A plain `csa run` (non-review) therefore recorded the prompt as a successful response. Secondary issue: the review-layer detector only scanned stdout and was susceptible to guard-noise / length-threshold mismatches.

## Fix

- **csa-executor**: added guard-aware, substring-based OAuth prompt detector for Gemini covering **both streams** (stdout + stderr); wired into the legacy AND ACP transports so every execution path flows through it.
- **Retry policy preserved**: detector hit → existing GEMINI_API_KEY failover is invoked; no available failover → classified failure (`gemini_oauth_expired`, `status="failure"`, `exit_code != 0`).
- **Review layer hardened**: existing detector now scans stdout/stderr together, with a regression test for the preserved guarded variant.

## Verification

- `cargo test -p csa-executor transport::tests::test_detect_gemini_oauth_prompt_result_handles_guarded_browser_prompt_variant` ✓
- `cargo test -p cli-sub-agent review_cmd::output::tests::detect_tool_review_failure_handles_guarded_browser_prompt_variant` ✓
- `cargo test -p cli-sub-agent review_cmd::execute::tests::execute_review_classifies_gemini_oauth_prompt_without_api_key` ✓
- `cargo test -p cli-sub-agent review_cmd::execute::tests::execute_review_retries_gemini_with_api_key_after_oauth_prompt` ✓
- `just pre-commit` ✓
- Layer 0 review on main...HEAD: decision=pass, severity_counts all 0

## Test plan
- [x] Unit: executor-level detector on guarded variant
- [x] Unit: review-layer detector dual-stream
- [x] Integration: OAuth classification without API key
- [x] Integration: OAuth retry with API key failover

## Version

0.1.334 → 0.1.335

🤖 Generated with [Claude Code](https://claude.com/claude-code)