### PR TITLE
chore: wc -l over grep -c + clearer tier-unknown log + fix review_cmd_output parallel race (#786, #836)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.360"
+version = "0.1.361"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.360"
+version = "0.1.361"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -2,6 +2,7 @@ use super::{
     PersistedReviewArtifact, ToolReviewFailureKind, derive_decision_from_text,
     detect_tool_review_failure, ensure_review_summary_artifact, persist_review_verdict,
 };
+use crate::test_env_lock::TEST_ENV_LOCK;
 use csa_core::types::{ReviewDecision, ToolName};
 use csa_session::state::ReviewSessionMeta;
 use csa_session::{Finding, ReviewArtifact, ReviewVerdictArtifact, Severity, SeveritySummary};
@@ -9,6 +10,7 @@ use serde_json::json;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::MutexGuard;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn make_review_meta(session_id: &str) -> ReviewSessionMeta {
@@ -69,6 +71,18 @@ fn create_session_dir(project_root: &Path, session_id: &str) -> PathBuf {
         .join(session_id);
     fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
     session_dir
+}
+
+fn lock_test_session(
+    test_name: &str,
+    session_id: &str,
+) -> (MutexGuard<'static, ()>, PathBuf, PathBuf) {
+    let env_lock = TEST_ENV_LOCK
+        .lock()
+        .expect("review_cmd_output env lock poisoned");
+    let project_root = temp_project_root(test_name);
+    let session_dir = create_session_dir(&project_root, session_id);
+    (env_lock, project_root, session_dir)
 }
 
 #[test]
@@ -153,9 +167,9 @@ fn detect_tool_review_failure_handles_guarded_browser_prompt_variant() {
 
 #[test]
 fn persist_review_verdict_skips_when_ai_file_exists() {
-    let project_root = temp_project_root("persist-review-verdict-skip");
     let session_id = "01TESTSKIP0000000000000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-skip", session_id);
     let verdict_path = session_dir.join("output").join("review-verdict.json");
     let ai_payload = r#"{"ai":"preserved"}"#;
     fs::write(&verdict_path, ai_payload).expect("write AI verdict artifact");
@@ -171,9 +185,9 @@ fn persist_review_verdict_skips_when_ai_file_exists() {
 
 #[test]
 fn persist_review_verdict_prefers_structured_findings_summary() {
-    let project_root = temp_project_root("persist-review-verdict-findings");
     let session_id = "01TESTFINDINGS000000000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-findings", session_id);
     let findings_path = session_dir.join("review-findings.json");
     let findings = vec![
         make_finding(Severity::High, "high"),
@@ -219,9 +233,9 @@ fn persist_review_verdict_prefers_structured_findings_summary() {
 
 #[test]
 fn persist_review_verdict_falls_back_to_full_output_transcript_counts() {
-    let project_root = temp_project_root("persist-review-verdict-full-output");
     let session_id = "01TESTFULL0000000000000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-full-output", session_id);
     let full_output = [
         json!({"type":"thread.started","thread_id":"thread-1"}),
         json!({"type":"item.completed","item":{
@@ -257,9 +271,9 @@ fn persist_review_verdict_falls_back_to_full_output_transcript_counts() {
 
 #[test]
 fn persist_review_verdict_falls_back_to_priority_markers_in_full_output() {
-    let project_root = temp_project_root("persist-review-verdict-priority-markers");
     let session_id = "01TESTPRIORITYMARKERS000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-priority-markers", session_id);
     let full_output = [json!({"type":"item.completed","item":{
         "id":"item_1",
         "type":"agent_message",
@@ -292,9 +306,9 @@ fn persist_review_verdict_falls_back_to_priority_markers_in_full_output() {
 
 #[test]
 fn ensure_review_summary_artifact_synthesizes_summary_from_details_only_output() {
-    let project_root = temp_project_root("review-summary-synthesis");
     let session_id = "01TESTSUMMARYSYNTH000000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("review-summary-synthesis", session_id);
     let details_only =
         "<!-- CSA:SECTION:details -->\nFAIL\nDetailed body\n<!-- CSA:SECTION:details:END -->\n";
     csa_session::persist_structured_output(&session_dir, details_only).expect("persist details");
@@ -319,9 +333,9 @@ fn ensure_review_summary_artifact_synthesizes_summary_from_details_only_output()
 
 #[test]
 fn ensure_review_summary_artifact_preserves_existing_summary_section() {
-    let project_root = temp_project_root("review-summary-preserve");
     let session_id = "01TESTSUMMARYKEEP0000000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("review-summary-preserve", session_id);
     let output = "<!-- CSA:SECTION:summary -->\nReview completed successfully.\n<!-- CSA:SECTION:summary:END -->\n\
 <!-- CSA:SECTION:details -->\nDetailed body\n<!-- CSA:SECTION:details:END -->\n";
     csa_session::persist_structured_output(&session_dir, output).expect("persist structured");
@@ -348,9 +362,9 @@ fn ensure_review_summary_artifact_preserves_existing_summary_section() {
 
 #[test]
 fn ensure_review_summary_artifact_preserves_existing_multiline_summary_section() {
-    let project_root = temp_project_root("review-summary-preserve-multiline");
     let session_id = "01TESTSUMMARYMULTILINE000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("review-summary-preserve-multiline", session_id);
     let output = "<!-- CSA:SECTION:summary -->\nLine 1\nLine 2\nLine 3\n<!-- CSA:SECTION:summary:END -->\n\
 <!-- CSA:SECTION:details -->\nFAIL\nDetailed body\n<!-- CSA:SECTION:details:END -->\n";
     csa_session::persist_structured_output(&session_dir, output).expect("persist structured");
@@ -377,9 +391,9 @@ fn ensure_review_summary_artifact_preserves_existing_multiline_summary_section()
 
 #[test]
 fn ensure_review_summary_artifact_replaces_stale_summary_for_same_session_fix_rounds() {
-    let project_root = temp_project_root("review-summary-same-session-fix");
     let session_id = "01TESTSUMMARYSAMEROUND000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("review-summary-same-session-fix", session_id);
     let round_1 = "<!-- CSA:SECTION:summary -->\nFAIL: stale finding\n<!-- CSA:SECTION:summary:END -->\n\
 <!-- CSA:SECTION:details -->\nFAIL: stale finding\nDetailed body\n<!-- CSA:SECTION:details:END -->\n";
     csa_session::persist_structured_output(&session_dir, round_1).expect("persist round 1");
@@ -399,9 +413,9 @@ fn ensure_review_summary_artifact_replaces_stale_summary_for_same_session_fix_ro
 
 #[test]
 fn persist_review_verdict_marks_clean_transcript_as_pass() {
-    let project_root = temp_project_root("persist-review-verdict-pass");
     let session_id = "01TESTPASS0000000000000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-pass", session_id);
     let full_output = [json!({"type":"item.completed","item":{
         "id":"item_1",
         "type":"agent_message",
@@ -430,9 +444,9 @@ fn persist_review_verdict_marks_clean_transcript_as_pass() {
 
 #[test]
 fn persist_review_verdict_plain_text_full_output_falls_back_to_review_meta_findings() {
-    let project_root = temp_project_root("persist-review-verdict-meta-fallback");
     let session_id = "01TESTMETAFALLBACK000000000";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-meta-fallback", session_id);
     fs::write(
         session_dir.join("output").join("full.md"),
         "Findings\n1. [High][regression] fallback path should preserve review_meta\nOverall risk: high",
@@ -460,9 +474,9 @@ fn persist_review_verdict_plain_text_full_output_falls_back_to_review_meta_findi
 
 #[test]
 fn persist_review_verdict_concrete_findings_override_uncertain_token() {
-    let project_root = temp_project_root("persist-review-verdict-concrete-over-uncertain");
     let session_id = "01TESTCONCRETEOVERUNCERTAIN";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-concrete-over-uncertain", session_id);
     let full_output = [json!({"type":"item.completed","item":{
         "id":"item_1",
         "type":"agent_message",
@@ -492,9 +506,11 @@ fn persist_review_verdict_concrete_findings_override_uncertain_token() {
 
 #[test]
 fn persist_review_verdict_empty_structured_findings_preserve_uncertain_meta() {
-    let project_root = temp_project_root("persist-review-verdict-empty-findings-uncertain");
     let session_id = "01TESTEMPTYFINDINGSUNCERTAIN";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) = lock_test_session(
+        "persist-review-verdict-empty-findings-uncertain",
+        session_id,
+    );
     let findings_path = session_dir.join("review-findings.json");
     let artifact = json!({
         "findings": [],
@@ -523,9 +539,9 @@ fn persist_review_verdict_empty_structured_findings_preserve_uncertain_meta() {
 
 #[test]
 fn persist_review_verdict_json_transcript_without_review_message_falls_back_to_review_meta() {
-    let project_root = temp_project_root("persist-review-verdict-json-no-review-message");
     let session_id = "01TESTJSONNOREVIEWMESSAGE00";
-    let session_dir = create_session_dir(&project_root, session_id);
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-json-no-review-message", session_id);
     let full_output = [
         json!({"type":"thread.started","thread_id":"thread-1"}),
         json!({"type":"item.completed","item":{

--- a/crates/cli-sub-agent/src/review_cmd_reviewers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers.rs
@@ -124,7 +124,9 @@ pub(crate) fn resolve_effective_reviewer_count(request: &AutoReviewerRequest<'_>
         info!(
             "Auto-selected {} heterogeneous reviewers from tier '{}': {}",
             selection.reviewers,
-            request.resolved_tier_name.unwrap_or("unknown"),
+            request
+                .resolved_tier_name
+                .unwrap_or("no tier name resolved"),
             tool_list
         );
         selection.reviewers

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -59,7 +59,7 @@ path to avoid no-op commit/version-bump steps.
 
 ```bash
 set -euo pipefail
-CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
+CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -vE '\.(md|txt|lock|toml)$' | wc -l | xargs)"
 TOTAL_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | wc -l | xargs)"
 TOTAL_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
 if [ "${TOTAL_FILES}" -eq 0 ]; then

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -59,7 +59,7 @@ path to avoid no-op commit/version-bump steps.
 
 ```bash
 set -euo pipefail
-CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -vE '\.(md|txt|lock|toml)$' | wc -l | xargs)"
+CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | awk '!/\.(md|txt|lock|toml)$/ { count++ } END { print count + 0 }')"
 TOTAL_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | wc -l | xargs)"
 TOTAL_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
 if [ "${TOTAL_FILES}" -eq 0 ]; then

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -60,7 +60,7 @@ path to avoid no-op commit/version-bump steps.
 ```bash
 set -euo pipefail
 CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
-TOTAL_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -c . || true)"
+TOTAL_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | wc -l | xargs)"
 TOTAL_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
 if [ "${TOTAL_FILES}" -eq 0 ]; then
   # Empty diff means HEAD matches the base branch; do not treat that as docs-only,

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -163,7 +163,7 @@ skip mktd/mktsk/debate but keep L1/L2 quality checks.
 ```bash
 set -euo pipefail
 CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
-TOTAL_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -c . || true)"
+TOTAL_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | wc -l | xargs)"
 TOTAL_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
 if [ "${TOTAL_FILES}" -eq 0 ]; then
   # Empty diff means HEAD matches the base branch; do not treat that as docs-only,

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -162,7 +162,7 @@ skip mktd/mktsk/debate but keep L1/L2 quality checks.
 
 ```bash
 set -euo pipefail
-CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -vE '\.(md|txt|lock|toml)$' | wc -l | xargs)"
+CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | awk '!/\.(md|txt|lock|toml)$/ { count++ } END { print count + 0 }')"
 TOTAL_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | wc -l | xargs)"
 TOTAL_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
 if [ "${TOTAL_FILES}" -eq 0 ]; then

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -162,7 +162,7 @@ skip mktd/mktsk/debate but keep L1/L2 quality checks.
 
 ```bash
 set -euo pipefail
-CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
+CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -vE '\.(md|txt|lock|toml)$' | wc -l | xargs)"
 TOTAL_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | wc -l | xargs)"
 TOTAL_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)"
 if [ "${TOTAL_FILES}" -eq 0 ]; then


### PR DESCRIPTION
## #786: replace `grep -c` with `wc -l`
The dev2merge pattern and workflow now count changed files with `wc -l | xargs` instead of `grep -c .`, which keeps empty-diff handling explicit and avoids the papercut around grep-specific counting behavior.

## #836: clarify unresolved tier-name logging
The auto-reviewer info log now says `no tier name resolved` instead of `unknown`, so the output reflects the actual state instead of implying an opaque fallback tier.

## review_cmd_output parallel race fix
`review_cmd_output_tests` now reuses the shared `TEST_ENV_LOCK` when a test resolves session paths through `get_session_root` / `get_session_dir`. That serializes the module against concurrent `HOME` / `XDG_STATE_HOME` mutation in other tests, which is the same class of process-wide env race previously fixed in #811/#813.

Closes #786
Closes #836
