### PR TITLE
fix(csa-session): honor progress signals during reconciliation (#808)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.352"
+version = "0.1.353"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.351"
+version = "0.1.352"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.350"
+version = "0.1.351"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.353"
+version = "0.1.354"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.354"
+version = "0.1.355"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.352"
+version = "0.1.353"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.350"
+version = "0.1.351"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.354"
+version = "0.1.355"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.351"
+version = "0.1.352"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.353"
+version = "0.1.354"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -15,6 +15,9 @@ use csa_session::{
 use crate::plan_cmd::shell_escape_for_command;
 #[path = "session_cmds_reconcile_cleanup.rs"]
 mod reconcile_cleanup;
+#[path = "session_cmds_reconcile_liveness.rs"]
+mod reconcile_liveness;
+use reconcile_liveness::reconcile_liveness_decision;
 
 type PersistSessionFn<'a> = dyn Fn(&Path, &MetaSessionState) -> Result<()> + 'a;
 const UNPUSHED_COMMITS_SIDECAR_PATH: &str = "output/unpushed_commits.json";
@@ -184,10 +187,6 @@ fn persist_unpushed_commits_sidecar(project_root: &Path, session: &MetaSessionSt
     Ok(rollback_guard)
 }
 
-fn session_has_terminal_process(session_dir: &Path) -> bool {
-    ToolLiveness::has_live_process(session_dir) || ToolLiveness::daemon_pid_is_alive(session_dir)
-}
-
 pub(crate) fn ensure_terminal_result_for_dead_active_session(
     project_root: &Path,
     session_id: &str,
@@ -258,9 +257,22 @@ fn dead_active_session_needs_terminal_result(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    if session_has_terminal_process(session_dir) {
+    let liveness = reconcile_liveness_decision(session_dir);
+    if liveness.blocks_synthesis {
+        info!(
+            session_id = %session_id,
+            trigger = %trigger,
+            reconciliation_reason = %liveness.reason,
+            "Dead-session reconciliation skipped because liveness signals still block synthetic fallback"
+        );
         return Ok(false);
     }
+    info!(
+        session_id = %session_id,
+        trigger = %trigger,
+        reconciliation_reason = %liveness.reason,
+        "Dead-session reconciliation confirmed no pid/progress blocker before checking result.toml"
+    );
     let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
     match load_result(project_root, session_id) {
         Ok(Some(_)) => Ok(false),
@@ -300,9 +312,22 @@ where
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(DeadActiveSessionReconciliation::NoChange);
     }
-    if session_has_terminal_process(session_dir) {
+    let liveness = reconcile_liveness_decision(session_dir);
+    if liveness.blocks_synthesis {
+        info!(
+            session_id = %session_id,
+            trigger = %trigger,
+            reconciliation_reason = %liveness.reason,
+            "Dead-session reconciliation re-check skipped synthetic fallback because liveness signals are still present"
+        );
         return Ok(DeadActiveSessionReconciliation::NoChange);
     }
+    info!(
+        session_id = %session_id,
+        trigger = %trigger,
+        reconciliation_reason = %liveness.reason,
+        "Dead-session reconciliation re-check confirmed no pid/progress blocker before synthesizing fallback"
+    );
     let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
     match load_result(project_root, session_id) {
         Ok(Some(_)) => return Ok(DeadActiveSessionReconciliation::NoChange),
@@ -491,7 +516,8 @@ fn dead_session_with_result_needs_retire(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    if session_has_terminal_process(session_dir) {
+    if ToolLiveness::has_live_process(session_dir) || ToolLiveness::daemon_pid_is_alive(session_dir)
+    {
         return Ok(false);
     }
     Ok(load_result(project_root, session_id)?.is_some())
@@ -508,7 +534,9 @@ fn retire_if_dead_with_result_impl(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    if session_has_terminal_process(session_dir) || load_result(project_root, session_id)?.is_none()
+    if ToolLiveness::has_live_process(session_dir)
+        || ToolLiveness::daemon_pid_is_alive(session_dir)
+        || load_result(project_root, session_id)?.is_none()
     {
         return Ok(false);
     }
@@ -746,3 +774,7 @@ mod tests;
 #[cfg(test)]
 #[path = "session_cmds_reconcile_tests_tail.rs"]
 mod tail_tests;
+
+#[cfg(test)]
+#[path = "session_cmds_reconcile_progress_tests.rs"]
+mod progress_tests;

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -1,16 +1,14 @@
 use anyhow::{Context, Result, anyhow};
 use csa_core::vcs::VcsKind;
+use csa_session::{
+    MetaSessionState, SessionPhase, SessionResult, get_session_dir, load_result, load_session,
+};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use tracing::{info, warn};
-
-use csa_process::ToolLiveness;
-use csa_session::{
-    MetaSessionState, SessionPhase, SessionResult, get_session_dir, load_result, load_session,
-};
+use tracing::{debug, info, warn};
 
 use crate::plan_cmd::shell_escape_for_command;
 #[path = "session_cmds_reconcile_cleanup.rs"]
@@ -516,8 +514,13 @@ fn dead_session_with_result_needs_retire(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    if ToolLiveness::has_live_process(session_dir) || ToolLiveness::daemon_pid_is_alive(session_dir)
-    {
+    let liveness = reconcile_liveness_decision(session_dir);
+    if liveness.blocks_synthesis {
+        debug!(
+            session_id = %session_id,
+            reason = %liveness.reason,
+            "Dead-session retirement deferred: progress/liveness still detected"
+        );
         return Ok(false);
     }
     Ok(load_result(project_root, session_id)?.is_some())
@@ -534,10 +537,16 @@ fn retire_if_dead_with_result_impl(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    if ToolLiveness::has_live_process(session_dir)
-        || ToolLiveness::daemon_pid_is_alive(session_dir)
-        || load_result(project_root, session_id)?.is_none()
-    {
+    let liveness = reconcile_liveness_decision(session_dir);
+    if liveness.blocks_synthesis {
+        debug!(
+            session_id = %session_id,
+            reason = %liveness.reason,
+            "retire_if_dead_with_result: progress/liveness detected, skipping retirement"
+        );
+        return Ok(false);
+    }
+    if load_result(project_root, session_id)?.is_none() {
         return Ok(false);
     }
     if session

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_liveness.rs
@@ -1,11 +1,15 @@
 use std::fs;
 use std::path::Path;
+use std::time::{Duration, SystemTime};
 
 use csa_process::ToolLiveness;
 
 const LIVENESS_SNAPSHOT_FILE: &str = ".liveness.snapshot";
+const OUTPUT_LOG_FILE: &str = "output.log";
 const ACP_EVENTS_LOG_FILE: &str = "output/acp-events.jsonl";
 const STDERR_LOG_FILE: &str = "stderr.log";
+// Keep this aligned with csa_process::tool_liveness::LIVENESS_RECENT_WINDOW_SECS.
+const RECENT_SESSION_WRITE_WINDOW_SECS: u64 = 30;
 
 pub(crate) struct ReconcileLivenessDecision {
     pub(crate) blocks_synthesis: bool,
@@ -18,6 +22,21 @@ struct ReconcileLivenessSnapshot {
     observed_spool_bytes_written: Option<u64>,
     acp_events_size: Option<u64>,
     stderr_log_size: Option<u64>,
+}
+
+struct ReconcileDecisionInputs {
+    snapshot: Option<ReconcileObservedSnapshot>,
+    spool_bytes_written: Option<u64>,
+    acp_events_size: Option<u64>,
+    stderr_log_size: Option<u64>,
+    output_log_mtime_within_grace: bool,
+    stderr_log_mtime_within_grace: bool,
+}
+
+struct ReconcileObservedSnapshot {
+    observed_spool_bytes_written: Option<u64>,
+    observed_acp_events_size: Option<u64>,
+    observed_stderr_log_size: Option<u64>,
 }
 
 pub(crate) fn reconcile_liveness_decision(session_dir: &Path) -> ReconcileLivenessDecision {
@@ -46,37 +65,74 @@ pub(crate) fn reconcile_liveness_decision(session_dir: &Path) -> ReconcileLivene
 }
 
 fn has_reconcile_progress_signal(session_dir: &Path) -> bool {
+    let now = SystemTime::now();
     let mut snapshot = load_reconcile_liveness_snapshot(session_dir);
-    let spool_growth = matches!(
-        (
-            snapshot.spool_bytes_written,
-            snapshot.observed_spool_bytes_written
+    let acp_size = fs::metadata(session_dir.join(ACP_EVENTS_LOG_FILE))
+        .ok()
+        .map(|meta| meta.len());
+    let stderr_size = fs::metadata(session_dir.join(STDERR_LOG_FILE))
+        .ok()
+        .map(|meta| meta.len());
+    let decision_inputs = ReconcileDecisionInputs {
+        snapshot: snapshot.prior_observation(),
+        spool_bytes_written: snapshot.spool_bytes_written,
+        acp_events_size: acp_size,
+        stderr_log_size: stderr_size,
+        output_log_mtime_within_grace: file_modified_recently(
+            &session_dir.join(OUTPUT_LOG_FILE),
+            now,
         ),
-        (Some(current), Some(previous)) if current != previous
-    );
+        stderr_log_mtime_within_grace: file_modified_recently(
+            &session_dir.join(STDERR_LOG_FILE),
+            now,
+        ),
+    };
+
     snapshot.observed_spool_bytes_written = snapshot.spool_bytes_written;
-
-    let (acp_growth, acp_size) = detect_file_growth(
-        &session_dir.join(ACP_EVENTS_LOG_FILE),
-        snapshot.acp_events_size,
-    );
     snapshot.acp_events_size = acp_size;
-
-    let (stderr_growth, stderr_size) =
-        detect_file_growth(&session_dir.join(STDERR_LOG_FILE), snapshot.stderr_log_size);
     snapshot.stderr_log_size = stderr_size;
 
     save_reconcile_liveness_snapshot(session_dir, &snapshot);
-    spool_growth || acp_growth || stderr_growth
+
+    has_reconcile_progress_signal_from_inputs(&decision_inputs)
 }
 
-fn detect_file_growth(path: &Path, previous_size: Option<u64>) -> (bool, Option<u64>) {
-    let current_size = fs::metadata(path).ok().map(|meta| meta.len());
-    let growth = match (previous_size, current_size) {
-        (Some(prev), Some(current)) => current != prev,
-        _ => false,
+fn has_reconcile_progress_signal_from_inputs(decision_inputs: &ReconcileDecisionInputs) -> bool {
+    if let Some(snapshot) = &decision_inputs.snapshot {
+        if decision_inputs.spool_bytes_written != snapshot.observed_spool_bytes_written {
+            return true;
+        }
+        if decision_inputs.acp_events_size != snapshot.observed_acp_events_size {
+            return true;
+        }
+        if decision_inputs.stderr_log_size != snapshot.observed_stderr_log_size {
+            return true;
+        }
+    }
+
+    if decision_inputs.snapshot.is_none() {
+        if decision_inputs.spool_bytes_written.unwrap_or(0) > 0
+            && decision_inputs.output_log_mtime_within_grace
+        {
+            return true;
+        }
+        if decision_inputs.stderr_log_size.unwrap_or(0) > 0
+            && decision_inputs.stderr_log_mtime_within_grace
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn file_modified_recently(path: &Path, now: SystemTime) -> bool {
+    let modified = match fs::metadata(path).and_then(|meta| meta.modified()) {
+        Ok(modified) => modified,
+        Err(_) => return false,
     };
-    (growth, current_size)
+    let elapsed = now.duration_since(modified).unwrap_or(Duration::ZERO);
+    elapsed <= Duration::from_secs(RECENT_SESSION_WRITE_WINDOW_SECS)
 }
 
 fn load_reconcile_liveness_snapshot(session_dir: &Path) -> ReconcileLivenessSnapshot {
@@ -99,6 +155,19 @@ fn load_reconcile_liveness_snapshot(session_dir: &Path) -> ReconcileLivenessSnap
         }
     }
     snapshot
+}
+
+impl ReconcileLivenessSnapshot {
+    fn prior_observation(&self) -> Option<ReconcileObservedSnapshot> {
+        let has_prior_observation = self.observed_spool_bytes_written.is_some()
+            || self.acp_events_size.is_some()
+            || self.stderr_log_size.is_some();
+        has_prior_observation.then_some(ReconcileObservedSnapshot {
+            observed_spool_bytes_written: self.observed_spool_bytes_written,
+            observed_acp_events_size: self.acp_events_size,
+            observed_stderr_log_size: self.stderr_log_size,
+        })
+    }
 }
 
 fn save_reconcile_liveness_snapshot(session_dir: &Path, snapshot: &ReconcileLivenessSnapshot) {

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_liveness.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime};
 
 use csa_process::ToolLiveness;
 
-const LIVENESS_SNAPSHOT_FILE: &str = ".liveness.snapshot";
+const RUNTIME_LIVENESS_SNAPSHOT_FILE: &str = ".liveness.snapshot";
 const OUTPUT_LOG_FILE: &str = "output.log";
 const ACP_EVENTS_LOG_FILE: &str = "output/acp-events.jsonl";
 const STDERR_LOG_FILE: &str = "stderr.log";
@@ -30,6 +30,7 @@ struct ReconcileDecisionInputs {
     acp_events_size: Option<u64>,
     stderr_log_size: Option<u64>,
     output_log_mtime_within_grace: bool,
+    acp_events_mtime_within_grace: bool,
     stderr_log_mtime_within_grace: bool,
 }
 
@@ -66,7 +67,7 @@ pub(crate) fn reconcile_liveness_decision(session_dir: &Path) -> ReconcileLivene
 
 fn has_reconcile_progress_signal(session_dir: &Path) -> bool {
     let now = SystemTime::now();
-    let mut snapshot = load_reconcile_liveness_snapshot(session_dir);
+    let snapshot = load_runtime_liveness_snapshot(session_dir);
     let acp_size = fs::metadata(session_dir.join(ACP_EVENTS_LOG_FILE))
         .ok()
         .map(|meta| meta.len());
@@ -82,36 +83,45 @@ fn has_reconcile_progress_signal(session_dir: &Path) -> bool {
             &session_dir.join(OUTPUT_LOG_FILE),
             now,
         ),
+        acp_events_mtime_within_grace: file_modified_recently(
+            &session_dir.join(ACP_EVENTS_LOG_FILE),
+            now,
+        ),
         stderr_log_mtime_within_grace: file_modified_recently(
             &session_dir.join(STDERR_LOG_FILE),
             now,
         ),
     };
 
-    snapshot.observed_spool_bytes_written = snapshot.spool_bytes_written;
-    snapshot.acp_events_size = acp_size;
-    snapshot.stderr_log_size = stderr_size;
-
-    save_reconcile_liveness_snapshot(session_dir, &snapshot);
-
     has_reconcile_progress_signal_from_inputs(&decision_inputs)
 }
 
 fn has_reconcile_progress_signal_from_inputs(decision_inputs: &ReconcileDecisionInputs) -> bool {
     if let Some(snapshot) = &decision_inputs.snapshot {
-        if decision_inputs.spool_bytes_written != snapshot.observed_spool_bytes_written {
+        if decision_inputs.spool_bytes_written.is_some()
+            && decision_inputs.spool_bytes_written != snapshot.observed_spool_bytes_written
+        {
             return true;
         }
-        if decision_inputs.acp_events_size != snapshot.observed_acp_events_size {
+        if decision_inputs.acp_events_size.is_some()
+            && decision_inputs.acp_events_size != snapshot.observed_acp_events_size
+        {
             return true;
         }
-        if decision_inputs.stderr_log_size != snapshot.observed_stderr_log_size {
+        if decision_inputs.stderr_log_size.is_some()
+            && decision_inputs.stderr_log_size != snapshot.observed_stderr_log_size
+        {
             return true;
         }
     }
 
     if decision_inputs.spool_bytes_written.unwrap_or(0) > 0
         && decision_inputs.output_log_mtime_within_grace
+    {
+        return true;
+    }
+    if decision_inputs.acp_events_size.unwrap_or(0) > 0
+        && decision_inputs.acp_events_mtime_within_grace
     {
         return true;
     }
@@ -133,8 +143,8 @@ fn file_modified_recently(path: &Path, now: SystemTime) -> bool {
     elapsed <= Duration::from_secs(RECENT_SESSION_WRITE_WINDOW_SECS)
 }
 
-fn load_reconcile_liveness_snapshot(session_dir: &Path) -> ReconcileLivenessSnapshot {
-    let snapshot_path = session_dir.join(LIVENESS_SNAPSHOT_FILE);
+fn load_runtime_liveness_snapshot(session_dir: &Path) -> ReconcileLivenessSnapshot {
+    let snapshot_path = session_dir.join(RUNTIME_LIVENESS_SNAPSHOT_FILE);
     let Ok(content) = fs::read_to_string(snapshot_path) else {
         return ReconcileLivenessSnapshot::default();
     };
@@ -166,24 +176,4 @@ impl ReconcileLivenessSnapshot {
             observed_stderr_log_size: self.stderr_log_size,
         })
     }
-}
-
-fn save_reconcile_liveness_snapshot(session_dir: &Path, snapshot: &ReconcileLivenessSnapshot) {
-    let mut lines = Vec::with_capacity(4);
-    if let Some(value) = snapshot.spool_bytes_written {
-        lines.push(format!("spool_bytes_written={value}"));
-    }
-    if let Some(value) = snapshot.observed_spool_bytes_written {
-        lines.push(format!("observed_spool_bytes_written={value}"));
-    }
-    if let Some(value) = snapshot.acp_events_size {
-        lines.push(format!("acp_events_size={value}"));
-    }
-    if let Some(value) = snapshot.stderr_log_size {
-        lines.push(format!("stderr_log_size={value}"));
-    }
-    if lines.is_empty() {
-        return;
-    }
-    let _ = fs::write(session_dir.join(LIVENESS_SNAPSHOT_FILE), lines.join("\n"));
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_liveness.rs
@@ -110,17 +110,15 @@ fn has_reconcile_progress_signal_from_inputs(decision_inputs: &ReconcileDecision
         }
     }
 
-    if decision_inputs.snapshot.is_none() {
-        if decision_inputs.spool_bytes_written.unwrap_or(0) > 0
-            && decision_inputs.output_log_mtime_within_grace
-        {
-            return true;
-        }
-        if decision_inputs.stderr_log_size.unwrap_or(0) > 0
-            && decision_inputs.stderr_log_mtime_within_grace
-        {
-            return true;
-        }
+    if decision_inputs.spool_bytes_written.unwrap_or(0) > 0
+        && decision_inputs.output_log_mtime_within_grace
+    {
+        return true;
+    }
+    if decision_inputs.stderr_log_size.unwrap_or(0) > 0
+        && decision_inputs.stderr_log_mtime_within_grace
+    {
+        return true;
     }
 
     false

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_liveness.rs
@@ -1,0 +1,122 @@
+use std::fs;
+use std::path::Path;
+
+use csa_process::ToolLiveness;
+
+const LIVENESS_SNAPSHOT_FILE: &str = ".liveness.snapshot";
+const ACP_EVENTS_LOG_FILE: &str = "output/acp-events.jsonl";
+const STDERR_LOG_FILE: &str = "stderr.log";
+
+pub(crate) struct ReconcileLivenessDecision {
+    pub(crate) blocks_synthesis: bool,
+    pub(crate) reason: &'static str,
+}
+
+#[derive(Default)]
+struct ReconcileLivenessSnapshot {
+    spool_bytes_written: Option<u64>,
+    observed_spool_bytes_written: Option<u64>,
+    acp_events_size: Option<u64>,
+    stderr_log_size: Option<u64>,
+}
+
+pub(crate) fn reconcile_liveness_decision(session_dir: &Path) -> ReconcileLivenessDecision {
+    if ToolLiveness::has_live_process(session_dir) {
+        return ReconcileLivenessDecision {
+            blocks_synthesis: true,
+            reason: "live_pid",
+        };
+    }
+    if ToolLiveness::daemon_pid_is_alive(session_dir) {
+        return ReconcileLivenessDecision {
+            blocks_synthesis: true,
+            reason: "live_daemon_pid",
+        };
+    }
+    if has_reconcile_progress_signal(session_dir) {
+        return ReconcileLivenessDecision {
+            blocks_synthesis: true,
+            reason: "progress_signal",
+        };
+    }
+    ReconcileLivenessDecision {
+        blocks_synthesis: false,
+        reason: "no_pid_no_progress",
+    }
+}
+
+fn has_reconcile_progress_signal(session_dir: &Path) -> bool {
+    let mut snapshot = load_reconcile_liveness_snapshot(session_dir);
+    let spool_growth = matches!(
+        (
+            snapshot.spool_bytes_written,
+            snapshot.observed_spool_bytes_written
+        ),
+        (Some(current), Some(previous)) if current != previous
+    );
+    snapshot.observed_spool_bytes_written = snapshot.spool_bytes_written;
+
+    let (acp_growth, acp_size) = detect_file_growth(
+        &session_dir.join(ACP_EVENTS_LOG_FILE),
+        snapshot.acp_events_size,
+    );
+    snapshot.acp_events_size = acp_size;
+
+    let (stderr_growth, stderr_size) =
+        detect_file_growth(&session_dir.join(STDERR_LOG_FILE), snapshot.stderr_log_size);
+    snapshot.stderr_log_size = stderr_size;
+
+    save_reconcile_liveness_snapshot(session_dir, &snapshot);
+    spool_growth || acp_growth || stderr_growth
+}
+
+fn detect_file_growth(path: &Path, previous_size: Option<u64>) -> (bool, Option<u64>) {
+    let current_size = fs::metadata(path).ok().map(|meta| meta.len());
+    let growth = match (previous_size, current_size) {
+        (Some(prev), Some(current)) => current != prev,
+        _ => false,
+    };
+    (growth, current_size)
+}
+
+fn load_reconcile_liveness_snapshot(session_dir: &Path) -> ReconcileLivenessSnapshot {
+    let snapshot_path = session_dir.join(LIVENESS_SNAPSHOT_FILE);
+    let Ok(content) = fs::read_to_string(snapshot_path) else {
+        return ReconcileLivenessSnapshot::default();
+    };
+
+    let mut snapshot = ReconcileLivenessSnapshot::default();
+    for line in content.lines() {
+        let mut parts = line.splitn(2, '=');
+        let key = parts.next().unwrap_or_default().trim();
+        let value = parts.next().unwrap_or_default().trim().parse::<u64>().ok();
+        match key {
+            "spool_bytes_written" => snapshot.spool_bytes_written = value,
+            "observed_spool_bytes_written" => snapshot.observed_spool_bytes_written = value,
+            "acp_events_size" => snapshot.acp_events_size = value,
+            "stderr_log_size" => snapshot.stderr_log_size = value,
+            _ => {}
+        }
+    }
+    snapshot
+}
+
+fn save_reconcile_liveness_snapshot(session_dir: &Path, snapshot: &ReconcileLivenessSnapshot) {
+    let mut lines = Vec::with_capacity(4);
+    if let Some(value) = snapshot.spool_bytes_written {
+        lines.push(format!("spool_bytes_written={value}"));
+    }
+    if let Some(value) = snapshot.observed_spool_bytes_written {
+        lines.push(format!("observed_spool_bytes_written={value}"));
+    }
+    if let Some(value) = snapshot.acp_events_size {
+        lines.push(format!("acp_events_size={value}"));
+    }
+    if let Some(value) = snapshot.stderr_log_size {
+        lines.push(format!("stderr_log_size={value}"));
+    }
+    if lines.is_empty() {
+        return;
+    }
+    let _ = fs::write(session_dir.join(LIVENESS_SNAPSHOT_FILE), lines.join("\n"));
+}

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -70,6 +70,66 @@ fn write_liveness_snapshot(
     .expect("write liveness snapshot");
 }
 
+#[test]
+fn reconciler_does_not_clobber_runtime_liveness_snapshot() {
+    let td = tempdir().expect("tempdir");
+    let session_dir = td.path();
+
+    fs::write(session_dir.join("output.log"), "fresh output bytes\n").expect("write output log");
+    write_liveness_snapshot(&session_dir, ["spool_bytes_written=19"]);
+
+    let snapshot_path = session_dir.join(".liveness.snapshot");
+    let before = fs::read(&snapshot_path).expect("read runtime snapshot before reconcile");
+    let before_mtime = fs::metadata(&snapshot_path)
+        .expect("stat runtime snapshot before reconcile")
+        .modified()
+        .expect("mtime before reconcile");
+
+    let decision = reconcile_liveness_decision(session_dir);
+
+    let after = fs::read(&snapshot_path).expect("read runtime snapshot after reconcile");
+    let after_mtime = fs::metadata(&snapshot_path)
+        .expect("stat runtime snapshot after reconcile")
+        .modified()
+        .expect("mtime after reconcile");
+
+    assert!(
+        decision.blocks_synthesis,
+        "fresh runtime liveness signal should still block synthesis"
+    );
+    assert_eq!(
+        after, before,
+        "reconcile must not rewrite the runtime-owned .liveness.snapshot"
+    );
+    assert_eq!(
+        after_mtime, before_mtime,
+        "reconcile must not update the runtime snapshot mtime"
+    );
+}
+
+#[test]
+fn missing_current_sizes_do_not_count_as_reconcile_progress() {
+    let td = tempdir().expect("tempdir");
+    let session_dir = td.path();
+
+    write_liveness_snapshot(
+        &session_dir,
+        [
+            "observed_spool_bytes_written=19",
+            "acp_events_size=7",
+            "stderr_log_size=3",
+        ],
+    );
+
+    let decision = reconcile_liveness_decision(session_dir);
+
+    assert!(
+        !decision.blocks_synthesis,
+        "missing current files should not be misclassified as fresh progress"
+    );
+    assert_eq!(decision.reason, "no_pid_no_progress");
+}
+
 fn make_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
     let now = Utc::now();
     csa_session::SessionResult {
@@ -176,6 +236,40 @@ fn first_reconcile_with_fresh_output_no_prior_snapshot_blocks_synthesis() {
     assert!(
         load_result(project, &session_id).unwrap().is_none(),
         "fresh output before any observed snapshot should block synthetic failure"
+    );
+}
+
+#[test]
+fn first_reconcile_with_fresh_acp_events_no_prior_snapshot_blocks_synthesis() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("first-reconcile-fresh-acp-events"),
+        None,
+        None,
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    fs::create_dir_all(session_dir.join("output")).unwrap();
+    fs::write(
+        session_dir.join("output/acp-events.jsonl"),
+        "{\"type\":\"event\"}\n",
+    )
+    .unwrap();
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
+            .unwrap();
+
+    assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
+    assert!(
+        load_result(project, &session_id).unwrap().is_none(),
+        "fresh ACP event output before any observed snapshot should block synthetic failure"
     );
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -1,0 +1,205 @@
+use super::*;
+use crate::test_env_lock::TEST_ENV_LOCK;
+use csa_session::{create_session, get_session_dir, load_result};
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+use tempfile::tempdir;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+struct SessionTestEnv {
+    _env_lock: std::sync::MutexGuard<'static, ()>,
+    _home_guard: EnvVarGuard,
+    _state_guard: EnvVarGuard,
+}
+
+impl SessionTestEnv {
+    fn new(td: &tempfile::TempDir) -> Self {
+        let env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+        let state_home = td.path().join("xdg-state");
+        fs::create_dir_all(&state_home).expect("create state home");
+        let home_guard = EnvVarGuard::set("HOME", td.path());
+        let state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+        Self {
+            _env_lock: env_lock,
+            _home_guard: home_guard,
+            _state_guard: state_guard,
+        }
+    }
+}
+
+fn write_liveness_snapshot(
+    session_dir: &std::path::Path,
+    lines: impl IntoIterator<Item = impl AsRef<str>>,
+) {
+    let contents = lines
+        .into_iter()
+        .map(|line| line.as_ref().to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(
+        session_dir.join(".liveness.snapshot"),
+        format!("{contents}\n"),
+    )
+    .expect("write liveness snapshot");
+}
+
+#[cfg(unix)]
+fn set_file_mtime_seconds_ago(path: &std::path::Path, seconds_ago: u64) {
+    use std::ffi::CString;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .expect("system clock before unix epoch");
+    let target = now.saturating_sub(std::time::Duration::from_secs(seconds_ago));
+    let tv_sec = target.as_secs() as libc::time_t;
+    let tv_nsec = target.subsec_nanos() as libc::c_long;
+    let times = [
+        libc::timespec { tv_sec, tv_nsec },
+        libc::timespec { tv_sec, tv_nsec },
+    ];
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("path contains NUL");
+    // SAFETY: `utimensat` receives a valid C path pointer and valid timespec array.
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    assert_eq!(rc, 0, "utimensat failed for {}", path.display());
+}
+
+#[cfg(target_os = "linux")]
+fn read_process_start_time_ticks(pid: u32) -> u64 {
+    let stat_path = format!("/proc/{pid}/stat");
+    let content = fs::read_to_string(stat_path).expect("read /proc stat");
+    let close_paren = content.rfind(')').expect("stat comm terminator");
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    parts.next().expect("state");
+    parts.next().expect("ppid");
+    parts.next().expect("pgrp");
+    for _ in 0..16 {
+        parts.next().expect("intermediate stat field");
+    }
+    parts
+        .next()
+        .expect("starttime")
+        .parse::<u64>()
+        .expect("starttime parse")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_record(pid: u32) -> String {
+    format!("{pid} {}\n", read_process_start_time_ticks(pid))
+}
+
+#[test]
+fn fresh_stderr_activity_blocks_synthesis() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(project, Some("fresh-stderr-activity"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    fs::write(session_dir.join("stderr.log"), "new stderr bytes\n").unwrap();
+    write_liveness_snapshot(&session_dir, ["stderr_log_size=1"]);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
+            .unwrap();
+
+    assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
+    assert!(
+        load_result(project, &session_id).unwrap().is_none(),
+        "stderr growth should block synthetic failure"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn stale_output_after_grace_still_allows_synthesis() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(project, Some("stale-output-after-grace"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    let output_path = session_dir.join("output.log");
+    fs::write(&output_path, "old output bytes\n").unwrap();
+    set_file_mtime_seconds_ago(&output_path, 31);
+    write_liveness_snapshot(
+        &session_dir,
+        ["spool_bytes_written=16", "observed_spool_bytes_written=16"],
+    );
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
+            .unwrap();
+
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
+    assert!(
+        load_result(project, &session_id).unwrap().is_some(),
+        "stale output without live pid/progress should still synthesize a terminal result"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn live_daemon_pid_still_blocks_synthesis() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(project, Some("live-daemon-pid-blocks"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .unwrap();
+    let pid = child.id();
+    fs::write(session_dir.join("daemon.pid"), daemon_pid_record(pid)).unwrap();
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
+            .unwrap();
+
+    child.kill().ok();
+    child.wait().ok();
+
+    assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
+    assert!(
+        load_result(project, &session_id).unwrap().is_none(),
+        "live daemon.pid must continue blocking synthetic failure"
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -210,6 +210,39 @@ fn retirement_with_fresh_output_and_existing_result_blocks_retirement() {
     assert_eq!(persisted.termination_reason, None);
 }
 
+#[test]
+fn concurrent_reconcile_with_synced_snapshot_still_blocks_synthesis() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("concurrent-reconcile-synced-snapshot"),
+        None,
+        None,
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    fs::write(session_dir.join("output.log"), "fresh output bytes\n").unwrap();
+    write_liveness_snapshot(
+        &session_dir,
+        ["spool_bytes_written=19", "observed_spool_bytes_written=19"],
+    );
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
+            .unwrap();
+
+    assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
+    assert!(
+        load_result(project, &session_id).unwrap().is_none(),
+        "fresh output with a synced snapshot should still block synthetic failure"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn stale_output_after_grace_still_allows_synthesis() {

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::test_env_lock::TEST_ENV_LOCK;
-use csa_session::{create_session, get_session_dir, load_result};
+use chrono::Utc;
+use csa_session::{create_session, get_session_dir, load_result, load_session, save_result};
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
@@ -67,6 +68,21 @@ fn write_liveness_snapshot(
         format!("{contents}\n"),
     )
     .expect("write liveness snapshot");
+}
+
+fn make_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
+    let now = Utc::now();
+    csa_session::SessionResult {
+        status: status.to_string(),
+        exit_code,
+        summary: "summary".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+    }
 }
 
 #[cfg(unix)]
@@ -163,6 +179,37 @@ fn first_reconcile_with_fresh_output_no_prior_snapshot_blocks_synthesis() {
     );
 }
 
+#[test]
+fn retirement_with_fresh_output_and_existing_result_blocks_retirement() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("retirement-fresh-output-existing-result"),
+        None,
+        None,
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    save_result(project, &session_id, &make_result("success", 0)).unwrap();
+    fs::write(session_dir.join("output.log"), "fresh output bytes\n").unwrap();
+    write_liveness_snapshot(&session_dir, ["spool_bytes_written=19"]);
+
+    let retired = retire_if_dead_with_result(project, &session_id, "session list").unwrap();
+
+    assert!(
+        !retired,
+        "fresh output should block dead-session retirement even when result.toml exists"
+    );
+    let persisted = load_session(project, &session_id).unwrap();
+    assert_eq!(persisted.phase, csa_session::SessionPhase::Active);
+    assert_eq!(persisted.termination_reason, None);
+}
+
 #[cfg(unix)]
 #[test]
 fn stale_output_after_grace_still_allows_synthesis() {
@@ -194,6 +241,43 @@ fn stale_output_after_grace_still_allows_synthesis() {
         load_result(project, &session_id).unwrap().is_some(),
         "stale output without live pid/progress should still synthesize a terminal result"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn retirement_with_stale_output_and_existing_result_still_retires() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("retirement-stale-output-existing-result"),
+        None,
+        None,
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    save_result(project, &session_id, &make_result("success", 0)).unwrap();
+    let output_path = session_dir.join("output.log");
+    fs::write(&output_path, "old output bytes\n").unwrap();
+    set_file_mtime_seconds_ago(&output_path, 31);
+    write_liveness_snapshot(
+        &session_dir,
+        ["spool_bytes_written=16", "observed_spool_bytes_written=16"],
+    );
+
+    let retired = retire_if_dead_with_result(project, &session_id, "session list").unwrap();
+
+    assert!(
+        retired,
+        "stale output should still allow legitimate retirement"
+    );
+    let persisted = load_session(project, &session_id).unwrap();
+    assert_eq!(persisted.phase, csa_session::SessionPhase::Retired);
+    assert_eq!(persisted.termination_reason.as_deref(), Some("completed"));
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -138,6 +138,31 @@ fn fresh_stderr_activity_blocks_synthesis() {
     );
 }
 
+#[test]
+fn first_reconcile_with_fresh_output_no_prior_snapshot_blocks_synthesis() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session =
+        create_session(project, Some("first-reconcile-fresh-output"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    fs::write(session_dir.join("output.log"), "fresh output bytes\n").unwrap();
+    write_liveness_snapshot(&session_dir, ["spool_bytes_written=19"]);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
+            .unwrap();
+
+    assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
+    assert!(
+        load_result(project, &session_id).unwrap().is_none(),
+        "fresh output before any observed snapshot should block synthetic failure"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn stale_output_after_grace_still_allows_synthesis() {

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -413,7 +413,7 @@ fn ensure_terminal_result_for_dead_active_session_preserves_late_real_result() {
 }
 
 #[test]
-fn ensure_terminal_result_for_dead_active_session_reconciles_fresh_output_without_live_process() {
+fn ensure_terminal_result_for_dead_active_session_preserves_session_with_recent_output() {
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
     let state_home = td.path().join("xdg-state");
@@ -430,16 +430,21 @@ fn ensure_terminal_result_for_dead_active_session_reconciles_fresh_output_withou
         "recent output that should not block reconciliation\n",
     )
     .unwrap();
+    std::fs::write(
+        session_dir.join(".liveness.snapshot"),
+        "spool_bytes_written=48\nobserved_spool_bytes_written=12\n",
+    )
+    .unwrap();
 
     let reconciled =
         ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
             .unwrap();
     assert_eq!(
         reconciled,
-        DeadActiveSessionReconciliation::SynthesizedFailure,
-        "fresh file writes without a live process should still synthesize a terminal result"
+        DeadActiveSessionReconciliation::NoChange,
+        "recent output growth should block synthetic orphaned_process reconciliation"
     );
-    assert!(load_result(project, &session_id).unwrap().is_some());
+    assert!(load_result(project, &session_id).unwrap().is_none());
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Closes #808 — debate sessions were falsely reconciled as `orphaned_process` mid-flight when the wrapper PID transiently disappeared but the tool was still producing output, causing pr-bot Step 7 arbitration to receive no verdict.

Three layered fixes on the reconciliation side:

1. **Honor file-progress signals before synthesis** (bf91006c) — `session_cmds_reconcile.rs` now consults `reconcile_liveness_decision()` (new helper) before synthesizing a terminal `orphaned_process` result. Blocks synthesis on `live_pid`, `live_daemon_pid`, or `progress_signal` (output_growth / stderr_activity). `session_write` kept narrow (not used as a broad signal — too noisy).

2. **First-reconcile fallback** (9e7d95a3) — round-1 gate relied on deltas vs a prior `.liveness.snapshot`. On the very first reconcile pass for a session, the runtime never pre-fills `observed_*` fields, so delta-based progress always returned false → the exact false-orphan we were trying to prevent. Added `snapshot.is_none()` mtime-based fallback using the same recency window as `ToolLiveness::has_recent_session_write_signal()`.

3. **Extend guard to the retirement path** (a7d98786) — `retire_if_dead_with_result_impl` + `dead_session_with_result_needs_retire` used a PID-only gate, so a stale/false `result.toml` combined with a transient PID disappearance would retire a still-writing session. Both helpers now consult `reconcile_liveness_decision()`. Race-condition `load_result(...).is_none()` check inside the locked critical section is preserved.

Rust `reconcile_liveness_decision()` is a strict superset of the old PID-only gate (live_process + daemon_pid checks first), so no legitimate retirement path is lost.

## Test plan

- [x] New regression tests (`session_cmds_reconcile_progress_tests.rs`):
  - `fresh_stderr_activity_blocks_synthesis`
  - `stale_output_after_grace_still_allows_synthesis`
  - `live_daemon_pid_still_blocks_synthesis`
  - `first_reconcile_with_fresh_output_no_prior_snapshot_blocks_synthesis` (round 2 red→green proof captured)
  - `retirement_with_fresh_output_and_existing_result_blocks_retirement` (round 3 red→green proof captured)
  - `retirement_with_stale_output_and_existing_result_still_retires` (invariant: true completion still retires)
- [x] Flipped `ensure_terminal_result_for_dead_active_session_preserves_session_with_recent_output` (semantic change: `NoChange` not `SynthesizedFailure`)
- [x] `cargo test -p cli-sub-agent session_cmds_reconcile` passes
- [x] `cargo test -p csa-process tool_liveness` no regression
- [x] `just pre-commit` passes
- [x] Workspace bumped 0.1.350 → 0.1.353, Cargo.lock synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)