### PR TITLE
refactor(cli-sub-agent): centralize consolidated findings filename (#809)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.396"
+version = "0.1.397"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.396"
+version = "0.1.397"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/bug_class.rs
+++ b/crates/cli-sub-agent/src/bug_class.rs
@@ -16,7 +16,7 @@ pub(crate) use sanitization::{
     SANITIZED_CONTENT_PLACEHOLDER, sanitize_code_for_skill, sanitize_text_for_skill,
 };
 
-const CONSOLIDATED_REVIEW_ARTIFACT_FILE: &str = "review-findings-consolidated.json";
+pub(crate) const CONSOLIDATED_REVIEW_ARTIFACT_FILE: &str = "review-findings-consolidated.json";
 const SINGLE_REVIEW_ARTIFACT_FILE: &str = "review-findings.json";
 const REVIEW_DETAILS_CONTEXT_FILE: &str = "output/details.md";
 const BUG_CLASS_RECURRENCE_THRESHOLD: u32 = 2;

--- a/crates/cli-sub-agent/src/bug_class_tests.rs
+++ b/crates/cli-sub-agent/src/bug_class_tests.rs
@@ -8,8 +8,9 @@ use csa_session::{create_session, get_session_dir};
 use crate::test_session_sandbox::ScopedSessionSandbox;
 
 use super::{
-    BugClassCandidate, CaseStudy, SkillExtractor, classify_recurring_bug_classes,
-    load_review_artifacts_for_project, sanitize_code_for_skill, sanitize_text_for_skill,
+    BugClassCandidate, CONSOLIDATED_REVIEW_ARTIFACT_FILE, CaseStudy, SkillExtractor,
+    classify_recurring_bug_classes, load_review_artifacts_for_project, sanitize_code_for_skill,
+    sanitize_text_for_skill,
 };
 
 fn sample_finding(
@@ -213,7 +214,7 @@ fn loader_prefers_consolidated_artifacts_and_skips_sessions_without_reviews() {
     );
     write_review_artifact(
         &consolidated_dir,
-        "review-findings-consolidated.json",
+        CONSOLIDATED_REVIEW_ARTIFACT_FILE,
         &sample_artifact(
             &consolidated_session.meta_session_id,
             vec![sample_finding(

--- a/crates/cli-sub-agent/src/review_cmd_bug_class.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class.rs
@@ -6,14 +6,14 @@ use csa_session::review_artifact::ReviewArtifact;
 use tracing::{info, warn};
 
 use crate::bug_class::{
-    SkillExtractor, classify_recurring_bug_classes, load_review_artifacts_for_project,
+    CONSOLIDATED_REVIEW_ARTIFACT_FILE, SkillExtractor, classify_recurring_bug_classes,
+    load_review_artifacts_for_project,
 };
 use crate::review_consensus::build_consolidated_artifact;
 use crate::review_consensus::review_iteration_resolver::{
     load_review_meta, try_max_review_iterations_for_branch,
 };
 
-const REVIEW_CONSOLIDATED_ARTIFACT_FILE: &str = "review-findings-consolidated.json";
 const REVIEW_FINDINGS_ARTIFACT_FILE: &str = "review-findings.json";
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -95,7 +95,7 @@ fn session_has_high_or_critical_review_findings(
 
 fn load_session_review_artifact(session_dir: &Path) -> Result<Option<ReviewArtifact>> {
     for artifact_file in [
-        REVIEW_CONSOLIDATED_ARTIFACT_FILE,
+        CONSOLIDATED_REVIEW_ARTIFACT_FILE,
         REVIEW_FINDINGS_ARTIFACT_FILE,
     ] {
         let artifact_path = session_dir.join(artifact_file);
@@ -220,7 +220,7 @@ fn session_has_consolidated_artifact(project_root: &Path, session_id: &str) -> R
     let session_dir = csa_session::get_session_dir(project_root, session_id)
         .with_context(|| format!("failed to resolve review session dir for {session_id}"))?;
     Ok(session_dir
-        .join(REVIEW_CONSOLIDATED_ARTIFACT_FILE)
+        .join(CONSOLIDATED_REVIEW_ARTIFACT_FILE)
         .is_file())
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::bug_class::classify_recurring_bug_classes;
+use crate::bug_class::{CONSOLIDATED_REVIEW_ARTIFACT_FILE, classify_recurring_bug_classes};
 use crate::review_cmd::bug_class_pipeline::load_bug_class_review_artifacts;
 use crate::review_consensus::write_consolidated_artifact;
 use crate::test_session_sandbox::ScopedSessionSandbox;
@@ -361,7 +361,7 @@ fn bug_class_loader_skips_parent_consolidated_artifact_to_avoid_false_promotion(
 
     write_review_artifact_file(
         &parent_dir,
-        "review-findings-consolidated.json",
+        CONSOLIDATED_REVIEW_ARTIFACT_FILE,
         &sample_review_artifact(&parent.meta_session_id, Severity::High, "rust/002"),
     );
     write_review_artifact(
@@ -428,7 +428,7 @@ fn bug_class_loader_keeps_sessions_with_review_meta_even_if_consolidated_exists(
 
     write_review_artifact_file(
         &child_dir,
-        "review-findings-consolidated.json",
+        CONSOLIDATED_REVIEW_ARTIFACT_FILE,
         &sample_review_artifact(&child.meta_session_id, Severity::High, "rust/002"),
     );
     write_review_meta(
@@ -492,7 +492,7 @@ fn bug_class_loader_reads_exact_consolidated_path_written_by_consensus_writer() 
     )
     .expect("review meta");
 
-    let writer_path = session_dir.join("review-findings-consolidated.json");
+    let writer_path = session_dir.join(CONSOLIDATED_REVIEW_ARTIFACT_FILE);
     assert!(
         writer_path.is_file(),
         "writer should use consolidated findings path"

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -614,6 +614,7 @@ pub(crate) struct ReviewProjectPromptOptions<'a> {
 #[cfg(test)]
 mod tests {
     use super::write_multi_reviewer_consolidated_artifact;
+    use crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE;
     use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
     use csa_core::env::CSA_SESSION_DIR_ENV_KEY;
     use csa_session::review_artifact::{Finding, ReviewArtifact, Severity, SeveritySummary};
@@ -657,7 +658,7 @@ mod tests {
         write_multi_reviewer_consolidated_artifact(1)
             .expect("consolidated artifact should be produced");
 
-        let consolidated_path = temp.path().join("review-findings-consolidated.json");
+        let consolidated_path = temp.path().join(CONSOLIDATED_REVIEW_ARTIFACT_FILE);
         let consolidated: ReviewArtifact = serde_json::from_str(
             &fs::read_to_string(&consolidated_path).expect("consolidated artifact should exist"),
         )

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -1,3 +1,4 @@
+use crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE;
 use crate::review_prior_rounds::{PRIOR_ROUNDS_SECTION_HEADING, REVIEW_FINDINGS_TOML_INSTRUCTION};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
@@ -512,7 +513,7 @@ pub(crate) fn write_consolidated_artifact(
     artifact: &ReviewArtifact,
     output_dir: &Path,
 ) -> Result<()> {
-    let artifact_path = output_dir.join("review-findings-consolidated.json");
+    let artifact_path = output_dir.join(CONSOLIDATED_REVIEW_ARTIFACT_FILE);
     let payload = serde_json::to_string_pretty(artifact)
         .context("failed to serialize consolidated review artifact")?;
     fs::write(&artifact_path, payload).with_context(|| {

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE;
 use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use csa_config::{GlobalConfig, ProjectMeta, ResourcesConfig, ToolConfig};
 use csa_core::env::{CSA_PARENT_SESSION_DIR_ENV_KEY, CSA_SESSION_DIR_ENV_KEY};
@@ -622,7 +623,7 @@ fn write_consolidated_artifact_creates_json_file_at_expected_path() {
 
     write_consolidated_artifact(&artifact, temp.path()).expect("artifact should be written");
 
-    let artifact_path = temp.path().join("review-findings-consolidated.json");
+    let artifact_path = temp.path().join(CONSOLIDATED_REVIEW_ARTIFACT_FILE);
     assert!(artifact_path.exists());
     let contents = std::fs::read_to_string(&artifact_path).expect("json file should be readable");
     let parsed: ReviewArtifact =

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -5,6 +5,8 @@ use csa_session::{Finding, ReviewArtifact, ReviewSessionMeta, Severity};
 use csa_todo::{CriterionKind, CriterionStatus, SpecDocument, TodoManager};
 use tracing::warn;
 
+use crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ResolvedReviewContextKind {
     TodoMarkdown,
@@ -242,7 +244,7 @@ fn load_whitelisted_findings(
     session_id: &str,
 ) -> Option<Vec<PriorRoundFinding>> {
     let session_dir = csa_session::get_session_dir(project_root, session_id).ok()?;
-    for name in ["review-findings-consolidated.json", "review-findings.json"] {
+    for name in [CONSOLIDATED_REVIEW_ARTIFACT_FILE, "review-findings.json"] {
         let path = session_dir.join(name);
         if !path.is_file() {
             continue;

--- a/crates/cli-sub-agent/tests/review_mode_compat.rs
+++ b/crates/cli-sub-agent/tests/review_mode_compat.rs
@@ -1,6 +1,13 @@
 #[path = "../src/cli.rs"]
 mod cli_defs;
 
+#[allow(dead_code)]
+#[path = "../src/bug_class.rs"]
+mod bug_class;
+#[allow(dead_code)]
+#[path = "../src/test_session_sandbox.rs"]
+mod test_session_sandbox;
+
 #[path = "../src/review_consensus.rs"]
 mod review_consensus;
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary

PR #807 renamed the consolidated findings artifact to `review-findings-consolidated.json` but left duplicated literals at 3 other sites. Collapse them to `bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE` so a future rename only touches one place.

Sites collapsed: `review_cmd_bug_class.rs`, `review_consensus.rs`, `review_consensus_tests.rs`.

Pure maintainability refactor, no behavior change.

Closes #809.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p cli-sub-agent`
- [x] `just pre-commit`
- [x] Only 1 literal occurrence remains (in `bug_class.rs` definition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)