### PR TITLE
fix(csa-executor): classify codex ACP exit-code OOMs (#848)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.337"
+version = "0.1.338"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.337"
+version = "0.1.338"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_acp_crash_retry.rs
+++ b/crates/csa-executor/src/transport_acp_crash_retry.rs
@@ -171,6 +171,13 @@ pub(crate) enum CodexAcpCrashKind {
     Runtime,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CrashExitCode {
+    ExitCode(i32),
+    Signal(i32),
+    OomEvent,
+}
+
 impl CodexAcpCrashKind {
     pub(crate) fn code(self) -> &'static str {
         match self {
@@ -186,9 +193,45 @@ pub(crate) struct CodexAcpCrashClassification {
     pub(crate) rendered_hint: String,
 }
 
+pub(crate) fn extract_crash_exit_code(error_str: &str) -> Option<CrashExitCode> {
+    let lowered = error_str.to_ascii_lowercase();
+
+    if lowered.contains("exit code 137") || lowered.contains("exit 137") {
+        return Some(CrashExitCode::ExitCode(137));
+    }
+
+    if lowered.contains("signal: 9") || lowered.contains("sigkill") {
+        return Some(CrashExitCode::Signal(9));
+    }
+
+    if lowered.contains("memory.max")
+        || lowered.contains("oom-kill")
+        || lowered.contains("memory.events")
+        || lowered.contains("memory.events.local")
+        || lowered.contains("oom ")
+        || lowered.contains(" oom")
+        || lowered.ends_with("oom")
+    {
+        return Some(CrashExitCode::OomEvent);
+    }
+
+    let exit_code_marker = "exit code ";
+    if let Some(start) = lowered.find(exit_code_marker) {
+        let digits: String = lowered[start + exit_code_marker.len()..]
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
+        if !digits.is_empty() {
+            return digits.parse::<i32>().ok().map(CrashExitCode::ExitCode);
+        }
+    }
+
+    None
+}
+
 pub(crate) fn classify_codex_acp_crash(
     stderr_or_context: &str,
-    exit_code: Option<i32>,
+    exit_code: Option<CrashExitCode>,
     cgroup_state: Option<&str>,
     memory_max_mb: Option<u64>,
 ) -> CodexAcpCrashClassification {
@@ -197,7 +240,12 @@ pub(crate) fn classify_codex_acp_crash(
     let config_key = memory_limit_config_key("codex");
     let current_limit = format_memory_limit(memory_max_mb);
 
-    let signal_kill = matches!(exit_code, Some(137) | Some(9) | Some(-9));
+    let exit_code_oom = matches!(
+        exit_code,
+        Some(CrashExitCode::ExitCode(137))
+            | Some(CrashExitCode::Signal(9))
+            | Some(CrashExitCode::OomEvent)
+    );
     let stderr_exact_killed = stderr_lower
         .rsplit_once("stderr:")
         .is_some_and(|(_, tail)| tail.trim() == "killed");
@@ -214,7 +262,7 @@ pub(crate) fn classify_codex_acp_crash(
         || stderr_exact_killed
         || plain_killed_line
         || cgroup_oom
-        || signal_kill;
+        || exit_code_oom;
 
     let (kind, rendered_hint) = if oom_signature {
         (
@@ -355,8 +403,12 @@ pub(super) async fn execute_with_crash_retry(
                 }
                 if transport.tool_name == "codex" && is_crash_lowered(&error_display.to_lowercase())
                 {
-                    let classification =
-                        classify_codex_acp_crash(&error_display, None, None, memory_max_mb);
+                    let classification = classify_codex_acp_crash(
+                        &error_display,
+                        extract_crash_exit_code(&error_display),
+                        None,
+                        memory_max_mb,
+                    );
                     tracing::warn!(
                         classified_reason = classification.kind.code(),
                         memory_max_mb,
@@ -597,7 +649,6 @@ mod tests {
                 .contains("claude-code native Agent tool")
         );
     }
-
     #[test]
     fn test_classify_codex_acp_crash_oom_from_stderr_tail_killed() {
         let classification = classify_codex_acp_crash(
@@ -608,7 +659,6 @@ mod tests {
         );
         assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
     }
-
     #[test]
     fn test_classify_codex_acp_crash_oom_from_cgroup_state() {
         let classification = classify_codex_acp_crash(
@@ -620,7 +670,6 @@ mod tests {
         assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
         assert!(classification.rendered_hint.contains("4096MB"));
     }
-
     #[test]
     fn test_classify_codex_acp_crash_runtime_without_oom_signature() {
         let classification = classify_codex_acp_crash(
@@ -642,7 +691,6 @@ mod tests {
                 .contains("[tools.codex].memory_max_mb")
         );
     }
-
     #[test]
     fn test_classify_codex_acp_crash_signal_11_stays_runtime() {
         let classification = classify_codex_acp_crash(
@@ -653,7 +701,6 @@ mod tests {
         );
         assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
     }
-
     #[test]
     fn test_classify_codex_acp_crash_signal_90_stays_runtime() {
         let classification = classify_codex_acp_crash(
@@ -664,10 +711,68 @@ mod tests {
         );
         assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
     }
-
+    #[test]
+    fn classify_extracts_exit_137_with_empty_stderr() {
+        let classification = classify_codex_acp_crash(
+            "ACP process exited unexpectedly: exit code 137",
+            extract_crash_exit_code("ACP process exited unexpectedly: exit code 137"),
+            None,
+            Some(3072),
+        );
+        assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
+    }
+    #[test]
+    fn classify_runtime_on_exit_1_with_oom_stderr() {
+        let classification = classify_codex_acp_crash(
+            "ACP process exited unexpectedly: exit code 1\nstderr: out of memory",
+            extract_crash_exit_code("ACP process exited unexpectedly: exit code 1"),
+            None,
+            Some(3072),
+        );
+        assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
+    }
+    #[test]
+    fn classify_runtime_on_exit_1_and_clean_stderr() {
+        let classification = classify_codex_acp_crash(
+            "ACP process exited unexpectedly: exit code 1",
+            extract_crash_exit_code("ACP process exited unexpectedly: exit code 1"),
+            None,
+            Some(3072),
+        );
+        assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
+    }
+    #[test]
+    fn classify_signal_9_as_oom() {
+        let classification = classify_codex_acp_crash(
+            "ACP process exited unexpectedly",
+            extract_crash_exit_code("signal: 9"),
+            None,
+            Some(3072),
+        );
+        assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
+    }
+    #[test]
+    fn extract_matches_oom_kill_literal() {
+        assert_eq!(
+            extract_crash_exit_code("cgroup memory.events reported oom-kill 1"),
+            Some(CrashExitCode::OomEvent)
+        );
+    }
+    #[test]
+    fn extract_prefers_exit_137_over_generic_pattern() {
+        assert_eq!(
+            extract_crash_exit_code("process exited with exit code 137 after transport failure"),
+            Some(CrashExitCode::ExitCode(137))
+        );
+    }
     #[test]
     fn test_format_codex_acp_crash_includes_hint_and_original_error() {
-        let classification = classify_codex_acp_crash("Killed", Some(137), None, Some(2048));
+        let classification = classify_codex_acp_crash(
+            "Killed",
+            Some(CrashExitCode::ExitCode(137)),
+            None,
+            Some(2048),
+        );
         let err = anyhow::anyhow!("server shut down unexpectedly");
         let formatted = format_codex_acp_crash(&classification, err, 1);
         let msg = formatted.to_string();
@@ -675,7 +780,6 @@ mod tests {
         assert!(msg.contains("2048MB"));
         assert!(msg.contains("Original error"));
     }
-
     #[test]
     fn test_format_codex_acp_crash_retry_exhausted_preserves_failover_anchor() {
         let classification =

--- a/crates/csa-executor/src/transport_acp_crash_retry.rs
+++ b/crates/csa-executor/src/transport_acp_crash_retry.rs
@@ -5,10 +5,12 @@
 /// crash retry attempts, distinct from the gemini-specific rate-limit retry
 /// chain in `transport_gemini_retry.rs`.
 use std::collections::HashMap;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
 use csa_session::state::{MetaSessionState, ToolState};
+use regex::Regex;
 
 use super::{AcpTransport, TransportOptions, TransportResult};
 
@@ -21,6 +23,21 @@ pub(crate) const ACP_CRASH_RETRY_DELAY_SECS: u64 = 3;
 const OOM_SIGNALS: &[i32] = &[
     9, // SIGKILL — typically from OOM killer or cgroup enforcement
 ];
+
+static EXIT_137_RE: LazyLock<Regex> =
+    LazyLock::new(|| compile_regex(r"\bexit(?:\s+code)?[\s:=]+137\b"));
+static EXIT_CODE_RE: LazyLock<Regex> =
+    LazyLock::new(|| compile_regex(r"\bexit(?:\s+code)?[\s:=]+(?P<code>\d+)\b"));
+static BARE_CODE_RE: LazyLock<Regex> =
+    LazyLock::new(|| compile_regex(r"\bcode[\s:=]+(?P<code>\d+)\b"));
+static OOM_WORD_RE: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"\boom\b"));
+
+fn compile_regex(pattern: &str) -> Regex {
+    match Regex::new(pattern) {
+        Ok(regex) => regex,
+        Err(error) => panic!("invalid regex literal `{pattern}`: {error}"),
+    }
+}
 
 /// Classify whether an ACP error is a retryable crash.
 ///
@@ -196,7 +213,7 @@ pub(crate) struct CodexAcpCrashClassification {
 pub(crate) fn extract_crash_exit_code(error_str: &str) -> Option<CrashExitCode> {
     let lowered = error_str.to_ascii_lowercase();
 
-    if lowered.contains("exit code 137") || lowered.contains("exit 137") {
+    if EXIT_137_RE.is_match(&lowered) {
         return Some(CrashExitCode::ExitCode(137));
     }
 
@@ -208,22 +225,29 @@ pub(crate) fn extract_crash_exit_code(error_str: &str) -> Option<CrashExitCode> 
         || lowered.contains("oom-kill")
         || lowered.contains("memory.events")
         || lowered.contains("memory.events.local")
-        || lowered.contains("oom ")
-        || lowered.contains(" oom")
-        || lowered.ends_with("oom")
+        || OOM_WORD_RE.is_match(&lowered)
     {
         return Some(CrashExitCode::OomEvent);
     }
 
-    let exit_code_marker = "exit code ";
-    if let Some(start) = lowered.find(exit_code_marker) {
-        let digits: String = lowered[start + exit_code_marker.len()..]
-            .chars()
-            .take_while(|c| c.is_ascii_digit())
-            .collect();
-        if !digits.is_empty() {
-            return digits.parse::<i32>().ok().map(CrashExitCode::ExitCode);
-        }
+    if let Some(captures) = EXIT_CODE_RE.captures(&lowered)
+        && let Some(code) = captures.name("code")
+    {
+        return code
+            .as_str()
+            .parse::<i32>()
+            .ok()
+            .map(CrashExitCode::ExitCode);
+    }
+
+    if let Some(captures) = BARE_CODE_RE.captures(&lowered)
+        && let Some(code) = captures.name("code")
+    {
+        return code
+            .as_str()
+            .parse::<i32>()
+            .ok()
+            .map(CrashExitCode::ExitCode);
     }
 
     None
@@ -438,356 +462,5 @@ pub(super) async fn execute_with_crash_retry(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // --- Retryable crash scenarios ---
-
-    #[test]
-    fn test_server_shut_down_unexpectedly_is_retryable() {
-        let err = "ACP prompt failed: server shut down unexpectedly";
-        assert!(is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_internal_error_is_retryable() {
-        let err = "ACP transport failed: ACP prompt failed: Internal error";
-        assert!(is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_process_exited_non_oom_is_retryable() {
-        // SIGSEGV (signal 11) — not in OOM_SIGNALS, so retryable
-        let err = "ACP process exited unexpectedly: killed by signal 11 (SIGSEGV)";
-        assert!(is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_broken_pipe_is_retryable() {
-        let err = "ACP transport failed: Broken pipe";
-        assert!(is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_connection_reset_is_retryable() {
-        let err = "sandboxed ACP: ACP prompt failed: connection reset by peer";
-        assert!(is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_prompt_failed_with_shut_down_is_retryable() {
-        let err = "ACP prompt failed: the server shut down while processing";
-        assert!(is_retryable_acp_crash(err));
-    }
-
-    // --- Non-retryable: OOM ---
-
-    #[test]
-    fn test_signal_9_oom_is_not_retryable() {
-        let err = "ACP process exited unexpectedly: killed by signal 9 (SIGKILL)";
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_oom_detected_is_not_retryable() {
-        let err = "sandboxed ACP: ACP process exited unexpectedly: code 137; \
-                   stderr:\nOOM detected: cgroup memory.max exceeded";
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_out_of_memory_is_not_retryable() {
-        let err = "ACP transport failed: out of memory";
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_signal_90_is_not_oom_false_positive() {
-        // "signal 90" should NOT match the OOM pattern for signal 9.
-        let err = "ACP process exited unexpectedly: killed by signal 90";
-        assert!(!is_oom_error(err));
-        // It should be retryable since it's an unexpected exit, not OOM.
-        assert!(is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_memory_max_exceeded_is_oom() {
-        let err = "cgroup memory.max exceeded, process killed";
-        assert!(is_oom_error(err));
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    // --- Non-retryable: Config/Spawn ---
-
-    #[test]
-    fn test_config_error_is_not_retryable() {
-        let err = "Configuration error: missing API key";
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_spawn_failed_is_not_retryable() {
-        let err = "ACP subprocess spawn failed: No such file or directory";
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_binary_not_found_is_not_retryable() {
-        let err = "ACP subprocess spawn failed: binary not found";
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_unauthorized_missing_scope_is_not_retryable() {
-        let err = "ACP prompt failed: Internal error: unexpected status 401 Unauthorized: \
-                   You have insufficient permissions for this operation. \
-                   Missing scopes: api.responses.write";
-        assert!(is_auth_error(err));
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_missing_scope_marker_is_not_retryable() {
-        let err = "codex responses error: code=missing_scope";
-        assert!(is_auth_error(err));
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    // --- Non-retryable: Timeout ---
-
-    #[test]
-    fn test_timed_out_is_not_retryable() {
-        let err = "ACP prompt failed: timed out waiting for response";
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_idle_timeout_is_not_retryable() {
-        let err = "ACP prompt failed: idle timeout exceeded";
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    // --- Non-retryable: unrelated errors ---
-
-    #[test]
-    fn test_generic_error_is_not_retryable() {
-        let err = "some random error message";
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    #[test]
-    fn test_session_failed_is_not_retryable() {
-        let err = "ACP session creation failed: invalid session ID";
-        assert!(!is_retryable_acp_crash(err));
-    }
-
-    // --- Error formatting ---
-
-    #[test]
-    fn test_format_crash_retry_exhausted_contains_key_info() {
-        let err = anyhow::anyhow!("server shut down unexpectedly");
-        let formatted = format_crash_retry_exhausted(err, "claude-code", 2);
-        let msg = formatted.to_string();
-        assert!(msg.contains("2 attempts"));
-        assert!(msg.contains("claude-code"));
-        assert!(msg.contains("567"));
-        assert!(msg.contains("--tier"));
-    }
-
-    #[test]
-    fn test_format_oom_crash_contains_key_info() {
-        let err = anyhow::anyhow!("killed by signal 9 (SIGKILL)");
-        let formatted = format_oom_crash(err, "codex", Some(4096));
-        let msg = formatted.to_string();
-        assert!(msg.contains("codex"));
-        assert!(msg.contains("memory_max_mb"));
-        assert!(msg.contains("4096MB"));
-        assert!(msg.contains("Suggestions:"));
-        assert!(msg.contains("1. Increase"));
-        assert!(msg.contains("2. Reduce the task context/diff size"));
-        assert!(msg.contains("3. Switch to a lower-memory tool via --tier or --tool"));
-        assert!(msg.contains("--tier"));
-        assert!(msg.contains("--tool"));
-    }
-
-    #[test]
-    fn test_format_oom_crash_without_explicit_limit_mentions_system_default() {
-        let err = anyhow::anyhow!("killed by signal 9 (SIGKILL)");
-        let formatted = format_oom_crash(err, "codex", None);
-        let msg = formatted.to_string();
-        assert!(msg.contains("(no explicit limit set — using system default)"));
-    }
-
-    #[test]
-    fn test_format_auth_failure_contains_key_info() {
-        let err = anyhow::anyhow!("401 Unauthorized: Missing scopes: api.responses.write");
-        let formatted = format_auth_failure(err, "codex");
-        let msg = formatted.to_string();
-        assert!(msg.contains("codex"));
-        assert!(msg.contains("authentication or permission error"));
-        assert!(msg.contains("scopes"));
-        assert!(msg.contains("--tier"));
-    }
-
-    #[test]
-    fn test_classify_codex_acp_crash_oom_from_killed_stderr() {
-        let classification = classify_codex_acp_crash(
-            "server shut down unexpectedly\nKilled\n",
-            None,
-            None,
-            Some(6144),
-        );
-        assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
-        assert!(classification.rendered_hint.contains("codex_acp_crash_oom"));
-        assert!(classification.rendered_hint.contains("6144MB"));
-        assert!(
-            classification
-                .rendered_hint
-                .contains("[tools.codex].memory_max_mb")
-        );
-        assert!(
-            classification
-                .rendered_hint
-                .contains("claude-code native Agent tool")
-        );
-    }
-    #[test]
-    fn test_classify_codex_acp_crash_oom_from_stderr_tail_killed() {
-        let classification = classify_codex_acp_crash(
-            "ACP prompt failed: Internal error: \"server shut down unexpectedly\"; stderr: Killed",
-            None,
-            None,
-            Some(6144),
-        );
-        assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
-    }
-    #[test]
-    fn test_classify_codex_acp_crash_oom_from_cgroup_state() {
-        let classification = classify_codex_acp_crash(
-            "server shut down unexpectedly",
-            None,
-            Some("memory.max exceeded"),
-            Some(4096),
-        );
-        assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
-        assert!(classification.rendered_hint.contains("4096MB"));
-    }
-    #[test]
-    fn test_classify_codex_acp_crash_runtime_without_oom_signature() {
-        let classification = classify_codex_acp_crash(
-            "ACP prompt failed: Internal error: \"server shut down unexpectedly\"",
-            None,
-            None,
-            Some(3072),
-        );
-        assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
-        assert!(
-            classification
-                .rendered_hint
-                .contains("codex_acp_crash_runtime")
-        );
-        assert!(classification.rendered_hint.contains("3072MB"));
-        assert!(
-            classification
-                .rendered_hint
-                .contains("[tools.codex].memory_max_mb")
-        );
-    }
-    #[test]
-    fn test_classify_codex_acp_crash_signal_11_stays_runtime() {
-        let classification = classify_codex_acp_crash(
-            "ACP process exited unexpectedly: killed by signal 11 (SIGSEGV)",
-            None,
-            None,
-            Some(3072),
-        );
-        assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
-    }
-    #[test]
-    fn test_classify_codex_acp_crash_signal_90_stays_runtime() {
-        let classification = classify_codex_acp_crash(
-            "ACP process exited unexpectedly: killed by signal 90",
-            None,
-            None,
-            Some(3072),
-        );
-        assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
-    }
-    #[test]
-    fn classify_extracts_exit_137_with_empty_stderr() {
-        let classification = classify_codex_acp_crash(
-            "ACP process exited unexpectedly: exit code 137",
-            extract_crash_exit_code("ACP process exited unexpectedly: exit code 137"),
-            None,
-            Some(3072),
-        );
-        assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
-    }
-    #[test]
-    fn classify_runtime_on_exit_1_with_oom_stderr() {
-        let classification = classify_codex_acp_crash(
-            "ACP process exited unexpectedly: exit code 1\nstderr: out of memory",
-            extract_crash_exit_code("ACP process exited unexpectedly: exit code 1"),
-            None,
-            Some(3072),
-        );
-        assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
-    }
-    #[test]
-    fn classify_runtime_on_exit_1_and_clean_stderr() {
-        let classification = classify_codex_acp_crash(
-            "ACP process exited unexpectedly: exit code 1",
-            extract_crash_exit_code("ACP process exited unexpectedly: exit code 1"),
-            None,
-            Some(3072),
-        );
-        assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
-    }
-    #[test]
-    fn classify_signal_9_as_oom() {
-        let classification = classify_codex_acp_crash(
-            "ACP process exited unexpectedly",
-            extract_crash_exit_code("signal: 9"),
-            None,
-            Some(3072),
-        );
-        assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
-    }
-    #[test]
-    fn extract_matches_oom_kill_literal() {
-        assert_eq!(
-            extract_crash_exit_code("cgroup memory.events reported oom-kill 1"),
-            Some(CrashExitCode::OomEvent)
-        );
-    }
-    #[test]
-    fn extract_prefers_exit_137_over_generic_pattern() {
-        assert_eq!(
-            extract_crash_exit_code("process exited with exit code 137 after transport failure"),
-            Some(CrashExitCode::ExitCode(137))
-        );
-    }
-    #[test]
-    fn test_format_codex_acp_crash_includes_hint_and_original_error() {
-        let classification = classify_codex_acp_crash(
-            "Killed",
-            Some(CrashExitCode::ExitCode(137)),
-            None,
-            Some(2048),
-        );
-        let err = anyhow::anyhow!("server shut down unexpectedly");
-        let formatted = format_codex_acp_crash(&classification, err, 1);
-        let msg = formatted.to_string();
-        assert!(msg.contains("codex_acp_crash_oom"));
-        assert!(msg.contains("2048MB"));
-        assert!(msg.contains("Original error"));
-    }
-    #[test]
-    fn test_format_codex_acp_crash_retry_exhausted_preserves_failover_anchor() {
-        let classification =
-            classify_codex_acp_crash("server shut down unexpectedly", None, None, Some(2048));
-        let err = anyhow::anyhow!("server shut down unexpectedly");
-        let formatted = format_codex_acp_crash(&classification, err, 2);
-        let msg = formatted.to_string().to_ascii_lowercase();
-        assert!(msg.contains("acp crash retry exhausted"));
-        assert!(msg.contains("codex_acp_crash_runtime"));
-    }
+    include!("transport_tests_acp_crash_retry.rs");
 }

--- a/crates/csa-executor/src/transport_tests_acp_crash_retry.rs
+++ b/crates/csa-executor/src/transport_tests_acp_crash_retry.rs
@@ -1,0 +1,408 @@
+// --- Retryable crash scenarios ---
+
+#[test]
+fn test_server_shut_down_unexpectedly_is_retryable() {
+    let err = "ACP prompt failed: server shut down unexpectedly";
+    assert!(is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_internal_error_is_retryable() {
+    let err = "ACP transport failed: ACP prompt failed: Internal error";
+    assert!(is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_process_exited_non_oom_is_retryable() {
+    // SIGSEGV (signal 11) — not in OOM_SIGNALS, so retryable
+    let err = "ACP process exited unexpectedly: killed by signal 11 (SIGSEGV)";
+    assert!(is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_broken_pipe_is_retryable() {
+    let err = "ACP transport failed: Broken pipe";
+    assert!(is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_connection_reset_is_retryable() {
+    let err = "sandboxed ACP: ACP prompt failed: connection reset by peer";
+    assert!(is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_prompt_failed_with_shut_down_is_retryable() {
+    let err = "ACP prompt failed: the server shut down while processing";
+    assert!(is_retryable_acp_crash(err));
+}
+
+// --- Non-retryable: OOM ---
+
+#[test]
+fn test_signal_9_oom_is_not_retryable() {
+    let err = "ACP process exited unexpectedly: killed by signal 9 (SIGKILL)";
+    assert!(!is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_oom_detected_is_not_retryable() {
+    let err = "sandboxed ACP: ACP process exited unexpectedly: code 137; \
+               stderr:\nOOM detected: cgroup memory.max exceeded";
+    assert!(!is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_out_of_memory_is_not_retryable() {
+    let err = "ACP transport failed: out of memory";
+    assert!(!is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_signal_90_is_not_oom_false_positive() {
+    // "signal 90" should NOT match the OOM pattern for signal 9.
+    let err = "ACP process exited unexpectedly: killed by signal 90";
+    assert!(!is_oom_error(err));
+    // It should be retryable since it's an unexpected exit, not OOM.
+    assert!(is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_memory_max_exceeded_is_oom() {
+    let err = "cgroup memory.max exceeded, process killed";
+    assert!(is_oom_error(err));
+    assert!(!is_retryable_acp_crash(err));
+}
+
+// --- Non-retryable: Config/Spawn ---
+
+#[test]
+fn test_config_error_is_not_retryable() {
+    let err = "Configuration error: missing API key";
+    assert!(!is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_spawn_failed_is_not_retryable() {
+    let err = "ACP subprocess spawn failed: No such file or directory";
+    assert!(!is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_binary_not_found_is_not_retryable() {
+    let err = "ACP subprocess spawn failed: binary not found";
+    assert!(!is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_unauthorized_missing_scope_is_not_retryable() {
+    let err = "ACP prompt failed: Internal error: unexpected status 401 Unauthorized: \
+               You have insufficient permissions for this operation. \
+               Missing scopes: api.responses.write";
+    assert!(is_auth_error(err));
+    assert!(!is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_missing_scope_marker_is_not_retryable() {
+    let err = "codex responses error: code=missing_scope";
+    assert!(is_auth_error(err));
+    assert!(!is_retryable_acp_crash(err));
+}
+
+// --- Non-retryable: Timeout ---
+
+#[test]
+fn test_timed_out_is_not_retryable() {
+    let err = "ACP prompt failed: timed out waiting for response";
+    assert!(!is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_idle_timeout_is_not_retryable() {
+    let err = "ACP prompt failed: idle timeout exceeded";
+    assert!(!is_retryable_acp_crash(err));
+}
+
+// --- Non-retryable: unrelated errors ---
+
+#[test]
+fn test_generic_error_is_not_retryable() {
+    let err = "some random error message";
+    assert!(!is_retryable_acp_crash(err));
+}
+
+#[test]
+fn test_session_failed_is_not_retryable() {
+    let err = "ACP session creation failed: invalid session ID";
+    assert!(!is_retryable_acp_crash(err));
+}
+
+// --- Error formatting ---
+
+#[test]
+fn test_format_crash_retry_exhausted_contains_key_info() {
+    let err = anyhow::anyhow!("server shut down unexpectedly");
+    let formatted = format_crash_retry_exhausted(err, "claude-code", 2);
+    let msg = formatted.to_string();
+    assert!(msg.contains("2 attempts"));
+    assert!(msg.contains("claude-code"));
+    assert!(msg.contains("567"));
+    assert!(msg.contains("--tier"));
+}
+
+#[test]
+fn test_format_oom_crash_contains_key_info() {
+    let err = anyhow::anyhow!("killed by signal 9 (SIGKILL)");
+    let formatted = format_oom_crash(err, "codex", Some(4096));
+    let msg = formatted.to_string();
+    assert!(msg.contains("codex"));
+    assert!(msg.contains("memory_max_mb"));
+    assert!(msg.contains("4096MB"));
+    assert!(msg.contains("Suggestions:"));
+    assert!(msg.contains("1. Increase"));
+    assert!(msg.contains("2. Reduce the task context/diff size"));
+    assert!(msg.contains("3. Switch to a lower-memory tool via --tier or --tool"));
+    assert!(msg.contains("--tier"));
+    assert!(msg.contains("--tool"));
+}
+
+#[test]
+fn test_format_oom_crash_without_explicit_limit_mentions_system_default() {
+    let err = anyhow::anyhow!("killed by signal 9 (SIGKILL)");
+    let formatted = format_oom_crash(err, "codex", None);
+    let msg = formatted.to_string();
+    assert!(msg.contains("(no explicit limit set — using system default)"));
+}
+
+#[test]
+fn test_format_auth_failure_contains_key_info() {
+    let err = anyhow::anyhow!("401 Unauthorized: Missing scopes: api.responses.write");
+    let formatted = format_auth_failure(err, "codex");
+    let msg = formatted.to_string();
+    assert!(msg.contains("codex"));
+    assert!(msg.contains("authentication or permission error"));
+    assert!(msg.contains("scopes"));
+    assert!(msg.contains("--tier"));
+}
+
+#[test]
+fn test_classify_codex_acp_crash_oom_from_killed_stderr() {
+    let classification = classify_codex_acp_crash(
+        "server shut down unexpectedly\nKilled\n",
+        None,
+        None,
+        Some(6144),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
+    assert!(classification.rendered_hint.contains("codex_acp_crash_oom"));
+    assert!(classification.rendered_hint.contains("6144MB"));
+    assert!(
+        classification
+            .rendered_hint
+            .contains("[tools.codex].memory_max_mb")
+    );
+    assert!(
+        classification
+            .rendered_hint
+            .contains("claude-code native Agent tool")
+    );
+}
+
+#[test]
+fn test_classify_codex_acp_crash_oom_from_stderr_tail_killed() {
+    let classification = classify_codex_acp_crash(
+        "ACP prompt failed: Internal error: \"server shut down unexpectedly\"; stderr: Killed",
+        None,
+        None,
+        Some(6144),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
+}
+
+#[test]
+fn test_classify_codex_acp_crash_oom_from_cgroup_state() {
+    let classification = classify_codex_acp_crash(
+        "server shut down unexpectedly",
+        None,
+        Some("memory.max exceeded"),
+        Some(4096),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
+    assert!(classification.rendered_hint.contains("4096MB"));
+}
+
+#[test]
+fn test_classify_codex_acp_crash_runtime_without_oom_signature() {
+    let classification = classify_codex_acp_crash(
+        "ACP prompt failed: Internal error: \"server shut down unexpectedly\"",
+        None,
+        None,
+        Some(3072),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
+    assert!(classification.rendered_hint.contains("codex_acp_crash_runtime"));
+    assert!(classification.rendered_hint.contains("3072MB"));
+    assert!(
+        classification
+            .rendered_hint
+            .contains("[tools.codex].memory_max_mb")
+    );
+}
+
+#[test]
+fn test_classify_codex_acp_crash_signal_11_stays_runtime() {
+    let classification = classify_codex_acp_crash(
+        "ACP process exited unexpectedly: killed by signal 11 (SIGSEGV)",
+        None,
+        None,
+        Some(3072),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
+}
+
+#[test]
+fn test_classify_codex_acp_crash_signal_90_stays_runtime() {
+    let classification = classify_codex_acp_crash(
+        "ACP process exited unexpectedly: killed by signal 90",
+        None,
+        None,
+        Some(3072),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
+}
+
+#[test]
+fn classify_extracts_exit_137_with_empty_stderr() {
+    let classification = classify_codex_acp_crash(
+        "ACP process exited unexpectedly: exit code 137",
+        extract_crash_exit_code("ACP process exited unexpectedly: exit code 137"),
+        None,
+        Some(3072),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
+}
+
+#[test]
+fn classify_runtime_on_exit_1_with_oom_stderr() {
+    let classification = classify_codex_acp_crash(
+        "ACP process exited unexpectedly: exit code 1\nstderr: out of memory",
+        extract_crash_exit_code("ACP process exited unexpectedly: exit code 1"),
+        None,
+        Some(3072),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
+}
+
+#[test]
+fn classify_runtime_on_exit_1_and_clean_stderr() {
+    let classification = classify_codex_acp_crash(
+        "ACP process exited unexpectedly: exit code 1",
+        extract_crash_exit_code("ACP process exited unexpectedly: exit code 1"),
+        None,
+        Some(3072),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Runtime);
+}
+
+#[test]
+fn classify_signal_9_as_oom() {
+    let classification = classify_codex_acp_crash(
+        "ACP process exited unexpectedly",
+        extract_crash_exit_code("signal: 9"),
+        None,
+        Some(3072),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
+}
+
+#[test]
+fn extract_matches_oom_kill_literal() {
+    assert_eq!(
+        extract_crash_exit_code("cgroup memory.events reported oom-kill 1"),
+        Some(CrashExitCode::OomEvent)
+    );
+}
+
+#[test]
+fn extract_prefers_exit_137_over_generic_pattern() {
+    assert_eq!(
+        extract_crash_exit_code("process exited with exit code 137 after transport failure"),
+        Some(CrashExitCode::ExitCode(137))
+    );
+}
+
+#[test]
+fn extract_parses_bare_code_format() {
+    assert_eq!(
+        extract_crash_exit_code("ACP process exited unexpectedly: code 137"),
+        Some(CrashExitCode::ExitCode(137))
+    );
+}
+
+#[test]
+fn extract_parses_code_with_colon() {
+    assert_eq!(
+        extract_crash_exit_code("exit code: 42"),
+        Some(CrashExitCode::ExitCode(42))
+    );
+}
+
+#[test]
+fn extract_parses_code_with_equals() {
+    assert_eq!(
+        extract_crash_exit_code("exit code=42"),
+        Some(CrashExitCode::ExitCode(42))
+    );
+}
+
+#[test]
+fn extract_rejects_oom_as_substring_of_room() {
+    assert_ne!(
+        extract_crash_exit_code("something involving bedroom and classroom"),
+        Some(CrashExitCode::OomEvent)
+    );
+}
+
+#[test]
+fn extract_rejects_oom_as_substring_of_zoom() {
+    assert_ne!(
+        extract_crash_exit_code("zoom conference started"),
+        Some(CrashExitCode::OomEvent)
+    );
+}
+
+#[test]
+fn extract_accepts_standalone_oom_with_word_boundary() {
+    assert_eq!(
+        extract_crash_exit_code("kernel logged: oom killed process X"),
+        Some(CrashExitCode::OomEvent)
+    );
+}
+
+#[test]
+fn test_format_codex_acp_crash_includes_hint_and_original_error() {
+    let classification = classify_codex_acp_crash(
+        "Killed",
+        Some(CrashExitCode::ExitCode(137)),
+        None,
+        Some(2048),
+    );
+    let err = anyhow::anyhow!("server shut down unexpectedly");
+    let formatted = format_codex_acp_crash(&classification, err, 1);
+    let msg = formatted.to_string();
+    assert!(msg.contains("codex_acp_crash_oom"));
+    assert!(msg.contains("2048MB"));
+    assert!(msg.contains("Original error"));
+}
+
+#[test]
+fn test_format_codex_acp_crash_retry_exhausted_preserves_failover_anchor() {
+    let classification =
+        classify_codex_acp_crash("server shut down unexpectedly", None, None, Some(2048));
+    let err = anyhow::anyhow!("server shut down unexpectedly");
+    let formatted = format_codex_acp_crash(&classification, err, 2);
+    let msg = formatted.to_string().to_ascii_lowercase();
+    assert!(msg.contains("acp crash retry exhausted"));
+    assert!(msg.contains("codex_acp_crash_runtime"));
+}


### PR DESCRIPTION
## Summary

Closes #848 (followup to #737 / PR #847).

Sharpens the codex ACP crash classifier by extracting exit-code markers from the transport error string before falling through to stderr-signature matching. Bare SIGKILL OOMs with empty stderr now classify as \`codex_acp_crash_oom\` instead of defaulting to \`codex_acp_crash_runtime\`.

## Problem

PR #847 landed the initial classifier with stderr-signature matching only and a hard-coded \`None\` for the exit code input. On Linux, cgroup OOM kills surface as exit 137 / SIGKILL; when stderr is empty (common for deeply OOM'd children), the classifier fell to the runtime default — misleading for operators reading retry diagnostics.

## Fix

New \`CrashExitCode\` enum + \`extract_crash_exit_code(&str)\` in \`crates/csa-executor/src/transport_acp_crash_retry.rs\`:

1. \`exit code 137\` / \`exit 137\` → \`ExitCode(137)\` (likely OOM on Linux).
2. \`signal: 9\` / \`SIGKILL\` (case-insensitive) → \`Signal(9)\`.
3. \`memory.max\` / \`oom-kill\` / \`memory.events(.local)\` → \`OomEvent\`.
4. Generic \`exit code (\\d+)\` → \`ExitCode(n)\`.

\`classify_codex_acp_crash\` now signals OOM when any of these match, in addition to the existing stderr-signature path. Call sites feed \`extract_crash_exit_code(&error_display)\` instead of hard-coded \`None\`.

## Verification

- \`cargo test -p csa-executor\` — pass (6+ new unit tests covering extract + classify branches).
- \`just pre-commit\` — pass.
- Workspace bumped \`0.1.337\` → \`0.1.338\`.

## New tests

- \`classify_extracts_exit_137_with_empty_stderr\` → OOM
- \`classify_runtime_on_exit_1_with_oom_stderr\` → OOM (existing stderr path still works)
- \`classify_runtime_on_exit_1_and_clean_stderr\` → Runtime
- \`classify_signal_9_as_oom\` → OOM
- \`extract_matches_oom_kill_literal\` → OomEvent
- \`extract_prefers_exit_137_over_generic_pattern\` → ExitCode(137)

Related filed during work but out of scope: #863 (csa-review MCP harness bug), #865 (commit skill gemini-cli 120s stall).