### PR TITLE
refactor(csa-session): dedupe ACP detection helper + path parse (#818)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.394"
+version = "0.1.395"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.394"
+version = "0.1.395"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
@@ -22,8 +22,13 @@ fn runtime_binary_file_name(runtime_binary: &str) -> Option<&str> {
         .and_then(|name| name.to_str())
 }
 
-fn runtime_binary_indicates_codex_acp(runtime_binary: &str) -> bool {
-    runtime_binary_file_name(runtime_binary).is_some_and(|name| name.contains("codex-acp"))
+pub(super) fn runtime_binary_indicates_codex_acp_file_name(file_name: &str) -> bool {
+    file_name.contains("codex-acp")
+}
+
+pub(super) fn runtime_binary_indicates_codex_acp(runtime_binary: &str) -> bool {
+    runtime_binary_file_name(runtime_binary)
+        .is_some_and(runtime_binary_indicates_codex_acp_file_name)
 }
 
 fn routes_session_output_to_output_log(metadata: &csa_session::metadata::SessionMetadata) -> bool {
@@ -86,7 +91,7 @@ fn attach_primary_output_from_metadata_fragment(
     let tool = metadata_fragment_value(contents, "tool").or_else(|| {
         let binary = runtime_binary.as_deref()?;
         let file_name = runtime_binary_file_name(binary).unwrap_or(binary);
-        if file_name == "codex" || runtime_binary_indicates_codex_acp(binary) {
+        if file_name == "codex" || runtime_binary_indicates_codex_acp_file_name(file_name) {
             return Some("codex".to_string());
         }
         file_name

--- a/crates/cli-sub-agent/src/session_cmds_daemon_routing_proptest.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_routing_proptest.rs
@@ -115,16 +115,9 @@ fn attach_tool_cases() -> [&'static str; 4] {
 }
 
 fn codex_routes_to_output_log(tool: &str, runtime_binary: Option<&str>) -> bool {
-    tool == "codex" && runtime_binary.is_none_or(runtime_binary_indicates_codex_acp)
+    tool == "codex" && runtime_binary.is_none_or(super::attach::runtime_binary_indicates_codex_acp)
 }
 
 fn routes_to_output_log_independent_of_files(tool: &str, runtime_binary: Option<&str>) -> bool {
     tool == "claude-code" || codex_routes_to_output_log(tool, runtime_binary)
-}
-
-fn runtime_binary_indicates_codex_acp(runtime_binary: &str) -> bool {
-    std::path::Path::new(runtime_binary)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.contains("codex-acp"))
 }


### PR DESCRIPTION
## Summary

Two MEDIUM findings from PR #816 round-1 gemini review (deferred per severity-tiered policy):

- Eliminate redundant `runtime_binary_file_name` parse in `session_cmds_daemon_attach.rs` — the check was re-parsing the binary path already computed on the line above.
- Delete the duplicate `runtime_binary_indicates_codex_acp` in `session_cmds_daemon_routing_proptest.rs` and re-import from attach.rs (visibility promoted). Removes drift risk.

Pure refactor, no behavior change.

Closes #818.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p cli-sub-agent session_cmds_daemon_attach`
- [x] `cargo test -p cli-sub-agent session_cmds_daemon_routing_proptest`
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)