### PR TITLE
refactor(csa-pipeline): deduplicate per-tool initial-response timeout match arms (#879)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.365"
+version = "0.1.366"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.365"
+version = "0.1.366"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -85,16 +85,34 @@ pub(crate) fn resolve_idle_timeout_seconds(
 ///
 /// Priority: CLI override > project config > default (120s).
 /// Returns `None` when explicitly disabled (set to 0 in config or CLI).
+fn resolve_initial_response_timeout_with_default(
+    config: Option<&ProjectConfig>,
+    cli_override: Option<u64>,
+    default_seconds: u64,
+) -> Option<u64> {
+    let raw = cli_override
+        .or_else(|| config.and_then(|cfg| cfg.resources.initial_response_timeout_seconds));
+    csa_executor::resolve_initial_response_timeout(raw, default_seconds)
+}
+
+#[cfg(test)]
 pub(crate) fn resolve_initial_response_timeout_seconds(
     config: Option<&ProjectConfig>,
     cli_override: Option<u64>,
 ) -> Option<u64> {
-    let raw = cli_override
-        .or_else(|| config.and_then(|cfg| cfg.resources.initial_response_timeout_seconds));
-    csa_executor::resolve_initial_response_timeout(
-        raw,
+    resolve_initial_response_timeout_with_default(
+        config,
+        cli_override,
         DEFAULT_RESOURCES_INITIAL_RESPONSE_TIMEOUT_SECONDS,
     )
+}
+
+fn per_tool_default(tool_name: &str) -> u64 {
+    match tool_name {
+        "codex" => DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS,
+        "gemini-cli" => DEFAULT_GEMINI_INITIAL_RESPONSE_TIMEOUT_SECONDS,
+        _ => DEFAULT_RESOURCES_INITIAL_RESPONSE_TIMEOUT_SECONDS,
+    }
 }
 
 pub(crate) fn resolve_initial_response_timeout_for_tool(
@@ -110,40 +128,15 @@ pub(crate) fn resolve_initial_response_timeout_for_tool(
     if let Some(cli_override) = cli_initial_response_timeout {
         return csa_executor::resolve_initial_response_timeout(
             Some(cli_override),
-            DEFAULT_RESOURCES_INITIAL_RESPONSE_TIMEOUT_SECONDS,
+            per_tool_default(tool_name),
         );
     }
 
-    let tool_override = config.and_then(|cfg| cfg.tool_initial_response_timeout_seconds(tool_name));
+    let configured = config
+        .and_then(|cfg| cfg.tool_initial_response_timeout_seconds(tool_name))
+        .or_else(|| config.and_then(|cfg| cfg.resources.initial_response_timeout_seconds));
 
-    match tool_name {
-        "codex" => {
-            let configured = tool_override
-                .or_else(|| config.and_then(|cfg| cfg.resources.initial_response_timeout_seconds));
-            csa_executor::resolve_initial_response_timeout(
-                configured,
-                DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS,
-            )
-        }
-        "gemini-cli" => {
-            let configured = tool_override
-                .or_else(|| config.and_then(|cfg| cfg.resources.initial_response_timeout_seconds));
-            csa_executor::resolve_initial_response_timeout(
-                configured,
-                DEFAULT_GEMINI_INITIAL_RESPONSE_TIMEOUT_SECONDS,
-            )
-        }
-        _ => {
-            if let Some(seconds) = tool_override {
-                csa_executor::resolve_initial_response_timeout(
-                    Some(seconds),
-                    DEFAULT_RESOURCES_INITIAL_RESPONSE_TIMEOUT_SECONDS,
-                )
-            } else {
-                resolve_initial_response_timeout_seconds(config, None)
-            }
-        }
-    }
+    resolve_initial_response_timeout_with_default(config, configured, per_tool_default(tool_name))
 }
 
 pub(crate) fn resolve_liveness_dead_seconds(config: Option<&ProjectConfig>) -> u64 {

--- a/crates/cli-sub-agent/src/pipeline_tests_initial_response.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_initial_response.rs
@@ -133,6 +133,14 @@ fn test_resolve_initial_response_timeout_uses_config_value() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn test_per_tool_default_unknown_tool_uses_resources_default() {
+    assert_eq!(
+        per_tool_default("opencode"),
+        DEFAULT_RESOURCES_INITIAL_RESPONSE_TIMEOUT_SECONDS
+    );
+}
+
+#[test]
 fn test_resolve_initial_response_timeout_for_tool_disabled_when_idle_timeout_explicit() {
     // User set --idle-timeout but NOT --initial-response-timeout → disabled.
     let cfg = ProjectConfig {


### PR DESCRIPTION
## Summary

Closes #879. Collapses `resolve_initial_response_timeout_for_tool` from a 3-arm match (codex / gemini-cli / default — each following an identical override→resources→default pattern) into a single flow backed by private helper `per_tool_default(tool_name)`. Behavior preserved; tests green unmodified plus one new test for the helper.

## Test plan

- [x] `cargo test -p cli-sub-agent --lib pipeline_tests_initial_response` passes
- [x] `just pre-commit` passes
- [x] Local review CLEAN (session \`01KPJE603VZNSJ4B6C6FXEZ5BX\`, 0 findings)
- [ ] Cloud bot: deferred — gemini-code-assist quota exhausted (pr-bot auto-skip will kick in via PR #894)

## Merge rationale

Cosmetic refactor, behavior-preserving. Gemini cloud bot quota exhausted 2026-04-19 ~07:20Z (expected reset ~2026-04-20 07:20Z). Per pr-bot Step 6a bot-unavailable path + local review CLEAN, merging via bot-unavailable route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)