### PR TITLE
fix(pr-bot): Step 5 inline quota branch persists 24h cache (#898)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.426"
+version = "0.1.427"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.426"
+version = "0.1.427"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -527,6 +527,8 @@ configured bot is gemini-code-assist) and includes them with a quota warning.
 If a bot issue comment contains `daily quota limit` (case-insensitive), record
 the 24h quota window in the cache file, mark the bot unavailable, and continue
 through the Step 6a merge-without-bot path instead of spending another wait cycle.
+This applies both to the polling helper path and to the later Step 5
+post-verification quota-comment check.
 
 ```bash
 set -euo pipefail
@@ -625,9 +627,13 @@ query_current_window_current_head_review_ts() {
 # --- Launch self-contained poller once; main workflow only checks the result file ---
 if [ -n "${CSA_WORKFLOW_DIR:-}" ]; then
   PR_BOT_WAIT_SCRIPT="${CSA_WORKFLOW_DIR}/scripts/pr-bot-wait.sh"
+  PR_BOT_QUOTA_CACHE_SCRIPT="${CSA_WORKFLOW_DIR}/scripts/pr-bot-quota-cache.sh"
 else
   PR_BOT_WAIT_SCRIPT="patterns/pr-bot/scripts/pr-bot-wait.sh"
+  PR_BOT_QUOTA_CACHE_SCRIPT="patterns/pr-bot/scripts/pr-bot-quota-cache.sh"
 fi
+# shellcheck source=patterns/pr-bot/scripts/pr-bot-quota-cache.sh
+. "${PR_BOT_QUOTA_CACHE_SCRIPT}"
 OUTPUT_FILE="$(mktemp -t pr-bot-wait-${PR_NUM}-XXXXXX.json)"
 INTERVAL="$(csa config get pr_review.cloud_bot_poll_interval_seconds --default 30)"
 WAIT_LONG_POLL_SECS="$(csa config get kv_cache.long_poll_seconds --default 240)"
@@ -758,6 +764,8 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   check_quota_message_step5() {
     set +e
     local quota_body
+    local quota_now_utc
+    local quota_expected_reset_at
     quota_body="$(
       gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
         | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select((.body // "") | test("daily quota limit"; "i"))] | .[0].body // ""' \
@@ -766,6 +774,12 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     set -e
     if [ -n "${quota_body}" ]; then
       echo "Quota exhaustion detected from cloud bot comment during post-poll verification." >&2
+      quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      quota_expected_reset_at="$(compute_quota_expected_reset_at)"
+      QUOTA_CACHE_FILE="${CLOUD_BOT_QUOTA_CACHE_FILE}" \
+      BOT_NAME="${CLOUD_BOT_NAME}" \
+      PR_NUMBER="${PR_NUM}" \
+      write_quota_cache "${quota_now_utc}" "${quota_expected_reset_at}" "cloud_bot_quota_exhausted" "${quota_body}"
       CLOUD_BOT_SKIPPED=true
       CLOUD_BOT_SKIP_KIND="quota_exhausted"
       CLOUD_BOT_SKIP_REASON="quota exhausted detected on PR #${PR_NUM}"

--- a/patterns/pr-bot/scripts/pr-bot-quota-cache.sh
+++ b/patterns/pr-bot/scripts/pr-bot-quota-cache.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+quota_cache_preview_body() {
+  printf '%s' "$1" | tr '\r\n\t' '   ' | head -c 200
+}
+
+compute_quota_expected_reset_at() {
+  date -u -d '+24 hours' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+24H +%Y-%m-%dT%H:%M:%SZ
+}
+
+write_quota_cache() {
+  local exhausted_at="$1"
+  local expected_reset_at="$2"
+  local reason_kind="$3"
+  local comment_body="${4:-}"
+  local quota_cache_file="${QUOTA_CACHE_FILE:-${CLOUD_BOT_QUOTA_CACHE_FILE:-${CSA_PR_BOT_QUOTA_CACHE:-${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/pr_review/cloud_bot_quota.toml}}}"
+  local bot_name="${BOT_NAME:-${CLOUD_BOT_NAME:-${CSA_PR_BOT_NAME:-bot}}}"
+  local pr_number="${PR_NUMBER:-${PR_NUM:-}}"
+  local quota_section_header="[cloud_bot_quota.${bot_name}]"
+  local quota_write_tmp="${quota_cache_file}.tmp"
+  local quota_body_tmp="${quota_cache_file}.body.tmp"
+  local quota_short_message
+  local quota_short_message_escaped
+
+  if [ -z "${exhausted_at}" ] || [ -z "${expected_reset_at}" ] || [ -z "${reason_kind}" ]; then
+    echo "write_quota_cache requires exhausted_at, expected_reset_at, and reason_kind" >&2
+    return 2
+  fi
+
+  if [ -z "${pr_number}" ]; then
+    echo "write_quota_cache requires PR_NUMBER or PR_NUM" >&2
+    return 2
+  fi
+
+  quota_short_message="$(quota_cache_preview_body "${comment_body}")"
+  quota_short_message_escaped="$(printf '%s' "${quota_short_message}" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+
+  mkdir -p "$(dirname "${quota_cache_file}")"
+  if [ -f "${quota_cache_file}" ]; then
+    awk -v target="${quota_section_header}" '
+      $0 == target { skip = 1; next }
+      skip && /^\[/ { skip = 0 }
+      !skip { print }
+    ' "${quota_cache_file}" >"${quota_body_tmp}"
+  else
+    : >"${quota_body_tmp}"
+  fi
+
+  {
+    cat "${quota_body_tmp}"
+    if [ -s "${quota_body_tmp}" ]; then
+      printf '\n'
+    fi
+    printf '%s\n' "${quota_section_header}"
+    printf 'exhausted_at = "%s"\n' "${exhausted_at}"
+    printf 'expected_reset_at = "%s"\n' "${expected_reset_at}"
+    printf 'last_pr_seen = %s\n' "${pr_number}"
+    printf 'last_quota_message = "%s"\n' "${quota_short_message_escaped}"
+  } >"${quota_write_tmp}"
+  rm -f "${quota_body_tmp}"
+  mv "${quota_write_tmp}" "${quota_cache_file}"
+
+  export QUOTA_EXHAUSTED_AT="${exhausted_at}"
+  export QUOTA_EXPECTED_RESET_AT="${expected_reset_at}"
+  export CLOUD_BOT_QUOTA_EXHAUSTED_AT="${exhausted_at}"
+  export CLOUD_BOT_QUOTA_EXPECTED_RESET_AT="${expected_reset_at}"
+  export MERGE_WITHOUT_BOT_REASON_KIND="${reason_kind}"
+}

--- a/patterns/pr-bot/scripts/pr-bot-wait.sh
+++ b/patterns/pr-bot/scripts/pr-bot-wait.sh
@@ -32,6 +32,7 @@ SCRIPT_START_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 WINDOW_START="${CSA_PR_BOT_WINDOW_START:-${SCRIPT_START_TIME}}"
 QUOTA_CACHE_FILE="${CSA_PR_BOT_QUOTA_CACHE:-${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/pr_review/cloud_bot_quota.toml}"
 BOT_NAME="${CSA_PR_BOT_NAME:-}"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -130,60 +131,15 @@ if [ -z "${BOT_NAME}" ]; then
   fi
 fi
 
+# shellcheck source=patterns/pr-bot/scripts/pr-bot-quota-cache.sh
+. "${SCRIPT_DIR}/pr-bot-quota-cache.sh"
+
 write_output() {
   local json="$1"
   local tmp_file="${OUTPUT_FILE}.tmp"
   mkdir -p "$(dirname "${OUTPUT_FILE}")"
   printf '%s\n' "${json}" >"${tmp_file}"
   mv "${tmp_file}" "${OUTPUT_FILE}"
-}
-
-preview_body() {
-  printf '%s' "$1" | tr '\r\n\t' '   ' | head -c 200
-}
-
-write_quota_cache() {
-  local comment_body="$1"
-  local quota_section_header="[cloud_bot_quota.${BOT_NAME}]"
-  local quota_write_tmp="${QUOTA_CACHE_FILE}.tmp"
-  local quota_body_tmp="${QUOTA_CACHE_FILE}.body.tmp"
-  local quota_now_utc
-  local quota_expected_reset_at
-  local quota_short_message
-  local quota_short_message_escaped
-
-  quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  quota_expected_reset_at="$(date -u -d '+24 hours' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+24H +%Y-%m-%dT%H:%M:%SZ)"
-  quota_short_message="$(preview_body "${comment_body}")"
-  quota_short_message_escaped="$(printf '%s' "${quota_short_message}" | sed 's/\\/\\\\/g; s/"/\\"/g')"
-
-  mkdir -p "$(dirname "${QUOTA_CACHE_FILE}")"
-  if [ -f "${QUOTA_CACHE_FILE}" ]; then
-    awk -v target="${quota_section_header}" '
-      $0 == target { skip = 1; next }
-      skip && /^\[/ { skip = 0 }
-      !skip { print }
-    ' "${QUOTA_CACHE_FILE}" >"${quota_body_tmp}"
-  else
-    : >"${quota_body_tmp}"
-  fi
-
-  {
-    cat "${quota_body_tmp}"
-    if [ -s "${quota_body_tmp}" ]; then
-      printf '\n'
-    fi
-    printf '%s\n' "${quota_section_header}"
-    printf 'exhausted_at = "%s"\n' "${quota_now_utc}"
-    printf 'expected_reset_at = "%s"\n' "${quota_expected_reset_at}"
-    printf 'last_pr_seen = %s\n' "${PR_NUMBER}"
-    printf 'last_quota_message = "%s"\n' "${quota_short_message_escaped}"
-  } >"${quota_write_tmp}"
-  rm -f "${quota_body_tmp}"
-  mv "${quota_write_tmp}" "${QUOTA_CACHE_FILE}"
-
-  QUOTA_EXHAUSTED_AT="${quota_now_utc}"
-  QUOTA_EXPECTED_RESET_AT="${quota_expected_reset_at}"
 }
 
 review_filter() {
@@ -261,9 +217,11 @@ while [ "${elapsed}" -le "${TIMEOUT_SEC}" ]; do
   )"
   if [ -n "${quota_comment_json}" ]; then
     quota_body="$(printf '%s\n' "${quota_comment_json}" | jq -r '.body // ""')"
-    quota_preview="$(preview_body "${quota_body}")"
+    quota_preview="$(quota_cache_preview_body "${quota_body}")"
     quota_created_at="$(printf '%s\n' "${quota_comment_json}" | jq -r '.created_at // ""')"
-    write_quota_cache "${quota_body}"
+    quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    quota_expected_reset_at="$(compute_quota_expected_reset_at)"
+    write_quota_cache "${quota_now_utc}" "${quota_expected_reset_at}" "cloud_bot_quota_exhausted" "${quota_body}"
     result_json="$(
       jq -n \
         --argjson pr "${PR_NUMBER}" \

--- a/patterns/pr-bot/scripts/tests/pr-bot-quota-cache-tests.sh
+++ b/patterns/pr-bot/scripts/tests/pr-bot-quota-cache-tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+SCRIPT_PATH="${ROOT_DIR}/patterns/pr-bot/scripts/pr-bot-quota-cache.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+run_inline_branch_cache_regression_test() {
+  local case_dir="${TMP_ROOT}/inline-branch"
+  local quota_cache="${case_dir}/cloud_bot_quota.toml"
+  local exhausted_at="2026-04-20T08:00:00Z"
+  local expected_reset_at="2026-04-21T08:00:00Z"
+
+  mkdir -p "${case_dir}"
+  cat >"${quota_cache}" <<'EOF'
+[cloud_bot_quota.other-bot]
+exhausted_at = "2026-04-18T08:00:00Z"
+expected_reset_at = "2026-04-19T08:00:00Z"
+last_pr_seen = 7
+last_quota_message = "keep me"
+EOF
+
+  (
+    export QUOTA_CACHE_FILE="${quota_cache}"
+    export BOT_NAME="test-bot"
+    export PR_NUMBER="42"
+    # REGRESSION: covers #898 inline-branch cache
+    # shellcheck source=patterns/pr-bot/scripts/pr-bot-quota-cache.sh
+    . "${SCRIPT_PATH}"
+    write_quota_cache "${exhausted_at}" "${expected_reset_at}" "cloud_bot_quota_exhausted" "Daily quota limit reached for today."
+    [ "${CLOUD_BOT_QUOTA_EXHAUSTED_AT}" = "${exhausted_at}" ]
+    [ "${CLOUD_BOT_QUOTA_EXPECTED_RESET_AT}" = "${expected_reset_at}" ]
+    [ "${MERGE_WITHOUT_BOT_REASON_KIND}" = "cloud_bot_quota_exhausted" ]
+  )
+
+  grep -q '\[cloud_bot_quota.other-bot\]' "${quota_cache}"
+  grep -q '\[cloud_bot_quota.test-bot\]' "${quota_cache}"
+  grep -q 'exhausted_at = "2026-04-20T08:00:00Z"' "${quota_cache}"
+  grep -q 'expected_reset_at = "2026-04-21T08:00:00Z"' "${quota_cache}"
+  grep -q 'last_pr_seen = 42' "${quota_cache}"
+  grep -q 'last_quota_message = "Daily quota limit reached for today."' "${quota_cache}"
+}
+
+run_inline_branch_cache_regression_test
+
+echo "pr-bot-quota-cache tests: PASS"

--- a/patterns/pr-bot/skills/pr-bot/SKILL.md
+++ b/patterns/pr-bot/skills/pr-bot/SKILL.md
@@ -164,7 +164,8 @@ window in `${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/pr_review/cloud_b
 Subsequent PR runs skip Step 4 bot triggering/polling during that window and go
 straight to the existing merge-without-bot path after confirming the local
 review state. When the window elapses, the cached section is cleared
-automatically and normal bot triggering resumes.
+automatically and normal bot triggering resumes. The same cache write happens if
+the quota warning only appears during the later Step 5 post-verification check.
 
 **Manual override / reset**:
 - `CSA_PR_BOT_FORCE=1` bypasses the quota cache for a single invocation.

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -285,6 +285,9 @@ name = "POST_REBASE_TIMEOUT"
 name = "PR_BODY"
 
 [[workflow.variables]]
+name = "PR_BOT_QUOTA_CACHE_SCRIPT"
+
+[[workflow.variables]]
 name = "PR_BOT_WAIT_SCRIPT"
 
 [[workflow.variables]]
@@ -433,6 +436,12 @@ name = "owner_matches"
 
 [[workflow.variables]]
 name = "quota_body"
+
+[[workflow.variables]]
+name = "quota_expected_reset_at"
+
+[[workflow.variables]]
+name = "quota_now_utc"
 
 [[workflow.variables]]
 name = "quota_section_header"
@@ -957,6 +966,8 @@ configured bot is gemini-code-assist) and includes them with a quota warning.
 If a bot issue comment contains `daily quota limit` (case-insensitive), record
 the 24h quota window in the cache file, mark the bot unavailable, and continue
 through the Step 6a merge-without-bot path instead of spending another wait cycle.
+This applies both to the polling helper path and to the later Step 5
+post-verification quota-comment check.
 
 ```bash
 set -euo pipefail
@@ -1055,9 +1066,13 @@ query_current_window_current_head_review_ts() {
 # --- Launch self-contained poller once; main workflow only checks the result file ---
 if [ -n "${CSA_WORKFLOW_DIR:-}" ]; then
   PR_BOT_WAIT_SCRIPT="${CSA_WORKFLOW_DIR}/scripts/pr-bot-wait.sh"
+  PR_BOT_QUOTA_CACHE_SCRIPT="${CSA_WORKFLOW_DIR}/scripts/pr-bot-quota-cache.sh"
 else
   PR_BOT_WAIT_SCRIPT="patterns/pr-bot/scripts/pr-bot-wait.sh"
+  PR_BOT_QUOTA_CACHE_SCRIPT="patterns/pr-bot/scripts/pr-bot-quota-cache.sh"
 fi
+# shellcheck source=patterns/pr-bot/scripts/pr-bot-quota-cache.sh
+. "${PR_BOT_QUOTA_CACHE_SCRIPT}"
 OUTPUT_FILE="$(mktemp -t pr-bot-wait-${PR_NUM}-XXXXXX.json)"
 INTERVAL="$(csa config get pr_review.cloud_bot_poll_interval_seconds --default 30)"
 WAIT_LONG_POLL_SECS="$(csa config get kv_cache.long_poll_seconds --default 240)"
@@ -1188,6 +1203,8 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   check_quota_message_step5() {
     set +e
     local quota_body
+    local quota_now_utc
+    local quota_expected_reset_at
     quota_body="$(
       gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
         | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select((.body // "") | test("daily quota limit"; "i"))] | .[0].body // ""' \
@@ -1196,6 +1213,12 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     set -e
     if [ -n "${quota_body}" ]; then
       echo "Quota exhaustion detected from cloud bot comment during post-poll verification." >&2
+      quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      quota_expected_reset_at="$(compute_quota_expected_reset_at)"
+      QUOTA_CACHE_FILE="${CLOUD_BOT_QUOTA_CACHE_FILE}" \
+      BOT_NAME="${CLOUD_BOT_NAME}" \
+      PR_NUMBER="${PR_NUM}" \
+      write_quota_cache "${quota_now_utc}" "${quota_expected_reset_at}" "cloud_bot_quota_exhausted" "${quota_body}"
       CLOUD_BOT_SKIPPED=true
       CLOUD_BOT_SKIP_KIND="quota_exhausted"
       CLOUD_BOT_SKIP_REASON="quota exhausted detected on PR #${PR_NUM}"


### PR DESCRIPTION
## Summary
- Extract shared quota-cache-write helper from pr-bot-wait.sh
- Inline `check_quota_message_step5` branch in workflow.toml now invokes helper
- Both helper path and post-verification path persist `cloud_bot_quota.toml` + export `CLOUD_BOT_QUOTA_*` timestamps

## Test plan
- [x] `weave compile` green
- [x] `bash -n` on updated scripts green
- [x] `just pre-commit` green

Followup to PR #897. Closes #898.