### PR TITLE
fix(hooks): auto-bypass review-check in nested CSA sessions (#890)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.363"
+version = "0.1.364"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.363"
+version = "0.1.364"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/scripts/hooks/review-check.sh
+++ b/scripts/hooks/review-check.sh
@@ -9,6 +9,18 @@
 
 set -euo pipefail
 
+# Auto-bypass when running inside a nested CSA session (depth > 0).
+# Rationale: parent orchestrator reviews the final SHA before the user push
+# (pr-bot Step 2 cumulative local review + Step 8 fix re-review). Employee
+# push attempts should NOT trigger a nested csa review — that duplicates the
+# audit the parent already runs, burning ~1M tokens per duplicate session
+# (issue #890). The bypass is logged below with a distinguishable reason
+# starting with "nested CSA session" so audit trail is preserved.
+if [ -z "${CSA_SKIP_REVIEW_CHECK:-}" ] && [ "${CSA_DEPTH:-0}" -gt 0 ]; then
+  CSA_SKIP_REVIEW_CHECK=1
+  CSA_SKIP_REVIEW_CHECK_REASON="nested CSA session (depth=${CSA_DEPTH}, sid=${CSA_SESSION_ID:-<unknown>}); parent will review final SHA"
+fi
+
 if [ "${CSA_SKIP_REVIEW_CHECK:-0}" = "1" ]; then
   timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   head_sha="$(git rev-parse HEAD 2>/dev/null || echo "<unknown-head>")"


### PR DESCRIPTION
## Summary

- Auto-bypass `review-check.sh` when running inside a nested CSA session (`CSA_DEPTH > 0`), with audit log entry
- Depth-0 / unset: unchanged (original block-on-miss behavior preserved)
- Explicit `CSA_SKIP_REVIEW_CHECK=1`: unchanged (takes precedence)

## Why

When an employee CSA session's `git push` hit the pre-push `review-check.sh` block, the employee ran `csa review --range main...HEAD` itself to satisfy the gate, producing a depth-2 `review[2]` session that burned ~1.14M input tokens duplicating the audit the parent orchestrator will run anyway (pr-bot Step 2 + Step 8). See #890 for token-cost breakdown (~$4 per PR).

Empirically observed on PRs #888, #889, #891 — every employee push cycle spawned a nested review session.

## Fix

5 lines added to `scripts/hooks/review-check.sh` between `set -euo pipefail` and the existing `CSA_SKIP_REVIEW_CHECK` handler:

```bash
if [ -z "${CSA_SKIP_REVIEW_CHECK:-}" ] && [ "${CSA_DEPTH:-0}" -gt 0 ]; then
  CSA_SKIP_REVIEW_CHECK=1
  CSA_SKIP_REVIEW_CHECK_REASON="nested CSA session (depth=${CSA_DEPTH}, sid=${CSA_SESSION_ID:-<unknown>}); parent will review final SHA"
fi
```

The bypass falls through to the existing audit-log handler, which writes to `.csa/review-bypass.log` with the distinguishable reason starting `nested CSA session`.

## Semantic analysis

- **Gate preserved**: parent orchestrator (Layer 0 main agent running pr-bot) still runs Step 2 cumulative local review on the final SHA before user push. The employee is an intermediate node — its HEAD is not the final HEAD.
- **Audit preserved**: every bypass logged with depth + session id + reason. Distinguishable from manual bypasses by the reason prefix.
- **Attack surface**: `CSA_DEPTH` / `CSA_SESSION_ID` env vars are set by CSA itself, not user input. No realistic abuse path.
- **Back-compat**: depth=0, depth unset, explicit skip all behave identically to before.

## Test plan

- [x] `CSA_DEPTH=0` → block with "Push blocked — no csa review session recorded" (exit 1)
- [x] `CSA_DEPTH=1 CSA_SESSION_ID=01KTEST` → auto-bypass with audit log (exit 0, reason "nested CSA session (depth=1, sid=01KTEST)")
- [x] `CSA_DEPTH` unset → block (exit 1, unchanged)
- [x] `CSA_SKIP_REVIEW_CHECK=1` explicit → bypass with user reason (exit 0, existing path)
- [x] `.csa/review-bypass.log` records both nested and explicit bypasses with distinguishable reasons
- [x] `just pre-commit` passes (27/27 e2e + 3710 unit tests)
- [x] `just deny` passes (licenses ok, advisories ok)

Closes #890

🤖 Generated with [Claude Code](https://claude.com/claude-code)
