### PR TITLE
fix(justfile): strip `@` from install verification lines (regression from #744)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.362"
+version = "0.1.363"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.362"
+version = "0.1.363"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/justfile
+++ b/justfile
@@ -382,9 +382,9 @@ install:
     cargo build --release --all-features -p cli-sub-agent -p weave
     install -m 755 "${target_dir}/release/csa" /usr/local/bin/csa
     install -m 755 "${target_dir}/release/weave" /usr/local/bin/weave
-    @echo "Verifying installation..."
-    @csa --version
-    @weave --version
+    echo "Verifying installation..."
+    csa --version
+    weave --version
 
 # Bump patch version of all workspace crates atomically.
 # All crates inherit version.workspace, so a single workspace bump suffices.


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by PR #889 (#744 fix): the rewritten `install` recipe mixed `#!/usr/bin/env bash` shebang with `@echo` / `@csa --version` / `@weave --version` lines that only work under just's native line-mode. Under bash, `@echo` is parsed as a command literal → `@echo: command not found` (exit 127). This breaks `just install` on every clone since the merge.

## Repro

```
git checkout main           # at 270d2ded (post-#889 merge)
just install
# ...
# /path/to/just-XXXX/install: line 385: @echo: command not found
# error: Recipe `install` failed with exit code 127
```

## Fix

Remove the `@` prefix from three lines inside the bash-shebang recipe. bash doesn't need just's silent-echo semantics; the commands run identically without `@`.

```diff
-    @echo "Verifying installation..."
-    @csa --version
-    @weave --version
+    echo "Verifying installation..."
+    csa --version
+    weave --version
```

## Verification

`just install` now completes cleanly:

```
Verifying installation...
csa 0.1.362 (...)
weave 0.1.362 (...)
```

## Context

Found within minutes of merging #889 by the orchestrator running its own `git fetch && just install` post-merge step. A senior-engineer follow-up would have caught this during the pre-push `just pre-commit` run if `just pre-commit` exercised `just install` — it doesn't, so the break only surfaced post-merge. Followup worth filing: consider adding `just install` to pre-commit quality gates so this class of break is caught before landing.

## Version

0.1.362 → 0.1.363