### PR TITLE
fix(csa-executor): add gemini legacy initial-stall classifier (#865)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.379"
+version = "0.1.380"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.380"
+version = "0.1.381"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.380"
+version = "0.1.381"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.379"
+version = "0.1.380"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -426,13 +426,12 @@ impl LegacyTransport {
                 attempt = attempt.saturating_add(1);
                 continue;
             }
-            if let Some(classification) = classify_codex_exec_initial_stall(
-                &executor,
-                &result.execution,
-                consume_resolved_execute_in_initial_response_timeout_seconds(
-                    initial_response_timeout_seconds,
-                ),
-            ) {
+            let direct_timeout = consume_resolved_execute_in_initial_response_timeout_seconds(
+                initial_response_timeout_seconds,
+            );
+            if let Some(classification) =
+                classify_codex_exec_initial_stall(&executor, &result.execution, direct_timeout)
+            {
                 if let Some(retry_budget) = classification.retry_effort.clone() {
                     let mut downgraded_executor = executor.clone();
                     downgraded_executor.override_thinking_budget(retry_budget.clone());
@@ -456,9 +455,7 @@ impl LegacyTransport {
                     if let Some(retry_classification) = classify_codex_exec_initial_stall(
                         &downgraded_executor,
                         &retry_result.execution,
-                        consume_resolved_execute_in_initial_response_timeout_seconds(
-                            initial_response_timeout_seconds,
-                        ),
+                        direct_timeout,
                     ) {
                         apply_codex_exec_initial_stall_summary(
                             &mut retry_result.execution,
@@ -477,6 +474,13 @@ impl LegacyTransport {
                     false,
                     None,
                 );
+                return Ok(result);
+            }
+            if let Some(classification) =
+                classify_gemini_legacy_initial_stall(&executor, &result.execution, direct_timeout)
+            {
+                let mut result = result;
+                apply_gemini_legacy_initial_stall_summary(&mut result.execution, &classification);
                 return Ok(result);
             }
             return Ok(result);

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -31,8 +31,9 @@ mod transport_gemini_helpers;
 use transport_gemini_helpers::format_gemini_retry_report;
 use transport_gemini_helpers::{
     GeminiRetryPhase, annotate_gemini_retry_error, append_gemini_retry_report,
-    apply_gemini_acp_initial_stall_summary, apply_gemini_sandbox_runtime_env_overrides,
-    classify_gemini_acp_init_failure, classify_gemini_acp_initial_stall,
+    apply_gemini_acp_initial_stall_summary, apply_gemini_legacy_initial_stall_summary,
+    apply_gemini_sandbox_runtime_env_overrides, classify_gemini_acp_init_failure,
+    classify_gemini_acp_initial_stall, classify_gemini_legacy_initial_stall,
     classify_gemini_oauth_prompt_result, classify_join_error,
     ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure,
     gemini_acp_initial_response_timeout_seconds, gemini_phase_desc,

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -7,11 +7,13 @@ use csa_process::ExecutionResult;
 use csa_resource::isolation_plan::IsolationPlan;
 
 use super::transport_codex_exec_stall::resolve_initial_response_timeout;
+use crate::executor::Executor;
 use crate::transport_gemini_retry::{gemini_retry_model, gemini_should_use_api_key};
 
 pub(crate) const GEMINI_OAUTH_PROMPT_SUMMARY: &str =
     "gemini-cli auth failure: OAuth browser prompt detected; no tool output produced";
 pub(crate) const GEMINI_ACP_INITIAL_STALL_REASON: &str = "gemini_acp_initial_stall";
+pub(crate) const GEMINI_LEGACY_INITIAL_STALL_REASON: &str = "gemini_legacy_initial_stall";
 const DEFAULT_GEMINI_ACP_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 180;
 
 #[derive(Debug, Clone)]
@@ -37,6 +39,12 @@ impl GeminiRetryPhase {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct GeminiAcpInitialStallClassification {
+    pub(super) code: &'static str,
+    pub(super) timeout_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct GeminiLegacyInitialStallClassification {
     pub(super) code: &'static str,
     pub(super) timeout_seconds: u64,
 }
@@ -79,6 +87,43 @@ pub(super) fn apply_gemini_acp_initial_stall_summary(
 ) {
     let summary = format!(
         "{reason}: no ACP events/stderr within {}s",
+        classification.timeout_seconds,
+        reason = classification.code
+    );
+
+    execution.summary = summary.clone();
+    if !execution.stderr_output.is_empty() && !execution.stderr_output.ends_with('\n') {
+        execution.stderr_output.push('\n');
+    }
+    execution.stderr_output.push_str(&summary);
+    execution.stderr_output.push('\n');
+}
+
+pub(super) fn classify_gemini_legacy_initial_stall(
+    executor: &Executor,
+    execution: &ExecutionResult,
+    timeout_seconds: Option<u64>,
+) -> Option<GeminiLegacyInitialStallClassification> {
+    if !matches!(executor, Executor::GeminiCli { .. })
+        || !execution.output.is_empty()
+        || execution.exit_code != 137
+        || !execution.summary.starts_with("initial_response_timeout:")
+    {
+        return None;
+    }
+
+    Some(GeminiLegacyInitialStallClassification {
+        code: GEMINI_LEGACY_INITIAL_STALL_REASON,
+        timeout_seconds: timeout_seconds.unwrap_or(120),
+    })
+}
+
+pub(super) fn apply_gemini_legacy_initial_stall_summary(
+    execution: &mut ExecutionResult,
+    classification: &GeminiLegacyInitialStallClassification,
+) {
+    let summary = format!(
+        "{reason}: no stdout within {}s",
         classification.timeout_seconds,
         reason = classification.code
     );

--- a/crates/csa-executor/src/transport_legacy_impl.rs
+++ b/crates/csa-executor/src/transport_legacy_impl.rs
@@ -121,6 +121,17 @@ impl Transport for LegacyTransport {
                 );
                 return Ok(result);
             }
+            if let Some(classification) = classify_gemini_legacy_initial_stall(
+                &executor,
+                &result.execution,
+                Self::consume_resolved_transport_initial_response_timeout_seconds(
+                    options.initial_response_timeout_seconds,
+                ),
+            ) {
+                let mut result = result;
+                apply_gemini_legacy_initial_stall_summary(&mut result.execution, &classification);
+                return Ok(result);
+            }
             return Ok(result);
         }
     }

--- a/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
@@ -273,6 +273,59 @@ fn test_apply_gemini_legacy_initial_stall_summary_rewrites_summary() {
 }
 
 #[tokio::test]
+async fn test_execute_in_rewrites_gemini_legacy_initial_stall_summary() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script_path = temp.path().join("gemini");
+    std::fs::write(
+        &script_path,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+sleep 2
+"#,
+    )
+    .expect("write fake gemini");
+    let mut perms = std::fs::metadata(&script_path)
+        .expect("metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script_path, perms).expect("chmod +x");
+
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let env = HashMap::from([(
+        "PATH".to_string(),
+        format!("{}:{old_path}", temp.path().display()),
+    )]);
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+
+    let result = transport
+        .execute_in(
+            "test direct-entry gemini legacy initial stall",
+            temp.path(),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+            Some(1),
+        )
+        .await
+        .expect("execute_in should return classified gemini legacy stall");
+
+    assert_eq!(result.execution.exit_code, 137);
+    assert!(
+        result
+            .execution
+            .summary
+            .starts_with("gemini_legacy_initial_stall:"),
+        "expected stable gemini legacy initial stall summary, got: {}",
+        result.execution.summary
+    );
+}
+
+#[tokio::test]
 async fn test_execute_in_classifies_pre_handshake_gemini_failure_with_child_stderr() {
     use std::os::unix::fs::PermissionsExt;
 

--- a/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
@@ -150,6 +150,128 @@ fn test_apply_gemini_acp_initial_stall_summary_rewrites_summary() {
     );
 }
 
+#[test]
+fn test_classify_gemini_legacy_initial_stall_detects_first_response_timeout() {
+    let executor = Executor::GeminiCli {
+        model_override: Some("gemini-2.5-pro".to_string()),
+        thinking_budget: None,
+    };
+    let execution = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: "initial_response_timeout: no stdout output for 120s; process killed immediately"
+            .to_string(),
+        summary: "initial_response_timeout: no stdout output for 120s; process killed immediately"
+            .to_string(),
+        exit_code: 137,
+        peak_memory_mb: None,
+    };
+
+    let classification = classify_gemini_legacy_initial_stall(&executor, &execution, Some(120))
+        .expect("gemini legacy initial timeout should classify");
+    assert_eq!(classification.code, "gemini_legacy_initial_stall");
+    assert_eq!(classification.timeout_seconds, 120);
+}
+
+#[test]
+fn test_classify_gemini_legacy_initial_stall_is_gemini_only() {
+    let executor = Executor::Codex {
+        model_override: Some("gpt-5-codex".to_string()),
+        thinking_budget: None,
+        runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
+    };
+    let execution = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: "initial_response_timeout: no stdout output for 120s; process killed immediately"
+            .to_string(),
+        summary: "initial_response_timeout: no stdout output for 120s; process killed immediately"
+            .to_string(),
+        exit_code: 137,
+        peak_memory_mb: None,
+    };
+
+    assert!(
+        classify_gemini_legacy_initial_stall(&executor, &execution, Some(120)).is_none(),
+        "codex legacy stall should not classify as gemini legacy stall"
+    );
+}
+
+#[test]
+fn test_classify_gemini_legacy_initial_stall_requires_silent_output() {
+    let executor = Executor::GeminiCli {
+        model_override: Some("gemini-2.5-pro".to_string()),
+        thinking_budget: None,
+    };
+    let execution = csa_process::ExecutionResult {
+        output: "hello".to_string(),
+        stderr_output: "initial_response_timeout: no stdout output for 120s; process killed immediately"
+            .to_string(),
+        summary: "initial_response_timeout: no stdout output for 120s; process killed immediately"
+            .to_string(),
+        exit_code: 137,
+        peak_memory_mb: None,
+    };
+
+    assert!(
+        classify_gemini_legacy_initial_stall(&executor, &execution, Some(120)).is_none(),
+        "non-silent legacy execution should not classify as initial stall"
+    );
+}
+
+#[test]
+fn test_classify_gemini_legacy_initial_stall_requires_exit_137() {
+    let executor = Executor::GeminiCli {
+        model_override: Some("gemini-2.5-pro".to_string()),
+        thinking_budget: None,
+    };
+    let execution = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: "initial_response_timeout: no stdout output for 120s; process killed immediately"
+            .to_string(),
+        summary: "initial_response_timeout: no stdout output for 120s; process killed immediately"
+            .to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+    };
+
+    assert!(
+        classify_gemini_legacy_initial_stall(&executor, &execution, Some(120)).is_none(),
+        "successful execution should not classify as initial stall"
+    );
+}
+
+#[test]
+fn test_apply_gemini_legacy_initial_stall_summary_rewrites_summary() {
+    let executor = Executor::GeminiCli {
+        model_override: Some("gemini-2.5-pro".to_string()),
+        thinking_budget: None,
+    };
+    let mut execution = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: "initial_response_timeout: no stdout output for 120s; process killed immediately"
+            .to_string(),
+        summary: "initial_response_timeout: no stdout output for 120s; process killed immediately"
+            .to_string(),
+        exit_code: 137,
+        peak_memory_mb: None,
+    };
+    let classification = classify_gemini_legacy_initial_stall(&executor, &execution, Some(120))
+        .expect("gemini legacy initial timeout should classify");
+
+    apply_gemini_legacy_initial_stall_summary(&mut execution, &classification);
+
+    assert_eq!(
+        execution.summary,
+        "gemini_legacy_initial_stall: no stdout within 120s"
+    );
+    assert!(
+        execution
+            .stderr_output
+            .contains("gemini_legacy_initial_stall: no stdout within 120s"),
+        "expected stable classifier in stderr, got: {}",
+        execution.stderr_output
+    );
+}
+
 #[tokio::test]
 async fn test_execute_in_classifies_pre_handshake_gemini_failure_with_child_stderr() {
     use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
## Summary
- Mirror codex-exec's stall classifier on the gemini legacy-CLI transport path.
- Emit stable `gemini_legacy_initial_stall` reason code (was raw `initial_response_timeout:` text).
- No retry — fail-fast, matches PR #911's reasoning for the ACP path.

## Test plan
- [x] `cargo test -p csa-executor transport_` green
- [x] `just pre-commit` green
- [x] Positive + negative unit tests added (codex-path still unchanged, non-137 → None, non-empty output → None)

Closes #865.

Batch 11 PR-B (PR-A = #911 ACP watchdog, merged as v0.1.379).

🤖 Generated with [Claude Code](https://claude.com/claude-code)