### PR TITLE
test(cli-sub-agent): ScopedSessionSandbox auto-tracks env vars via track_env (#862)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.403"
+version = "0.1.404"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.403"
+version = "0.1.404"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_fork.rs
+++ b/crates/cli-sub-agent/src/run_cmd_fork.rs
@@ -412,7 +412,10 @@ mod tests {
     #[test]
     fn pre_created_native_fork_session_ignores_daemon_parent_session_id() {
         let td = tempfile::tempdir().expect("tempdir");
-        let _sandbox = ScopedSessionSandbox::new(&td);
+        let mut sandbox = ScopedSessionSandbox::new(&td);
+        sandbox.track_env("CSA_DAEMON_SESSION_ID");
+        sandbox.track_env("CSA_DAEMON_PROJECT_ROOT");
+        sandbox.track_env("CSA_DAEMON_SESSION_DIR");
         let project_root = td.path();
 
         let parent = csa_session::create_session(project_root, Some("parent"), None, Some("codex"))

--- a/crates/cli-sub-agent/src/test_session_sandbox.rs
+++ b/crates/cli-sub-agent/src/test_session_sandbox.rs
@@ -6,6 +6,7 @@
 ///
 /// Internally acquires [`TEST_ENV_LOCK`] to serialise all env-mutating tests
 /// across the process. Callers do NOT need to acquire any additional lock.
+use std::ffi::OsString;
 use std::sync::MutexGuard;
 
 use crate::test_env_lock::TEST_ENV_LOCK;
@@ -15,7 +16,7 @@ use crate::test_env_lock::TEST_ENV_LOCK;
 /// Holds [`TEST_ENV_LOCK`] for its entire lifetime so concurrent tests cannot
 /// observe partially-mutated environment state.
 pub(crate) struct ScopedSessionSandbox {
-    originals: Vec<(&'static str, Option<String>)>,
+    originals: Vec<(&'static str, Option<OsString>)>,
     // Guard is held alive until drop (ordering: restored env *then* lock released).
     _lock: MutexGuard<'static, ()>,
 }
@@ -30,7 +31,7 @@ impl ScopedSessionSandbox {
             "CSA_DAEMON_SESSION_DIR",
             "CSA_DAEMON_PROJECT_ROOT",
         ];
-        let originals: Vec<_> = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+        let originals: Vec<_> = keys.iter().map(|k| (*k, std::env::var_os(k))).collect();
         let state_path = tmp.path().join("state");
         // SAFETY: test-scoped env mutation protected by TEST_ENV_LOCK.
         unsafe {
@@ -43,6 +44,17 @@ impl ScopedSessionSandbox {
             originals,
             _lock: lock,
         }
+    }
+
+    /// Snapshot the current value of `key` and restore it when the sandbox drops.
+    ///
+    /// Call this before mutating any additional env var that is not part of the
+    /// sandbox's built-in restore set.
+    pub(crate) fn track_env(&mut self, key: &'static str) {
+        if self.originals.iter().any(|(tracked, _)| *tracked == key) {
+            return;
+        }
+        self.originals.push((key, std::env::var_os(key)));
     }
 }
 
@@ -58,5 +70,33 @@ impl Drop for ScopedSessionSandbox {
             }
         }
         // _lock drops after this, releasing TEST_ENV_LOCK.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScopedSessionSandbox;
+
+    #[test]
+    fn tracked_env_var_is_restored_on_drop() {
+        const KEY: &str = "CSA_TEST_LEAK_PROBE_TRACKED";
+        let td = tempfile::tempdir().expect("tempdir");
+
+        unsafe { std::env::remove_var(KEY) };
+
+        {
+            let mut sandbox = ScopedSessionSandbox::new(&td);
+            sandbox.track_env(KEY);
+
+            // SAFETY: test-scoped env mutation while ScopedSessionSandbox holds TEST_ENV_LOCK.
+            unsafe { std::env::set_var(KEY, "sandbox-value") };
+            assert_eq!(std::env::var(KEY).as_deref(), Ok("sandbox-value"));
+        }
+
+        assert_eq!(
+            std::env::var(KEY),
+            Err(std::env::VarError::NotPresent),
+            "tracked env var should be removed when it did not exist before sandboxing"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `ScopedSessionSandbox::track_env(key)` — snapshots current value and registers it for restore-on-drop, generalizing the hardcoded `CSA_DAEMON_*`/`XDG_STATE_HOME` list
- Updates `pre_created_native_fork_session_ignores_daemon_parent_session_id` to call `track_env` for each written env var
- Adds regression test verifying restore of arbitrary tracked env var

Defense-in-depth MEDIUM from PR #861 gemini review, deferred per severity-tiered policy.

## Test plan

- [x] `cargo test -p cli-sub-agent pre_created_native_fork_session_ignores_daemon_parent_session_id` exit 0
- [x] regression test asserts arbitrary tracked var restored
- [x] `just pre-commit` exit 0

Closes #862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)