### PR TITLE
fix(pr-bot): clean up workflow dead code + condition + manifest pollution (#870, #872)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.381"
+version = "0.1.382"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.381"
+version = "0.1.382"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -263,6 +263,36 @@ fn pr_bot_pattern_and_workflow_reuse_existing_current_head_reviews() {
 }
 
 #[test]
+fn pr_bot_artifacts_drop_timeout_merge_branch_and_step_local_manifest_vars() {
+    let workflow = pr_bot_artifact_text("patterns/pr-bot/workflow.toml");
+    let pattern = pr_bot_artifact_text("patterns/pr-bot/PATTERN.md");
+
+    for artifact in [&workflow, &pattern] {
+        assert!(
+            !artifact
+                .contains("cloud_bot=true but bot timed out; merging on fallback review clean"),
+            "pr-bot merge-without-bot path must not retain the dead timeout rationale branch"
+        );
+        assert!(
+            artifact.contains("cloud_bot=true`, bot is skipped due to cached quota exhaustion, and fallback local review is clean"),
+            "pr-bot merge-without-bot docs must describe the reachable quota-exhausted path"
+        );
+    }
+
+    for dead_var in [
+        "REUSABLE_CURRENT_HEAD_REVIEW_RECORD",
+        "REUSABLE_CURRENT_HEAD_REVIEW_RECORD_RC",
+        "REUSABLE_CURRENT_HEAD_REVIEW_TS",
+        "REUSE_EXISTING_CURRENT_HEAD_REVIEW",
+    ] {
+        assert!(
+            !workflow.contains(&format!("name = \"{dead_var}\"")),
+            "workflow manifest must not declare step-local variable {dead_var}"
+        );
+    }
+}
+
+#[test]
 fn pr_bot_artifacts_paginate_current_head_trigger_lookup() {
     for artifact in [
         "patterns/pr-bot/workflow.toml",

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -496,26 +496,26 @@ query_reusable_current_head_review_record() {
 set +e
 LATEST_CURRENT_HEAD_TRIGGER_TS="$(query_latest_current_head_trigger_ts)"
 LATEST_CURRENT_HEAD_TRIGGER_TS_RC=$?
-REUSABLE_CURRENT_HEAD_REVIEW_RECORD="$(query_reusable_current_head_review_record "${LATEST_CURRENT_HEAD_TRIGGER_TS}")"
-REUSABLE_CURRENT_HEAD_REVIEW_RECORD_RC=$?
+reusable_current_head_review_record="$(query_reusable_current_head_review_record "${LATEST_CURRENT_HEAD_TRIGGER_TS}")"
+reusable_current_head_review_record_rc=$?
 set -e
 
-REUSABLE_CURRENT_HEAD_REVIEW_TS=""
-if [ "${REUSABLE_CURRENT_HEAD_REVIEW_RECORD_RC}" -eq 0 ] && [ -n "${REUSABLE_CURRENT_HEAD_REVIEW_RECORD}" ]; then
-  IFS=$'\t' read -r BOT_REUSED_REVIEW_ID REUSABLE_CURRENT_HEAD_REVIEW_TS <<<"${REUSABLE_CURRENT_HEAD_REVIEW_RECORD}"
+reusable_current_head_review_ts=""
+if [ "${reusable_current_head_review_record_rc}" -eq 0 ] && [ -n "${reusable_current_head_review_record}" ]; then
+  IFS=$'\t' read -r BOT_REUSED_REVIEW_ID reusable_current_head_review_ts <<<"${reusable_current_head_review_record}"
 fi
 
-REUSE_EXISTING_CURRENT_HEAD_REVIEW=false
-if [ -n "${BOT_REUSED_REVIEW_ID}" ] && [ -n "${REUSABLE_CURRENT_HEAD_REVIEW_TS}" ]; then
-  REUSE_EXISTING_CURRENT_HEAD_REVIEW=true
+reuse_existing_current_head_review=false
+if [ -n "${BOT_REUSED_REVIEW_ID}" ] && [ -n "${reusable_current_head_review_ts}" ]; then
+  reuse_existing_current_head_review=true
   BOT_UNAVAILABLE=false
-  BOT_REVIEW_WINDOW_START="${REUSABLE_CURRENT_HEAD_REVIEW_TS}"
+  BOT_REVIEW_WINDOW_START="${reusable_current_head_review_ts}"
   WAIT_MARKER="BOT_REPLY=received"
-  echo "Reusable @${CLOUD_BOT_NAME} review #${BOT_REUSED_REVIEW_ID} already exists for HEAD ${CURRENT_SHA} at ${REUSABLE_CURRENT_HEAD_REVIEW_TS}; skipping trigger and delegated wait."
+  echo "Reusable @${CLOUD_BOT_NAME} review #${BOT_REUSED_REVIEW_ID} already exists for HEAD ${CURRENT_SHA} at ${reusable_current_head_review_ts}; skipping trigger and delegated wait."
 fi
 
 # --- Trigger cloud bot review for current HEAD ---
-if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "false" ]; then
+if [ "${reuse_existing_current_head_review}" = "false" ]; then
 TRIGGER_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 # Round-aware trigger logic (#506):
@@ -678,7 +678,7 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   # --- Positive signal check (#505): verify a current-HEAD review EVENT exists ---
   # If this run reused a specific current-HEAD review object, that selection is
   # already the positive signal and later checks must stay scoped to that review.
-  if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "true" ]; then
+  if [ "${reuse_existing_current_head_review}" = "true" ]; then
     REVIEW_EVENT_RC=0
     REVIEW_EVENT_COUNT=1
   else
@@ -744,7 +744,7 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   # post inline comments without a formal review event.
   if [ "${BOT_UNAVAILABLE}" = "false" ] && [ "${BOT_NEEDS_SETUP:-false}" = "false" ]; then
     set +e
-    if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "true" ]; then
+    if [ "${reuse_existing_current_head_review}" = "true" ]; then
       ACTIONABLE_COMMENT_COUNT="$(
         gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews/${BOT_REUSED_REVIEW_ID}/comments?per_page=100" \
           | jq -r '[.[] | .[] | select((.user.login // "") == "'"${CLOUD_BOT_LOGIN}"'") | select((.body | test("P0|P1|P2"))) ] | length' \
@@ -770,7 +770,7 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
         ;;
     esac
     if [ "${ACTIONABLE_COMMENT_COUNT}" -gt 0 ]; then
-      if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "true" ]; then
+      if [ "${reuse_existing_current_head_review}" = "true" ]; then
         echo "Detected ${ACTIONABLE_COMMENT_COUNT} actionable bot comment(s) in reusable review #${BOT_REUSED_REVIEW_ID}; marking BOT_HAS_ISSUES=true."
         BOT_HAS_ISSUES_SOURCE="reused_review_comments"
       else
@@ -791,7 +791,7 @@ fi
 # --- Check for non-target bot comments (e.g., codex auto-review) ---
 if [ "${BOT_UNAVAILABLE}" = "false" ] && [ "${BOT_HAS_ISSUES}" = "false" ]; then
   set +e
-  if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "true" ]; then
+  if [ "${reuse_existing_current_head_review}" = "true" ]; then
     OTHER_BOT_COUNT="$(
       gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/comments" \
         | jq -r '[.[] | .[] | select(.user.type == "Bot") | select(.user.login != "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .original_commit_id == "'"${CURRENT_SHA}"'") | select((.body | test("P0|P1|P2"))) ] | length' \
@@ -809,7 +809,7 @@ if [ "${BOT_UNAVAILABLE}" = "false" ] && [ "${BOT_HAS_ISSUES}" = "false" ]; then
     echo "WARNING: Detected ${OTHER_BOT_COUNT} actionable comment(s) from non-target bot(s)." >&2
     echo "WARNING: These may consume coding quota for the originating bot service." >&2
     echo "Including non-target bot findings in review."
-    if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "true" ]; then
+    if [ "${reuse_existing_current_head_review}" = "true" ]; then
       BOT_HAS_ISSUES_SOURCE="current_sha_comments"
     else
       BOT_HAS_ISSUES_SOURCE="current_window_comments"
@@ -1757,12 +1757,12 @@ Cloud bot explicitly disabled (cloud_bot=false). Local fallback review passed
 guarantees `FALLBACK_REVIEW_HAS_ISSUES=false` before reaching this point.
 This step executes in either of these cases:
 - `cloud_bot=false` (no cloud bot path)
-- `cloud_bot=true`, `BOT_UNAVAILABLE=true`, and fallback local review is clean
+- `cloud_bot=true`, bot is skipped due to cached quota exhaustion, and fallback local review is clean
 
 **MANDATORY**: Before merging, leave a PR comment explaining the merge rationale.
-This step has three audit-trail cases:
+This step has two audit-trail cases:
 - `cloud_bot=false`: "cloud_bot=false (disabled in config); merging on local review clean"
-- `cloud_bot=true` and `BOT_UNAVAILABLE=true`: "cloud_bot=true but bot timed out; merging on fallback review clean"
+- `MERGE_WITHOUT_BOT_REASON_KIND=cloud_bot_quota_exhausted`: explain the cached quota window and cite the local review session ID
 When `MERGE_WITHOUT_BOT_REASON_KIND=cloud_bot_quota_exhausted`, the audit trail
 must explain the cached quota window and cite the local review session ID.
 
@@ -1807,10 +1807,6 @@ ${DIFF_SUMMARY}
 \`\`\`
 EOF
 )"
-elif [ "${BOT_UNAVAILABLE:-false}" = "true" ]; then
-  MERGE_REASON="cloud_bot=true but bot timed out; merging on fallback review clean"
-  MERGE_WITHOUT_BOT_REASON_KIND="${MERGE_WITHOUT_BOT_REASON_KIND:-cloud_bot_timeout}"
-  COMMENT_BODY="**Merge rationale**: ${MERGE_REASON}. Local \`csa review --branch ${DEFAULT_BRANCH}\` passed CLEAN (or issues were fixed in fallback cycle). Proceeding to merge with local review as the review layer."
 else
   echo "ERROR: Step 6a reached without a valid merge-without-bot rationale."
   exit 1

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -294,15 +294,6 @@ name = "RETRIGGER_BODY"
 name = "RETRIGGER_TS"
 
 [[workflow.variables]]
-name = "REUSABLE_CURRENT_HEAD_REVIEW_RECORD"
-
-[[workflow.variables]]
-name = "REUSABLE_CURRENT_HEAD_REVIEW_RECORD_RC"
-
-[[workflow.variables]]
-name = "REUSABLE_CURRENT_HEAD_REVIEW_TS"
-
-[[workflow.variables]]
 name = "REUSABLE_POST_FIX_REVIEW_RECORD"
 
 [[workflow.variables]]
@@ -310,9 +301,6 @@ name = "REUSABLE_POST_FIX_REVIEW_RECORD_RC"
 
 [[workflow.variables]]
 name = "REUSABLE_POST_FIX_REVIEW_TS"
-
-[[workflow.variables]]
-name = "REUSE_EXISTING_CURRENT_HEAD_REVIEW"
 
 [[workflow.variables]]
 name = "REUSE_EXISTING_POST_FIX_REVIEW"
@@ -867,26 +855,26 @@ query_reusable_current_head_review_record() {
 set +e
 LATEST_CURRENT_HEAD_TRIGGER_TS="$(query_latest_current_head_trigger_ts)"
 LATEST_CURRENT_HEAD_TRIGGER_TS_RC=$?
-REUSABLE_CURRENT_HEAD_REVIEW_RECORD="$(query_reusable_current_head_review_record "${LATEST_CURRENT_HEAD_TRIGGER_TS}")"
-REUSABLE_CURRENT_HEAD_REVIEW_RECORD_RC=$?
+reusable_current_head_review_record="$(query_reusable_current_head_review_record "${LATEST_CURRENT_HEAD_TRIGGER_TS}")"
+reusable_current_head_review_record_rc=$?
 set -e
 
-REUSABLE_CURRENT_HEAD_REVIEW_TS=""
-if [ "${REUSABLE_CURRENT_HEAD_REVIEW_RECORD_RC}" -eq 0 ] && [ -n "${REUSABLE_CURRENT_HEAD_REVIEW_RECORD}" ]; then
-  IFS=$'\t' read -r BOT_REUSED_REVIEW_ID REUSABLE_CURRENT_HEAD_REVIEW_TS <<<"${REUSABLE_CURRENT_HEAD_REVIEW_RECORD}"
+reusable_current_head_review_ts=""
+if [ "${reusable_current_head_review_record_rc}" -eq 0 ] && [ -n "${reusable_current_head_review_record}" ]; then
+  IFS=$'\t' read -r BOT_REUSED_REVIEW_ID reusable_current_head_review_ts <<<"${reusable_current_head_review_record}"
 fi
 
-REUSE_EXISTING_CURRENT_HEAD_REVIEW=false
-if [ -n "${BOT_REUSED_REVIEW_ID}" ] && [ -n "${REUSABLE_CURRENT_HEAD_REVIEW_TS}" ]; then
-  REUSE_EXISTING_CURRENT_HEAD_REVIEW=true
+reuse_existing_current_head_review=false
+if [ -n "${BOT_REUSED_REVIEW_ID}" ] && [ -n "${reusable_current_head_review_ts}" ]; then
+  reuse_existing_current_head_review=true
   BOT_UNAVAILABLE=false
-  BOT_REVIEW_WINDOW_START="${REUSABLE_CURRENT_HEAD_REVIEW_TS}"
+  BOT_REVIEW_WINDOW_START="${reusable_current_head_review_ts}"
   WAIT_MARKER="BOT_REPLY=received"
-  echo "Reusable @${CLOUD_BOT_NAME} review #${BOT_REUSED_REVIEW_ID} already exists for HEAD ${CURRENT_SHA} at ${REUSABLE_CURRENT_HEAD_REVIEW_TS}; skipping trigger and delegated wait."
+  echo "Reusable @${CLOUD_BOT_NAME} review #${BOT_REUSED_REVIEW_ID} already exists for HEAD ${CURRENT_SHA} at ${reusable_current_head_review_ts}; skipping trigger and delegated wait."
 fi
 
 # --- Trigger cloud bot review for current HEAD ---
-if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "false" ]; then
+if [ "${reuse_existing_current_head_review}" = "false" ]; then
 TRIGGER_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 # Round-aware trigger logic (#506):
@@ -1049,7 +1037,7 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   # --- Positive signal check (#505): verify a current-HEAD review EVENT exists ---
   # If this run reused a specific current-HEAD review object, that selection is
   # already the positive signal and later checks must stay scoped to that review.
-  if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "true" ]; then
+  if [ "${reuse_existing_current_head_review}" = "true" ]; then
     REVIEW_EVENT_RC=0
     REVIEW_EVENT_COUNT=1
   else
@@ -1115,7 +1103,7 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   # post inline comments without a formal review event.
   if [ "${BOT_UNAVAILABLE}" = "false" ] && [ "${BOT_NEEDS_SETUP:-false}" = "false" ]; then
     set +e
-    if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "true" ]; then
+    if [ "${reuse_existing_current_head_review}" = "true" ]; then
       ACTIONABLE_COMMENT_COUNT="$(
         gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews/${BOT_REUSED_REVIEW_ID}/comments?per_page=100" \
           | jq -r '[.[] | .[] | select((.user.login // "") == "'"${CLOUD_BOT_LOGIN}"'") | select((.body | test("P0|P1|P2"))) ] | length' \
@@ -1141,7 +1129,7 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
         ;;
     esac
     if [ "${ACTIONABLE_COMMENT_COUNT}" -gt 0 ]; then
-      if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "true" ]; then
+      if [ "${reuse_existing_current_head_review}" = "true" ]; then
         echo "Detected ${ACTIONABLE_COMMENT_COUNT} actionable bot comment(s) in reusable review #${BOT_REUSED_REVIEW_ID}; marking BOT_HAS_ISSUES=true."
         BOT_HAS_ISSUES_SOURCE="reused_review_comments"
       else
@@ -1162,7 +1150,7 @@ fi
 # --- Check for non-target bot comments (e.g., codex auto-review) ---
 if [ "${BOT_UNAVAILABLE}" = "false" ] && [ "${BOT_HAS_ISSUES}" = "false" ]; then
   set +e
-  if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "true" ]; then
+  if [ "${reuse_existing_current_head_review}" = "true" ]; then
     OTHER_BOT_COUNT="$(
       gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/comments" \
         | jq -r '[.[] | .[] | select(.user.type == "Bot") | select(.user.login != "'"${CLOUD_BOT_LOGIN}"'") | select(.commit_id == "'"${CURRENT_SHA}"'" or .original_commit_id == "'"${CURRENT_SHA}"'") | select((.body | test("P0|P1|P2"))) ] | length' \
@@ -1180,7 +1168,7 @@ if [ "${BOT_UNAVAILABLE}" = "false" ] && [ "${BOT_HAS_ISSUES}" = "false" ]; then
     echo "WARNING: Detected ${OTHER_BOT_COUNT} actionable comment(s) from non-target bot(s)." >&2
     echo "WARNING: These may consume coding quota for the originating bot service." >&2
     echo "Including non-target bot findings in review."
-    if [ "${REUSE_EXISTING_CURRENT_HEAD_REVIEW}" = "true" ]; then
+    if [ "${reuse_existing_current_head_review}" = "true" ]; then
       BOT_HAS_ISSUES_SOURCE="current_sha_comments"
     else
       BOT_HAS_ISSUES_SOURCE="current_window_comments"
@@ -2110,12 +2098,12 @@ Cloud bot explicitly disabled (cloud_bot=false). Local fallback review passed
 guarantees `FALLBACK_REVIEW_HAS_ISSUES=false` before reaching this point.
 This step executes in either of these cases:
 - `cloud_bot=false` (no cloud bot path)
-- `cloud_bot=true`, `BOT_UNAVAILABLE=true`, and fallback local review is clean
+- `cloud_bot=true`, bot is skipped due to cached quota exhaustion, and fallback local review is clean
 
 **MANDATORY**: Before merging, leave a PR comment explaining the merge rationale.
-This step has three audit-trail cases:
+This step has two audit-trail cases:
 - `cloud_bot=false`: "cloud_bot=false (disabled in config); merging on local review clean"
-- `cloud_bot=true` and `BOT_UNAVAILABLE=true`: "cloud_bot=true but bot timed out; merging on fallback review clean"
+- `MERGE_WITHOUT_BOT_REASON_KIND=cloud_bot_quota_exhausted`: explain the cached quota window and cite the local review session ID
 When `MERGE_WITHOUT_BOT_REASON_KIND=cloud_bot_quota_exhausted`, the audit trail
 must explain the cached quota window and cite the local review session ID.
 
@@ -2160,10 +2148,6 @@ ${DIFF_SUMMARY}
 \`\`\`
 EOF
 )"
-elif [ "${BOT_UNAVAILABLE:-false}" = "true" ]; then
-  MERGE_REASON="cloud_bot=true but bot timed out; merging on fallback review clean"
-  MERGE_WITHOUT_BOT_REASON_KIND="${MERGE_WITHOUT_BOT_REASON_KIND:-cloud_bot_timeout}"
-  COMMENT_BODY="**Merge rationale**: ${MERGE_REASON}. Local \`csa review --branch ${DEFAULT_BRANCH}\` passed CLEAN (or issues were fixed in fallback cycle). Proceeding to merge with local review as the review layer."
 else
   echo "ERROR: Step 6a reached without a valid merge-without-bot rationale."
   exit 1


### PR DESCRIPTION
## Summary
- Simplify Step 17 condition — drop redundant `(!(BOT_UNAVAILABLE && FALLBACK_REVIEW_HAS_ISSUES))` clause
- Delete unreachable Step 19 `elif BOT_UNAVAILABLE` branch (Step 6 `exit 1`s on bot timeout per SKILL.md contract)
- Move step-local shell variables out of `[variables]` manifest
- PATTERN.md narrative updated in lockstep (Rule 027 round-trip)

## Test plan
- [x] `weave compile` exit 0
- [x] `just pre-commit` exit 0
- [x] Runtime behavior unchanged (Option A: abort on bot timeout, already documented in SKILL.md)

Closes #870, closes #872.

Batch 12a (pr-bot hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)