### PR TITLE
refactor(csa-config): use anyhow context helpers for validation errors (#884)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.393"
+version = "0.1.394"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.393"
+version = "0.1.394"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -202,7 +202,7 @@ transport = "acp"
     );
 
     let err = load_doctor_project_config_from(td.path()).unwrap_err();
-    let message = err.to_string();
+    let message = format!("{err:#}");
 
     assert!(
         message.contains("[tools.codex].transport"),
@@ -311,9 +311,7 @@ transport = "cli"
 
     let merged_error = ProjectConfig::load(td.path()).expect_err("merged load should fail");
     assert!(
-        merged_error
-            .to_string()
-            .contains("[tools.claude-code].transport"),
+        format!("{merged_error:#}").contains("[tools.claude-code].transport"),
         "test fixture should exercise an invalid user-level transport override: {merged_error}"
     );
 

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -98,7 +98,7 @@ transport = "acp"
     .unwrap();
 
     let err = load_and_validate(tmp.path(), 0).unwrap_err();
-    let message = err.to_string();
+    let message = format!("{err:#}");
 
     assert!(
         message.contains("[tools.codex].transport"),

--- a/crates/cli-sub-agent/src/run_helpers_transport_integration_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_transport_integration_tests.rs
@@ -112,7 +112,7 @@ transport = "acp"
     );
 
     let err = ProjectConfig::load_project_only(dir.path()).expect_err("config should fail");
-    let message = err.to_string();
+    let message = format!("{err:#}");
 
     assert!(
         message.contains("[tools.codex].transport"),

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -253,12 +253,8 @@ impl ProjectConfig {
         // Check for deprecated keys before deserializing (serde silently ignores them)
         if let Ok(raw) = toml::from_str::<toml::Value>(&content) {
             warn_deprecated_keys(&raw, &path.display().to_string());
-            crate::validate::validate_tool_transport_overrides_in_raw_config(&raw).map_err(
-                |error| {
-                    let summary = error.to_string();
-                    error.context(format!("Invalid config: {}: {summary}", path.display()))
-                },
-            )?;
+            crate::validate::validate_tool_transport_overrides_in_raw_config(&raw)
+                .with_context(|| format!("Invalid config: {}", path.display()))?;
         }
         let config: Self = toml::from_str(&content)
             .with_context(|| format!("Failed to parse config: {}", path.display()))?;
@@ -287,24 +283,10 @@ impl ProjectConfig {
         // Check for deprecated keys in both configs
         warn_deprecated_keys(&base_val, &base_path.display().to_string());
         warn_deprecated_keys(&overlay_val, &overlay_path.display().to_string());
-        crate::validate::validate_tool_transport_overrides_in_raw_config(&base_val).map_err(
-            |error| {
-                let summary = error.to_string();
-                error.context(format!(
-                    "Invalid user config: {}: {summary}",
-                    base_path.display()
-                ))
-            },
-        )?;
-        crate::validate::validate_tool_transport_overrides_in_raw_config(&overlay_val).map_err(
-            |error| {
-                let summary = error.to_string();
-                error.context(format!(
-                    "Invalid project config: {}: {summary}",
-                    overlay_path.display()
-                ))
-            },
-        )?;
+        crate::validate::validate_tool_transport_overrides_in_raw_config(&base_val)
+            .with_context(|| format!("Invalid user config: {}", base_path.display()))?;
+        crate::validate::validate_tool_transport_overrides_in_raw_config(&overlay_val)
+            .with_context(|| format!("Invalid project config: {}", overlay_path.display()))?;
 
         // Preserve the higher schema_version before merging so that
         // check_schema_version() catches incompatibility from either source.
@@ -336,12 +318,8 @@ impl ProjectConfig {
         // cannot reverse — this prevents stale project configs from resurrecting
         // tools the user explicitly disabled at the global level.
         enforce_global_tool_disables(&base_val, &mut merged);
-        crate::validate::validate_tool_transport_overrides_in_raw_config(&merged).map_err(
-            |error| {
-                let summary = error.to_string();
-                error.context(format!("Invalid merged config after layering: {summary}"))
-            },
-        )?;
+        crate::validate::validate_tool_transport_overrides_in_raw_config(&merged)
+            .context("Invalid merged config after layering")?;
 
         // Roundtrip through string for reliable deserialization
         let merged_str = toml::to_string(&merged).context("Failed to serialize merged config")?;

--- a/crates/csa-config/src/validate_tests_transport.rs
+++ b/crates/csa-config/src/validate_tests_transport.rs
@@ -24,7 +24,7 @@ transport = "acp"
     );
 
     let err = validate_config_with_paths(None, &config_path).unwrap_err();
-    let message = err.to_string();
+    let message = format!("{err:#}");
 
     assert!(
         message.contains("[tools.codex].transport"),
@@ -97,7 +97,7 @@ transport = "stdio"
     );
 
     let err = validate_config_with_paths(None, &config_path).unwrap_err();
-    let message = err.to_string();
+    let message = format!("{err:#}");
 
     assert!(
         message.contains("[tools.codex].transport"),
@@ -125,7 +125,7 @@ transport = "cli"
     );
 
     let err = validate_config_with_paths(None, &config_path).unwrap_err();
-    let message = err.to_string();
+    let message = format!("{err:#}");
 
     assert!(
         message.contains("[tools.gemini-cli].transport"),


### PR DESCRIPTION
## Summary

Four MEDIUM findings from PR #883 round-0 gemini review (deferred per severity-tiered policy):

Migrate 4 call sites in `crates/csa-config/src/config.rs` from `.map_err(|e| anyhow!(\"... {e}\"))` / format!-built context strings to `.with_context(|| format!(\"...\"))`. This lets anyhow chain the inner error natively instead of duplicating the inner message when printing with `{:#}`.

Pure refactor — no change in error paths or validation semantics. Net -24 LOC.

Closes #884.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p csa-config`
- [x] `just pre-commit`
- [x] No `map_err(|e| anyhow!(\"Invalid...\"))` pattern remains at the 4 sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)