### PR TITLE
fix(commit-skill): enforce just test as hard abort gate (#777)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.418"
+version = "0.1.419"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.418"
+version = "0.1.419"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
@@ -280,3 +280,77 @@ fn commit_reviewer_guidance_schema_requires_regression_tests_for_timing_scenario
         "commit pattern/workflow should no longer require the old Risk Areas reviewer-guidance field"
     );
 }
+
+#[cfg(unix)]
+#[tokio::test]
+async fn commit_workflow_test_gate_aborts_before_following_steps() {
+    use std::os::unix::fs::PermissionsExt;
+    use weave::compiler::ExecutionPlan;
+
+    let td = tempfile::tempdir().unwrap();
+    let bin_dir = td.path().join("bin");
+    let marker = td.path().join("should-not-exist");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+
+    let just_path = bin_dir.join("just");
+    std::fs::write(
+        &just_path,
+        "#!/bin/sh\nif [ \"$1\" = \"test\" ]; then\n  echo 'failing just test' >&2\n  exit 1\nfi\nexit 0\n",
+    )
+    .unwrap();
+    let mut just_perms = std::fs::metadata(&just_path).unwrap().permissions();
+    just_perms.set_mode(0o755);
+    std::fs::set_permissions(&just_path, just_perms).unwrap();
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+
+    let plan = ExecutionPlan {
+        name: "commit-test-gate".into(),
+        description: "Verify a failing just test aborts the workflow.".into(),
+        variables: vec![],
+        steps: vec![
+            PlanStep {
+                id: 1,
+                title: "Run Tests".into(),
+                tool: Some("bash".into()),
+                prompt: "```bash\nset -o pipefail\njust test 2>&1\n```".into(),
+                tier: None,
+                depends_on: vec![],
+                on_fail: FailAction::Abort,
+                condition: None,
+                loop_var: None,
+                session: None,
+            },
+            PlanStep {
+                id: 2,
+                title: "Commit Marker".into(),
+                tool: Some("bash".into()),
+                prompt: format!("```bash\ntouch {}\n```", marker.display()),
+                tier: None,
+                depends_on: vec![],
+                on_fail: FailAction::Abort,
+                condition: None,
+                loop_var: None,
+                session: None,
+            },
+        ],
+    };
+
+    let vars = HashMap::from([("PATH".to_string(), patched_path)]);
+    let results = execute_plan(&plan, &vars, td.path(), None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        results.len(),
+        1,
+        "workflow should stop after failing test gate"
+    );
+    assert_eq!(results[0].title, "Run Tests");
+    assert_ne!(results[0].exit_code, 0, "test gate must report failure");
+    assert!(
+        !marker.exists(),
+        "subsequent steps must not run after a failing just test gate"
+    );
+}

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -93,8 +93,20 @@ Tool: bash
 OnFail: abort
 
 ```bash
-just test
+set -o pipefail
+just test 2>&1
 ```
+
+This is a hard gate. If `just test` exits non-zero, the workflow MUST stop
+immediately and MUST NOT continue to staging or commit creation. The merged
+test stream is preserved in step/session output for auditability.
+
+When `just test` fails:
+1. Abort the commit workflow immediately
+2. Report the exact failing command/output
+3. NEVER retry with a narrower scope
+4. NEVER bypass hooks or continue with `git commit`
+5. NEVER relabel the failure as "pre-existing" and proceed anyway
 
 ## Step 6: Stage Changes
 

--- a/patterns/commit/skills/commit/SKILL.md
+++ b/patterns/commit/skills/commit/SKILL.md
@@ -46,6 +46,13 @@ When `just pre-commit` fails:
 2. Environment/sandbox limitations → report status="needs_clarification" with exact error, do NOT bypass
 3. Pre-existing failures from unrelated crates → report as blocker with exact error, do NOT bypass
 NEVER treat pre-existing failures as justification for LEFTHOOK=0.
+
+When `just test` fails:
+1. Abort the commit workflow immediately
+2. Report the exact failing command/output
+3. NEVER retry with a narrower scope
+4. NEVER bypass hooks or continue with `git commit`
+5. NEVER relabel the failure as "pre-existing" and proceed anyway
 </prompt-guard>
 
 ### Prerequisites

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -174,7 +174,8 @@ title = "Run Tests"
 tool = "bash"
 prompt = """
 ```bash
-just test
+set -o pipefail
+just test 2>&1
 ```"""
 on_fail = "abort"
 


### PR DESCRIPTION
## Summary

- Makes `just test` a hard-abort gate in /commit workflow (`on_fail = "abort"` + stdout/stderr capture).
- Adds explicit prompt-guard that employees MUST abort on non-zero exit, never retry with narrower scope, never bypass.
- PATTERN.md + SKILL.md mirrored (Rule 027).
- Plan-cmd regression test added.

Closes #777.

## Test plan

- [ ] weave compile patterns/commit/workflow.toml exit 0
- [ ] patterns/commit/workflow.toml TOML-parses clean
- [ ] cargo test plan_cmd_tests_commit exit 0
- [ ] just pre-commit exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)