### PR TITLE
fix(csa-hooks): move items above test module to silence clippy (#860)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.402"
+version = "0.1.403"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.402"
+version = "0.1.403"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-hooks/src/lib.rs
+++ b/crates/csa-hooks/src/lib.rs
@@ -54,14 +54,6 @@ pub mod policy;
 pub mod runner;
 pub mod waiver;
 
-#[cfg(test)]
-pub(crate) mod test_support {
-    use std::sync::{LazyLock, Mutex};
-
-    /// Process-wide lock for tests that mutate shared process environment.
-    pub(crate) static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-}
-
 // Re-export key types
 pub use audit::{MergeAuditEvent, audit_log_path, emit_merge_completed_event};
 pub use config::{HookConfig, HooksConfig, global_hooks_path, load_hooks_config};
@@ -83,3 +75,11 @@ pub use merge_guard::{
 pub use policy::FailPolicy;
 pub use runner::{run_hook, run_hook_capturing, run_hooks_for_event};
 pub use waiver::{Waiver, WaiverSet};
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::{LazyLock, Mutex};
+
+    /// Process-wide lock for tests that mutate shared process environment.
+    pub(crate) static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+}


### PR DESCRIPTION
## Summary

- Reorders items in `crates/csa-hooks/src/lib.rs` so `#[cfg(test)] mod tests` is the last item in the file
- Eliminates `clippy::items_after_test_module` without resorting to `#[allow(...)]` (Rule 011)
- Pure reordering, no behavior change

## Test plan

- [x] `cargo build --release -p csa-hooks` exit 0
- [x] `cargo clippy -p csa-hooks -- -D warnings` — no warning
- [x] `cargo test -p csa-hooks` exit 0
- [x] `just pre-commit` exit 0

Closes #860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)