### PR TITLE
fix(csa-pipeline): extend initial-response timeout per-tool to gemini-cli (#829)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.355"
+version = "0.1.356"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.355"
+version = "0.1.356"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -52,6 +52,7 @@ pub(crate) const DEFAULT_IDLE_TIMEOUT_SECONDS: u64 = 250;
 pub(crate) const DEFAULT_LIVENESS_DEAD_SECONDS: u64 = csa_process::DEFAULT_LIVENESS_DEAD_SECS;
 pub(crate) const DEFAULT_RESOURCES_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 120;
 pub(crate) const DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 300;
+pub(crate) const DEFAULT_GEMINI_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 600;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ParentSessionSource {
@@ -113,22 +114,36 @@ pub(crate) fn resolve_initial_response_timeout_for_tool(
         );
     }
 
-    if tool_name == "codex" {
-        let configured = if let Some(seconds) =
-            config.and_then(|cfg| cfg.tool_initial_response_timeout_seconds(tool_name))
-        {
-            Some(seconds)
-        } else {
-            config.and_then(|cfg| cfg.resources.initial_response_timeout_seconds)
-        };
+    let tool_override = config.and_then(|cfg| cfg.tool_initial_response_timeout_seconds(tool_name));
 
-        return csa_executor::resolve_initial_response_timeout(
-            configured,
-            DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS,
-        );
+    match tool_name {
+        "codex" => {
+            let configured = tool_override
+                .or_else(|| config.and_then(|cfg| cfg.resources.initial_response_timeout_seconds));
+            csa_executor::resolve_initial_response_timeout(
+                configured,
+                DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS,
+            )
+        }
+        "gemini-cli" => {
+            let configured = tool_override
+                .or_else(|| config.and_then(|cfg| cfg.resources.initial_response_timeout_seconds));
+            csa_executor::resolve_initial_response_timeout(
+                configured,
+                DEFAULT_GEMINI_INITIAL_RESPONSE_TIMEOUT_SECONDS,
+            )
+        }
+        _ => {
+            if let Some(seconds) = tool_override {
+                csa_executor::resolve_initial_response_timeout(
+                    Some(seconds),
+                    DEFAULT_RESOURCES_INITIAL_RESPONSE_TIMEOUT_SECONDS,
+                )
+            } else {
+                resolve_initial_response_timeout_seconds(config, None)
+            }
+        }
     }
-
-    resolve_initial_response_timeout_seconds(config, None)
 }
 
 pub(crate) fn resolve_liveness_dead_seconds(config: Option<&ProjectConfig>) -> u64 {

--- a/crates/cli-sub-agent/src/pipeline_tests_initial_response.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_initial_response.rs
@@ -264,6 +264,38 @@ fn test_resolve_initial_response_timeout_for_codex_defaults_to_300_without_overr
 }
 
 #[test]
+fn test_resolve_initial_response_timeout_for_gemini_cli_default() {
+    let cfg = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig {
+            initial_response_timeout_seconds: None,
+            ..Default::default()
+        },
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    assert_eq!(
+        resolve_initial_response_timeout_for_tool(Some(&cfg), None, None, "gemini-cli"),
+        Some(DEFAULT_GEMINI_INITIAL_RESPONSE_TIMEOUT_SECONDS)
+    );
+}
+
+#[test]
 fn test_resolve_initial_response_timeout_for_non_codex_cli_zero_disables_watchdog() {
     let cfg = ProjectConfig {
         schema_version: CURRENT_SCHEMA_VERSION,
@@ -290,6 +322,112 @@ fn test_resolve_initial_response_timeout_for_non_codex_cli_zero_disables_watchdo
         resolve_initial_response_timeout_for_tool(Some(&cfg), Some(0), None, "gemini-cli"),
         None,
         "non-codex callers must translate the disabled sentinel before csa-process sees it"
+    );
+}
+
+#[test]
+fn test_resolve_initial_response_timeout_gemini_cli_honors_override() {
+    let mut tools = HashMap::new();
+    tools.insert(
+        "gemini-cli".to_string(),
+        ToolConfig {
+            initial_response_timeout_seconds: Some(900),
+            ..Default::default()
+        },
+    );
+    let cfg = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools,
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    assert_eq!(
+        resolve_initial_response_timeout_for_tool(Some(&cfg), None, None, "gemini-cli"),
+        Some(900)
+    );
+}
+
+#[test]
+fn test_resolve_initial_response_timeout_gemini_cli_disable() {
+    let mut tools = HashMap::new();
+    tools.insert(
+        "gemini-cli".to_string(),
+        ToolConfig {
+            initial_response_timeout_seconds: Some(0),
+            ..Default::default()
+        },
+    );
+    let cfg = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools,
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    assert_eq!(
+        resolve_initial_response_timeout_for_tool(Some(&cfg), None, None, "gemini-cli"),
+        None
+    );
+}
+
+#[test]
+fn test_resolve_initial_response_timeout_for_unknown_tool_uses_global_default() {
+    let cfg = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig {
+            initial_response_timeout_seconds: None,
+            ..Default::default()
+        },
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    assert_eq!(
+        resolve_initial_response_timeout_for_tool(Some(&cfg), None, None, "opencode"),
+        Some(DEFAULT_RESOURCES_INITIAL_RESPONSE_TIMEOUT_SECONDS)
     );
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_timeout_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_timeout_tests.rs
@@ -20,7 +20,7 @@ fn review_initial_response_timeout_is_resolved_per_reviewer_tool() {
 
     assert_eq!(
         gemini_timeout,
-        Some(crate::pipeline::DEFAULT_RESOURCES_INITIAL_RESPONSE_TIMEOUT_SECONDS)
+        Some(crate::pipeline::DEFAULT_GEMINI_INITIAL_RESPONSE_TIMEOUT_SECONDS)
     );
     assert_eq!(codex_timeout, Some(300));
 }

--- a/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
@@ -541,7 +541,10 @@ fn resolve_attempt_initial_response_timeout_uses_fallback_tool_defaults() {
     let codex_timeout =
         resolve_attempt_initial_response_timeout_seconds(Some(&config), None, None, false, "codex");
 
-    assert_eq!(gemini_timeout, Some(120));
+    assert_eq!(
+        gemini_timeout,
+        Some(crate::pipeline::DEFAULT_GEMINI_INITIAL_RESPONSE_TIMEOUT_SECONDS)
+    );
     assert_eq!(
         codex_timeout,
         Some(300),

--- a/crates/csa-config/src/config_tool.rs
+++ b/crates/csa-config/src/config_tool.rs
@@ -64,11 +64,12 @@ pub struct ToolConfig {
     /// Accepts the same values as `--thinking`: low, medium, high, xhigh, or a number.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking_lock: Option<String>,
-    /// Codex exec initial-response timeout override (seconds).
+    /// Per-tool initial-response timeout override (seconds).
     ///
-    /// Currently only used for `[tools.codex]`. When set, it overrides
-    /// `resources.initial_response_timeout_seconds` for codex exec dispatch.
-    /// `0` explicitly disables the initial-response watchdog.
+    /// When set, it overrides `resources.initial_response_timeout_seconds` for
+    /// this tool. `None` means fall back to the generic resources timeout (or a
+    /// tool-specific default when the runtime defines one). `0` explicitly
+    /// disables the initial-response watchdog.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub initial_response_timeout_seconds: Option<u64>,
     /// Optional tool transport override.


### PR DESCRIPTION
## Summary

Three open issues (#826 #827 #829) reported CSA sessions exiting `137` on small text-only changes. Initially misread as OOM; recon (session `01KPGD6J618R041Q8BXAYZ3AXJ`) showed the actual cause is the 120s `initial_response_timeout` watchdog killing gemini-cli sessions that take longer than 120s to produce first stdout (OAuth refresh + model init).

- `resolve_initial_response_timeout_for_tool` previously only special-cased `codex`
- gemini-cli fell through to the 120s generic default
- Extend the match to cover `gemini-cli` with a 600s default
- Generalise the per-tool override path so any tool can set `[tools.<name>].initial_response_timeout_seconds`

Closes #826
Closes #827
Closes #829

## Test plan

- [x] `cargo test -p cli-sub-agent resolve_initial_response_timeout` — 23 pass, new gemini-cli cases (default/override/disable) green
- [x] `cargo test -p cli-sub-agent review_initial_response` — green
- [x] `just pre-commit` — exit 0
- [x] `csa review --range main...HEAD` — CLEAN (session `01KPGECC8E3S6T8TFV6T5844VD`)
- [ ] Cloud bot (gemini-code-assist) review

## Note for users

After merge, to raise the default beyond 600s (if your gemini-cli startup regularly exceeds it), add to `~/.config/cli-sub-agent/config.toml`:

```toml
[tools.gemini-cli]
initial_response_timeout_seconds = 900
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)