### PR TITLE
fix(pr-bot): fork convention documented + fail-closed on ambiguity (#917)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.412"
+version = "0.1.413"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.412"
+version = "0.1.413"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -42,6 +42,36 @@ This pattern follows a 3-layer dispatcher architecture:
 
 Each step below is annotated with its execution layer.
 
+## Assumed Fork Convention
+
+pr-bot assumes the GitHub-common fork convention:
+
+- `origin` = your personal fork (push target and PR source)
+- a separate remote such as `upstream` = canonical repository
+
+Under this convention, the default remote resolution order
+`branch.<branch>.pushRemote -> remote.pushDefault -> origin -> branch.<branch>.remote -> checkout.defaultRemote -> single remote`
+pushes to your fork and opens PRs against the canonical repository.
+
+If you use the alternate convention where `origin` points at the canonical
+repository and a separate remote points at your fork, you must configure the
+push remote explicitly before running pr-bot:
+
+```bash
+git config branch.<your-branch>.pushRemote <fork-remote-name>
+```
+
+Or set a global default:
+
+```bash
+git config remote.pushDefault <fork-remote-name>
+```
+
+When multiple remotes exist, `origin` does not reference the authenticated
+GitHub login, and no explicit push remote is configured, pr-bot fails closed
+with an actionable error instead of guessing and risking a push to the
+canonical repository.
+
 ## Step 1: Commit Changes
 
 > **Layer**: 0 (Orchestrator) -- lightweight shell command, no code reading.
@@ -55,35 +85,10 @@ Ensure all changes committed. Set `WORKFLOW_BRANCH`, `REMOTE_NAME`, `REPO_SLUG`,
 # Force weave to pick up workflow variables used across steps.
 : "${WORKFLOW_BRANCH}" "${REVIEW_COMPLETED}" "${REMOTE_NAME}" "${REPO_SLUG}" "${DEFAULT_BRANCH}"
 
+ROOT_DIR="$(git rev-parse --show-toplevel)"
 WORKFLOW_BRANCH="$(git branch --show-current)"
 CURRENT_BRANCH="${WORKFLOW_BRANCH:-$(git branch --show-current)}"
-# Resolve the push target using push-side precedence, then fork-safe origin, then fetch-side fallbacks.
-REMOTE_NAME=$(git config --get "branch.${CURRENT_BRANCH}.pushRemote" 2>/dev/null || true)
-if [ -z "$REMOTE_NAME" ]; then
-  REMOTE_NAME=$(git config --get remote.pushDefault 2>/dev/null || true)
-fi
-if [ -z "$REMOTE_NAME" ] && git remote | grep -qx origin; then
-  REMOTE_NAME=origin
-fi
-if [ -z "$REMOTE_NAME" ]; then
-  REMOTE_NAME=$(git config --get "branch.${CURRENT_BRANCH}.remote" 2>/dev/null || true)
-fi
-if [ -z "$REMOTE_NAME" ]; then
-  REMOTE_NAME=$(git config --get checkout.defaultRemote 2>/dev/null || true)
-fi
-if [ -z "$REMOTE_NAME" ]; then
-  REMOTE_COUNT=$(git remote | wc -l | tr -d ' ')
-  if [ "$REMOTE_COUNT" = "1" ]; then
-    REMOTE_NAME=$(git remote | head -1)
-  fi
-fi
-if [ -z "$REMOTE_NAME" ]; then
-  echo "ERROR: cannot determine target remote. Multiple remotes exist and neither" >&2
-  echo "  'branch.${CURRENT_BRANCH}.pushRemote', 'remote.pushDefault'," >&2
-  echo "  'branch.${CURRENT_BRANCH}.remote', 'checkout.defaultRemote', nor 'origin' is set." >&2
-  echo "  Configure one with: git config --local branch.${CURRENT_BRANCH}.pushRemote <name>" >&2
-  exit 1
-fi
+REMOTE_NAME="$("${ROOT_DIR}/patterns/pr-bot/scripts/resolve-push-remote.sh" "${CURRENT_BRANCH}")"
 REMOTE_URL=$(git remote get-url --push "$REMOTE_NAME" 2>/dev/null)
 if [ -z "$REMOTE_URL" ]; then
   echo "ERROR: git remote '$REMOTE_NAME' has no push URL" >&2

--- a/patterns/pr-bot/scripts/resolve-push-remote.sh
+++ b/patterns/pr-bot/scripts/resolve-push-remote.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CURRENT_BRANCH="${1:-$(git branch --show-current)}"
+
+if [ -z "${CURRENT_BRANCH}" ]; then
+  echo "ERROR: cannot determine current branch for pr-bot remote resolution." >&2
+  exit 1
+fi
+
+BRANCH_PUSH_REMOTE="$(git config --get "branch.${CURRENT_BRANCH}.pushRemote" 2>/dev/null || true)"
+PUSH_DEFAULT_REMOTE="$(git config --get remote.pushDefault 2>/dev/null || true)"
+REMOTE_COUNT="$(git remote | wc -l | tr -d ' ')"
+
+if [ -z "${BRANCH_PUSH_REMOTE}" ] && [ -z "${PUSH_DEFAULT_REMOTE}" ] && [ "${REMOTE_COUNT}" -gt 1 ] && git remote | grep -qx origin; then
+  ORIGIN_URL="$(git remote get-url --push origin 2>/dev/null || true)"
+  GITHUB_LOGIN="$(gh api user --jq .login 2>/dev/null || true)"
+
+  if [ -n "${GITHUB_LOGIN}" ] && [ -n "${ORIGIN_URL}" ] && ! printf '%s' "${ORIGIN_URL}" | grep -qiE "[:/]${GITHUB_LOGIN}/"; then
+    echo "ERROR: pr-bot detected an ambiguous fork convention." >&2
+    echo "  origin URL: ${ORIGIN_URL}" >&2
+    echo "  authenticated GitHub login: ${GITHUB_LOGIN}" >&2
+    echo "  origin does not reference your login, so it likely points at the canonical repository." >&2
+    echo "  Multiple remotes exist and neither 'branch.${CURRENT_BRANCH}.pushRemote' nor 'remote.pushDefault' is configured." >&2
+    echo "  Set the branch push remote explicitly:" >&2
+    echo "    git config branch.${CURRENT_BRANCH}.pushRemote <your-fork-remote-name>" >&2
+    echo "  Or set a global default:" >&2
+    echo "    git config remote.pushDefault <your-fork-remote-name>" >&2
+    echo "  Then re-run pr-bot." >&2
+    exit 2
+  fi
+fi
+
+REMOTE_NAME="${BRANCH_PUSH_REMOTE}"
+if [ -z "${REMOTE_NAME}" ]; then
+  REMOTE_NAME="${PUSH_DEFAULT_REMOTE}"
+fi
+if [ -z "${REMOTE_NAME}" ] && git remote | grep -qx origin; then
+  REMOTE_NAME=origin
+fi
+if [ -z "${REMOTE_NAME}" ]; then
+  REMOTE_NAME="$(git config --get "branch.${CURRENT_BRANCH}.remote" 2>/dev/null || true)"
+fi
+if [ -z "${REMOTE_NAME}" ]; then
+  REMOTE_NAME="$(git config --get checkout.defaultRemote 2>/dev/null || true)"
+fi
+if [ -z "${REMOTE_NAME}" ] && [ "${REMOTE_COUNT}" = "1" ]; then
+  REMOTE_NAME="$(git remote | head -1)"
+fi
+
+if [ -z "${REMOTE_NAME}" ]; then
+  echo "ERROR: cannot determine target remote. Multiple remotes exist and neither" >&2
+  echo "  'branch.${CURRENT_BRANCH}.pushRemote', 'remote.pushDefault'," >&2
+  echo "  'branch.${CURRENT_BRANCH}.remote', 'checkout.defaultRemote', nor 'origin' is set." >&2
+  echo "  Configure one with: git config --local branch.${CURRENT_BRANCH}.pushRemote <name>" >&2
+  exit 1
+fi
+
+printf '%s\n' "${REMOTE_NAME}"

--- a/patterns/pr-bot/scripts/tests/resolve-push-remote-tests.sh
+++ b/patterns/pr-bot/scripts/tests/resolve-push-remote-tests.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+SCRIPT_PATH="${ROOT_DIR}/patterns/pr-bot/scripts/resolve-push-remote.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+make_repo() {
+  local repo_dir="$1"
+  mkdir -p "${repo_dir}"
+  git init "${repo_dir}" >/dev/null 2>&1
+  git -C "${repo_dir}" config user.name "Test User"
+  git -C "${repo_dir}" config user.email "test@example.com"
+  printf 'test\n' >"${repo_dir}/README.md"
+  git -C "${repo_dir}" add README.md
+  git -C "${repo_dir}" commit -m "init" >/dev/null 2>&1
+  git -C "${repo_dir}" branch -M main
+}
+
+make_gh_stub() {
+  local stub_dir="$1"
+  local login="$2"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/gh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "\${1:-}" = "api" ] && [ "\${2:-}" = "user" ] && [ "\${3:-}" = "--jq" ] && [ "\${4:-}" = ".login" ]; then
+  printf '%s\n' "${login}"
+  exit 0
+fi
+
+echo "unexpected gh invocation: \$*" >&2
+exit 1
+EOF
+  chmod +x "${stub_dir}/gh"
+}
+
+run_ambiguous_origin_fail_closed_test() {
+  local case_dir="${TMP_ROOT}/ambiguous-origin"
+  local repo_dir="${case_dir}/repo"
+  local stub_dir="${case_dir}/bin"
+  local stderr_file="${case_dir}/stderr.txt"
+
+  make_repo "${repo_dir}"
+  git -C "${repo_dir}" checkout -b fix/917-fork-convention >/dev/null 2>&1
+  git -C "${repo_dir}" remote add origin "git@github.com:canonical-org/cli-sub-agent.git"
+  git -C "${repo_dir}" remote add fork "git@github.com:test-user/cli-sub-agent.git"
+  git -C "${repo_dir}" config "branch.fix/917-fork-convention.remote" "fork"
+  make_gh_stub "${stub_dir}" "test-user"
+
+  set +e
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" "${SCRIPT_PATH}" "fix/917-fork-convention" >"${case_dir}/stdout.txt" 2>"${stderr_file}"
+  )
+  rc=$?
+  set -e
+
+  if [ "${rc}" -ne 2 ]; then
+    echo "expected ambiguous origin scenario to exit 2, got ${rc}" >&2
+    exit 1
+  fi
+
+  grep -q "pr-bot detected an ambiguous fork convention" "${stderr_file}"
+  grep -q "git config branch.fix/917-fork-convention.pushRemote <your-fork-remote-name>" "${stderr_file}"
+}
+
+run_explicit_push_remote_wins_test() {
+  local case_dir="${TMP_ROOT}/push-remote"
+  local repo_dir="${case_dir}/repo"
+  local stub_dir="${case_dir}/bin"
+  local resolved_remote
+
+  make_repo "${repo_dir}"
+  git -C "${repo_dir}" checkout -b fix/917-explicit-remote >/dev/null 2>&1
+  git -C "${repo_dir}" remote add origin "git@github.com:canonical-org/cli-sub-agent.git"
+  git -C "${repo_dir}" remote add fork "git@github.com:test-user/cli-sub-agent.git"
+  git -C "${repo_dir}" config "branch.fix/917-explicit-remote.pushRemote" "fork"
+  make_gh_stub "${stub_dir}" "test-user"
+
+  resolved_remote="$(
+    cd "${repo_dir}" &&
+      PATH="${stub_dir}:${PATH}" "${SCRIPT_PATH}" "fix/917-explicit-remote"
+  )"
+
+  if [ "${resolved_remote}" != "fork" ]; then
+    echo "expected explicit pushRemote to resolve to fork, got ${resolved_remote}" >&2
+    exit 1
+  fi
+}
+
+run_ambiguous_origin_fail_closed_test
+run_explicit_push_remote_wins_test
+
+echo "resolve-push-remote tests: PASS"

--- a/patterns/pr-bot/skills/pr-bot/SKILL.md
+++ b/patterns/pr-bot/skills/pr-bot/SKILL.md
@@ -171,6 +171,36 @@ automatically and normal bot triggering resumes.
 - Manual cache clear: `rm "${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/pr_review/cloud_bot_quota.toml"`
 - There is currently no dedicated CLI flag wiring for `--force-cloud-bot` in this skill entrypoint.
 
+### Assumed Fork Convention
+
+pr-bot assumes the GitHub-common fork convention:
+
+- `origin` = your personal fork (where PR pushes come from)
+- a separate remote such as `upstream` = canonical repository
+
+Under this convention, the default remote resolution order
+`branch.<branch>.pushRemote -> remote.pushDefault -> origin -> branch.<branch>.remote -> checkout.defaultRemote -> single remote`
+pushes to your fork and opens PRs against the canonical repository.
+
+If you use the alternate convention where `origin` points at the canonical
+repository and your fork lives on another remote, configure the push remote
+explicitly before running pr-bot:
+
+```bash
+git config branch.<your-branch>.pushRemote <fork-remote-name>
+```
+
+Or set a global default:
+
+```bash
+git config remote.pushDefault <fork-remote-name>
+```
+
+When multiple remotes exist, `origin` does not reference the authenticated
+GitHub login, and no explicit push remote is configured, pr-bot fails closed
+with an actionable error instead of guessing and risking a push to the
+canonical repository.
+
 When `cloud_bot = false`:
 - Steps 4-9 (cloud bot trigger, delegated wait gate, classify, arbitrate, fix) are **skipped entirely**
 - A SHA-verified fast-path check is applied before supplementary local review
@@ -195,7 +225,7 @@ breaks prompt-guard propagation.
 
 1. **Commit check**: Ensure all changes are committed. Record `WORKFLOW_BRANCH`.
 2. **Local pre-PR review** (SYNCHRONOUS -- MUST NOT background): use SHA-verified fast-path first (`CURRENT_HEAD` vs latest reviewed session HEAD SHA from `review_meta.json`). If matched, skip review; if mismatched/missing, run full `csa review --branch main --fix --max-rounds 3` (the `--fix` flag resumes the same reviewer session to fix issues, preserving full review context). This is the foundation -- without it, bot unavailability cannot safely merge. Sets `REVIEW_COMPLETED=true` on success.
-3. **Push and ensure PR** (PRECONDITION: `REVIEW_COMPLETED=true`): Detect if branch was already pushed (early-push warning). Push with `--force-with-lease`, derive `source_owner` from `origin` remote URL, then resolve PR strictly by owner-aware lookup (`base=main + head=<source_owner>:${WORKFLOW_BRANCH}`). If none exists, create with `--head <source_owner>:<branch>` and re-resolve; handle create races where PR was created concurrently. FORBIDDEN: creating/reusing PR without Step 2 completion.
+3. **Push and ensure PR** (PRECONDITION: `REVIEW_COMPLETED=true`): Detect if branch was already pushed (early-push warning). Resolve the push remote using the documented fork-convention guard; if `origin` looks canonical and no explicit push remote is configured, fail closed with a fix command instead of guessing. Then push with `--force-with-lease`, derive `source_owner` from `origin` remote URL, and resolve PR strictly by owner-aware lookup (`base=main + head=<source_owner>:${WORKFLOW_BRANCH}`). If none exists, create with `--head <source_owner>:<branch>` and re-resolve; handle create races where PR was created concurrently. FORBIDDEN: creating/reusing PR without Step 2 completion.
 3a. **Check cloud bot config**: Run `csa config get pr_review.cloud_bot --default true`.
     If `false` → skip Steps 4-9. Apply the same SHA-verified fast-path before
     supplementary review. If SHA matches, skip review; if SHA mismatches/missing

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -351,6 +351,9 @@ name = "REVIEW_ROUND"
 name = "REVIEW_SESSION_RECORD"
 
 [[workflow.variables]]
+name = "ROOT_DIR"
+
+[[workflow.variables]]
 name = "ROUND_LIMIT_ACTION"
 
 [[workflow.variables]]
@@ -460,6 +463,39 @@ name = "tmp_file"
 
 [[workflow.steps]]
 id = 1
+title = "Assumed Fork Convention"
+prompt = """
+pr-bot assumes the GitHub-common fork convention:
+
+- `origin` = your personal fork (push target and PR source)
+- a separate remote such as `upstream` = canonical repository
+
+Under this convention, the default remote resolution order
+`branch.<branch>.pushRemote -> remote.pushDefault -> origin -> branch.<branch>.remote -> checkout.defaultRemote -> single remote`
+pushes to your fork and opens PRs against the canonical repository.
+
+If you use the alternate convention where `origin` points at the canonical
+repository and a separate remote points at your fork, you must configure the
+push remote explicitly before running pr-bot:
+
+```bash
+git config branch.<your-branch>.pushRemote <fork-remote-name>
+```
+
+Or set a global default:
+
+```bash
+git config remote.pushDefault <fork-remote-name>
+```
+
+When multiple remotes exist, `origin` does not reference the authenticated
+GitHub login, and no explicit push remote is configured, pr-bot fails closed
+with an actionable error instead of guessing and risking a push to the
+canonical repository."""
+on_fail = "abort"
+
+[[workflow.steps]]
+id = 2
 title = "Commit Changes"
 tool = "bash"
 prompt = '''
@@ -473,35 +509,10 @@ Ensure all changes committed. Set `WORKFLOW_BRANCH`, `REMOTE_NAME`, `REPO_SLUG`,
 # Force weave to pick up workflow variables used across steps.
 : "${WORKFLOW_BRANCH}" "${REVIEW_COMPLETED}" "${REMOTE_NAME}" "${REPO_SLUG}" "${DEFAULT_BRANCH}"
 
+ROOT_DIR="$(git rev-parse --show-toplevel)"
 WORKFLOW_BRANCH="$(git branch --show-current)"
 CURRENT_BRANCH="${WORKFLOW_BRANCH:-$(git branch --show-current)}"
-# Resolve the push target using push-side precedence, then fork-safe origin, then fetch-side fallbacks.
-REMOTE_NAME=$(git config --get "branch.${CURRENT_BRANCH}.pushRemote" 2>/dev/null || true)
-if [ -z "$REMOTE_NAME" ]; then
-  REMOTE_NAME=$(git config --get remote.pushDefault 2>/dev/null || true)
-fi
-if [ -z "$REMOTE_NAME" ] && git remote | grep -qx origin; then
-  REMOTE_NAME=origin
-fi
-if [ -z "$REMOTE_NAME" ]; then
-  REMOTE_NAME=$(git config --get "branch.${CURRENT_BRANCH}.remote" 2>/dev/null || true)
-fi
-if [ -z "$REMOTE_NAME" ]; then
-  REMOTE_NAME=$(git config --get checkout.defaultRemote 2>/dev/null || true)
-fi
-if [ -z "$REMOTE_NAME" ]; then
-  REMOTE_COUNT=$(git remote | wc -l | tr -d ' ')
-  if [ "$REMOTE_COUNT" = "1" ]; then
-    REMOTE_NAME=$(git remote | head -1)
-  fi
-fi
-if [ -z "$REMOTE_NAME" ]; then
-  echo "ERROR: cannot determine target remote. Multiple remotes exist and neither" >&2
-  echo "  'branch.${CURRENT_BRANCH}.pushRemote', 'remote.pushDefault'," >&2
-  echo "  'branch.${CURRENT_BRANCH}.remote', 'checkout.defaultRemote', nor 'origin' is set." >&2
-  echo "  Configure one with: git config --local branch.${CURRENT_BRANCH}.pushRemote <name>" >&2
-  exit 1
-fi
+REMOTE_NAME="$("${ROOT_DIR}/patterns/pr-bot/scripts/resolve-push-remote.sh" "${CURRENT_BRANCH}")"
 REMOTE_URL=$(git remote get-url --push "$REMOTE_NAME" 2>/dev/null)
 if [ -z "$REMOTE_URL" ]; then
   echo "ERROR: git remote '$REMOTE_NAME' has no push URL" >&2
@@ -549,7 +560,7 @@ echo "CSA_VAR:DEFAULT_BRANCH=$DEFAULT_BRANCH"
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 2
+id = 3
 title = "Local Pre-PR Review (SYNCHRONOUS — MUST NOT background)"
 tool = "bash"
 prompt = '''
@@ -595,7 +606,7 @@ echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 4)" required=true -->'
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 3
+id = 4
 title = "Fix Local Review Issues"
 tool = "csa"
 prompt = """
@@ -611,7 +622,7 @@ condition = "${LOCAL_REVIEW_HAS_ISSUES}"
 retry = 3
 
 [[workflow.steps]]
-id = 4
+id = 5
 title = "Push and Ensure PR"
 tool = "bash"
 prompt = '''
@@ -737,7 +748,7 @@ echo '<!-- CSA:NEXT_STEP cmd="trigger cloud bot review or merge (Step 4a/5)" req
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 5
+id = 6
 title = "Step 4a: Check Cloud Bot Configuration"
 tool = "bash"
 prompt = '''
@@ -918,7 +929,7 @@ If `CLOUD_BOT` is `false`:
 on_fail = "abort"
 
 [[workflow.steps]]
-id = 6
+id = 7
 title = "Trigger Cloud Bot Review and Delegate Waiting"
 tool = "bash"
 prompt = '''
@@ -1335,7 +1346,7 @@ on_fail = "abort"
 condition = "(${CLOUD_BOT}) && (!(${BOT_UNAVAILABLE}))"
 
 [[workflow.steps]]
-id = 7
+id = 8
 title = "Step 5a: Abort — Bot Needs Environment Configuration"
 tool = "await-user"
 prompt = """
@@ -1352,7 +1363,7 @@ on_fail = "abort"
 condition = "(${CLOUD_BOT}) && (${BOT_NEEDS_SETUP})"
 
 [[workflow.steps]]
-id = 8
+id = 9
 title = "Step 6-fix: Fallback Review Fix Cycle (Bot Timeout Path)"
 tool = "bash"
 prompt = '''
@@ -1414,7 +1425,7 @@ on_fail = "abort"
 condition = "(${CLOUD_BOT}) && (${BOT_UNAVAILABLE} && ${FALLBACK_REVIEW_HAS_ISSUES})"
 
 [[workflow.steps]]
-id = 9
+id = 10
 title = "Select Current Bot Comment"
 tool = "bash"
 prompt = '''
@@ -1481,7 +1492,7 @@ on_fail = "abort"
 condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE} && ${FALLBACK_REVIEW_HAS_ISSUES})) && (${BOT_HAS_ISSUES}))"
 
 [[workflow.steps]]
-id = 10
+id = 11
 title = "Step 7a: Staleness Filter"
 tool = "bash"
 prompt = '''
@@ -1508,7 +1519,7 @@ on_fail = "skip"
 condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE} && ${FALLBACK_REVIEW_HAS_ISSUES})) && (${BOT_HAS_ISSUES}))"
 
 [[workflow.steps]]
-id = 11
+id = 12
 title = "Arbitrate via Debate"
 tool = "csa"
 prompt = """
@@ -1520,7 +1531,7 @@ on_fail = "abort"
 condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE} && ${FALLBACK_REVIEW_HAS_ISSUES})) && ((${BOT_HAS_ISSUES}) && (${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE}))))"
 
 [[workflow.steps]]
-id = 12
+id = 13
 title = "Include debate"
 tool = "weave"
 prompt = "debate"
@@ -1528,7 +1539,7 @@ on_fail = "abort"
 condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE} && ${FALLBACK_REVIEW_HAS_ISSUES})) && ((${BOT_HAS_ISSUES}) && (${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE}))))"
 
 [[workflow.steps]]
-id = 13
+id = 14
 title = "Step 8a: Post Debate Audit Trail Comment"
 tool = "bash"
 prompt = '''
@@ -1618,7 +1629,7 @@ on_fail = "abort"
 condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE} && ${FALLBACK_REVIEW_HAS_ISSUES})) && ((${BOT_HAS_ISSUES}) && (${COMMENT_IS_FALSE_POSITIVE} && !(${COMMENT_IS_STALE}))))"
 
 [[workflow.steps]]
-id = 14
+id = 15
 title = "Fix Real Issue"
 tool = "csa"
 prompt = """
@@ -1637,7 +1648,7 @@ condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE} && ${FALLBACK_REVIEW_HAS_I
 retry = 2
 
 [[workflow.steps]]
-id = 15
+id = 16
 title = "Push Fixes and Continue Loop"
 tool = "bash"
 prompt = '''
@@ -1764,7 +1775,7 @@ on_fail = "abort"
 condition = "(${CLOUD_BOT}) && ((!(${BOT_UNAVAILABLE} && ${FALLBACK_REVIEW_HAS_ISSUES})) && (${BOT_HAS_ISSUES}))"
 
 [[workflow.steps]]
-id = 16
+id = 17
 title = "Step 10b: Post-Fix Re-Review Gate (HARD GATE)"
 tool = "bash"
 prompt = '''
@@ -2030,7 +2041,7 @@ on_fail = "abort"
 condition = "(${CLOUD_BOT}) && !(${BOT_UNAVAILABLE}) && (${BOT_HAS_ISSUES}) && !(${ROUND_LIMIT_REACHED})"
 
 [[workflow.steps]]
-id = 17
+id = 18
 title = "Step 10a: Bot Review Clean"
 tool = "note"
 prompt = """
@@ -2041,7 +2052,7 @@ on_fail = "abort"
 condition = "(${CLOUD_BOT}) && !(${BOT_UNAVAILABLE}) && !(${BOT_HAS_ISSUES}) && !(${ROUND_LIMIT_REACHED})"
 
 [[workflow.steps]]
-id = 18
+id = 19
 title = "Step 10.5: Rebase for Clean History (DISABLED)"
 tool = "bash"
 prompt = '''
@@ -2209,7 +2220,7 @@ on_fail = "abort"
 condition = "false"
 
 [[workflow.steps]]
-id = 19
+id = 20
 title = "Step 6a: Merge Without Bot"
 tool = "bash"
 prompt = '''
@@ -2302,7 +2313,7 @@ on_fail = "abort"
 condition = "!(${CLOUD_BOT}) || ((${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && !(${FALLBACK_REVIEW_HAS_ISSUES}))"
 
 [[workflow.steps]]
-id = 20
+id = 21
 title = "Clean Resubmission (if needed)"
 tool = "bash"
 prompt = '''
@@ -2321,7 +2332,7 @@ on_fail = "abort"
 condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED})"
 
 [[workflow.steps]]
-id = 21
+id = 22
 title = "Final Merge"
 tool = "bash"
 prompt = '''
@@ -2369,7 +2380,7 @@ on_fail = "abort"
 condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED})"
 
 [[workflow.steps]]
-id = 22
+id = 23
 title = "Step 12b: Final Merge (Direct)"
 tool = "bash"
 prompt = '''


### PR DESCRIPTION
## Summary

- Documents GitHub-common fork convention (origin=fork) in pr-bot SKILL.md/PATTERN.md (Rule 027 sync).
- Adds fail-closed detection: when origin URL does NOT reference authenticated user's login AND no branch.<name>.pushRemote is set, aborts with actionable git config command.
- No auto-probe via gh api / git push --dry-run (Options A/B deferred until real user report).

Closes #917.

## Test plan

- [ ] cargo build --release exit 0
- [ ] weave compile exit 0 (if pattern touched)
- [ ] patterns/pr-bot/workflow.toml TOML-parses clean
- [ ] Manual: repo with origin=canonical_fake + no pushRemote → pr-bot detection aborts with actionable error
- [ ] just pre-commit exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)