### PR TITLE
fix(csa-executor): gemini stall classifier preserves specific stderr failures (#912)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.424"
+version = "0.1.425"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.424"
+version = "0.1.425"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -15,6 +15,7 @@ pub(crate) const GEMINI_OAUTH_PROMPT_SUMMARY: &str =
 pub(crate) const GEMINI_ACP_INITIAL_STALL_REASON: &str = "gemini_acp_initial_stall";
 pub(crate) const GEMINI_LEGACY_INITIAL_STALL_REASON: &str = "gemini_legacy_initial_stall";
 const DEFAULT_GEMINI_ACP_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 180;
+const ACP_TIMEOUT_FOOTER_SUFFIX: &str = "s; process killed";
 
 #[derive(Debug, Clone)]
 pub(super) struct GeminiRetryPhase {
@@ -70,6 +71,12 @@ pub(super) fn classify_gemini_acp_initial_stall(
     {
         return None;
     }
+    if !strip_acp_timeout_footer(&execution.stderr_output)
+        .trim()
+        .is_empty()
+    {
+        return None;
+    }
 
     Some(GeminiAcpInitialStallClassification {
         code: GEMINI_ACP_INITIAL_STALL_REASON,
@@ -94,6 +101,34 @@ pub(super) fn apply_gemini_acp_initial_stall_summary(
     }
     execution.stderr_output.push_str(&summary);
     execution.stderr_output.push('\n');
+}
+
+fn strip_acp_timeout_footer(stderr: &str) -> &str {
+    let trimmed = stderr.strip_suffix('\n').unwrap_or(stderr);
+    if let Some((prefix, last_line)) = trimmed.rsplit_once('\n') {
+        if is_acp_timeout_footer(last_line) {
+            return prefix;
+        }
+    } else if is_acp_timeout_footer(trimmed) {
+        return "";
+    }
+
+    stderr
+}
+
+fn is_acp_timeout_footer(line: &str) -> bool {
+    [
+        "initial response timeout: no ACP events/stderr for ",
+        "idle timeout: no ACP events/stderr for ",
+    ]
+    .iter()
+    .any(|prefix| {
+        line.strip_prefix(prefix)
+            .and_then(|suffix| suffix.strip_suffix(ACP_TIMEOUT_FOOTER_SUFFIX))
+            .is_some_and(|seconds| {
+                !seconds.is_empty() && seconds.bytes().all(|b| b.is_ascii_digit())
+            })
+    })
 }
 
 pub(super) fn classify_gemini_legacy_initial_stall(

--- a/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
@@ -134,6 +134,25 @@ fn test_classify_gemini_acp_initial_stall_detects_first_response_timeout() {
 }
 
 #[test]
+fn test_classify_gemini_acp_initial_stall_preserves_specific_stderr() {
+    let execution = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: concat!(
+            "gemini: GEMINI_API_KEY not set\n",
+            "initial response timeout: no ACP events/stderr for 180s; process killed\n"
+        )
+        .to_string(),
+        summary: "initial response timeout: no ACP events/stderr for 180s; process killed"
+            .to_string(),
+        exit_code: 137,
+        peak_memory_mb: None,
+    };
+
+    let classification = classify_gemini_acp_initial_stall(&execution, Some(180));
+    assert_eq!(classification, None);
+}
+
+#[test]
 fn test_apply_gemini_acp_initial_stall_summary_rewrites_summary() {
     let mut execution = csa_process::ExecutionResult {
         output: String::new(),


### PR DESCRIPTION
## Summary
- Gate `classify_gemini_acp_initial_stall()` on stderr being empty of non-footer content
- Preserve specific child-stderr diagnostics instead of overwriting with generic stall label
- Negative regression test: stderr with concrete error + ACP timeout footer → classifier returns None

## Test plan
- [x] `cargo test --workspace` green
- [x] `just pre-commit` green
- [x] Positive path (stderr truly empty → stall fires) preserved

Closes #912.