### PR TITLE
fix(csa-executor): codex subprocess cannot bypass lefthook (#882)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.411"
+version = "0.1.412"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.411"
+version = "0.1.412"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -7,6 +7,7 @@ use csa_process::ExecutionResult;
 use csa_session::state::{MetaSessionState, ToolState};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::path::Path;
 use tokio::process::Command;
 
@@ -15,6 +16,7 @@ use crate::install_hints::{
     CLAUDE_CODE_ACP_INSTALL_HINT, GEMINI_CLI_INSTALL_HINT, OPENAI_COMPAT_INSTALL_HINT,
     OPENCODE_INSTALL_HINT,
 };
+use crate::lefthook_guard::{sanitize_args_for_codex, sanitize_env_for_codex};
 use crate::model_spec::{ModelSpec, ThinkingBudget};
 use crate::transport::{
     ResolvedTimeout, SandboxTransportConfig, Transport, TransportFactory, TransportOptions,
@@ -318,6 +320,10 @@ impl Executor {
             prompt_transport,
             &gemini_include_directories,
         );
+        if matches!(self, Self::Codex { .. }) {
+            sanitize_env_for_codex(&mut cmd);
+            cmd = Self::sanitize_codex_command_args(cmd);
+        }
         (cmd, stdin_data)
     }
 
@@ -471,7 +477,45 @@ impl Executor {
         } else {
             self.append_prompt_args_with_transport(&mut cmd, prompt, prompt_transport);
         }
+        if matches!(self, Self::Codex { .. }) {
+            sanitize_env_for_codex(&mut cmd);
+            cmd = Self::sanitize_codex_command_args(cmd);
+        }
         (cmd, stdin_data)
+    }
+
+    fn sanitize_codex_command_args(cmd: Command) -> Command {
+        let program = cmd.as_std().get_program().to_os_string();
+        let current_dir = cmd.as_std().get_current_dir().map(|dir| dir.to_path_buf());
+        let envs = cmd
+            .as_std()
+            .get_envs()
+            .map(|(key, value)| (key.to_os_string(), value.map(|v| v.to_os_string())))
+            .collect::<Vec<_>>();
+        let mut args = cmd
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        sanitize_args_for_codex(&mut args);
+
+        let mut sanitized = Command::new(program);
+        if let Some(dir) = current_dir {
+            sanitized.current_dir(dir);
+        }
+        for (key, value) in envs {
+            match value {
+                Some(value) => {
+                    sanitized.env(key, value);
+                }
+                None => {
+                    sanitized.env_remove(key);
+                }
+            }
+        }
+        let os_args = args.into_iter().map(OsString::from).collect::<Vec<_>>();
+        sanitized.args(os_args);
+        sanitized
     }
 
     /// Environment variables to strip from child processes.

--- a/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
@@ -343,6 +343,66 @@ fn test_build_execute_in_command_strips_claudecode_env() {
 }
 
 #[test]
+fn test_build_command_codex_strips_lefthook_env_reinjected_by_extra_env() {
+    let exec = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
+    };
+    let session = make_test_session();
+    let extra_env = HashMap::from([
+        ("LEFTHOOK".to_string(), "0".to_string()),
+        ("LEFTHOOK_SKIP_PRE_COMMIT".to_string(), "1".to_string()),
+        ("SAFE_ENV".to_string(), "ok".to_string()),
+    ]);
+
+    let (cmd, _stdin_data) = exec.build_command("test", None, &session, Some(&extra_env));
+
+    let envs: Vec<_> = cmd.as_std().get_envs().collect();
+    let env_map: HashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> = envs.into_iter().collect();
+
+    assert_eq!(env_map.get(std::ffi::OsStr::new("LEFTHOOK")), Some(&None));
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("LEFTHOOK_SKIP_PRE_COMMIT")),
+        Some(&None)
+    );
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("SAFE_ENV")),
+        Some(&Some(std::ffi::OsStr::new("ok")))
+    );
+}
+
+#[test]
+fn test_build_execute_in_command_codex_strips_lefthook_env_reinjected_by_extra_env() {
+    let exec = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
+    };
+    let work_dir = std::path::Path::new("/tmp/test-project");
+    let extra_env = HashMap::from([
+        ("LEFTHOOK".to_string(), "0".to_string()),
+        ("LEFTHOOK_EXCLUDE_PRE_PUSH".to_string(), "1".to_string()),
+        ("SAFE_ENV".to_string(), "ok".to_string()),
+    ]);
+
+    let (cmd, _stdin_data) = exec.build_execute_in_command("test", work_dir, Some(&extra_env));
+
+    let envs: Vec<_> = cmd.as_std().get_envs().collect();
+    let env_map: HashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> = envs.into_iter().collect();
+
+    assert_eq!(env_map.get(std::ffi::OsStr::new("LEFTHOOK")), Some(&None));
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("LEFTHOOK_EXCLUDE_PRE_PUSH")),
+        Some(&None)
+    );
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("SAFE_ENV")),
+        Some(&Some(std::ffi::OsStr::new("ok")))
+    );
+}
+
+#[test]
 fn test_build_execute_in_command_strips_claudecode_for_all_executors() {
     let executors: Vec<Executor> = vec![
         Executor::GeminiCli {

--- a/crates/csa-executor/src/lefthook_guard.rs
+++ b/crates/csa-executor/src/lefthook_guard.rs
@@ -1,0 +1,130 @@
+use std::collections::HashMap;
+
+use tokio::process::Command;
+
+const FORBIDDEN_ENV_KEYS: &[&str] = &[
+    "LEFTHOOK",
+    "LEFTHOOK_BIN",
+    "LEFTHOOK_VERBOSE",
+    "LEFTHOOK_QUIET",
+    "LEFTHOOK_PROFILE",
+    "LEFTHOOK_SKIP",
+    "LEFTHOOK_EXCLUDE",
+    "SKIP",
+];
+
+pub(crate) fn sanitize_env_for_codex(cmd: &mut Command) {
+    for key in FORBIDDEN_ENV_KEYS {
+        cmd.env_remove(key);
+    }
+
+    let explicit_prefixed_keys = cmd
+        .as_std()
+        .get_envs()
+        .filter_map(|(key, _)| {
+            let key = key.to_string_lossy();
+            is_forbidden_env_key_prefix(key.as_ref()).then(|| key.into_owned())
+        })
+        .collect::<Vec<_>>();
+    for key in explicit_prefixed_keys {
+        cmd.env_remove(key);
+    }
+
+    for (key, _) in std::env::vars_os() {
+        if is_forbidden_env_key_prefix(key.to_string_lossy().as_ref()) {
+            cmd.env_remove(key);
+        }
+    }
+}
+
+pub(crate) fn sanitize_env_map_for_codex(env: &mut HashMap<String, String>) {
+    env.retain(|key, _| !is_forbidden_env_key(key));
+}
+
+pub(crate) fn sanitize_args_for_codex(args: &mut Vec<String>) {
+    args.retain(|arg| !is_forbidden_arg(arg));
+}
+
+fn is_forbidden_env_key(key: &str) -> bool {
+    FORBIDDEN_ENV_KEYS.contains(&key) || is_forbidden_env_key_prefix(key)
+}
+
+fn is_forbidden_env_key_prefix(key: &str) -> bool {
+    key.starts_with("LEFTHOOK_SKIP_") || key.starts_with("LEFTHOOK_EXCLUDE_")
+}
+
+fn is_forbidden_arg(arg: &str) -> bool {
+    arg == "--no-verify" || arg.starts_with("--no-verify=")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sanitize_args_for_codex, sanitize_env_for_codex, sanitize_env_map_for_codex};
+    use std::collections::HashMap;
+    use std::ffi::OsStr;
+    use tokio::process::Command;
+
+    #[test]
+    fn sanitize_command_removes_lefthook_env_keys() {
+        let mut cmd = Command::new("/bin/true");
+        cmd.env("LEFTHOOK", "0");
+        cmd.env("LEFTHOOK_SKIP", "pre-commit");
+        cmd.env("LEFTHOOK_SKIP_PRE_COMMIT", "1");
+        cmd.env("SAFE_ENV", "ok");
+
+        sanitize_env_for_codex(&mut cmd);
+
+        let envs: Vec<_> = cmd.as_std().get_envs().collect();
+        let env_map: HashMap<&OsStr, Option<&OsStr>> = envs.into_iter().collect();
+
+        assert_eq!(env_map.get(OsStr::new("LEFTHOOK")), Some(&None));
+        assert_eq!(env_map.get(OsStr::new("LEFTHOOK_SKIP")), Some(&None));
+        assert_eq!(
+            env_map.get(OsStr::new("LEFTHOOK_SKIP_PRE_COMMIT")),
+            Some(&None)
+        );
+        assert_eq!(
+            env_map.get(OsStr::new("SAFE_ENV")),
+            Some(&Some(OsStr::new("ok")))
+        );
+    }
+
+    #[test]
+    fn sanitize_env_map_removes_prefixed_lefthook_keys() {
+        let mut env = HashMap::from([
+            ("LEFTHOOK".to_string(), "0".to_string()),
+            ("LEFTHOOK_EXCLUDE_PRE_PUSH".to_string(), "1".to_string()),
+            ("SAFE_ENV".to_string(), "ok".to_string()),
+        ]);
+
+        sanitize_env_map_for_codex(&mut env);
+
+        assert!(!env.contains_key("LEFTHOOK"));
+        assert!(!env.contains_key("LEFTHOOK_EXCLUDE_PRE_PUSH"));
+        assert_eq!(env.get("SAFE_ENV"), Some(&"ok".to_string()));
+    }
+
+    #[test]
+    fn sanitize_args_removes_no_verify_variants_only() {
+        let mut args = vec![
+            "--model".to_string(),
+            "gpt-5".to_string(),
+            "--no-verify".to_string(),
+            "--no-verify=pre-commit".to_string(),
+            "-n".to_string(),
+            "exec".to_string(),
+        ];
+
+        sanitize_args_for_codex(&mut args);
+
+        assert_eq!(
+            args,
+            vec![
+                "--model".to_string(),
+                "gpt-5".to_string(),
+                "-n".to_string(),
+                "exec".to_string()
+            ]
+        );
+    }
+}

--- a/crates/csa-executor/src/lib.rs
+++ b/crates/csa-executor/src/lib.rs
@@ -6,6 +6,7 @@ pub mod context_loader;
 pub mod design_context;
 pub mod executor;
 pub mod install_hints;
+mod lefthook_guard;
 pub mod logging;
 pub mod model_spec;
 pub mod session_id;

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use crate::executor::Executor;
+use crate::lefthook_guard::sanitize_args_for_codex;
 use crate::transport_gemini_retry::{
     gemini_auth_mode, gemini_inject_api_key_fallback, gemini_max_attempts,
     gemini_rate_limit_backoff, gemini_retry_model, gemini_should_use_api_key,
@@ -532,6 +533,9 @@ impl AcpTransport {
             acp_command = launch.command;
             acp_args = launch.args;
             gemini_runtime_home = gemini_runtime_home_from_env(&env);
+        }
+        if self.tool_name == "codex" {
+            sanitize_args_for_codex(&mut acp_args);
         }
         let gemini_sandbox_env_overrides =
             (self.tool_name == "gemini-cli").then(|| gemini_sandbox_runtime_env_overrides(&env));

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -13,6 +13,7 @@ use csa_resource::isolation_plan::IsolationPlan;
 use csa_session::state::MetaSessionState;
 
 use super::AcpTransport;
+use crate::lefthook_guard::sanitize_env_map_for_codex;
 
 const SUMMARY_MAX_CHARS: usize = 200;
 const CSA_SESSION_ID_ENV: &str = "CSA_SESSION_ID";
@@ -151,7 +152,9 @@ impl AcpTransport {
         // bash execution.  Legacy tools (gemini-cli, opencode) are text-mode
         // and cannot independently call `gh pr merge`.
         csa_hooks::merge_guard::inject_merge_guard_env(&mut env);
-
+        if self.tool_name == "codex" {
+            sanitize_env_map_for_codex(&mut env);
+        }
         env
     }
 

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -324,6 +324,41 @@ fn test_apply_codex_exec_initial_stall_summary_renders_reason_for_result_toml() 
 }
 
 #[test]
+fn test_build_env_codex_strips_lefthook_bypass_env_only_for_codex() {
+    let transport = AcpTransport::new("codex", None);
+    let session = build_ephemeral_meta_session(std::path::Path::new("/tmp/test"));
+    let extra = HashMap::from([
+        ("LEFTHOOK".to_string(), "0".to_string()),
+        ("LEFTHOOK_SKIP_PRE_COMMIT".to_string(), "1".to_string()),
+        ("SAFE_ENV".to_string(), "ok".to_string()),
+    ]);
+
+    let env = transport.build_env(&session, Some(&extra));
+
+    assert!(!env.contains_key("LEFTHOOK"));
+    assert!(!env.contains_key("LEFTHOOK_SKIP_PRE_COMMIT"));
+    assert_eq!(env.get("SAFE_ENV").map(String::as_str), Some("ok"));
+}
+
+#[test]
+fn test_build_env_non_codex_preserves_lefthook_bypass_env() {
+    let transport = AcpTransport::new("claude-code", None);
+    let session = build_ephemeral_meta_session(std::path::Path::new("/tmp/test"));
+    let extra = HashMap::from([
+        ("LEFTHOOK".to_string(), "0".to_string()),
+        ("LEFTHOOK_SKIP_PRE_COMMIT".to_string(), "1".to_string()),
+    ]);
+
+    let env = transport.build_env(&session, Some(&extra));
+
+    assert_eq!(env.get("LEFTHOOK").map(String::as_str), Some("0"));
+    assert_eq!(
+        env.get("LEFTHOOK_SKIP_PRE_COMMIT").map(String::as_str),
+        Some("1")
+    );
+}
+
+#[test]
 fn test_daemon_mode_disables_acp_stderr_streaming_when_output_spool_exists() {
     let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
     let original = std::env::var(DAEMON_SESSION_ID_ENV).ok();


### PR DESCRIPTION
## Summary

Codex sessions recurrently tried to set \`LEFTHOOK=0\` / \`LEFTHOOK_SKIP\` or pass \`--no-verify\` to bypass failing hooks. The post-run policy caught these, but wasted the session's tokens and occasionally left a half-committed state.

Physically strip the \`LEFTHOOK*\` env family and \`--no-verify\`/\`--no-verify=*\` args from the codex \`Command\` before spawn. Gated to tool == "codex"; gemini-cli and claude-code untouched. Unit tests verify the sanitizer removes forbidden keys even when the caller sets them.

Post-run policy remains as defense-in-depth.

User-approved Option 2.

## Test plan

- [x] \`cargo test --workspace\` exit 0
- [x] \`just pre-commit\` exit 0

Closes #882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)