### PR TITLE
feat(pr-bot): built-in cloud bot polling script (#691)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,10 @@ strix_runs
 result.toml
 .letta/
 proptest-regressions/
+
+# Override ~/.gitignore_noai's `patterns` blanket rule —
+# this dev repo tracks patterns/ by design (CLAUDE.md rule 036 exception).
+# Without this negation, `git add patterns/...` is silently blocked for NEW files
+# (existing tracked files still work because git doesn't re-check ignore on tracked paths).
+!patterns
+!patterns/**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.367"
+version = "0.1.368"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.367"
+version = "0.1.368"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -256,6 +256,7 @@ max_recursion_depth = 5
 #                                            # Default: "/gemini review" for gemini-code-assist,
 #                                            #          "@<name> review" for others
 # cloud_bot_wait_seconds = 60                # Quiet wait before polling (default: kv_cache.frequent_poll_seconds = 60)
+# cloud_bot_poll_interval_seconds = 30       # Shell helper poll interval during wait script (default: 30)
 # cloud_bot_poll_max_seconds = 240           # Max poll duration after quiet wait (default: kv_cache.long_poll_seconds = 240)
 # merge_strategy = "merge"                   # "merge" | "rebase" (squash is forbidden, default: "merge")
 # delete_branch = false                      # Delete remote branch after merge (default: false)

--- a/crates/cli-sub-agent/src/config_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_tests.rs
@@ -381,6 +381,7 @@ schema_version = 1
 [pr_review]
 cloud_bot_name = "gemini-code-assist"
 cloud_bot_trigger = "comment"
+cloud_bot_poll_interval_seconds = 30
 merge_strategy = "merge"
 delete_branch = false
 "#,
@@ -402,6 +403,12 @@ delete_branch = false
             .unwrap()
             .and_then(|value| value.as_str().map(str::to_string)),
         Some("comment".to_string())
+    );
+    assert_eq!(
+        resolve_lookup_sources(&lookup.sources, "pr_review.cloud_bot_poll_interval_seconds")
+            .unwrap()
+            .and_then(|value| value.as_integer()),
+        Some(30)
     );
     assert_eq!(
         resolve_lookup_sources(&lookup.sources, "pr_review.merge_strategy")

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -575,6 +575,7 @@ CSA_PR_BOT_NAME="${CLOUD_BOT_NAME}" nohup "${PR_BOT_WAIT_SCRIPT}" "${PR_NUM}" \
   --interval "${INTERVAL}" \
   --bot-login "${CLOUD_BOT_LOGIN}" \
   --push-sha "${CURRENT_SHA}" \
+  --window-start "${WAIT_BASE_TS}" \
   --quota-cache "${CLOUD_BOT_QUOTA_CACHE_FILE}" \
   --output "${OUTPUT_FILE}" \
   >/dev/null 2>&1 &

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -437,10 +437,11 @@ If `CLOUD_BOT` is `false`:
 
 ## Step 5: Trigger Cloud Bot Review and Delegate Waiting
 
-> **Layer**: 0 + 1 (Orchestrator + CSA executor).
+> **Layer**: 0 (Orchestrator + shell helper).
 > Layer 0 triggers cloud bot review (via @mention or auto-review depending on
-> `cloud_bot_trigger` config and review round) and delegates the long wait to a
-> single CSA-managed step. No explicit caller-side polling loop.
+> `cloud_bot_trigger` config and review round), launches a self-contained shell
+> poller once, then checks a deterministic result file after at most two
+> long-poll windows. Intermediate GitHub polling happens entirely in shell.
 
 Tool: bash
 OnFail: abort
@@ -453,7 +454,7 @@ Trigger cloud bot review for current HEAD. Trigger method is **round-aware**:
   (`cloud_bot_retrigger_command`, default: `/gemini review` for gemini-code-assist)
   because bots do NOT auto-review on subsequent pushes (#506).
 
-Wait `cloud_bot_wait_seconds` (default: `kv_cache.frequent_poll_seconds`, 60s), then delegate `cloud_bot_poll_max_seconds` (default: `kv_cache.long_poll_seconds`, 240s) polling to CSA.
+Wait `cloud_bot_wait_seconds` (default: `kv_cache.frequent_poll_seconds`, 60s), then launch `patterns/pr-bot/scripts/pr-bot-wait.sh` with `cloud_bot_poll_max_seconds` (default: `kv_cache.long_poll_seconds`, 240s) as its internal timeout and `cloud_bot_poll_interval_seconds` (default: `30`) as its shell-level poll interval.
 If an exact current-HEAD bot review already exists before this run triggers the
 bot, reuse that specific review object instead of posting a duplicate trigger
 or aborting on resume/rerun.
@@ -550,122 +551,96 @@ echo "Waiting ${CLOUD_BOT_WAIT_SECONDS}s before polling (bot responses rarely ar
 sleep "${CLOUD_BOT_WAIT_SECONDS}"
 BOT_REVIEW_WINDOW_START="${WAIT_BASE_TS}"
 
-# --- Delegate remaining polling to CSA-managed step ---
+# Compatibility + recovery probe: keep the current-window review helper shape
+# so pr-bot can still confirm a HEAD-matching review event when the helper's
+# result file only contains a comment timestamp.
 query_current_window_current_head_review_ts() {
   gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" 2>/dev/null \
     | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${WAIT_BASE_TS}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null) | .submitted_at] | sort | last // ""'
 }
 
-refresh_current_window_review_signal() {
-  set +e
-  CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS="$(query_current_window_current_head_review_ts)"
-  CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS_RC=$?
-  set -e
-  if [ "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS_RC}" -eq 0 ] \
-    && [ -n "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS}" ]
-  then
-    echo "Detected current-window @${CLOUD_BOT_NAME} review on HEAD ${CURRENT_SHA} at ${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS}."
-  fi
-}
-check_quota_message_step5() {
-  local quota_message_body
-  set +e
-  quota_message_body="$(
-    gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
-      | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select((.body // "") | test("daily quota limit"; "i"))] | sort_by(.created_at) | last | .body // ""' \
-      2>/dev/null
-  )"
-  set -e
-  if [ -z "${quota_message_body}" ]; then
-    return 1
-  fi
-
-  quota_section_header="[cloud_bot_quota.${CLOUD_BOT_NAME}]"
-  quota_write_tmp="${CLOUD_BOT_QUOTA_CACHE_FILE}.tmp"
-  quota_body_tmp="${CLOUD_BOT_QUOTA_CACHE_FILE}.body.tmp"
-  quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  quota_expected_reset_at="$(date -u -d '+24 hours' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+24H +%Y-%m-%dT%H:%M:%SZ)"
-  quota_short_message="$(printf '%s' "${quota_message_body}" | tr '\r\n\t' '   ' | head -c 200)"
-  quota_short_message_escaped="$(printf '%s' "${quota_short_message}" | sed 's/\\/\\\\/g; s/"/\\"/g')"
-  mkdir -p "$(dirname "${CLOUD_BOT_QUOTA_CACHE_FILE}")"
-  if [ -f "${CLOUD_BOT_QUOTA_CACHE_FILE}" ]; then
-    awk -v target="${quota_section_header}" '
-      $0 == target { skip = 1; next }
-      skip && /^\[/ { skip = 0 }
-      !skip { print }
-    ' "${CLOUD_BOT_QUOTA_CACHE_FILE}" >"${quota_body_tmp}"
-  else
-    : >"${quota_body_tmp}"
-  fi
-  {
-    cat "${quota_body_tmp}"
-    if [ -s "${quota_body_tmp}" ]; then
-      printf '\n'
-    fi
-    printf '%s\n' "${quota_section_header}"
-    printf 'exhausted_at = "%s"\n' "${quota_now_utc}"
-    printf 'expected_reset_at = "%s"\n' "${quota_expected_reset_at}"
-    printf 'last_pr_seen = %s\n' "${PR_NUM}"
-    printf 'last_quota_message = "%s"\n' "${quota_short_message_escaped}"
-  } >"${quota_write_tmp}"
-  rm -f "${quota_body_tmp}"
-  mv "${quota_write_tmp}" "${CLOUD_BOT_QUOTA_CACHE_FILE}"
-  CLOUD_BOT_QUOTA_EXHAUSTED_AT="${quota_now_utc}"
-  CLOUD_BOT_QUOTA_EXPECTED_RESET_AT="${quota_expected_reset_at}"
-  CLOUD_BOT_SKIPPED=true
-  CLOUD_BOT_SKIP_KIND="quota_exhausted"
-  CLOUD_BOT_SKIP_REASON="quota exhausted detected on PR #${PR_NUM}"
-  BOT_UNAVAILABLE=true
-  BOT_HAS_ISSUES=false
-  BOT_HAS_ISSUES_SOURCE=""
-  MERGE_WITHOUT_BOT_REASON_KIND="cloud_bot_quota_exhausted"
-  echo "Quota exhaustion detected for ${CLOUD_BOT_NAME}; cache updated at ${CLOUD_BOT_QUOTA_CACHE_FILE}. Routing to merge-without-bot path." >&2
-  return 0
-}
-WAIT_MARKER=""
-# POLL_IDLE_TIMEOUT and POLL_MAX_TIMEOUT are pre-computed in Step 4a.
-set +e
-WAIT_SID="$(csa run --sa-mode true --tier tier-1 --timeout ${POLL_MAX_TIMEOUT} --idle-timeout ${POLL_IDLE_TIMEOUT} "Bounded wait task only. Do NOT invoke pr-bot skill or any full PR workflow. Operate on PR #${PR_NUM} in repo ${REPO}. Wait for @${CLOUD_BOT_NAME} review on HEAD ${CURRENT_SHA}. Check for a review EVENT via 'gh api repos/${REPO}/pulls/${PR_NUM}/reviews' with submitted_at after ${WAIT_BASE_TS} and user.login matching the bot. Also check issue comments for bot activity. Max wait ${CLOUD_BOT_POLL_MAX_SECONDS} seconds (quiet wait already elapsed before this step). Do not edit code. Return exactly one marker line: BOT_REPLY=received or BOT_REPLY=timeout.")"
-DAEMON_RC=$?
-set -e
-if [ "${DAEMON_RC}" -ne 0 ] || [ -z "${WAIT_SID}" ]; then
-  echo "WARN: Failed to launch daemon for bot wait (rc=${DAEMON_RC}); treating cloud bot as unavailable." >&2
-  BOT_UNAVAILABLE=true
+# --- Launch self-contained poller once; main workflow only checks the result file ---
+if [ -n "${CSA_WORKFLOW_DIR:-}" ]; then
+  PR_BOT_WAIT_SCRIPT="${CSA_WORKFLOW_DIR}/scripts/pr-bot-wait.sh"
 else
-  set +e
-  WAIT_RESULT="$(bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "${WAIT_SID}")"
-  WAIT_RC=$?
-  set -e
-  if [ "${WAIT_RC}" -ne 0 ]; then
-    echo "WARN: Delegated bot wait failed (rc=${WAIT_RC}); treating cloud bot as unavailable." >&2
-    BOT_UNAVAILABLE=true
-  else
-    WAIT_MARKER="$(
-      printf '%s\n' "${WAIT_RESULT}" \
-        | grep -E '^[[:space:]]*BOT_REPLY=(received|timeout)[[:space:]]*$' \
-        | tail -n 1 \
-        | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
-        || true
-    )"
-    if [ "${WAIT_MARKER}" = "BOT_REPLY=timeout" ]; then
-      BOT_UNAVAILABLE=true
-    elif [ "${WAIT_MARKER}" != "BOT_REPLY=received" ]; then
-      echo "WARN: Delegated bot wait returned no marker; treating cloud bot as unavailable." >&2
-      BOT_UNAVAILABLE=true
-    fi
-  fi
+  PR_BOT_WAIT_SCRIPT="patterns/pr-bot/scripts/pr-bot-wait.sh"
 fi
+OUTPUT_FILE="$(mktemp -t pr-bot-wait-${PR_NUM}-XXXXXX.json)"
+INTERVAL="$(csa config get pr_review.cloud_bot_poll_interval_seconds --default 30)"
+WAIT_LONG_POLL_SECS="$(csa config get kv_cache.long_poll_seconds --default 240)"
+POLL_RESULT_STATUS=""
+WAIT_MARKER=""
+CSA_PR_BOT_NAME="${CLOUD_BOT_NAME}" nohup "${PR_BOT_WAIT_SCRIPT}" "${PR_NUM}" \
+  --timeout "${CLOUD_BOT_POLL_MAX_SECONDS}" \
+  --interval "${INTERVAL}" \
+  --bot-login "${CLOUD_BOT_LOGIN}" \
+  --push-sha "${CURRENT_SHA}" \
+  --quota-cache "${CLOUD_BOT_QUOTA_CACHE_FILE}" \
+  --output "${OUTPUT_FILE}" \
+  >/dev/null 2>&1 &
+POLL_PID=$!
+
+sleep "${WAIT_LONG_POLL_SECS}"
+if [ ! -f "${OUTPUT_FILE}" ]; then
+  echo "Polling helper still running after first long-poll window; waiting one more window."
+  sleep "${WAIT_LONG_POLL_SECS}"
 fi
 
-if [ "${WAIT_MARKER}" != "BOT_REPLY=received" ]; then
-  refresh_current_window_review_signal
-  if [ "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS_RC}" -eq 0 ] && [ -n "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS}" ]; then
+if [ ! -f "${OUTPUT_FILE}" ]; then
+  if kill -0 "${POLL_PID}" 2>/dev/null; then
+    kill "${POLL_PID}" 2>/dev/null || true
+  fi
+  echo "ERROR: Cloud bot polling helper did not produce a result file after two long-poll windows." >&2
+  exit 1
+fi
+
+POLL_RESULT_STATUS="$(jq -r '.status // empty' "${OUTPUT_FILE}")"
+case "${POLL_RESULT_STATUS}" in
+  replied)
     WAIT_MARKER="BOT_REPLY=received"
     BOT_UNAVAILABLE=false
-    echo "Detected current-window @${CLOUD_BOT_NAME} review for HEAD ${CURRENT_SHA} after delegated wait; continuing."
-  else
-    check_quota_message_step5 || true
-  fi
+    BOT_REVIEW_WINDOW_START="$(jq -r '.review.submitted_at // .comment.created_at // empty' "${OUTPUT_FILE}")"
+    if [ -z "${BOT_REVIEW_WINDOW_START}" ]; then
+      set +e
+      CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS="$(query_current_window_current_head_review_ts)"
+      CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS_RC=$?
+      set -e
+      if [ "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS_RC}" -eq 0 ] && [ -n "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS}" ]; then
+        BOT_REVIEW_WINDOW_START="${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS}"
+      else
+        BOT_REVIEW_WINDOW_START="${WAIT_BASE_TS}"
+      fi
+    fi
+    ;;
+  quota_exhausted)
+    WAIT_MARKER="BOT_REPLY=quota_exhausted"
+    BOT_UNAVAILABLE=true
+    BOT_HAS_ISSUES=false
+    BOT_HAS_ISSUES_SOURCE=""
+    CLOUD_BOT_SKIPPED=true
+    CLOUD_BOT_SKIP_KIND="quota_exhausted"
+    CLOUD_BOT_SKIP_REASON="quota exhausted detected on PR #${PR_NUM}"
+    CLOUD_BOT_QUOTA_EXHAUSTED_AT="$(jq -r '.exhausted_at // empty' "${OUTPUT_FILE}")"
+    CLOUD_BOT_QUOTA_EXPECTED_RESET_AT="$(jq -r '.expected_reset_at // empty' "${OUTPUT_FILE}")"
+    MERGE_WITHOUT_BOT_REASON_KIND="cloud_bot_quota_exhausted"
+    BOT_REVIEW_WINDOW_START="$(jq -r '.comment.created_at // empty' "${OUTPUT_FILE}")"
+    if [ -z "${BOT_REVIEW_WINDOW_START}" ]; then
+      BOT_REVIEW_WINDOW_START="${WAIT_BASE_TS}"
+    fi
+    echo "Quota exhaustion detected for ${CLOUD_BOT_NAME}; cache updated at ${CLOUD_BOT_QUOTA_CACHE_FILE}. Routing to merge-without-bot path." >&2
+    ;;
+  timeout)
+    echo "ERROR: Cloud bot did not respond within ${CLOUD_BOT_POLL_MAX_SECONDS}s after the quiet wait." >&2
+    echo "Options: retry later, inspect the PR page manually, or disable the cloud bot for this run." >&2
+    exit 1
+    ;;
+  *)
+    echo "ERROR: Unknown polling helper status '${POLL_RESULT_STATUS}'." >&2
+    cat "${OUTPUT_FILE}" >&2
+    exit 1
+    ;;
+esac
+rm -f "${OUTPUT_FILE}"
 fi
 
 if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -568,6 +568,7 @@ fi
 OUTPUT_FILE="$(mktemp -t pr-bot-wait-${PR_NUM}-XXXXXX.json)"
 INTERVAL="$(csa config get pr_review.cloud_bot_poll_interval_seconds --default 30)"
 WAIT_LONG_POLL_SECS="$(csa config get kv_cache.long_poll_seconds --default 240)"
+WAIT_RESULT_GRACE_SECS=1
 POLL_RESULT_STATUS=""
 WAIT_MARKER=""
 CSA_PR_BOT_NAME="${CLOUD_BOT_NAME}" nohup "${PR_BOT_WAIT_SCRIPT}" "${PR_NUM}" \
@@ -580,19 +581,44 @@ CSA_PR_BOT_NAME="${CLOUD_BOT_NAME}" nohup "${PR_BOT_WAIT_SCRIPT}" "${PR_NUM}" \
   --output "${OUTPUT_FILE}" \
   >/dev/null 2>&1 &
 POLL_PID=$!
+WAIT_STARTED_AT="$(date +%s)"
+WAIT_ELAPSED_SECS=0
 
-sleep "${WAIT_LONG_POLL_SECS}"
-if [ ! -f "${OUTPUT_FILE}" ]; then
-  echo "Polling helper still running after first long-poll window; waiting one more window."
-  sleep "${WAIT_LONG_POLL_SECS}"
-fi
+while [ "${WAIT_ELAPSED_SECS}" -lt "${CLOUD_BOT_POLL_MAX_SECONDS}" ]; do
+  if [ -f "${OUTPUT_FILE}" ]; then
+    break
+  fi
+  if ! kill -0 "${POLL_PID}" 2>/dev/null; then
+    sleep "${WAIT_RESULT_GRACE_SECS}"
+    break
+  fi
+
+  remaining=$((CLOUD_BOT_POLL_MAX_SECONDS - WAIT_ELAPSED_SECS))
+  step="${WAIT_LONG_POLL_SECS}"
+  if [ "${step}" -gt "${remaining}" ]; then
+    step="${remaining}"
+  fi
+
+  sleep "${step}" &
+  WAIT_SLEEP_PID=$!
+  wait -n "${POLL_PID}" "${WAIT_SLEEP_PID}" 2>/dev/null || true
+  if kill -0 "${WAIT_SLEEP_PID}" 2>/dev/null; then
+    kill "${WAIT_SLEEP_PID}" 2>/dev/null || true
+    wait "${WAIT_SLEEP_PID}" 2>/dev/null || true
+  fi
+  WAIT_ELAPSED_SECS=$(( $(date +%s) - WAIT_STARTED_AT ))
+done
+
+WAIT_ELAPSED_SECS=$(( $(date +%s) - WAIT_STARTED_AT ))
 
 if [ ! -f "${OUTPUT_FILE}" ]; then
   if kill -0 "${POLL_PID}" 2>/dev/null; then
     kill "${POLL_PID}" 2>/dev/null || true
+    wait "${POLL_PID}" 2>/dev/null || true
   fi
-  echo "ERROR: Cloud bot polling helper did not produce a result file after two long-poll windows." >&2
-  exit 1
+  printf '{"status":"timeout","pr":%s,"elapsed_seconds":%s}\n' \
+    "${PR_NUM}" "${WAIT_ELAPSED_SECS}" > "${OUTPUT_FILE}.tmp"
+  mv "${OUTPUT_FILE}.tmp" "${OUTPUT_FILE}"
 fi
 
 POLL_RESULT_STATUS="$(jq -r '.status // empty' "${OUTPUT_FILE}")"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -665,6 +665,26 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     REVIEW_EVENT_COUNT="$(echo "${REVIEW_EVENT_RAW}" | awk '{s+=$1} END {print s+0}')"
   fi
   # Helper: check for setup/configuration messages before marking unavailable
+  check_quota_message_step5() {
+    set +e
+    local quota_body
+    quota_body="$(
+      gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
+        | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select((.body // "") | test("daily quota limit"; "i"))] | .[0].body // ""' \
+        2>/dev/null
+    )"
+    set -e
+    if [ -n "${quota_body}" ]; then
+      echo "Quota exhaustion detected from cloud bot comment during post-poll verification." >&2
+      CLOUD_BOT_SKIPPED=true
+      CLOUD_BOT_SKIP_KIND="quota_exhausted"
+      CLOUD_BOT_SKIP_REASON="quota exhausted detected on PR #${PR_NUM}"
+      BOT_UNAVAILABLE=true
+      return 0
+    fi
+    return 1
+  }
+
   _check_setup_message_step5() {
     set +e
     local setup_body

--- a/patterns/pr-bot/scripts/pr-bot-wait.sh
+++ b/patterns/pr-bot/scripts/pr-bot-wait.sh
@@ -10,6 +10,7 @@ usage: pr-bot-wait.sh <PR_NUMBER> [options]
   --bot-login <LOGIN>     bot GitHub login to match
   --output <FILE>         result JSON path
   --push-sha <SHA>        only accept reviews whose commit_id == this
+  --window-start <ISO8601> accept null-commit reviews submitted at/after this window
   --quota-cache <FILE>    quota cache file
 EOF
 }
@@ -27,6 +28,8 @@ INTERVAL_SEC="${CSA_PR_BOT_INTERVAL:-30}"
 BOT_LOGIN="${CSA_PR_BOT_LOGIN:-}"
 OUTPUT_FILE="${CSA_PR_BOT_OUTPUT:-/tmp/pr-bot-wait-${PR_NUMBER}.json}"
 PUSH_SHA=""
+SCRIPT_START_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+WINDOW_START="${CSA_PR_BOT_WINDOW_START:-${SCRIPT_START_TIME}}"
 QUOTA_CACHE_FILE="${CSA_PR_BOT_QUOTA_CACHE:-${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/pr_review/cloud_bot_quota.toml}"
 BOT_NAME="${CSA_PR_BOT_NAME:-}"
 
@@ -50,6 +53,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --push-sha)
       PUSH_SHA="${2:?missing value for --push-sha}"
+      shift 2
+      ;;
+    --window-start)
+      WINDOW_START="${2:?missing value for --window-start}"
       shift 2
       ;;
     --quota-cache)
@@ -181,21 +188,29 @@ write_quota_cache() {
 
 review_filter() {
   if [ -n "${BOT_LOGIN}" ]; then
-    jq -c --arg login "${BOT_LOGIN}" --arg push_time "${PUSH_TIME}" --arg push_sha "${PUSH_SHA}" '
+    jq -c --arg login "${BOT_LOGIN}" --arg push_time "${PUSH_TIME}" --arg push_sha "${PUSH_SHA}" --arg window_start "${WINDOW_START}" '
       [ .[] | .[]
         | select((.user.login // "") == $login)
         | select($push_time == "" or (.submitted_at // "") > $push_time)
-        | select($push_sha == "" or (.commit_id // "") == $push_sha)
+        | select(
+            $push_sha == ""
+            or (.commit_id // "") == $push_sha
+            or (.commit_id == null and $window_start != "" and (.submitted_at // "") >= $window_start)
+          )
       ]
       | sort_by(.submitted_at)
       | last // empty
     '
   else
-    jq -c --arg push_time "${PUSH_TIME}" --arg push_sha "${PUSH_SHA}" '
+    jq -c --arg push_time "${PUSH_TIME}" --arg push_sha "${PUSH_SHA}" --arg window_start "${WINDOW_START}" '
       [ .[] | .[]
         | select((.user.type // "") == "Bot" or ((.user.login // "") | test("\\[bot\\]$")))
         | select($push_time == "" or (.submitted_at // "") > $push_time)
-        | select($push_sha == "" or (.commit_id // "") == $push_sha)
+        | select(
+            $push_sha == ""
+            or (.commit_id // "") == $push_sha
+            or (.commit_id == null and $window_start != "" and (.submitted_at // "") >= $window_start)
+          )
       ]
       | sort_by(.submitted_at)
       | last // empty

--- a/patterns/pr-bot/scripts/pr-bot-wait.sh
+++ b/patterns/pr-bot/scripts/pr-bot-wait.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: pr-bot-wait.sh <PR_NUMBER> [options]
+  --timeout <SEC>         total wait budget
+  --interval <SEC>        seconds between gh poll calls
+  --bot-login <LOGIN>     bot GitHub login to match
+  --output <FILE>         result JSON path
+  --push-sha <SHA>        only accept reviews whose commit_id == this
+  --quota-cache <FILE>    quota cache file
+EOF
+}
+
+if [ "$#" -lt 1 ]; then
+  usage
+  exit 2
+fi
+
+PR_NUMBER="$1"
+shift
+
+TIMEOUT_SEC="${CSA_PR_BOT_TIMEOUT:-900}"
+INTERVAL_SEC="${CSA_PR_BOT_INTERVAL:-30}"
+BOT_LOGIN="${CSA_PR_BOT_LOGIN:-}"
+OUTPUT_FILE="${CSA_PR_BOT_OUTPUT:-/tmp/pr-bot-wait-${PR_NUMBER}.json}"
+PUSH_SHA=""
+QUOTA_CACHE_FILE="${CSA_PR_BOT_QUOTA_CACHE:-${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/pr_review/cloud_bot_quota.toml}"
+BOT_NAME="${CSA_PR_BOT_NAME:-}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --timeout)
+      TIMEOUT_SEC="${2:?missing value for --timeout}"
+      shift 2
+      ;;
+    --interval)
+      INTERVAL_SEC="${2:?missing value for --interval}"
+      shift 2
+      ;;
+    --bot-login)
+      BOT_LOGIN="${2:?missing value for --bot-login}"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_FILE="${2:?missing value for --output}"
+      shift 2
+      ;;
+    --push-sha)
+      PUSH_SHA="${2:?missing value for --push-sha}"
+      shift 2
+      ;;
+    --quota-cache)
+      QUOTA_CACHE_FILE="${2:?missing value for --quota-cache}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "${TIMEOUT_SEC}" in
+  ''|*[!0-9]*)
+    echo "timeout must be an integer" >&2
+    exit 2
+    ;;
+esac
+
+case "${INTERVAL_SEC}" in
+  ''|*[!0-9]*)
+    echo "interval must be an integer" >&2
+    exit 2
+    ;;
+esac
+
+if [ "${INTERVAL_SEC}" -le 0 ]; then
+  echo "interval must be > 0" >&2
+  exit 2
+fi
+
+if [ "${TIMEOUT_SEC}" -lt 0 ]; then
+  echo "timeout must be >= 0" >&2
+  exit 2
+fi
+
+repo_from_origin() {
+  local origin_url
+  local repo
+  origin_url="$(git remote get-url origin 2>/dev/null || true)"
+  if [ -z "${origin_url}" ]; then
+    echo "ERROR: unable to determine GitHub repo from origin remote" >&2
+    exit 2
+  fi
+  repo="$(
+    printf '%s\n' "${origin_url}" | sed -nE \
+    -e 's#^https?://([^@/]+@)?github\.com/([^/]+/[^/]+?)(\.git)?$#\2#p' \
+    -e 's#^(ssh://)?([^@]+@)?github\.com[:/]([^/]+/[^/]+?)(\.git)?$#\3#p' \
+    | head -n 1
+  )"
+  printf '%s\n' "${repo%.git}"
+}
+
+REPO="$(repo_from_origin)"
+PUSH_TIME=""
+if [ -n "${PUSH_SHA}" ]; then
+  PUSH_TIME="$(git show -s --format=%cI "${PUSH_SHA}")"
+fi
+
+if [ -z "${BOT_NAME}" ]; then
+  if [ -n "${BOT_LOGIN}" ]; then
+    BOT_NAME="${BOT_LOGIN%\[bot\]}"
+  else
+    BOT_NAME="bot"
+  fi
+fi
+
+write_output() {
+  local json="$1"
+  local tmp_file="${OUTPUT_FILE}.tmp"
+  mkdir -p "$(dirname "${OUTPUT_FILE}")"
+  printf '%s\n' "${json}" >"${tmp_file}"
+  mv "${tmp_file}" "${OUTPUT_FILE}"
+}
+
+preview_body() {
+  printf '%s' "$1" | tr '\r\n\t' '   ' | head -c 200
+}
+
+write_quota_cache() {
+  local comment_body="$1"
+  local quota_section_header="[cloud_bot_quota.${BOT_NAME}]"
+  local quota_write_tmp="${QUOTA_CACHE_FILE}.tmp"
+  local quota_body_tmp="${QUOTA_CACHE_FILE}.body.tmp"
+  local quota_now_utc
+  local quota_expected_reset_at
+  local quota_short_message
+  local quota_short_message_escaped
+
+  quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  quota_expected_reset_at="$(date -u -d '+24 hours' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+24H +%Y-%m-%dT%H:%M:%SZ)"
+  quota_short_message="$(preview_body "${comment_body}")"
+  quota_short_message_escaped="$(printf '%s' "${quota_short_message}" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+
+  mkdir -p "$(dirname "${QUOTA_CACHE_FILE}")"
+  if [ -f "${QUOTA_CACHE_FILE}" ]; then
+    awk -v target="${quota_section_header}" '
+      $0 == target { skip = 1; next }
+      skip && /^\[/ { skip = 0 }
+      !skip { print }
+    ' "${QUOTA_CACHE_FILE}" >"${quota_body_tmp}"
+  else
+    : >"${quota_body_tmp}"
+  fi
+
+  {
+    cat "${quota_body_tmp}"
+    if [ -s "${quota_body_tmp}" ]; then
+      printf '\n'
+    fi
+    printf '%s\n' "${quota_section_header}"
+    printf 'exhausted_at = "%s"\n' "${quota_now_utc}"
+    printf 'expected_reset_at = "%s"\n' "${quota_expected_reset_at}"
+    printf 'last_pr_seen = %s\n' "${PR_NUMBER}"
+    printf 'last_quota_message = "%s"\n' "${quota_short_message_escaped}"
+  } >"${quota_write_tmp}"
+  rm -f "${quota_body_tmp}"
+  mv "${quota_write_tmp}" "${QUOTA_CACHE_FILE}"
+
+  QUOTA_EXHAUSTED_AT="${quota_now_utc}"
+  QUOTA_EXPECTED_RESET_AT="${quota_expected_reset_at}"
+}
+
+review_filter() {
+  if [ -n "${BOT_LOGIN}" ]; then
+    jq -c --arg login "${BOT_LOGIN}" --arg push_time "${PUSH_TIME}" --arg push_sha "${PUSH_SHA}" '
+      [ .[] | .[]
+        | select((.user.login // "") == $login)
+        | select($push_time == "" or (.submitted_at // "") > $push_time)
+        | select($push_sha == "" or (.commit_id // "") == $push_sha)
+      ]
+      | sort_by(.submitted_at)
+      | last // empty
+    '
+  else
+    jq -c --arg push_time "${PUSH_TIME}" --arg push_sha "${PUSH_SHA}" '
+      [ .[] | .[]
+        | select((.user.type // "") == "Bot" or ((.user.login // "") | test("\\[bot\\]$")))
+        | select($push_time == "" or (.submitted_at // "") > $push_time)
+        | select($push_sha == "" or (.commit_id // "") == $push_sha)
+      ]
+      | sort_by(.submitted_at)
+      | last // empty
+    '
+  fi
+}
+
+elapsed=0
+
+while [ "${elapsed}" -le "${TIMEOUT_SEC}" ]; do
+  reviews_json="$(gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100")"
+  review_json="$(printf '%s\n' "${reviews_json}" | review_filter || true)"
+  if [ -n "${review_json}" ]; then
+    result_json="$(
+      jq -n \
+        --argjson pr "${PR_NUMBER}" \
+        --argjson elapsed "${elapsed}" \
+        --argjson review "${review_json}" \
+        '{status:"replied", pr:$pr, elapsed_seconds:$elapsed, review:$review}'
+    )"
+    write_output "${result_json}"
+    exit 0
+  fi
+
+  comments_json="$(gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100")"
+  quota_comment_json="$(
+    if [ -n "${BOT_LOGIN}" ]; then
+      printf '%s\n' "${comments_json}" | jq -c --arg login "${BOT_LOGIN}" --arg push_time "${PUSH_TIME}" '
+        [ .[] | .[]
+          | select((.user.login // "") == $login)
+          | select($push_time == "" or (.created_at // "") > $push_time)
+          | select((.body // "") | test("daily quota limit"; "i"))
+        ]
+        | sort_by(.created_at)
+        | last // empty
+      ' || true
+    else
+      printf '%s\n' "${comments_json}" | jq -c --arg push_time "${PUSH_TIME}" '
+        [ .[] | .[]
+          | select((.user.type // "") == "Bot" or ((.user.login // "") | test("\\[bot\\]$")))
+          | select($push_time == "" or (.created_at // "") > $push_time)
+          | select((.body // "") | test("daily quota limit"; "i"))
+        ]
+        | sort_by(.created_at)
+        | last // empty
+      ' || true
+    fi
+  )"
+  if [ -n "${quota_comment_json}" ]; then
+    quota_body="$(printf '%s\n' "${quota_comment_json}" | jq -r '.body // ""')"
+    quota_preview="$(preview_body "${quota_body}")"
+    quota_created_at="$(printf '%s\n' "${quota_comment_json}" | jq -r '.created_at // ""')"
+    write_quota_cache "${quota_body}"
+    result_json="$(
+      jq -n \
+        --argjson pr "${PR_NUMBER}" \
+        --argjson elapsed "${elapsed}" \
+        --arg preview "${quota_preview}" \
+        --arg created_at "${quota_created_at}" \
+        --arg exhausted_at "${QUOTA_EXHAUSTED_AT}" \
+        --arg expected_reset_at "${QUOTA_EXPECTED_RESET_AT}" \
+        '{status:"quota_exhausted", pr:$pr, elapsed_seconds:$elapsed, exhausted_at:$exhausted_at, expected_reset_at:$expected_reset_at, comment:{preview:$preview, created_at:$created_at}}'
+    )"
+    write_output "${result_json}"
+    exit 0
+  fi
+
+  reply_comment_json="$(
+    if [ -n "${BOT_LOGIN}" ]; then
+      printf '%s\n' "${comments_json}" | jq -c --arg login "${BOT_LOGIN}" --arg push_time "${PUSH_TIME}" '
+        [ .[] | .[]
+          | select((.user.login // "") == $login)
+          | select($push_time == "" or (.created_at // "") > $push_time)
+        ]
+        | sort_by(.created_at)
+        | last // empty
+      ' || true
+    else
+      printf '%s\n' "${comments_json}" | jq -c --arg push_time "${PUSH_TIME}" '
+        [ .[] | .[]
+          | select((.user.type // "") == "Bot" or ((.user.login // "") | test("\\[bot\\]$")))
+          | select($push_time == "" or (.created_at // "") > $push_time)
+        ]
+        | sort_by(.created_at)
+        | last // empty
+      ' || true
+    fi
+  )"
+  if [ -n "${reply_comment_json}" ]; then
+    reply_body="$(printf '%s\n' "${reply_comment_json}" | jq -r '.body // ""')"
+    reply_preview="$(preview_body "${reply_body}")"
+    reply_created_at="$(printf '%s\n' "${reply_comment_json}" | jq -r '.created_at // ""')"
+    result_json="$(
+      jq -n \
+        --argjson pr "${PR_NUMBER}" \
+        --argjson elapsed "${elapsed}" \
+        --arg preview "${reply_preview}" \
+        --arg created_at "${reply_created_at}" \
+        '{status:"replied", pr:$pr, elapsed_seconds:$elapsed, comment:{preview:$preview, created_at:$created_at}}'
+    )"
+    write_output "${result_json}"
+    exit 0
+  fi
+
+  if [ "${elapsed}" -ge "${TIMEOUT_SEC}" ]; then
+    break
+  fi
+
+  sleep "${INTERVAL_SEC}"
+  elapsed=$((elapsed + INTERVAL_SEC))
+done
+
+timeout_json="$(
+  jq -n \
+    --argjson pr "${PR_NUMBER}" \
+    --argjson elapsed "${TIMEOUT_SEC}" \
+    '{status:"timeout", pr:$pr, elapsed_seconds:$elapsed}'
+)"
+write_output "${timeout_json}"
+exit 1

--- a/patterns/pr-bot/scripts/tests/pr-bot-wait-tests.sh
+++ b/patterns/pr-bot/scripts/tests/pr-bot-wait-tests.sh
@@ -129,6 +129,84 @@ assert_json_value() {
   fi
 }
 
+run_wait_wrapper_loop() {
+  local output_file="$1"
+  local poll_pid="$2"
+  local wait_long_poll_secs="$3"
+  local cloud_bot_poll_max_seconds="$4"
+  local pr_number="$5"
+  local wait_result_grace_secs="${6:-1}"
+  local wait_started_at
+  local wait_elapsed_secs
+
+  wait_started_at="$(date +%s)"
+  wait_elapsed_secs=0
+
+  while [ "${wait_elapsed_secs}" -lt "${cloud_bot_poll_max_seconds}" ]; do
+    if [ -f "${output_file}" ]; then
+      break
+    fi
+    if ! kill -0 "${poll_pid}" 2>/dev/null; then
+      sleep "${wait_result_grace_secs}"
+      break
+    fi
+
+    local remaining=$((cloud_bot_poll_max_seconds - wait_elapsed_secs))
+    local step="${wait_long_poll_secs}"
+    if [ "${step}" -gt "${remaining}" ]; then
+      step="${remaining}"
+    fi
+
+    sleep "${step}" &
+    local wait_sleep_pid=$!
+    wait -n "${poll_pid}" "${wait_sleep_pid}" 2>/dev/null || true
+    if kill -0 "${wait_sleep_pid}" 2>/dev/null; then
+      kill "${wait_sleep_pid}" 2>/dev/null || true
+      wait "${wait_sleep_pid}" 2>/dev/null || true
+    fi
+    wait_elapsed_secs=$(( $(date +%s) - wait_started_at ))
+  done
+
+  wait_elapsed_secs=$(( $(date +%s) - wait_started_at ))
+
+  if [ ! -f "${output_file}" ]; then
+    if kill -0 "${poll_pid}" 2>/dev/null; then
+      kill "${poll_pid}" 2>/dev/null || true
+      wait "${poll_pid}" 2>/dev/null || true
+    fi
+    printf '{"status":"timeout","pr":%s,"elapsed_seconds":%s}\n' \
+      "${pr_number}" "${wait_elapsed_secs}" > "${output_file}.tmp"
+    mv "${output_file}.tmp" "${output_file}"
+  fi
+}
+
+SPAWNED_WAIT_WRAPPER_PID=""
+
+spawn_wait_wrapper_helper() {
+  local output_file="$1"
+  local delay_seconds="$2"
+  local status="$3"
+
+  (
+    sleep "${delay_seconds}"
+    printf '{"status":"%s"}\n' "${status}" > "${output_file}.tmp"
+    mv "${output_file}.tmp" "${output_file}"
+  ) &
+  SPAWNED_WAIT_WRAPPER_PID="$!"
+}
+
+assert_elapsed_between() {
+  local actual="$1"
+  local min_expected="$2"
+  local max_expected="$3"
+  local description="$4"
+
+  if [ "${actual}" -lt "${min_expected}" ] || [ "${actual}" -gt "${max_expected}" ]; then
+    echo "${description}: expected elapsed in [${min_expected}, ${max_expected}], got ${actual}" >&2
+    exit 1
+  fi
+}
+
 run_replied_test() {
   local case_dir="${TMP_ROOT}/replied"
   local repo_dir="${case_dir}/repo"
@@ -322,10 +400,44 @@ run_quiet_wait_window_regression_test() {
   assert_json_value "${output_without_window}" '.status' 'timeout'
 }
 
+run_wait_wrapper_short_helper_timeout_test() {
+  local case_dir="${TMP_ROOT}/wait-wrapper-short-helper"
+  local output_file="${case_dir}/result.json"
+  local started_at
+  local elapsed_seconds
+
+  mkdir -p "${case_dir}"
+  spawn_wait_wrapper_helper "${output_file}" 3 replied
+  started_at="$(date +%s)"
+  run_wait_wrapper_loop "${output_file}" "${SPAWNED_WAIT_WRAPPER_PID}" 240 30 42
+  elapsed_seconds=$(( $(date +%s) - started_at ))
+
+  assert_elapsed_between "${elapsed_seconds}" 2 5 "short helper timeout wrapper regression"
+  assert_json_value "${output_file}" '.status' 'replied'
+}
+
+run_wait_wrapper_long_helper_timeout_test() {
+  local case_dir="${TMP_ROOT}/wait-wrapper-long-helper"
+  local output_file="${case_dir}/result.json"
+  local started_at
+  local elapsed_seconds
+
+  mkdir -p "${case_dir}"
+  spawn_wait_wrapper_helper "${output_file}" 15 timeout
+  started_at="$(date +%s)"
+  run_wait_wrapper_loop "${output_file}" "${SPAWNED_WAIT_WRAPPER_PID}" 10 15 77
+  elapsed_seconds=$(( $(date +%s) - started_at ))
+
+  assert_elapsed_between "${elapsed_seconds}" 14 20 "long helper timeout wrapper regression"
+  assert_json_value "${output_file}" '.status' 'timeout'
+}
+
 run_replied_test
 run_quota_test
 run_null_commit_replied_test
 run_timeout_test
 run_quiet_wait_window_regression_test
+run_wait_wrapper_short_helper_timeout_test
+run_wait_wrapper_long_helper_timeout_test
 
 echo "pr-bot-wait tests: PASS"

--- a/patterns/pr-bot/scripts/tests/pr-bot-wait-tests.sh
+++ b/patterns/pr-bot/scripts/tests/pr-bot-wait-tests.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+SCRIPT_PATH="${ROOT_DIR}/patterns/pr-bot/scripts/pr-bot-wait.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+make_repo() {
+  local repo_dir="$1"
+  mkdir -p "${repo_dir}"
+  git init "${repo_dir}" >/dev/null 2>&1
+  git -C "${repo_dir}" config user.name "Test User"
+  git -C "${repo_dir}" config user.email "test@example.com"
+  git -C "${repo_dir}" remote add origin "git@github.com:test-owner/test-repo.git"
+  printf 'test\n' >"${repo_dir}/README.md"
+  git -C "${repo_dir}" add README.md
+  git -C "${repo_dir}" commit -m "init" >/dev/null 2>&1
+}
+
+make_gh_stub() {
+  local stub_dir="$1"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_dir="${GH_STUB_STATE_DIR:?}"
+scenario="${GH_STUB_SCENARIO:?}"
+push_sha="${GH_STUB_PUSH_SHA:-PUSH_SHA}"
+
+if [ "${1:-}" = "api" ]; then
+  shift
+  while [ "$#" -gt 0 ] && [ "${1}" = "--paginate" -o "${1}" = "--slurp" ]; do
+    shift
+  done
+  endpoint="${1:-}"
+  case "${endpoint}" in
+    repos/test-owner/test-repo/pulls/*/reviews?per_page=100)
+      review_count_file="${state_dir}/review-count"
+      review_count=0
+      if [ -f "${review_count_file}" ]; then
+        review_count="$(cat "${review_count_file}")"
+      fi
+      review_count=$((review_count + 1))
+      printf '%s' "${review_count}" >"${review_count_file}"
+      case "${scenario}" in
+        replied)
+          cat <<'JSON'
+[[{"id":101,"state":"COMMENTED","submitted_at":"2026-04-19T10:01:00Z","commit_id":"__PUSH_SHA__","user":{"login":"test-bot[bot]","type":"Bot"}}]]
+JSON
+          ;;
+        quota|timeout)
+          echo '[[]]'
+          ;;
+        *)
+          echo "unknown scenario: ${scenario}" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    repos/test-owner/test-repo/issues/*/comments?per_page=100)
+      comment_count_file="${state_dir}/comment-count"
+      comment_count=0
+      if [ -f "${comment_count_file}" ]; then
+        comment_count="$(cat "${comment_count_file}")"
+      fi
+      comment_count=$((comment_count + 1))
+      printf '%s' "${comment_count}" >"${comment_count_file}"
+      case "${scenario}" in
+        replied)
+          echo '[[]]'
+          ;;
+        quota)
+          if [ "${comment_count}" -lt 4 ]; then
+            echo '[[]]'
+          else
+            cat <<'JSON'
+[[{"id":202,"created_at":"2026-04-19T10:04:00Z","body":"Daily quota limit reached for today.","user":{"login":"test-bot[bot]","type":"Bot"}}]]
+JSON
+          fi
+          ;;
+        timeout)
+          echo '[[]]'
+          ;;
+        *)
+          echo "unknown scenario: ${scenario}" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "unexpected gh api endpoint: ${endpoint}" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 1
+EOF
+  sed -i "s/__PUSH_SHA__/${GH_STUB_PUSH_SHA:-PUSH_SHA}/g" "${stub_dir}/gh"
+  chmod +x "${stub_dir}/gh"
+}
+
+assert_json_value() {
+  local file="$1"
+  local jq_expr="$2"
+  local expected="$3"
+  local actual
+  actual="$(jq -r "${jq_expr}" "${file}")"
+  if [ "${actual}" != "${expected}" ]; then
+    echo "assertion failed: ${jq_expr} expected '${expected}', got '${actual}'" >&2
+    exit 1
+  fi
+}
+
+run_replied_test() {
+  local case_dir="${TMP_ROOT}/replied"
+  local repo_dir="${case_dir}/repo"
+  local stub_dir="${case_dir}/bin"
+  local output_file="${case_dir}/result.json"
+  local push_sha
+
+  make_repo "${repo_dir}"
+  push_sha="$(git -C "${repo_dir}" rev-parse HEAD)"
+  GH_STUB_PUSH_SHA="${push_sha}" make_gh_stub "${stub_dir}"
+
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" \
+    GH_STUB_STATE_DIR="${case_dir}" \
+    GH_STUB_SCENARIO="replied" \
+    GH_STUB_PUSH_SHA="${push_sha}" \
+    CSA_PR_BOT_NAME="test-bot" \
+    "${SCRIPT_PATH}" 42 \
+      --timeout 3 \
+      --interval 1 \
+      --bot-login "test-bot[bot]" \
+      --push-sha "${push_sha}" \
+      --output "${output_file}"
+  )
+
+  assert_json_value "${output_file}" '.status' 'replied'
+  assert_json_value "${output_file}" '.review.id' '101'
+  assert_json_value "${output_file}" '.review.commit_id' "${push_sha}"
+}
+
+run_quota_test() {
+  local case_dir="${TMP_ROOT}/quota"
+  local repo_dir="${case_dir}/repo"
+  local stub_dir="${case_dir}/bin"
+  local output_file="${case_dir}/result.json"
+  local quota_cache="${case_dir}/quota.toml"
+  local push_sha
+
+  make_repo "${repo_dir}"
+  push_sha="$(git -C "${repo_dir}" rev-parse HEAD)"
+  GH_STUB_PUSH_SHA="${push_sha}" make_gh_stub "${stub_dir}"
+
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" \
+    GH_STUB_STATE_DIR="${case_dir}" \
+    GH_STUB_SCENARIO="quota" \
+    GH_STUB_PUSH_SHA="${push_sha}" \
+    CSA_PR_BOT_NAME="test-bot" \
+    "${SCRIPT_PATH}" 77 \
+      --timeout 4 \
+      --interval 1 \
+      --bot-login "test-bot[bot]" \
+      --push-sha "${push_sha}" \
+      --quota-cache "${quota_cache}" \
+      --output "${output_file}"
+  )
+
+  assert_json_value "${output_file}" '.status' 'quota_exhausted'
+  assert_json_value "${output_file}" '.pr' '77'
+  grep -q '\[cloud_bot_quota.test-bot\]' "${quota_cache}"
+  grep -q 'last_pr_seen = 77' "${quota_cache}"
+}
+
+run_timeout_test() {
+  local case_dir="${TMP_ROOT}/timeout"
+  local repo_dir="${case_dir}/repo"
+  local stub_dir="${case_dir}/bin"
+  local output_file="${case_dir}/result.json"
+  local push_sha
+
+  make_repo "${repo_dir}"
+  push_sha="$(git -C "${repo_dir}" rev-parse HEAD)"
+  GH_STUB_PUSH_SHA="${push_sha}" make_gh_stub "${stub_dir}"
+
+  set +e
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" \
+    GH_STUB_STATE_DIR="${case_dir}" \
+    GH_STUB_SCENARIO="timeout" \
+    GH_STUB_PUSH_SHA="${push_sha}" \
+    CSA_PR_BOT_NAME="test-bot" \
+    "${SCRIPT_PATH}" 99 \
+      --timeout 3 \
+      --interval 1 \
+      --bot-login "test-bot[bot]" \
+      --push-sha "${push_sha}" \
+      --output "${output_file}"
+  )
+  rc=$?
+  set -e
+
+  if [ "${rc}" -ne 1 ]; then
+    echo "timeout scenario expected exit 1, got ${rc}" >&2
+    exit 1
+  fi
+
+  assert_json_value "${output_file}" '.status' 'timeout'
+  assert_json_value "${output_file}" '.elapsed_seconds' '3'
+}
+
+run_replied_test
+run_quota_test
+run_timeout_test
+
+echo "pr-bot-wait tests: PASS"

--- a/patterns/pr-bot/scripts/tests/pr-bot-wait-tests.sh
+++ b/patterns/pr-bot/scripts/tests/pr-bot-wait-tests.sh
@@ -51,6 +51,11 @@ if [ "${1:-}" = "api" ]; then
 [[{"id":101,"state":"COMMENTED","submitted_at":"2026-04-19T10:01:00Z","commit_id":"__PUSH_SHA__","user":{"login":"test-bot[bot]","type":"Bot"}}]]
 JSON
           ;;
+        replied-null-commit)
+          cat <<'JSON'
+[[{"id":102,"state":"COMMENTED","submitted_at":"2026-04-19T10:02:00Z","commit_id":null,"user":{"login":"test-bot[bot]","type":"Bot"}}]]
+JSON
+          ;;
         quota|timeout)
           echo '[[]]'
           ;;
@@ -182,6 +187,38 @@ run_quota_test() {
   grep -q 'last_pr_seen = 77' "${quota_cache}"
 }
 
+run_null_commit_replied_test() {
+  local case_dir="${TMP_ROOT}/replied-null-commit"
+  local repo_dir="${case_dir}/repo"
+  local stub_dir="${case_dir}/bin"
+  local output_file="${case_dir}/result.json"
+  local push_sha
+
+  make_repo "${repo_dir}"
+  push_sha="$(git -C "${repo_dir}" rev-parse HEAD)"
+  GH_STUB_PUSH_SHA="${push_sha}" make_gh_stub "${stub_dir}"
+
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" \
+    GH_STUB_STATE_DIR="${case_dir}" \
+    GH_STUB_SCENARIO="replied-null-commit" \
+    GH_STUB_PUSH_SHA="${push_sha}" \
+    CSA_PR_BOT_NAME="test-bot" \
+    "${SCRIPT_PATH}" 52 \
+      --timeout 3 \
+      --interval 1 \
+      --bot-login "test-bot[bot]" \
+      --push-sha "${push_sha}" \
+      --window-start "2026-04-19T10:00:00Z" \
+      --output "${output_file}"
+  )
+
+  assert_json_value "${output_file}" '.status' 'replied'
+  assert_json_value "${output_file}" '.review.id' '102'
+  assert_json_value "${output_file}" '.review.commit_id' 'null'
+}
+
 run_timeout_test() {
   local case_dir="${TMP_ROOT}/timeout"
   local repo_dir="${case_dir}/repo"
@@ -222,6 +259,7 @@ run_timeout_test() {
 
 run_replied_test
 run_quota_test
+run_null_commit_replied_test
 run_timeout_test
 
 echo "pr-bot-wait tests: PASS"

--- a/patterns/pr-bot/scripts/tests/pr-bot-wait-tests.sh
+++ b/patterns/pr-bot/scripts/tests/pr-bot-wait-tests.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "${TMP_ROOT}"' EXIT
 
 make_repo() {
   local repo_dir="$1"
+  local commit_date="${2:-2026-04-19T00:00:00Z}"
   mkdir -p "${repo_dir}"
   git init "${repo_dir}" >/dev/null 2>&1
   git -C "${repo_dir}" config user.name "Test User"
@@ -16,7 +17,8 @@ make_repo() {
   git -C "${repo_dir}" remote add origin "git@github.com:test-owner/test-repo.git"
   printf 'test\n' >"${repo_dir}/README.md"
   git -C "${repo_dir}" add README.md
-  git -C "${repo_dir}" commit -m "init" >/dev/null 2>&1
+  GIT_AUTHOR_DATE="${commit_date}" GIT_COMMITTER_DATE="${commit_date}" \
+    git -C "${repo_dir}" commit -m "init" >/dev/null 2>&1
 }
 
 make_gh_stub() {
@@ -56,6 +58,11 @@ JSON
 [[{"id":102,"state":"COMMENTED","submitted_at":"2026-04-19T10:02:00Z","commit_id":null,"user":{"login":"test-bot[bot]","type":"Bot"}}]]
 JSON
           ;;
+        quiet-wait-gap)
+          cat <<'JSON'
+[[{"id":103,"state":"COMMENTED","submitted_at":"2026-04-19T00:05:00Z","commit_id":null,"user":{"login":"test-bot[bot]","type":"Bot"}}]]
+JSON
+          ;;
         quota|timeout)
           echo '[[]]'
           ;;
@@ -74,7 +81,7 @@ JSON
       comment_count=$((comment_count + 1))
       printf '%s' "${comment_count}" >"${comment_count_file}"
       case "${scenario}" in
-        replied)
+        replied|quiet-wait-gap)
           echo '[[]]'
           ;;
         quota)
@@ -257,9 +264,68 @@ run_timeout_test() {
   assert_json_value "${output_file}" '.elapsed_seconds' '3'
 }
 
+run_quiet_wait_window_regression_test() {
+  local case_dir="${TMP_ROOT}/quiet-wait-gap"
+  local repo_dir="${case_dir}/repo"
+  local stub_dir="${case_dir}/bin"
+  local output_with_window="${case_dir}/result-with-window.json"
+  local output_without_window="${case_dir}/result-without-window.json"
+  local push_sha
+
+  make_repo "${repo_dir}" "2026-04-19T00:00:00Z"
+  push_sha="$(git -C "${repo_dir}" rev-parse HEAD)"
+  GH_STUB_PUSH_SHA="${push_sha}" make_gh_stub "${stub_dir}"
+
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" \
+    GH_STUB_STATE_DIR="${case_dir}" \
+    GH_STUB_SCENARIO="quiet-wait-gap" \
+    GH_STUB_PUSH_SHA="${push_sha}" \
+    CSA_PR_BOT_NAME="test-bot" \
+    "${SCRIPT_PATH}" 64 \
+      --timeout 3 \
+      --interval 1 \
+      --bot-login "test-bot[bot]" \
+      --push-sha "${push_sha}" \
+      --window-start "2026-04-19T00:00:00Z" \
+      --output "${output_with_window}"
+  )
+
+  assert_json_value "${output_with_window}" '.status' 'replied'
+  assert_json_value "${output_with_window}" '.review.id' '103'
+  assert_json_value "${output_with_window}" '.review.commit_id' 'null'
+
+  set +e
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" \
+    GH_STUB_STATE_DIR="${case_dir}" \
+    GH_STUB_SCENARIO="quiet-wait-gap" \
+    GH_STUB_PUSH_SHA="${push_sha}" \
+    CSA_PR_BOT_NAME="test-bot" \
+    "${SCRIPT_PATH}" 64 \
+      --timeout 3 \
+      --interval 1 \
+      --bot-login "test-bot[bot]" \
+      --push-sha "${push_sha}" \
+      --output "${output_without_window}"
+  )
+  rc=$?
+  set -e
+
+  if [ "${rc}" -ne 1 ]; then
+    echo "quiet-wait regression scenario without window-start expected exit 1, got ${rc}" >&2
+    exit 1
+  fi
+
+  assert_json_value "${output_without_window}" '.status' 'timeout'
+}
+
 run_replied_test
 run_quota_test
 run_null_commit_replied_test
 run_timeout_test
+run_quiet_wait_window_regression_test
 
 echo "pr-bot-wait tests: PASS"

--- a/patterns/pr-bot/skills/pr-bot/SKILL.md
+++ b/patterns/pr-bot/skills/pr-bot/SKILL.md
@@ -131,6 +131,7 @@ cloud_bot_name = "gemini-code-assist"      # bot name (for @mention and display)
 cloud_bot_trigger = "auto"                 # "auto" (bot auto-reviews) | "comment" (@bot review)
 cloud_bot_login = ""                       # bot GitHub login override (default: "${cloud_bot_name}[bot]")
 cloud_bot_retrigger_command = ""           # command to re-trigger after fix push (default: derived from name)
+cloud_bot_poll_interval_seconds = 30       # helper-script gh poll interval (default: 30s)
 merge_strategy = "merge"                   # "merge" | "rebase" (squash is forbidden for audit)
 delete_branch = false                      # delete remote branch after merge
 ```
@@ -148,10 +149,14 @@ Default: `/gemini review` for gemini-code-assist, `@{name} review` for others.
 Override via `cloud_bot_retrigger_command`.
 
 **Timeout behavior**: If bot does not respond within the configured polling window
-(`cloud_bot_wait_seconds` + `cloud_bot_poll_max_seconds`, default ~5 minutes via `kv_cache.frequent_poll_seconds = 60` and `kv_cache.long_poll_seconds = 240`),
+(`cloud_bot_wait_seconds` + helper timeout `cloud_bot_poll_max_seconds`, with helper poll interval `cloud_bot_poll_interval_seconds`, default ~5 minutes via `kv_cache.frequent_poll_seconds = 60`, `cloud_bot_poll_interval_seconds = 30`, and `kv_cache.long_poll_seconds = 240`),
 the workflow **aborts** and presents options to the user. It does NOT silently
 fall back to local review and merge, except for the explicit quota-exhaustion
 path described below.
+
+**Helper env overrides**: the built-in polling helper honors `CSA_PR_BOT_TIMEOUT`
+and `CSA_PR_BOT_INTERVAL` for ad-hoc override/testing. Normal workflow runs pass
+explicit CLI arguments, so these env vars are mainly for direct script use.
 
 **Quota auto-skip cache**: When the configured cloud bot posts a warning that
 contains `daily quota limit` (case-insensitive), pr-bot records a 24h skip
@@ -199,7 +204,7 @@ breaks prompt-guard propagation.
 4. **Trigger cloud bot and delegate waiting** (SELF-CONTAINED -- trigger + wait gate are atomic):
    - **Round 0** (initial PR): follows `cloud_bot_trigger` config (`"comment"` → @mention, `"auto"` → skip).
    - **Round 1+** (after fix push): ALWAYS posts explicit retrigger command (`cloud_bot_retrigger_command`, default: `/gemini review` for gemini-code-assist) because bots do NOT auto-review on subsequent pushes.
-   - Wait `cloud_bot_wait_seconds` quietly, then delegate `cloud_bot_poll_max_seconds` polling to CSA. Defaults are `kv_cache.frequent_poll_seconds` (60s) for the quiet wait and `kv_cache.long_poll_seconds` (240s) for the total poll budget unless explicitly overridden.
+   - Wait `cloud_bot_wait_seconds` quietly, then launch `patterns/pr-bot/scripts/pr-bot-wait.sh` once. The helper polls GitHub in shell using `cloud_bot_poll_interval_seconds` (default: 30s) and writes an atomic JSON result file; the main workflow only checks that file after up to two `kv_cache.long_poll_seconds` windows.
    - **Positive signal**: verifies a review EVENT exists (via `pulls/{pr}/reviews` API with `submitted_at` > push time), not merely absence of comments.
    - **Quota warning shortcut**: if bot comments contain `daily quota limit`, record the 24h quota cache entry and route to the merge-without-bot path instead of repeatedly waiting for a reply that cannot arrive during the quota window.
    - If bot times out: **ABORT workflow** and present options to user. NO silent fallback.
@@ -238,7 +243,7 @@ breaks prompt-guard propagation.
 2. Any local review issues are fixed before PR creation.
 3. PR resolved for the workflow branch (existing PR reused or a new PR created via strict owner-aware match, with create-race recovery and Step 4 precondition verified: `REVIEW_COMPLETED=true`).
 4. Cloud bot config checked (`csa config get pr_review.cloud_bot --default true`).
-5. **If cloud_bot enabled (default)**: cloud bot triggered (round-aware: auto on round 0, explicit retrigger on round 1+), wait handled by delegated CSA gate with hard timeout and positive review-event signal checks, and timeout path handled. If bot responds with environment/configuration setup message instead of actual review, workflow STOPS and reports to user (Step 5a).
+5. **If cloud_bot enabled (default)**: cloud bot triggered (round-aware: auto on round 0, explicit retrigger on round 1+), wait handled by the built-in `pr-bot-wait.sh` helper with hard timeout and positive review-event signal checks, and timeout path handled. If bot responds with environment/configuration setup message instead of actual review, workflow STOPS and reports to user (Step 5a).
 6. **If cloud_bot disabled**: supplementary check completed via one of:
    - fast-path: SHA match, review skipped, or
    - fallback path: SHA mismatch/missing (HEAD drift) and full `csa review --branch main` executed.

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -946,6 +946,7 @@ CSA_PR_BOT_NAME="${CLOUD_BOT_NAME}" nohup "${PR_BOT_WAIT_SCRIPT}" "${PR_NUM}" \
   --interval "${INTERVAL}" \
   --bot-login "${CLOUD_BOT_LOGIN}" \
   --push-sha "${CURRENT_SHA}" \
+  --window-start "${WAIT_BASE_TS}" \
   --quota-cache "${CLOUD_BOT_QUOTA_CACHE_FILE}" \
   --output "${OUTPUT_FILE}" \
   >/dev/null 2>&1 &

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -1036,6 +1036,26 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     REVIEW_EVENT_COUNT="$(echo "${REVIEW_EVENT_RAW}" | awk '{s+=$1} END {print s+0}')"
   fi
   # Helper: check for setup/configuration messages before marking unavailable
+  check_quota_message_step5() {
+    set +e
+    local quota_body
+    quota_body="$(
+      gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
+        | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select((.body // "") | test("daily quota limit"; "i"))] | .[0].body // ""' \
+        2>/dev/null
+    )"
+    set -e
+    if [ -n "${quota_body}" ]; then
+      echo "Quota exhaustion detected from cloud bot comment during post-poll verification." >&2
+      CLOUD_BOT_SKIPPED=true
+      CLOUD_BOT_SKIP_KIND="quota_exhausted"
+      CLOUD_BOT_SKIP_REASON="quota exhausted detected on PR #${PR_NUM}"
+      BOT_UNAVAILABLE=true
+      return 0
+    fi
+    return 1
+  }
+
   _check_setup_message_step5() {
     set +e
     local setup_body

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -939,6 +939,7 @@ fi
 OUTPUT_FILE="$(mktemp -t pr-bot-wait-${PR_NUM}-XXXXXX.json)"
 INTERVAL="$(csa config get pr_review.cloud_bot_poll_interval_seconds --default 30)"
 WAIT_LONG_POLL_SECS="$(csa config get kv_cache.long_poll_seconds --default 240)"
+WAIT_RESULT_GRACE_SECS=1
 POLL_RESULT_STATUS=""
 WAIT_MARKER=""
 CSA_PR_BOT_NAME="${CLOUD_BOT_NAME}" nohup "${PR_BOT_WAIT_SCRIPT}" "${PR_NUM}" \
@@ -951,19 +952,44 @@ CSA_PR_BOT_NAME="${CLOUD_BOT_NAME}" nohup "${PR_BOT_WAIT_SCRIPT}" "${PR_NUM}" \
   --output "${OUTPUT_FILE}" \
   >/dev/null 2>&1 &
 POLL_PID=$!
+WAIT_STARTED_AT="$(date +%s)"
+WAIT_ELAPSED_SECS=0
 
-sleep "${WAIT_LONG_POLL_SECS}"
-if [ ! -f "${OUTPUT_FILE}" ]; then
-  echo "Polling helper still running after first long-poll window; waiting one more window."
-  sleep "${WAIT_LONG_POLL_SECS}"
-fi
+while [ "${WAIT_ELAPSED_SECS}" -lt "${CLOUD_BOT_POLL_MAX_SECONDS}" ]; do
+  if [ -f "${OUTPUT_FILE}" ]; then
+    break
+  fi
+  if ! kill -0 "${POLL_PID}" 2>/dev/null; then
+    sleep "${WAIT_RESULT_GRACE_SECS}"
+    break
+  fi
+
+  remaining=$((CLOUD_BOT_POLL_MAX_SECONDS - WAIT_ELAPSED_SECS))
+  step="${WAIT_LONG_POLL_SECS}"
+  if [ "${step}" -gt "${remaining}" ]; then
+    step="${remaining}"
+  fi
+
+  sleep "${step}" &
+  WAIT_SLEEP_PID=$!
+  wait -n "${POLL_PID}" "${WAIT_SLEEP_PID}" 2>/dev/null || true
+  if kill -0 "${WAIT_SLEEP_PID}" 2>/dev/null; then
+    kill "${WAIT_SLEEP_PID}" 2>/dev/null || true
+    wait "${WAIT_SLEEP_PID}" 2>/dev/null || true
+  fi
+  WAIT_ELAPSED_SECS=$(( $(date +%s) - WAIT_STARTED_AT ))
+done
+
+WAIT_ELAPSED_SECS=$(( $(date +%s) - WAIT_STARTED_AT ))
 
 if [ ! -f "${OUTPUT_FILE}" ]; then
   if kill -0 "${POLL_PID}" 2>/dev/null; then
     kill "${POLL_PID}" 2>/dev/null || true
+    wait "${POLL_PID}" 2>/dev/null || true
   fi
-  echo "ERROR: Cloud bot polling helper did not produce a result file after two long-poll windows." >&2
-  exit 1
+  printf '{"status":"timeout","pr":%s,"elapsed_seconds":%s}\n' \
+    "${PR_NUM}" "${WAIT_ELAPSED_SECS}" > "${OUTPUT_FILE}.tmp"
+  mv "${OUTPUT_FILE}.tmp" "${OUTPUT_FILE}"
 fi
 
 POLL_RESULT_STATUS="$(jq -r '.status // empty' "${OUTPUT_FILE}")"

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -66,6 +66,9 @@ name = "CLOUD_BOT_QUOTA_EXPECTED_RESET_AT"
 name = "CLOUD_BOT_POLL_MAX_SECONDS"
 
 [[workflow.variables]]
+name = "OUTPUT_FILE"
+
+[[workflow.variables]]
 name = "CLOUD_BOT_RETRIGGER_CMD"
 
 [[workflow.variables]]
@@ -241,6 +244,12 @@ name = "POLL_IDLE_TIMEOUT"
 
 [[workflow.variables]]
 name = "POLL_MAX_TIMEOUT"
+
+[[workflow.variables]]
+name = "POLL_PID"
+
+[[workflow.variables]]
+name = "POLL_RESULT_STATUS"
 
 [[workflow.variables]]
 name = "POST_FIX_REUSED_REVIEW_ID"
@@ -797,8 +806,9 @@ tool = "bash"
 prompt = '''
 > **Layer**: 0 + 1 (Orchestrator + CSA executor).
 > Layer 0 triggers cloud bot review (via @mention or auto-review depending on
-> `cloud_bot_trigger` config and review round) and delegates the long wait to a
-> single CSA-managed step. No explicit caller-side polling loop.
+> `cloud_bot_trigger` config and review round), launches a self-contained shell
+> poller once, then checks a deterministic result file after at most two
+> long-poll windows. Intermediate GitHub polling happens entirely in shell.
 
 
 Trigger cloud bot review for current HEAD. Trigger method is **round-aware**:
@@ -808,7 +818,7 @@ Trigger cloud bot review for current HEAD. Trigger method is **round-aware**:
   (`cloud_bot_retrigger_command`, default: `/gemini review` for gemini-code-assist)
   because bots do NOT auto-review on subsequent pushes (#506).
 
-Wait `cloud_bot_wait_seconds` (default: `kv_cache.frequent_poll_seconds`, 60s), then delegate `cloud_bot_poll_max_seconds` (default: `kv_cache.long_poll_seconds`, 240s) polling to CSA.
+Wait `cloud_bot_wait_seconds` (default: `kv_cache.frequent_poll_seconds`, 60s), then launch `patterns/pr-bot/scripts/pr-bot-wait.sh` with `cloud_bot_poll_max_seconds` (default: `kv_cache.long_poll_seconds`, 240s) as its internal timeout and `cloud_bot_poll_interval_seconds` (default: `30`) as its shell-level poll interval.
 If an exact current-HEAD bot review already exists before this run triggers the
 bot, reuse that specific review object instead of posting a duplicate trigger
 or aborting on resume/rerun.
@@ -912,122 +922,96 @@ echo "Waiting ${CLOUD_BOT_WAIT_SECONDS}s before polling (bot responses rarely ar
 sleep "${CLOUD_BOT_WAIT_SECONDS}"
 BOT_REVIEW_WINDOW_START="${WAIT_BASE_TS}"
 
-# --- Delegate remaining polling to CSA-managed step ---
+# Compatibility + recovery probe: keep the current-window review helper shape
+# so pr-bot can still confirm a HEAD-matching review event when the helper's
+# result file only contains a comment timestamp.
 query_current_window_current_head_review_ts() {
   gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews?per_page=100" 2>/dev/null \
     | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.submitted_at >= "'"${WAIT_BASE_TS}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .commit_id == null) | .submitted_at] | sort | last // ""'
 }
 
-refresh_current_window_review_signal() {
-  set +e
-  CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS="$(query_current_window_current_head_review_ts)"
-  CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS_RC=$?
-  set -e
-  if [ "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS_RC}" -eq 0 ] \
-    && [ -n "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS}" ]
-  then
-    echo "Detected current-window @${CLOUD_BOT_NAME} review on HEAD ${CURRENT_SHA} at ${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS}."
-  fi
-}
-check_quota_message_step5() {
-  local quota_message_body
-  set +e
-  quota_message_body="$(
-    gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
-      | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select((.body // "") | test("daily quota limit"; "i"))] | sort_by(.created_at) | last | .body // ""' \
-      2>/dev/null
-  )"
-  set -e
-  if [ -z "${quota_message_body}" ]; then
-    return 1
-  fi
-
-  quota_section_header="[cloud_bot_quota.${CLOUD_BOT_NAME}]"
-  quota_write_tmp="${CLOUD_BOT_QUOTA_CACHE_FILE}.tmp"
-  quota_body_tmp="${CLOUD_BOT_QUOTA_CACHE_FILE}.body.tmp"
-  quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  quota_expected_reset_at="$(date -u -d '+24 hours' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+24H +%Y-%m-%dT%H:%M:%SZ)"
-  quota_short_message="$(printf '%s' "${quota_message_body}" | tr '\r\n\t' '   ' | head -c 200)"
-  quota_short_message_escaped="$(printf '%s' "${quota_short_message}" | sed 's/\\/\\\\/g; s/"/\\"/g')"
-  mkdir -p "$(dirname "${CLOUD_BOT_QUOTA_CACHE_FILE}")"
-  if [ -f "${CLOUD_BOT_QUOTA_CACHE_FILE}" ]; then
-    awk -v target="${quota_section_header}" '
-      $0 == target { skip = 1; next }
-      skip && /^\[/ { skip = 0 }
-      !skip { print }
-    ' "${CLOUD_BOT_QUOTA_CACHE_FILE}" >"${quota_body_tmp}"
-  else
-    : >"${quota_body_tmp}"
-  fi
-  {
-    cat "${quota_body_tmp}"
-    if [ -s "${quota_body_tmp}" ]; then
-      printf '\n'
-    fi
-    printf '%s\n' "${quota_section_header}"
-    printf 'exhausted_at = "%s"\n' "${quota_now_utc}"
-    printf 'expected_reset_at = "%s"\n' "${quota_expected_reset_at}"
-    printf 'last_pr_seen = %s\n' "${PR_NUM}"
-    printf 'last_quota_message = "%s"\n' "${quota_short_message_escaped}"
-  } >"${quota_write_tmp}"
-  rm -f "${quota_body_tmp}"
-  mv "${quota_write_tmp}" "${CLOUD_BOT_QUOTA_CACHE_FILE}"
-  CLOUD_BOT_QUOTA_EXHAUSTED_AT="${quota_now_utc}"
-  CLOUD_BOT_QUOTA_EXPECTED_RESET_AT="${quota_expected_reset_at}"
-  CLOUD_BOT_SKIPPED=true
-  CLOUD_BOT_SKIP_KIND="quota_exhausted"
-  CLOUD_BOT_SKIP_REASON="quota exhausted detected on PR #${PR_NUM}"
-  BOT_UNAVAILABLE=true
-  BOT_HAS_ISSUES=false
-  BOT_HAS_ISSUES_SOURCE=""
-  MERGE_WITHOUT_BOT_REASON_KIND="cloud_bot_quota_exhausted"
-  echo "Quota exhaustion detected for ${CLOUD_BOT_NAME}; cache updated at ${CLOUD_BOT_QUOTA_CACHE_FILE}. Routing to merge-without-bot path." >&2
-  return 0
-}
-WAIT_MARKER=""
-# POLL_IDLE_TIMEOUT and POLL_MAX_TIMEOUT are pre-computed in Step 4a.
-set +e
-WAIT_SID="$(csa run --sa-mode true --tier tier-1 --timeout ${POLL_MAX_TIMEOUT} --idle-timeout ${POLL_IDLE_TIMEOUT} "Bounded wait task only. Do NOT invoke pr-bot skill or any full PR workflow. Operate on PR #${PR_NUM} in repo ${REPO}. Wait for @${CLOUD_BOT_NAME} review on HEAD ${CURRENT_SHA}. Check for a review EVENT via 'gh api repos/${REPO}/pulls/${PR_NUM}/reviews' with submitted_at after ${WAIT_BASE_TS} and user.login matching the bot. Also check issue comments for bot activity. Max wait ${CLOUD_BOT_POLL_MAX_SECONDS} seconds (quiet wait already elapsed before this step). Do not edit code. Return exactly one marker line: BOT_REPLY=received or BOT_REPLY=timeout.")"
-DAEMON_RC=$?
-set -e
-if [ "${DAEMON_RC}" -ne 0 ] || [ -z "${WAIT_SID}" ]; then
-  echo "WARN: Failed to launch daemon for bot wait (rc=${DAEMON_RC}); treating cloud bot as unavailable." >&2
-  BOT_UNAVAILABLE=true
+# --- Launch self-contained poller once; main workflow only checks the result file ---
+if [ -n "${CSA_WORKFLOW_DIR:-}" ]; then
+  PR_BOT_WAIT_SCRIPT="${CSA_WORKFLOW_DIR}/scripts/pr-bot-wait.sh"
 else
-  set +e
-  WAIT_RESULT="$(bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "${WAIT_SID}")"
-  WAIT_RC=$?
-  set -e
-  if [ "${WAIT_RC}" -ne 0 ]; then
-    echo "WARN: Delegated bot wait failed (rc=${WAIT_RC}); treating cloud bot as unavailable." >&2
-    BOT_UNAVAILABLE=true
-  else
-    WAIT_MARKER="$(
-      printf '%s\n' "${WAIT_RESULT}" \
-        | grep -E '^[[:space:]]*BOT_REPLY=(received|timeout)[[:space:]]*$' \
-        | tail -n 1 \
-        | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
-        || true
-    )"
-    if [ "${WAIT_MARKER}" = "BOT_REPLY=timeout" ]; then
-      BOT_UNAVAILABLE=true
-    elif [ "${WAIT_MARKER}" != "BOT_REPLY=received" ]; then
-      echo "WARN: Delegated bot wait returned no marker; treating cloud bot as unavailable." >&2
-      BOT_UNAVAILABLE=true
-    fi
-  fi
+  PR_BOT_WAIT_SCRIPT="patterns/pr-bot/scripts/pr-bot-wait.sh"
 fi
+OUTPUT_FILE="$(mktemp -t pr-bot-wait-${PR_NUM}-XXXXXX.json)"
+INTERVAL="$(csa config get pr_review.cloud_bot_poll_interval_seconds --default 30)"
+WAIT_LONG_POLL_SECS="$(csa config get kv_cache.long_poll_seconds --default 240)"
+POLL_RESULT_STATUS=""
+WAIT_MARKER=""
+CSA_PR_BOT_NAME="${CLOUD_BOT_NAME}" nohup "${PR_BOT_WAIT_SCRIPT}" "${PR_NUM}" \
+  --timeout "${CLOUD_BOT_POLL_MAX_SECONDS}" \
+  --interval "${INTERVAL}" \
+  --bot-login "${CLOUD_BOT_LOGIN}" \
+  --push-sha "${CURRENT_SHA}" \
+  --quota-cache "${CLOUD_BOT_QUOTA_CACHE_FILE}" \
+  --output "${OUTPUT_FILE}" \
+  >/dev/null 2>&1 &
+POLL_PID=$!
+
+sleep "${WAIT_LONG_POLL_SECS}"
+if [ ! -f "${OUTPUT_FILE}" ]; then
+  echo "Polling helper still running after first long-poll window; waiting one more window."
+  sleep "${WAIT_LONG_POLL_SECS}"
 fi
 
-if [ "${WAIT_MARKER}" != "BOT_REPLY=received" ]; then
-  refresh_current_window_review_signal
-  if [ "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS_RC}" -eq 0 ] && [ -n "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS}" ]; then
+if [ ! -f "${OUTPUT_FILE}" ]; then
+  if kill -0 "${POLL_PID}" 2>/dev/null; then
+    kill "${POLL_PID}" 2>/dev/null || true
+  fi
+  echo "ERROR: Cloud bot polling helper did not produce a result file after two long-poll windows." >&2
+  exit 1
+fi
+
+POLL_RESULT_STATUS="$(jq -r '.status // empty' "${OUTPUT_FILE}")"
+case "${POLL_RESULT_STATUS}" in
+  replied)
     WAIT_MARKER="BOT_REPLY=received"
     BOT_UNAVAILABLE=false
-    echo "Detected current-window @${CLOUD_BOT_NAME} review for HEAD ${CURRENT_SHA} after delegated wait; continuing."
-  else
-    check_quota_message_step5 || true
-  fi
+    BOT_REVIEW_WINDOW_START="$(jq -r '.review.submitted_at // .comment.created_at // empty' "${OUTPUT_FILE}")"
+    if [ -z "${BOT_REVIEW_WINDOW_START}" ]; then
+      set +e
+      CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS="$(query_current_window_current_head_review_ts)"
+      CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS_RC=$?
+      set -e
+      if [ "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS_RC}" -eq 0 ] && [ -n "${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS}" ]; then
+        BOT_REVIEW_WINDOW_START="${CURRENT_WINDOW_CURRENT_HEAD_REVIEW_TS}"
+      else
+        BOT_REVIEW_WINDOW_START="${WAIT_BASE_TS}"
+      fi
+    fi
+    ;;
+  quota_exhausted)
+    WAIT_MARKER="BOT_REPLY=quota_exhausted"
+    BOT_UNAVAILABLE=true
+    BOT_HAS_ISSUES=false
+    BOT_HAS_ISSUES_SOURCE=""
+    CLOUD_BOT_SKIPPED=true
+    CLOUD_BOT_SKIP_KIND="quota_exhausted"
+    CLOUD_BOT_SKIP_REASON="quota exhausted detected on PR #${PR_NUM}"
+    CLOUD_BOT_QUOTA_EXHAUSTED_AT="$(jq -r '.exhausted_at // empty' "${OUTPUT_FILE}")"
+    CLOUD_BOT_QUOTA_EXPECTED_RESET_AT="$(jq -r '.expected_reset_at // empty' "${OUTPUT_FILE}")"
+    MERGE_WITHOUT_BOT_REASON_KIND="cloud_bot_quota_exhausted"
+    BOT_REVIEW_WINDOW_START="$(jq -r '.comment.created_at // empty' "${OUTPUT_FILE}")"
+    if [ -z "${BOT_REVIEW_WINDOW_START}" ]; then
+      BOT_REVIEW_WINDOW_START="${WAIT_BASE_TS}"
+    fi
+    echo "Quota exhaustion detected for ${CLOUD_BOT_NAME}; cache updated at ${CLOUD_BOT_QUOTA_CACHE_FILE}. Routing to merge-without-bot path." >&2
+    ;;
+  timeout)
+    echo "ERROR: Cloud bot did not respond within ${CLOUD_BOT_POLL_MAX_SECONDS}s after the quiet wait." >&2
+    echo "Options: retry later, inspect the PR page manually, or disable the cloud bot for this run." >&2
+    exit 1
+    ;;
+  *)
+    echo "ERROR: Unknown polling helper status '${POLL_RESULT_STATUS}'." >&2
+    cat "${OUTPUT_FILE}" >&2
+    exit 1
+    ;;
+esac
+rm -f "${OUTPUT_FILE}"
 fi
 
 if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then


### PR DESCRIPTION
## Summary

- Adds `patterns/pr-bot/scripts/pr-bot-wait.sh` self-contained poller that emits atomic JSON (`replied`/`quota_exhausted`/`timeout`), eliminating agent-side token burn during 5+ min cloud-bot wait windows.
- Wires the helper into Step 5 of `patterns/pr-bot/workflow.toml` + `PATTERN.md`. Wrapper honors `cloud_bot_poll_max_seconds` as the ground-truth budget with `WAIT_LONG_POLL_SECS` granularity.
- Adds new config key `pr_review.cloud_bot_poll_interval_seconds` (default 30).
- Unblocks `patterns/` tracking in this dev repo by negating the global `~/.gitignore_noai` `patterns` blanket rule in the project `.gitignore` (rule 036 exception).

## Iteration

Four narrow fix rounds, each finding a DIFFERENT concrete bug (valid iterative quality work per CLAUDE.md "iterative narrow fixes ≠ ping-pong"):

- Round 1 — initial impl (`2c1b4bea`)
- Round 2 (`df027c3a`) — null-commit review filter added + dangling `check_quota_message_step5` restored
- Round 3 (`e7d55b68`) — pass `--window-start ${WAIT_BASE_TS}` from workflow/PATTERN so quiet-wait-window reviews count
- Round 4 (`b80a5dd3`) — Step 5 wrapper polls OUTPUT_FILE + helper pid with `cloud_bot_poll_max_seconds` total budget instead of 1-or-2 hardcoded long-poll sleeps

## Cloud bot status

gemini-code-assist cloud bot is quota-exhausted (est reset ~2026-04-20 07:20Z per #892 cache). Local review (session `01KPJSP5JG4PPYZECA6W8SGTH3`) passed with verdict **CLEAN** (0 HIGH/CRITICAL). Merging via bot-unavailable path per pr-bot Step 6a.

## Followup

- 1 MEDIUM remaining (REV2-M01): post-poll inline `check_quota_message_step5` branch doesn't persist `cloud_bot_quota.toml` + exported timestamps. To be filed as a followup issue after merge.

## Test plan

- [x] `patterns/pr-bot/scripts/tests/pr-bot-wait-tests.sh` — all scenarios pass (replied / quota / timeout / null-commit / wrapper short-helper / wrapper long-helper)
- [x] `just pre-commit` passes at HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)