### PR TITLE
fix(csa-process): stderr-only activity no longer masks stdout-progress timeout (#831)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.359"
+version = "0.1.360"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.359"
+version = "0.1.360"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-process/src/lib.rs
+++ b/crates/csa-process/src/lib.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, BufReader};
 use tokio::process::Command;
+use tokio::time::MissedTickBehavior;
 use tracing::warn;
 mod idle_watchdog;
 use idle_watchdog::should_terminate_for_idle;
@@ -321,7 +322,7 @@ pub async fn wait_and_capture_with_idle_timeout(
     let mut stderr_output = String::new();
     let execution_start = Instant::now();
     let mut last_activity = Instant::now();
-    let mut last_stdout_activity = last_activity;
+    let last_stdout_activity = last_activity;
     let mut last_heartbeat = execution_start;
     let heartbeat_interval = resolve_heartbeat_interval();
     let mut liveness_dead_since: Option<Instant> = None;
@@ -346,6 +347,8 @@ pub async fn wait_and_capture_with_idle_timeout(
         let mut stderr_done = false;
         let mut stdout_buf = [0u8; READ_BUF_SIZE];
         let mut stderr_buf = [0u8; READ_BUF_SIZE];
+        let mut watchdog_tick = tokio::time::interval(IDLE_POLL_INTERVAL);
+        watchdog_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         while !stdout_done || !stderr_done {
             tokio::select! {
@@ -359,7 +362,6 @@ pub async fn wait_and_capture_with_idle_timeout(
                         Ok(n) => {
                             received_first_output = true;
                             last_activity = Instant::now();
-                            last_stdout_activity = last_activity;
                             last_heartbeat = last_activity;
                             liveness_dead_since = None;
                             next_liveness_poll_at = None;
@@ -443,7 +445,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                         }
                     }
                 }
-                _ = tokio::time::sleep(IDLE_POLL_INTERVAL) => {
+                _ = watchdog_tick.tick() => {
                     let effective_idle = if !received_first_output {
                         initial_response_timeout.unwrap_or(idle_timeout)
                     } else {
@@ -503,6 +505,8 @@ pub async fn wait_and_capture_with_idle_timeout(
     } else {
         // No stderr handle (shouldn't happen with spawn_tool, but handle gracefully)
         let mut stdout_buf = [0u8; READ_BUF_SIZE];
+        let mut watchdog_tick = tokio::time::interval(IDLE_POLL_INTERVAL);
+        watchdog_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
         loop {
             tokio::select! {
                 result = stdout_reader.read(&mut stdout_buf) => {
@@ -514,7 +518,6 @@ pub async fn wait_and_capture_with_idle_timeout(
                         Ok(n) => {
                             received_first_output = true;
                             last_activity = Instant::now();
-                            last_stdout_activity = last_activity;
                             last_heartbeat = last_activity;
                             liveness_dead_since = None;
                             next_liveness_poll_at = None;
@@ -547,7 +550,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                         }
                     }
                 }
-                _ = tokio::time::sleep(IDLE_POLL_INTERVAL) => {
+                _ = watchdog_tick.tick() => {
                     let effective_idle = if !received_first_output {
                         initial_response_timeout.unwrap_or(idle_timeout)
                     } else {

--- a/crates/csa-process/src/lib.rs
+++ b/crates/csa-process/src/lib.rs
@@ -321,6 +321,7 @@ pub async fn wait_and_capture_with_idle_timeout(
     let mut stderr_output = String::new();
     let execution_start = Instant::now();
     let mut last_activity = Instant::now();
+    let mut last_stdout_activity = last_activity;
     let mut last_heartbeat = execution_start;
     let heartbeat_interval = resolve_heartbeat_interval();
     let mut liveness_dead_since: Option<Instant> = None;
@@ -358,6 +359,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                         Ok(n) => {
                             received_first_output = true;
                             last_activity = Instant::now();
+                            last_stdout_activity = last_activity;
                             last_heartbeat = last_activity;
                             liveness_dead_since = None;
                             next_liveness_poll_at = None;
@@ -457,7 +459,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                     // Skip liveness polling for initial-response timeout:
                     // kill immediately once elapsed time exceeds the threshold.
                     let should_kill = if !received_first_output && initial_response_timeout.is_some() {
-                        last_activity.elapsed() >= effective_idle
+                        last_stdout_activity.elapsed() >= effective_idle
                     } else {
                         should_terminate_for_idle(
                             &mut last_activity,
@@ -512,6 +514,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                         Ok(n) => {
                             received_first_output = true;
                             last_activity = Instant::now();
+                            last_stdout_activity = last_activity;
                             last_heartbeat = last_activity;
                             liveness_dead_since = None;
                             next_liveness_poll_at = None;
@@ -560,7 +563,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                     // Skip liveness polling for initial-response timeout:
                     // kill immediately once elapsed time exceeds the threshold.
                     let should_kill = if !received_first_output && initial_response_timeout.is_some() {
-                        last_activity.elapsed() >= effective_idle
+                        last_stdout_activity.elapsed() >= effective_idle
                     } else {
                         should_terminate_for_idle(
                             &mut last_activity,

--- a/crates/csa-process/src/lib_tests_tail.rs
+++ b/crates/csa-process/src/lib_tests_tail.rs
@@ -388,6 +388,50 @@ async fn initial_response_timeout_ignores_stderr_only_activity_for_legacy_proces
 }
 
 #[tokio::test]
+async fn initial_response_timeout_fires_under_high_frequency_stderr() {
+    let mut cmd = Command::new("bash");
+    cmd.args([
+        "-c",
+        "while true; do printf 'tick\\n' >&2; sleep 0.01; done",
+    ]);
+
+    let child = spawn_tool(cmd, None).await.expect("spawn");
+    let start = Instant::now();
+    let result = wait_and_capture_with_idle_timeout(
+        child,
+        StreamMode::BufferOnly,
+        Duration::from_secs(10),
+        Duration::from_secs(10),
+        Duration::from_millis(100),
+        None,
+        SpawnOptions::default(),
+        Some(Duration::from_secs(1)),
+    )
+    .await
+    .expect("wait");
+    let elapsed = start.elapsed();
+
+    assert_eq!(
+        result.exit_code, 137,
+        "high-frequency stderr chatter must not starve the initial-response watchdog"
+    );
+    assert!(
+        result.summary.contains("initial_response_timeout"),
+        "summary should classify the kill as initial_response_timeout, got: {}",
+        result.summary
+    );
+    assert!(
+        result.summary.contains("no stdout output"),
+        "summary should explain that no stdout was observed, got: {}",
+        result.summary
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "watchdog should still fire promptly under stderr chatter, elapsed={elapsed:?}"
+    );
+}
+
+#[tokio::test]
 async fn idle_timeout_still_respects_stderr_after_first_stdout() {
     let mut cmd = Command::new("bash");
     cmd.args([

--- a/crates/csa-process/src/lib_tests_tail.rs
+++ b/crates/csa-process/src/lib_tests_tail.rs
@@ -349,6 +349,77 @@ async fn test_idle_timeout_with_dead_process_kills_after_dead_timeout() {
     );
 }
 
+#[tokio::test]
+async fn initial_response_timeout_ignores_stderr_only_activity_for_legacy_process() {
+    let mut cmd = Command::new("bash");
+    cmd.args([
+        "-c",
+        "while true; do printf 'heartbeat\\n' >&2; sleep 0.3; done",
+    ]);
+
+    let child = spawn_tool(cmd, None).await.expect("spawn");
+    let result = wait_and_capture_with_idle_timeout(
+        child,
+        StreamMode::BufferOnly,
+        Duration::from_secs(10),
+        Duration::from_secs(10),
+        Duration::from_secs(DEFAULT_TERMINATION_GRACE_PERIOD_SECS),
+        None,
+        SpawnOptions::default(),
+        Some(Duration::from_secs(2)),
+    )
+    .await
+    .expect("wait");
+
+    assert_eq!(
+        result.exit_code, 137,
+        "stderr-only chatter must not keep the initial-response watchdog alive"
+    );
+    assert!(
+        result.summary.contains("initial_response_timeout"),
+        "summary should classify the kill as initial_response_timeout, got: {}",
+        result.summary
+    );
+    assert!(
+        result.summary.contains("no stdout output"),
+        "summary should explain that no stdout was observed, got: {}",
+        result.summary
+    );
+}
+
+#[tokio::test]
+async fn idle_timeout_still_respects_stderr_after_first_stdout() {
+    let mut cmd = Command::new("bash");
+    cmd.args([
+        "-c",
+        "printf x; for _ in 1 2 3 4 5 6; do printf 'heartbeat\\n' >&2; sleep 0.3; done",
+    ]);
+
+    let child = spawn_tool(cmd, None).await.expect("spawn");
+    let result = wait_and_capture_with_idle_timeout(
+        child,
+        StreamMode::BufferOnly,
+        Duration::from_secs(1),
+        Duration::from_secs(10),
+        Duration::from_secs(DEFAULT_TERMINATION_GRACE_PERIOD_SECS),
+        None,
+        SpawnOptions::default(),
+        Some(Duration::from_secs(2)),
+    )
+    .await
+    .expect("wait");
+
+    assert_eq!(
+        result.exit_code, 0,
+        "stderr after first stdout should continue counting as liveness"
+    );
+    assert_eq!(result.output, "x");
+    assert!(
+        !result.summary.contains("initial_response_timeout"),
+        "post-first-stdout process should not be classified as initial_response_timeout"
+    );
+}
+
 #[test]
 fn test_is_working_reads_proc_stat() {
     // Our own process should be in R or S state.


### PR DESCRIPTION
## Summary
- separate the pre-first-stdout watchdog from the general activity clock in legacy process watching
- keep stderr-driven liveness for the post-first-stdout idle path while making initial-response timeout stdout-strict
- add regression tests for stderr-only chatter and post-first-stdout stderr heartbeats

## Verification
- cargo test -p csa-process
- cargo test -p cli-sub-agent
- just pre-commit
- csa review --range main...HEAD --sa-mode true --tier tier-4-critical

Recon session: `01KPH3NW3WMXQVQRKTQ41TDM4Q`

Closes #831