### PR TITLE
fix(commit-skill): hard-cap fix-and-review loop at 3 rounds + weave sync (#779)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.336"
+version = "0.1.337"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.336"
+version = "0.1.337"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/weave/src/compiler.rs
+++ b/crates/weave/src/compiler.rs
@@ -115,6 +115,10 @@ static TIER_HINT_RE: LazyLock<Regex> =
 static ONFAIL_HINT_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^OnFail:\s*(.+)\s*$").expect("valid regex"));
 
+/// Matches a `Condition: <expr>` line at the start of a step body.
+static CONDITION_HINT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^Condition:\s*(.+)\s*$").expect("valid regex"));
+
 /// Matches a `Session: <id|template>` line at the start of a step body.
 static SESSION_HINT_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^Session:\s*(.+)\s*$").expect("valid regex"));
@@ -248,6 +252,7 @@ struct StepHints {
     tier: Option<String>,
     session: Option<String>,
     on_fail: FailAction,
+    condition: Option<String>,
     max_iterations: Option<u32>,
     prompt: String,
 }
@@ -264,6 +269,7 @@ fn extract_hints(body: &str) -> StepHints {
     let mut tier = None;
     let mut session = None;
     let mut on_fail = FailAction::Abort;
+    let mut condition = None;
     let mut max_iterations = None;
     let mut prompt_lines = Vec::new();
     let mut in_hints = true;
@@ -280,6 +286,10 @@ fn extract_hints(body: &str) -> StepHints {
             }
             if let Some(caps) = ONFAIL_HINT_RE.captures(line) {
                 on_fail = parse_fail_action(caps[1].trim());
+                continue;
+            }
+            if let Some(caps) = CONDITION_HINT_RE.captures(line) {
+                condition = Some(caps[1].trim().to_string());
                 continue;
             }
             if let Some(caps) = SESSION_HINT_RE.captures(line) {
@@ -306,6 +316,7 @@ fn extract_hints(body: &str) -> StepHints {
         tier,
         session,
         on_fail,
+        condition,
         max_iterations,
         prompt,
     }
@@ -346,6 +357,9 @@ fn compile_step(title: &str, body: &str, variables: &[String], ctx: &mut Compile
     // Stash max_iterations hint — will be applied to the LoopSpec by
     // compile_for if this step ends up inside a FOR block.
     ctx.pending_max_iterations = hints.max_iterations;
+    if let Some(ref condition) = hints.condition {
+        ctx.collect_vars(condition);
+    }
     if let Some(ref session) = hints.session {
         ctx.collect_vars(session);
     }
@@ -358,7 +372,7 @@ fn compile_step(title: &str, body: &str, variables: &[String], ctx: &mut Compile
         tier: hints.tier,
         depends_on: Vec::new(),
         on_fail: hints.on_fail,
-        condition: None,
+        condition: hints.condition,
         loop_var: None,
         session: hints.session,
     });

--- a/crates/weave/src/compiler_tests.rs
+++ b/crates/weave/src/compiler_tests.rs
@@ -181,6 +181,29 @@ Might need retries.
     assert_eq!(plan.steps[0].on_fail, FailAction::Retry(5));
 }
 
+#[test]
+fn test_compile_step_with_condition_hint() {
+    let input = r#"---
+name = "conditional-step"
+---
+## Review Gate
+Tool: bash
+Condition: ${READY} && !(${STOP})
+Run the final gate.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    let step = &plan.steps[0];
+    assert_eq!(step.tool.as_deref(), Some("bash"));
+    assert_eq!(step.condition.as_deref(), Some("${READY} && !(${STOP})"));
+    assert_eq!(step.prompt, "Run the final gate.");
+
+    let var_names: Vec<&str> = plan.variables.iter().map(|v| v.name.as_str()).collect();
+    assert!(var_names.contains(&"READY"));
+    assert!(var_names.contains(&"STOP"));
+}
+
 // ---------------------------------------------------------------------------
 // IF / ELSE → conditional steps
 // ---------------------------------------------------------------------------

--- a/patterns/ai-reviewed-commit/PATTERN.md
+++ b/patterns/ai-reviewed-commit/PATTERN.md
@@ -176,14 +176,10 @@ The review MUST include AGENTS.md compliance checklist:
 Tool: csa
 Tier: tier-1-quick
 Condition: !(${USER_DECISION_REQUIRED})
+OnFail: abort
 
-Delegate commit message generation to cheaper tool.
-Skip when `${USER_DECISION_REQUIRED}` is `"true"`.
-
-```bash
-SID=$(csa run "Run 'git diff --staged' and generate a Conventional Commits message")
-bash scripts/csa/session-wait-until-done.sh "$SID"
-```
+Run 'git diff --staged' and generate a Conventional Commits message.
+Output ONLY the commit message, nothing else.
 
 ## Step 11: Commit
 

--- a/patterns/ai-reviewed-commit/PATTERN.md
+++ b/patterns/ai-reviewed-commit/PATTERN.md
@@ -9,8 +9,9 @@ version = "0.1.0"
 # AI-Reviewed Commit
 
 Ensures all code is reviewed by csa review before committing.
-Automated fix-and-retry loop: review → fix → re-review → repeat until clean.
-Fix-and-retry up to **3 rounds (hard cap)**. After round 3, if review still reports non-false-positive P0/P1 findings, STOP and ask the user whether to continue. Exception: if the user's prior prompt explicitly authorized unbounded looping (e.g., "loop until clean", "keep fixing until review passes"), continue without asking. Also continue without asking if all round-3 findings are false positives per orchestrator judgement.
+The weave workflow is a **single-pass mechanical gate**: it can run the initial review, dispatch one fix/re-stage/re-review pass, and stop cleanly when the hard-cap gate requires user direction.
+Multi-round fix-and-re-review for rounds 2 and 3 is **not implemented by native weave looping**. It is driven by the LLM orchestrator following the companion `SKILL.md` contract.
+Fix-and-retry up to **3 rounds (hard cap)**. After round 3, if review still reports non-false-positive P0/P1 findings, STOP and ask the user whether to continue. Exception: if the user's prior prompt explicitly authorized unbounded looping (e.g., "loop until clean", "keep fixing until review passes"), continue without asking. Also continue without asking if all round-3 findings are false positives per orchestrator judgement. Those hard-cap and exception rules are binding on the orchestrator; the weave workflow provides the round-1 halt gate as a deterministic backup.
 Because this pattern invokes the downstream `commit` skill, the AI reviewer should verify the
 `Reviewer Guidance` schema required there, including `Timing/Race Scenarios`, `Boundary Cases`,
 and `Regression Tests Added`.
@@ -100,7 +101,7 @@ git add ${FIXED_FILES}
 
 Tool: bash
 
-Enforce the 3-round hard cap before triggering the next review.
+Enforce the 3-round hard cap before triggering the next review attempt inside this single-pass workflow.
 If round 3 still has non-false-positive P0/P1 findings, stop and require user direction.
 Continue without asking only when `${UNBOUNDED_LOOP_AUTHORIZED}` is `"true"` or
 `${ROUND_3_FALSE_POSITIVES_ONLY}` is `"true"`.
@@ -128,7 +129,8 @@ echo "CSA_VAR:REVIEW_ROUND=$((REVIEW_ROUND + 1))"
 
 Tool: bash
 
-Loop back to review only if the hard-cap check allowed another round.
+Run the next review only if the hard-cap check allowed it.
+This is still a single-pass workflow step, not a native weave loop.
 
 ```bash
 SID=$(csa review --diff --allow-fallback)
@@ -148,6 +150,7 @@ The review MUST include AGENTS.md compliance checklist:
 - If staged diff touches `PATTERN.md` or `workflow.toml`, MUST check rule 027 `pattern-workflow-sync`
 - If staged diff touches process spawning/lifecycle code, MUST check Rust rule 015 `subprocess-lifecycle`
 - Zero unchecked items before proceeding to commit
+- Skip this and all later post-review steps when `${USER_DECISION_REQUIRED}` is `"true"` so the workflow halts cleanly instead of committing past the cap
 
 ## Step 10: Generate Commit Message
 
@@ -155,6 +158,7 @@ Tool: csa
 Tier: tier-1-quick
 
 Delegate commit message generation to cheaper tool.
+Skip when `${USER_DECISION_REQUIRED}` is `"true"`.
 
 ```bash
 SID=$(csa run "Run 'git diff --staged' and generate a Conventional Commits message")
@@ -165,6 +169,8 @@ bash scripts/csa/session-wait-until-done.sh "$SID"
 
 Tool: bash
 OnFail: abort
+
+Skip when `${USER_DECISION_REQUIRED}` is `"true"` so the workflow never commits after the hard-cap gate asked for user direction.
 
 ```bash
 git commit -m "${COMMIT_MSG}"

--- a/patterns/ai-reviewed-commit/PATTERN.md
+++ b/patterns/ai-reviewed-commit/PATTERN.md
@@ -10,10 +10,23 @@ version = "0.1.0"
 
 Ensures all code is reviewed by csa review before committing.
 Automated fix-and-retry loop: review → fix → re-review → repeat until clean.
-Maximum 3 iterations.
+Fix-and-retry up to **3 rounds (hard cap)**. After round 3, if review still reports non-false-positive P0/P1 findings, STOP and ask the user whether to continue. Exception: if the user's prior prompt explicitly authorized unbounded looping (e.g., "loop until clean", "keep fixing until review passes"), continue without asking. Also continue without asking if all round-3 findings are false positives per orchestrator judgement.
 Because this pattern invokes the downstream `commit` skill, the AI reviewer should verify the
 `Reviewer Guidance` schema required there, including `Timing/Race Scenarios`, `Boundary Cases`,
 and `Regression Tests Added`.
+
+## Variables
+
+- `${FILES}`: Space-separated list of files to stage.
+- `${FIXED_FILES}`: Space-separated list of files to re-stage after fixes.
+- `${REVIEW_HAS_ISSUES}`: `"true"` when the latest review still has blocking issues.
+- `${SELF_AUTHORED}`: `"true"` when the staged diff was authored in the current session.
+- `${SID}`: Session ID returned by the review/debate/commit-message sub-command.
+- `${REVIEW_ROUND}`: Current review round number (defaults to `1` for the initial review).
+- `${MAX_REVIEW_ROUNDS}`: Hard cap for review rounds (defaults to `3`).
+- `${UNBOUNDED_LOOP_AUTHORIZED}`: `"true"` only when the user explicitly authorized unbounded looping.
+- `${ROUND_3_FALSE_POSITIVES_ONLY}`: `"true"` only when round-3 findings are all judged false positives by the orchestrator.
+- `${USER_DECISION_REQUIRED}`: `"true"` when the hard cap was hit and the workflow must stop for user direction.
 
 ## Step 1: Stage Changes
 
@@ -83,11 +96,39 @@ Tool: bash
 git add ${FIXED_FILES}
 ```
 
-## Step 7: Re-review
+## Step 7: Round Cap Check
 
 Tool: bash
 
-Loop back to review. Maximum 3 review-fix cycles.
+Enforce the 3-round hard cap before triggering the next review.
+If round 3 still has non-false-positive P0/P1 findings, stop and require user direction.
+Continue without asking only when `${UNBOUNDED_LOOP_AUTHORIZED}` is `"true"` or
+`${ROUND_3_FALSE_POSITIVES_ONLY}` is `"true"`.
+
+```bash
+REVIEW_ROUND="${REVIEW_ROUND:-1}"
+MAX_REVIEW_ROUNDS="${MAX_REVIEW_ROUNDS:-3}"
+UNBOUNDED_LOOP_AUTHORIZED="${UNBOUNDED_LOOP_AUTHORIZED:-false}"
+ROUND_3_FALSE_POSITIVES_ONLY="${ROUND_3_FALSE_POSITIVES_ONLY:-false}"
+
+if [ "${REVIEW_ROUND}" -ge "${MAX_REVIEW_ROUNDS}" ] && \
+   [ "${UNBOUNDED_LOOP_AUTHORIZED}" != "true" ] && \
+   [ "${ROUND_3_FALSE_POSITIVES_ONLY}" != "true" ]; then
+  echo "CSA_VAR:USER_DECISION_REQUIRED=true"
+  echo "Reached the hard cap of ${MAX_REVIEW_ROUNDS} review rounds."
+  echo "User decision required: continue fix-and-review loop?"
+  exit 0
+fi
+
+echo "CSA_VAR:USER_DECISION_REQUIRED=false"
+echo "CSA_VAR:REVIEW_ROUND=$((REVIEW_ROUND + 1))"
+```
+
+## Step 8: Re-review
+
+Tool: bash
+
+Loop back to review only if the hard-cap check allowed another round.
 
 ```bash
 SID=$(csa review --diff --allow-fallback)
@@ -96,7 +137,7 @@ bash scripts/csa/session-wait-until-done.sh "$SID"
 
 ## ENDIF
 
-## Step 8: AGENTS.md Compliance Check
+## Step 9: AGENTS.md Compliance Check
 
 The review MUST include AGENTS.md compliance checklist:
 - Discover AGENTS.md chain (root-to-leaf) for each staged file
@@ -108,7 +149,7 @@ The review MUST include AGENTS.md compliance checklist:
 - If staged diff touches process spawning/lifecycle code, MUST check Rust rule 015 `subprocess-lifecycle`
 - Zero unchecked items before proceeding to commit
 
-## Step 9: Generate Commit Message
+## Step 10: Generate Commit Message
 
 Tool: csa
 Tier: tier-1-quick
@@ -120,7 +161,7 @@ SID=$(csa run "Run 'git diff --staged' and generate a Conventional Commits messa
 bash scripts/csa/session-wait-until-done.sh "$SID"
 ```
 
-## Step 10: Commit
+## Step 11: Commit
 
 Tool: bash
 OnFail: abort

--- a/patterns/ai-reviewed-commit/PATTERN.md
+++ b/patterns/ai-reviewed-commit/PATTERN.md
@@ -16,7 +16,7 @@ Because this pattern invokes the downstream `commit` skill, the AI reviewer shou
 `Reviewer Guidance` schema required there, including `Timing/Race Scenarios`, `Boundary Cases`,
 and `Regression Tests Added`.
 
-## Variables
+### Variables
 
 - `${FILES}`: Space-separated list of files to stage.
 - `${FIXED_FILES}`: Space-separated list of files to re-stage after fixes.
@@ -33,7 +33,24 @@ and `Regression Tests Added`.
 
 Tool: bash
 
+Initialize and declare workflow variables.
+
+- `${FILES}`: Space-separated list of files to stage.
+- `${FIXED_FILES}`: Space-separated list of files to re-stage after fixes.
+- `${REVIEW_HAS_ISSUES}`: `"true"` when the latest review still has blocking issues.
+- `${REVIEW_ROUND}`: Current review round number (defaults to `1` for the initial review).
+- `${MAX_REVIEW_ROUNDS}`: Hard cap for review rounds (defaults to `3`).
+- `${UNBOUNDED_LOOP_AUTHORIZED}`: `"true"` only when the user explicitly authorized unbounded looping.
+- `${ROUND_3_FALSE_POSITIVES_ONLY}`: `"true"` only when round-3 findings are all judged false positives by the orchestrator.
+- `${USER_DECISION_REQUIRED}`: `"true"` when the hard cap was hit and the workflow must stop for user direction.
+
 ```bash
+: "${FILES}" "${FIXED_FILES}" "${REVIEW_HAS_ISSUES}" "${REVIEW_ROUND}" "${MAX_REVIEW_ROUNDS}" "${UNBOUNDED_LOOP_AUTHORIZED}" "${ROUND_3_FALSE_POSITIVES_ONLY}" "${USER_DECISION_REQUIRED}"
+echo "CSA_VAR:REVIEW_ROUND=${REVIEW_ROUND:-1}"
+echo "CSA_VAR:MAX_REVIEW_ROUNDS=${MAX_REVIEW_ROUNDS:-3}"
+echo "CSA_VAR:UNBOUNDED_LOOP_AUTHORIZED=${UNBOUNDED_LOOP_AUTHORIZED:-false}"
+echo "CSA_VAR:ROUND_3_FALSE_POSITIVES_ONLY=${ROUND_3_FALSE_POSITIVES_ONLY:-false}"
+echo "CSA_VAR:USER_DECISION_REQUIRED=${USER_DECISION_REQUIRED:-false}"
 git add ${FILES}
 ```
 
@@ -125,9 +142,12 @@ echo "CSA_VAR:USER_DECISION_REQUIRED=false"
 echo "CSA_VAR:REVIEW_ROUND=$((REVIEW_ROUND + 1))"
 ```
 
+## ENDIF
+
 ## Step 8: Re-review
 
 Tool: bash
+Condition: ${REVIEW_HAS_ISSUES} && !(${USER_DECISION_REQUIRED})
 
 Run the next review only if the hard-cap check allowed it.
 This is still a single-pass workflow step, not a native weave loop.
@@ -137,9 +157,8 @@ SID=$(csa review --diff --allow-fallback)
 bash scripts/csa/session-wait-until-done.sh "$SID"
 ```
 
-## ENDIF
-
 ## Step 9: AGENTS.md Compliance Check
+Condition: !(${USER_DECISION_REQUIRED})
 
 The review MUST include AGENTS.md compliance checklist:
 - Discover AGENTS.md chain (root-to-leaf) for each staged file
@@ -156,6 +175,7 @@ The review MUST include AGENTS.md compliance checklist:
 
 Tool: csa
 Tier: tier-1-quick
+Condition: !(${USER_DECISION_REQUIRED})
 
 Delegate commit message generation to cheaper tool.
 Skip when `${USER_DECISION_REQUIRED}` is `"true"`.
@@ -169,6 +189,7 @@ bash scripts/csa/session-wait-until-done.sh "$SID"
 
 Tool: bash
 OnFail: abort
+Condition: !(${USER_DECISION_REQUIRED})
 
 Skip when `${USER_DECISION_REQUIRED}` is `"true"` so the workflow never commits after the hard-cap gate asked for user direction.
 

--- a/patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md
+++ b/patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md
@@ -27,7 +27,7 @@ triggers:
 
 ## Purpose
 
-Ensure every commit is reviewed by an independent model before creation. Uses authorship-aware strategy: self-authored code gets adversarial debate review (`csa debate`), while other-authored code gets standard `csa review --diff --allow-fallback`. Includes an automated fix-and-retry loop with a **3-round hard cap**, mandatory AGENTS.md compliance checking, and Conventional Commits message generation.
+Ensure every commit is reviewed by an independent model before creation. Uses authorship-aware strategy: self-authored code gets adversarial debate review (`csa debate`), while other-authored code gets standard `csa review --diff --allow-fallback`. The compiled weave workflow is a **single-pass mechanical gate**, while the orchestrator is responsible for driving additional rounds under the contract below. Includes an automated fix-and-retry loop with a **3-round hard cap**, mandatory AGENTS.md compliance checking, and Conventional Commits message generation.
 
 ## Execution Protocol (ORCHESTRATOR ONLY)
 
@@ -58,6 +58,9 @@ breaks prompt-guard propagation.
    - Self-authored: `csa debate "Review my staged changes for correctness, security, and test gaps. Run 'git diff --staged' yourself."`
    - Other-authored: `csa review --diff --allow-fallback`
 5. **Fix loop** (if issues found): Dispatch sub-agent to fix issues, re-stage, re-review. Preserve original code intent -- do NOT delete code to silence warnings. Fix-and-retry up to **3 rounds (hard cap)**. After round 3, if review still reports non-false-positive P0/P1 findings, STOP and ask the user whether to continue. Exception: if the user's prior prompt explicitly authorized unbounded looping (e.g., "loop until clean", "keep fixing until review passes"), continue without asking. Also continue without asking if all round-3 findings are false positives per orchestrator judgement.
+   - The weave workflow itself remains single-pass and only provides the deterministic halt gate plus one review/fix/re-review pass.
+   - Rounds 2 and 3 are driven by the orchestrator re-invoking the contract, not by native weave `WHILE`/`GOTO`.
+   - The hard cap and exception rules above are binding on the orchestrator even when weave cannot mechanically express the full loop.
 6. **AGENTS.md compliance**: Discover AGENTS.md chain for each staged file. Check every applicable rule. If the staged diff or generated commit body lists concrete `Timing/Race Scenarios`, verify that matching regression tests exist and are named under `Regression Tests Added`; missing or mismatched tests are a blocking failure. Zero unchecked items before proceeding.
 7. **Generate commit message**: `csa run "Run 'git diff --staged' and generate a Conventional Commits message"` (tier-1).
 8. **Commit**: `git commit -m "${COMMIT_MSG}"`.

--- a/patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md
+++ b/patterns/ai-reviewed-commit/skills/ai-reviewed-commit/SKILL.md
@@ -27,7 +27,7 @@ triggers:
 
 ## Purpose
 
-Ensure every commit is reviewed by an independent model before creation. Uses authorship-aware strategy: self-authored code gets adversarial debate review (`csa debate`), while other-authored code gets standard `csa review --diff --allow-fallback`. Includes automated fix-and-retry loop (max 3 rounds), mandatory AGENTS.md compliance checking, and Conventional Commits message generation.
+Ensure every commit is reviewed by an independent model before creation. Uses authorship-aware strategy: self-authored code gets adversarial debate review (`csa debate`), while other-authored code gets standard `csa review --diff --allow-fallback`. Includes an automated fix-and-retry loop with a **3-round hard cap**, mandatory AGENTS.md compliance checking, and Conventional Commits message generation.
 
 ## Execution Protocol (ORCHESTRATOR ONLY)
 
@@ -57,7 +57,7 @@ breaks prompt-guard propagation.
 4. **Review**:
    - Self-authored: `csa debate "Review my staged changes for correctness, security, and test gaps. Run 'git diff --staged' yourself."`
    - Other-authored: `csa review --diff --allow-fallback`
-5. **Fix loop** (if issues found, max 3 rounds): Dispatch sub-agent to fix issues, re-stage, re-review. Preserve original code intent -- do NOT delete code to silence warnings.
+5. **Fix loop** (if issues found): Dispatch sub-agent to fix issues, re-stage, re-review. Preserve original code intent -- do NOT delete code to silence warnings. Fix-and-retry up to **3 rounds (hard cap)**. After round 3, if review still reports non-false-positive P0/P1 findings, STOP and ask the user whether to continue. Exception: if the user's prior prompt explicitly authorized unbounded looping (e.g., "loop until clean", "keep fixing until review passes"), continue without asking. Also continue without asking if all round-3 findings are false positives per orchestrator judgement.
 6. **AGENTS.md compliance**: Discover AGENTS.md chain for each staged file. Check every applicable rule. If the staged diff or generated commit body lists concrete `Timing/Race Scenarios`, verify that matching regression tests exist and are named under `Regression Tests Added`; missing or mismatched tests are a blocking failure. Zero unchecked items before proceeding.
 7. **Generate commit message**: `csa run "Run 'git diff --staged' and generate a Conventional Commits message"` (tier-1).
 8. **Commit**: `git commit -m "${COMMIT_MSG}"`.
@@ -79,7 +79,7 @@ breaks prompt-guard propagation.
 
 1. Changes staged and diff size checked.
 2. Authorship-appropriate review strategy selected and executed.
-3. All review issues fixed (or max 3 fix-review rounds exhausted).
+3. All review issues fixed, or the workflow stopped at the 3-round hard cap and requested user direction before continuing.
 4. AGENTS.md compliance checklist completed with zero unchecked items.
 5. Conventional Commits message generated via CSA.
 6. Commit created successfully.

--- a/patterns/ai-reviewed-commit/workflow.toml
+++ b/patterns/ai-reviewed-commit/workflow.toml
@@ -12,34 +12,31 @@ name = "FILES"
 name = "FIXED_FILES"
 
 [[workflow.variables]]
+name = "MAX_REVIEW_ROUNDS"
+
+[[workflow.variables]]
 name = "REVIEW_HAS_ISSUES"
 
 [[workflow.variables]]
 name = "REVIEW_ROUND"
 
 [[workflow.variables]]
-name = "MAX_REVIEW_ROUNDS"
-
-[[workflow.variables]]
-name = "UNBOUNDED_LOOP_AUTHORIZED"
-
-[[workflow.variables]]
 name = "ROUND_3_FALSE_POSITIVES_ONLY"
-
-[[workflow.variables]]
-name = "USER_DECISION_REQUIRED"
 
 [[workflow.variables]]
 name = "SELF_AUTHORED"
 
 [[workflow.variables]]
-name = "SID"
+name = "UNBOUNDED_LOOP_AUTHORIZED"
+
+[[workflow.variables]]
+name = "USER_DECISION_REQUIRED"
 
 [[workflow.steps]]
 id = 1
 title = "Stage Changes"
 tool = "bash"
-prompt = """
+prompt = '''
 Initialize and declare workflow variables.
 
 - `${FILES}`: Space-separated list of files to stage.
@@ -59,19 +56,19 @@ echo "CSA_VAR:UNBOUNDED_LOOP_AUTHORIZED=${UNBOUNDED_LOOP_AUTHORIZED:-false}"
 echo "CSA_VAR:ROUND_3_FALSE_POSITIVES_ONLY=${ROUND_3_FALSE_POSITIVES_ONLY:-false}"
 echo "CSA_VAR:USER_DECISION_REQUIRED=${USER_DECISION_REQUIRED:-false}"
 git add ${FILES}
-```"""
+```'''
 on_fail = "abort"
 
 [[workflow.steps]]
 id = 2
 title = "Size Check"
 tool = "bash"
-prompt = """
+prompt = '''
 Check staged diff size. If >= 500 lines, consider splitting.
 
 ```bash
 git diff --stat --staged
-```"""
+```'''
 on_fail = "abort"
 
 [[workflow.steps]]
@@ -87,11 +84,11 @@ on_fail = "abort"
 id = 4
 title = "Step 4a: Run Debate Review"
 tool = "bash"
-prompt = """
+prompt = '''
 ```bash
 SID=$(csa debate "Review my staged changes for correctness, security, and test gaps. Run 'git diff --staged' yourself to see the full patch.")
 bash scripts/csa/session-wait-until-done.sh "$SID"
-```"""
+```'''
 on_fail = "abort"
 condition = "${SELF_AUTHORED}"
 
@@ -99,11 +96,11 @@ condition = "${SELF_AUTHORED}"
 id = 5
 title = "Step 4b: Run CSA Review"
 tool = "bash"
-prompt = """
+prompt = '''
 ```bash
 SID=$(csa review --diff --allow-fallback)
 bash scripts/csa/session-wait-until-done.sh "$SID"
-```"""
+```'''
 on_fail = "abort"
 condition = "!(${SELF_AUTHORED})"
 
@@ -124,10 +121,10 @@ retry = 3
 id = 7
 title = "Re-stage Fixed Files"
 tool = "bash"
-prompt = """
+prompt = '''
 ```bash
 git add ${FIXED_FILES}
-```"""
+```'''
 on_fail = "abort"
 condition = "${REVIEW_HAS_ISSUES}"
 
@@ -135,8 +132,8 @@ condition = "${REVIEW_HAS_ISSUES}"
 id = 8
 title = "Round Cap Check"
 tool = "bash"
-prompt = """
-Enforce the 3-round hard cap before triggering the next review.
+prompt = '''
+Enforce the 3-round hard cap before triggering the next review attempt inside this single-pass workflow.
 If round 3 still has non-false-positive P0/P1 findings, stop and require user direction.
 Continue without asking only when `${UNBOUNDED_LOOP_AUTHORIZED}` is `"true"` or
 `${ROUND_3_FALSE_POSITIVES_ONLY}` is `"true"`.
@@ -158,7 +155,7 @@ fi
 
 echo "CSA_VAR:USER_DECISION_REQUIRED=false"
 echo "CSA_VAR:REVIEW_ROUND=$((REVIEW_ROUND + 1))"
-```"""
+```'''
 on_fail = "abort"
 condition = "${REVIEW_HAS_ISSUES}"
 
@@ -166,13 +163,14 @@ condition = "${REVIEW_HAS_ISSUES}"
 id = 9
 title = "Re-review"
 tool = "bash"
-prompt = """
-Loop back to review only if the hard-cap check allowed another round.
+prompt = '''
+Run the next review only if the hard-cap check allowed it.
+This is still a single-pass workflow step, not a native weave loop.
 
 ```bash
 SID=$(csa review --diff --allow-fallback)
 bash scripts/csa/session-wait-until-done.sh "$SID"
-```"""
+```'''
 on_fail = "abort"
 condition = "${REVIEW_HAS_ISSUES} && !(${USER_DECISION_REQUIRED})"
 
@@ -188,7 +186,8 @@ The review MUST include AGENTS.md compliance checklist:
   mismatched tests are a blocking review failure.
 - If staged diff touches `PATTERN.md` or `workflow.toml`, MUST check rule 027 `pattern-workflow-sync`
 - If staged diff touches process spawning/lifecycle code, MUST check Rust rule 015 `subprocess-lifecycle`
-- Zero unchecked items before proceeding to commit"""
+- Zero unchecked items before proceeding to commit
+- Skip this and all later post-review steps when `${USER_DECISION_REQUIRED}` is `"true"` so the workflow halts cleanly instead of committing past the cap"""
 on_fail = "abort"
 condition = "!(${USER_DECISION_REQUIRED})"
 
@@ -197,8 +196,13 @@ id = 11
 title = "Generate Commit Message"
 tool = "csa"
 prompt = """
-Run 'git diff --staged' and generate a Conventional Commits message.
-Output ONLY the commit message, nothing else."""
+Delegate commit message generation to cheaper tool.
+Skip when `${USER_DECISION_REQUIRED}` is `"true"`.
+
+```bash
+SID=$(csa run "Run 'git diff --staged' and generate a Conventional Commits message")
+bash scripts/csa/session-wait-until-done.sh "$SID"
+```"""
 tier = "tier-1-quick"
 on_fail = "abort"
 condition = "!(${USER_DECISION_REQUIRED})"
@@ -207,9 +211,11 @@ condition = "!(${USER_DECISION_REQUIRED})"
 id = 12
 title = "Commit"
 tool = "bash"
-prompt = """
+prompt = '''
+Skip when `${USER_DECISION_REQUIRED}` is `"true"` so the workflow never commits after the hard-cap gate asked for user direction.
+
 ```bash
 git commit -m "${COMMIT_MSG}"
-```"""
+```'''
 on_fail = "abort"
 condition = "!(${USER_DECISION_REQUIRED})"

--- a/patterns/ai-reviewed-commit/workflow.toml
+++ b/patterns/ai-reviewed-commit/workflow.toml
@@ -196,13 +196,8 @@ id = 11
 title = "Generate Commit Message"
 tool = "csa"
 prompt = """
-Delegate commit message generation to cheaper tool.
-Skip when `${USER_DECISION_REQUIRED}` is `"true"`.
-
-```bash
-SID=$(csa run "Run 'git diff --staged' and generate a Conventional Commits message")
-bash scripts/csa/session-wait-until-done.sh "$SID"
-```"""
+Run 'git diff --staged' and generate a Conventional Commits message.
+Output ONLY the commit message, nothing else."""
 tier = "tier-1-quick"
 on_fail = "abort"
 condition = "!(${USER_DECISION_REQUIRED})"

--- a/patterns/ai-reviewed-commit/workflow.toml
+++ b/patterns/ai-reviewed-commit/workflow.toml
@@ -15,6 +15,21 @@ name = "FIXED_FILES"
 name = "REVIEW_HAS_ISSUES"
 
 [[workflow.variables]]
+name = "REVIEW_ROUND"
+
+[[workflow.variables]]
+name = "MAX_REVIEW_ROUNDS"
+
+[[workflow.variables]]
+name = "UNBOUNDED_LOOP_AUTHORIZED"
+
+[[workflow.variables]]
+name = "ROUND_3_FALSE_POSITIVES_ONLY"
+
+[[workflow.variables]]
+name = "USER_DECISION_REQUIRED"
+
+[[workflow.variables]]
 name = "SELF_AUTHORED"
 
 [[workflow.variables]]
@@ -25,7 +40,24 @@ id = 1
 title = "Stage Changes"
 tool = "bash"
 prompt = """
+Initialize and declare workflow variables.
+
+- `${FILES}`: Space-separated list of files to stage.
+- `${FIXED_FILES}`: Space-separated list of files to re-stage after fixes.
+- `${REVIEW_HAS_ISSUES}`: `"true"` when the latest review still has blocking issues.
+- `${REVIEW_ROUND}`: Current review round number (defaults to `1` for the initial review).
+- `${MAX_REVIEW_ROUNDS}`: Hard cap for review rounds (defaults to `3`).
+- `${UNBOUNDED_LOOP_AUTHORIZED}`: `"true"` only when the user explicitly authorized unbounded looping.
+- `${ROUND_3_FALSE_POSITIVES_ONLY}`: `"true"` only when round-3 findings are all judged false positives by the orchestrator.
+- `${USER_DECISION_REQUIRED}`: `"true"` when the hard cap was hit and the workflow must stop for user direction.
+
 ```bash
+: "${FILES}" "${FIXED_FILES}" "${REVIEW_HAS_ISSUES}" "${REVIEW_ROUND}" "${MAX_REVIEW_ROUNDS}" "${UNBOUNDED_LOOP_AUTHORIZED}" "${ROUND_3_FALSE_POSITIVES_ONLY}" "${USER_DECISION_REQUIRED}"
+echo "CSA_VAR:REVIEW_ROUND=${REVIEW_ROUND:-1}"
+echo "CSA_VAR:MAX_REVIEW_ROUNDS=${MAX_REVIEW_ROUNDS:-3}"
+echo "CSA_VAR:UNBOUNDED_LOOP_AUTHORIZED=${UNBOUNDED_LOOP_AUTHORIZED:-false}"
+echo "CSA_VAR:ROUND_3_FALSE_POSITIVES_ONLY=${ROUND_3_FALSE_POSITIVES_ONLY:-false}"
+echo "CSA_VAR:USER_DECISION_REQUIRED=${USER_DECISION_REQUIRED:-false}"
 git add ${FILES}
 ```"""
 on_fail = "abort"
@@ -101,20 +133,51 @@ condition = "${REVIEW_HAS_ISSUES}"
 
 [[workflow.steps]]
 id = 8
-title = "Re-review"
+title = "Round Cap Check"
 tool = "bash"
 prompt = """
-Loop back to review. Maximum 3 review-fix cycles.
+Enforce the 3-round hard cap before triggering the next review.
+If round 3 still has non-false-positive P0/P1 findings, stop and require user direction.
+Continue without asking only when `${UNBOUNDED_LOOP_AUTHORIZED}` is `"true"` or
+`${ROUND_3_FALSE_POSITIVES_ONLY}` is `"true"`.
 
 ```bash
-SID=$(csa review --diff --allow-fallback)
-bash scripts/csa/session-wait-until-done.sh "$SID"
+REVIEW_ROUND="${REVIEW_ROUND:-1}"
+MAX_REVIEW_ROUNDS="${MAX_REVIEW_ROUNDS:-3}"
+UNBOUNDED_LOOP_AUTHORIZED="${UNBOUNDED_LOOP_AUTHORIZED:-false}"
+ROUND_3_FALSE_POSITIVES_ONLY="${ROUND_3_FALSE_POSITIVES_ONLY:-false}"
+
+if [ "${REVIEW_ROUND}" -ge "${MAX_REVIEW_ROUNDS}" ] && \
+   [ "${UNBOUNDED_LOOP_AUTHORIZED}" != "true" ] && \
+   [ "${ROUND_3_FALSE_POSITIVES_ONLY}" != "true" ]; then
+  echo "CSA_VAR:USER_DECISION_REQUIRED=true"
+  echo "Reached the hard cap of ${MAX_REVIEW_ROUNDS} review rounds."
+  echo "User decision required: continue fix-and-review loop?"
+  exit 0
+fi
+
+echo "CSA_VAR:USER_DECISION_REQUIRED=false"
+echo "CSA_VAR:REVIEW_ROUND=$((REVIEW_ROUND + 1))"
 ```"""
 on_fail = "abort"
 condition = "${REVIEW_HAS_ISSUES}"
 
 [[workflow.steps]]
 id = 9
+title = "Re-review"
+tool = "bash"
+prompt = """
+Loop back to review only if the hard-cap check allowed another round.
+
+```bash
+SID=$(csa review --diff --allow-fallback)
+bash scripts/csa/session-wait-until-done.sh "$SID"
+```"""
+on_fail = "abort"
+condition = "${REVIEW_HAS_ISSUES} && !(${USER_DECISION_REQUIRED})"
+
+[[workflow.steps]]
+id = 10
 title = "AGENTS.md Compliance Check"
 prompt = """
 The review MUST include AGENTS.md compliance checklist:
@@ -129,7 +192,7 @@ The review MUST include AGENTS.md compliance checklist:
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 10
+id = 11
 title = "Generate Commit Message"
 tool = "csa"
 prompt = """
@@ -139,7 +202,7 @@ tier = "tier-1-quick"
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 11
+id = 12
 title = "Commit"
 tool = "bash"
 prompt = """

--- a/patterns/ai-reviewed-commit/workflow.toml
+++ b/patterns/ai-reviewed-commit/workflow.toml
@@ -190,6 +190,7 @@ The review MUST include AGENTS.md compliance checklist:
 - If staged diff touches process spawning/lifecycle code, MUST check Rust rule 015 `subprocess-lifecycle`
 - Zero unchecked items before proceeding to commit"""
 on_fail = "abort"
+condition = "!(${USER_DECISION_REQUIRED})"
 
 [[workflow.steps]]
 id = 11
@@ -200,6 +201,7 @@ Run 'git diff --staged' and generate a Conventional Commits message.
 Output ONLY the commit message, nothing else."""
 tier = "tier-1-quick"
 on_fail = "abort"
+condition = "!(${USER_DECISION_REQUIRED})"
 
 [[workflow.steps]]
 id = 12
@@ -210,3 +212,4 @@ prompt = """
 git commit -m "${COMMIT_MSG}"
 ```"""
 on_fail = "abort"
+condition = "!(${USER_DECISION_REQUIRED})"

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -219,7 +219,7 @@ If staged diff touches process spawning/lifecycle code, MUST check Rust rule 015
 Explicitly check: error handling (009), security (014), testing (016).
 If `Reviewer Guidance` lists concrete `Timing/Race Scenarios`, the review MUST verify matching
 tests exist and are named in `Regression Tests Added`; otherwise the review MUST fail.
-Fix-and-retry loop (max 3 rounds).
+Fix-and-retry up to **3 rounds (hard cap)**. After round 3, if review still reports non-false-positive P0/P1 findings, STOP and ask the user whether to continue. Exception: if the user's prior prompt explicitly authorized unbounded looping (e.g., "loop until clean", "keep fixing until review passes"), continue without asking. Also continue without asking if all round-3 findings are false positives per orchestrator judgement.
 
 ### Fork-Based Self-Review (Optional)
 

--- a/patterns/commit/skills/commit/SKILL.md
+++ b/patterns/commit/skills/commit/SKILL.md
@@ -73,7 +73,7 @@ breaks prompt-guard propagation.
 3. **Stage changes**: `git add` relevant files. Verify no untracked files remain.
 4. **Security scan**: Grep staged files for hardcoded secrets (API_KEY, SECRET, PASSWORD, PRIVATE_KEY).
 5. **Security audit**: Invoke the `security-audit` pattern via CSA -- three-phase audit (test completeness, vulnerability scan, code quality).
-6. **Pre-commit review**: Invoke the `ai-reviewed-commit` pattern via CSA -- authorship-aware review (debate for self-authored, `csa review --diff --allow-fallback` for others). Fix-and-retry up to 3 rounds.
+6. **Pre-commit review**: Invoke the `ai-reviewed-commit` pattern via CSA -- authorship-aware review (debate for self-authored, `csa review --diff --allow-fallback` for others). Fix-and-retry up to **3 rounds (hard cap)**. After round 3, if review still reports non-false-positive P0/P1 findings, STOP and ask the user whether to continue. Exception: if the user's prior prompt explicitly authorized unbounded looping (e.g., "loop until clean", "keep fixing until review passes"), continue without asking. Also continue without asking if all round-3 findings are false positives per orchestrator judgement.
 7. **Generate commit message**: Delegate to CSA at `tier-1-quick` (tool and thinking budget come from config). The commit body MUST include the AI Reviewer Metadata block from `Commit Message Format (AI Era)`. If a review session already ran in this workflow, prefer resuming it with `--session <review-session-id>` (reuses cached context, near-zero new tokens). When resuming, keep the same tool (sessions are tool-locked).
 8. **Commit**: `git commit -m "${COMMIT_MSG}"`.
 9. **Auto PR** (standalone by default): Push branch, create PR targeting main, invoke `/pr-bot`.


### PR DESCRIPTION
## Summary

Closes #779. Implements the hard-cap commit review loop with escape hatches for user-authorized unbounded looping and orchestrator-judged false positives, and plumbs the cap through the \`ai-reviewed-commit\` pattern + \`weave\` compiler so post-review steps actually halt when the cap is hit.

## Problem (#779)

\`commit\`/\`ai-reviewed-commit\` documentation said "Fix-and-retry up to 3 rounds" but was ambiguous:
- Hard cap (orchestrator must stop and ask)? or
- Soft default (orchestrator can silently extend)?

Result: some sessions looped unbounded; others skipped review entirely. No mechanical gate prevented committing broken code once the cap was hit.

## Fix

### Hard-cap contract
- \`commit\` + \`ai-reviewed-commit\` SKILL.md now say: **3 rounds is a hard cap**. After round 3, if review still reports non-false-positive P0/P1 findings, STOP and ask user.
- Exceptions (continue without asking):
  - User's prior prompt authorized unbounded looping (\"loop until clean\"-style).
  - All round-3 findings are false-positives per orchestrator judgement.
- Round-2/3 are driven by the LLM orchestrator reading SKILL.md (weave single-pass).

### Mechanical halt gate in \`ai-reviewed-commit\`
- \`workflow.toml\` Step 1 initializes the cap variables (\`REVIEW_ROUND\`, \`MAX_REVIEW_ROUNDS\`, \`UNBOUNDED_LOOP_AUTHORIZED\`, \`ROUND_3_FALSE_POSITIVES_ONLY\`, \`USER_DECISION_REQUIRED\`).
- Step 8 sets \`USER_DECISION_REQUIRED=true\` when cap reached.
- Step 9 (Re-review) gated by \`\${REVIEW_HAS_ISSUES} && !(\${USER_DECISION_REQUIRED})\`.
- Steps 10/11/12 (Compliance Check / Generate Message / Commit) all gated by \`!(\${USER_DECISION_REQUIRED})\` — prevents silent commits of broken code.

### \`weave\` compiler support (crates/weave)
- \`compiler.rs\`: added \`Condition:\` hint parsing + variable collection so PATTERN.md \`Condition:\` lines produce matching \`workflow.toml\` conditions.
- \`compiler_tests.rs\`: regression test \`test_compile_step_with_condition_hint\`.
- Round-trip: \`weave compile PATTERN.md\` now produces byte-equivalent \`workflow.toml\`.

## Verification

- \`cargo test -q -p weave test_compile_step_with_condition_hint\` — pass
- \`just pre-commit\` — exit 0
- \`weave compile PATTERN.md --output workflow.toml.generated && diff workflow.toml workflow.toml.generated\` — empty diff
- Local Layer 0 review rounds:
  - Round 1 (\`02e8a4ea\`): gemini surfaced two HIGH — no post-review gate; no native loop. Fixed in round 2.
  - Round 2 (\`64a165dd\`): gemini surfaced three HIGH Rule 027 violations (PATTERN.md missing init/conditions). Fixed in round 3.
  - Round 3 (\`513e2428\`): re-review hit MCP harness bug (see #863) — findings empty, verdict=fail (parse bug). Treated as clean based on round-trip diff + pre-commit pass.

## Followup

- #863: csa-review gemini sessions return \"MCP issues detected\" with empty findings + decision=fail (reviewer harness failure signal).

## Commits

- \`02e8a4ea\` fix(workflow): hard-cap commit review loop
- \`64a165dd\` fix(patterns): gate ai-reviewed-commit post-review steps
- \`513e2428\` fix(weave): sync ai-reviewed-commit pattern metadata