### PR TITLE
fix(cli-sub-agent): maybe_synthesize_missing_review_result hardening (#815)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.405"
+version = "0.1.406"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.405"
+version = "0.1.406"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -5,6 +5,7 @@ mod artifact_guard;
 
 use std::collections::HashMap;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -17,7 +18,7 @@ use csa_core::{
     },
     types::{OutputFormat, ToolName},
 };
-use csa_executor::Executor;
+use csa_executor::{Executor, PeakMemoryContext};
 use csa_session::{
     SessionResult, get_session_dir, load_result, load_session, save_result, save_session,
 };
@@ -420,6 +421,10 @@ fn maybe_synthesize_missing_review_result(
         200,
     );
     let completed_at = Utc::now();
+    let peak_memory_mb = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<PeakMemoryContext>())
+        .and_then(|ctx| ctx.0);
     let fallback_result = SessionResult {
         status: status.to_string(),
         exit_code,
@@ -429,7 +434,7 @@ fn maybe_synthesize_missing_review_result(
         completed_at,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
+        peak_memory_mb,
     };
 
     if let Err(save_err) = save_result(project_root, &session_id, &fallback_result) {
@@ -459,7 +464,7 @@ fn extract_meta_session_id_from_error(error: &anyhow::Error) -> Option<String> {
         let suffix = &message[idx + MARKER.len()..];
         let session_id: String = suffix
             .chars()
-            .take_while(|ch| ch.is_ascii_alphanumeric())
+            .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '-' || *ch == '_')
             .collect();
         if !session_id.is_empty() {
             return Some(session_id);
@@ -470,7 +475,10 @@ fn extract_meta_session_id_from_error(error: &anyhow::Error) -> Option<String> {
 
 fn read_review_failure_excerpt(session_dir: &Path) -> Option<String> {
     let stderr_path = session_dir.join("stderr.log");
-    let contents = fs::read_to_string(stderr_path).ok()?;
+    let mut buf = Vec::with_capacity(4096);
+    let file = fs::File::open(stderr_path).ok()?;
+    let _ = file.take(4096).read_to_end(&mut buf);
+    let contents = String::from_utf8_lossy(&buf);
     let trimmed = contents.trim();
     if trimmed.is_empty() {
         return None;

--- a/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
@@ -6,6 +6,7 @@ use crate::session_cmds_result::{StructuredOutputOpts, handle_session_result};
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_config::{GlobalConfig, ProjectProfile, ToolRestrictions, global::GlobalToolConfig};
 use csa_core::types::ToolName;
+use csa_executor::PeakMemoryContext;
 use std::path::Path;
 
 #[cfg(unix)]
@@ -325,6 +326,54 @@ fn synthesize_missing_review_result_makes_session_result_readable() {
         StructuredOutputOpts::default(),
     )
     .expect("session result should read the synthetic review failure");
+}
+
+#[test]
+fn read_review_failure_excerpt_ignores_bytes_beyond_4kb() {
+    let td = tempfile::tempdir().unwrap();
+    let session_dir = td.path();
+    std::fs::write(
+        session_dir.join("stderr.log"),
+        format!("{}late failure marker", " ".repeat(4096)),
+    )
+    .unwrap();
+
+    assert_eq!(read_review_failure_excerpt(session_dir), None);
+}
+
+#[test]
+fn synthesize_missing_review_result_propagates_peak_memory_from_error_chain() {
+    let td = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&td);
+    let project_root = td.path();
+
+    let session =
+        csa_session::create_session(project_root, Some("review-failure"), None, Some("codex"))
+            .expect("session creation");
+    let session_id = session.meta_session_id.clone();
+    let session_dir = csa_session::get_session_dir(project_root, &session_id).unwrap();
+    std::fs::write(session_dir.join("stderr.log"), "tool terminated by signal").unwrap();
+
+    let started_at = Utc::now();
+    let err = PeakMemoryContext(Some(512))
+        .into_anyhow("codex process exited")
+        .context(format!("meta_session_id={session_id}"));
+
+    maybe_synthesize_missing_review_result(project_root, ToolName::Codex, started_at, &err);
+
+    let result = csa_session::load_result(project_root, &session.meta_session_id)
+        .unwrap()
+        .expect("synthetic result.toml should exist");
+    assert_eq!(result.peak_memory_mb, Some(512));
+}
+
+#[test]
+fn extract_meta_session_id_from_error_accepts_hyphen_and_underscore() {
+    let err = anyhow::anyhow!("review failed").context("meta_session_id=session-1_abc");
+    assert_eq!(
+        extract_meta_session_id_from_error(&err).as_deref(),
+        Some("session-1_abc")
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Three MEDIUM/LOW followups from PR #814 gemini review:

- **Bounded stderr.log read** — `read_review_failure_excerpt` now uses a 4KB-capped reader instead of `fs::read_to_string`. Prevents OOM on runaway tools that write GBs to stderr before failing. Only ~500 chars are needed for the excerpt.
- **Peak memory from error chain** — Synthetic `SessionResult` now walks the error chain for `PeakMemoryContext` (mirroring `pipeline_execute.rs`). When the sandbox captured peak memory before execution failed (e.g., OOM kill), the synthetic result now surfaces it.
- **Defensive session ID extraction** — `extract_meta_session_id_from_error` now accepts `-` and `_` in addition to alphanumeric. Harmless hardening; current ULIDs unaffected.

Regression tests added for each.

## Test plan

- [x] `cargo test -p cli-sub-agent` exit 0
- [x] `just pre-commit` exit 0

Closes #815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)