### PR TITLE
fix(cli-sub-agent): review-verdict parser recognizes prose-only CLEAN conclusions (#946)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.419"
+version = "0.1.420"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.420"
+version = "0.1.421"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.419"
+version = "0.1.420"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.420"
+version = "0.1.421"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -72,6 +72,14 @@ struct PersistedReviewArtifact {
     overall_risk: Option<String>,
 }
 
+impl PersistedReviewArtifact {
+    fn overall_risk_is_severe(&self) -> bool {
+        self.overall_risk.as_deref().is_some_and(|risk| {
+            risk.eq_ignore_ascii_case("high") || risk.eq_ignore_ascii_case("critical")
+        })
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct TranscriptEvent {
     #[serde(rename = "type")]
@@ -278,6 +286,7 @@ fn derive_review_verdict_artifact(
         let severity_counts = severity_counts_for_artifact(&artifact);
         let decision = if artifact.findings.is_empty()
             && severity_counts_are_zero(&severity_counts)
+            && !artifact.overall_risk_is_severe()
             && review_contains_prose_clean_conclusion(session_dir)?
         {
             ReviewDecision::Pass

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -16,8 +16,11 @@ use regex::Regex;
 use serde::Deserialize;
 use tracing::{debug, warn};
 
+#[path = "review_cmd_output_clean.rs"]
+mod clean_detection;
 #[path = "review_cmd_output_summary.rs"]
 mod summary_artifact;
+use clean_detection::{contains_clean_phrase, review_contains_prose_clean_conclusion};
 pub(super) use summary_artifact::{
     ensure_review_summary_artifact, is_edit_restriction_summary, truncate_review_result_summary,
 };
@@ -272,16 +275,24 @@ fn derive_review_verdict_artifact(
     findings: &[Finding],
 ) -> Result<ReviewVerdictArtifact, anyhow::Error> {
     if let Some(artifact) = load_review_artifact_from_output(session_dir)? {
-        let decision = derive_decision_from_findings(
-            artifact.findings.is_empty(),
-            artifact.overall_risk.as_deref(),
-            ReviewDecision::from_str(&meta.decision).ok(),
-        );
+        let severity_counts = severity_counts_for_artifact(&artifact);
+        let decision = if artifact.findings.is_empty()
+            && severity_counts_are_zero(&severity_counts)
+            && review_contains_prose_clean_conclusion(session_dir)?
+        {
+            ReviewDecision::Pass
+        } else {
+            derive_decision_from_findings(
+                artifact.findings.is_empty(),
+                artifact.overall_risk.as_deref(),
+                ReviewDecision::from_str(&meta.decision).ok(),
+            )
+        };
         return Ok(build_review_verdict_artifact(
             meta.session_id.clone(),
             decision,
             legacy_verdict_for_decision(decision, &meta.verdict),
-            severity_counts_for_artifact(&artifact),
+            severity_counts,
             Vec::new(),
         ));
     }
@@ -451,6 +462,10 @@ fn severity_counts_for_artifact(
         return severity_counts_from_findings(&artifact.findings);
     }
     counts
+}
+
+fn severity_counts_are_zero(counts: &std::collections::BTreeMap<Severity, u32>) -> bool {
+    counts.values().all(|count| *count == 0)
 }
 
 fn zero_severity_counts() -> std::collections::BTreeMap<Severity, u32> {
@@ -728,60 +743,6 @@ fn contains_verdict_token(haystack: &str, token: &str) -> bool {
     haystack
         .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
         .any(|part| part.eq_ignore_ascii_case(token))
-}
-
-fn contains_clean_phrase(output: &str) -> bool {
-    let lower = output.to_ascii_lowercase();
-    [
-        "no issues found",
-        "no issues were found",
-        "no blocking issues",
-        "no findings",
-        "\u{672a}\u{53d1}\u{73b0}\u{95ee}\u{9898}",
-        "\u{6ca1}\u{6709}\u{53d1}\u{73b0}\u{95ee}\u{9898}",
-        "\u{65e0}\u{963b}\u{585e}\u{95ee}\u{9898}",
-    ]
-    .iter()
-    .any(|phrase| lower.contains(phrase))
-        || contains_positive_no_issue_clause(&lower)
-}
-
-fn contains_positive_no_issue_clause(lower: &str) -> bool {
-    const NOUNS: &[&str] = &[
-        "issue", "issues", "finding", "findings", "concern", "concerns",
-    ];
-    const TAIL_VERBS: &[&str] = &["found", "identified", "detected", "introduced"];
-    const MAX_TOKENS_BEFORE_NOUN: usize = 6;
-    const MAX_TOKENS_AFTER_NOUN: usize = 4;
-
-    let tokens: Vec<&str> = lower
-        .split(|c: char| !c.is_ascii_alphanumeric())
-        .filter(|token| !token.is_empty())
-        .collect();
-
-    for (no_index, token) in tokens.iter().enumerate() {
-        if *token != "no" {
-            continue;
-        }
-
-        let search_end = (no_index + 1 + MAX_TOKENS_BEFORE_NOUN).min(tokens.len());
-        let Some(relative_noun_index) = tokens[no_index + 1..search_end]
-            .iter()
-            .position(|candidate| NOUNS.contains(candidate))
-        else {
-            continue;
-        };
-        let noun_index = no_index + 1 + relative_noun_index;
-        let tail_end = (noun_index + 1 + MAX_TOKENS_AFTER_NOUN).min(tokens.len());
-        if tokens[noun_index + 1..tail_end]
-            .iter()
-            .any(|candidate| TAIL_VERBS.contains(candidate))
-        {
-            return true;
-        }
-    }
-
-    false
 }
 
 fn is_findings_header(line: &str) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -1,0 +1,99 @@
+use std::{fs, path::Path};
+
+use anyhow::Result;
+
+use super::extract_review_text;
+
+pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    [
+        "no blocking",
+        "no issues found",
+        "no issues were found",
+        "no actionable findings",
+        "ship-ready",
+        "ship ready",
+        "\u{672a}\u{53d1}\u{73b0}\u{9700}\u{8981}\u{963b}\u{585e}\u{5408}\u{5e76}",
+        "\u{672a}\u{53d1}\u{73b0}\u{963b}\u{585e}",
+    ]
+    .iter()
+    .any(|phrase| lower.contains(phrase))
+        || (lower.contains("no correctness")
+            && [
+                "issue", "issues", "problem", "problems", "finding", "findings",
+            ]
+            .iter()
+            .any(|noun| lower.contains(noun)))
+}
+
+pub(super) fn review_contains_prose_clean_conclusion(session_dir: &Path) -> Result<bool> {
+    if let Some(summary) = csa_session::read_section(session_dir, "summary")?
+        && detect_prose_clean_conclusion(&summary)
+    {
+        return Ok(true);
+    }
+
+    let full_output_path = session_dir.join("output").join("full.md");
+    if !full_output_path.exists() {
+        return Ok(false);
+    }
+
+    let raw_output = fs::read_to_string(&full_output_path)
+        .map_err(|error| anyhow::anyhow!("read {}: {error}", full_output_path.display()))?;
+    let review_text = extract_review_text(&raw_output).unwrap_or(raw_output);
+    Ok(detect_prose_clean_conclusion(&review_text))
+}
+
+pub(super) fn contains_clean_phrase(output: &str) -> bool {
+    let lower = output.to_ascii_lowercase();
+    [
+        "no issues found",
+        "no issues were found",
+        "no blocking issues",
+        "no findings",
+        "\u{672a}\u{53d1}\u{73b0}\u{95ee}\u{9898}",
+        "\u{6ca1}\u{6709}\u{53d1}\u{73b0}\u{95ee}\u{9898}",
+        "\u{65e0}\u{963b}\u{585e}\u{95ee}\u{9898}",
+    ]
+    .iter()
+    .any(|phrase| lower.contains(phrase))
+        || contains_positive_no_issue_clause(&lower)
+}
+
+fn contains_positive_no_issue_clause(lower: &str) -> bool {
+    const NOUNS: &[&str] = &[
+        "issue", "issues", "finding", "findings", "concern", "concerns",
+    ];
+    const TAIL_VERBS: &[&str] = &["found", "identified", "detected", "introduced"];
+    const MAX_TOKENS_BEFORE_NOUN: usize = 6;
+    const MAX_TOKENS_AFTER_NOUN: usize = 4;
+
+    let tokens: Vec<&str> = lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .collect();
+
+    for (index, token) in tokens.iter().enumerate() {
+        if *token != "no" && *token != "without" {
+            continue;
+        }
+
+        let noun_index = ((index + 1)..tokens.len()).find(|candidate| {
+            candidate.saturating_sub(index + 1) <= MAX_TOKENS_BEFORE_NOUN
+                && NOUNS.contains(&tokens[*candidate])
+        });
+        let Some(noun_index) = noun_index else {
+            continue;
+        };
+
+        let verb_matches = ((noun_index + 1)..tokens.len()).any(|candidate| {
+            candidate.saturating_sub(noun_index + 1) <= MAX_TOKENS_AFTER_NOUN
+                && TAIL_VERBS.contains(&tokens[candidate])
+        });
+        if verb_matches || noun_index == tokens.len() - 1 {
+            return true;
+        }
+    }
+
+    false
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
@@ -8,7 +8,7 @@ fn persist_review_verdict_empty_findings_with_prose_clean_summary_emits_pass() {
     let artifact = json!({
         "findings": [],
         "severity_summary": SeveritySummary::default(),
-        "overall_risk": "high"
+        "overall_risk": "low"
     });
     fs::write(
         session_dir.join("review-findings.json"),
@@ -43,7 +43,7 @@ fn persist_review_verdict_empty_findings_with_chinese_prose_clean_summary_emits_
     let artifact = json!({
         "findings": [],
         "severity_summary": SeveritySummary::default(),
-        "overall_risk": "high"
+        "overall_risk": "low"
     });
     fs::write(
         session_dir.join("review-findings.json"),
@@ -141,6 +141,41 @@ fn persist_review_verdict_findings_dominate_prose_clean_summary() {
     assert_eq!(artifact.decision, ReviewDecision::Fail);
     assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
     assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn persist_review_verdict_prose_clean_summary_respects_high_overall_risk_fail_closed() {
+    let session_id = "01TESTPROSECLEANRISK0000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-prose-clean-high-risk", session_id);
+    let artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary::default(),
+        "overall_risk": "high"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
+    )
+    .expect("write findings artifact");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nNo blocking issues found.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert!(artifact.severity_counts.values().all(|value| *value == 0));
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
@@ -1,0 +1,146 @@
+use super::*;
+
+#[test]
+fn persist_review_verdict_empty_findings_with_prose_clean_summary_emits_pass() {
+    let session_id = "01TESTPROSECLEANEN000000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-prose-clean-en", session_id);
+    let artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary::default(),
+        "overall_risk": "high"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
+    )
+    .expect("write findings artifact");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nNo blocking correctness, contract, or security issues found.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|value| *value == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn persist_review_verdict_empty_findings_with_chinese_prose_clean_summary_emits_pass() {
+    let session_id = "01TESTPROSECLEANCN000000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-prose-clean-cn", session_id);
+    let artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary::default(),
+        "overall_risk": "high"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
+    )
+    .expect("write findings artifact");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\n\u{672a}\u{53d1}\u{73b0}\u{9700}\u{8981}\u{963b}\u{585e}\u{5408}\u{5e76}\u{7684}\u{95ee}\u{9898}\u{ff0c}\u{5c5e}\u{4e8e}\u{8bed}\u{4e49}\u{7b49}\u{4ef7}\u{91cd}\u{6784}\u{3002}\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|value| *value == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn persist_review_verdict_empty_findings_without_prose_clean_marker_stays_fail_closed() {
+    let session_id = "01TESTNOPROSECLEAN000000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-no-prose-clean", session_id);
+    let artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary::default(),
+        "overall_risk": "low"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
+    )
+    .expect("write findings artifact");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nSemantics-preserving refactor.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn persist_review_verdict_findings_dominate_prose_clean_summary() {
+    let session_id = "01TESTFINDINGSDOMINATE000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-findings-dominate", session_id);
+    let findings = vec![make_finding(Severity::High, "blocking-high")];
+    let artifact = json!({
+        "findings": findings,
+        "severity_summary": SeveritySummary {
+            critical: 0,
+            high: 1,
+            medium: 0,
+            low: 0,
+        },
+        "overall_risk": "low"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
+    )
+    .expect("write findings artifact");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nNo blocking issues found.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -637,6 +637,9 @@ fn persist_review_verdict_empty_structured_findings_preserve_uncertain_meta() {
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
+#[path = "review_cmd_output_prose_clean_tests.rs"]
+mod prose_clean_tests;
+
 #[test]
 fn persist_review_verdict_json_transcript_without_review_message_emits_uncertain_verdict() {
     let session_id = "01TESTJSONNOREVIEWMESSAGE00";


### PR DESCRIPTION
## Summary

- Adds `review_cmd_output_clean` module with prose CLEAN detector (English + Chinese markers).
- Parser precedence: findings present → Fail unchanged; findings empty + prose CLEAN + severity 0 → Pass (new); findings empty + no prose → Fail (fail-closed unchanged); no structured section + truly-empty → Uncertain (unchanged).
- 4+ regression tests cover English, Chinese, findings-dominate-prose, and no-marker fail-closed.

Closes #946.

## Test plan

- [ ] cargo test -p cli-sub-agent review_cmd_output exit 0
- [ ] just pre-commit exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)