### PR TITLE
refactor(cli-sub-agent): dedupe design-anchor + VCS branch resolution (#823)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.406"
+version = "0.1.407"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.406"
+version = "0.1.407"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -41,6 +41,7 @@ mod process_tree;
 mod review_cmd;
 mod review_consensus;
 mod review_context;
+mod review_design_anchor;
 mod review_findings;
 mod review_prior_rounds;
 mod review_routing;

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -577,6 +577,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             &prompt,
             reviewer_index + 1,
             reviewer_tool,
+            &project_root,
             prior_rounds_section.as_deref(),
         );
         let reviewer_model = review_model.clone();

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -539,7 +539,7 @@ pub(crate) fn build_review_instruction(
             instruction.push_str(&render_spec_review_context(spec));
         }
     }
-    append_design_anchor(&mut instruction);
+    crate::review_design_anchor::append_design_anchor(&mut instruction);
     instruction
 }
 
@@ -569,7 +569,7 @@ pub(crate) fn build_review_instruction_for_project(
 
     // Inject prior-round assumptions when a previous review session exists on
     // the same branch (#764). Skipped on first-round reviews.
-    let branch = current_git_branch_for_review(project_root);
+    let branch = crate::review_design_anchor::resolve_current_branch_via_vcs(project_root);
     if let Some(branch) = branch.as_deref()
         && let Some(iteration_context) =
             crate::review_consensus::review_iteration::render_review_iteration_context(
@@ -591,19 +591,6 @@ pub(crate) fn build_review_instruction_for_project(
     instruction.push_str(REVIEW_FINDINGS_TOML_INSTRUCTION);
 
     (instruction, review_routing)
-}
-
-fn current_git_branch_for_review(project_root: &Path) -> Option<String> {
-    let backend = csa_session::vcs_backends::create_vcs_backend(project_root);
-    backend.current_branch(project_root).ok().flatten()
-}
-
-fn append_design_anchor(prompt: &mut String) {
-    if prompt.contains("## Design preferences vs correctness bugs") {
-        return;
-    }
-    prompt.push_str("\n\n");
-    prompt.push_str(crate::review_consensus::review_design_anchor::REVIEW_DESIGN_PREFERENCE_ANCHOR);
 }
 
 pub(crate) struct ReviewProjectPromptOptions<'a> {

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -12,24 +12,6 @@ use std::path::Path;
 use std::process::Command;
 use tempfile::tempdir;
 
-struct CurrentDirGuard {
-    original: std::path::PathBuf,
-}
-
-impl CurrentDirGuard {
-    fn change_to(path: &Path) -> Self {
-        let original = std::env::current_dir().expect("current dir");
-        std::env::set_current_dir(path).expect("set current dir");
-        Self { original }
-    }
-}
-
-impl Drop for CurrentDirGuard {
-    fn drop(&mut self) {
-        let _ = std::env::set_current_dir(&self.original);
-    }
-}
-
 fn run_git(dir: &Path, args: &[&str]) {
     let status = Command::new("git")
         .args(args)
@@ -139,10 +121,12 @@ fn build_review_instruction_for_project_contains_design_preference_anchor() {
 
 #[test]
 fn build_multi_reviewer_instruction_contains_design_preference_anchor() {
+    let project_dir = tempdir().unwrap();
     let prompt = crate::review_consensus::build_multi_reviewer_instruction(
         "Base prompt",
         1,
         ToolName::Codex,
+        project_dir.path(),
         None,
     );
 
@@ -243,11 +227,11 @@ fn count_prior_reviews_three_adds_multi_round_escalation() {
         3
     );
 
-    let _cwd = CurrentDirGuard::change_to(project_dir.path());
     let prompt = crate::review_consensus::build_multi_reviewer_instruction(
         "Base prompt",
         2,
         ToolName::Codex,
+        project_dir.path(),
         None,
     );
 
@@ -284,15 +268,44 @@ fn multi_round_escalation_keeps_persistent_correctness_bugs_blocking() {
         3,
     );
 
-    let _cwd = CurrentDirGuard::change_to(project_dir.path());
     let prompt = crate::review_consensus::build_multi_reviewer_instruction(
         "Base prompt",
         2,
         ToolName::Codex,
+        project_dir.path(),
         None,
     );
 
     assert!(prompt.contains("persistent correctness bugs remain blocking"));
+}
+
+#[test]
+fn build_multi_reviewer_instruction_uses_explicit_project_root_outside_cwd() {
+    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let project_dir = tempdir().unwrap();
+    let unrelated_dir = tempdir().unwrap();
+    init_git_repo_with_branch(project_dir.path(), "feat/iter-explicit-root");
+    create_mock_review_session(
+        project_dir.path(),
+        "01K7ER7A0E0000000000000091",
+        Some("feat/iter-explicit-root"),
+        "fail",
+        1,
+    );
+
+    let current_dir = std::env::current_dir().expect("current dir");
+    assert_ne!(current_dir, project_dir.path());
+    assert_ne!(unrelated_dir.path(), project_dir.path());
+
+    let prompt = crate::review_consensus::build_multi_reviewer_instruction(
+        "Base prompt",
+        2,
+        ToolName::Codex,
+        project_dir.path(),
+        None,
+    );
+
+    assert!(prompt.contains("This is review iteration 2 on branch 'feat/iter-explicit-root'."));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
@@ -77,6 +77,7 @@ invariant = "lock-losing resume cannot mutate metadata of winning session"
         "Base prompt",
         2,
         ToolName::Codex,
+        project_dir.path(),
         Some(&prior_rounds),
     );
     assert!(prompt.contains("Round 6 (commit 29b6c34c)"));
@@ -159,6 +160,7 @@ fn multi_reviewer_prompt_does_not_duplicate_prior_rounds_section_from_base_promp
         &base_prompt,
         2,
         ToolName::Codex,
+        tempdir().unwrap().path(),
         Some(prior_rounds),
     );
 

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -21,8 +21,6 @@ use csa_core::types::ToolName;
 use csa_executor::{CodexRuntimeMetadata, CodexTransport};
 use csa_session::review_artifact::{Finding, ReviewArtifact, SeveritySummary};
 
-#[path = "review_design_anchor.rs"]
-pub(crate) mod review_design_anchor;
 #[path = "review_iteration.rs"]
 pub(crate) mod review_iteration;
 #[path = "review_iteration_resolver.rs"]
@@ -38,14 +36,6 @@ pub(crate) const UNCERTAIN: &str = "UNCERTAIN";
 pub(crate) const RULE_SPEC_DEVIATION: &str = "spec-deviation";
 pub(crate) const RULE_UNVERIFIED_CRITERION: &str = "unverified-criterion";
 pub(crate) const RULE_BOUNDARY_VIOLATION: &str = "boundary-violation";
-
-fn append_design_anchor(prompt: &mut String) {
-    if prompt.contains("## Design preferences vs correctness bugs") {
-        return;
-    }
-    prompt.push_str("\n\n");
-    prompt.push_str(review_design_anchor::REVIEW_DESIGN_PREFERENCE_ANCHOR);
-}
 
 #[cfg(test)]
 fn reviewer_tool_binary_available(_tool_name: &str, _config: Option<&ProjectConfig>) -> bool {
@@ -169,6 +159,7 @@ pub(crate) fn build_multi_reviewer_instruction(
     base_prompt: &str,
     reviewer_index: usize,
     tool: ToolName,
+    project_root: &Path,
     prior_rounds_section: Option<&str>,
 ) -> String {
     let output_dir = reviewer_output_dir(reviewer_index);
@@ -190,18 +181,15 @@ When spec/contract context is provided, use rule_id values: \
 Reviewer tool hint: {}.",
         tool.as_str()
     );
-    append_design_anchor(&mut prompt);
+    crate::review_design_anchor::append_design_anchor(&mut prompt);
     if !prompt.contains("## Review iteration context")
-        && let Ok(project_root) = std::env::current_dir()
+        && let Some(branch) =
+            crate::review_design_anchor::resolve_current_branch_via_vcs(project_root)
+        && let Some(iteration_context) =
+            review_iteration::render_review_iteration_context(project_root, &branch)
     {
-        let backend = csa_session::vcs_backends::create_vcs_backend(&project_root);
-        if let Ok(Some(branch)) = backend.current_branch(&project_root)
-            && let Some(iteration_context) =
-                review_iteration::render_review_iteration_context(&project_root, &branch)
-        {
-            prompt.push_str("\n\n");
-            prompt.push_str(&iteration_context);
-        }
+        prompt.push_str("\n\n");
+        prompt.push_str(&iteration_context);
     }
     if let Some(prior_rounds_section) = prior_rounds_section
         && !base_prompt.contains(PRIOR_ROUNDS_SECTION_HEADING)

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -234,8 +234,15 @@ fn build_multi_reviewer_instruction_prefers_current_session_dir_env_when_both_ex
     let _parent_guard =
         ScopedEnvVarRestore::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
     let _session_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, "/tmp/child-session");
+    let project_dir = tempdir().expect("tempdir should be created");
 
-    let prompt = build_multi_reviewer_instruction("Base prompt", 2, ToolName::Codex, None);
+    let prompt = build_multi_reviewer_instruction(
+        "Base prompt",
+        2,
+        ToolName::Codex,
+        project_dir.path(),
+        None,
+    );
 
     assert!(prompt.contains("/tmp/child-session/reviewer-2/review-findings.json"));
     assert!(
@@ -250,8 +257,15 @@ fn build_multi_reviewer_instruction_falls_back_to_parent_session_dir_env() {
     let _parent_guard =
         ScopedEnvVarRestore::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
     let _session_guard = ScopedEnvVarRestore::unset(CSA_SESSION_DIR_ENV_KEY);
+    let project_dir = tempdir().expect("tempdir should be created");
 
-    let prompt = build_multi_reviewer_instruction("Base prompt", 3, ToolName::Codex, None);
+    let prompt = build_multi_reviewer_instruction(
+        "Base prompt",
+        3,
+        ToolName::Codex,
+        project_dir.path(),
+        None,
+    );
 
     assert!(prompt.contains("/tmp/parent-session/reviewer-3/review-findings.json"));
 }
@@ -261,8 +275,15 @@ fn build_multi_reviewer_instruction_uses_session_first_shell_fallback_when_env_m
     let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock poisoned");
     let _parent_guard = ScopedEnvVarRestore::unset(CSA_PARENT_SESSION_DIR_ENV_KEY);
     let _session_guard = ScopedEnvVarRestore::unset(CSA_SESSION_DIR_ENV_KEY);
+    let project_dir = tempdir().expect("tempdir should be created");
 
-    let prompt = build_multi_reviewer_instruction("Base prompt", 4, ToolName::Codex, None);
+    let prompt = build_multi_reviewer_instruction(
+        "Base prompt",
+        4,
+        ToolName::Codex,
+        project_dir.path(),
+        None,
+    );
 
     assert!(
         prompt.contains(
@@ -274,8 +295,15 @@ fn build_multi_reviewer_instruction_uses_session_first_shell_fallback_when_env_m
 #[test]
 fn build_multi_reviewer_instruction_does_not_duplicate_findings_contract_from_base_prompt() {
     let base_prompt = format!("Base prompt\n\n{REVIEW_FINDINGS_TOML_INSTRUCTION}");
+    let project_dir = tempdir().expect("tempdir should be created");
 
-    let prompt = build_multi_reviewer_instruction(&base_prompt, 4, ToolName::Codex, None);
+    let prompt = build_multi_reviewer_instruction(
+        &base_prompt,
+        4,
+        ToolName::Codex,
+        project_dir.path(),
+        None,
+    );
 
     assert_eq!(prompt.matches(REVIEW_FINDINGS_TOML_INSTRUCTION).count(), 1);
 }

--- a/crates/cli-sub-agent/src/review_design_anchor.rs
+++ b/crates/cli-sub-agent/src/review_design_anchor.rs
@@ -12,3 +12,18 @@ Design preferences may have multiple valid answers. If the current choice works,
 
 Rationale: review ping-pong on design preferences wastes iterations and does NOT converge to better code quality. A reviewer that flip-flops on the same design point across rounds is a stronger signal of design residual than of real bugs.
 "#;
+
+use std::path::Path;
+
+pub(crate) fn append_design_anchor(prompt: &mut String) {
+    if prompt.contains("## Design preferences vs correctness bugs") {
+        return;
+    }
+    prompt.push_str("\n\n");
+    prompt.push_str(REVIEW_DESIGN_PREFERENCE_ANCHOR);
+}
+
+pub(crate) fn resolve_current_branch_via_vcs(project_root: &Path) -> Option<String> {
+    let backend = csa_session::vcs_backends::create_vcs_backend(project_root);
+    backend.current_branch(project_root).ok().flatten()
+}

--- a/crates/cli-sub-agent/tests/review_mode_compat.rs
+++ b/crates/cli-sub-agent/tests/review_mode_compat.rs
@@ -10,6 +10,8 @@ mod test_session_sandbox;
 
 #[path = "../src/review_consensus.rs"]
 mod review_consensus;
+#[path = "../src/review_design_anchor.rs"]
+mod review_design_anchor;
 #[allow(dead_code)]
 #[path = "../src/review_prior_rounds.rs"]
 mod review_prior_rounds;
@@ -120,9 +122,15 @@ fn review_cli_validation_and_consensus_helpers_remain_compatible() {
         .expect("red-team review args should parse");
     cli_defs::validate_command_args(&cli.command, 1800)
         .expect("red-team review args should validate");
+    let project_dir = tempfile::tempdir().expect("tempdir should be created");
 
-    let instruction =
-        review_consensus::build_multi_reviewer_instruction("Base prompt", 2, ToolName::Codex, None);
+    let instruction = review_consensus::build_multi_reviewer_instruction(
+        "Base prompt",
+        2,
+        ToolName::Codex,
+        project_dir.path(),
+        None,
+    );
     assert!(instruction.contains("reviewer 2"));
     assert!(instruction.contains("CLEAN"));
     assert!(instruction.contains("HAS_ISSUES"));


### PR DESCRIPTION
## Summary

Nine MEDIUM findings from PR #822 gemini review cluster into two concerns:

- **Duplication** — `append_design_anchor` logic and VCS branch resolver duplicated between `review_cmd_resolve.rs` and `review_consensus.rs`. Extracted to shared `review_design_anchor` module; both sites now call the shared impl.
- **current_dir() fragility** — threaded `project_root: &Path` through `review_consensus` call sites (no more `std::env::current_dir()` inference in production). Tests replaced `std::env::set_current_dir` with `tempdir` + explicit path param (no more process-wide state race).

No behavior change — anchor text, branch-resolution algorithm, and public API surface all unchanged.

## Test plan

- [x] `cargo test -p cli-sub-agent review` exit 0
- [x] grep confirms `std::env::current_dir` gone from review_consensus.rs
- [x] grep confirms `std::env::set_current_dir` gone from review_cmd_tests_iteration.rs
- [x] `just pre-commit` exit 0

Closes #823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)