### PR TITLE
refactor(cli-sub-agent): extract shared helper for env/export bypass scan (#803)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.397"
+version = "0.1.398"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.397"
+version = "0.1.398"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_shell.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell.rs
@@ -715,43 +715,21 @@ fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
         if token.eq_ignore_ascii_case("env") || token.ends_with("/env") {
             idx += 1;
             idx = skip_prefixed_command_options(tokens, idx, env_option_consumes_value);
-            while idx < tokens.len() {
-                let next = tokens[idx].as_str();
-                if is_command_separator_token(next) {
-                    idx += 1;
-                    idx = skip_command_wrapper_tokens(tokens, idx);
-                    break;
-                }
-                if !is_env_assignment(next) {
-                    idx = skip_to_next_command_boundary(tokens, idx + 1);
-                    break;
-                }
-                if is_lefthook_env_assignment(next) {
-                    return true;
-                }
-                idx += 1;
+            let (contains_bypass, next_idx) = scan_env_assignments_for_lefthook_bypass(tokens, idx);
+            if contains_bypass {
+                return true;
             }
+            idx = next_idx;
             continue;
         }
 
         if token.eq_ignore_ascii_case("export") {
             idx += 1;
-            while idx < tokens.len() {
-                let next = tokens[idx].as_str();
-                if is_command_separator_token(next) {
-                    idx += 1;
-                    idx = skip_command_wrapper_tokens(tokens, idx);
-                    break;
-                }
-                if !is_env_assignment(next) {
-                    idx = skip_to_next_command_boundary(tokens, idx + 1);
-                    break;
-                }
-                if is_lefthook_env_assignment(next) {
-                    return true;
-                }
-                idx += 1;
+            let (contains_bypass, next_idx) = scan_env_assignments_for_lefthook_bypass(tokens, idx);
+            if contains_bypass {
+                return true;
             }
+            idx = next_idx;
             continue;
         }
 
@@ -767,6 +745,27 @@ fn tokens_contain_lefthook_bypass(tokens: &[String]) -> bool {
     }
 
     false
+}
+
+fn scan_env_assignments_for_lefthook_bypass(tokens: &[String], mut idx: usize) -> (bool, usize) {
+    while idx < tokens.len() {
+        let next = tokens[idx].as_str();
+        if is_command_separator_token(next) {
+            idx += 1;
+            idx = skip_command_wrapper_tokens(tokens, idx);
+            break;
+        }
+        if !is_env_assignment(next) {
+            idx = skip_to_next_command_boundary(tokens, idx + 1);
+            break;
+        }
+        if is_lefthook_env_assignment(next) {
+            return (true, idx);
+        }
+        idx += 1;
+    }
+
+    (false, idx)
 }
 
 /// Return true if `token` is `LEFTHOOK=<val>` or `LEFTHOOK_SKIP=<val>`.

--- a/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_lefthook.rs
@@ -352,6 +352,12 @@ fn segment_contains_forbidden_lefthook_bypass_blocks_separator_resets_after_env_
     assert!(segment_contains_forbidden_lefthook_bypass(
         "sh -c \"export FOO=1 BAR ; LEFTHOOK=0 other_cmd\""
     ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "export FOO=1 LEFTHOOK=0 git status"
+    ));
+    assert!(segment_contains_forbidden_lefthook_bypass(
+        "env -i FOO=1 LEFTHOOK=0 git status"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

One MEDIUM maintainability finding from PR #802 gemini review: the `env` and `export` match arms in `tokens_contain_lefthook_bypass` had near-identical scanning loops. Extracted into `scan_env_assignments_for_lefthook_bypass` called from both arms, so future policy changes only touch one site.

Pure refactor + added two regression tests (`export FOO=1 LEFTHOOK=0 git status`, `env -i FOO=1 LEFTHOOK=0 git status`).

Closes #803.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p cli-sub-agent`
- [x] New lefthook-bypass regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)