### PR TITLE
fix(csa-session): load_result + csa session result surface output sidecar (#686)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.423"
+version = "0.1.424"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "chrono",
@@ -952,12 +952,13 @@ dependencies = [
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "tracing-subscriber",
  "ulid",
 ]
 
 [[package]]
 name = "csa-todo"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.422"
+version = "0.1.423"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.421"
+version = "0.1.422"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.422"
+version = "0.1.423"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.423"
+version = "0.1.424"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.421"
+version = "0.1.422"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -629,6 +629,7 @@ fn append_debate_artifacts_to_result_updates_summary_and_artifacts() {
             events_count: 0,
             artifacts: Vec::new(),
             peak_memory_mb: None,
+            manager_fields: Default::default(),
         },
     )
     .unwrap();

--- a/crates/cli-sub-agent/src/pipeline_execute.rs
+++ b/crates/cli-sub-agent/src/pipeline_execute.rs
@@ -175,6 +175,7 @@ pub(crate) async fn execute_transport_with_signal(
                 events_count: 0,
                 artifacts: Vec::new(),
                 peak_memory_mb,
+                manager_fields: Default::default(),
             };
             if let Err(save_err) = save_result(project_root, &session.meta_session_id, &result) {
                 warn!("Failed to save transport error result: {}", save_err);
@@ -218,6 +219,7 @@ fn record_session_termination(
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     };
     if let Err(e) = save_result(project_root, &session.meta_session_id, &updated_result) {
         warn!(

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -118,6 +118,7 @@ pub(crate) async fn process_execution_result(
         events_count: ctx.events_count,
         artifacts: ctx.transcript_artifacts,
         peak_memory_mb: result.peak_memory_mb,
+        manager_fields: Default::default(),
     };
     if let Err(err) = crate::session_observability::enrich_result_from_session_dir(
         ctx.project_root,
@@ -383,6 +384,7 @@ pub(crate) fn ensure_terminal_result_on_post_exec_error(
         events_count: 0,
         artifacts,
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     };
 
     if let Err(save_err) = save_result(project_root, &session.meta_session_id, &fallback_result) {
@@ -643,6 +645,7 @@ mod tests {
             events_count: 1,
             artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
             peak_memory_mb: None,
+            manager_fields: Default::default(),
         };
         save_result(project_root, &session.meta_session_id, &existing)
             .expect("write existing result");
@@ -735,6 +738,7 @@ mod tests {
             events_count: 0,
             artifacts: Vec::new(),
             peak_memory_mb: None,
+            manager_fields: Default::default(),
         };
 
         if is_codex_exec_initial_stall_summary(&result.tool, result.exit_code, &result.summary) {

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -435,6 +435,7 @@ fn maybe_synthesize_missing_review_result(
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb,
+        manager_fields: Default::default(),
     };
 
     if let Err(save_err) = save_result(project_root, &session_id, &fallback_result) {

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -364,6 +364,7 @@ where
         events_count: 0,
         artifacts,
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     };
     #[rustfmt::skip]
     let result_contents = toml::to_string_pretty(&fallback).map_err(|err| anyhow!("Failed to serialize synthetic result for {session_id}: {err}"))?;

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -142,6 +142,7 @@ fn make_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     }
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
@@ -105,6 +105,7 @@ fn make_result(status: &str, exit_code: i32) -> SessionResult {
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     }
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -69,6 +69,7 @@ fn make_result(status: &str, exit_code: i32) -> SessionResult {
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     }
 }
 
@@ -488,6 +489,7 @@ fn late_real_result_already_exists_cleans_up_reconcile_owned_sidecar() {
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     })
     .unwrap();
 
@@ -542,6 +544,7 @@ fn retire_if_dead_with_result_preserves_pr_bot_handoff_for_real_results() {
             events_count: 0,
             artifacts: Vec::new(),
             peak_memory_mb: None,
+            manager_fields: Default::default(),
         },
     )
     .unwrap();

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -168,7 +168,7 @@ pub(crate) fn handle_session_result(
                 Ok(Some(view)) => view,
                 Ok(None) => SessionResultView {
                     envelope: result.clone(),
-                    manager_sidecar: None,
+                    manager_sidecar: result.manager_fields.as_sidecar(),
                     legacy_sidecar: None,
                 },
                 Err(err) => {
@@ -179,7 +179,7 @@ pub(crate) fn handle_session_result(
                     );
                     SessionResultView {
                         envelope: result.clone(),
-                        manager_sidecar: None,
+                        manager_sidecar: result.manager_fields.as_sidecar(),
                         legacy_sidecar: None,
                     }
                 }

--- a/crates/cli-sub-agent/src/session_cmds_result_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests.rs
@@ -335,6 +335,7 @@ fn build_result_json_payload_includes_review_iterations() {
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     };
     let review_meta = ReviewSessionMeta {
         session_id: "01JTESTPAYLOAD00000000000001".to_string(),
@@ -380,6 +381,7 @@ fn build_result_json_payload_includes_result_sidecars() {
             events_count: 0,
             artifacts: Vec::new(),
             peak_memory_mb: None,
+            manager_fields: Default::default(),
         },
         manager_sidecar: Some(
             toml::toml! {
@@ -419,6 +421,7 @@ fn build_result_json_payload_redacts_result_sidecars() {
             events_count: 0,
             artifacts: Vec::new(),
             peak_memory_mb: None,
+            manager_fields: Default::default(),
         },
         manager_sidecar: Some(
             toml::toml! {
@@ -434,6 +437,48 @@ fn build_result_json_payload_redacts_result_sidecars() {
     let rendered = serde_json::to_string(&payload).unwrap();
     assert!(!rendered.contains("hunter2"));
     assert!(rendered.contains("[REDACTED]"));
+}
+
+#[test]
+fn sidecar_from_manager_fields_rehydrates_manager_sections() {
+    let sidecar = csa_session::SessionManagerFields {
+        result: Some(
+            toml::toml! {
+                done = true
+            }
+            .into(),
+        ),
+        report: Some(
+            toml::toml! {
+                summary = "manager-visible"
+            }
+            .into(),
+        ),
+        artifacts: Some(
+            toml::toml! {
+                count = 2
+            }
+            .into(),
+        ),
+    }
+    .as_sidecar()
+    .expect("sidecar should be rehydrated");
+
+    assert_eq!(sidecar["result"]["done"], toml::Value::Boolean(true));
+    assert_eq!(
+        sidecar["report"]["summary"],
+        toml::Value::String("manager-visible".to_string())
+    );
+    assert_eq!(sidecar["artifacts"]["count"], toml::Value::Integer(2));
+}
+
+#[test]
+fn sidecar_from_manager_fields_skips_empty_manager_sections() {
+    assert!(
+        csa_session::SessionManagerFields::default()
+            .as_sidecar()
+            .is_none()
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_result_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests.rs
@@ -454,6 +454,30 @@ fn sidecar_from_manager_fields_rehydrates_manager_sections() {
             }
             .into(),
         ),
+        timing: Some(
+            toml::toml! {
+                started_at = "2026-02-11T10:00:00Z"
+            }
+            .into(),
+        ),
+        tool: Some(
+            toml::toml! {
+                name = "claude-code"
+            }
+            .into(),
+        ),
+        review: Some(
+            toml::toml! {
+                reviewer_tool = "codex"
+            }
+            .into(),
+        ),
+        clarification: Some(
+            toml::toml! {
+                blocking_reason = "Need answer"
+            }
+            .into(),
+        ),
         artifacts: Some(
             toml::toml! {
                 count = 2
@@ -468,6 +492,22 @@ fn sidecar_from_manager_fields_rehydrates_manager_sections() {
     assert_eq!(
         sidecar["report"]["summary"],
         toml::Value::String("manager-visible".to_string())
+    );
+    assert_eq!(
+        sidecar["timing"]["started_at"],
+        toml::Value::String("2026-02-11T10:00:00Z".to_string())
+    );
+    assert_eq!(
+        sidecar["tool"]["name"],
+        toml::Value::String("claude-code".to_string())
+    );
+    assert_eq!(
+        sidecar["review"]["reviewer_tool"],
+        toml::Value::String("codex".to_string())
+    );
+    assert_eq!(
+        sidecar["clarification"]["blocking_reason"],
+        toml::Value::String("Need answer".to_string())
     );
     assert_eq!(sidecar["artifacts"]["count"], toml::Value::Integer(2));
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -53,6 +53,7 @@ fn make_result(status: &str, exit_code: i32) -> SessionResult {
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     }
 }
 

--- a/crates/cli-sub-agent/src/session_guard.rs
+++ b/crates/cli-sub-agent/src/session_guard.rs
@@ -89,6 +89,7 @@ pub(crate) fn write_pre_exec_error_result(
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     };
     if let Err(e) = save_result(project_root, session_id, &result) {
         warn!("Failed to save pre-execution error result: {}", e);

--- a/crates/csa-executor/src/transport_fork.rs
+++ b/crates/csa-executor/src/transport_fork.rs
@@ -395,6 +395,7 @@ mod tests {
             events_count: 0,
             artifacts: vec![],
             peak_memory_mb: None,
+            manager_fields: Default::default(),
         };
         std::fs::write(
             tmp.path().join(RESULT_FILE_NAME),

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -315,6 +315,7 @@ fn test_apply_codex_exec_initial_stall_summary_renders_reason_for_result_toml() 
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     };
     let toml = toml::to_string_pretty(&result).expect("serialize session result");
 

--- a/crates/csa-session/Cargo.toml
+++ b/crates/csa-session/Cargo.toml
@@ -23,3 +23,4 @@ data-encoding = "2.6"
 tempfile.workspace = true
 
 [dev-dependencies]
+tracing-subscriber.workspace = true

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -66,7 +66,7 @@ pub use output_section::{
     RETURN_PACKET_SECTION_ID, ReturnPacket, ReturnPacketRef, ReturnStatus,
 };
 pub use redact::{redact_event, redact_text_content};
-pub use result::{SessionArtifact, SessionResult};
+pub use result::{SessionArtifact, SessionManagerFields, SessionResult};
 pub use review_artifact::{
     Finding, FindingsFile, REVIEW_VERDICT_SCHEMA_VERSION, ReviewArtifact, ReviewFinding,
     ReviewFindingFileRange, ReviewVerdictArtifact, Severity, SeveritySummary, write_findings_toml,

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -333,6 +333,7 @@ pub(crate) fn load_result_in(base_dir: &Path, session_id: &str) -> Result<Option
     validate_session_id(session_id)?;
     let session_dir = super::get_session_dir_in(base_dir, session_id);
     let result_path = session_dir.join(RESULT_FILE_NAME);
+    let manager_sidecar_path = session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH);
     if !result_path.exists() {
         return Ok(None);
     }
@@ -340,9 +341,17 @@ pub(crate) fn load_result_in(base_dir: &Path, session_id: &str) -> Result<Option
         .with_context(|| format!("Failed to read result: {}", result_path.display()))?;
     let mut result: SessionResult = toml::from_str(&contents)
         .with_context(|| format!("Failed to parse result: {}", result_path.display()))?;
-    if let Some(sidecar) =
-        load_optional_result_sidecar(&session_dir, CONTRACT_RESULT_ARTIFACT_PATH)?
-    {
+    let manager_sidecar = load_optional_result_sidecar(&session_dir, CONTRACT_RESULT_ARTIFACT_PATH)
+        .unwrap_or_else(|error| {
+            tracing::warn!(
+                target: "csa-session.load_result",
+                path = %manager_sidecar_path.display(),
+                error = %error,
+                "sidecar present but unreadable/malformed; ignoring (runtime envelope still loaded)"
+            );
+            None
+        });
+    if let Some(sidecar) = manager_sidecar {
         result.manager_fields = crate::result::SessionManagerFields::from_sidecar(&sidecar);
     }
     Ok(Some(result))

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -338,8 +338,13 @@ pub(crate) fn load_result_in(base_dir: &Path, session_id: &str) -> Result<Option
     }
     let contents = fs::read_to_string(&result_path)
         .with_context(|| format!("Failed to read result: {}", result_path.display()))?;
-    let result: SessionResult = toml::from_str(&contents)
+    let mut result: SessionResult = toml::from_str(&contents)
         .with_context(|| format!("Failed to parse result: {}", result_path.display()))?;
+    if let Some(sidecar) =
+        load_optional_result_sidecar(&session_dir, CONTRACT_RESULT_ARTIFACT_PATH)?
+    {
+        result.manager_fields = crate::result::SessionManagerFields::from_sidecar(&sidecar);
+    }
     Ok(Some(result))
 }
 

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -1,3 +1,49 @@
+use std::io;
+use std::sync::{Arc, LazyLock, Mutex};
+use tracing_subscriber::fmt::MakeWriter;
+
+static TEST_TRACING_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[derive(Clone, Default)]
+struct SharedLogBuffer {
+    inner: Arc<Mutex<Vec<u8>>>,
+}
+
+impl SharedLogBuffer {
+    fn contents(&self) -> String {
+        String::from_utf8(self.inner.lock().expect("log buffer poisoned").clone())
+            .expect("log buffer should be valid UTF-8")
+    }
+}
+
+impl<'a> MakeWriter<'a> for SharedLogBuffer {
+    type Writer = SharedLogWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        SharedLogWriter {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+struct SharedLogWriter {
+    inner: Arc<Mutex<Vec<u8>>>,
+}
+
+impl io::Write for SharedLogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner
+            .lock()
+            .expect("log buffer poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 #[test]
 fn test_load_result_view_surfaces_manager_and_legacy_sidecars() {
     let td = tempdir().unwrap();
@@ -139,6 +185,54 @@ fn test_load_result_without_sidecar_keeps_manager_fields_empty() {
         .unwrap()
         .expect("result should exist");
     assert!(loaded.manager_fields.is_empty());
+}
+
+#[test]
+fn test_load_result_with_malformed_manager_sidecar_is_non_fatal() {
+    let _tracing_guard = TEST_TRACING_LOCK.lock().expect("tracing lock poisoned");
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+
+    let now = chrono::Utc::now();
+    let runtime_result = crate::result::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "runtime summary".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        peak_memory_mb: None,
+        manager_fields: Default::default(),
+    };
+    save_result_in(td.path(), &state.meta_session_id, &runtime_result).unwrap();
+
+    std::fs::write(
+        session_dir.join(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        "not = [valid toml",
+    )
+    .unwrap();
+
+    let buffer = SharedLogBuffer::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .with_max_level(tracing::Level::WARN)
+        .with_writer(buffer.clone())
+        .without_time()
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .expect("result should exist");
+
+    assert_eq!(loaded.summary, "runtime summary");
+    assert!(loaded.manager_fields.is_empty());
+    assert!(buffer.contents().contains(
+        "sidecar present but unreadable/malformed; ignoring (runtime envelope still loaded)"
+    ));
 }
 
 #[test]

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -15,6 +15,7 @@ fn test_load_result_view_surfaces_manager_and_legacy_sidecars() {
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     save_result_in(td.path(), &state.meta_session_id, &runtime_result).unwrap();
 
@@ -49,6 +50,95 @@ fn test_load_result_view_surfaces_manager_and_legacy_sidecars() {
                 .collect()
         ))
     );
+}
+
+#[test]
+fn test_load_result_merges_manager_sidecar_sections_into_runtime_result() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+
+    let now = chrono::Utc::now();
+    let runtime_result = crate::result::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "runtime summary".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        peak_memory_mb: None,
+        manager_fields: Default::default(),
+    };
+    save_result_in(td.path(), &state.meta_session_id, &runtime_result).unwrap();
+
+    std::fs::write(
+        session_dir.join(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        r#"
+[result]
+done = true
+
+[report]
+summary = "manager-visible"
+
+[artifacts]
+count = 2
+"#,
+    )
+    .unwrap();
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .expect("result should exist");
+
+    assert_eq!(loaded.summary, "runtime summary");
+    assert_eq!(
+        loaded.manager_fields.result.as_ref().and_then(|value| value.get("done")),
+        Some(&toml::Value::Boolean(true))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .report
+            .as_ref()
+            .and_then(|value| value.get("summary")),
+        Some(&toml::Value::String("manager-visible".to_string()))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .artifacts
+            .as_ref()
+            .and_then(|value| value.get("count")),
+        Some(&toml::Value::Integer(2))
+    );
+}
+
+#[test]
+fn test_load_result_without_sidecar_keeps_manager_fields_empty() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+
+    let now = chrono::Utc::now();
+    let runtime_result = crate::result::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "runtime summary".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        peak_memory_mb: None,
+        manager_fields: Default::default(),
+    };
+    save_result_in(td.path(), &state.meta_session_id, &runtime_result).unwrap();
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .expect("result should exist");
+    assert!(loaded.manager_fields.is_empty());
 }
 
 #[test]

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -128,6 +128,21 @@ done = true
 [report]
 summary = "manager-visible"
 
+[timing]
+started_at = "2026-02-11T10:00:00Z"
+ended_at = "2026-02-11T10:05:00Z"
+
+[tool]
+name = "claude-code"
+
+[review]
+author_tool = "claude-code"
+reviewer_tool = "codex"
+
+[clarification]
+blocking_reason = "Need scope confirmation"
+questions = ["Question 1", "Question 2"]
+
 [artifacts]
 count = 2
 "#,
@@ -154,11 +169,185 @@ count = 2
     assert_eq!(
         loaded
             .manager_fields
+            .timing
+            .as_ref()
+            .and_then(|value| value.get("started_at")),
+        Some(&toml::Value::String("2026-02-11T10:00:00Z".to_string()))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .tool
+            .as_ref()
+            .and_then(|value| value.get("name")),
+        Some(&toml::Value::String("claude-code".to_string()))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .review
+            .as_ref()
+            .and_then(|value| value.get("reviewer_tool")),
+        Some(&toml::Value::String("codex".to_string()))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .clarification
+            .as_ref()
+            .and_then(|value| value.get("blocking_reason")),
+        Some(&toml::Value::String("Need scope confirmation".to_string()))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
             .artifacts
             .as_ref()
             .and_then(|value| value.get("count")),
         Some(&toml::Value::Integer(2))
     );
+}
+
+#[test]
+fn test_manager_sidecar_roundtrip_preserves_full_sa_schema() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+
+    let now = chrono::Utc::now();
+    let runtime_result = crate::result::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "runtime summary".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        peak_memory_mb: None,
+        manager_fields: Default::default(),
+    };
+    save_result_in(td.path(), &state.meta_session_id, &runtime_result).unwrap();
+
+    let input_sidecar = toml::Value::Table(toml::toml! {
+        [result]
+        status = "needs_clarification"
+        summary = "Need guidance on rollout"
+        error_code = ""
+        session_id = "019c4c24-full-schema"
+
+        [report]
+        what_was_done = "Collected manager-facing report fields"
+        key_decisions = ["Kept sidecar load non-fatal", "Preserved contract sections"]
+        risks_identified = ["Awaiting user answer"]
+        files_changed = 2
+        tests_added = 1
+        tests_passing = true
+
+        [timing]
+        started_at = "2026-02-11T10:00:00Z"
+        ended_at = "2026-02-11T10:05:00Z"
+
+        [tool]
+        name = "claude-code"
+
+        [review]
+        author_tool = "claude-code"
+        reviewer_tool = "codex"
+
+        [clarification]
+        questions = ["Should token expiry be configurable?", "Should refresh tokens be included in this scope?"]
+        blocking_reason = "Security requirement is ambiguous"
+
+        [artifacts]
+        todo_path = "output/TODO.md"
+        commit_hash = "abc1234"
+        review_result = "CLEAN"
+    });
+    let input_sidecar_str = toml::to_string_pretty(&input_sidecar).unwrap();
+    std::fs::write(
+        session_dir.join(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        &input_sidecar_str,
+    )
+    .unwrap();
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .expect("result should exist");
+    assert_eq!(loaded.manager_fields.as_sidecar(), Some(input_sidecar.clone()));
+    assert_eq!(
+        loaded
+            .manager_fields
+            .result
+            .as_ref()
+            .and_then(|value| value.get("status")),
+        Some(&toml::Value::String("needs_clarification".to_string()))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .report
+            .as_ref()
+            .and_then(|value| value.get("files_changed")),
+        Some(&toml::Value::Integer(2))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .timing
+            .as_ref()
+            .and_then(|value| value.get("ended_at")),
+        Some(&toml::Value::String("2026-02-11T10:05:00Z".to_string()))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .tool
+            .as_ref()
+            .and_then(|value| value.get("name")),
+        Some(&toml::Value::String("claude-code".to_string()))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .review
+            .as_ref()
+            .and_then(|value| value.get("author_tool")),
+        Some(&toml::Value::String("claude-code".to_string()))
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .clarification
+            .as_ref()
+            .and_then(|value| value.get("questions"))
+            .and_then(toml::Value::as_array)
+            .map(Vec::len),
+        Some(2)
+    );
+    assert_eq!(
+        loaded
+            .manager_fields
+            .artifacts
+            .as_ref()
+            .and_then(|value| value.get("review_result")),
+        Some(&toml::Value::String("CLEAN".to_string()))
+    );
+
+    let roundtrip_sidecar = loaded
+        .manager_fields
+        .as_sidecar()
+        .expect("sidecar should round-trip");
+    let roundtrip_path = session_dir.join("output/result.roundtrip.toml");
+    std::fs::write(
+        &roundtrip_path,
+        toml::to_string_pretty(&roundtrip_sidecar).unwrap(),
+    )
+    .unwrap();
+
+    let reloaded: toml::Value =
+        toml::from_str(&std::fs::read_to_string(&roundtrip_path).unwrap()).unwrap();
+    assert_eq!(reloaded, input_sidecar);
 }
 
 #[test]

--- a/crates/csa-session/src/manager_tests_tail.rs
+++ b/crates/csa-session/src/manager_tests_tail.rs
@@ -40,6 +40,7 @@ fn test_save_and_load_result() {
         events_count: 0,
         artifacts: vec![crate::result::SessionArtifact::new("output/result.txt")],
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     save_result_in(td.path(), &state.meta_session_id, &result).unwrap();
     let loaded = load_result_in(td.path(), &state.meta_session_id)
@@ -85,6 +86,7 @@ fn test_save_session_and_result_preserve_legacy_symlink_root() {
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     let canonical_project = project.canonicalize().unwrap();
     let mut loaded = load_session(&canonical_project, &state.meta_session_id).unwrap();
@@ -141,6 +143,7 @@ name = "gemini-cli"
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     save_result_in(td.path(), &state.meta_session_id, &runtime_result).unwrap();
 
@@ -196,6 +199,7 @@ artifacts = [1, 2]
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     save_result_in(td.path(), &state.meta_session_id, &runtime_result).unwrap();
 
@@ -237,6 +241,7 @@ fn test_save_result_retain_contract_result_artifact_when_output_result_exists() 
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     save_result_in(td.path(), &state.meta_session_id, &runtime_result).unwrap();
 
@@ -282,6 +287,7 @@ name = "gemini-cli"
         events_count: 1,
         artifacts: vec![],
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     save_result_in(td.path(), &state.meta_session_id, &first_runtime).unwrap();
 
@@ -295,6 +301,7 @@ name = "gemini-cli"
         events_count: 2,
         artifacts: vec![],
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     save_result_in(td.path(), &state.meta_session_id, &second_runtime).unwrap();
 
@@ -344,6 +351,7 @@ done = false
         events_count: 0,
         artifacts: vec![],
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     let err = save_result_in(td.path(), &state.meta_session_id, &runtime_result).unwrap_err();
     assert!(err.to_string().contains("not a file"));
@@ -365,6 +373,7 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
         events_count: 7,
         artifacts: vec![crate::result::SessionArtifact::new("output/old-artifact.txt")],
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     save_result_in(td.path(), &state.meta_session_id, &old_result).unwrap();
 
@@ -378,6 +387,7 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
         events_count: 0,
         artifacts: vec![],
         peak_memory_mb: None,
+            manager_fields: Default::default(),
     };
     save_result_in(td.path(), &state.meta_session_id, &new_result).unwrap();
 

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -3,6 +3,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
+use toml::Value as TomlValue;
 
 pub const RESULT_FILE_NAME: &str = "result.toml";
 
@@ -74,6 +75,48 @@ fn is_zero(value: &u64) -> bool {
     *value == 0
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SessionManagerFields {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<TomlValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub report: Option<TomlValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<TomlValue>,
+}
+
+impl SessionManagerFields {
+    pub fn from_sidecar(sidecar: &TomlValue) -> Self {
+        Self {
+            result: sidecar.get("result").cloned(),
+            report: sidecar.get("report").cloned(),
+            artifacts: sidecar.get("artifacts").cloned(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.result.is_none() && self.report.is_none() && self.artifacts.is_none()
+    }
+
+    pub fn as_sidecar(&self) -> Option<TomlValue> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let mut table = toml::map::Map::<String, TomlValue>::new();
+        if let Some(result) = self.result.as_ref() {
+            table.insert("result".to_string(), result.clone());
+        }
+        if let Some(report) = self.report.as_ref() {
+            table.insert("report".to_string(), report.clone());
+        }
+        if let Some(artifacts) = self.artifacts.as_ref() {
+            table.insert("artifacts".to_string(), artifacts.clone());
+        }
+        Some(TomlValue::Table(table))
+    }
+}
+
 /// Structured result of a session execution.
 /// Written to `sessions/{id}/result.toml` after each tool invocation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -104,6 +147,11 @@ pub struct SessionResult {
     /// `None` when cgroup monitoring is unavailable or the scope was already removed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub peak_memory_mb: Option<u64>,
+    /// Manager-facing data loaded from `output/result.toml` sidecars at read time.
+    /// This is intentionally read-only metadata and is never serialized back into
+    /// the runtime `result.toml` envelope.
+    #[serde(skip_serializing, skip_deserializing, default)]
+    pub manager_fields: SessionManagerFields,
 }
 
 impl SessionResult {
@@ -137,6 +185,7 @@ mod tests {
             events_count: 4,
             artifacts: vec![SessionArtifact::new("output/diff.patch")],
             peak_memory_mb: None,
+            manager_fields: Default::default(),
         };
 
         let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
@@ -164,6 +213,7 @@ mod tests {
             events_count: 0,
             artifacts: vec![],
             peak_memory_mb: None,
+            manager_fields: Default::default(),
         };
 
         let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
@@ -245,6 +295,7 @@ artifacts = ["output/a.txt", "output/b.txt"]
                 SessionArtifact::with_stats("output/acp-events.jsonl", 10, 256),
             ],
             peak_memory_mb: None,
+            manager_fields: Default::default(),
         };
 
         let contents = toml::to_string_pretty(&result).unwrap();

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -82,6 +82,14 @@ pub struct SessionManagerFields {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub report: Option<TomlValue>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timing: Option<TomlValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<TomlValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review: Option<TomlValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clarification: Option<TomlValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifacts: Option<TomlValue>,
 }
 
@@ -90,12 +98,22 @@ impl SessionManagerFields {
         Self {
             result: sidecar.get("result").cloned(),
             report: sidecar.get("report").cloned(),
+            timing: sidecar.get("timing").cloned(),
+            tool: sidecar.get("tool").cloned(),
+            review: sidecar.get("review").cloned(),
+            clarification: sidecar.get("clarification").cloned(),
             artifacts: sidecar.get("artifacts").cloned(),
         }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.result.is_none() && self.report.is_none() && self.artifacts.is_none()
+        self.result.is_none()
+            && self.report.is_none()
+            && self.timing.is_none()
+            && self.tool.is_none()
+            && self.review.is_none()
+            && self.clarification.is_none()
+            && self.artifacts.is_none()
     }
 
     pub fn as_sidecar(&self) -> Option<TomlValue> {
@@ -109,6 +127,18 @@ impl SessionManagerFields {
         }
         if let Some(report) = self.report.as_ref() {
             table.insert("report".to_string(), report.clone());
+        }
+        if let Some(timing) = self.timing.as_ref() {
+            table.insert("timing".to_string(), timing.clone());
+        }
+        if let Some(tool) = self.tool.as_ref() {
+            table.insert("tool".to_string(), tool.clone());
+        }
+        if let Some(review) = self.review.as_ref() {
+            table.insert("review".to_string(), review.clone());
+        }
+        if let Some(clarification) = self.clarification.as_ref() {
+            table.insert("clarification".to_string(), clarification.clone());
         }
         if let Some(artifacts) = self.artifacts.as_ref() {
             table.insert("artifacts".to_string(), artifacts.clone());

--- a/crates/csa-session/src/soft_fork_tests.rs
+++ b/crates/csa-session/src/soft_fork_tests.rs
@@ -22,6 +22,7 @@ fn test_soft_fork_full_parent_session() {
         events_count: 0,
         artifacts: vec![SessionArtifact::new("output/diff.patch")],
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     };
     let result_toml = toml::to_string_pretty(&result).unwrap();
     std::fs::write(session_dir.join(RESULT_FILE_NAME), &result_toml).unwrap();
@@ -65,6 +66,7 @@ fn test_soft_fork_truncation_on_large_summary() {
         events_count: 0,
         artifacts: vec![],
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     };
     std::fs::write(
         session_dir.join(RESULT_FILE_NAME),
@@ -122,6 +124,7 @@ fn test_soft_fork_result_only_no_output() {
         events_count: 0,
         artifacts: vec![],
         peak_memory_mb: None,
+        manager_fields: Default::default(),
     };
     std::fs::write(
         session_dir.join(RESULT_FILE_NAME),


### PR DESCRIPTION
## Summary

- `load_result()` now merges `sessions/<id>/output/result.toml` sidecar into returned struct (manager-facing `[result]`, `[report]`, `[artifacts]` fields).
- `csa session result` CLI renders sidecar sections when present.
- Root envelope precedence preserved for overlapping fields (exit_code, status).
- Absent sidecar returns runtime envelope only, no error.

Closes #686.

## Test plan

- [ ] cargo test -p csa-session manager_result_view exit 0
- [ ] cargo test --workspace exit 0
- [ ] just pre-commit exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)