### PR TITLE
fix(mktd): unblock Step 9 debate (#905, #906)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.376"
+version = "0.1.377"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.376"
+version = "0.1.377"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -352,7 +352,7 @@ DEBATE_PROMPT="$(printf '%s\n' \
 "" \
 "## Output Requirements" \
 "Provide explicit verdict and confidence in your conclusion." )"
-SID=$(printf '%s\n' "${DEBATE_PROMPT}" | csa debate --rounds 3 --format json --idle-timeout 120 --no-stream-stdout) || { echo "csa debate failed" >&2; exit 1; }
+SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout "${DEBATE_PROMPT}") || { echo "csa debate failed" >&2; exit 1; }
 DEBATE_JSON="$(csa session wait --session "$SID" 2>&1)" || { echo "csa debate failed" >&2; exit 1; }
 [[ -n "${DEBATE_JSON:-}" ]] || { echo "empty debate json output" >&2; exit 1; }
 RAW_VERDICT="$(printf '%s\n' "${DEBATE_JSON}" | jq -r '.verdict // "UNKNOWN"' | tr '[:lower:]' '[:upper:]')"

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -401,7 +401,7 @@ DEBATE_PROMPT="$(printf '%s\n' \
 "" \
 "## Output Requirements" \
 "Provide explicit verdict and confidence in your conclusion." )"
-SID=$(printf '%s\n' "${DEBATE_PROMPT}" | csa debate --rounds 3 --format json --idle-timeout 600 --no-stream-stdout) || { echo "csa debate failed" >&2; exit 1; }
+SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout "${DEBATE_PROMPT}") || { echo "csa debate failed" >&2; exit 1; }
 DEBATE_JSON="$(csa session wait --session "$SID" 2>&1)" || { echo "csa debate failed" >&2; exit 1; }
 [[ -n "${DEBATE_JSON:-}" ]] || { echo "empty debate json output" >&2; exit 1; }
 RAW_VERDICT="$(printf '%s\n' "${DEBATE_JSON}" | jq -r '.verdict // "UNKNOWN"' | tr '[:lower:]' '[:upper:]')"


### PR DESCRIPTION
## Summary

Fixes two concurrent bugs in `patterns/mktd/workflow.toml` Step 9 (and the mirrored `PATTERN.md` recipe) that together prevented mktd from running under SA-mode propagation:

- **#905** — `csa debate` daemon ignores piped stdin (reports *"Empty prompt from stdin"* and exits in ~2s). Switched the invocation from `printf … | csa debate` to the documented positional-arg workaround.
- **#906** — workflow did not pass `--sa-mode`, violating the mandatory SA Mode Propagation rule. Hard-coded `--sa-mode true` since mktd is always SA-propagating per its SKILL.md.

Also harmonises a pre-existing `--idle-timeout` drift between `PATTERN.md` (120) and `workflow.toml` (600) per Rule 027.

## Scope

- `patterns/mktd/workflow.toml` Step 9 line (1 line)
- `patterns/mktd/PATTERN.md` mirrored recipe (1 line)
- Workspace `Cargo.toml` + `Cargo.lock` version bump (0.1.376 → 0.1.377)

## Test plan

- [x] `just pre-commit` — exit 0 (27 e2e tests pass)
- [x] Local `csa review --range main...HEAD --tier tier-4-critical` — decision=pass / CLEAN / 0 findings
- [ ] Cloud bot review (gemini-code-assist is currently quota-exhausted → likely bot-unavailable merge path)

## Closes

Closes #905
Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)