### PR TITLE
fix(commit): dynamic base-branch + arithmetic executor-mode check (#797)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.399"
+version = "0.1.400"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.399"
+version = "0.1.400"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -7,14 +7,16 @@ use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use tracing::{debug, info, warn};
 
 use crate::plan_cmd::shell_escape_for_command;
 #[path = "session_cmds_reconcile_cleanup.rs"]
 mod reconcile_cleanup;
+#[path = "session_cmds_reconcile_git.rs"]
+mod reconcile_git;
 #[path = "session_cmds_reconcile_liveness.rs"]
 mod reconcile_liveness;
+use reconcile_git::{git_output, git_success, resolve_fallback_base_branch};
 use reconcile_liveness::reconcile_liveness_decision;
 
 type PersistSessionFn<'a> = dyn Fn(&Path, &MetaSessionState) -> Result<()> + 'a;
@@ -85,20 +87,6 @@ fn with_reconcile_lock<R>(
 
 fn noop_path(_: &Path) {}
 
-fn git_output(project_root: &Path, args: &[&str]) -> Result<std::process::Output> {
-    Command::new("git")
-        .args(args)
-        .current_dir(project_root)
-        .output()
-        .with_context(|| format!("Failed to run git {:?}", args))
-}
-
-fn git_success(project_root: &Path, args: &[&str]) -> bool {
-    git_output(project_root, args)
-        .map(|output| output.status.success())
-        .unwrap_or(false)
-}
-
 fn inspect_unpushed_commits(
     project_root: &Path,
     branch: &str,
@@ -117,18 +105,11 @@ fn inspect_unpushed_commits(
             Some(format!("origin/{branch}")),
             format!("origin/{branch}..{session_branch_ref}"),
         )
-    } else if git_success(
-        project_root,
-        &["rev-parse", "--verify", "--quiet", "refs/heads/main"],
-    ) {
-        (None, format!("main..{session_branch_ref}"))
-    } else if git_success(
-        project_root,
-        &["rev-parse", "--verify", "--quiet", "refs/heads/master"],
-    ) {
-        (None, format!("master..{session_branch_ref}"))
     } else {
-        return Ok(None);
+        let Some(base_branch) = resolve_fallback_base_branch(project_root) else {
+            return Ok(None);
+        };
+        (None, format!("{base_branch}..{session_branch_ref}"))
     };
     let (remote_ref, rev_range) = range;
 

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_git.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_git.rs
@@ -1,0 +1,80 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+pub(super) fn git_output(project_root: &Path, args: &[&str]) -> Result<std::process::Output> {
+    Command::new("git")
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .with_context(|| format!("Failed to run git {:?}", args))
+}
+
+pub(super) fn git_success(project_root: &Path, args: &[&str]) -> bool {
+    git_output(project_root, args)
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn git_quiet_stdout(project_root: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(project_root)
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn normalize_branch_name(candidate: &str) -> Option<String> {
+    let trimmed = candidate.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(
+        trimmed
+            .strip_prefix("refs/remotes/origin/")
+            .or_else(|| trimmed.strip_prefix("origin/"))
+            .unwrap_or(trimmed)
+            .to_string(),
+    )
+}
+
+pub(super) fn resolve_fallback_base_branch(project_root: &Path) -> Option<String> {
+    git_quiet_stdout(
+        project_root,
+        &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+    )
+    .and_then(|value| normalize_branch_name(&value))
+    .or_else(|| {
+        git_quiet_stdout(project_root, &["rev-parse", "--abbrev-ref", "@{upstream}"])
+            .and_then(|value| normalize_branch_name(&value))
+    })
+    .or_else(|| {
+        git_quiet_stdout(project_root, &["config", "init.defaultBranch"])
+            .and_then(|value| normalize_branch_name(&value))
+    })
+    .or_else(|| {
+        ["main", "master"].into_iter().find_map(|candidate| {
+            git_success(
+                project_root,
+                &[
+                    "rev-parse",
+                    "--verify",
+                    "--quiet",
+                    &format!("refs/heads/{candidate}"),
+                ],
+            )
+            .then(|| candidate.to_string())
+        })
+    })
+}

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -682,3 +682,56 @@ fn inspect_unpushed_commits_uses_session_branch_not_checked_out_head() {
             .any(|entry| entry["subject"] == "fix: second progress")
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn inspect_unpushed_commits_falls_back_to_init_default_branch() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+
+    run_git(&project, &["init", "--initial-branch", "trunk"]);
+    run_git(&project, &["config", "init.defaultBranch", "trunk"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test User"]);
+    fs::write(project.join("README.md"), "base\n").unwrap();
+    run_git(&project, &["add", "README.md"]);
+    run_git(&project, &["commit", "-m", "init"]);
+
+    run_git(&project, &["checkout", "-b", "fix/session-progress"]);
+    fs::write(project.join("progress.txt"), "first\n").unwrap();
+    run_git(&project, &["add", "progress.txt"]);
+    run_git(&project, &["commit", "-m", "feat: trunk fallback progress"]);
+
+    let session = create_session(&project, Some("unpushed-progress"), None, Some("codex")).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(&project, &session_id).unwrap();
+    tail_backdate_tree(&session_dir, 120);
+
+    run_git(&project, &["checkout", "trunk"]);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(&project, &session_id, "session wait")
+            .unwrap();
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
+
+    let sidecar_path = session_dir.join("output").join("unpushed_commits.json");
+    let sidecar: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&sidecar_path).unwrap()).unwrap();
+    assert_eq!(sidecar["branch"], "fix/session-progress");
+    assert_eq!(sidecar["remote_ref"], serde_json::Value::Null);
+    assert_eq!(sidecar["commits_ahead"], 1);
+    assert_eq!(
+        sidecar["recovery_command"],
+        "git push -u origin fix/session-progress"
+    );
+    assert_eq!(sidecar["commits"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        sidecar["commits"][0]["subject"],
+        "feat: trunk fallback progress"
+    );
+}

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -24,7 +24,7 @@ Initialize and declare workflow variables.
 - `${COMMIT_SUBJECT}`: Generated or provided commit subject
 - `${COMMIT_BODY}`: Generated or provided commit body
 - `${COMMIT_MESSAGE_FILE}`: Path to temporary commit message file
-- `${SKIP_PUBLISH}`: Set to `"true"` to skip auto-PR (parent workflow handles publish). Workflow auto-activates this when `CSA_SKIP_PUBLISH=true` or in executor mode (`CSA_DEPTH` set and non-zero plus `CSA_INTERNAL_INVOCATION=1`) to keep employee sessions orchestration-pure — the Layer 0 orchestrator owns publish/pr-bot (#752 Bug 4, #782).
+- `${SKIP_PUBLISH}`: Set to `"true"` to skip auto-PR (parent workflow handles publish). Workflow auto-activates this when `CSA_SKIP_PUBLISH=true` or in executor mode (`CSA_DEPTH>0` plus `CSA_INTERNAL_INVOCATION=1`) to keep employee sessions orchestration-pure — the Layer 0 orchestrator owns publish/pr-bot (#752 Bug 4, #782).
 - `${ENABLE_REVIEW_LOOP}`: Set to `"true"` to run iterative review loop
 - `${AUDIT_FAIL}`: Set by `security-audit` if blocking issues found
 - `${AUDIT_PASS_DEFERRED}`: Set by `security-audit` if non-blocking issues found
@@ -44,8 +44,7 @@ Initialize and declare workflow variables.
 # guard or leak grandchild processes if the chain fails mid-flight (see #752 Bug 4).
 if [ "${CSA_SKIP_PUBLISH:-}" = "true" ]; then
   SKIP_PUBLISH=true
-elif [ "${CSA_DEPTH:-0}" != "0" ] && [ -n "${CSA_DEPTH:-}" ] && \
-     { [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ] || [ "${CSA_INTERNAL_INVOCATION:-}" = "true" ]; }; then
+elif [ "${CSA_DEPTH:-0}" -gt 0 ] && [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ]; then
   SKIP_PUBLISH=true
 else
   : "${SKIP_PUBLISH:=false}"
@@ -477,13 +476,12 @@ Push, create or reuse the PR, then synchronously run the post-create helper.
 This makes PR creation + pr-bot a single shell-enforced transaction.
 Runs by default when standalone. Skipped when parent workflow sets
 `CSA_SKIP_PUBLISH=true`, or automatically in executor mode
-(`CSA_DEPTH` set and non-zero plus `CSA_INTERNAL_INVOCATION=1`) — the Layer 0
+(`CSA_DEPTH>0` plus `CSA_INTERNAL_INVOCATION=1`) — the Layer 0
 orchestrator owns the publish/pr-bot transaction in that case.
 
 ```bash
 set -euo pipefail
-if [ "${CSA_DEPTH:-0}" != "0" ] && [ -n "${CSA_DEPTH:-}" ] && \
-   { [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ] || [ "${CSA_INTERNAL_INVOCATION:-}" = "true" ]; }; then
+if [ "${CSA_DEPTH:-0}" -gt 0 ] && [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ]; then
   echo "INFO: Executor mode detected; skipping push/PR transaction."
   exit 0
 fi

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -116,8 +116,7 @@ Initialize and declare workflow variables.
 # guard or leak grandchild processes if the chain fails mid-flight (see #752 Bug 4).
 if [ "${CSA_SKIP_PUBLISH:-}" = "true" ]; then
   echo "CSA_VAR:SKIP_PUBLISH=true"
-elif [ "${CSA_DEPTH:-0}" != "0" ] && [ -n "${CSA_DEPTH:-}" ] && \
-     { [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ] || [ "${CSA_INTERNAL_INVOCATION:-}" = "true" ]; }; then
+elif [ "${CSA_DEPTH:-0}" -gt 0 ] && [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ]; then
   echo "CSA_VAR:SKIP_PUBLISH=true"
   echo "INFO: Detected executor mode (CSA_DEPTH=${CSA_DEPTH}, CSA_INTERNAL_INVOCATION=${CSA_INTERNAL_INVOCATION:-0}); auto-skipping push/PR to keep employee sessions orchestration-pure."
 else
@@ -541,8 +540,7 @@ Runs by default when commit is standalone. Skipped when parent workflow
 
 ```bash
 set -euo pipefail
-if [ "${CSA_DEPTH:-0}" != "0" ] && [ -n "${CSA_DEPTH:-}" ] && \
-   { [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ] || [ "${CSA_INTERNAL_INVOCATION:-}" = "true" ]; }; then
+if [ "${CSA_DEPTH:-0}" -gt 0 ] && [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ]; then
   echo "INFO: Executor mode detected; skipping push/PR transaction."
   exit 0
 fi


### PR DESCRIPTION
## Summary

Two MEDIUMs from PR #796 deferred per severity-tiered policy:

- **`inspect_unpushed_commits` dynamic base-branch** — Resolves default branch via `git symbolic-ref refs/remotes/origin/HEAD` → upstream tracking → `git config init.defaultBranch` → existing main/master fallback. Repos using `trunk`/`develop` now produce `unpushed_commits.json` instead of silently skipping the recovery sidecar.
- **Arithmetic executor-mode check** — `patterns/commit/workflow.toml` swaps multi-string-compare for `[ "${CSA_DEPTH:-0}" -gt 0 ] && [ "${CSA_INTERNAL_INVOCATION:-0}" = "1" ]`. PATTERN.md mirrored (Rule 027).

Regression test uses `init.defaultBranch=trunk`.

Closes #797.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p cli-sub-agent session_cmds_reconcile`
- [x] `weave compile`
- [x] TOML parses
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)