### PR TITLE
fix(cli-sub-agent): pre-exec routing conflict persistence via structured detection (#735)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.370"
+version = "0.1.371"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.370"
+version = "0.1.371"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -301,7 +301,7 @@ pub(crate) async fn handle_run(
         force_ignore_tier_setting,
     )
     .map_err(|err| {
-        if err.to_string().contains("Conflicting routing flags") {
+        if crate::run_helpers::is_routing_conflict(&err) {
             crate::session_guard::persist_pre_exec_error_result(
                 crate::session_guard::PreExecErrorCtx {
                     project_root: &project_root,

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -66,6 +66,10 @@ fn write_project_config(project_root: &Path, config: &ProjectConfig) {
     std::fs::write(config_path, toml::to_string_pretty(config).unwrap()).unwrap();
 }
 
+fn run_config_without_routable_tools() -> ProjectConfig {
+    run_config_with_tier("default", Vec::new(), &[])
+}
+
 #[tokio::test]
 async fn handle_run_persists_result_for_model_spec_tier_conflict() {
     let project_dir = tempdir().unwrap();
@@ -120,6 +124,10 @@ async fn handle_run_persists_result_for_model_spec_tier_conflict() {
     .expect_err("model-spec + tier conflict must return an error");
 
     assert!(
+        crate::run_helpers::is_routing_conflict(&err),
+        "routing conflict classification should be structured: {err:#}"
+    );
+    assert!(
         err.chain()
             .any(|cause| cause.to_string().contains("Conflicting routing flags")),
         "unexpected error chain: {err:#}"
@@ -144,5 +152,71 @@ async fn handle_run_persists_result_for_model_spec_tier_conflict() {
         result
             .summary
             .contains("--model-spec and --tier are mutually exclusive")
+    );
+}
+
+#[tokio::test]
+async fn handle_run_does_not_persist_result_for_non_conflict_pre_exec_error() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let config = run_config_without_routable_tools();
+    write_project_config(project_dir.path(), &config);
+
+    let err = handle_run(
+        None,
+        None,
+        None,
+        Some("inspect the repository".to_string()),
+        None,
+        None,
+        None,
+        false,
+        None,
+        false,
+        None,
+        false,
+        None,
+        None,
+        false,
+        Some(project_dir.path().display().to_string()),
+        None,
+        None,
+        None,
+        false,
+        false,
+        false,
+        false,
+        None,
+        None,
+        None,
+        false,
+        false,
+        None,
+        0,
+        OutputFormat::Text,
+        csa_process::StreamMode::BufferOnly,
+        None,
+        false,
+        false,
+        Vec::new(),
+        Vec::new(),
+    )
+    .await
+    .expect_err("non-conflict pre-exec error must return an error");
+
+    assert!(
+        !crate::run_helpers::is_routing_conflict(&err),
+        "unrelated pre-exec failures should not classify as routing conflicts: {err:#}"
+    );
+    assert!(
+        err.to_string()
+            .contains("No tool specified and no tier-based or auto-selectable tool available"),
+        "unexpected error: {err:#}"
+    );
+
+    let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
+    assert!(
+        sessions.is_empty(),
+        "non-conflict pre-exec errors should not create persisted run sessions"
     );
 }

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -11,10 +11,13 @@ use csa_session::TokenUsage;
 
 #[path = "run_helpers_edit_requirement.rs"]
 mod edit_requirement;
+#[path = "run_helpers_routing_conflict.rs"]
+mod routing_conflict;
 #[path = "run_helpers_tool_availability.rs"]
 mod tool_availability;
 
 pub(crate) use edit_requirement::{infer_task_edit_requirement, resolve_task_edit_requirement};
+pub(crate) use routing_conflict::{is_routing_conflict, routing_conflict_error};
 pub(crate) use tool_availability::{
     ToolBinaryAvailability, is_tool_binary_available_for_config, resolved_tool_binary_name,
     tool_binary_availability,
@@ -35,12 +38,12 @@ pub(crate) fn validate_tool_tier_override_flags(
     force_ignore_tier_setting: bool,
 ) -> Result<()> {
     if explicit_tool_requested && tier.is_some() && force_ignore_tier_setting {
-        anyhow::bail!(
+        return Err(routing_conflict_error(
             "Conflicting routing flags: --tool + --tier uses the tier's model/thinking for \
              that tool, while --force-ignore-tier-setting bypasses tier routing.\n\
              Remove --force-ignore-tier-setting to use tier routing, or remove --tier to \
-             bypass tiers entirely."
-        );
+             bypass tiers entirely.",
+        ));
     }
 
     Ok(())
@@ -52,10 +55,10 @@ pub(crate) fn validate_model_spec_tier_conflict(
     command: &str,
 ) -> Result<()> {
     if model_spec.is_some() && tier.is_some() {
-        anyhow::bail!(
+        return Err(routing_conflict_error(format!(
             "Conflicting routing flags for `csa {command}`: --model-spec and --tier are mutually exclusive.\n\
              Use --model-spec for an exact `tool/provider/model/thinking` selection, or use --tier for tier-managed routing and failover."
-        );
+        )));
     }
 
     Ok(())
@@ -202,13 +205,13 @@ pub(crate) fn resolve_tool_and_model(
         if let Some(requested_tool) = tool.filter(|_| !tool_is_auto_resolved)
             && requested_tool != tool_name
         {
-            anyhow::bail!(
+            return Err(routing_conflict_error(format!(
                 "Conflicting routing flags: --tool {} does not match --model-spec {}.\n\
                  The model spec selects tool {}. Use a matching --tool value or omit --tool.",
                 requested_tool.as_str(),
                 spec,
                 tool_name.as_str()
-            );
+            )));
         }
         // Enforce tool enablement from user config
         if let Some(cfg) = config {

--- a/crates/cli-sub-agent/src/run_helpers_routing_conflict.rs
+++ b/crates/cli-sub-agent/src/run_helpers_routing_conflict.rs
@@ -1,0 +1,27 @@
+use anyhow::Error;
+use std::{error::Error as StdError, fmt};
+
+pub(crate) struct RoutingConflict;
+
+impl fmt::Debug for RoutingConflict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("RoutingConflict")
+    }
+}
+
+impl fmt::Display for RoutingConflict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("routing conflict")
+    }
+}
+
+impl StdError for RoutingConflict {}
+
+pub(crate) fn routing_conflict_error(message: impl Into<String>) -> Error {
+    Error::new(RoutingConflict).context(message.into())
+}
+
+pub(crate) fn is_routing_conflict(err: &Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<RoutingConflict>().is_some())
+}


### PR DESCRIPTION
## Summary
- Replace fragile \`err.to_string().contains(\"Conflicting routing flags\")\` with a typed routing-conflict marker so \`handle_run()\` persistence no longer depends on human-facing error wording.
- Introduce \`run_helpers_routing_conflict\` module exposing \`RoutingConflict\` marker + \`is_routing_conflict(&anyhow::Error) -> bool\`.
- Regression tests cover both the persisted conflict path and the non-persisted non-conflict pre-exec path.

Closes #735.

## Test plan
- [x] \`just pre-commit\`
- [x] \`cargo test -p cli-sub-agent 'run_cmd::execute::pre_exec_tests::handle_run_persists_result_for_model_spec_tier_conflict'\`
- [x] \`cargo test -p cli-sub-agent 'run_cmd::execute::pre_exec_tests::handle_run_does_not_persist_result_for_non_conflict_pre_exec_error'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)