### PR TITLE
fix(csa-executor): gemini-cli MCP init degradation is warning, not fatal (#886, #914)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.428"
+version = "0.1.429"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.427"
+version = "0.1.428"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.427"
+version = "0.1.428"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.428"
+version = "0.1.429"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_env.rs
@@ -26,6 +26,7 @@ pub(crate) fn resolve_cooldown_seconds(config: Option<&ProjectConfig>) -> u64 {
 pub(crate) fn build_merged_env(
     extra_env: Option<&HashMap<String, String>>,
     config: Option<&ProjectConfig>,
+    global_config: Option<&csa_config::GlobalConfig>,
     tool_name: &str,
 ) -> HashMap<String, String> {
     let suppress = config
@@ -50,6 +51,14 @@ pub(crate) fn build_merged_env(
                 }
             })
             .or_insert(heap_flag);
+    }
+
+    if tool_name == "gemini-cli" {
+        let allow_degraded_mcp = global_config.is_none_or(|gc| gc.allow_degraded_mcp("gemini-cli"));
+        merged_env.insert(
+            "CSA_GEMINI_ALLOW_DEGRADED_MCP".to_string(),
+            if allow_degraded_mcp { "1" } else { "0" }.to_string(),
+        );
     }
 
     merged_env.insert("CSA_DEPTH".to_string(), next_depth_value());

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -465,19 +465,19 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         }
     });
 
-    let mut merged_env =
-        crate::pipeline_env::build_merged_env(extra_env, config, executor.tool_name());
+    let mut merged_env = crate::pipeline_env::build_merged_env(
+        extra_env,
+        config,
+        global_config,
+        executor.tool_name(),
+    );
     crate::pipeline_env::apply_task_target_dir_guards(
         task_type,
         executor.tool_name(),
         project_root,
         &mut merged_env,
     );
-    let merged_env_ref = if merged_env.is_empty() {
-        None
-    } else {
-        Some(&merged_env)
-    };
+    let merged_env_ref = (!merged_env.is_empty()).then_some(&merged_env);
     // Project [hooks] overrides take priority over hooks.toml entries.
     let project_hook_overrides =
         super::session_hooks::build_project_hook_overrides(config, task_type);

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -460,8 +460,7 @@ fn test_config_with_node_heap_limit(node_heap_limit_mb: Option<u64>) -> ProjectC
 #[test]
 fn build_merged_env_injects_node_options_when_heap_limit_configured() {
     let cfg = test_config_with_node_heap_limit(Some(2048));
-    let merged = crate::pipeline_env::build_merged_env(None, Some(&cfg), "claude-code");
-
+    let merged = crate::pipeline_env::build_merged_env(None, Some(&cfg), None, "claude-code");
     assert_eq!(
         merged.get("NODE_OPTIONS"),
         Some(&"--max-old-space-size=2048".to_string())
@@ -476,9 +475,8 @@ fn build_merged_env_injects_node_options_when_heap_limit_configured() {
 #[test]
 fn build_merged_env_does_not_inject_node_options_without_heap_limit() {
     let cfg = test_config_with_node_heap_limit(None);
-    // Use a lightweight tool (opencode) whose profile does not default node_heap_limit_mb.
-    // Heavyweight tools (claude-code, codex) now default to Some(2048) even without explicit config.
-    let merged = crate::pipeline_env::build_merged_env(None, Some(&cfg), "opencode");
+    // Use a lightweight tool (opencode); heavyweight tools default node_heap_limit_mb to Some(2048).
+    let merged = crate::pipeline_env::build_merged_env(None, Some(&cfg), None, "opencode");
 
     assert!(
         !merged.contains_key("NODE_OPTIONS"),
@@ -492,7 +490,8 @@ fn build_merged_env_appends_node_options_when_existing_value_present() {
     let mut extra_env = HashMap::new();
     extra_env.insert("NODE_OPTIONS".to_string(), "--trace-warnings".to_string());
 
-    let merged = crate::pipeline_env::build_merged_env(Some(&extra_env), Some(&cfg), "claude-code");
+    let merged =
+        crate::pipeline_env::build_merged_env(Some(&extra_env), Some(&cfg), None, "claude-code");
 
     assert_eq!(
         merged.get("NODE_OPTIONS"),

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -637,9 +637,9 @@ pub(super) fn detect_tool_diagnostic(stdout: &str, stderr: &str) -> Option<Strin
 
     if has_mcp_issue(stdout) || has_mcp_issue(stderr) {
         return Some(
-            "gemini-cli encountered MCP server connectivity issues. \
-             Run `gemini /mcp list` to diagnose. \
-             Consider using `--tool claude-code` as a fallback."
+            "gemini-cli MCP init degraded. \
+             Retry with `--force-ignore-tier-setting` + a different `--tool`, \
+             or run `csa doctor` to diagnose unhealthy MCP servers."
                 .to_string(),
         );
     }

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -122,9 +122,9 @@ fn test_detect_tool_diagnostic_mcp_issues_in_stdout_returns_diagnostic() {
     let result = detect_tool_diagnostic(stdout, "");
     assert!(result.is_some());
     let msg = result.unwrap();
-    assert!(msg.contains("MCP server connectivity"));
-    assert!(msg.contains("gemini /mcp list"));
-    assert!(msg.contains("--tool claude-code"));
+    assert!(msg.contains("MCP init degraded"));
+    assert!(msg.contains("csa doctor"));
+    assert!(msg.contains("--force-ignore-tier-setting"));
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn test_detect_tool_diagnostic_mcp_issues_in_stderr_returns_diagnostic() {
     let stderr = "Warning: MCP issues detected during startup";
     let result = detect_tool_diagnostic("", stderr);
     assert!(result.is_some());
-    assert!(result.unwrap().contains("MCP server connectivity"));
+    assert!(result.unwrap().contains("MCP init degraded"));
 }
 
 #[test]
@@ -140,7 +140,7 @@ fn test_detect_tool_diagnostic_mcp_list_in_stderr_returns_diagnostic() {
     let stderr = "Run /mcp list to check server status";
     let result = detect_tool_diagnostic("", stderr);
     assert!(result.is_some());
-    assert!(result.unwrap().contains("gemini /mcp list"));
+    assert!(result.unwrap().contains("csa doctor"));
 }
 
 #[test]

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -508,6 +508,10 @@ pub struct GlobalToolConfig {
     /// NOT injected into env by default — only used as a last resort.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
+    /// Allow gemini-cli to continue after disabling unhealthy MCP servers.
+    /// Defaults to true so startup-time MCP degradation is non-fatal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_degraded_mcp: Option<bool>,
 }
 
 fn default_max_concurrent() -> u32 {

--- a/crates/csa-config/src/global_impl.rs
+++ b/crates/csa-config/src/global_impl.rs
@@ -182,6 +182,16 @@ impl GlobalConfig {
         self.tools.get(tool).and_then(|t| t.api_key.as_deref())
     }
 
+    /// Whether gemini-cli may retry after stripping unhealthy MCP servers.
+    ///
+    /// Missing config defaults to `true` to keep MCP degradation non-fatal.
+    pub fn allow_degraded_mcp(&self, tool: &str) -> bool {
+        self.tools
+            .get(tool)
+            .and_then(|t| t.allow_degraded_mcp)
+            .unwrap_or(true)
+    }
+
     /// Get the thinking budget lock for a tool from global config.
     pub fn thinking_lock(&self, tool: &str) -> Option<&str> {
         self.tools

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -33,12 +33,12 @@ use transport_gemini_helpers::format_gemini_retry_report;
 use transport_gemini_helpers::{
     GeminiRetryPhase, annotate_gemini_retry_error, append_gemini_retry_report,
     apply_gemini_acp_initial_stall_summary, apply_gemini_legacy_initial_stall_summary,
-    apply_gemini_sandbox_runtime_env_overrides, classify_gemini_acp_init_failure,
-    classify_gemini_acp_initial_stall, classify_gemini_legacy_initial_stall,
-    classify_gemini_oauth_prompt_result, classify_join_error,
+    apply_gemini_mcp_warning_summary, apply_gemini_sandbox_runtime_env_overrides,
+    classify_gemini_acp_init_failure, classify_gemini_acp_initial_stall,
+    classify_gemini_legacy_initial_stall, classify_gemini_oauth_prompt_result, classify_join_error,
     ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure,
     gemini_acp_initial_response_timeout_seconds, gemini_phase_desc,
-    gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure,
+    gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure, is_gemini_mcp_issue_result,
     is_gemini_oauth_prompt_result,
 };
 pub use transport_gemini_helpers::{
@@ -46,7 +46,15 @@ pub use transport_gemini_helpers::{
 };
 #[path = "transport_gemini_acp_runtime.rs"]
 mod transport_gemini_acp_runtime;
-use transport_gemini_acp_runtime::{gemini_runtime_home_from_env, prepare_gemini_acp_runtime};
+use transport_gemini_acp_runtime::{
+    gemini_runtime_home_from_env, prepare_gemini_acp_runtime, prepare_gemini_runtime_env,
+};
+#[path = "transport_gemini_mcp_diagnostic.rs"]
+mod transport_gemini_mcp_diagnostic;
+use transport_gemini_mcp_diagnostic::{
+    diagnose_mcp_init_failure, disable_mcp_servers_in_runtime, format_mcp_init_warning_summary,
+    gemini_allow_degraded_mcp,
+};
 #[path = "transport_acp_crash_retry.rs"]
 mod transport_acp_crash_retry;
 use transport_acp_crash_retry::execute_with_crash_retry;
@@ -346,120 +354,6 @@ impl LegacyTransport {
             events: Vec::new(),
             metadata: Default::default(),
         })
-    }
-
-    /// Execute the legacy direct-entry path.
-    ///
-    /// `initial_response_timeout_seconds` is already resolved by
-    /// `Executor::execute_in_with_transport()`: `None` means disabled, and positive values are
-    /// concrete watchdog durations. This layer must not re-apply executor defaults.
-    pub async fn execute_in(
-        &self,
-        prompt: &str,
-        work_dir: &Path,
-        extra_env: Option<&HashMap<String, String>>,
-        stream_mode: StreamMode,
-        idle_timeout_seconds: u64,
-        initial_response_timeout: ResolvedTimeout,
-    ) -> Result<TransportResult> {
-        // 3-phase fallback: OAuth(original) → APIKey(original) → APIKey(flash)
-        let has_fallback_key = extra_env
-            .is_some_and(|env| env.contains_key(csa_core::gemini::API_KEY_FALLBACK_ENV_KEY));
-        let auth_mode = gemini_auth_mode(extra_env).unwrap_or("unknown");
-        let max_attempts = gemini_max_attempts(extra_env);
-        tracing::debug!(
-            max_attempts,
-            has_fallback_key,
-            auth_mode,
-            "gemini-cli legacy retry chain initialized"
-        );
-
-        let mut attempt = 1u8;
-        loop {
-            let executor = self.executor_for_attempt(attempt);
-
-            // Phase 2+: inject API key auth if available, otherwise keep original env.
-            let api_key_env = if gemini_should_use_api_key(attempt) {
-                let injected = gemini_inject_api_key_fallback(extra_env);
-                if injected.is_none() {
-                    tracing::warn!(
-                        attempt,
-                        auth_mode,
-                        has_fallback_key,
-                        "gemini-cli legacy: API key fallback unavailable for retry \
-                         (auth_mode must be 'oauth' and _CSA_API_KEY_FALLBACK must be set); \
-                         retrying with original auth"
-                    );
-                }
-                injected
-            } else {
-                None
-            };
-            let attempt_env = api_key_env.as_ref().map_or(extra_env, Some);
-
-            let result = self
-                .execute_in_single_attempt(ExecuteInAttempt {
-                    executor: &executor,
-                    prompt,
-                    work_dir,
-                    extra_env: attempt_env,
-                    stream_mode,
-                    idle_timeout_seconds,
-                    resolved_initial_response_timeout: initial_response_timeout,
-                })
-                .await?;
-            if let Some(backoff) =
-                self.should_retry_gemini_rate_limited(&result.execution, attempt, extra_env)
-            {
-                let phase_desc = match attempt {
-                    1 => "OAuth→APIKey(same model)",
-                    2 => "APIKey(same model)→APIKey(flash)",
-                    _ => "final",
-                };
-                tracing::info!(
-                    attempt,
-                    phase_desc,
-                    "gemini-cli rate limited; advancing phase"
-                );
-                tokio::time::sleep(backoff).await;
-                attempt = attempt.saturating_add(1);
-                continue;
-            }
-            let direct_timeout = consume_resolved_execute_in_initial_response_timeout_seconds(
-                initial_response_timeout,
-            );
-            let retry_executor = executor.clone();
-            let result = apply_and_maybe_retry_codex_exec_initial_stall(
-                &executor,
-                result,
-                direct_timeout,
-                |retry_budget| async move {
-                    let mut downgraded_executor = retry_executor;
-                    downgraded_executor.override_thinking_budget(retry_budget);
-                    let retry_result = self
-                        .execute_in_single_attempt(ExecuteInAttempt {
-                            executor: &downgraded_executor,
-                            prompt,
-                            work_dir,
-                            extra_env: attempt_env,
-                            stream_mode,
-                            idle_timeout_seconds,
-                            resolved_initial_response_timeout: initial_response_timeout,
-                        })
-                        .await?;
-                    Ok((downgraded_executor, retry_result))
-                },
-            )
-            .await?;
-            if let Some(classification) =
-                classify_gemini_legacy_initial_stall(&executor, &result.execution, direct_timeout)
-            {
-                let mut result = result;
-                apply_gemini_legacy_initial_stall_summary(&mut result.execution, &classification);
-                return Ok(result);
-            }
-            return Ok(result);
-        }
     }
 }
 

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -33,7 +33,6 @@ const GEMINI_MIRROR_FILES: &[&str] = &[
 const GEMINI_MIRROR_DIRS: &[&str] = &["extensions", "antigravity"];
 const GEMINI_SELECTED_TYPE_OAUTH: &str = "oauth-personal";
 const GEMINI_SELECTED_TYPE_API_KEY: &str = "gemini-api-key";
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GeminiAcpLaunch {
     pub(crate) command: String,
@@ -131,6 +130,16 @@ pub(crate) fn prepare_gemini_acp_runtime(
         command: "gemini".to_string(),
         args: base_args.to_vec(),
     })
+}
+
+pub(crate) fn prepare_gemini_runtime_env(
+    env: &mut HashMap<String, String>,
+    project_dir: Option<&Path>,
+    session_dir: Option<&Path>,
+    session_id: &str,
+) -> Result<PathBuf> {
+    let _ = prepare_gemini_acp_runtime(env, project_dir, session_dir, session_id, &[])?;
+    gemini_runtime_home_from_env(env).context("gemini runtime home missing after preparation")
 }
 
 pub(crate) fn gemini_runtime_home_from_env(env: &HashMap<String, String>) -> Option<PathBuf> {

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -12,6 +12,8 @@ use crate::transport_gemini_retry::{gemini_retry_model, gemini_should_use_api_ke
 
 pub(crate) const GEMINI_OAUTH_PROMPT_SUMMARY: &str =
     "gemini-cli auth failure: OAuth browser prompt detected; no tool output produced";
+pub(crate) const GEMINI_MCP_ISSUES_DETECTED_SUMMARY: &str =
+    "MCP issues detected. Run /mcp list for status.";
 pub(crate) const GEMINI_ACP_INITIAL_STALL_REASON: &str = "gemini_acp_initial_stall";
 pub(crate) const GEMINI_LEGACY_INITIAL_STALL_REASON: &str = "gemini_legacy_initial_stall";
 const DEFAULT_GEMINI_ACP_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 180;
@@ -165,6 +167,37 @@ pub(super) fn apply_gemini_legacy_initial_stall_summary(
         execution.stderr_output.push('\n');
     }
     execution.stderr_output.push_str(&summary);
+    execution.stderr_output.push('\n');
+}
+
+pub(crate) fn is_gemini_mcp_issue_result(execution: &ExecutionResult) -> bool {
+    execution.exit_code != 0
+        && [
+            execution.summary.as_str(),
+            execution.output.as_str(),
+            execution.stderr_output.as_str(),
+        ]
+        .into_iter()
+        .any(|text| {
+            text.contains("MCP issues detected")
+                || text.contains("Run /mcp list")
+                || text.contains(GEMINI_MCP_ISSUES_DETECTED_SUMMARY)
+        })
+}
+
+pub(crate) fn apply_gemini_mcp_warning_summary(
+    execution: &mut ExecutionResult,
+    warning_summary: &str,
+) {
+    execution.summary = if execution.summary.trim().is_empty() {
+        warning_summary.to_string()
+    } else {
+        format!("{warning_summary} | {}", execution.summary.trim())
+    };
+    if !execution.stderr_output.is_empty() && !execution.stderr_output.ends_with('\n') {
+        execution.stderr_output.push('\n');
+    }
+    execution.stderr_output.push_str(warning_summary);
     execution.stderr_output.push('\n');
 }
 

--- a/crates/csa-executor/src/transport_gemini_mcp_diagnostic.rs
+++ b/crates/csa-executor/src/transport_gemini_mcp_diagnostic.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -23,7 +24,10 @@ pub(crate) fn gemini_allow_degraded_mcp(env: &HashMap<String, String>) -> bool {
         .unwrap_or(true)
 }
 
-pub(crate) fn diagnose_mcp_init_failure(runtime_home: &Path) -> McpInitDiagnostic {
+pub(crate) fn diagnose_mcp_init_failure(
+    runtime_home: &Path,
+    path_override: Option<&OsStr>,
+) -> McpInitDiagnostic {
     let mut diagnostic = McpInitDiagnostic {
         hub_reachable: true,
         ..Default::default()
@@ -41,7 +45,7 @@ pub(crate) fn diagnose_mcp_init_failure(runtime_home: &Path) -> McpInitDiagnosti
             if !seen.insert(server_name.clone()) {
                 continue;
             }
-            if let Some(error) = probe_mcp_server(server_config) {
+            if let Some(error) = probe_mcp_server(server_config, path_override) {
                 diagnostic.unhealthy_servers.push(server_name.clone());
                 diagnostic.probe_errors.insert(server_name.clone(), error);
             }
@@ -111,7 +115,7 @@ retry with --force-ignore-tier-setting + different --tool, or run 'csa doctor' t
     )
 }
 
-fn probe_mcp_server(server_config: &Value) -> Option<String> {
+fn probe_mcp_server(server_config: &Value, path_override: Option<&OsStr>) -> Option<String> {
     let command = server_config.get("command").and_then(Value::as_str)?;
     if command.contains(std::path::MAIN_SEPARATOR) {
         let path = Path::new(command);
@@ -121,15 +125,17 @@ fn probe_mcp_server(server_config: &Value) -> Option<String> {
         return None;
     }
 
-    if resolve_command_path(command).is_none() {
+    if resolve_command_path(command, path_override).is_none() {
         return Some(format!("command not found on PATH: {command}"));
     }
 
     None
 }
 
-fn resolve_command_path(command: &str) -> Option<PathBuf> {
-    let path_var = std::env::var_os("PATH")?;
+fn resolve_command_path(command: &str, path_override: Option<&OsStr>) -> Option<PathBuf> {
+    let path_var = path_override
+        .map(ToOwned::to_owned)
+        .or_else(|| std::env::var_os("PATH"))?;
     for entry in std::env::split_paths(&path_var) {
         let candidate = entry.join(command);
         if candidate.is_file() {
@@ -145,4 +151,154 @@ fn load_runtime_settings(settings_path: &Path) -> Value {
     };
 
     serde_json::from_str(&raw).unwrap_or_else(|_| Value::Object(Default::default()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::diagnose_mcp_init_failure;
+    use std::ffi::OsString;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+
+    static PATH_ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
+    struct ScopedPathEnv {
+        original: Option<OsString>,
+    }
+
+    impl ScopedPathEnv {
+        fn set(value: &OsString) -> Self {
+            let original = std::env::var_os("PATH");
+            // SAFETY: test-scoped env mutation guarded by PATH_ENV_LOCK.
+            unsafe { std::env::set_var("PATH", value) };
+            Self { original }
+        }
+    }
+
+    impl Drop for ScopedPathEnv {
+        fn drop(&mut self) {
+            // SAFETY: test-scoped env mutation guarded by PATH_ENV_LOCK.
+            unsafe {
+                match self.original.take() {
+                    Some(value) => std::env::set_var("PATH", value),
+                    None => std::env::remove_var("PATH"),
+                }
+            }
+        }
+    }
+
+    fn write_runtime_settings(runtime_home: &Path, command: &str) {
+        let gemini_dir = runtime_home.join(".gemini");
+        fs::create_dir_all(&gemini_dir).expect("create .gemini");
+        fs::write(
+            gemini_dir.join("settings.json"),
+            format!(
+                r#"{{
+  "mcpServers": {{
+    "fake-mcp": {{
+      "command": "{command}",
+      "args": ["--mcp"]
+    }}
+  }}
+}}"#
+            ),
+        )
+        .expect("write settings");
+    }
+
+    fn write_executable(dir: &Path, name: &str) -> PathBuf {
+        let script_path = dir.join(name);
+        fs::write(&script_path, "#!/bin/sh\nexit 0\n").expect("write fake executable");
+        let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).expect("chmod +x");
+        script_path
+    }
+
+    #[test]
+    fn diagnose_mcp_init_failure_probe_respects_prepared_path_over_parent_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_runtime_settings(temp.path(), "fake-mcp-server");
+
+        let prepared_bin = temp.path().join("prepared-bin");
+        fs::create_dir_all(&prepared_bin).expect("create prepared bin");
+        write_executable(&prepared_bin, "fake-mcp-server");
+
+        let prepared_path = prepared_bin.into_os_string();
+        let diagnostic = diagnose_mcp_init_failure(temp.path(), Some(prepared_path.as_os_str()));
+
+        assert!(
+            diagnostic.probe_errors.is_empty(),
+            "expected prepared PATH command to resolve, got: {:?}",
+            diagnostic.probe_errors
+        );
+        assert!(
+            diagnostic.unhealthy_servers.is_empty(),
+            "expected no unhealthy servers, got: {:?}",
+            diagnostic.unhealthy_servers
+        );
+    }
+
+    #[test]
+    fn diagnose_mcp_init_failure_probe_without_override_falls_back_to_parent_path() {
+        let _env_lock = PATH_ENV_LOCK.lock().expect("PATH env lock poisoned");
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_runtime_settings(temp.path(), "fake-mcp-server");
+
+        let parent_bin = temp.path().join("parent-bin");
+        fs::create_dir_all(&parent_bin).expect("create parent bin");
+        write_executable(&parent_bin, "fake-mcp-server");
+
+        let mut joined = OsString::from(parent_bin.as_os_str());
+        if let Some(existing) = std::env::var_os("PATH") {
+            joined.push(OsString::from(":"));
+            joined.push(existing);
+        }
+        let _path = ScopedPathEnv::set(&joined);
+
+        let diagnostic = diagnose_mcp_init_failure(temp.path(), None);
+
+        assert!(
+            diagnostic.probe_errors.is_empty(),
+            "expected parent PATH fallback to resolve command, got: {:?}",
+            diagnostic.probe_errors
+        );
+        assert!(
+            diagnostic.unhealthy_servers.is_empty(),
+            "expected no unhealthy servers, got: {:?}",
+            diagnostic.unhealthy_servers
+        );
+    }
+
+    #[test]
+    fn diagnose_mcp_init_failure_prepared_path_hides_parent_path_only_command() {
+        let _env_lock = PATH_ENV_LOCK.lock().expect("PATH env lock poisoned");
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_runtime_settings(temp.path(), "fake-mcp-server");
+
+        let parent_bin = temp.path().join("parent-bin");
+        fs::create_dir_all(&parent_bin).expect("create parent bin");
+        write_executable(&parent_bin, "fake-mcp-server");
+
+        let prepared_bin = temp.path().join("prepared-bin");
+        fs::create_dir_all(&prepared_bin).expect("create prepared bin");
+
+        let mut joined = OsString::from(parent_bin.as_os_str());
+        if let Some(existing) = std::env::var_os("PATH") {
+            joined.push(OsString::from(":"));
+            joined.push(existing);
+        }
+        let _path = ScopedPathEnv::set(&joined);
+
+        let prepared_path = prepared_bin.into_os_string();
+        let diagnostic = diagnose_mcp_init_failure(temp.path(), Some(prepared_path.as_os_str()));
+
+        assert_eq!(diagnostic.unhealthy_servers, vec!["fake-mcp".to_string()]);
+        assert_eq!(
+            diagnostic.probe_errors.get("fake-mcp").map(String::as_str),
+            Some("command not found on PATH: fake-mcp-server")
+        );
+    }
 }

--- a/crates/csa-executor/src/transport_gemini_mcp_diagnostic.rs
+++ b/crates/csa-executor/src/transport_gemini_mcp_diagnostic.rs
@@ -1,0 +1,148 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+pub(crate) const GEMINI_ALLOW_DEGRADED_MCP_ENV: &str = "CSA_GEMINI_ALLOW_DEGRADED_MCP";
+const GEMINI_RUNTIME_SETTINGS_PATHS: &[&str] =
+    &[".gemini/settings.json", ".config/gemini-cli/settings.json"];
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct McpInitDiagnostic {
+    pub(crate) unhealthy_servers: Vec<String>,
+    pub(crate) probe_errors: BTreeMap<String, String>,
+    pub(crate) hub_reachable: bool,
+}
+
+pub(crate) fn gemini_allow_degraded_mcp(env: &HashMap<String, String>) -> bool {
+    env.get(GEMINI_ALLOW_DEGRADED_MCP_ENV)
+        .map(String::as_str)
+        .map(|value| matches!(value, "1" | "true" | "yes" | "on"))
+        .unwrap_or(true)
+}
+
+pub(crate) fn diagnose_mcp_init_failure(runtime_home: &Path) -> McpInitDiagnostic {
+    let mut diagnostic = McpInitDiagnostic {
+        hub_reachable: true,
+        ..Default::default()
+    };
+    let mut seen = BTreeSet::new();
+
+    for relative_path in GEMINI_RUNTIME_SETTINGS_PATHS {
+        let settings_path = runtime_home.join(relative_path);
+        let settings = load_runtime_settings(&settings_path);
+        let Some(servers) = settings.get("mcpServers").and_then(Value::as_object) else {
+            continue;
+        };
+
+        for (server_name, server_config) in servers {
+            if !seen.insert(server_name.clone()) {
+                continue;
+            }
+            if let Some(error) = probe_mcp_server(server_config) {
+                diagnostic.unhealthy_servers.push(server_name.clone());
+                diagnostic.probe_errors.insert(server_name.clone(), error);
+            }
+        }
+    }
+
+    diagnostic
+}
+
+pub(crate) fn disable_mcp_servers_in_runtime(
+    runtime_home: &Path,
+    diagnostic: &McpInitDiagnostic,
+    disable_all: bool,
+) -> Result<()> {
+    for relative_path in GEMINI_RUNTIME_SETTINGS_PATHS {
+        let settings_path = runtime_home.join(relative_path);
+        if !settings_path.exists() {
+            continue;
+        }
+
+        let mut settings = load_runtime_settings(&settings_path);
+        let Some(servers) = settings
+            .get_mut("mcpServers")
+            .and_then(serde_json::Value::as_object_mut)
+        else {
+            continue;
+        };
+
+        if disable_all {
+            servers.clear();
+        } else {
+            for server_name in &diagnostic.unhealthy_servers {
+                servers.remove(server_name);
+            }
+        }
+
+        let serialized = serde_json::to_string_pretty(&settings)
+            .context("failed to serialize degraded gemini runtime settings")?;
+        fs::write(&settings_path, format!("{serialized}\n")).with_context(|| {
+            format!(
+                "failed to write degraded gemini runtime settings {}",
+                settings_path.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn format_mcp_init_warning_summary(
+    diagnostic: &McpInitDiagnostic,
+    retried_without_all_servers: bool,
+) -> String {
+    let server_list = if diagnostic.unhealthy_servers.is_empty() {
+        "unknown server".to_string()
+    } else {
+        diagnostic.unhealthy_servers.join(", ")
+    };
+    let mode_note = if retried_without_all_servers {
+        "disabled all configured MCP servers after gemini-cli startup refusal"
+    } else {
+        "disabled unhealthy MCP servers and continued with degraded MCP"
+    };
+    format!(
+        "gemini-cli MCP init degraded ({server_list}) — {mode_note}; \
+retry with --force-ignore-tier-setting + different --tool, or run 'csa doctor' to diagnose"
+    )
+}
+
+fn probe_mcp_server(server_config: &Value) -> Option<String> {
+    let command = server_config.get("command").and_then(Value::as_str)?;
+    if command.contains(std::path::MAIN_SEPARATOR) {
+        let path = Path::new(command);
+        if !path.exists() {
+            return Some(format!("command path missing: {}", path.display()));
+        }
+        return None;
+    }
+
+    if resolve_command_path(command).is_none() {
+        return Some(format!("command not found on PATH: {command}"));
+    }
+
+    None
+}
+
+fn resolve_command_path(command: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for entry in std::env::split_paths(&path_var) {
+        let candidate = entry.join(command);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn load_runtime_settings(settings_path: &Path) -> Value {
+    let Ok(raw) = fs::read_to_string(settings_path) else {
+        return Value::Object(Default::default());
+    };
+
+    serde_json::from_str(&raw).unwrap_or_else(|_| Value::Object(Default::default()))
+}

--- a/crates/csa-executor/src/transport_legacy_impl.rs
+++ b/crates/csa-executor/src/transport_legacy_impl.rs
@@ -16,6 +16,7 @@ impl Transport for LegacyTransport {
         let mut attempt = 1u8;
         loop {
             let executor = self.executor_for_attempt(attempt);
+            let mut retried_degraded_mcp = false;
 
             // Phase 2+: inject API key auth if available, otherwise keep original env.
             let api_key_env = if gemini_should_use_api_key(attempt) {
@@ -23,18 +24,90 @@ impl Transport for LegacyTransport {
             } else {
                 None
             };
-            let attempt_env = api_key_env.as_ref().map_or(extra_env, Some);
-
-            let result = self
-                .execute_single_attempt(
-                    &executor,
-                    prompt,
-                    tool_state,
-                    session,
-                    attempt_env,
-                    options.clone(),
+            let mut prepared_attempt_env = api_key_env
+                .as_ref()
+                .map_or_else(|| extra_env.cloned().unwrap_or_default(), Clone::clone);
+            let mut gemini_runtime_home = None;
+            let mut mcp_diagnostic = None;
+            let allow_degraded_mcp = if executor.tool_name() == "gemini-cli" {
+                let session_dir = csa_session::manager::get_session_dir(
+                    Path::new(&session.project_path),
+                    &session.meta_session_id,
                 )
-                .await?;
+                .ok();
+                let runtime_home = prepare_gemini_runtime_env(
+                    &mut prepared_attempt_env,
+                    Some(Path::new(&session.project_path)),
+                    session_dir.as_deref(),
+                    &session.meta_session_id,
+                )?;
+                let diagnostic = diagnose_mcp_init_failure(&runtime_home);
+                gemini_runtime_home = Some(runtime_home);
+                mcp_diagnostic = Some(diagnostic);
+                gemini_allow_degraded_mcp(&prepared_attempt_env)
+            } else {
+                true
+            };
+
+            let result = loop {
+                let result = self
+                    .execute_single_attempt(
+                        &executor,
+                        prompt,
+                        tool_state,
+                        session,
+                        Some(&prepared_attempt_env),
+                        options.clone(),
+                    )
+                    .await?;
+                if executor.tool_name() != "gemini-cli"
+                    || !is_gemini_mcp_issue_result(&result.execution)
+                    || retried_degraded_mcp
+                    || !allow_degraded_mcp
+                {
+                    break result;
+                }
+
+                let diagnostic = mcp_diagnostic
+                    .clone()
+                    .unwrap_or_else(|| diagnose_mcp_init_failure(gemini_runtime_home.as_deref().expect("gemini runtime home")));
+                let disable_all = diagnostic.unhealthy_servers.is_empty();
+                if let Some(runtime_home) = gemini_runtime_home.as_deref() {
+                    disable_mcp_servers_in_runtime(runtime_home, &diagnostic, disable_all)?;
+                }
+                tracing::warn!(
+                    unhealthy_servers = %diagnostic.unhealthy_servers.join(","),
+                    disable_all,
+                    "gemini-cli reported MCP startup issues; retrying with degraded MCP"
+                );
+                mcp_diagnostic = Some(diagnostic);
+                retried_degraded_mcp = true;
+            };
+            let mut result = result;
+            if retried_degraded_mcp {
+                let warning_summary = format_mcp_init_warning_summary(
+                    mcp_diagnostic
+                        .as_ref()
+                        .expect("degraded MCP retry should preserve diagnostic"),
+                    mcp_diagnostic
+                        .as_ref()
+                        .is_some_and(|diagnostic| diagnostic.unhealthy_servers.is_empty()),
+                );
+                apply_gemini_mcp_warning_summary(&mut result.execution, &warning_summary);
+            } else if executor.tool_name() == "gemini-cli"
+                && is_gemini_mcp_issue_result(&result.execution)
+                && !allow_degraded_mcp
+            {
+                let warning_summary = format_mcp_init_warning_summary(
+                    mcp_diagnostic
+                        .as_ref()
+                        .expect("gemini diagnostic should exist"),
+                    mcp_diagnostic
+                        .as_ref()
+                        .is_some_and(|diagnostic| diagnostic.unhealthy_servers.is_empty()),
+                );
+                apply_gemini_mcp_warning_summary(&mut result.execution, &warning_summary);
+            }
             if is_gemini_oauth_prompt_result(&result.execution) {
                 if attempt == 1
                     && gemini_inject_api_key_fallback(extra_env).is_some()
@@ -87,7 +160,7 @@ impl Transport for LegacyTransport {
                                 prompt,
                                 tool_state,
                                 session,
-                                attempt_env,
+                                Some(&prepared_attempt_env),
                                 retry_options,
                             )
                             .await?;
@@ -132,5 +205,192 @@ impl Transport for LegacyTransport {
     #[cfg(test)]
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+impl LegacyTransport {
+    /// Execute the legacy direct-entry path.
+    ///
+    /// `initial_response_timeout_seconds` is already resolved by
+    /// `Executor::execute_in_with_transport()`: `None` means disabled, and positive values are
+    /// concrete watchdog durations. This layer must not re-apply executor defaults.
+    pub async fn execute_in(
+        &self,
+        prompt: &str,
+        work_dir: &Path,
+        extra_env: Option<&HashMap<String, String>>,
+        stream_mode: StreamMode,
+        idle_timeout_seconds: u64,
+        initial_response_timeout: ResolvedTimeout,
+    ) -> Result<TransportResult> {
+        let has_fallback_key = extra_env
+            .is_some_and(|env| env.contains_key(csa_core::gemini::API_KEY_FALLBACK_ENV_KEY));
+        let auth_mode = gemini_auth_mode(extra_env).unwrap_or("unknown");
+        let max_attempts = gemini_max_attempts(extra_env);
+        tracing::debug!(
+            max_attempts,
+            has_fallback_key,
+            auth_mode,
+            "gemini-cli legacy retry chain initialized"
+        );
+
+        let mut attempt = 1u8;
+        loop {
+            let executor = self.executor_for_attempt(attempt);
+            let mut retried_degraded_mcp = false;
+
+            let api_key_env = if gemini_should_use_api_key(attempt) {
+                let injected = gemini_inject_api_key_fallback(extra_env);
+                if injected.is_none() {
+                    tracing::warn!(
+                        attempt,
+                        auth_mode,
+                        has_fallback_key,
+                        "gemini-cli legacy: API key fallback unavailable for retry \
+                         (auth_mode must be 'oauth' and _CSA_API_KEY_FALLBACK must be set); \
+                         retrying with original auth"
+                    );
+                }
+                injected
+            } else {
+                None
+            };
+            let mut prepared_attempt_env = api_key_env
+                .as_ref()
+                .map_or_else(|| extra_env.cloned().unwrap_or_default(), Clone::clone);
+            let mut gemini_runtime_home = None;
+            let mut mcp_diagnostic = None;
+            let allow_degraded_mcp = if executor.tool_name() == "gemini-cli" {
+                let session_id = format!("execute-in-{}", new_session_id());
+                let runtime_home = prepare_gemini_runtime_env(
+                    &mut prepared_attempt_env,
+                    Some(work_dir),
+                    None,
+                    &session_id,
+                )?;
+                let diagnostic = diagnose_mcp_init_failure(&runtime_home);
+                gemini_runtime_home = Some(runtime_home);
+                mcp_diagnostic = Some(diagnostic);
+                gemini_allow_degraded_mcp(&prepared_attempt_env)
+            } else {
+                true
+            };
+
+            let result = loop {
+                let result = self
+                    .execute_in_single_attempt(ExecuteInAttempt {
+                        executor: &executor,
+                        prompt,
+                        work_dir,
+                        extra_env: Some(&prepared_attempt_env),
+                        stream_mode,
+                        idle_timeout_seconds,
+                        resolved_initial_response_timeout: initial_response_timeout,
+                    })
+                    .await?;
+                if executor.tool_name() != "gemini-cli"
+                    || !is_gemini_mcp_issue_result(&result.execution)
+                    || retried_degraded_mcp
+                    || !allow_degraded_mcp
+                {
+                    break result;
+                }
+
+                let diagnostic = mcp_diagnostic.clone().unwrap_or_else(|| {
+                    diagnose_mcp_init_failure(
+                        gemini_runtime_home
+                            .as_deref()
+                            .expect("gemini runtime home"),
+                    )
+                });
+                let disable_all = diagnostic.unhealthy_servers.is_empty();
+                if let Some(runtime_home) = gemini_runtime_home.as_deref() {
+                    disable_mcp_servers_in_runtime(runtime_home, &diagnostic, disable_all)?;
+                }
+                tracing::warn!(
+                    unhealthy_servers = %diagnostic.unhealthy_servers.join(","),
+                    disable_all,
+                    "gemini-cli execute_in reported MCP startup issues; retrying with degraded MCP"
+                );
+                mcp_diagnostic = Some(diagnostic);
+                retried_degraded_mcp = true;
+            };
+            let mut result = result;
+            if retried_degraded_mcp {
+                let warning_summary = format_mcp_init_warning_summary(
+                    mcp_diagnostic
+                        .as_ref()
+                        .expect("degraded MCP retry should preserve diagnostic"),
+                    mcp_diagnostic
+                        .as_ref()
+                        .is_some_and(|diagnostic| diagnostic.unhealthy_servers.is_empty()),
+                );
+                apply_gemini_mcp_warning_summary(&mut result.execution, &warning_summary);
+            } else if executor.tool_name() == "gemini-cli"
+                && is_gemini_mcp_issue_result(&result.execution)
+                && !allow_degraded_mcp
+            {
+                let warning_summary = format_mcp_init_warning_summary(
+                    mcp_diagnostic
+                        .as_ref()
+                        .expect("gemini diagnostic should exist"),
+                    mcp_diagnostic
+                        .as_ref()
+                        .is_some_and(|diagnostic| diagnostic.unhealthy_servers.is_empty()),
+                );
+                apply_gemini_mcp_warning_summary(&mut result.execution, &warning_summary);
+            }
+            if let Some(backoff) =
+                self.should_retry_gemini_rate_limited(&result.execution, attempt, extra_env)
+            {
+                let phase_desc = match attempt {
+                    1 => "OAuth→APIKey(same model)",
+                    2 => "APIKey(same model)→APIKey(flash)",
+                    _ => "final",
+                };
+                tracing::info!(
+                    attempt,
+                    phase_desc,
+                    "gemini-cli rate limited; advancing phase"
+                );
+                tokio::time::sleep(backoff).await;
+                attempt = attempt.saturating_add(1);
+                continue;
+            }
+            let direct_timeout = consume_resolved_execute_in_initial_response_timeout_seconds(
+                initial_response_timeout,
+            );
+            let retry_executor = executor.clone();
+            let result = apply_and_maybe_retry_codex_exec_initial_stall(
+                &executor,
+                result,
+                direct_timeout,
+                |retry_budget| async move {
+                    let mut downgraded_executor = retry_executor;
+                    downgraded_executor.override_thinking_budget(retry_budget);
+                    let retry_result = self
+                        .execute_in_single_attempt(ExecuteInAttempt {
+                            executor: &downgraded_executor,
+                            prompt,
+                            work_dir,
+                            extra_env: Some(&prepared_attempt_env),
+                            stream_mode,
+                            idle_timeout_seconds,
+                            resolved_initial_response_timeout: initial_response_timeout,
+                        })
+                        .await?;
+                    Ok((downgraded_executor, retry_result))
+                },
+            )
+            .await?;
+            if let Some(classification) =
+                classify_gemini_legacy_initial_stall(&executor, &result.execution, direct_timeout)
+            {
+                let mut result = result;
+                apply_gemini_legacy_initial_stall_summary(&mut result.execution, &classification);
+                return Ok(result);
+            }
+            return Ok(result);
+        }
     }
 }

--- a/crates/csa-executor/src/transport_legacy_impl.rs
+++ b/crates/csa-executor/src/transport_legacy_impl.rs
@@ -41,7 +41,10 @@ impl Transport for LegacyTransport {
                     session_dir.as_deref(),
                     &session.meta_session_id,
                 )?;
-                let diagnostic = diagnose_mcp_init_failure(&runtime_home);
+                let diagnostic = diagnose_mcp_init_failure(
+                    &runtime_home,
+                    prepared_attempt_env.get("PATH").map(std::ffi::OsStr::new),
+                );
                 gemini_runtime_home = Some(runtime_home);
                 mcp_diagnostic = Some(diagnostic);
                 gemini_allow_degraded_mcp(&prepared_attempt_env)
@@ -70,7 +73,12 @@ impl Transport for LegacyTransport {
 
                 let diagnostic = mcp_diagnostic
                     .clone()
-                    .unwrap_or_else(|| diagnose_mcp_init_failure(gemini_runtime_home.as_deref().expect("gemini runtime home")));
+                    .unwrap_or_else(|| {
+                        diagnose_mcp_init_failure(
+                            gemini_runtime_home.as_deref().expect("gemini runtime home"),
+                            prepared_attempt_env.get("PATH").map(std::ffi::OsStr::new),
+                        )
+                    });
                 let disable_all = diagnostic.unhealthy_servers.is_empty();
                 if let Some(runtime_home) = gemini_runtime_home.as_deref() {
                     disable_mcp_servers_in_runtime(runtime_home, &diagnostic, disable_all)?;
@@ -268,7 +276,10 @@ impl LegacyTransport {
                     None,
                     &session_id,
                 )?;
-                let diagnostic = diagnose_mcp_init_failure(&runtime_home);
+                let diagnostic = diagnose_mcp_init_failure(
+                    &runtime_home,
+                    prepared_attempt_env.get("PATH").map(std::ffi::OsStr::new),
+                );
                 gemini_runtime_home = Some(runtime_home);
                 mcp_diagnostic = Some(diagnostic);
                 gemini_allow_degraded_mcp(&prepared_attempt_env)
@@ -301,6 +312,7 @@ impl LegacyTransport {
                         gemini_runtime_home
                             .as_deref()
                             .expect("gemini runtime home"),
+                        prepared_attempt_env.get("PATH").map(std::ffi::OsStr::new),
                     )
                 });
                 let disable_all = diagnostic.unhealthy_servers.is_empty();

--- a/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
@@ -406,3 +406,204 @@ exit 1
         "expected child stderr in error text, got: {error_text}"
     );
 }
+
+fn write_fake_gemini_startup_script(script_path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::write(
+        script_path,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+settings_path="${GEMINI_CLI_HOME:-$HOME/.gemini}/.gemini/settings.json"
+if [ -f "$settings_path" ] && grep -q '"mcpServers"[[:space:]]*:[[:space:]]*{' "$settings_path" && ! grep -q '"mcpServers"[[:space:]]*:[[:space:]]*{}' "$settings_path"; then
+  echo "MCP issues detected. Run /mcp list for status."
+  exit 1
+fi
+echo "hello"
+"#,
+    )
+    .expect("write fake gemini");
+    let mut perms = std::fs::metadata(script_path)
+        .expect("metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(script_path, perms).expect("chmod +x");
+}
+
+fn write_gemini_settings(home: &std::path::Path, command: &str) {
+    let gemini_dir = home.join(".gemini");
+    std::fs::create_dir_all(&gemini_dir).expect("create .gemini");
+    std::fs::write(
+        gemini_dir.join("settings.json"),
+        format!(
+            r#"{{
+  "mcpServers": {{
+    "broken-mcp": {{
+      "command": "{command}",
+      "args": ["--mcp"]
+    }}
+  }}
+}}"#
+        ),
+    )
+    .expect("write gemini settings");
+}
+
+#[tokio::test]
+async fn test_execute_in_retries_with_degraded_mcp_when_allowed() {
+    let _env_lock = GEMINI_INIT_ENV_LOCK
+        .lock()
+        .expect("gemini init env lock poisoned");
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script_path = temp.path().join("gemini");
+    write_fake_gemini_startup_script(&script_path);
+
+    let source_home = temp.path().join("source-home");
+    write_gemini_settings(&source_home, "missing-mcp-command");
+
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let env = HashMap::from([
+        ("HOME".to_string(), source_home.to_string_lossy().into_owned()),
+        (
+            "PATH".to_string(),
+            format!("{}:{old_path}", temp.path().display()),
+        ),
+        (
+            "CSA_GEMINI_ALLOW_DEGRADED_MCP".to_string(),
+            "1".to_string(),
+        ),
+    ]);
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+
+    let result = transport
+        .execute_in(
+            "print hello",
+            temp.path(),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+            super::ResolvedTimeout(Some(5)),
+        )
+        .await
+        .expect("execute_in should succeed after degraded retry");
+
+    assert_eq!(result.execution.exit_code, 0);
+    assert_eq!(result.execution.output.trim(), "hello");
+    assert!(
+        result.execution.summary.contains("gemini-cli MCP init degraded"),
+        "expected degraded MCP warning in summary, got: {}",
+        result.execution.summary
+    );
+    assert!(
+        result.execution.summary.contains("broken-mcp"),
+        "expected unhealthy server name in summary, got: {}",
+        result.execution.summary
+    );
+}
+
+#[tokio::test]
+async fn test_execute_in_hard_fails_when_degraded_mcp_disabled() {
+    let _env_lock = GEMINI_INIT_ENV_LOCK
+        .lock()
+        .expect("gemini init env lock poisoned");
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script_path = temp.path().join("gemini");
+    write_fake_gemini_startup_script(&script_path);
+
+    let source_home = temp.path().join("source-home");
+    write_gemini_settings(&source_home, "missing-mcp-command");
+
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let env = HashMap::from([
+        ("HOME".to_string(), source_home.to_string_lossy().into_owned()),
+        (
+            "PATH".to_string(),
+            format!("{}:{old_path}", temp.path().display()),
+        ),
+        (
+            "CSA_GEMINI_ALLOW_DEGRADED_MCP".to_string(),
+            "0".to_string(),
+        ),
+    ]);
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+
+    let result = transport
+        .execute_in(
+            "print hello",
+            temp.path(),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+            super::ResolvedTimeout(Some(5)),
+        )
+        .await
+        .expect("execute_in should return startup failure result");
+
+    assert_eq!(result.execution.exit_code, 1);
+    assert!(
+        result.execution.summary.contains("broken-mcp"),
+        "expected unhealthy server name in summary, got: {}",
+        result.execution.summary
+    );
+    assert!(
+        result.execution.output.contains("MCP issues detected"),
+        "expected original gemini startup failure to remain visible, got: {}",
+        result.execution.output
+    );
+}
+
+#[tokio::test]
+async fn test_execute_in_healthy_mcp_has_no_warning() {
+    let _env_lock = GEMINI_INIT_ENV_LOCK
+        .lock()
+        .expect("gemini init env lock poisoned");
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let script_path = temp.path().join("gemini");
+    write_fake_gemini_startup_script(&script_path);
+
+    let source_home = temp.path().join("source-home");
+    std::fs::create_dir_all(source_home.join(".gemini")).expect("create .gemini");
+    std::fs::write(source_home.join(".gemini/settings.json"), "{}").expect("write settings");
+
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    let env = HashMap::from([
+        ("HOME".to_string(), source_home.to_string_lossy().into_owned()),
+        (
+            "PATH".to_string(),
+            format!("{}:{old_path}", temp.path().display()),
+        ),
+    ]);
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+
+    let result = transport
+        .execute_in(
+            "print hello",
+            temp.path(),
+            Some(&env),
+            StreamMode::BufferOnly,
+            30,
+            super::ResolvedTimeout(Some(5)),
+        )
+        .await
+        .expect("healthy MCP config should succeed");
+
+    assert_eq!(result.execution.exit_code, 0);
+    assert_eq!(result.execution.output.trim(), "hello");
+    assert!(
+        !result.execution.summary.contains("gemini-cli MCP init degraded"),
+        "healthy startup should not inject degraded warning: {}",
+        result.execution.summary
+    );
+}


### PR DESCRIPTION
## Summary
- Investigation: "MCP issues detected" text originates from gemini-cli startup output; CSA previously propagated as fatal
- Demote to warning by default; gemini-cli retries once with unhealthy MCP servers disabled
- New config: `[tools.gemini-cli] allow_degraded_mcp = true` (default on; set `false` to restore hard-fail)
- Synthesized summaries now name unhealthy MCP server(s) with `csa doctor` remediation hint
- Gated to gemini-cli; codex/claude-code untouched

## Scope
15 files, +737 / -170 LOC. New modules: `transport_gemini_mcp_diagnostic.rs` (~150 LOC), `transport_tests_gemini_init_classification.rs` (~200 LOC).

## Test plan
- [x] `cargo test --workspace` green
- [x] `just pre-commit` green

Closes #886, closes #914.