### PR TITLE
fix(csa-executor): enable gemini ACP first-response watchdog (#825)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.378"
+version = "0.1.379"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.378"
+version = "0.1.379"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -25,39 +25,35 @@ use csa_session::{
 mod transport_meta;
 pub use transport_meta::PeakMemoryContext;
 use transport_meta::{build_summary, run_acp_sandboxed};
-
 #[path = "transport_gemini_helpers.rs"]
 mod transport_gemini_helpers;
 #[cfg(test)]
 use transport_gemini_helpers::format_gemini_retry_report;
 use transport_gemini_helpers::{
     GeminiRetryPhase, annotate_gemini_retry_error, append_gemini_retry_report,
-    apply_gemini_sandbox_runtime_env_overrides, classify_gemini_acp_init_failure,
+    apply_gemini_acp_initial_stall_summary, apply_gemini_sandbox_runtime_env_overrides,
+    classify_gemini_acp_init_failure, classify_gemini_acp_initial_stall,
     classify_gemini_oauth_prompt_result, classify_join_error,
-    ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure, gemini_phase_desc,
+    ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure,
+    gemini_acp_initial_response_timeout_seconds, gemini_phase_desc,
     gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure,
     is_gemini_oauth_prompt_result,
 };
 #[path = "transport_gemini_acp_runtime.rs"]
 mod transport_gemini_acp_runtime;
 use transport_gemini_acp_runtime::{gemini_runtime_home_from_env, prepare_gemini_acp_runtime};
-
 #[path = "transport_acp_crash_retry.rs"]
 mod transport_acp_crash_retry;
 use transport_acp_crash_retry::execute_with_crash_retry;
-
 #[path = "transport_fork.rs"]
 mod transport_fork;
 pub use transport_fork::{ForkInfo, ForkMethod, ForkRequest};
-
 #[path = "transport_factory.rs"]
 mod transport_factory;
 pub use transport_factory::{TransportFactory, TransportMode};
-
 #[path = "transport_acp_payload_debug.rs"]
 mod transport_acp_payload_debug;
 use transport_acp_payload_debug::{AcpPayloadDebugRequest, maybe_write_acp_payload_debug};
-
 #[path = "transport_codex_exec_stall.rs"]
 mod transport_codex_exec_stall;
 #[cfg(test)]
@@ -585,9 +581,10 @@ impl AcpTransport {
         let sandbox_session_id = options.sandbox.map(|s| s.session_id.clone());
         let sandbox_best_effort = options.sandbox.is_some_and(|s| s.best_effort);
         let idle_timeout_seconds = options.idle_timeout_seconds;
-        // ACP transport: skip initial_response_timeout; ACP init_timeout already catches
-        // startup failures, and idle_timeout handles post-start hangs for heavy post-init tools.
-        let initial_response_timeout_seconds: Option<u64> = None;
+        let initial_response_timeout_seconds = gemini_acp_initial_response_timeout_seconds(
+            &self.tool_name,
+            options.initial_response_timeout_seconds,
+        );
         let acp_init_timeout_seconds = options.acp_init_timeout_seconds;
         let termination_grace_period_seconds = options.termination_grace_period_seconds;
         let session_meta = Self::build_session_meta(
@@ -761,13 +758,21 @@ impl AcpTransport {
                     error
                 }
             })?;
-        let execution = ExecutionResult {
+        let mut execution = ExecutionResult {
             summary: build_summary(&output.output, &output.stderr, output.exit_code),
             output: output.output,
             stderr_output: output.stderr,
             exit_code: output.exit_code,
             peak_memory_mb: output.peak_memory_mb,
         };
+        if let Some(classification) = (self.tool_name == "gemini-cli")
+            .then(|| {
+                classify_gemini_acp_initial_stall(&execution, initial_response_timeout_seconds)
+            })
+            .flatten()
+        {
+            apply_gemini_acp_initial_stall_summary(&mut execution, &classification);
+        }
 
         Ok(TransportResult {
             execution,
@@ -781,19 +786,8 @@ impl AcpTransport {
 include!("transport_acp_impl.rs");
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::transport_gemini_retry::*;
-    use csa_acp::SessionConfig;
-    use csa_resource::isolation_plan::IsolationPlan;
-
-    include!("transport_tests_tail.rs");
-    include!("transport_tests_ephemeral.rs");
-    include!("transport_tests_gemini_fallback.rs");
-    include!("transport_tests_gemini_init_classification.rs");
-    include!("transport_tests_gemini_oauth_prompt.rs");
-    include!("transport_tests_extra.rs");
-}
+#[path = "transport_tests_mod.rs"]
+mod tests;
 
 #[cfg(test)]
 #[path = "transport_lean_mode_tests.rs"]

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -6,10 +6,13 @@ use anyhow::anyhow;
 use csa_process::ExecutionResult;
 use csa_resource::isolation_plan::IsolationPlan;
 
+use super::transport_codex_exec_stall::resolve_initial_response_timeout;
 use crate::transport_gemini_retry::{gemini_retry_model, gemini_should_use_api_key};
 
 pub(crate) const GEMINI_OAUTH_PROMPT_SUMMARY: &str =
     "gemini-cli auth failure: OAuth browser prompt detected; no tool output produced";
+pub(crate) const GEMINI_ACP_INITIAL_STALL_REASON: &str = "gemini_acp_initial_stall";
+const DEFAULT_GEMINI_ACP_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 180;
 
 #[derive(Debug, Clone)]
 pub(super) struct GeminiRetryPhase {
@@ -30,6 +33,62 @@ impl GeminiRetryPhase {
             model: gemini_retry_model(attempt).unwrap_or("inherit"),
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct GeminiAcpInitialStallClassification {
+    pub(super) code: &'static str,
+    pub(super) timeout_seconds: u64,
+}
+
+pub(super) fn gemini_acp_initial_response_timeout_seconds(
+    tool_name: &str,
+    configured_timeout_seconds: Option<u64>,
+) -> Option<u64> {
+    if tool_name != "gemini-cli" {
+        return None;
+    }
+
+    resolve_initial_response_timeout(
+        configured_timeout_seconds,
+        DEFAULT_GEMINI_ACP_INITIAL_RESPONSE_TIMEOUT_SECONDS,
+    )
+}
+
+pub(super) fn classify_gemini_acp_initial_stall(
+    execution: &ExecutionResult,
+    timeout_seconds: Option<u64>,
+) -> Option<GeminiAcpInitialStallClassification> {
+    if !execution.output.is_empty()
+        || execution.exit_code != 137
+        || !execution.summary.starts_with("initial response timeout:")
+    {
+        return None;
+    }
+
+    Some(GeminiAcpInitialStallClassification {
+        code: GEMINI_ACP_INITIAL_STALL_REASON,
+        timeout_seconds: timeout_seconds
+            .unwrap_or(DEFAULT_GEMINI_ACP_INITIAL_RESPONSE_TIMEOUT_SECONDS),
+    })
+}
+
+pub(super) fn apply_gemini_acp_initial_stall_summary(
+    execution: &mut ExecutionResult,
+    classification: &GeminiAcpInitialStallClassification,
+) {
+    let summary = format!(
+        "{reason}: no ACP events/stderr within {}s",
+        classification.timeout_seconds,
+        reason = classification.code
+    );
+
+    execution.summary = summary.clone();
+    if !execution.stderr_output.is_empty() && !execution.stderr_output.ends_with('\n') {
+        execution.stderr_output.push('\n');
+    }
+    execution.stderr_output.push_str(&summary);
+    execution.stderr_output.push('\n');
 }
 
 pub(super) fn gemini_phase_desc(attempt: u8) -> &'static str {

--- a/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
@@ -82,6 +82,74 @@ fn test_classify_gemini_acp_init_failure_defaults_to_handshake_timeout() {
     assert_eq!(classification.code, "gemini_acp_init_handshake_timeout");
 }
 
+#[test]
+fn test_gemini_acp_initial_response_timeout_resolver_is_gemini_only() {
+    assert_eq!(
+        gemini_acp_initial_response_timeout_seconds("gemini-cli", None),
+        Some(180)
+    );
+    assert_eq!(
+        gemini_acp_initial_response_timeout_seconds("gemini-cli", Some(0)),
+        None
+    );
+    assert_eq!(
+        gemini_acp_initial_response_timeout_seconds("gemini-cli", Some(45)),
+        Some(45)
+    );
+    assert_eq!(
+        gemini_acp_initial_response_timeout_seconds("claude-code", None),
+        None
+    );
+    assert_eq!(gemini_acp_initial_response_timeout_seconds("codex", None), None);
+}
+
+#[test]
+fn test_classify_gemini_acp_initial_stall_detects_first_response_timeout() {
+    let execution = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: "initial response timeout: no ACP events/stderr for 180s; process killed"
+            .to_string(),
+        summary: "initial response timeout: no ACP events/stderr for 180s; process killed"
+            .to_string(),
+        exit_code: 137,
+        peak_memory_mb: None,
+    };
+
+    let classification = classify_gemini_acp_initial_stall(&execution, Some(180))
+        .expect("gemini ACP initial timeout should classify");
+    assert_eq!(classification.code, "gemini_acp_initial_stall");
+    assert_eq!(classification.timeout_seconds, 180);
+}
+
+#[test]
+fn test_apply_gemini_acp_initial_stall_summary_rewrites_summary() {
+    let mut execution = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: "initial response timeout: no ACP events/stderr for 180s; process killed"
+            .to_string(),
+        summary: "initial response timeout: no ACP events/stderr for 180s; process killed"
+            .to_string(),
+        exit_code: 137,
+        peak_memory_mb: None,
+    };
+    let classification = classify_gemini_acp_initial_stall(&execution, Some(180))
+        .expect("gemini ACP initial timeout should classify");
+
+    apply_gemini_acp_initial_stall_summary(&mut execution, &classification);
+
+    assert_eq!(
+        execution.summary,
+        "gemini_acp_initial_stall: no ACP events/stderr within 180s"
+    );
+    assert!(
+        execution
+            .stderr_output
+            .contains("gemini_acp_initial_stall: no ACP events/stderr within 180s"),
+        "expected stable classifier in stderr, got: {}",
+        execution.stderr_output
+    );
+}
+
 #[tokio::test]
 async fn test_execute_in_classifies_pre_handshake_gemini_failure_with_child_stderr() {
     use std::os::unix::fs::PermissionsExt;

--- a/crates/csa-executor/src/transport_tests_mod.rs
+++ b/crates/csa-executor/src/transport_tests_mod.rs
@@ -1,0 +1,11 @@
+use super::*;
+use crate::transport_gemini_retry::*;
+use csa_acp::SessionConfig;
+use csa_resource::isolation_plan::IsolationPlan;
+
+include!("transport_tests_tail.rs");
+include!("transport_tests_ephemeral.rs");
+include!("transport_tests_gemini_fallback.rs");
+include!("transport_tests_gemini_init_classification.rs");
+include!("transport_tests_gemini_oauth_prompt.rs");
+include!("transport_tests_extra.rs");


### PR DESCRIPTION
## Summary

`execute_acp_attempt()` previously hard-coded `initial_response_timeout_seconds = None` for all ACP tools, relying on ACP init-handshake timeout + long idle timeout. For gemini-cli ACP that meant the session could sit silent for the entire idle budget (1800s+) with zero output, forcing long manual kills.

This PR:
- Resolves a 180s first-response timeout for gemini-cli ACP sessions (other ACP tools preserve prior `None` behaviour)
- Adds stable classifier `gemini_acp_initial_stall` (analogous to codex's `codex_exec_initial_stall` from #757)
- No retry on first-response stall — silent stalls often mask real bugs, fail-fast first

## Recon

Batch 11 recon (session `01KPK97H458WQB9D01WXM9SG61`) split the gemini stall cluster:
- **This PR** (#825): ACP watchdog — highest value, addresses silent-ACP-stall
- **Next PR** (#865): legacy direct-entry 137 classifier parity
- **Deferred** (#839): likely upstream gemini-cli MCP generic failure after long idle, not CSA

## Test plan

- [x] `cargo test -p csa-executor` — new unit test + existing pass
- [x] `just pre-commit` — exit 0
- [x] `--no-failover` interaction: watchdog still fires, only model/auth retry is disabled
- [ ] Cloud bot review (gemini-code-assist quota-exhausted → bot-unavailable merge path)

## Closes

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)