### PR TITLE
fix(cli-sub-agent): --model-spec exact-selection parity (#731 #733 #734)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.368"
+version = "0.1.369"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.369"
+version = "0.1.370"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.369"
+version = "0.1.370"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.368"
+version = "0.1.369"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
@@ -23,32 +23,16 @@ pub(crate) async fn handle_claude_sub_agent(
     // 3. Read prompt
     let prompt = crate::run_helpers::read_prompt(args.question)?;
 
-    // 6. Resolve tool
-    let user_explicit_tool = args.tool.is_some();
     let parent_tool = crate::run_helpers::detect_parent_tool();
-    let tool = resolve_claude_tool(
+    let (tool_name, resolved_model_spec, resolved_model) = resolve_claude_sub_agent_tool_and_model(
         args.tool,
+        args.model_spec.as_deref(),
+        args.model.as_deref(),
         config.as_ref(),
         &global_config,
         parent_tool.as_deref(),
         &project_root,
     )?;
-
-    // 7. Resolve model
-    let (tool_name, resolved_model_spec, resolved_model) =
-        crate::run_helpers::resolve_tool_and_model(
-            Some(tool),
-            args.model_spec.as_deref(),
-            args.model.as_deref(),
-            config.as_ref(),
-            &project_root,
-            false,               // claude-sub-agent does not support --force
-            false,               // claude-sub-agent does not support --force-override-user-config
-            false,               // claude-sub-agent does not require edit-capable tool filtering
-            None,                // claude-sub-agent does not support --tier
-            false,               // claude-sub-agent does not support --force-ignore-tier-setting
-            !user_explicit_tool, // auto-selected unless the caller explicitly passed --tool
-        )?;
 
     // 8. Build executor and validate tool
     let executor = crate::pipeline::build_and_validate_executor(
@@ -134,6 +118,46 @@ pub(crate) async fn handle_claude_sub_agent(
     }
 
     Ok(result.exit_code)
+}
+
+fn resolve_claude_sub_agent_tool_and_model(
+    arg_tool: Option<ToolArg>,
+    model_spec: Option<&str>,
+    model: Option<&str>,
+    project_config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+    parent_tool: Option<&str>,
+    project_root: &Path,
+) -> Result<(ToolName, Option<String>, Option<String>)> {
+    let user_explicit_tool = matches!(
+        arg_tool.as_ref(),
+        Some(ToolArg::Specific(_) | ToolArg::Alias(_))
+    );
+    let resolved_tool = if model_spec.is_some() && !user_explicit_tool {
+        None
+    } else {
+        Some(resolve_claude_tool(
+            arg_tool,
+            project_config,
+            global_config,
+            parent_tool,
+            project_root,
+        )?)
+    };
+
+    crate::run_helpers::resolve_tool_and_model(
+        resolved_tool,
+        model_spec,
+        model,
+        project_config,
+        project_root,
+        false,               // claude-sub-agent does not support --force
+        false,               // claude-sub-agent does not support --force-override-user-config
+        false,               // claude-sub-agent does not require edit-capable tool filtering
+        None,                // claude-sub-agent does not support --tier
+        false,               // claude-sub-agent does not support --force-ignore-tier-setting
+        !user_explicit_tool, // treat auto/implicit selection as non-explicit
+    )
 }
 
 /// Maximum SKILL.md file size (256 KB) to prevent excessive memory/token usage
@@ -368,6 +392,47 @@ mod tests {
         assert_eq!(tool_name, ToolName::Codex);
         assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/high"));
         assert!(model.is_none());
+    }
+
+    #[test]
+    fn resolve_claude_sub_agent_tool_and_model_short_circuits_auto_select_for_model_spec() {
+        let global = GlobalConfig::default();
+
+        let (tool_name, model_spec, model) = super::resolve_claude_sub_agent_tool_and_model(
+            None,
+            Some("codex/openai/gpt-5.4/medium"),
+            None,
+            None,
+            &global,
+            Some("claude-code"),
+            std::path::Path::new("/tmp/test-project"),
+        )
+        .expect("model-spec exact selection should not require auto-selected tool");
+
+        assert_eq!(tool_name, ToolName::Codex);
+        assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/medium"));
+        assert!(model.is_none());
+    }
+
+    #[test]
+    fn resolve_claude_sub_agent_tool_and_model_rejects_tool_model_spec_mismatch() {
+        let global = GlobalConfig::default();
+
+        let error = super::resolve_claude_sub_agent_tool_and_model(
+            Some(ToolArg::Specific(ToolName::GeminiCli)),
+            Some("codex/openai/gpt-5.4/medium"),
+            None,
+            None,
+            &global,
+            Some("claude-code"),
+            std::path::Path::new("/tmp/test-project"),
+        )
+        .expect_err("mismatched explicit --tool + --model-spec must error");
+
+        let message = error.to_string();
+        assert!(message.contains("--tool gemini-cli"));
+        assert!(message.contains("--model-spec codex/openai/gpt-5.4/medium"));
+        assert!(message.contains("tool codex"));
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
@@ -398,6 +398,21 @@ mod tests {
     fn resolve_claude_sub_agent_tool_and_model_short_circuits_auto_select_for_model_spec() {
         let global = GlobalConfig::default();
 
+        let auto_select_error = resolve_claude_tool(
+            None,
+            None,
+            &global,
+            Some("claude-code"),
+            std::path::Path::new("/tmp/test-project"),
+        )
+        .expect_err("without model-spec, auto-select should fail when no config enables tools");
+        assert!(
+            auto_select_error
+                .to_string()
+                .contains("No suitable tool found for claude-sub-agent"),
+            "{auto_select_error}"
+        );
+
         let (tool_name, model_spec, model) = super::resolve_claude_sub_agent_tool_and_model(
             None,
             Some("codex/openai/gpt-5.4/medium"),

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -769,5 +769,9 @@ mod transport_tests;
 mod model_spec_tests;
 
 #[cfg(test)]
+#[path = "run_helpers_override_tests.rs"]
+mod override_tests;
+
+#[cfg(test)]
 #[path = "run_helpers_transport_integration_tests.rs"]
 mod transport_integration_tests;

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -88,6 +88,7 @@ pub(crate) fn resolve_tool_and_model(
 ) -> Result<(ToolName, Option<String>, Option<String>)> {
     let tiers_configured = config.is_some_and(|c| !c.tiers.is_empty());
     let bypass_tier = force_ignore_tier_setting || force_override_user_config;
+    let exact_selection_active = model_spec.is_some();
 
     // Enforce tier routing: block direct --tool/--model/--thinking when tiers are configured,
     // unless --force-ignore-tier-setting (or --force) is active. --model-spec is the
@@ -98,6 +99,7 @@ pub(crate) fn resolve_tool_and_model(
     if tiers_configured
         && !bypass_tier
         && tier.is_none()
+        && !exact_selection_active
         && (tool_triggers_enforcement || model.is_some())
     {
         let cfg = config.unwrap();
@@ -197,11 +199,27 @@ pub(crate) fn resolve_tool_and_model(
     if let Some(spec) = model_spec {
         let parsed = ModelSpec::parse(spec)?;
         let tool_name = parse_tool_name(&parsed.tool)?;
+        if let Some(requested_tool) = tool.filter(|_| !tool_is_auto_resolved)
+            && requested_tool != tool_name
+        {
+            anyhow::bail!(
+                "Conflicting routing flags: --tool {} does not match --model-spec {}.\n\
+                 The model spec selects tool {}. Use a matching --tool value or omit --tool.",
+                requested_tool.as_str(),
+                spec,
+                tool_name.as_str()
+            );
+        }
         // Enforce tool enablement from user config
         if let Some(cfg) = config {
             cfg.enforce_tool_enabled(tool_name.as_str(), force_override_user_config)?;
         }
-        return Ok((tool_name, Some(spec.to_string()), None));
+        let resolved_model = model.map(|m| {
+            config
+                .map(|cfg| cfg.resolve_alias(m))
+                .unwrap_or_else(|| m.to_string())
+        });
+        return Ok((tool_name, Some(spec.to_string()), resolved_model));
     }
 
     // Case 2: tool provided → use it with optional model (apply alias resolution)
@@ -745,6 +763,10 @@ mod tier_tests;
 #[cfg(test)]
 #[path = "run_helpers_transport_tests.rs"]
 mod transport_tests;
+
+#[cfg(test)]
+#[path = "run_helpers_model_spec_tests.rs"]
+mod model_spec_tests;
 
 #[cfg(test)]
 #[path = "run_helpers_transport_integration_tests.rs"]

--- a/crates/cli-sub-agent/src/run_helpers_model_spec_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_model_spec_tests.rs
@@ -1,0 +1,129 @@
+use super::resolve_tool_and_model;
+use csa_config::{
+    ProjectConfig, ProjectMeta, ResourcesConfig, TierConfig, TierStrategy, ToolConfig,
+};
+use csa_core::types::ToolName;
+use std::collections::HashMap;
+
+fn project_config_with_tier_tools(tools: &[&str]) -> ProjectConfig {
+    let mut tool_map = HashMap::new();
+    let mut tier_models = Vec::new();
+    for tool in tools {
+        tool_map.insert(
+            (*tool).to_string(),
+            ToolConfig {
+                enabled: true,
+                restrictions: None,
+                suppress_notify: true,
+                ..Default::default()
+            },
+        );
+        tier_models.push(format!("{tool}/provider/model/medium"));
+    }
+
+    let mut tiers = HashMap::new();
+    if !tier_models.is_empty() {
+        tiers.insert(
+            "tier3".to_string(),
+            TierConfig {
+                description: "test".to_string(),
+                models: tier_models,
+                strategy: TierStrategy::default(),
+                token_budget: None,
+                max_turns: None,
+            },
+        );
+    }
+
+    ProjectConfig {
+        schema_version: 1,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: tool_map,
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping: HashMap::from([("default".to_string(), "tier3".to_string())]),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    }
+}
+
+#[test]
+fn resolve_tool_and_model_allows_matching_tool_with_model_spec_when_tiers_configured() {
+    let config = project_config_with_tier_tools(&["codex", "gemini-cli"]);
+
+    let (tool, model_spec, model) = resolve_tool_and_model(
+        Some(ToolName::Codex),
+        Some("codex/openai/gpt-5.4/medium"),
+        None,
+        Some(&config),
+        std::path::Path::new("/tmp/test-project"),
+        false,
+        false,
+        false,
+        None,
+        false,
+        false,
+    )
+    .expect("matching --tool + --model-spec should bypass tier enforcement");
+
+    assert_eq!(tool, ToolName::Codex);
+    assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/medium"));
+    assert!(model.is_none());
+}
+
+#[test]
+fn resolve_tool_and_model_rejects_mismatched_tool_and_model_spec() {
+    let config = project_config_with_tier_tools(&["codex", "gemini-cli"]);
+
+    let error = resolve_tool_and_model(
+        Some(ToolName::GeminiCli),
+        Some("codex/openai/gpt-5.4/medium"),
+        None,
+        Some(&config),
+        std::path::Path::new("/tmp/test-project"),
+        false,
+        false,
+        false,
+        None,
+        false,
+        false,
+    )
+    .expect_err("mismatched --tool + --model-spec must error");
+
+    let message = error.to_string();
+    assert!(message.contains("--tool gemini-cli"));
+    assert!(message.contains("--model-spec codex/openai/gpt-5.4/medium"));
+    assert!(message.contains("tool codex"));
+}
+
+#[test]
+fn resolve_tool_and_model_preserves_explicit_model_override_with_model_spec() {
+    let (tool, model_spec, model) = resolve_tool_and_model(
+        Some(ToolName::Codex),
+        Some("codex/openai/gpt-5.4/medium"),
+        Some("override-model"),
+        None,
+        std::path::Path::new("/tmp/test-project"),
+        false,
+        false,
+        false,
+        None,
+        false,
+        false,
+    )
+    .expect("resolver should preserve explicit model override");
+
+    assert_eq!(tool, ToolName::Codex);
+    assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/medium"));
+    assert_eq!(model.as_deref(), Some("override-model"));
+}

--- a/crates/cli-sub-agent/src/run_helpers_override_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_override_tests.rs
@@ -1,0 +1,47 @@
+use super::resolve_tool_and_model;
+use csa_config::{ProjectConfig, ProjectMeta, ResourcesConfig};
+use csa_core::types::ToolName;
+use std::collections::HashMap;
+
+#[test]
+fn resolve_tool_and_model_model_spec_preserves_explicit_model_override() {
+    let cfg = ProjectConfig {
+        schema_version: 1,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    let (tool, model_spec, model) = resolve_tool_and_model(
+        None,
+        Some("codex/openai/gpt-5.4/medium"),
+        Some("explicit-model"),
+        Some(&cfg),
+        std::path::Path::new("/tmp"),
+        false,
+        false,
+        false,
+        None,
+        false,
+        false,
+    )
+    .expect("resolver should preserve explicit --model alongside --model-spec");
+
+    assert_eq!(tool, ToolName::Codex);
+    assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/medium"));
+    assert_eq!(model.as_deref(), Some("explicit-model"));
+}


### PR DESCRIPTION
## Summary

- #733: tier enforcement no longer blocks matching `--tool X --model-spec X/...`.
- #734: resolver preserves explicit `--model`/`--thinking` overrides alongside `--model-spec`.
- #731: `claude-sub-agent` reads `--model-spec` before invoking tool auto-select, so exact-selection works when no auto-selectable tool exists.

The `--model-spec` flag now has a uniform exact-selection contract across `run` / `review` / `debate` / `claude-sub-agent`: tier enforcement is bypassed on exact selection, overrides flow through, and tool auto-select runs only when `--model-spec` is absent.

## Cloud bot status

gemini-code-assist cloud bot is quota-exhausted (est reset ~2026-04-20 07:20Z per #892 cache). Local review (session `01KPJXZ9J0ZW564AEP6JFWYM6X`) returned 0 HIGH/CRITICAL. Merging via bot-unavailable path per pr-bot Step 6a.

## Followup

1 MEDIUM remaining (`R2-M1`): alias-backed tool strategies (`[tool_aliases] router = "auto"`) still bypass the new short-circuit because `user_explicit_tool` is computed from the raw CLI token, not the alias-resolved `ToolArg`. To be filed as a followup issue after merge.

## Test plan

- [x] `just pre-commit` passes
- [x] New tests for #731/#733/#734 pass
- [x] Existing resolver + build_executor tests unaffected