### PR TITLE
fix(justfile): respect CARGO_TARGET_DIR + extra_writable missing-path guidance (#744)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.361"
+version = "0.1.362"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.361"
+version = "0.1.362"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/justfile
+++ b/justfile
@@ -36,11 +36,15 @@ _check_writable path attempted:
     fi
     echo >&2 "ERROR: attempted to write ${attempted} at ${path} (resolved: ${resolved_path}), but the path is not writable."
     echo >&2 "Adjust filesystem_sandbox.extra_writable in ~/.config/cli-sub-agent/config.toml to include ${resolved_path}."
+    echo >&2 "If ${resolved_path} does not exist yet, create it first (for example: mkdir -p '${resolved_path}'). CSA only auto-creates the default cargo/rustup/tmp writable paths, not user-supplied extra_writable entries."
     echo >&2 "If this is unexpected, file an issue: GH_CONFIG_DIR=~/.config/gh-aider gh issue create --repo RyderFreeman4Logos/cli-sub-agent --title \"Sandbox write denial for ${attempted}\" --body \"Attempted to write ${attempted} at ${path} (resolved: ${resolved_path}), but the sandbox denied it. Please include your sandbox mode and the writable path you expected.\""
     exit 2
 
 check-cargo-target-writable:
-    just _check_writable "{{_repo_root}}/target" "cargo build artifacts"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target_dir="${CARGO_TARGET_DIR:-{{_repo_root}}/target}"
+    just _check_writable "$target_dir" "cargo build artifacts"
 
 check-nextest-state-writable:
     #!/usr/bin/env bash
@@ -371,10 +375,13 @@ install-hooks:
 
 # Install latest local build to /usr/local/bin (reuses workspace target/ cache).
 install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target_dir="${CARGO_TARGET_DIR:-{{_repo_root}}/target}"
     just check-cargo-target-writable
     cargo build --release --all-features -p cli-sub-agent -p weave
-    install -m 755 "{{_repo_root}}"/target/release/csa /usr/local/bin/csa
-    install -m 755 "{{_repo_root}}"/target/release/weave /usr/local/bin/weave
+    install -m 755 "${target_dir}/release/csa" /usr/local/bin/csa
+    install -m 755 "${target_dir}/release/weave" /usr/local/bin/weave
     @echo "Verifying installation..."
     @csa --version
     @weave --version


### PR DESCRIPTION
Closes #744.

## What changed

### 1. Respect `CARGO_TARGET_DIR` in `justfile`

Before:
```bash
just _check_writable "{{_repo_root}}/target" "cargo build artifacts"
install -m 755 "{{_repo_root}}"/target/release/csa /usr/local/bin/csa
install -m 755 "{{_repo_root}}"/target/release/weave /usr/local/bin/weave
```

After:
```bash
target_dir="${CARGO_TARGET_DIR:-{{_repo_root}}/target}"
just _check_writable "$target_dir" "cargo build artifacts"
install -m 755 "${target_dir}/release/csa" /usr/local/bin/csa
install -m 755 "${target_dir}/release/weave" /usr/local/bin/weave
```

This keeps the writable preflight and install artifact path aligned with the caller-selected cargo target dir instead of assuming the repo-local `target/` tree.

### 2. Clarify missing-path guidance for `extra_writable`

Before:
```text
Adjust filesystem_sandbox.extra_writable in ~/.config/cli-sub-agent/config.toml to include <resolved_path>.
```

After:
```text
Adjust filesystem_sandbox.extra_writable in ~/.config/cli-sub-agent/config.toml to include <resolved_path>.
If <resolved_path> does not exist yet, create it first (for example: mkdir -p '<resolved_path>'). CSA only auto-creates the default cargo/rustup/tmp writable paths, not user-supplied extra_writable entries.
```

This makes the fail-fast hint actionable on fresh machines where the user follows the suggestion but the requested writable path has not been created yet.
