### PR TITLE
fix(cli-sub-agent): claude-sub-agent alias strategies honor --model-spec (#900)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.425"
+version = "0.1.426"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.425"
+version = "0.1.426"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use std::path::Path;
 use tracing::info;
 
@@ -129,15 +129,14 @@ fn resolve_claude_sub_agent_tool_and_model(
     parent_tool: Option<&str>,
     project_root: &Path,
 ) -> Result<(ToolName, Option<String>, Option<String>)> {
-    let user_explicit_tool = matches!(
-        arg_tool.as_ref(),
-        Some(ToolArg::Specific(_) | ToolArg::Alias(_))
-    );
+    let resolved_arg_tool =
+        resolve_tool_arg_alias(arg_tool, project_config, global_config).map_err(|e| anyhow!(e))?;
+    let user_explicit_tool = matches!(resolved_arg_tool, Some(ToolArg::Specific(_)));
     let resolved_tool = if model_spec.is_some() && !user_explicit_tool {
         None
     } else {
         Some(resolve_claude_tool(
-            arg_tool,
+            resolved_arg_tool,
             project_config,
             global_config,
             parent_tool,
@@ -158,6 +157,21 @@ fn resolve_claude_sub_agent_tool_and_model(
         false,               // claude-sub-agent does not support --force-ignore-tier-setting
         !user_explicit_tool, // treat auto/implicit selection as non-explicit
     )
+}
+
+fn resolve_tool_arg_alias(
+    arg_tool: Option<ToolArg>,
+    project_config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+) -> std::result::Result<Option<ToolArg>, String> {
+    let mut merged_aliases = global_config.tool_aliases.clone();
+    if let Some(c) = project_config {
+        merged_aliases.extend(c.tool_aliases.iter().map(|(k, v)| (k.clone(), v.clone())));
+    }
+
+    arg_tool
+        .map(|tool_arg| tool_arg.resolve_alias(&merged_aliases))
+        .transpose()
 }
 
 /// Maximum SKILL.md file size (256 KB) to prevent excessive memory/token usage
@@ -184,14 +198,9 @@ fn resolve_claude_tool(
 ) -> Result<ToolName> {
     // CLI override is highest priority
     if let Some(tool_arg) = arg_tool {
-        // Merge global + project aliases (project takes priority)
-        let mut merged_aliases = global_config.tool_aliases.clone();
-        if let Some(c) = project_config {
-            merged_aliases.extend(c.tool_aliases.iter().map(|(k, v)| (k.clone(), v.clone())));
-        }
-        let resolved = tool_arg
-            .resolve_alias(&merged_aliases)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let resolved = resolve_tool_arg_alias(Some(tool_arg), project_config, global_config)
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .expect("Some(tool_arg) should remain Some after alias resolution");
         return match resolved {
             ToolArg::Specific(t) => Ok(t),
             ToolArg::Auto => resolve_auto_tool(parent_tool, project_config, project_root),
@@ -448,6 +457,63 @@ mod tests {
         assert!(message.contains("--tool gemini-cli"));
         assert!(message.contains("--model-spec codex/openai/gpt-5.4/medium"));
         assert!(message.contains("tool codex"));
+    }
+
+    #[test]
+    fn alias_to_auto_with_model_spec_resolves_via_spec() {
+        let mut global = GlobalConfig::default();
+        global
+            .tool_aliases
+            .insert("router".to_string(), "auto".to_string());
+
+        let (tool_name, model_spec, model) = super::resolve_claude_sub_agent_tool_and_model(
+            Some(ToolArg::Alias("router".to_string())),
+            Some("codex/openai/gpt-5.4/medium"),
+            None,
+            None,
+            &global,
+            Some("claude-code"),
+            std::path::Path::new("/tmp/test-project"),
+        )
+        .expect("alias to auto should let model-spec choose the tool");
+
+        assert_eq!(tool_name, ToolName::Codex);
+        assert_eq!(model_spec.as_deref(), Some("codex/openai/gpt-5.4/medium"));
+        assert!(model.is_none());
+    }
+
+    #[test]
+    fn alias_to_any_available_matches_direct_any_available() {
+        let _tool_availability = assume_tier_tools_available();
+        let mut global = GlobalConfig::default();
+        global
+            .tool_aliases
+            .insert("router".to_string(), "any-available".to_string());
+        let cfg = project_config_with_enabled_tools(&["codex", "claude-code"]);
+
+        let aliased = super::resolve_claude_sub_agent_tool_and_model(
+            Some(ToolArg::Alias("router".to_string())),
+            Some("codex/openai/gpt-5.4/medium"),
+            None,
+            Some(&cfg),
+            &global,
+            Some("gemini-cli"),
+            std::path::Path::new("/tmp/test-project"),
+        )
+        .expect("alias to any-available should behave like direct any-available");
+
+        let direct = super::resolve_claude_sub_agent_tool_and_model(
+            Some(ToolArg::AnyAvailable),
+            Some("codex/openai/gpt-5.4/medium"),
+            None,
+            Some(&cfg),
+            &global,
+            Some("gemini-cli"),
+            std::path::Path::new("/tmp/test-project"),
+        )
+        .expect("direct any-available should resolve");
+
+        assert_eq!(aliased, direct);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Compute `user_explicit_tool` from alias-resolved `ToolArg` (not raw CLI token)
- `[tool_aliases]` strategies (`"auto"`, `"any-available"`) now correctly pair with `--model-spec`
- Regression tests: alias-to-auto + model-spec, alias-to-any-available parity

## Test plan
- [x] `cargo test --workspace` green
- [x] `just pre-commit` green

Followup to PR #899. Closes #900.