### PR TITLE
refactor(cli-sub-agent): simplify apply_review_target_dir signature (#856)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.390"
+version = "0.1.391"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.390"
+version = "0.1.391"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_env.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use csa_config::ProjectConfig;
 use tracing::info;
@@ -58,39 +58,34 @@ pub(crate) fn build_merged_env(
     merged_env
 }
 
-pub(crate) fn apply_review_target_dir(
-    task_type: Option<&str>,
-    session_dir: &std::path::Path,
-    _merged_env: &mut HashMap<String, String>,
-) {
-    if matches!(task_type, Some("review")) {
-        let project_root = resolve_review_project_root(session_dir)
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-        let repo_target_dir = project_root.join("target");
-        if let Some(target_kind) = detect_project_target_kind(&repo_target_dir) {
-            info!(
-                project_target = %repo_target_dir.display(),
-                target_kind,
-                "honoring user ./target ({target_kind}), CARGO_TARGET_DIR untouched"
-            );
-            return;
-        }
-
+pub(crate) fn apply_review_target_dir(project_root: &Path, tool_name: &str) {
+    let repo_target_dir = project_root.join("target");
+    if let Some(target_kind) = detect_project_target_kind(&repo_target_dir) {
         info!(
             project_target = %repo_target_dir.display(),
-            "no ./target present, CARGO_TARGET_DIR left at codex/cargo default"
+            tool = tool_name,
+            target_kind,
+            "honoring user ./target ({target_kind}), CARGO_TARGET_DIR untouched"
         );
+        return;
     }
+
+    info!(
+        project_target = %repo_target_dir.display(),
+        tool = tool_name,
+        "no ./target present, CARGO_TARGET_DIR left at codex/cargo default"
+    );
 }
 
 pub(crate) fn apply_task_target_dir_guards(
     task_type: Option<&str>,
     tool_name: &str,
     project_root: &Path,
-    session_dir: &Path,
     merged_env: &mut HashMap<String, String>,
 ) {
-    apply_review_target_dir(task_type, session_dir, merged_env);
+    if matches!(task_type, Some("review")) {
+        apply_review_target_dir(project_root, tool_name);
+    }
     apply_run_target_dir_guard(task_type, tool_name, project_root, merged_env);
 }
 
@@ -98,11 +93,13 @@ pub(crate) fn apply_run_target_dir_guard(
     task_type: Option<&str>,
     tool_name: &str,
     project_root: &Path,
-    _merged_env: &mut HashMap<String, String>,
+    merged_env: &mut HashMap<String, String>,
 ) {
     if !matches!(task_type, Some("run")) || tool_name != "codex" {
         return;
     }
+
+    let _ = merged_env;
 
     let repo_target_dir = project_root.join("target");
     let user_configured_target = std::fs::symlink_metadata(&repo_target_dir).is_ok();
@@ -119,14 +116,6 @@ pub(crate) fn apply_run_target_dir_guard(
         project_target = %repo_target_dir.display(),
         "Run session: no user-configured ./target, leaving codex default CARGO_TARGET_DIR behavior (no CSA override)"
     );
-}
-
-fn resolve_review_project_root(session_dir: &Path) -> Option<PathBuf> {
-    let state_path = session_dir.join("state.toml");
-    let state_contents = std::fs::read_to_string(state_path).ok()?;
-    let state_value: toml::Value = toml::from_str(&state_contents).ok()?;
-    let project_path = state_value.get("project_path")?.as_str()?;
-    Some(PathBuf::from(project_path))
 }
 
 fn detect_project_target_kind(repo_target_dir: &Path) -> Option<&'static str> {

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -471,7 +471,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         task_type,
         executor.tool_name(),
         project_root,
-        &session_dir,
         &mut merged_env,
     );
     let merged_env_ref = if merged_env.is_empty() {

--- a/crates/cli-sub-agent/src/pipeline_tests_review_target.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_review_target.rs
@@ -1,46 +1,18 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
 
 use tempfile::tempdir;
 
-fn current_dir_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
-struct CurrentDirGuard {
-    original: PathBuf,
-}
-
-impl CurrentDirGuard {
-    fn enter(path: &Path) -> Self {
-        let original = std::env::current_dir().expect("read current dir");
-        std::env::set_current_dir(path).expect("set current dir");
-        Self { original }
-    }
-}
-
-impl Drop for CurrentDirGuard {
-    fn drop(&mut self) {
-        std::env::set_current_dir(&self.original).expect("restore current dir");
-    }
-}
-
 #[test]
 fn apply_review_target_dir_leaves_existing_directory_target_untouched() {
-    let _lock = current_dir_lock().lock().expect("current dir lock");
     let project = tempdir().expect("tempdir");
-    let _cwd = CurrentDirGuard::enter(project.path());
     std::fs::create_dir(project.path().join("target")).expect("create target dir");
-    let session_dir = project.path().join("session");
     let mut env = HashMap::new();
     env.insert(
         "CARGO_TARGET_DIR".to_string(),
         "/repo/legacy-review-target".to_string(),
     );
 
-    crate::pipeline_env::apply_review_target_dir(Some("review"), &session_dir, &mut env);
+    crate::pipeline_env::apply_review_target_dir(project.path(), "codex");
 
     assert_eq!(
         env.get("CARGO_TARGET_DIR").map(String::as_str),
@@ -53,47 +25,16 @@ fn apply_review_target_dir_leaves_existing_directory_target_untouched() {
 fn apply_review_target_dir_leaves_broken_target_symlink_untouched() {
     use std::os::unix::fs::symlink;
 
-    let _lock = current_dir_lock().lock().expect("current dir lock");
     let project = tempdir().expect("tempdir");
-    let _cwd = CurrentDirGuard::enter(project.path());
     symlink("missing-mount/target", project.path().join("target"))
         .expect("create broken target symlink");
-    let session_dir = project.path().join("session");
     let mut env = HashMap::new();
     env.insert(
         "CARGO_TARGET_DIR".to_string(),
         "/repo/legacy-review-target".to_string(),
     );
 
-    crate::pipeline_env::apply_review_target_dir(Some("review"), &session_dir, &mut env);
-
-    assert_eq!(
-        env.get("CARGO_TARGET_DIR").map(String::as_str),
-        Some("/repo/legacy-review-target")
-    );
-}
-
-#[test]
-fn apply_review_target_dir_prefers_project_path_from_session_state() {
-    let _lock = current_dir_lock().lock().expect("current dir lock");
-    let project = tempdir().expect("project tempdir");
-    let unrelated_cwd = tempdir().expect("cwd tempdir");
-    let _cwd = CurrentDirGuard::enter(unrelated_cwd.path());
-    std::fs::create_dir(project.path().join("target")).expect("create target dir");
-    let session_dir = project.path().join("session");
-    std::fs::create_dir_all(&session_dir).expect("create session dir");
-    std::fs::write(
-        session_dir.join("state.toml"),
-        format!("project_path = {:?}\n", project.path()),
-    )
-    .expect("write state file");
-    let mut env = HashMap::new();
-    env.insert(
-        "CARGO_TARGET_DIR".to_string(),
-        "/repo/legacy-review-target".to_string(),
-    );
-
-    crate::pipeline_env::apply_review_target_dir(Some("review"), &session_dir, &mut env);
+    crate::pipeline_env::apply_review_target_dir(project.path(), "codex");
 
     assert_eq!(
         env.get("CARGO_TARGET_DIR").map(String::as_str),
@@ -103,30 +44,29 @@ fn apply_review_target_dir_prefers_project_path_from_session_state() {
 
 #[test]
 fn apply_review_target_dir_leaves_default_behavior_when_repo_target_missing() {
-    let _lock = current_dir_lock().lock().expect("current dir lock");
     let project = tempdir().expect("tempdir");
-    let _cwd = CurrentDirGuard::enter(project.path());
-    let session_dir = project.path().join("session");
-    let mut env = HashMap::new();
+    let env: HashMap<String, String> = HashMap::new();
 
-    crate::pipeline_env::apply_review_target_dir(Some("review"), &session_dir, &mut env);
+    crate::pipeline_env::apply_review_target_dir(project.path(), "codex");
 
     assert_eq!(env.get("CARGO_TARGET_DIR").map(String::as_str), None);
 }
 
 #[test]
 fn apply_review_target_dir_leaves_non_review_sessions_unchanged() {
-    let _lock = current_dir_lock().lock().expect("current dir lock");
     let project = tempdir().expect("tempdir");
-    let _cwd = CurrentDirGuard::enter(project.path());
-    let session_dir = project.path().join("session");
     let mut env = HashMap::new();
     env.insert(
         "CARGO_TARGET_DIR".to_string(),
         "/repo/legacy-review-target".to_string(),
     );
 
-    crate::pipeline_env::apply_review_target_dir(Some("run"), &session_dir, &mut env);
+    crate::pipeline_env::apply_task_target_dir_guards(
+        Some("run"),
+        "codex",
+        project.path(),
+        &mut env,
+    );
 
     assert_eq!(
         env.get("CARGO_TARGET_DIR").map(String::as_str),


### PR DESCRIPTION
## Summary
Three MEDIUM cleanups from #855 gemini review rounds:
- Drop redundant state.toml I/O; accept project_root: &Path from caller
- Remove current_dir() fallback (always-known)
- Remove unused _merged_env parameter

No behavior change; regression coverage retained.

Closes #856.

## Test plan
- [ ] cargo test -p cli-sub-agent apply_review_target_dir exit 0
- [ ] cargo test -p cli-sub-agent execute_review_preserves_codex_default_target_when_project_target_exists exit 0
- [ ] just pre-commit exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)