### PR TITLE
fix(csa-executor): harden ACP crash classifier regex (#868)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.392"
+version = "0.1.393"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.392"
+version = "0.1.393"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_acp_crash_retry.rs
+++ b/crates/csa-executor/src/transport_acp_crash_retry.rs
@@ -27,10 +27,11 @@ const OOM_SIGNALS: &[i32] = &[
 static EXIT_137_RE: LazyLock<Regex> =
     LazyLock::new(|| compile_regex(r"\bexit(?:\s+code)?[\s:=]+137\b"));
 static EXIT_CODE_RE: LazyLock<Regex> =
-    LazyLock::new(|| compile_regex(r"\bexit(?:\s+code)?[\s:=]+(?P<code>\d+)\b"));
+    LazyLock::new(|| compile_regex(r"\bexit(?:\s+code)?[\s:=]+(?P<code>-?\d+)\b"));
 static BARE_CODE_RE: LazyLock<Regex> =
-    LazyLock::new(|| compile_regex(r"\bcode[\s:=]+(?P<code>\d+)\b"));
+    LazyLock::new(|| compile_regex(r"\bcode[\s:=]+(?P<code>-?\d+)\b"));
 static OOM_WORD_RE: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"\boom\b"));
+static SIGNAL_9_RE: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"\bsignal\s*[:\-]?\s*9\b"));
 
 fn compile_regex(pattern: &str) -> Regex {
     match Regex::new(pattern) {
@@ -114,6 +115,7 @@ fn is_oom_lowered(lowered: &str) -> bool {
         || lowered.contains("out of memory")
         || lowered.contains("memory.max")
         || lowered.contains("memorymax")
+        || OOM_WORD_RE.is_match(lowered)
 }
 
 /// Authentication or authorization failures (deterministic, never retry).
@@ -217,15 +219,14 @@ pub(crate) fn extract_crash_exit_code(error_str: &str) -> Option<CrashExitCode> 
         return Some(CrashExitCode::ExitCode(137));
     }
 
-    if lowered.contains("signal: 9") || lowered.contains("sigkill") {
+    if SIGNAL_9_RE.is_match(&lowered) || lowered.contains("sigkill") {
         return Some(CrashExitCode::Signal(9));
     }
 
-    if lowered.contains("memory.max")
-        || lowered.contains("oom-kill")
+    if lowered.contains("oom-kill")
         || lowered.contains("memory.events")
         || lowered.contains("memory.events.local")
-        || OOM_WORD_RE.is_match(&lowered)
+        || is_oom_lowered(&lowered)
     {
         return Some(CrashExitCode::OomEvent);
     }
@@ -267,6 +268,7 @@ pub(crate) fn classify_codex_acp_crash(
     let exit_code_oom = matches!(
         exit_code,
         Some(CrashExitCode::ExitCode(137))
+            | Some(CrashExitCode::ExitCode(-9))
             | Some(CrashExitCode::Signal(9))
             | Some(CrashExitCode::OomEvent)
     );

--- a/crates/csa-executor/src/transport_tests_acp_crash_retry.rs
+++ b/crates/csa-executor/src/transport_tests_acp_crash_retry.rs
@@ -59,6 +59,14 @@ fn test_out_of_memory_is_not_retryable() {
 }
 
 #[test]
+fn test_oom_word_boundary_cases() {
+    assert!(is_oom_error("ACP transport failed: out of memory"));
+    assert!(is_oom_error("kernel logged: oom killed process X"));
+    assert!(!is_oom_error("room available"));
+    assert!(!is_oom_error("zoom level"));
+}
+
+#[test]
 fn test_signal_90_is_not_oom_false_positive() {
     // "signal 90" should NOT match the OOM pattern for signal 9.
     let err = "ACP process exited unexpectedly: killed by signal 90";
@@ -357,6 +365,14 @@ fn extract_parses_code_with_equals() {
 }
 
 #[test]
+fn extract_parses_negative_exit_code() {
+    assert_eq!(
+        extract_crash_exit_code("exit code: -9"),
+        Some(CrashExitCode::ExitCode(-9))
+    );
+}
+
+#[test]
 fn extract_rejects_oom_as_substring_of_room() {
     assert_ne!(
         extract_crash_exit_code("something involving bedroom and classroom"),
@@ -377,6 +393,26 @@ fn extract_accepts_standalone_oom_with_word_boundary() {
     assert_eq!(
         extract_crash_exit_code("kernel logged: oom killed process X"),
         Some(CrashExitCode::OomEvent)
+    );
+}
+
+#[test]
+fn extract_signal_9_variants_and_sigkill() {
+    assert_eq!(
+        extract_crash_exit_code("ACP process exited unexpectedly: signal 9"),
+        Some(CrashExitCode::Signal(9))
+    );
+    assert_eq!(
+        extract_crash_exit_code("ACP process exited unexpectedly: signal:9"),
+        Some(CrashExitCode::Signal(9))
+    );
+    assert_eq!(
+        extract_crash_exit_code("ACP process exited unexpectedly: signal: 9"),
+        Some(CrashExitCode::Signal(9))
+    );
+    assert_eq!(
+        extract_crash_exit_code("ACP process exited unexpectedly: SIGKILL"),
+        Some(CrashExitCode::Signal(9))
     );
 }
 
@@ -405,4 +441,24 @@ fn test_format_codex_acp_crash_retry_exhausted_preserves_failover_anchor() {
     let msg = formatted.to_string().to_ascii_lowercase();
     assert!(msg.contains("acp crash retry exhausted"));
     assert!(msg.contains("codex_acp_crash_runtime"));
+}
+
+#[test]
+fn classify_signal_9_variants_as_oom() {
+    for signal_variant in ["signal 9", "signal:9", "signal: 9", "sigkill"] {
+        let classification =
+            classify_codex_acp_crash("ACP process exited unexpectedly", extract_crash_exit_code(signal_variant), None, Some(3072));
+        assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
+    }
+}
+
+#[test]
+fn classify_signal_negative_9_as_oom() {
+    let classification = classify_codex_acp_crash(
+        "ACP process exited unexpectedly: exit code -9",
+        extract_crash_exit_code("ACP process exited unexpectedly: exit code -9"),
+        None,
+        Some(3072),
+    );
+    assert_eq!(classification.kind, CodexAcpCrashKind::Oom);
 }


### PR DESCRIPTION
## Summary

Four MEDIUM hardening findings from PR #867 round-2 gemini review (deferred per severity-tiered policy, now resolved):

- **Word-boundary OOM** — Migrate substring `"oom "`/`" oom"`/`ends_with("oom")` path to word-boundary regex (or delegate to `is_oom_lowered`), eliminating false matches on "room"/"zoom"/"kaboom".
- **Negative exit codes** — Update exit-code regex from `\d+` to `-?\d+` so signal representations like `-9` parse.
- **Tolerant signal-9 detection** — Promote from brittle `contains("signal: 9")` to regex accepting `"signal 9"`, `"signal:9"`, `"signal: 9"`.
- **Restore `signal -9 → OomEvent`** — Parity branch dropped during #848 rewrite.

Adds regression tests for each change.

Closes #868.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p csa-executor transport_acp_crash_retry`
- [x] `cargo test -p csa-executor` (full crate)
- [x] `just pre-commit`
- [x] Version bumped 0.1.392 → 0.1.393

🤖 Generated with [Claude Code](https://claude.com/claude-code)