### PR TITLE
fix(csa-config): per-layer transport validation + hermetic test loading (#773 #774)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.357"
+version = "0.1.358"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.357"
+version = "0.1.358"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/doctor.rs
+++ b/crates/cli-sub-agent/src/doctor.rs
@@ -222,7 +222,7 @@ fn inspect_doctor_project_config_from(project_root: &Path) -> DoctorProjectConfi
     match load_doctor_project_config_from(project_root) {
         Ok(Some(config)) => DoctorProjectConfigStatus::Valid(Box::new(config)),
         Ok(None) => DoctorProjectConfigStatus::Missing,
-        Err(error) => DoctorProjectConfigStatus::Invalid(error.to_string()),
+        Err(error) => DoctorProjectConfigStatus::Invalid(format!("{error:#}")),
     }
 }
 
@@ -230,7 +230,7 @@ fn inspect_doctor_effective_config_from(project_root: &Path) -> DoctorEffectiveC
     match load_doctor_effective_config_from(project_root) {
         Ok(Some(config)) => DoctorEffectiveConfigStatus::Valid(Box::new(config)),
         Ok(None) => DoctorEffectiveConfigStatus::Defaults,
-        Err(error) => DoctorEffectiveConfigStatus::Invalid(error.to_string()),
+        Err(error) => DoctorEffectiveConfigStatus::Invalid(format!("{error:#}")),
     }
 }
 

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -253,7 +253,12 @@ impl ProjectConfig {
         // Check for deprecated keys before deserializing (serde silently ignores them)
         if let Ok(raw) = toml::from_str::<toml::Value>(&content) {
             warn_deprecated_keys(&raw, &path.display().to_string());
-            crate::validate::validate_tool_transport_overrides_in_raw_config(&raw)?;
+            crate::validate::validate_tool_transport_overrides_in_raw_config(&raw).map_err(
+                |error| {
+                    let summary = error.to_string();
+                    error.context(format!("Invalid config: {}: {summary}", path.display()))
+                },
+            )?;
         }
         let config: Self = toml::from_str(&content)
             .with_context(|| format!("Failed to parse config: {}", path.display()))?;
@@ -282,6 +287,24 @@ impl ProjectConfig {
         // Check for deprecated keys in both configs
         warn_deprecated_keys(&base_val, &base_path.display().to_string());
         warn_deprecated_keys(&overlay_val, &overlay_path.display().to_string());
+        crate::validate::validate_tool_transport_overrides_in_raw_config(&base_val).map_err(
+            |error| {
+                let summary = error.to_string();
+                error.context(format!(
+                    "Invalid user config: {}: {summary}",
+                    base_path.display()
+                ))
+            },
+        )?;
+        crate::validate::validate_tool_transport_overrides_in_raw_config(&overlay_val).map_err(
+            |error| {
+                let summary = error.to_string();
+                error.context(format!(
+                    "Invalid project config: {}: {summary}",
+                    overlay_path.display()
+                ))
+            },
+        )?;
 
         // Preserve the higher schema_version before merging so that
         // check_schema_version() catches incompatibility from either source.
@@ -313,7 +336,12 @@ impl ProjectConfig {
         // cannot reverse — this prevents stale project configs from resurrecting
         // tools the user explicitly disabled at the global level.
         enforce_global_tool_disables(&base_val, &mut merged);
-        crate::validate::validate_tool_transport_overrides_in_raw_config(&merged)?;
+        crate::validate::validate_tool_transport_overrides_in_raw_config(&merged).map_err(
+            |error| {
+                let summary = error.to_string();
+                error.context(format!("Invalid merged config after layering: {summary}"))
+            },
+        )?;
 
         // Roundtrip through string for reliable deserialization
         let merged_str = toml::to_string(&merged).context("Failed to serialize merged config")?;

--- a/crates/csa-config/src/config_merge_tests.rs
+++ b/crates/csa-config/src/config_merge_tests.rs
@@ -181,6 +181,94 @@ fn test_merged_schema_version_uses_max_when_explicit() {
 }
 
 #[test]
+fn test_invalid_user_transport_override_fails_before_merge() {
+    let tmp = tempdir().unwrap();
+    let user_path = tmp.path().join("user.toml");
+    let project_path = tmp.path().join("project.toml");
+
+    std::fs::write(
+        &user_path,
+        r#"
+schema_version = 1
+[tools.claude-code]
+transport = "cli"
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        &project_path,
+        r#"
+schema_version = 1
+[tools.codex]
+transport = "acp"
+"#,
+    )
+    .unwrap();
+
+    let err = ProjectConfig::load_with_paths(Some(&user_path), &project_path)
+        .expect_err("invalid user-layer transport override should fail");
+    let rendered = format!("{err:#}");
+
+    assert!(
+        rendered.contains("Invalid user config:"),
+        "error should identify the user config layer: {rendered}"
+    );
+    assert!(
+        rendered.contains(&user_path.display().to_string()),
+        "error should include the user config path: {rendered}"
+    );
+    assert!(
+        rendered.contains("[tools.claude-code].transport"),
+        "error should surface the invalid user transport key: {rendered}"
+    );
+}
+
+#[test]
+fn test_invalid_project_transport_override_fails_before_merge() {
+    let tmp = tempdir().unwrap();
+    let user_path = tmp.path().join("user.toml");
+    let project_path = tmp.path().join("project.toml");
+
+    std::fs::write(
+        &user_path,
+        r#"
+schema_version = 1
+[tools.codex]
+transport = "cli"
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        &project_path,
+        r#"
+schema_version = 1
+[tools.claude-code]
+transport = "cli"
+"#,
+    )
+    .unwrap();
+
+    let err = ProjectConfig::load_with_paths(Some(&user_path), &project_path)
+        .expect_err("invalid project-layer transport override should fail");
+    let rendered = format!("{err:#}");
+
+    assert!(
+        rendered.contains("Invalid project config:"),
+        "error should identify the project config layer: {rendered}"
+    );
+    assert!(
+        rendered.contains(&project_path.display().to_string()),
+        "error should include the project config path: {rendered}"
+    );
+    assert!(
+        rendered.contains("[tools.claude-code].transport"),
+        "error should surface the invalid project transport key: {rendered}"
+    );
+}
+
+#[test]
 #[serial]
 fn test_user_config_path_returns_some() {
     let dir = tempdir().unwrap();

--- a/crates/csa-config/src/config_tests.rs
+++ b/crates/csa-config/src/config_tests.rs
@@ -516,7 +516,8 @@ fn test_max_recursion_depth_override() {
 
     config.save(dir.path()).unwrap();
 
-    let loaded = ProjectConfig::load(dir.path()).unwrap();
+    let project_path = dir.path().join(".csa").join("config.toml");
+    let loaded = ProjectConfig::load_with_paths(None, &project_path).unwrap();
     assert!(loaded.is_some());
     let loaded = loaded.unwrap();
 


### PR DESCRIPTION
Closes #773 #774

Summary:
- `chore: bump to 0.1.358` updates the workspace version required by feature-branch hooks.
- `fix(csa-config): hermetic ProjectConfig test loading (#774)` switches the remaining project-config test to explicit project-only loading so host user config cannot leak into the assertion.
- `fix(csa-config): per-layer transport validation in load_merged (#773)` validates user and project raw TOML before merge, preserves source-path attribution in the resulting errors, keeps merged validation as a secondary guard, and adds regression coverage for invalid user/project transport overrides.

Recon:
- Based on recon session `01KPGS7D4D3VTD4HDE2HAH8PSV`
- Recon artifact: `~/.local/state/cli-sub-agent/home/obj/project/github/RyderFreeman4Logos/cli-sub-agent/sessions/01KPGS7D4D3VTD4HDE2HAH8PSV/output/recon.md`
