### PR TITLE
fix(csa-review): classify gemini quota-exhausted as rate-limit, not MCP (#871)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.444"
+version = "0.1.445"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.444"
+version = "0.1.445"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::Result;
+use csa_core::gemini::RATE_LIMIT_PATTERNS;
 use csa_core::types::{ReviewDecision, ToolName};
 use csa_executor::{
     contains_gemini_oauth_prompt, normalize_gemini_prompt_text, strip_ansi_escape_sequences,
@@ -632,8 +633,23 @@ pub(super) fn is_worktree_submodule(project_root: &Path) -> bool {
 /// Checks both stdout and stderr for known failure patterns.
 /// Returns a human-readable diagnostic summary when a known pattern is found.
 pub(super) fn detect_tool_diagnostic(stdout: &str, stderr: &str) -> Option<String> {
+    let has_quota_issue = |text: &str| {
+        let text_lower = text.to_ascii_lowercase();
+        RATE_LIMIT_PATTERNS
+            .iter()
+            .copied()
+            .any(|marker| text_lower.contains(marker))
+            || text_lower.contains("quota will reset")
+    };
     let has_mcp_issue =
         |text: &str| text.contains("MCP issues detected") || text.contains("Run /mcp list");
+
+    if has_quota_issue(stdout) || has_quota_issue(stderr) {
+        return Some(
+            "gemini-cli OAuth quota exhausted. Either (a) configure GEMINI_API_KEY in ~/.config/cli-sub-agent/config.toml under [tools.gemini-cli] api_key for automatic retry, or (b) wait for quota reset."
+                .to_string(),
+        );
+    }
 
     if has_mcp_issue(stdout) || has_mcp_issue(stderr) {
         return Some(

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -144,6 +144,38 @@ fn test_detect_tool_diagnostic_mcp_list_in_stderr_returns_diagnostic() {
 }
 
 #[test]
+fn detect_tool_diagnostic_returns_quota_message_for_gemini_429() {
+    let stderr = r#"{"code": 429, "reason": "QUOTA_EXHAUSTED", "message": "You have exhausted your capacity on this model. Your quota will reset after 16h8m32s."}"#;
+    let result = detect_tool_diagnostic("", stderr);
+    assert!(result.is_some());
+    let msg = result.unwrap();
+    assert!(msg.contains("OAuth quota exhausted"), "got: {msg}");
+    assert!(msg.contains("GEMINI_API_KEY"), "got: {msg}");
+}
+
+#[test]
+fn detect_tool_diagnostic_prefers_quota_over_mcp_when_both_present() {
+    let stderr = "MCP issues detected. Run /mcp list for status.\ncause: {code: 429, reason: 'QUOTA_EXHAUSTED'}";
+    let result = detect_tool_diagnostic("", stderr);
+    assert!(result.is_some());
+    let msg = result.unwrap();
+    assert!(msg.contains("OAuth quota exhausted"), "got: {msg}");
+    assert!(
+        !msg.contains("Run `csa doctor`"),
+        "should not emit MCP guidance when quota is root cause; got: {msg}"
+    );
+}
+
+#[test]
+fn detect_tool_diagnostic_still_returns_mcp_when_only_mcp_markers() {
+    let stderr = "MCP issues detected. Run /mcp list for status.";
+    let result = detect_tool_diagnostic("", stderr);
+    assert!(result.is_some());
+    let msg = result.unwrap();
+    assert!(msg.contains("MCP init degraded"), "got: {msg}");
+}
+
+#[test]
 fn test_detect_tool_diagnostic_unrelated_mcp_text_returns_none() {
     let stdout = "MCP servers loaded successfully";
     let stderr = "Connected to 2 MCP backends";


### PR DESCRIPTION
## Summary

- `detect_tool_diagnostic` in `review_cmd_output.rs` previously matched only the literal \"MCP issues detected\" / \"Run /mcp list\" substrings. Gemini-cli error envelopes that contain BOTH the MCP hint AND the real `QUOTA_EXHAUSTED` cause were misclassified — users saw \"Run /mcp list\" guidance and an incorrect fallback suggestion (`--tool claude-code`) when the actual remedy is to configure `GEMINI_API_KEY` or wait for quota reset.
- Add a quota-first branch that reuses `csa-core::gemini::RATE_LIMIT_PATTERNS` (plus `\"quota will reset\"`) and emits GEMINI_API_KEY-fallback guidance. The MCP branch still fires for genuine MCP-server connectivity issues.

Closes #871.

## Test plan

- [x] `cargo test -p cli-sub-agent detect_tool_diagnostic`
- [x] `cargo test -p cli-sub-agent review_cmd`
- [x] `cargo test --workspace`
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)