### PR TITLE
refactor(csa-executor): consolidate codex initial-stall DRY (#853)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.389"
+version = "0.1.390"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.389"
+version = "0.1.390"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -51,7 +51,7 @@ pub(crate) use session_exec::{
 pub(crate) const DEFAULT_IDLE_TIMEOUT_SECONDS: u64 = 250;
 pub(crate) const DEFAULT_LIVENESS_DEAD_SECONDS: u64 = csa_process::DEFAULT_LIVENESS_DEAD_SECS;
 pub(crate) const DEFAULT_RESOURCES_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 120;
-pub(crate) const DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 300;
+pub(crate) use csa_executor::DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS;
 pub(crate) const DEFAULT_GEMINI_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 600;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 
 use csa_config::{GlobalConfig, ProjectConfig};
-use csa_executor::Executor;
+use csa_executor::{CODEX_EXEC_INITIAL_STALL_REASON, Executor};
 use csa_hooks::{HookEvent, run_hooks_for_event};
 use csa_session::{
     MetaSessionState, SessionArtifact, SessionResult, TokenUsage, ToolState, get_session_dir,
@@ -23,8 +23,6 @@ use crate::run_helpers::{is_compress_command, parse_token_usage};
 
 const FALLBACK_OUTPUT_TAIL_LINES: usize = 8;
 const OUTPUT_LOG_TAIL_READ_BYTES: u64 = 8 * 1024;
-const CODEX_EXEC_INITIAL_STALL_REASON: &str = "codex_exec_initial_stall";
-
 /// All inputs needed for post-execution processing.
 pub(crate) struct PostExecContext<'a> {
     pub executor: &'a Executor,
@@ -746,7 +744,7 @@ mod tests {
         let toml = toml::to_string_pretty(&result).expect("serialize result.toml");
         assert_eq!(result.status, "failure");
         assert!(toml.contains("status = \"failure\""));
-        assert!(toml.contains("codex_exec_initial_stall"));
+        assert!(toml.contains(CODEX_EXEC_INITIAL_STALL_REASON));
     }
 
     #[test]

--- a/crates/csa-executor/src/lib.rs
+++ b/crates/csa-executor/src/lib.rs
@@ -30,9 +30,10 @@ pub use logging::create_session_log_writer;
 pub use model_spec::{ModelSpec, ThinkingBudget};
 pub use session_id::{extract_session_id, extract_session_id_from_transport};
 pub use transport::{
-    AcpTransport, LegacyTransport, PeakMemoryContext, SandboxTransportConfig, Transport,
-    TransportFactory, TransportMode, TransportOptions, TransportResult,
-    resolve_initial_response_timeout,
+    AcpTransport, CODEX_EXEC_INITIAL_STALL_REASON, DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS,
+    LegacyTransport, PeakMemoryContext, SandboxTransportConfig, Transport, TransportFactory,
+    TransportMode, TransportOptions, TransportResult, apply_codex_exec_initial_stall_summary,
+    classify_codex_exec_initial_stall, resolve_initial_response_timeout,
 };
 
 // Re-export session config types from csa-acp for pipeline integration.

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -57,15 +57,20 @@ mod transport_acp_payload_debug;
 use transport_acp_payload_debug::{AcpPayloadDebugRequest, maybe_write_acp_payload_debug};
 #[path = "transport_codex_exec_stall.rs"]
 mod transport_codex_exec_stall;
-#[cfg(test)]
-use transport_codex_exec_stall::CodexExecInitialStallClassification;
+#[path = "transport_legacy_codex_exec_stall.rs"]
+mod transport_legacy_codex_exec_stall;
 pub(crate) use transport_codex_exec_stall::resolve_execute_in_initial_response_timeout_seconds;
 pub use transport_codex_exec_stall::resolve_initial_response_timeout;
+pub use transport_codex_exec_stall::{
+    CODEX_EXEC_INITIAL_STALL_REASON, DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS,
+    apply_codex_exec_initial_stall_summary, classify_codex_exec_initial_stall,
+};
 use transport_codex_exec_stall::{
-    CODEX_EXEC_INITIAL_STALL_REASON, apply_codex_exec_initial_stall_summary,
-    classify_codex_exec_initial_stall,
     consume_resolved_execute_in_initial_response_timeout_seconds,
     consume_resolved_initial_response_timeout_seconds,
+};
+use transport_legacy_codex_exec_stall::{
+    apply_and_maybe_retry_codex_exec_initial_stall, log_codex_exec_initial_stall,
 };
 
 #[path = "transport_types.rs"]
@@ -206,13 +211,7 @@ impl LegacyTransport {
             &execution,
             initial_response_timeout_seconds,
         ) {
-            tracing::warn!(
-                classified_reason = CODEX_EXEC_INITIAL_STALL_REASON,
-                elapsed_seconds = classification.timeout_seconds,
-                effort = classification.effort,
-                child_pid = child_pid.unwrap_or(0),
-                "codex exec initial-response stall detected"
-            );
+            log_codex_exec_initial_stall(&classification, child_pid);
         }
         Ok(TransportResult {
             execution,
@@ -332,13 +331,7 @@ impl LegacyTransport {
             &execution,
             initial_response_timeout_seconds,
         ) {
-            tracing::warn!(
-                classified_reason = CODEX_EXEC_INITIAL_STALL_REASON,
-                elapsed_seconds = classification.timeout_seconds,
-                effort = classification.effort,
-                child_pid = child_pid.unwrap_or(0),
-                "codex exec initial-response stall detected"
-            );
+            log_codex_exec_initial_stall(&classification, child_pid);
         }
 
         Ok(TransportResult {
@@ -429,18 +422,15 @@ impl LegacyTransport {
             let direct_timeout = consume_resolved_execute_in_initial_response_timeout_seconds(
                 initial_response_timeout_seconds,
             );
-            if let Some(classification) =
-                classify_codex_exec_initial_stall(&executor, &result.execution, direct_timeout)
-            {
-                if let Some(retry_budget) = classification.retry_effort.clone() {
-                    let mut downgraded_executor = executor.clone();
-                    downgraded_executor.override_thinking_budget(retry_budget.clone());
-                    tracing::info!(
-                        original_effort = classification.effort,
-                        fallback_effort = retry_budget.codex_effort(),
-                        "retrying codex exec after initial-response stall"
-                    );
-                    let mut retry_result = self
+            let retry_executor = executor.clone();
+            let result = apply_and_maybe_retry_codex_exec_initial_stall(
+                &executor,
+                result,
+                direct_timeout,
+                |retry_budget| async move {
+                    let mut downgraded_executor = retry_executor;
+                    downgraded_executor.override_thinking_budget(retry_budget);
+                    let retry_result = self
                         .execute_in_single_attempt(ExecuteInAttempt {
                             executor: &downgraded_executor,
                             prompt,
@@ -452,30 +442,10 @@ impl LegacyTransport {
                                 initial_response_timeout_seconds,
                         })
                         .await?;
-                    if let Some(retry_classification) = classify_codex_exec_initial_stall(
-                        &downgraded_executor,
-                        &retry_result.execution,
-                        direct_timeout,
-                    ) {
-                        apply_codex_exec_initial_stall_summary(
-                            &mut retry_result.execution,
-                            &retry_classification,
-                            true,
-                            Some(classification.effort),
-                        );
-                    }
-                    return Ok(retry_result);
-                }
-
-                let mut result = result;
-                apply_codex_exec_initial_stall_summary(
-                    &mut result.execution,
-                    &classification,
-                    false,
-                    None,
-                );
-                return Ok(result);
-            }
+                    Ok((downgraded_executor, retry_result))
+                },
+            )
+            .await?;
             if let Some(classification) =
                 classify_gemini_legacy_initial_stall(&executor, &result.execution, direct_timeout)
             {

--- a/crates/csa-executor/src/transport_codex_exec_stall.rs
+++ b/crates/csa-executor/src/transport_codex_exec_stall.rs
@@ -1,12 +1,12 @@
 use crate::{executor::Executor, model_spec::ThinkingBudget};
 use csa_process::ExecutionResult;
 
-pub(crate) const CODEX_EXEC_INITIAL_STALL_REASON: &str = "codex_exec_initial_stall";
-const DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 300;
+pub const CODEX_EXEC_INITIAL_STALL_REASON: &str = "codex_exec_initial_stall";
+pub const DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 300;
 const DEFAULT_GENERIC_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 120;
 
 #[derive(Debug, Clone)]
-pub(crate) struct CodexExecInitialStallClassification {
+pub struct CodexExecInitialStallClassification {
     pub(crate) effort: &'static str,
     pub(crate) timeout_seconds: u64,
     pub(crate) retry_effort: Option<ThinkingBudget>,
@@ -31,7 +31,7 @@ fn executor_default_initial_response_timeout_seconds(executor: &Executor) -> u64
     }
 }
 
-pub(crate) fn resolve_execute_in_initial_response_timeout_seconds(
+pub fn resolve_execute_in_initial_response_timeout_seconds(
     executor: &Executor,
     configured_timeout_seconds: Option<u64>,
 ) -> Option<u64> {
@@ -60,7 +60,7 @@ pub(crate) fn consume_resolved_execute_in_initial_response_timeout_seconds(
     consume_resolved_initial_response_timeout_seconds(resolved_timeout_seconds)
 }
 
-pub(crate) fn classify_codex_exec_initial_stall(
+pub fn classify_codex_exec_initial_stall(
     executor: &Executor,
     execution: &ExecutionResult,
     timeout_seconds: Option<u64>,
@@ -88,7 +88,7 @@ pub(crate) fn classify_codex_exec_initial_stall(
     })
 }
 
-pub(crate) fn apply_codex_exec_initial_stall_summary(
+pub fn apply_codex_exec_initial_stall_summary(
     execution: &mut ExecutionResult,
     classification: &CodexExecInitialStallClassification,
     retry_attempted: bool,

--- a/crates/csa-executor/src/transport_legacy_codex_exec_stall.rs
+++ b/crates/csa-executor/src/transport_legacy_codex_exec_stall.rs
@@ -1,0 +1,67 @@
+use std::future::Future;
+
+use crate::executor::Executor;
+use crate::model_spec::ThinkingBudget;
+use anyhow::Result;
+
+use super::transport_codex_exec_stall::CodexExecInitialStallClassification;
+use super::{
+    CODEX_EXEC_INITIAL_STALL_REASON, TransportResult, apply_codex_exec_initial_stall_summary,
+    classify_codex_exec_initial_stall,
+};
+
+pub(super) fn log_codex_exec_initial_stall(
+    classification: &CodexExecInitialStallClassification,
+    child_pid: Option<u32>,
+) {
+    tracing::warn!(
+        classified_reason = CODEX_EXEC_INITIAL_STALL_REASON,
+        elapsed_seconds = classification.timeout_seconds,
+        effort = classification.effort,
+        child_pid = child_pid.unwrap_or(0),
+        "codex exec initial-response stall detected"
+    );
+}
+
+pub(super) async fn apply_and_maybe_retry_codex_exec_initial_stall<F, Fut>(
+    executor: &Executor,
+    result: TransportResult,
+    timeout_seconds: Option<u64>,
+    retry_once: F,
+) -> Result<TransportResult>
+where
+    F: FnOnce(ThinkingBudget) -> Fut,
+    Fut: Future<Output = Result<(Executor, TransportResult)>>,
+{
+    let Some(classification) =
+        classify_codex_exec_initial_stall(executor, &result.execution, timeout_seconds)
+    else {
+        return Ok(result);
+    };
+
+    if let Some(retry_budget) = classification.retry_effort.clone() {
+        tracing::info!(
+            original_effort = classification.effort,
+            fallback_effort = retry_budget.codex_effort(),
+            "retrying codex exec after initial-response stall"
+        );
+        let (downgraded_executor, mut retry_result) = retry_once(retry_budget).await?;
+        if let Some(retry_classification) = classify_codex_exec_initial_stall(
+            &downgraded_executor,
+            &retry_result.execution,
+            timeout_seconds,
+        ) {
+            apply_codex_exec_initial_stall_summary(
+                &mut retry_result.execution,
+                &retry_classification,
+                true,
+                Some(classification.effort),
+            );
+        }
+        return Ok(retry_result);
+    }
+
+    let mut result = result;
+    apply_codex_exec_initial_stall_summary(&mut result.execution, &classification, false, None);
+    Ok(result)
+}

--- a/crates/csa-executor/src/transport_legacy_impl.rs
+++ b/crates/csa-executor/src/transport_legacy_impl.rs
@@ -69,64 +69,36 @@ impl Transport for LegacyTransport {
                 attempt = attempt.saturating_add(1);
                 continue;
             }
-            if let Some(classification) = classify_codex_exec_initial_stall(
-                &executor,
-                &result.execution,
-                Self::consume_resolved_transport_initial_response_timeout_seconds(
-                    options.initial_response_timeout_seconds,
-                ),
-            ) {
-                if let Some(retry_budget) = classification.retry_effort.clone() {
-                    let mut downgraded_executor = executor.clone();
-                    downgraded_executor.override_thinking_budget(retry_budget.clone());
-                    tracing::info!(
-                        original_effort = classification.effort,
-                        fallback_effort = retry_budget.codex_effort(),
-                        "retrying codex exec after initial-response stall"
-                    );
-                    let mut retry_result = self
-                        .execute_single_attempt(
-                            &downgraded_executor,
-                            prompt,
-                            tool_state,
-                            session,
-                            attempt_env,
-                            options.clone(),
-                        )
-                        .await?;
-                    if let Some(retry_classification) = classify_codex_exec_initial_stall(
-                        &downgraded_executor,
-                        &retry_result.execution,
-                        Self::consume_resolved_transport_initial_response_timeout_seconds(
-                            options.initial_response_timeout_seconds,
-                        ),
-                    )
-                    {
-                        apply_codex_exec_initial_stall_summary(
-                            &mut retry_result.execution,
-                            &retry_classification,
-                            true,
-                            Some(classification.effort),
-                        );
-                    }
-                    return Ok(retry_result);
-                }
-
-                let mut result = result;
-                apply_codex_exec_initial_stall_summary(
-                    &mut result.execution,
-                    &classification,
-                    false,
-                    None,
-                );
-                return Ok(result);
-            }
+            let codex_timeout = Self::consume_resolved_transport_initial_response_timeout_seconds(
+                options.initial_response_timeout_seconds,
+            );
+            let retry_executor = executor.clone();
+            let retry_options = options.clone();
+            let result = apply_and_maybe_retry_codex_exec_initial_stall(
+                    &executor,
+                    result,
+                    codex_timeout,
+                    |retry_budget| async move {
+                        let mut downgraded_executor = retry_executor;
+                        downgraded_executor.override_thinking_budget(retry_budget);
+                        let retry_result = self
+                            .execute_single_attempt(
+                                &downgraded_executor,
+                                prompt,
+                                tool_state,
+                                session,
+                                attempt_env,
+                                retry_options,
+                            )
+                            .await?;
+                        Ok((downgraded_executor, retry_result))
+                    },
+                )
+                .await?;
             if let Some(classification) = classify_gemini_legacy_initial_stall(
                 &executor,
                 &result.execution,
-                Self::consume_resolved_transport_initial_response_timeout_seconds(
-                    options.initial_response_timeout_seconds,
-                ),
+                codex_timeout,
             ) {
                 let mut result = result;
                 apply_gemini_legacy_initial_stall_summary(&mut result.execution, &classification);

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -282,7 +282,7 @@ echo "ok persistent"
 
 #[test]
 fn test_apply_codex_exec_initial_stall_summary_renders_reason_for_result_toml() {
-    let classification = super::CodexExecInitialStallClassification {
+    let classification = super::transport_codex_exec_stall::CodexExecInitialStallClassification {
         effort: "high",
         timeout_seconds: 300,
         retry_effort: None,
@@ -314,9 +314,9 @@ fn test_apply_codex_exec_initial_stall_summary_renders_reason_for_result_toml() 
     };
     let toml = toml::to_string_pretty(&result).expect("serialize session result");
 
-    assert!(execution.summary.contains("codex_exec_initial_stall"));
+    assert!(execution.summary.contains(CODEX_EXEC_INITIAL_STALL_REASON));
     assert!(execution.summary.contains("retry_attempted=true"));
-    assert!(toml.contains("codex_exec_initial_stall"));
+    assert!(toml.contains(CODEX_EXEC_INITIAL_STALL_REASON));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Three MEDIUM DRY findings from PR #849 round-4 cloud review consolidated:
- Promote CODEX_EXEC_INITIAL_STALL_REASON + DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS to public in csa-executor; cli-sub-agent now imports instead of hardcoding 300 / string literals
- Verify transport.rs + transport_legacy_impl.rs both route through shared classify/apply helpers (collapse any drift)
- Pure refactor; no behavior change

Closes #853.

## Test plan
- [ ] cargo build --release exit 0
- [ ] cargo test -p csa-executor exit 0
- [ ] just pre-commit exit 0
- [ ] grep confirms no remaining literal 300 / codex_exec_initial_stall duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)