### PR TITLE
docs(skills): add while-waiting productive-work checklist (#772)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.375"
+version = "0.1.376"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.375"
+version = "0.1.376"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/commit/skills/commit/SKILL.md
+++ b/patterns/commit/skills/commit/SKILL.md
@@ -93,6 +93,25 @@ breaks prompt-guard propagation.
 
 Both layers are mandatory. The per-commit review catches issues in each individual change; the cumulative review catches cross-commit issues and ensures the full branch is coherent.
 
+## While awaiting review/fix session
+
+This is the while-waiting checklist. When you background a `csa session wait` via `run_in_background: true`, the next task-notification wakes you up automatically. Do not sleep or add extra polling on top.
+
+**Safe parallel work**:
+1. Draft the PR body or changelog entry for the current branch as local text only; do not run `gh pr create` yet.
+2. For deferred MEDIUM findings from prior rounds, queue issue-template drafts locally and batch filing later when the review cluster is clear.
+3. Read the next sprint task or issue to preload context for the next non-conflicting step.
+4. Check existing issues for possible duplicate-of candidates for findings already queued.
+5. Clean up stale TaskCreate or TaskUpdate entries.
+
+**Do NOT**:
+- Start new `csa run` or `csa review` sessions that could race on git branch or checkout state with the waiting one (single-checkout sequential rule, AGENTS.md 028).
+- Edit source files while the main agent is acting as the Layer 0 orchestrator; that violates the SA-mode separation this wait is protecting.
+- Run state-mutating git commands such as `git commit`, `git checkout <other-branch>`, or `git push`.
+- Stack a ScheduleWakeup backup on top of the backgrounded wait; the task-notification is already the wake signal (AGENTS.md 042f).
+
+If there is no useful parallel work available, return control and wait for the notification. Do not invent speculative work just to stay busy.
+
 ## Commit Message Format (AI Era)
 
 All commits created by this workflow must use:

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -86,6 +86,25 @@ Do NOT launch narrowed or duplicate review/debate sessions for the same scope
 unless there is explicit crash/error evidence, persistent liveness failure, or
 direct user instruction.
 
+## While awaiting review/fix session
+
+This is the while-waiting checklist. When you background a `csa session wait` via `run_in_background: true`, the next task-notification wakes you up automatically. Do not add sleep, hand-rolled polling, or a redundant wakeup on top.
+
+**Safe parallel work**:
+1. Draft the PR body or changelog entry for the current branch as local text only; do not run `gh pr create` yet.
+2. For deferred MEDIUM findings from prior rounds, queue issue-template drafts locally and batch filing later when the review cluster is clear.
+3. Read the next sprint task or issue to preload context for the next non-conflicting step.
+4. Check existing issues for possible duplicate-of candidates for findings already queued.
+5. Clean up stale TaskCreate or TaskUpdate entries.
+
+**Do NOT**:
+- Start new `csa run` or `csa review` sessions that could race on git branch or checkout state with the waiting one (single-checkout sequential rule, AGENTS.md 028).
+- Edit source files while the main agent is acting as the Layer 0 orchestrator; that violates the SA-mode separation this wait is protecting.
+- Run state-mutating git commands such as `git commit`, `git checkout <other-branch>`, or `git push`.
+- Stack a ScheduleWakeup backup on top of the backgrounded wait; the task-notification is already the wake signal (AGENTS.md 042f).
+
+If there is no useful parallel work available, return control and wait for the notification. Do not invent speculative work just to stay busy.
+
 ### Pipeline Steps
 
 The workflow is compiled from the companion `../../PATTERN.md` file (relative to this `SKILL.md`) into `workflow.toml`.

--- a/patterns/mktsk/skills/mktsk/SKILL.md
+++ b/patterns/mktsk/skills/mktsk/SKILL.md
@@ -29,6 +29,25 @@ step by step. You are executing directly — every step runs in your context.
 For `csa` commands within pattern steps (e.g., `csa review --diff`), add
 `--sa-mode true` when operating under SA mode.
 
+## While awaiting review/fix session
+
+This is the while-waiting checklist. When you background a `csa session wait` via `run_in_background: true`, the next task-notification wakes you up automatically. Do not add manual sleep or polling on top.
+
+**Safe parallel work**:
+1. Draft the PR body or changelog entry for the current branch as local text only; do not run `gh pr create` yet.
+2. For deferred MEDIUM findings from prior rounds, queue issue-template drafts locally and batch filing later when the review cluster is clear.
+3. Read the next sprint task or issue to preload context for the next non-conflicting step.
+4. Check existing issues for possible duplicate-of candidates for findings already queued.
+5. Clean up stale TaskCreate or TaskUpdate entries.
+
+**Do NOT**:
+- Start new `csa run` or `csa review` sessions that could race on git branch or checkout state with the waiting one (single-checkout sequential rule, AGENTS.md 028).
+- Edit source files while the main agent is acting as the Layer 0 orchestrator; that violates the SA-mode separation this wait is protecting.
+- Run state-mutating git commands such as `git commit`, `git checkout <other-branch>`, or `git push`.
+- Stack a ScheduleWakeup backup on top of the backgrounded wait; the task-notification is already the wake signal (AGENTS.md 042f).
+
+If there is no useful parallel work available, return control and wait for the notification. Do not invent speculative work just to stay busy.
+
 ## Example Usage
 
 | Command | Effect |


### PR DESCRIPTION
## Summary
- commit / mktsk / dev2merge skills now document what the main agent can safely do while a \`csa session wait\` is backgrounded — drafting PR bodies, queueing deferred issue templates, preloading next-task context — and what it must NOT do (start racing sessions, edit files in SA-mode, mutate git state, stack redundant ScheduleWakeup).
- Docs-only change across three skill symlink targets.

Closes #772.

## Test plan
- [x] \`just pre-commit\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)