### PR TITLE
fix: weave Condition whitespace + ai-reviewed-commit halt ordering (#866)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.401"
+version = "0.1.402"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.401"
+version = "0.1.402"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/weave/src/compiler.rs
+++ b/crates/weave/src/compiler.rs
@@ -117,7 +117,7 @@ static ONFAIL_HINT_RE: LazyLock<Regex> =
 
 /// Matches a `Condition: <expr>` line at the start of a step body.
 static CONDITION_HINT_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)^Condition:\s*(.+)\s*$").expect("valid regex"));
+    LazyLock::new(|| Regex::new(r"(?i)^Condition:\s*(.*)\s*$").expect("valid regex"));
 
 /// Matches a `Session: <id|template>` line at the start of a step body.
 static SESSION_HINT_RE: LazyLock<Regex> =
@@ -289,7 +289,8 @@ fn extract_hints(body: &str) -> StepHints {
                 continue;
             }
             if let Some(caps) = CONDITION_HINT_RE.captures(line) {
-                condition = Some(caps[1].trim().to_string());
+                let trimmed = caps[1].trim();
+                condition = (!trimmed.is_empty()).then(|| trimmed.to_string());
                 continue;
             }
             if let Some(caps) = SESSION_HINT_RE.captures(line) {
@@ -584,3 +585,7 @@ mod tests;
 #[cfg(test)]
 #[path = "compiler_literal_tests.rs"]
 mod literal_tests;
+
+#[cfg(test)]
+#[path = "compiler_condition_tests.rs"]
+mod condition_tests;

--- a/crates/weave/src/compiler_condition_tests.rs
+++ b/crates/weave/src/compiler_condition_tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+use crate::parser::parse_skill;
+
+#[test]
+fn test_compile_step_with_blank_condition_hint_treated_as_none() {
+    let cases = [
+        ("blank-condition", "Condition:\nRun the final gate.\n"),
+        (
+            "whitespace-condition",
+            "Condition:    \nRun the final gate.\n",
+        ),
+        (
+            "nonblank-condition",
+            "Condition: foo\nRun the final gate.\n",
+        ),
+    ];
+
+    for (name, body) in cases {
+        let input = format!("---\nname = \"{name}\"\n---\n## Review Gate\nTool: bash\n{body}");
+        let doc = parse_skill(&input).unwrap();
+        let plan = compile(&doc).unwrap();
+        let step = &plan.steps[0];
+
+        let expected = match name {
+            "nonblank-condition" => Some("foo"),
+            _ => None,
+        };
+        assert_eq!(step.condition.as_deref(), expected, "case={name}");
+        assert_eq!(step.prompt, "Run the final gate.");
+    }
+}

--- a/patterns/ai-reviewed-commit/PATTERN.md
+++ b/patterns/ai-reviewed-commit/PATTERN.md
@@ -106,7 +106,7 @@ OnFail: retry 3
 Dispatch sub-agent to fix issues found in review.
 Preserve original code intent. Do NOT delete code to silence warnings.
 
-## Step 6: Re-stage Fixed Files
+## Step 7: Re-stage Fixed Files
 
 Tool: bash
 
@@ -114,14 +114,31 @@ Tool: bash
 git add ${FIXED_FILES}
 ```
 
-## Step 7: Round Cap Check
+## ENDIF
+
+## Step 8: Re-review
 
 Tool: bash
+Condition: ${REVIEW_HAS_ISSUES}
 
-Enforce the 3-round hard cap before triggering the next review attempt inside this single-pass workflow.
-If round 3 still has non-false-positive P0/P1 findings, stop and require user direction.
-Continue without asking only when `${UNBOUNDED_LOOP_AUTHORIZED}` is `"true"` or
-`${ROUND_3_FALSE_POSITIVES_ONLY}` is `"true"`.
+Run the next review after the latest fix is staged.
+This is still a single-pass workflow step, not a native weave loop.
+
+```bash
+SID=$(csa review --diff --allow-fallback)
+bash scripts/csa/session-wait-until-done.sh "$SID"
+```
+
+## Step 9: Round Cap Check
+
+Tool: bash
+Condition: ${REVIEW_HAS_ISSUES}
+
+Enforce the 3-round hard cap only after the latest re-review completes.
+If the round-3 re-review still has non-false-positive P0/P1 findings, stop and require user direction.
+If the re-review passes, proceed without interruption.
+Continue into another fix-and-review round only when `${UNBOUNDED_LOOP_AUTHORIZED}` is `"true"` or
+`${ROUND_3_FALSE_POSITIVES_ONLY}` is `"true"`, or when the current round is still below the hard cap.
 
 ```bash
 REVIEW_ROUND="${REVIEW_ROUND:-1}"
@@ -142,22 +159,7 @@ echo "CSA_VAR:USER_DECISION_REQUIRED=false"
 echo "CSA_VAR:REVIEW_ROUND=$((REVIEW_ROUND + 1))"
 ```
 
-## ENDIF
-
-## Step 8: Re-review
-
-Tool: bash
-Condition: ${REVIEW_HAS_ISSUES} && !(${USER_DECISION_REQUIRED})
-
-Run the next review only if the hard-cap check allowed it.
-This is still a single-pass workflow step, not a native weave loop.
-
-```bash
-SID=$(csa review --diff --allow-fallback)
-bash scripts/csa/session-wait-until-done.sh "$SID"
-```
-
-## Step 9: AGENTS.md Compliance Check
+## Step 10: AGENTS.md Compliance Check
 Condition: !(${USER_DECISION_REQUIRED})
 
 The review MUST include AGENTS.md compliance checklist:
@@ -171,7 +173,7 @@ The review MUST include AGENTS.md compliance checklist:
 - Zero unchecked items before proceeding to commit
 - Skip this and all later post-review steps when `${USER_DECISION_REQUIRED}` is `"true"` so the workflow halts cleanly instead of committing past the cap
 
-## Step 10: Generate Commit Message
+## Step 11: Generate Commit Message
 
 Tool: csa
 Tier: tier-1-quick
@@ -181,7 +183,7 @@ OnFail: abort
 Run 'git diff --staged' and generate a Conventional Commits message.
 Output ONLY the commit message, nothing else.
 
-## Step 11: Commit
+## Step 12: Commit
 
 Tool: bash
 OnFail: abort

--- a/patterns/ai-reviewed-commit/workflow.toml
+++ b/patterns/ai-reviewed-commit/workflow.toml
@@ -130,13 +130,29 @@ condition = "${REVIEW_HAS_ISSUES}"
 
 [[workflow.steps]]
 id = 8
+title = "Re-review"
+tool = "bash"
+prompt = '''
+Run the next review after the latest fix is staged.
+This is still a single-pass workflow step, not a native weave loop.
+
+```bash
+SID=$(csa review --diff --allow-fallback)
+bash scripts/csa/session-wait-until-done.sh "$SID"
+```'''
+on_fail = "abort"
+condition = "${REVIEW_HAS_ISSUES}"
+
+[[workflow.steps]]
+id = 9
 title = "Round Cap Check"
 tool = "bash"
 prompt = '''
-Enforce the 3-round hard cap before triggering the next review attempt inside this single-pass workflow.
-If round 3 still has non-false-positive P0/P1 findings, stop and require user direction.
-Continue without asking only when `${UNBOUNDED_LOOP_AUTHORIZED}` is `"true"` or
-`${ROUND_3_FALSE_POSITIVES_ONLY}` is `"true"`.
+Enforce the 3-round hard cap only after the latest re-review completes.
+If the round-3 re-review still has non-false-positive P0/P1 findings, stop and require user direction.
+If the re-review passes, proceed without interruption.
+Continue into another fix-and-review round only when `${UNBOUNDED_LOOP_AUTHORIZED}` is `"true"` or
+`${ROUND_3_FALSE_POSITIVES_ONLY}` is `"true"`, or when the current round is still below the hard cap.
 
 ```bash
 REVIEW_ROUND="${REVIEW_ROUND:-1}"
@@ -158,21 +174,6 @@ echo "CSA_VAR:REVIEW_ROUND=$((REVIEW_ROUND + 1))"
 ```'''
 on_fail = "abort"
 condition = "${REVIEW_HAS_ISSUES}"
-
-[[workflow.steps]]
-id = 9
-title = "Re-review"
-tool = "bash"
-prompt = '''
-Run the next review only if the hard-cap check allowed it.
-This is still a single-pass workflow step, not a native weave loop.
-
-```bash
-SID=$(csa review --diff --allow-fallback)
-bash scripts/csa/session-wait-until-done.sh "$SID"
-```'''
-on_fail = "abort"
-condition = "${REVIEW_HAS_ISSUES} && !(${USER_DECISION_REQUIRED})"
 
 [[workflow.steps]]
 id = 10


### PR DESCRIPTION
## Summary

Two MEDIUMs from PR #864 round-4 gemini review (deferred per severity-tiered policy):

- **weave compiler** — `Condition:` with empty or whitespace-only value now returns `None` (was `Some("")`). Regression test covers `Condition:`, `Condition:    `, `Condition: foo`.
- **ai-reviewed-commit halt ordering** — Round-3 halt check moved AFTER the 3rd re-review. If the 3rd fix converges (no P0/P1), proceeds to commit without prompting user. Preserves the 3-round cap while avoiding false-positive halts. PATTERN.md mirrored (Rule 027).

Closes #866.

## Test plan

- [x] `cargo test -p weave`
- [x] `weave compile`
- [x] Rule 027 round-trip clean
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)