### PR TITLE
fix(cli-sub-agent): PR #800 review feedback followup (#801)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.400"
+version = "0.1.401"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.400"
+version = "0.1.401"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -281,7 +281,7 @@ fn derive_review_verdict_artifact(
             meta.session_id.clone(),
             decision,
             legacy_verdict_for_decision(decision, &meta.verdict),
-            severity_counts_from_summary(&artifact.severity_summary),
+            severity_counts_for_artifact(&artifact),
             Vec::new(),
         ));
     }
@@ -350,10 +350,14 @@ pub(super) fn extract_review_text(raw_output: &str) -> Option<String> {
     let mut saw_json_line = false;
 
     for line in raw_output.lines().filter(|line| !line.trim().is_empty()) {
-        let Ok(event) = serde_json::from_str::<TranscriptEvent>(line) else {
-            return Some(raw_output.to_string());
+        let event = match serde_json::from_str::<TranscriptEvent>(line) {
+            Ok(event) => {
+                saw_json_line = true;
+                event
+            }
+            Err(_) if !saw_json_line => continue,
+            Err(_) => return Some(raw_output.to_string()),
         };
-        saw_json_line = true;
         let Some(item) = event.item else {
             continue;
         };
@@ -401,6 +405,27 @@ fn severity_counts_from_summary(
     ]
     .into_iter()
     .collect()
+}
+
+fn severity_counts_from_findings(
+    findings: &[Finding],
+) -> std::collections::BTreeMap<Severity, u32> {
+    let mut counts = zero_severity_counts();
+    for finding in findings {
+        *counts.entry(finding.severity.clone()).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn severity_counts_for_artifact(
+    artifact: &PersistedReviewArtifact,
+) -> std::collections::BTreeMap<Severity, u32> {
+    let counts = severity_counts_from_summary(&artifact.severity_summary);
+    let total = counts.values().copied().sum::<u32>();
+    if total == 0 && !artifact.findings.is_empty() {
+        return severity_counts_from_findings(&artifact.findings);
+    }
+    counts
 }
 
 fn zero_severity_counts() -> std::collections::BTreeMap<Severity, u32> {
@@ -487,9 +512,6 @@ fn derive_decision_from_text(
     if contains_verdict_token(text, "UNCERTAIN") {
         return ReviewDecision::Uncertain;
     }
-    if counts.values().any(|count| *count > 0) {
-        return ReviewDecision::Fail;
-    }
     if (contains_verdict_token(text, "PASS")
         || contains_verdict_token(text, "CLEAN")
         || contains_clean_phrase(text))
@@ -502,6 +524,9 @@ fn derive_decision_from_text(
         && overall_risk.is_none_or(|risk| risk.eq_ignore_ascii_case("low"))
     {
         return ReviewDecision::Pass;
+    }
+    if overall_risk.is_some_and(|risk| !risk.eq_ignore_ascii_case("low")) {
+        return ReviewDecision::Fail;
     }
     ReviewDecision::Uncertain
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -1,6 +1,7 @@
 use super::{
     PersistedReviewArtifact, ToolReviewFailureKind, derive_decision_from_text,
-    detect_tool_review_failure, ensure_review_summary_artifact, persist_review_verdict,
+    detect_tool_review_failure, ensure_review_summary_artifact, extract_review_text,
+    persist_review_verdict,
 };
 use crate::test_env_lock::TEST_ENV_LOCK;
 use csa_core::types::{ReviewDecision, ToolName};
@@ -119,6 +120,31 @@ fn derive_decision_from_text_clean_phrase_without_skip_stays_pass() {
 }
 
 #[test]
+fn extract_review_text_skips_leading_non_json_preamble() {
+    let transcript = concat!(
+        "warning: provider banner\n",
+        "stdout noise before transcript\n",
+        "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"<!-- CSA:SECTION:summary -->\\nFAIL\\n<!-- CSA:SECTION:summary:END -->\"}}\n"
+    );
+
+    assert_eq!(
+        extract_review_text(transcript).as_deref(),
+        Some("<!-- CSA:SECTION:summary -->\nFAIL\n<!-- CSA:SECTION:summary:END -->")
+    );
+}
+
+#[test]
+fn derive_decision_from_text_high_risk_without_findings_fails() {
+    let decision = derive_decision_from_text(
+        "PASS\nNo blocking issues found in this scope.\nOverall risk: high",
+        &BTreeMap::new(),
+        Some("high"),
+    );
+
+    assert_eq!(decision, ReviewDecision::Fail);
+}
+
+#[test]
 fn detect_tool_review_failure_flags_gemini_oauth_prompt_without_real_turn() {
     let stdout = "Opening authentication page\nDo you want to continue? [Y/n]\n";
     let detected = detect_tool_review_failure(ToolName::GeminiCli, stdout, "");
@@ -227,6 +253,78 @@ fn persist_review_verdict_prefers_structured_findings_summary() {
     assert_eq!(artifact.severity_counts.get(&Severity::Low), Some(&1));
     assert_eq!(artifact.decision, ReviewDecision::Fail);
     assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn persist_review_verdict_reconciles_high_risk_no_findings_with_text_fallback() {
+    let session_id = "01TESTRISKRECONCILE00000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-high-risk-no-findings", session_id);
+    let artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary::default(),
+        "schema_version": "1.0",
+        "session_id": session_id,
+        "timestamp": chrono::Utc::now(),
+        "overall_risk": "high"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
+    )
+    .expect("write findings artifact");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn persist_review_verdict_recounts_findings_when_summary_is_zeroed() {
+    let session_id = "01TESTRECOUNT00000000000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-recount-findings", session_id);
+    let findings = vec![
+        make_finding(Severity::Critical, "critical"),
+        make_finding(Severity::Medium, "medium"),
+        make_finding(Severity::Medium, "medium-2"),
+    ];
+    let artifact = json!({
+        "findings": findings,
+        "severity_summary": SeveritySummary::default(),
+        "schema_version": "1.0",
+        "session_id": session_id,
+        "timestamp": chrono::Utc::now(),
+        "overall_risk": "high"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
+    )
+    .expect("write findings artifact");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.severity_counts.get(&Severity::Critical), Some(&1));
+    assert_eq!(artifact.severity_counts.get(&Severity::Medium), Some(&2));
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&0));
+    assert_eq!(artifact.severity_counts.get(&Severity::Low), Some(&0));
+    assert_eq!(artifact.severity_counts.get(&Severity::Info), Some(&0));
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }


### PR DESCRIPTION
## Summary

Three MEDIUMs from PR #800 round-1 review (deferred per severity-tiered policy):

- **`extract_review_text` preamble tolerance** — Skip leading non-JSON lines until first JSON-parseable line, then proceed structured. Fall back to raw-text only if no line parses.
- **`derive_decision_from_text` elevated-risk agreement** — Returns `Fail` (not `Uncertain`) on elevated-risk + zero-findings combination so text fallback agrees with the structured-artifact path.
- **`derive_review_verdict_artifact` recount** — Recounts severity from the findings array when `severity_summary` is missing or inconsistent (total=0 with `findings.len() > 0`). Prevents zeroed severity counts overriding actual findings.

Regression tests added for each.

Closes #801.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p cli-sub-agent`
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)