### PR TITLE
refactor: review artifact cleanup followups (#881)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.395"
+version = "0.1.396"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.395"
+version = "0.1.396"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_execute_artifact_guard.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_artifact_guard.rs
@@ -21,13 +21,13 @@ pub(super) fn detect_repo_root_review_artifact_violations(
 ) -> Result<Option<Vec<String>>> {
     if std::env::var_os(REVIEW_RELATIVE_ARTIFACT_GUARD_ENV).as_deref() == Some("1".as_ref()) {
         warn!(
-            "{}=1 bypasses deprecated review artifact contract guard",
+            "{}=1 bypasses the review artifact contract guard",
             REVIEW_RELATIVE_ARTIFACT_GUARD_ENV
         );
         return Ok(None);
     }
 
-    let started_at = system_time_from_utc(execution_started_at)
+    let started_at = SystemTime::from(execution_started_at)
         .checked_sub(Duration::from_secs(1))
         .unwrap_or(UNIX_EPOCH);
     let mut leaked_paths = Vec::new();
@@ -105,10 +105,4 @@ fn collect_guarded_review_artifacts(
     }
 
     Ok(())
-}
-
-fn system_time_from_utc(timestamp: DateTime<Utc>) -> SystemTime {
-    UNIX_EPOCH
-        + Duration::from_secs(timestamp.timestamp().max(0) as u64)
-        + Duration::from_nanos(u64::from(timestamp.timestamp_subsec_nanos()))
 }

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -36,14 +36,9 @@ pub fn render_redacted_result_sidecar(sidecar: &toml::Value) -> Result<String> {
 }
 
 pub fn redact_result_sidecar_value(sidecar: &toml::Value) -> Result<toml::Value> {
-    let json_value =
-        serde_json::to_value(sidecar).context("Failed to convert result sidecar to JSON")?;
-    let serialized =
-        serde_json::to_string(&json_value).context("Failed to serialize result sidecar JSON")?;
-    let redacted = crate::redact::redact_event(&serialized);
-    let redacted_json: serde_json::Value =
-        serde_json::from_str(&redacted).context("Failed to parse redacted result sidecar JSON")?;
-    toml::Value::try_from(redacted_json).context("Failed to convert redacted sidecar back to TOML")
+    let mut redacted = sidecar.clone();
+    redact_toml_value(&mut redacted, None)?;
+    Ok(redacted)
 }
 
 /// Write a session result to disk
@@ -221,6 +216,103 @@ fn artifacts_value_matches_runtime_schema(value: &toml::Value) -> bool {
         }
         _ => false,
     })
+}
+
+fn redact_toml_value(value: &mut toml::Value, key: Option<&str>) -> Result<()> {
+    if key.is_some_and(is_sensitive_key) {
+        *value = toml::Value::String("[REDACTED]".to_string());
+        return Ok(());
+    }
+
+    match value {
+        toml::Value::Table(table) => {
+            for (child_key, child_value) in table {
+                redact_toml_value(child_value, Some(child_key.as_str()))?;
+            }
+        }
+        toml::Value::Array(items) => {
+            for item in items {
+                redact_toml_value(item, None)?;
+            }
+        }
+        toml::Value::String(text) => {
+            let serialized =
+                serde_json::to_string(text).context("Failed to serialize result sidecar string")?;
+            let redacted = crate::redact::redact_event(&serialized);
+            *text = serde_json::from_str(&redacted)
+                .context("Failed to parse redacted result sidecar string")?;
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let normalized: String = key
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect();
+    matches!(
+        normalized.as_str(),
+        "password"
+            | "passwd"
+            | "pwd"
+            | "secret"
+            | "clientsecret"
+            | "apikey"
+            | "token"
+            | "accesstoken"
+            | "refreshtoken"
+            | "idtoken"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_result_sidecar_value;
+
+    #[test]
+    fn manager_result_redaction_preserves_toml_datetime_values() {
+        let sidecar = toml::toml! {
+            started_at = 2026-04-19T12:34:56Z
+            [auth]
+            token = "secret-token"
+        }
+        .into();
+
+        let redacted = redact_result_sidecar_value(&sidecar).expect("redacted sidecar");
+
+        assert!(matches!(
+            redacted.get("started_at"),
+            Some(toml::Value::Datetime(_))
+        ));
+        assert_eq!(
+            redacted
+                .get("auth")
+                .and_then(toml::Value::as_table)
+                .and_then(|table| table.get("token")),
+            Some(&toml::Value::String("[REDACTED]".to_string()))
+        );
+    }
+
+    #[test]
+    fn manager_result_redaction_preserves_nested_json_string_redaction() {
+        let sidecar = toml::toml! {
+            payload = "{\"secret\":\"top-secret\"}"
+        }
+        .into();
+
+        let redacted = redact_result_sidecar_value(&sidecar).expect("redacted sidecar");
+        let payload = redacted
+            .get("payload")
+            .and_then(toml::Value::as_str)
+            .expect("payload string");
+
+        assert!(!payload.contains("top-secret"));
+        assert!(payload.contains("[REDACTED]"));
+    }
 }
 
 /// Load a session result


### PR DESCRIPTION
## Summary

Three MEDIUM deferrals from PR #880 round-2 gemini review:

- Drop redundant `DateTime<Utc> -> SystemTime` conversion in `review_cmd_execute_artifact_guard.rs` (line ~114).
- Switch `csa-session` `manager_result.rs` TOML redaction from TOML→JSON→TOML string-coerced path to in-place `toml::Value` walk. Preserves native TOML types (e.g., datetime) that were being downgraded to strings.
- Tighten misleading "deprecated" wording in artifact-guard warning — the check is an artifact contract guard, not a deprecation notice.

Pure refactor, no behavior change beyond the type-fidelity fix.

Closes #881.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p cli-sub-agent`
- [x] `cargo test -p csa-session`
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)