### PR TITLE
test(review): centralize ScopedEnvVar helper and rename misleading consolidator test (#811)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.358"
+version = "0.1.359"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.358"
+version = "0.1.359"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml_tests.rs
@@ -1,4 +1,5 @@
 use super::{extract_findings_toml_from_text, persist_review_findings_toml};
+use crate::test_env_lock::ScopedTestEnvVar;
 use csa_core::types::ReviewDecision;
 use csa_session::state::ReviewSessionMeta;
 use csa_session::{FindingSeverity, FindingsFile, ReviewFinding, ReviewFindingFileRange};
@@ -6,9 +7,12 @@ use serde_json::json;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing_subscriber::fmt::MakeWriter;
+
+static SESSION_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn make_review_meta(session_id: &str) -> ReviewSessionMeta {
     ReviewSessionMeta {
@@ -36,6 +40,19 @@ fn temp_project_root(test_name: &str) -> PathBuf {
     let path = std::env::temp_dir().join(format!("csa-{test_name}-{suffix}"));
     fs::create_dir_all(&path).expect("create temp project root");
     path
+}
+
+fn unique_session_id(prefix: &str) -> String {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    let seq = SESSION_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{suffix}-{seq}")
+}
+
+fn pin_state_home(project_root: &Path) -> ScopedTestEnvVar {
+    ScopedTestEnvVar::set("XDG_STATE_HOME", project_root.join("state"))
 }
 
 fn create_session_dir(project_root: &Path, session_id: &str) -> PathBuf {
@@ -285,8 +302,9 @@ start = 101
 #[test]
 fn persist_review_findings_toml_writes_parsed_artifact() {
     let project_root = temp_project_root("persist-review-findings-toml");
-    let session_id = "01TESTFINDINGSTOML00000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let _state_home = pin_state_home(&project_root);
+    let session_id = unique_session_id("01TESTFINDINGSTOML00000000");
+    let session_dir = create_session_dir(&project_root, &session_id);
     write_review_full_output(
         &session_dir,
         r#"<!-- CSA:SECTION:summary -->
@@ -316,7 +334,7 @@ start = 425
     )
     .expect("write details.md");
 
-    let meta = make_review_meta(session_id);
+    let meta = make_review_meta(&session_id);
     persist_review_findings_toml(&project_root, &meta);
 
     let findings_path = session_dir.join("output").join("findings.toml");
@@ -348,8 +366,9 @@ start = 425
 #[test]
 fn persist_review_findings_toml_reads_output_log_when_full_md_is_missing() {
     let project_root = temp_project_root("persist-review-findings-output-log");
-    let session_id = "01TESTFINDINGSTOMLOUTPUTLOG";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let _state_home = pin_state_home(&project_root);
+    let session_id = unique_session_id("01TESTFINDINGSTOMLOUTPUTLOG");
+    let session_dir = create_session_dir(&project_root, &session_id);
     let full_output = [json!({"type":"item.completed","item":{
         "id":"item_1",
         "type":"agent_message",
@@ -383,7 +402,7 @@ start = 88
     )
     .expect("write details.md");
 
-    let meta = make_review_meta(session_id);
+    let meta = make_review_meta(&session_id);
     persist_review_findings_toml(&project_root, &meta);
 
     let findings_path = session_dir.join("output").join("findings.toml");
@@ -408,8 +427,9 @@ start = 88
 #[test]
 fn persist_review_findings_toml_writes_synthetic_empty_for_findings_fence_without_toml_extension() {
     let project_root = temp_project_root("persist-review-findings-no-extension");
-    let session_id = "01TESTFINDINGSTOMLNOEXT00";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let _state_home = pin_state_home(&project_root);
+    let session_id = unique_session_id("01TESTFINDINGSTOMLNOEXT00");
+    let session_dir = create_session_dir(&project_root, &session_id);
     write_review_full_output(
         &session_dir,
         r#"```findings
@@ -429,7 +449,7 @@ start = 130
     )
     .expect("write details.md");
 
-    let meta = make_review_meta(session_id);
+    let meta = make_review_meta(&session_id);
     let buffer = SharedLogBuffer::default();
     let subscriber = tracing_subscriber::fmt()
         .with_ansi(false)
@@ -456,8 +476,9 @@ start = 130
 #[test]
 fn persist_review_findings_toml_writes_synthetic_empty_when_block_missing() {
     let project_root = temp_project_root("persist-review-findings-toml-empty");
-    let session_id = "01TESTFINDINGSTOMLEMPTY000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let _state_home = pin_state_home(&project_root);
+    let session_id = unique_session_id("01TESTFINDINGSTOMLEMPTY000");
+    let session_dir = create_session_dir(&project_root, &session_id);
     write_review_full_output(
         &session_dir,
         r#"<!-- CSA:SECTION:summary -->
@@ -475,7 +496,7 @@ No blocking issues found.
     )
     .expect("write details.md");
 
-    let meta = make_review_meta(session_id);
+    let meta = make_review_meta(&session_id);
     let buffer = SharedLogBuffer::default();
     let subscriber = tracing_subscriber::fmt()
         .with_ansi(false)
@@ -502,8 +523,9 @@ No blocking issues found.
 #[test]
 fn persist_review_findings_toml_overwrites_existing_empty_artifact() {
     let project_root = temp_project_root("persist-review-findings-overwrite-empty");
-    let session_id = "01TESTFINDINGSEMPTYOVERWR0";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let _state_home = pin_state_home(&project_root);
+    let session_id = unique_session_id("01TESTFINDINGSEMPTYOVERWR0");
+    let session_dir = create_session_dir(&project_root, &session_id);
     write_review_full_output(
         &session_dir,
         r#"<!-- CSA:SECTION:summary -->
@@ -537,7 +559,7 @@ start = 31
     )
     .expect("write empty findings.toml");
 
-    let meta = make_review_meta(session_id);
+    let meta = make_review_meta(&session_id);
     persist_review_findings_toml(&project_root, &meta);
 
     let actual = fs::read_to_string(session_dir.join("output").join("findings.toml"))
@@ -562,8 +584,9 @@ start = 31
 #[test]
 fn persist_review_findings_toml_overwrites_existing_findings_toml_with_new_content() {
     let project_root = temp_project_root("persist-review-findings-overwrite-existing");
-    let session_id = "01TESTFINDINGSNONEMPTYOVR0";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let _state_home = pin_state_home(&project_root);
+    let session_id = unique_session_id("01TESTFINDINGSNONEMPTYOVR0");
+    let session_dir = create_session_dir(&project_root, &session_id);
     write_review_full_output(
         &session_dir,
         r#"<!-- CSA:SECTION:summary -->
@@ -607,7 +630,7 @@ start = 27
     )
     .expect("write existing findings.toml");
 
-    let meta = make_review_meta(session_id);
+    let meta = make_review_meta(&session_id);
     persist_review_findings_toml(&project_root, &meta);
 
     let actual = fs::read_to_string(session_dir.join("output").join("findings.toml"))
@@ -632,8 +655,9 @@ start = 27
 #[test]
 fn persist_review_findings_toml_overwrites_existing_empty_artifact_with_derived_empty() {
     let project_root = temp_project_root("persist-review-findings-empty-over-empty");
-    let session_id = "01TESTFINDINGSEMPTYEMPTY00";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let _state_home = pin_state_home(&project_root);
+    let session_id = unique_session_id("01TESTFINDINGSEMPTYEMPTY00");
+    let session_dir = create_session_dir(&project_root, &session_id);
     write_review_full_output(
         &session_dir,
         r#"<!-- CSA:SECTION:summary -->
@@ -656,7 +680,7 @@ No blocking issues found.
     )
     .expect("write empty findings.toml");
 
-    let meta = make_review_meta(session_id);
+    let meta = make_review_meta(&session_id);
     persist_review_findings_toml(&project_root, &meta);
 
     let actual = fs::read_to_string(session_dir.join("output").join("findings.toml"))
@@ -671,8 +695,9 @@ No blocking issues found.
 #[test]
 fn persist_review_findings_toml_overwrites_unparseable_existing_artifact_with_derived_empty() {
     let project_root = temp_project_root("persist-review-findings-empty-over-garbage");
-    let session_id = "01TESTFINDINGSEMPTYGARBAG0";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let _state_home = pin_state_home(&project_root);
+    let session_id = unique_session_id("01TESTFINDINGSEMPTYGARBAG0");
+    let session_dir = create_session_dir(&project_root, &session_id);
     write_review_full_output(
         &session_dir,
         r#"<!-- CSA:SECTION:summary -->
@@ -695,7 +720,7 @@ No blocking issues found.
     )
     .expect("write invalid findings.toml");
 
-    let meta = make_review_meta(session_id);
+    let meta = make_review_meta(&session_id);
     persist_review_findings_toml(&project_root, &meta);
 
     let actual = fs::read_to_string(session_dir.join("output").join("findings.toml"))
@@ -710,8 +735,9 @@ No blocking issues found.
 #[test]
 fn persist_review_findings_toml_overwrites_unparseable_existing_artifact() {
     let project_root = temp_project_root("persist-review-findings-overwrite-garbage");
-    let session_id = "01TESTFINDINGSGARBAGEOVR0";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let _state_home = pin_state_home(&project_root);
+    let session_id = unique_session_id("01TESTFINDINGSGARBAGEOVR0");
+    let session_dir = create_session_dir(&project_root, &session_id);
     write_review_full_output(
         &session_dir,
         r#"<!-- CSA:SECTION:summary -->
@@ -745,7 +771,7 @@ start = 300
     )
     .expect("write invalid findings.toml");
 
-    let meta = make_review_meta(session_id);
+    let meta = make_review_meta(&session_id);
     persist_review_findings_toml(&project_root, &meta);
 
     let actual = fs::read_to_string(session_dir.join("output").join("findings.toml"))

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -614,6 +614,7 @@ pub(crate) struct ReviewProjectPromptOptions<'a> {
 #[cfg(test)]
 mod tests {
     use super::write_multi_reviewer_consolidated_artifact;
+    use crate::test_env_lock::ScopedEnvVarRestore;
     use csa_core::env::CSA_SESSION_DIR_ENV_KEY;
     use csa_session::review_artifact::{Finding, ReviewArtifact, Severity, SeveritySummary};
     use std::fs;
@@ -622,41 +623,16 @@ mod tests {
 
     static REVIEW_RESOLVE_ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    struct ScopedEnvVar {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    impl ScopedEnvVar {
-        fn set(key: &'static str, value: &str) -> Self {
-            let original = std::env::var(key).ok();
-            // SAFETY: test-scoped env mutation guarded by REVIEW_RESOLVE_ENV_LOCK.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, original }
-        }
-    }
-
-    impl Drop for ScopedEnvVar {
-        fn drop(&mut self) {
-            // SAFETY: test-scoped env mutation guarded by REVIEW_RESOLVE_ENV_LOCK.
-            unsafe {
-                match self.original.take() {
-                    Some(value) => std::env::set_var(self.key, value),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
-    }
-
     #[test]
-    fn write_multi_reviewer_consolidated_artifact_reads_parent_reviewer_dir() {
+    fn write_multi_reviewer_consolidated_artifact_reads_current_session_reviewer_dir() {
         let _env_lock = REVIEW_RESOLVE_ENV_LOCK
             .lock()
             .expect("review resolve env lock poisoned");
         let temp = tempdir().expect("tempdir should be created");
         let session_dir = temp.path().display().to_string();
-        let _session_dir_guard = ScopedEnvVar::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
-        let _session_id_guard = ScopedEnvVar::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
+        let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
+        let _session_id_guard =
+            ScopedEnvVarRestore::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
 
         let reviewer_dir = temp.path().join("reviewer-1");
         fs::create_dir_all(&reviewer_dir).expect("reviewer dir should be created");

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -614,20 +614,15 @@ pub(crate) struct ReviewProjectPromptOptions<'a> {
 #[cfg(test)]
 mod tests {
     use super::write_multi_reviewer_consolidated_artifact;
-    use crate::test_env_lock::ScopedEnvVarRestore;
+    use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
     use csa_core::env::CSA_SESSION_DIR_ENV_KEY;
     use csa_session::review_artifact::{Finding, ReviewArtifact, Severity, SeveritySummary};
     use std::fs;
-    use std::sync::Mutex;
     use tempfile::tempdir;
-
-    static REVIEW_RESOLVE_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn write_multi_reviewer_consolidated_artifact_reads_current_session_reviewer_dir() {
-        let _env_lock = REVIEW_RESOLVE_ENV_LOCK
-            .lock()
-            .expect("review resolve env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock poisoned");
         let temp = tempdir().expect("tempdir should be created");
         let session_dir = temp.path().display().to_string();
         let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -11,31 +11,7 @@ use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, Todo
 use std::{collections::HashMap, process::Command};
 use tempfile::TempDir;
 
-pub(super) struct ScopedEnvVarRestore {
-    key: &'static str,
-    original: Option<String>,
-}
-
-impl ScopedEnvVarRestore {
-    pub(super) fn set(key: &'static str, value: &str) -> Self {
-        let original = std::env::var(key).ok();
-        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, original }
-    }
-}
-
-impl Drop for ScopedEnvVarRestore {
-    fn drop(&mut self) {
-        // SAFETY: restoration of test-scoped env mutation.
-        unsafe {
-            match self.original.take() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-}
+pub(crate) use crate::test_env_lock::ScopedEnvVarRestore;
 
 fn assume_review_tools_available() -> (std::sync::MutexGuard<'static, ()>, ScopedEnvVarRestore) {
     (

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -1,12 +1,9 @@
 use super::*;
-use crate::test_env_lock::ScopedEnvVarRestore;
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use csa_config::{GlobalConfig, ProjectMeta, ResourcesConfig, ToolConfig};
 use csa_core::env::{CSA_PARENT_SESSION_DIR_ENV_KEY, CSA_SESSION_DIR_ENV_KEY};
 use csa_session::review_artifact::{Finding, ReviewArtifact, Severity, SeveritySummary};
-use std::sync::Mutex;
 use tempfile::tempdir;
-
-static REVIEWER_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
     let mut tool_map = HashMap::new();
@@ -232,9 +229,7 @@ fn parse_review_verdict_accepts_clean_phrase_without_explicit_token() {
 
 #[test]
 fn build_multi_reviewer_instruction_prefers_current_session_dir_env_when_both_exist() {
-    let _env_lock = REVIEWER_ENV_LOCK
-        .lock()
-        .expect("reviewer env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock poisoned");
     let _parent_guard =
         ScopedEnvVarRestore::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
     let _session_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, "/tmp/child-session");
@@ -250,9 +245,7 @@ fn build_multi_reviewer_instruction_prefers_current_session_dir_env_when_both_ex
 
 #[test]
 fn build_multi_reviewer_instruction_falls_back_to_parent_session_dir_env() {
-    let _env_lock = REVIEWER_ENV_LOCK
-        .lock()
-        .expect("reviewer env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock poisoned");
     let _parent_guard =
         ScopedEnvVarRestore::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
     let _session_guard = ScopedEnvVarRestore::unset(CSA_SESSION_DIR_ENV_KEY);
@@ -264,9 +257,7 @@ fn build_multi_reviewer_instruction_falls_back_to_parent_session_dir_env() {
 
 #[test]
 fn build_multi_reviewer_instruction_uses_session_first_shell_fallback_when_env_missing() {
-    let _env_lock = REVIEWER_ENV_LOCK
-        .lock()
-        .expect("reviewer env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock poisoned");
     let _parent_guard = ScopedEnvVarRestore::unset(CSA_PARENT_SESSION_DIR_ENV_KEY);
     let _session_guard = ScopedEnvVarRestore::unset(CSA_SESSION_DIR_ENV_KEY);
 

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::test_env_lock::ScopedEnvVarRestore;
 use csa_config::{GlobalConfig, ProjectMeta, ResourcesConfig, ToolConfig};
 use csa_core::env::{CSA_PARENT_SESSION_DIR_ENV_KEY, CSA_SESSION_DIR_ENV_KEY};
 use csa_session::review_artifact::{Finding, ReviewArtifact, Severity, SeveritySummary};
@@ -6,39 +7,6 @@ use std::sync::Mutex;
 use tempfile::tempdir;
 
 static REVIEWER_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-struct ScopedEnvVar {
-    key: &'static str,
-    original: Option<String>,
-}
-
-impl ScopedEnvVar {
-    fn set(key: &'static str, value: &str) -> Self {
-        let original = std::env::var(key).ok();
-        // SAFETY: test-scoped env mutation guarded by REVIEWER_ENV_LOCK.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, original }
-    }
-
-    fn unset(key: &'static str) -> Self {
-        let original = std::env::var(key).ok();
-        // SAFETY: test-scoped env mutation guarded by REVIEWER_ENV_LOCK.
-        unsafe { std::env::remove_var(key) };
-        Self { key, original }
-    }
-}
-
-impl Drop for ScopedEnvVar {
-    fn drop(&mut self) {
-        // SAFETY: test-scoped env mutation guarded by REVIEWER_ENV_LOCK.
-        unsafe {
-            match self.original.take() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-}
 
 fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
     let mut tool_map = HashMap::new();
@@ -267,8 +235,9 @@ fn build_multi_reviewer_instruction_prefers_current_session_dir_env_when_both_ex
     let _env_lock = REVIEWER_ENV_LOCK
         .lock()
         .expect("reviewer env lock poisoned");
-    let _parent_guard = ScopedEnvVar::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
-    let _session_guard = ScopedEnvVar::set(CSA_SESSION_DIR_ENV_KEY, "/tmp/child-session");
+    let _parent_guard =
+        ScopedEnvVarRestore::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
+    let _session_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, "/tmp/child-session");
 
     let prompt = build_multi_reviewer_instruction("Base prompt", 2, ToolName::Codex, None);
 
@@ -284,8 +253,9 @@ fn build_multi_reviewer_instruction_falls_back_to_parent_session_dir_env() {
     let _env_lock = REVIEWER_ENV_LOCK
         .lock()
         .expect("reviewer env lock poisoned");
-    let _parent_guard = ScopedEnvVar::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
-    let _session_guard = ScopedEnvVar::unset(CSA_SESSION_DIR_ENV_KEY);
+    let _parent_guard =
+        ScopedEnvVarRestore::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
+    let _session_guard = ScopedEnvVarRestore::unset(CSA_SESSION_DIR_ENV_KEY);
 
     let prompt = build_multi_reviewer_instruction("Base prompt", 3, ToolName::Codex, None);
 
@@ -297,8 +267,8 @@ fn build_multi_reviewer_instruction_uses_session_first_shell_fallback_when_env_m
     let _env_lock = REVIEWER_ENV_LOCK
         .lock()
         .expect("reviewer env lock poisoned");
-    let _parent_guard = ScopedEnvVar::unset(CSA_PARENT_SESSION_DIR_ENV_KEY);
-    let _session_guard = ScopedEnvVar::unset(CSA_SESSION_DIR_ENV_KEY);
+    let _parent_guard = ScopedEnvVarRestore::unset(CSA_PARENT_SESSION_DIR_ENV_KEY);
+    let _session_guard = ScopedEnvVarRestore::unset(CSA_SESSION_DIR_ENV_KEY);
 
     let prompt = build_multi_reviewer_instruction("Base prompt", 4, ToolName::Codex, None);
 

--- a/crates/cli-sub-agent/src/test_env_lock.rs
+++ b/crates/cli-sub-agent/src/test_env_lock.rs
@@ -4,23 +4,26 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 #[allow(dead_code)]
 pub(crate) static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
-fn restore_env_var(key: &'static str, original: &mut Option<OsString>) {
+fn restore_env_snapshot(key: &'static str, previous: Option<OsString>) {
     // SAFETY: all tests in this crate that mutate process env must hold TEST_ENV_LOCK
     // for the entire lifetime of the restore guard; private per-module env locks are forbidden.
     unsafe {
-        match original.take() {
+        match previous {
             Some(value) => std::env::set_var(key, value),
             None => std::env::remove_var(key),
         }
     }
 }
 
+#[allow(dead_code)]
 pub(crate) struct ScopedEnvVarRestore {
     key: &'static str,
     original: Option<OsString>,
 }
 
+#[allow(dead_code)]
 impl ScopedEnvVarRestore {
+    #[allow(dead_code)]
     pub(crate) fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
         let original = std::env::var_os(key);
         // SAFETY: all tests in this crate that touch process env must hold TEST_ENV_LOCK;
@@ -29,6 +32,7 @@ impl ScopedEnvVarRestore {
         Self { key, original }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn unset(key: &'static str) -> Self {
         let original = std::env::var_os(key);
         // SAFETY: all tests in this crate that touch process env must hold TEST_ENV_LOCK;
@@ -40,7 +44,7 @@ impl ScopedEnvVarRestore {
 
 impl Drop for ScopedEnvVarRestore {
     fn drop(&mut self) {
-        restore_env_var(self.key, &mut self.original);
+        restore_env_snapshot(self.key, self.original.take());
     }
 }
 
@@ -68,6 +72,6 @@ impl ScopedTestEnvVar {
 
 impl Drop for ScopedTestEnvVar {
     fn drop(&mut self) {
-        restore_env_var(self.key, &mut self.original);
+        restore_env_snapshot(self.key, self.original.take());
     }
 }

--- a/crates/cli-sub-agent/src/test_env_lock.rs
+++ b/crates/cli-sub-agent/src/test_env_lock.rs
@@ -4,6 +4,17 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 #[allow(dead_code)]
 pub(crate) static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
+fn restore_env_var(key: &'static str, original: &mut Option<OsString>) {
+    // SAFETY: all tests in this crate that mutate process env must hold TEST_ENV_LOCK
+    // for the entire lifetime of the restore guard; private per-module env locks are forbidden.
+    unsafe {
+        match original.take() {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+}
+
 pub(crate) struct ScopedEnvVarRestore {
     key: &'static str,
     original: Option<OsString>,
@@ -12,14 +23,16 @@ pub(crate) struct ScopedEnvVarRestore {
 impl ScopedEnvVarRestore {
     pub(crate) fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
         let original = std::env::var_os(key);
-        // SAFETY: caller must hold TEST_ENV_LOCK or another equivalent test-only env lock.
+        // SAFETY: all tests in this crate that touch process env must hold TEST_ENV_LOCK;
+        // private per-module env locks are forbidden because env is process-wide.
         unsafe { std::env::set_var(key, value) };
         Self { key, original }
     }
 
     pub(crate) fn unset(key: &'static str) -> Self {
         let original = std::env::var_os(key);
-        // SAFETY: caller must hold TEST_ENV_LOCK or another equivalent test-only env lock.
+        // SAFETY: all tests in this crate that touch process env must hold TEST_ENV_LOCK;
+        // private per-module env locks are forbidden because env is process-wide.
         unsafe { std::env::remove_var(key) };
         Self { key, original }
     }
@@ -27,14 +40,7 @@ impl ScopedEnvVarRestore {
 
 impl Drop for ScopedEnvVarRestore {
     fn drop(&mut self) {
-        // SAFETY: caller holds TEST_ENV_LOCK or another equivalent test-only env lock
-        // for the entire lifetime of this guard.
-        unsafe {
-            match self.original.take() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
+        restore_env_var(self.key, &mut self.original);
     }
 }
 
@@ -62,12 +68,6 @@ impl ScopedTestEnvVar {
 
 impl Drop for ScopedTestEnvVar {
     fn drop(&mut self) {
-        // SAFETY: restoration of test-scoped env mutation guarded by a process-wide mutex.
-        unsafe {
-            match self.original.take() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
+        restore_env_var(self.key, &mut self.original);
     }
 }

--- a/crates/cli-sub-agent/src/test_env_lock.rs
+++ b/crates/cli-sub-agent/src/test_env_lock.rs
@@ -1,8 +1,44 @@
 use std::ffi::OsString;
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
+#[allow(dead_code)]
 pub(crate) static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
+pub(crate) struct ScopedEnvVarRestore {
+    key: &'static str,
+    original: Option<OsString>,
+}
+
+impl ScopedEnvVarRestore {
+    pub(crate) fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var_os(key);
+        // SAFETY: caller must hold TEST_ENV_LOCK or another equivalent test-only env lock.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+
+    pub(crate) fn unset(key: &'static str) -> Self {
+        let original = std::env::var_os(key);
+        // SAFETY: caller must hold TEST_ENV_LOCK or another equivalent test-only env lock.
+        unsafe { std::env::remove_var(key) };
+        Self { key, original }
+    }
+}
+
+impl Drop for ScopedEnvVarRestore {
+    fn drop(&mut self) {
+        // SAFETY: caller holds TEST_ENV_LOCK or another equivalent test-only env lock
+        // for the entire lifetime of this guard.
+        unsafe {
+            match self.original.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[allow(dead_code)]
 pub(crate) struct ScopedTestEnvVar {
     key: &'static str,
     original: Option<OsString>,
@@ -10,6 +46,7 @@ pub(crate) struct ScopedTestEnvVar {
 }
 
 impl ScopedTestEnvVar {
+    #[allow(dead_code)]
     pub(crate) fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
         let lock = TEST_ENV_LOCK.lock().unwrap();
         let original = std::env::var_os(key);

--- a/crates/cli-sub-agent/tests/review_mode_compat.rs
+++ b/crates/cli-sub-agent/tests/review_mode_compat.rs
@@ -6,6 +6,9 @@ mod review_consensus;
 #[allow(dead_code)]
 #[path = "../src/review_prior_rounds.rs"]
 mod review_prior_rounds;
+#[allow(dead_code)]
+#[path = "../src/test_env_lock.rs"]
+mod test_env_lock;
 
 use chrono::{TimeZone, Utc};
 use clap::{Parser, error::ErrorKind};


### PR DESCRIPTION
## Summary
- centralize the review test env restore helper into the shared test support module
- remove duplicate env guard implementations from review consensus and review resolve tests
- rename the consolidator test to match the current-session behavior it actually covers
- bump the workspace version to 0.1.359

## Why
- issue #811 was pure test cleanup: the same env-var RAII helper existed in multiple review test files, which made the test surface noisier and easier to drift
- issue #813 was revalidated on current `main` and closed separately as stale after confirming the old Unix-path-specific failure mode no longer exists after #843 and #850

## Validation
- `cargo test -p cli-sub-agent pipeline_tests_review_target`
- `cargo test -p cli-sub-agent write_multi_reviewer_consolidated_artifact_reads_current_session_reviewer_dir`
- `cargo test -p cli-sub-agent build_multi_reviewer_instruction_`
- `just pre-commit`
- `csa review --range main...HEAD --sa-mode true --tier tier-4-critical`

Closes #811

Recon session: `01KPGS7D4D3VTD4HDE2HAH8PSV`
