### PR TITLE
fix(cli-sub-agent): narrow Uncertain fallback to truly-empty transcripts (#909)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.414"
+version = "0.1.415"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.414"
+version = "0.1.415"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -290,6 +290,17 @@ fn derive_review_verdict_artifact(
         return Ok(artifact);
     }
 
+    if !full_output_is_effectively_empty(session_dir)? {
+        let decision = ReviewDecision::Fail;
+        return Ok(ReviewVerdictArtifact::from_parts(
+            meta.session_id.clone(),
+            decision,
+            legacy_verdict_for_decision(decision, &meta.verdict),
+            findings,
+            Vec::new(),
+        ));
+    }
+
     Ok(ReviewVerdictArtifact::from_parts(
         meta.session_id.clone(),
         ReviewDecision::Uncertain,
@@ -343,6 +354,21 @@ fn infer_review_verdict_from_full_output(
         counts,
         Vec::new(),
     )))
+}
+
+fn full_output_is_effectively_empty(session_dir: &Path) -> Result<bool, anyhow::Error> {
+    let full_output_path = session_dir.join("output").join("full.md");
+    if !full_output_path.exists() {
+        return Ok(true);
+    }
+
+    let raw_output = fs::read_to_string(&full_output_path)
+        .map_err(|error| anyhow::anyhow!("read {}: {error}", full_output_path.display()))?;
+    Ok(raw_output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .all(|line| line.starts_with('{')))
 }
 
 pub(super) fn extract_review_text(raw_output: &str) -> Option<String> {

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -538,7 +538,7 @@ fn persist_review_verdict_marks_clean_transcript_as_pass() {
 }
 
 #[test]
-fn persist_review_verdict_plain_text_full_output_without_review_message_emits_uncertain_verdict() {
+fn persist_review_verdict_plain_text_full_output_without_review_message_emits_fail_verdict() {
     let session_id = "01TESTMETAFALLBACK000000000";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("persist-review-verdict-meta-fallback", session_id);
@@ -556,8 +556,8 @@ fn persist_review_verdict_plain_text_full_output_without_review_message_emits_un
     let artifact: ReviewVerdictArtifact =
         serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
             .expect("parse verdict");
-    assert_eq!(artifact.decision, ReviewDecision::Uncertain);
-    assert_eq!(artifact.verdict_legacy, "UNCERTAIN");
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
     assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
     assert_eq!(artifact.severity_counts.get(&Severity::Medium), Some(&0));
     assert_eq!(artifact.severity_counts.get(&Severity::Low), Some(&0));
@@ -662,6 +662,38 @@ fn persist_review_verdict_json_transcript_without_review_message_emits_uncertain
     .join("\n");
     fs::write(session_dir.join("output").join("full.md"), full_output)
         .expect("write tool-only full output transcript");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Uncertain);
+    assert_eq!(artifact.verdict_legacy, "UNCERTAIN");
+    assert!(artifact.severity_counts.values().all(|value| *value == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn persist_review_verdict_json_noise_only_full_output_emits_uncertain_verdict() {
+    let session_id = "01TESTJSONNOISEONLY00000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-json-noise-only", session_id);
+    let full_output = [
+        String::new(),
+        "   ".to_string(),
+        serde_json::to_string(&json!({"type":"thread.started","thread_id":"thread-1"}))
+            .expect("serialize thread.started"),
+        serde_json::to_string(&json!({"type":"thread.completed","thread_id":"thread-1"}))
+            .expect("serialize thread.completed"),
+        "\t".to_string(),
+    ]
+    .join("\n");
+    fs::write(session_dir.join("output").join("full.md"), full_output)
+        .expect("write json-noise full output transcript");
 
     let meta = make_review_meta(session_id);
     persist_review_verdict(&project_root, &meta, &[], Vec::new());


### PR DESCRIPTION
## Summary

- Narrows Uncertain predicate in `derive_review_verdict_artifact()` to truly-empty full.md only (whitespace + JSON transcript noise).
- Substantive plain-text content that fails structured parsing stays fail-closed (Fail).
- Reverts PR #908 over-broadening that regressed malformed-but-substantive reviews from Fail → Uncertain.

Closes #909.

## Test plan

- [ ] cargo build --release -p cli-sub-agent exit 0
- [ ] cargo test -p cli-sub-agent review_cmd_output exit 0
- [ ] Plain-text high-severity test (line 448-470) asserts Fail
- [ ] New truly-empty test asserts Uncertain
- [ ] just pre-commit exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)