### PR TITLE
fix(cli-sub-agent): ScopedSessionSandbox uses tokio::sync::Mutex (#754)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.445"
+version = "0.1.446"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.445"
+version = "0.1.446"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/bug_class_tests.rs
+++ b/crates/cli-sub-agent/src/bug_class_tests.rs
@@ -189,7 +189,7 @@ fn aggregation_skips_findings_without_rule_id() {
 #[test]
 fn loader_prefers_consolidated_artifacts_and_skips_sessions_without_reviews() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let _sandbox = ScopedSessionSandbox::new(&temp);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&temp);
     let project_root = temp.path().join("project");
     fs::create_dir_all(&project_root).expect("project root");
 

--- a/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
@@ -51,7 +51,7 @@ fn write_global_config(contents: &str) -> std::path::PathBuf {
 
 #[test]
 fn build_config_get_lookup_global_kv_cache_returns_not_found_when_key_is_absent() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -76,7 +76,7 @@ tool = "auto"
 
 #[test]
 fn resolve_lookup_sources_global_raw_match_survives_invalid_unrelated_global_field() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -103,7 +103,7 @@ max_concurrent = "oops"
 
 #[test]
 fn resolve_lookup_sources_warns_when_raw_global_fallback_follows_effective_project_parse_error() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();

--- a/crates/cli-sub-agent/src/config_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_tests.rs
@@ -141,7 +141,7 @@ fn build_project_display_json_keeps_effective_execution_defaults_visible() {
 
 #[test]
 fn resolve_effective_execution_key_uses_compile_default_when_no_config_exists() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -182,7 +182,7 @@ auto_weave_upgrade = true
 
 #[test]
 fn resolve_effective_execution_key_uses_global_fallback_when_project_missing() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -211,7 +211,7 @@ auto_weave_upgrade = true
 
 #[test]
 fn build_config_get_lookup_resolves_effective_project_nested_resource_keys() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -251,7 +251,7 @@ memory_max_mb = 1024
 
 #[test]
 fn resolve_effective_global_key_uses_kv_cache_defaults_when_global_config_missing() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -271,7 +271,7 @@ fn resolve_effective_global_key_uses_kv_cache_defaults_when_global_config_missin
 
 #[test]
 fn resolve_effective_global_key_uses_configured_kv_cache_values() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -299,7 +299,7 @@ long_poll_seconds = 3000
 
 #[test]
 fn resolve_effective_global_key_sanitizes_zero_kv_cache_values() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -327,7 +327,7 @@ long_poll_seconds = 0
 
 #[test]
 fn resolve_effective_key_ignores_project_kv_cache_override() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -366,7 +366,7 @@ long_poll_seconds = 9999
 
 #[test]
 fn build_config_get_lookup_preserves_unknown_raw_project_sections() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -426,7 +426,7 @@ delete_branch = false
 
 #[test]
 fn build_config_get_lookup_prefers_effective_values_for_known_sections() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -463,7 +463,7 @@ enabled = true
 
 #[test]
 fn resolve_effective_key_redacts_global_memory_api_keys_in_project_scoped_lookups() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -507,7 +507,7 @@ inject = true
 
 #[test]
 fn build_config_get_lookup_project_only_uses_effective_project_defaults() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -541,7 +541,7 @@ memory_max_mb = 1024
 
 #[test]
 fn resolve_lookup_sources_falls_back_to_raw_project_for_known_sections_when_global_is_invalid() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -573,7 +573,7 @@ memory_max_mb = 1024
 
 #[test]
 fn resolve_lookup_sources_returns_project_raw_match_before_global_parse() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -606,7 +606,7 @@ cloud_bot_name = "gemini-code-assist"
 
 #[test]
 fn resolve_lookup_sources_invalid_project_raw_still_errors_before_global_match() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_root = dir.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).unwrap();
@@ -696,7 +696,7 @@ fn parse_editor_command_rejects_whitespace_only_value() {
 #[cfg(unix)]
 #[test]
 fn handle_config_edit_supports_quoted_editor_path_with_embedded_args() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
     let config_dir = dir.path().join(".csa");
     std::fs::create_dir_all(&config_dir).unwrap();

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -105,7 +105,7 @@ fn resolve_debate_tool_prefers_cli_override() {
 
 #[test]
 fn resolve_debate_tool_auto_maps_heterogeneous() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
     let global = GlobalConfig::default();
@@ -128,7 +128,7 @@ fn resolve_debate_tool_auto_maps_heterogeneous() {
 
 #[test]
 fn resolve_debate_tool_auto_maps_reverse() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
     let global = GlobalConfig::default();
@@ -153,7 +153,7 @@ fn resolve_debate_tool_auto_maps_reverse() {
 fn resolve_debate_tool_same_model_fallback_when_no_parent() {
     // With same_model_fallback enabled (default), no parent context should fall
     // back to same-model adversarial using any explicitly available tool.
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
     let global = GlobalConfig::default();
@@ -200,7 +200,7 @@ fn resolve_debate_tool_same_model_fallback_disabled_errors_without_parent() {
 #[test]
 fn resolve_debate_tool_same_model_fallback_uses_parent_tool() {
     // When only the parent tool family is available, fallback uses the parent tool.
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
     let global = GlobalConfig::default();
@@ -271,7 +271,7 @@ fn resolve_debate_tool_prefers_project_override() {
 
 #[test]
 fn resolve_debate_tool_project_auto_maps_heterogeneous() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
     let global = GlobalConfig::default();
@@ -299,7 +299,7 @@ fn resolve_debate_tool_project_auto_maps_heterogeneous() {
 
 #[test]
 fn resolve_debate_tool_project_auto_prefers_priority_over_counterpart() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
     let mut global = GlobalConfig::default();
@@ -329,7 +329,7 @@ fn resolve_debate_tool_project_auto_prefers_priority_over_counterpart() {
 
 #[test]
 fn resolve_debate_tool_unknown_priority_still_uses_auto_heterogeneous_selection() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
     let mut global = GlobalConfig::default();
@@ -607,7 +607,7 @@ fn persist_debate_output_artifacts_includes_mode_for_same_model() {
 #[test]
 fn append_debate_artifacts_to_result_updates_summary_and_artifacts() {
     let temp = tempfile::TempDir::new().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = temp.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", temp.path());

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -226,7 +226,7 @@ fn resolve_debate_tool_auto_skips_counterpart_without_configured_binary() {
     use std::os::unix::fs::PermissionsExt;
 
     let td = tempfile::tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let bin_dir = td.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
 
@@ -286,7 +286,7 @@ fn resolve_debate_tool_same_model_fallback_skips_unavailable_configured_binary()
     use std::os::unix::fs::PermissionsExt;
 
     let td = tempfile::tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let bin_dir = td.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
 
@@ -340,7 +340,7 @@ fn resolve_debate_tool_same_model_fallback_skips_unavailable_parent_binary() {
     use std::os::unix::fs::PermissionsExt;
 
     let td = tempfile::tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("debate env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let bin_dir = td.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
 
@@ -402,7 +402,7 @@ fn verify_debate_skill_no_fallback_without_skill() {
 #[tokio::test]
 async fn handle_debate_persists_result_for_direct_tool_tier_rejection() {
     let project_dir = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
     config.tiers.insert(
         "default".to_string(),

--- a/crates/cli-sub-agent/src/doctor_routing.rs
+++ b/crates/cli-sub-agent/src/doctor_routing.rs
@@ -685,9 +685,7 @@ mod tests {
 
     #[test]
     fn doctor_routing_reports_invalid_effective_config_and_renders_partial_context() {
-        let _env_lock = TEST_ENV_LOCK
-            .lock()
-            .expect("doctor routing env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let td = tempfile::tempdir().expect("tempdir");
         let config_root = td.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).expect("create config root");

--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -282,7 +282,7 @@ transport = "stdio"
 
 #[test]
 fn doctor_project_config_display_ignores_invalid_user_global_config() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("doctor env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let td = tempfile::tempdir().expect("tempdir");
     let config_root = td.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).expect("create config root");
@@ -330,7 +330,7 @@ transport = "cli"
 
 #[test]
 fn doctor_text_reports_invalid_effective_config() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("doctor env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let td = tempfile::tempdir().expect("tempdir");
     let config_root = td.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).expect("create config root");
@@ -391,7 +391,7 @@ transport = "cli"
 
 #[test]
 fn doctor_json_reports_invalid_effective_config() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("doctor env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let td = tempfile::tempdir().expect("tempdir");
     let config_root = td.path().join("xdg-config");
     std::fs::create_dir_all(&config_root).expect("create config root");

--- a/crates/cli-sub-agent/src/pipeline_handoff.rs
+++ b/crates/cli-sub-agent/src/pipeline_handoff.rs
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn write_handoff_artifact_creates_file_in_session_dir() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let _sandbox = ScopedSessionSandbox::new(&tmp);
+        let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
         let project_root = tmp.path();
         let session =
             csa_session::create_session(project_root, Some("handoff test"), None, Some("codex"))
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn write_handoff_artifact_skips_when_session_dir_missing() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let _sandbox = ScopedSessionSandbox::new(&tmp);
+        let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
         let project_root = tmp.path();
         let missing_dir = project_root.join("nonexistent");
 

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -600,7 +600,7 @@ mod tests {
     #[test]
     fn ensure_terminal_result_on_post_exec_error_writes_missing_result() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let _sandbox = ScopedSessionSandbox::new(&tmp);
+        let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
         let project_root = tmp.path();
         let mut session = create_session(project_root, Some("test"), None, Some("codex"))
             .expect("create session");
@@ -643,7 +643,7 @@ mod tests {
     #[test]
     fn ensure_terminal_result_on_post_exec_error_keeps_existing_result() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let _sandbox = ScopedSessionSandbox::new(&tmp);
+        let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
         let project_root = tmp.path();
         let mut session = create_session(project_root, Some("test"), None, Some("codex"))
             .expect("create session");
@@ -677,7 +677,7 @@ mod tests {
     #[test]
     fn ensure_terminal_result_for_session_on_post_exec_error_persists_output_tail_for_fork() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let _sandbox = ScopedSessionSandbox::new(&tmp);
+        let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
         let project_root = tmp.path();
         let parent = create_session(project_root, Some("parent"), None, Some("codex"))
             .expect("create parent session");

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -340,9 +340,7 @@ enforcement_mode = "best-effort"
 
 #[test]
 fn test_cross_repo_cd_uses_explicit_project_root_for_sandbox_plan() {
-    let _env_lock = TEST_ENV_LOCK
-        .lock()
-        .expect("pipeline sandbox env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let invocation_cwd = tempfile::tempdir().expect("invocation cwd tempdir");
     let target_project = tempfile::tempdir().expect("target project tempdir");
     let _cwd_guard = CurrentDirGuard::change_to(invocation_cwd.path());

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -46,7 +46,7 @@ fn sandbox_pipeline_config_env(
     ScopedEnvVarRestore,
     ScopedEnvVarRestore,
 ) {
-    let mut sandbox = ScopedSessionSandbox::new(tmp);
+    let mut sandbox = ScopedSessionSandbox::new_blocking(tmp);
     sandbox.track_env("HOME");
     sandbox.track_env("XDG_CONFIG_HOME");
     let home = ScopedEnvVarRestore::set("HOME", tmp.path().to_str().unwrap());
@@ -166,7 +166,7 @@ fn resolve_idle_timeout_prefers_cli_override() {
 fn auto_description_from_prompt_when_none_provided() {
     use crate::run_helpers::truncate_prompt;
     let tmp = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&tmp);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
     let project_root = tmp.path();
     let prompt = "Analyze the authentication module and fix the login bug";
     let description: Option<String> = None;
@@ -204,7 +204,7 @@ fn auto_description_from_prompt_when_none_provided() {
 fn auto_description_truncates_long_prompt() {
     use crate::run_helpers::truncate_prompt;
     let tmp = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&tmp);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
     let project_root = tmp.path();
     let long_prompt = "Please analyze the entire authentication module including OAuth2 flows, JWT token validation, session management, RBAC permissions, and the password reset workflow to identify all security vulnerabilities";
     let description: Option<String> = None;
@@ -226,7 +226,7 @@ fn auto_description_truncates_long_prompt() {
 #[test]
 fn resumed_session_keeps_existing_description() {
     let tmp = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&tmp);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
     let project_root = tmp.path();
     let original_desc = "original task description";
     let session =
@@ -543,7 +543,7 @@ fn cleanup_guard_preserves_dir_when_defused() {
 #[test]
 fn pre_exec_failure_preserves_session_with_error_result() {
     let tmp = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&tmp);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
     let project_root = tmp.path();
 
     let session = csa_session::create_session(project_root, Some("test"), None, Some("codex"))
@@ -577,7 +577,7 @@ fn pre_exec_failure_preserves_session_with_error_result() {
 #[test]
 fn pre_exec_error_writes_failure_result() {
     let tmp = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&tmp);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
     let project_root = tmp.path();
 
     let session = csa_session::create_session(project_root, Some("test"), None, Some("codex"))

--- a/crates/cli-sub-agent/src/pipeline_tests_locking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_locking.rs
@@ -5,7 +5,7 @@ use std::fs;
 #[tokio::test]
 async fn execute_with_session_and_meta_does_not_persist_runtime_binary_when_lock_is_held() {
     let temp = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&temp);
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
     let project_root = temp.path();
 
     let session =

--- a/crates/cli-sub-agent/src/pipeline_tests_prompt_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_prompt_guard.rs
@@ -13,9 +13,7 @@ fn restore_env_var(key: &str, original: Option<String>) {
 
 #[test]
 fn prompt_guard_caller_injection_defaults_to_enabled() {
-    let _env_lock = TEST_ENV_LOCK
-        .lock()
-        .expect("prompt guard env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let original_guard = std::env::var(PROMPT_GUARD_CALLER_INJECTION_ENV).ok();
     let original_depth = std::env::var("CSA_DEPTH").ok();
     // SAFETY: test-scoped env mutation, restored immediately.
@@ -31,9 +29,7 @@ fn prompt_guard_caller_injection_defaults_to_enabled() {
 
 #[test]
 fn prompt_guard_caller_injection_honors_disable_values() {
-    let _env_lock = TEST_ENV_LOCK
-        .lock()
-        .expect("prompt guard env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let original_guard = std::env::var(PROMPT_GUARD_CALLER_INJECTION_ENV).ok();
     let original_depth = std::env::var("CSA_DEPTH").ok();
     // SAFETY: test-scoped env mutation, restored immediately.
@@ -54,9 +50,7 @@ fn prompt_guard_caller_injection_honors_disable_values() {
 
 #[test]
 fn prompt_guard_caller_injection_disabled_for_recursive_depth() {
-    let _env_lock = TEST_ENV_LOCK
-        .lock()
-        .expect("prompt guard env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let original_guard = std::env::var(PROMPT_GUARD_CALLER_INJECTION_ENV).ok();
     let original_depth = std::env::var("CSA_DEPTH").ok();
 
@@ -77,9 +71,7 @@ fn prompt_guard_caller_injection_disabled_for_recursive_depth() {
 
 #[test]
 fn anti_recursion_guard_none_at_depth_zero() {
-    let _env_lock = TEST_ENV_LOCK
-        .lock()
-        .expect("prompt guard env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let original_depth = std::env::var("CSA_DEPTH").ok();
     // SAFETY: test-scoped env mutation, restored immediately.
     unsafe { std::env::remove_var("CSA_DEPTH") };
@@ -93,9 +85,7 @@ fn anti_recursion_guard_none_for_legitimate_fractal_depths() {
     // Layer 1 → Layer 2 (depth 1 → 2) and Layer 2 → Layer 3 (depth 2 → 3) are
     // documented fractal-recursion cases; the guard must not discourage them.
     for depth in ["1", "2", "3"] {
-        let _env_lock = TEST_ENV_LOCK
-            .lock()
-            .expect("prompt guard env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let original_depth = std::env::var("CSA_DEPTH").ok();
         // SAFETY: test-scoped env mutation, restored immediately.
         unsafe { std::env::set_var("CSA_DEPTH", depth) };
@@ -110,9 +100,7 @@ fn anti_recursion_guard_none_for_legitimate_fractal_depths() {
 
 #[test]
 fn anti_recursion_guard_warns_near_default_ceiling() {
-    let _env_lock = TEST_ENV_LOCK
-        .lock()
-        .expect("prompt guard env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let original_depth = std::env::var("CSA_DEPTH").ok();
     // SAFETY: test-scoped env mutation, restored immediately.
     unsafe { std::env::set_var("CSA_DEPTH", "4") };
@@ -130,9 +118,7 @@ fn anti_recursion_guard_warns_near_default_ceiling() {
 
 #[test]
 fn anti_recursion_guard_warns_at_default_ceiling() {
-    let _env_lock = TEST_ENV_LOCK
-        .lock()
-        .expect("prompt guard env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let original_depth = std::env::var("CSA_DEPTH").ok();
     // SAFETY: test-scoped env mutation, restored immediately.
     unsafe { std::env::set_var("CSA_DEPTH", "5") };
@@ -185,9 +171,7 @@ fn anti_recursion_guard_honors_custom_max_recursion_depth() {
     // rendered text so LLMs don't see a stale "max=5" number.
     let cfg_low = project_config_with_max_depth(3);
 
-    let _env_lock = TEST_ENV_LOCK
-        .lock()
-        .expect("prompt guard env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let original_depth = std::env::var("CSA_DEPTH").ok();
 
     // SAFETY: test-scoped env mutation, restored immediately.

--- a/crates/cli-sub-agent/src/pipeline_tests_tail.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_tail.rs
@@ -596,7 +596,7 @@ async fn execute_with_session_and_meta_rejects_illegal_result_path_in_real_flow(
     use std::os::unix::fs::PermissionsExt;
 
     let temp = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&temp);
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
     let _csa_session_id_guard = ScopedEnvVarRestore::unset("CSA_SESSION_ID");
 
     let project_root = temp.path();
@@ -676,7 +676,7 @@ async fn execute_with_session_and_meta_explicit_only_ignores_inherited_parent_se
     use std::os::unix::fs::PermissionsExt;
 
     let temp = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&temp);
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
     let _csa_session_id_guard =
         ScopedEnvVarRestore::set("CSA_SESSION_ID", "01K00000000000000000000000");
 

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn next_csa_depth_increments_or_defaults() {
-        let _env_lock = TEST_ENV_LOCK.lock().expect("plan env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let original_depth = std::env::var("CSA_DEPTH").ok();
 
         // SAFETY: test-scoped env mutation.

--- a/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
@@ -78,7 +78,7 @@ fn commit_workflow_csa_dispatch_steps_have_non_empty_prompts() {
 #[tokio::test]
 async fn execute_step_csa_nested_plan_uses_fresh_child_session() {
     let tmp = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&tmp);
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
     let project_root = tmp.path();
 
     let bin_dir = project_root.join("bin");

--- a/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_bug_class_tests.rs
@@ -41,7 +41,7 @@ fn write_review_artifact_file(session_dir: &Path, file_name: &str, artifact: &Re
 #[test]
 fn recurring_bug_class_skill_extraction_runs_for_high_severity_review_completion() {
     let temp = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&temp);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&temp);
     let config_home = temp.path().join("config");
     std::fs::create_dir_all(&config_home).unwrap();
     let _config_guard = ScopedEnvVarRestore::set("XDG_CONFIG_HOME", config_home.to_str().unwrap());
@@ -93,7 +93,7 @@ fn recurring_bug_class_skill_extraction_runs_for_high_severity_review_completion
 #[test]
 fn review_iterations_increment_from_prior_review_meta_on_same_branch() {
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
 
     let previous = create_session(
         project_dir.path(),
@@ -139,7 +139,7 @@ fn review_iterations_increment_from_prior_review_meta_on_same_branch() {
 #[test]
 fn review_iterations_do_not_undercount_after_more_than_ten_prior_reviews() {
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
 
     for iteration in 1..=11 {
         let session = create_session(
@@ -188,7 +188,7 @@ fn review_iterations_do_not_undercount_after_more_than_ten_prior_reviews() {
 #[test]
 fn review_iterations_use_max_prior_value_instead_of_most_recent_session() {
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
 
     let older_high = create_session(
         project_dir.path(),
@@ -262,7 +262,7 @@ fn review_iterations_use_max_prior_value_instead_of_most_recent_session() {
 #[test]
 fn bug_class_loader_collapses_multi_reviewer_sessions_into_one_logical_review() {
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
 
     let reviewer_one = create_session(
         project_dir.path(),
@@ -329,7 +329,7 @@ fn bug_class_loader_collapses_multi_reviewer_sessions_into_one_logical_review() 
 #[test]
 fn bug_class_loader_skips_parent_consolidated_artifact_to_avoid_false_promotion() {
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
 
     let parent = create_session(
         project_dir.path(),
@@ -415,7 +415,7 @@ fn bug_class_loader_skips_parent_consolidated_artifact_to_avoid_false_promotion(
 #[test]
 fn bug_class_loader_keeps_sessions_with_review_meta_even_if_consolidated_exists() {
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
 
     let child = create_session(
         project_dir.path(),
@@ -461,7 +461,7 @@ fn bug_class_loader_keeps_sessions_with_review_meta_even_if_consolidated_exists(
 #[test]
 fn bug_class_loader_reads_exact_consolidated_path_written_by_consensus_writer() {
     let temp = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&temp);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&temp);
     let project_root = temp.path().join("project");
     std::fs::create_dir_all(&project_root).unwrap();
 

--- a/crates/cli-sub-agent/src/review_cmd_execute_guard_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_guard_tests.rs
@@ -12,7 +12,7 @@ async fn execute_review_fails_when_repo_root_output_artifact_is_created() {
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_opencode = bin_dir.join("opencode");
@@ -93,7 +93,7 @@ async fn execute_review_error_path_still_checks_artifact_contract() {
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_opencode = bin_dir.join("opencode");
@@ -163,7 +163,7 @@ async fn execute_review_retry_path_still_checks_artifact_contract() {
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_gemini = bin_dir.join("gemini");
@@ -256,7 +256,7 @@ async fn execute_review_fails_when_repo_root_findings_artifact_is_created() {
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_opencode = bin_dir.join("opencode");

--- a/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
@@ -15,7 +15,7 @@ async fn execute_review_reclassifies_complete_review_after_edit_restriction() {
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_opencode = bin_dir.join("opencode");
@@ -114,7 +114,7 @@ async fn execute_review_preserves_codex_default_target_when_project_target_exist
     use std::os::unix::fs::{PermissionsExt, symlink};
 
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let target_mount = project_dir.path().join("ssd-target");
     std::fs::create_dir_all(&target_mount).unwrap();
     symlink(&target_mount, project_dir.path().join("target")).unwrap();
@@ -203,7 +203,7 @@ async fn execute_review_model_spec_bypasses_tier_enforcement_without_active_tier
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_opencode = bin_dir.join("opencode");
@@ -288,7 +288,7 @@ printf '%s\\n' \
 #[test]
 fn synthesize_missing_review_result_makes_session_result_readable() {
     let td = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&td);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
     let project_root = td.path();
 
     let session =
@@ -344,7 +344,7 @@ fn read_review_failure_excerpt_ignores_bytes_beyond_4kb() {
 #[test]
 fn synthesize_missing_review_result_propagates_peak_memory_from_error_chain() {
     let td = tempfile::tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&td);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
     let project_root = td.path();
 
     let session =
@@ -382,7 +382,7 @@ async fn execute_review_retries_gemini_with_api_key_after_oauth_prompt() {
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_gemini = bin_dir.join("gemini");
@@ -468,7 +468,7 @@ async fn execute_review_classifies_gemini_oauth_prompt_without_api_key() {
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_gemini = bin_dir.join("gemini");
@@ -543,7 +543,7 @@ async fn execute_review_does_not_retry_gemini_auth_prompt_when_no_failover_is_se
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_gemini = bin_dir.join("gemini");

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -11,8 +11,8 @@ use serde_json::json;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::MutexGuard;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::OwnedMutexGuard;
 
 fn make_review_meta(session_id: &str) -> ReviewSessionMeta {
     ReviewSessionMeta {
@@ -74,13 +74,8 @@ fn create_session_dir(project_root: &Path, session_id: &str) -> PathBuf {
     session_dir
 }
 
-fn lock_test_session(
-    test_name: &str,
-    session_id: &str,
-) -> (MutexGuard<'static, ()>, PathBuf, PathBuf) {
-    let env_lock = TEST_ENV_LOCK
-        .lock()
-        .expect("review_cmd_output env lock poisoned");
+fn lock_test_session(test_name: &str, session_id: &str) -> (OwnedMutexGuard<()>, PathBuf, PathBuf) {
+    let env_lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
     let project_root = temp_project_root(test_name);
     let session_dir = create_session_dir(&project_root, session_id);
     (env_lock, project_root, session_dir)

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -610,7 +610,7 @@ mod tests {
 
     #[test]
     fn write_multi_reviewer_consolidated_artifact_reads_current_session_reviewer_dir() {
-        let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let temp = tempdir().expect("tempdir should be created");
         let session_dir = temp.path().display().to_string();
         let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);

--- a/crates/cli-sub-agent/src/review_cmd_reviewers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers.rs
@@ -190,6 +190,7 @@ mod tests {
     };
     use csa_core::types::ToolName;
     use std::collections::HashMap;
+    use tokio::sync::OwnedMutexGuard;
 
     struct ScopedEnvVarRestore {
         key: &'static str,
@@ -217,10 +218,9 @@ mod tests {
         }
     }
 
-    fn assume_review_tools_available() -> (std::sync::MutexGuard<'static, ()>, ScopedEnvVarRestore)
-    {
+    fn assume_review_tools_available() -> (OwnedMutexGuard<()>, ScopedEnvVarRestore) {
         (
-            TEST_ENV_LOCK.lock().expect("review env lock poisoned"),
+            TEST_ENV_LOCK.clone().blocking_lock_owned(),
             ScopedEnvVarRestore::set(TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1"),
         )
     }

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -10,12 +10,13 @@ use csa_config::{ProjectMeta, ResourcesConfig, ToolConfig, ToolTransport};
 use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoManager};
 use std::{collections::HashMap, process::Command};
 use tempfile::TempDir;
+use tokio::sync::OwnedMutexGuard;
 
 pub(crate) use crate::test_env_lock::ScopedEnvVarRestore;
 
-fn assume_review_tools_available() -> (std::sync::MutexGuard<'static, ()>, ScopedEnvVarRestore) {
+fn assume_review_tools_available() -> (OwnedMutexGuard<()>, ScopedEnvVarRestore) {
     (
-        TEST_ENV_LOCK.lock().expect("review env lock poisoned"),
+        TEST_ENV_LOCK.clone().blocking_lock_owned(),
         ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1"),
     )
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -136,7 +136,7 @@ fn build_multi_reviewer_instruction_contains_design_preference_anchor() {
 
 #[test]
 fn count_prior_reviews_zero_omits_iteration_block() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-zero");
 
@@ -163,7 +163,7 @@ fn count_prior_reviews_zero_omits_iteration_block() {
 
 #[test]
 fn count_prior_reviews_one_injects_iteration_two() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-one");
     create_mock_review_session(
@@ -198,7 +198,7 @@ fn count_prior_reviews_one_injects_iteration_two() {
 
 #[test]
 fn count_prior_reviews_three_adds_multi_round_escalation() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-three");
     create_mock_review_session(
@@ -244,7 +244,7 @@ fn count_prior_reviews_three_adds_multi_round_escalation() {
 
 #[test]
 fn multi_round_escalation_keeps_persistent_correctness_bugs_blocking() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-persistent-bug");
     create_mock_review_session(
@@ -282,7 +282,7 @@ fn multi_round_escalation_keeps_persistent_correctness_bugs_blocking() {
 
 #[test]
 fn build_multi_reviewer_instruction_uses_explicit_project_root_outside_cwd() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let project_dir = tempdir().unwrap();
     let unrelated_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-explicit-root");
@@ -311,7 +311,7 @@ fn build_multi_reviewer_instruction_uses_explicit_project_root_outside_cwd() {
 
 #[test]
 fn count_prior_reviews_does_not_pull_reviews_from_other_branches() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-current");
     create_mock_review_session(
@@ -337,7 +337,7 @@ fn count_prior_reviews_does_not_pull_reviews_from_other_branches() {
 
 #[test]
 fn count_prior_reviews_branch_unknown_returns_safe_zero() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-unknown");
     create_mock_review_session(
@@ -362,7 +362,7 @@ fn count_prior_reviews_branch_unknown_returns_safe_zero() {
 
 #[test]
 fn count_prior_reviews_uses_canonical_max_after_more_than_ten_prior_reviews() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let project_dir = tempdir().unwrap();
     init_git_repo_with_branch(project_dir.path(), "feat/iter-many");
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_pre_exec.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_pre_exec.rs
@@ -3,7 +3,7 @@ use super::*;
 #[tokio::test]
 async fn handle_review_persists_result_for_prior_rounds_summary_parse_failure() {
     let project_dir = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     write_review_project_config(
         project_dir.path(),
         &project_config_with_enabled_tools(&["codex"]),

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -607,7 +607,7 @@ async fn execute_review_ignores_inherited_csa_session_id_without_explicit_sessio
     use std::os::unix::fs::PermissionsExt;
 
     let project_dir = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let _session_guard = ScopedEnvVarRestore::set("CSA_SESSION_ID", "01K00000000000000000000000");
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
@@ -675,7 +675,7 @@ fn install_pattern(project_root: &Path, name: &str) {
 #[tokio::test]
 async fn handle_review_persists_result_for_direct_tool_tier_rejection() {
     let project_dir = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
     config.tiers.insert(
         "default".to_string(),

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -230,7 +230,7 @@ fn parse_review_verdict_accepts_clean_phrase_without_explicit_token() {
 
 #[test]
 fn build_multi_reviewer_instruction_prefers_current_session_dir_env_when_both_exist() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _parent_guard =
         ScopedEnvVarRestore::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
     let _session_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, "/tmp/child-session");
@@ -253,7 +253,7 @@ fn build_multi_reviewer_instruction_prefers_current_session_dir_env_when_both_ex
 
 #[test]
 fn build_multi_reviewer_instruction_falls_back_to_parent_session_dir_env() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _parent_guard =
         ScopedEnvVarRestore::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
     let _session_guard = ScopedEnvVarRestore::unset(CSA_SESSION_DIR_ENV_KEY);
@@ -272,7 +272,7 @@ fn build_multi_reviewer_instruction_falls_back_to_parent_session_dir_env() {
 
 #[test]
 fn build_multi_reviewer_instruction_uses_session_first_shell_fallback_when_env_missing() {
-    let _env_lock = TEST_ENV_LOCK.lock().expect("test env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _parent_guard = ScopedEnvVarRestore::unset(CSA_PARENT_SESSION_DIR_ENV_KEY);
     let _session_guard = ScopedEnvVarRestore::unset(CSA_SESSION_DIR_ENV_KEY);
     let project_dir = tempdir().expect("tempdir should be created");

--- a/crates/cli-sub-agent/src/review_context_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_tests.rs
@@ -292,7 +292,7 @@ fn prior_round_assumptions_none_when_no_prior_session() {
     use crate::test_session_sandbox::ScopedSessionSandbox;
 
     let project = setup_git_repo_with_branch("feat/iter1");
-    let _sandbox = ScopedSessionSandbox::new(&project);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project);
 
     let result = discover_prior_round_assumptions(project.path(), Some("feat/iter1"), None);
     assert!(
@@ -308,7 +308,7 @@ fn prior_round_assumptions_render_when_prior_consolidated_artifact_exists() {
     use std::fs;
 
     let project = setup_git_repo_with_branch("feat/iter2");
-    let _sandbox = ScopedSessionSandbox::new(&project);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project);
 
     let prior = create_session(project.path(), Some("prior review"), None, Some("codex"))
         .expect("prior session created");
@@ -373,7 +373,7 @@ fn prior_round_assumptions_render_when_only_single_reviewer_artifact_exists() {
     use std::fs;
 
     let project = setup_git_repo_with_branch("feat/iter1-single");
-    let _sandbox = ScopedSessionSandbox::new(&project);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project);
 
     let prior = create_session(project.path(), Some("prior review"), None, Some("codex"))
         .expect("prior session created");
@@ -412,7 +412,7 @@ fn find_latest_branch_review_meta_breaks_timestamp_ties_by_session_id() {
     use csa_session::{create_session, get_session_dir, write_review_meta};
 
     let project = setup_git_repo_with_branch("feat/tie-break");
-    let _sandbox = ScopedSessionSandbox::new(&project);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project);
     let shared_timestamp = chrono::Utc::now();
 
     let session_a = create_session(project.path(), Some("review-a"), None, Some("codex"))

--- a/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
@@ -86,7 +86,7 @@ fn assert_no_rate_limit(action: RateLimitAction) {
 #[test]
 fn persist_fork_timeout_result_if_missing_skips_non_fork_sessions() {
     let td = tempfile::tempdir().expect("tempdir");
-    let _sandbox = ScopedSessionSandbox::new(&td);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
     let session =
         create_session(td.path(), Some("regular"), None, Some("codex")).expect("create session");
 
@@ -110,7 +110,7 @@ fn persist_fork_timeout_result_if_missing_skips_non_fork_sessions() {
 #[test]
 fn persist_fork_timeout_result_if_missing_writes_fork_failure() {
     let td = tempfile::tempdir().expect("tempdir");
-    let _sandbox = ScopedSessionSandbox::new(&td);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
     let parent = create_session(td.path(), Some("parent"), None, Some("codex")).expect("parent");
     let child = create_session(
         td.path(),

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -73,7 +73,7 @@ fn run_config_without_routable_tools() -> ProjectConfig {
 #[tokio::test]
 async fn handle_run_persists_result_for_model_spec_tier_conflict() {
     let project_dir = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let config = run_config_with_tier(
         "default",
         vec!["gemini-cli/google/default/xhigh"],
@@ -158,7 +158,7 @@ async fn handle_run_persists_result_for_model_spec_tier_conflict() {
 #[tokio::test]
 async fn handle_run_does_not_persist_result_for_non_conflict_pre_exec_error() {
     let project_dir = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let config = run_config_without_routable_tools();
     write_project_config(project_dir.path(), &config);
 

--- a/crates/cli-sub-agent/src/run_cmd_fork.rs
+++ b/crates/cli-sub-agent/src/run_cmd_fork.rs
@@ -412,7 +412,7 @@ mod tests {
     #[test]
     fn pre_created_native_fork_session_ignores_daemon_parent_session_id() {
         let td = tempfile::tempdir().expect("tempdir");
-        let mut sandbox = ScopedSessionSandbox::new(&td);
+        let mut sandbox = ScopedSessionSandbox::new_blocking(&td);
         sandbox.track_env("CSA_DAEMON_SESSION_ID");
         sandbox.track_env("CSA_DAEMON_PROJECT_ROOT");
         sandbox.track_env("CSA_DAEMON_SESSION_DIR");

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -68,7 +68,7 @@ fn write_project_config(project_root: &Path, config: &csa_config::ProjectConfig)
 #[tokio::test]
 async fn handle_run_persists_result_for_direct_tool_tier_rejection() {
     let project_dir = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir);
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let config = run_config_with_tier(
         "default",
         vec!["gemini-cli/google/default/xhigh"],

--- a/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
@@ -420,7 +420,7 @@ fn handle_session_attach_waits_for_live_daemon_before_consuming_completion_packe
     use std::time::Duration;
 
     let td = tempfile::tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).expect("create state home");
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -497,7 +497,7 @@ fn handle_session_attach_treats_stale_daemon_pid_as_dead() {
     use std::time::Duration;
 
     let td = tempfile::tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).expect("create state home");
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -554,7 +554,7 @@ fn handle_session_attach_treats_stale_daemon_pid_as_dead() {
 #[test]
 fn handle_session_kill_accepts_legacy_stderr_pid() {
     let td = tempfile::tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).expect("create state home");
     let _home_guard = EnvVarGuard::set("HOME", td.path());

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -6,6 +6,7 @@ use std::fs;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 use tempfile::tempdir;
+use tokio::sync::OwnedMutexGuard;
 
 struct EnvVarGuard {
     key: &'static str,
@@ -34,14 +35,14 @@ impl Drop for EnvVarGuard {
 }
 
 struct SessionTestEnv {
-    _env_lock: std::sync::MutexGuard<'static, ()>,
+    _env_lock: OwnedMutexGuard<()>,
     _home_guard: EnvVarGuard,
     _state_guard: EnvVarGuard,
 }
 
 impl SessionTestEnv {
     fn new(td: &tempfile::TempDir) -> Self {
-        let env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+        let env_lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
         let state_home = td.path().join("xdg-state");
         fs::create_dir_all(&state_home).expect("create state home");
         let home_guard = EnvVarGuard::set("HOME", td.path());

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
@@ -8,6 +8,7 @@ use csa_session::{
 };
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
+use tokio::sync::OwnedMutexGuard;
 use tracing_subscriber::fmt::MakeWriter;
 
 struct EnvVarGuard {
@@ -73,14 +74,14 @@ impl std::io::Write for SharedLogWriter {
 }
 
 struct SessionTestEnv {
-    _env_lock: std::sync::MutexGuard<'static, ()>,
+    _env_lock: OwnedMutexGuard<()>,
     _home_guard: EnvVarGuard,
     _state_guard: EnvVarGuard,
 }
 
 impl SessionTestEnv {
     fn new(td: &tempfile::TempDir) -> Self {
-        let env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+        let env_lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
         let state_home = td.path().join("xdg-state");
         std::fs::create_dir_all(&state_home).expect("create state home");
         let home_guard = EnvVarGuard::set("HOME", td.path());

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -9,6 +9,7 @@ use std::fs;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 use tempfile::tempdir;
+use tokio::sync::OwnedMutexGuard;
 
 struct EnvVarGuard {
     key: &'static str,
@@ -37,14 +38,14 @@ impl Drop for EnvVarGuard {
 }
 
 struct SessionTestEnv {
-    _env_lock: std::sync::MutexGuard<'static, ()>,
+    _env_lock: OwnedMutexGuard<()>,
     _home_guard: EnvVarGuard,
     _state_guard: EnvVarGuard,
 }
 
 impl SessionTestEnv {
     fn new(td: &tempfile::TempDir) -> Self {
-        let env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+        let env_lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
         let state_home = td.path().join("xdg-state");
         fs::create_dir_all(&state_home).expect("create state home");
         let home_guard = EnvVarGuard::set("HOME", td.path());

--- a/crates/cli-sub-agent/src/session_cmds_result_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests.rs
@@ -268,7 +268,7 @@ fn backdate_tree(path: &std::path::Path, seconds_ago: u64) {
 #[test]
 fn handle_session_result_reconciles_orphaned_active_session() {
     let tmp = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = tmp.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", tmp.path());
@@ -298,7 +298,7 @@ fn handle_session_result_reconciles_orphaned_active_session() {
 #[test]
 fn handle_session_artifacts_reconciles_orphaned_active_session() {
     let tmp = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = tmp.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", tmp.path());

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -232,7 +232,7 @@ fn session_to_json_includes_branch_and_task_type() {
 #[test]
 fn session_list_branch_filter_returns_matching_sessions() {
     let td = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&td);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
     let project = td.path();
 
     let s1 = create_session(project, Some("S1"), None, None).unwrap();
@@ -257,7 +257,7 @@ fn session_list_branch_filter_returns_matching_sessions() {
 #[test]
 fn session_list_selection_not_truncated_to_ten() {
     let td = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&td);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
     let project = td.path();
 
     for _ in 0..12 {

--- a/crates/cli-sub-agent/src/session_cmds_tests_daemon_pid_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_daemon_pid_tail.rs
@@ -31,7 +31,7 @@ fn handle_session_wait_ignores_completion_packet_while_raw_daemon_pid_is_alive()
     use std::process::Command;
 
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -83,7 +83,7 @@ fn handle_session_kill_rejects_daemon_pid_start_time_mismatch() {
     use std::process::Command;
 
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -24,7 +24,7 @@ fn wait_for_spawned_daemon_visibility(
 #[test]
 fn resolve_session_prefix_with_global_fallback_accepts_initializing_exact_session_dir() {
     let td = tempdir().unwrap();
-    let _sandbox = ScopedSessionSandbox::new(&td);
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
     let project = td.path();
     let session_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
 
@@ -43,7 +43,7 @@ fn resolve_session_prefix_with_global_fallback_accepts_initializing_exact_sessio
 #[test]
 fn ensure_terminal_result_for_dead_active_session_is_noop_when_result_exists() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -75,7 +75,7 @@ fn ensure_terminal_result_for_dead_active_session_is_noop_when_result_exists() {
 #[test]
 fn session_to_json_reconciles_orphaned_active_session_status() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -104,7 +104,7 @@ fn session_to_json_reconciles_orphaned_active_session_status() {
 #[test]
 fn ensure_terminal_result_for_dead_active_session_is_noop_for_non_active_phase() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -133,7 +133,7 @@ fn ensure_terminal_result_for_dead_active_session_is_noop_for_non_active_phase()
 #[rustfmt::skip]
 fn ensure_terminal_result_for_dead_active_session_is_noop_when_alive() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -164,7 +164,7 @@ fn ensure_terminal_result_for_dead_active_session_is_noop_when_alive() {
 #[test]
 fn ensure_terminal_result_for_dead_active_session_persists_into_legacy_session_dir() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -205,7 +205,7 @@ fn ensure_terminal_result_for_dead_active_session_persists_into_legacy_session_d
 #[test]
 fn handle_session_is_alive_reconciles_orphaned_active_session() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -235,7 +235,7 @@ fn handle_session_is_alive_reconciles_orphaned_active_session() {
 #[test]
 fn handle_session_is_alive_accepts_symlinked_project_path() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -270,7 +270,7 @@ fn handle_session_is_alive_accepts_symlinked_project_path() {
 #[test]
 fn handle_session_wait_reconciles_dead_lock_only_active_session() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -316,7 +316,7 @@ fn handle_session_wait_reconciles_dead_lock_only_active_session() {
 #[test]
 fn ensure_terminal_result_for_dead_active_session_persists_synthetic_failure() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -371,7 +371,7 @@ fn ensure_terminal_result_for_dead_active_session_persists_synthetic_failure() {
 #[test]
 fn ensure_terminal_result_for_dead_active_session_preserves_late_real_result() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -415,7 +415,7 @@ fn ensure_terminal_result_for_dead_active_session_preserves_late_real_result() {
 #[test]
 fn ensure_terminal_result_for_dead_active_session_preserves_session_with_recent_output() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -455,7 +455,7 @@ fn handle_session_wait_waits_for_daemon_exit_before_returning_success() {
     use std::time::{Duration, Instant};
 
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -516,7 +516,7 @@ fn handle_session_wait_waits_for_daemon_exit_before_returning_success() {
 #[test]
 fn handle_session_wait_ignores_incomplete_result_while_daemon_alive() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -572,7 +572,7 @@ fn handle_session_wait_ignores_incomplete_result_while_daemon_alive() {
 #[test]
 fn handle_session_wait_prefers_daemon_completion_exit_code() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -606,7 +606,7 @@ fn handle_session_wait_ignores_completion_packet_while_daemon_alive() {
     use std::process::Command;
 
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -655,7 +655,7 @@ fn handle_session_wait_ignores_completion_packet_while_daemon_alive() {
 #[test]
 fn handle_session_wait_returns_pre_exec_failure_without_timeout_packet() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -683,7 +683,7 @@ fn handle_session_wait_returns_pre_exec_failure_without_timeout_packet() {
 #[test]
 fn persist_daemon_completion_from_env_writes_packet_for_seeded_session() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -706,7 +706,7 @@ fn persist_daemon_completion_from_env_writes_packet_for_seeded_session() {
 #[cfg(unix)]
 #[test]
 fn synthesized_wait_next_step_returns_directive_for_clean_cumulative_review() {
-    let td = tempdir().unwrap(); let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned"); let state_home = td.path().join("xdg-state"); std::fs::create_dir_all(&state_home).unwrap(); let _home_guard = EnvVarGuard::set("HOME", td.path()); let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home); let project = td.path(); let session = create_session(project, Some("wait-next-step"), None, Some("codex")).unwrap(); let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
+    let td = tempdir().unwrap(); let _env_lock = TEST_ENV_LOCK.blocking_lock(); let state_home = td.path().join("xdg-state"); std::fs::create_dir_all(&state_home).unwrap(); let _home_guard = EnvVarGuard::set("HOME", td.path()); let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home); let project = td.path(); let session = create_session(project, Some("wait-next-step"), None, Some("codex")).unwrap(); let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
     std::fs::write(session_dir.join("review_meta.json"), r#"{
   "session_id": "01TEST",
   "head_sha": "deadbeef",
@@ -726,7 +726,7 @@ fn synthesized_wait_next_step_returns_directive_for_clean_cumulative_review() {
 #[cfg(unix)]
 #[test]
 fn synthesized_wait_next_step_skips_non_cumulative_or_existing_directive() {
-    let td = tempdir().unwrap(); let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned"); let state_home = td.path().join("xdg-state"); std::fs::create_dir_all(&state_home).unwrap(); let _home_guard = EnvVarGuard::set("HOME", td.path()); let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home); let project = td.path(); let session = create_session(project, Some("wait-next-step-skip"), None, Some("codex")).unwrap(); let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
+    let td = tempdir().unwrap(); let _env_lock = TEST_ENV_LOCK.blocking_lock(); let state_home = td.path().join("xdg-state"); std::fs::create_dir_all(&state_home).unwrap(); let _home_guard = EnvVarGuard::set("HOME", td.path()); let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home); let project = td.path(); let session = create_session(project, Some("wait-next-step-skip"), None, Some("codex")).unwrap(); let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
     std::fs::write(session_dir.join("review_meta.json"), r#"{
   "session_id": "01TEST",
   "head_sha": "deadbeef",
@@ -759,7 +759,7 @@ fn synthesized_wait_next_step_skips_non_cumulative_or_existing_directive() {
 #[cfg(unix)]
 #[test]
 fn synthesized_wait_next_step_ignores_malformed_unpushed_commit_sidecar() {
-    let td = tempdir().unwrap(); let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned"); let state_home = td.path().join("xdg-state"); std::fs::create_dir_all(&state_home).unwrap(); let _home_guard = EnvVarGuard::set("HOME", td.path()); let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home); let project = td.path(); let session = create_session(project, Some("wait-next-step-malformed-sidecar"), None, Some("codex")).unwrap(); let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
+    let td = tempdir().unwrap(); let _env_lock = TEST_ENV_LOCK.blocking_lock(); let state_home = td.path().join("xdg-state"); std::fs::create_dir_all(&state_home).unwrap(); let _home_guard = EnvVarGuard::set("HOME", td.path()); let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home); let project = td.path(); let session = create_session(project, Some("wait-next-step-malformed-sidecar"), None, Some("codex")).unwrap(); let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
     std::fs::write(session_dir.join("review_meta.json"), r#"{
   "session_id": "01TEST",
   "head_sha": "deadbeef",

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_recovery.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_recovery.rs
@@ -32,7 +32,7 @@ impl Drop for EnvVarGuard {
 #[test]
 fn synthesized_wait_next_step_returns_directive_for_unpushed_commit_recovery() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
@@ -33,7 +33,7 @@ impl Drop for EnvVarGuard {
 #[test]
 fn handle_session_wait_retires_active_session_after_dead_failure_completion_packet() {
     let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).unwrap();
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -80,7 +80,7 @@ fn handle_session_wait_retires_active_session_after_dead_failure_completion_pack
 #[test]
 fn handle_session_wait_prefers_synthetic_failure_status_and_exit_code_over_completion_packet() {
     let td = tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).expect("create state home");
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -129,7 +129,7 @@ fn handle_session_wait_prefers_synthetic_failure_status_and_exit_code_over_compl
 #[test]
 fn handle_session_wait_prefers_late_real_result_status_and_exit_code_over_completion_packet() {
     let td = tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).expect("create state home");
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -185,7 +185,7 @@ fn handle_session_wait_prefers_late_real_result_status_and_exit_code_over_comple
 #[test]
 fn handle_session_wait_prefers_refreshed_real_result_status_and_exit_code_over_completion_packet() {
     let td = tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).expect("create state home");
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -246,7 +246,7 @@ fn handle_session_wait_prefers_refreshed_real_result_status_and_exit_code_over_c
 #[test]
 fn handle_session_wait_prefers_refreshed_real_result_on_equal_mtime_with_completion_packet() {
     let td = tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).expect("create state home");
     let _home_guard = EnvVarGuard::set("HOME", td.path());
@@ -327,7 +327,7 @@ fn handle_session_wait_prefers_refreshed_real_result_on_equal_mtime_with_complet
 #[test]
 fn handle_session_wait_errors_when_refresh_branch_cannot_persist_retired_phase() {
     let td = tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.lock().expect("session env lock poisoned");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
     std::fs::create_dir_all(&state_home).expect("create state home");
     let _home_guard = EnvVarGuard::set("HOME", td.path());

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn resolve_daemon_wait_timeout_uses_global_kv_cache_long_poll_seconds() {
-        let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).unwrap();
@@ -293,7 +293,7 @@ long_poll_seconds = 3000
 
     #[test]
     fn resolve_daemon_wait_timeout_uses_documented_default_without_kv_cache_section() {
-        let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).unwrap();
@@ -312,7 +312,7 @@ tool = "auto"
 
     #[test]
     fn resolve_daemon_wait_timeout_prefers_global_kv_cache_over_legacy_session_key() {
-        let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).unwrap();
@@ -346,7 +346,7 @@ daemon_wait_seconds = 600
 
     #[test]
     fn resolve_daemon_wait_timeout_treats_explicit_default_as_higher_priority_than_legacy_key() {
-        let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).unwrap();
@@ -381,7 +381,7 @@ daemon_wait_seconds = 600
     #[test]
     fn resolve_daemon_wait_timeout_treats_kv_cache_section_default_as_higher_priority_than_legacy_key()
      {
-        let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).unwrap();
@@ -415,7 +415,7 @@ daemon_wait_seconds = 600
 
     #[test]
     fn resolve_daemon_wait_timeout_honors_legacy_project_session_override_with_warning_path() {
-        let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).unwrap();
@@ -442,7 +442,7 @@ daemon_wait_seconds = 600
 
     #[test]
     fn resolve_daemon_wait_timeout_honors_legacy_user_session_override_when_project_missing() {
-        let _env_lock = TEST_ENV_LOCK.lock().expect("config env lock poisoned");
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).unwrap();

--- a/crates/cli-sub-agent/src/test_env_lock.rs
+++ b/crates/cli-sub-agent/src/test_env_lock.rs
@@ -1,8 +1,10 @@
 use std::ffi::OsString;
-use std::sync::{LazyLock, Mutex, MutexGuard};
+use std::sync::{Arc, LazyLock};
+use tokio::sync::{Mutex, OwnedMutexGuard};
 
 #[allow(dead_code)]
-pub(crate) static TEST_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+pub(crate) static TEST_ENV_LOCK: LazyLock<Arc<Mutex<()>>> =
+    LazyLock::new(|| Arc::new(Mutex::new(())));
 
 fn restore_env_snapshot(key: &'static str, previous: Option<OsString>) {
     // SAFETY: all tests in this crate that mutate process env must hold TEST_ENV_LOCK
@@ -52,13 +54,13 @@ impl Drop for ScopedEnvVarRestore {
 pub(crate) struct ScopedTestEnvVar {
     key: &'static str,
     original: Option<OsString>,
-    _lock: MutexGuard<'static, ()>,
+    _lock: OwnedMutexGuard<()>,
 }
 
 impl ScopedTestEnvVar {
     #[allow(dead_code)]
     pub(crate) fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-        let lock = TEST_ENV_LOCK.lock().unwrap();
+        let lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
         let original = std::env::var_os(key);
         // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
         unsafe { std::env::set_var(key, value) };

--- a/crates/cli-sub-agent/src/test_session_sandbox.rs
+++ b/crates/cli-sub-agent/src/test_session_sandbox.rs
@@ -7,7 +7,7 @@
 /// Internally acquires [`TEST_ENV_LOCK`] to serialise all env-mutating tests
 /// across the process. Callers do NOT need to acquire any additional lock.
 use std::ffi::OsString;
-use std::sync::MutexGuard;
+use tokio::sync::OwnedMutexGuard;
 
 use crate::test_env_lock::TEST_ENV_LOCK;
 
@@ -18,13 +18,21 @@ use crate::test_env_lock::TEST_ENV_LOCK;
 pub(crate) struct ScopedSessionSandbox {
     originals: Vec<(&'static str, Option<OsString>)>,
     // Guard is held alive until drop (ordering: restored env *then* lock released).
-    _lock: MutexGuard<'static, ()>,
+    _lock: OwnedMutexGuard<()>,
 }
 
 impl ScopedSessionSandbox {
-    pub(crate) fn new(tmp: &tempfile::TempDir) -> Self {
-        let lock = TEST_ENV_LOCK.lock().expect("TEST_ENV_LOCK poisoned");
+    pub(crate) async fn new(tmp: &tempfile::TempDir) -> Self {
+        let lock = TEST_ENV_LOCK.clone().lock_owned().await;
+        Self::from_guard(tmp, lock)
+    }
 
+    pub(crate) fn new_blocking(tmp: &tempfile::TempDir) -> Self {
+        let lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
+        Self::from_guard(tmp, lock)
+    }
+
+    fn from_guard(tmp: &tempfile::TempDir, lock: OwnedMutexGuard<()>) -> Self {
         let keys: &[&'static str] = &[
             "XDG_STATE_HOME",
             "CSA_DAEMON_SESSION_ID",
@@ -85,7 +93,7 @@ mod tests {
         unsafe { std::env::remove_var(KEY) };
 
         {
-            let mut sandbox = ScopedSessionSandbox::new(&td);
+            let mut sandbox = ScopedSessionSandbox::new_blocking(&td);
             sandbox.track_env(KEY);
 
             // SAFETY: test-scoped env mutation while ScopedSessionSandbox holds TEST_ENV_LOCK.
@@ -98,5 +106,14 @@ mod tests {
             Err(std::env::VarError::NotPresent),
             "tracked env var should be removed when it did not exist before sandboxing"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sandbox_lock_can_span_await_without_deadlocking() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new(&td).await;
+
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
 }


### PR DESCRIPTION
## Summary

- `ScopedSessionSandbox` previously held a `std::sync::MutexGuard` across `.await` points in `#[tokio::test]` call sites, violating AGENTS.md Rule 006 and risking Tokio executor stalls under load.
- Migrate `TEST_ENV_LOCK` to `Arc<tokio::sync::Mutex<()>>`. Async tests use `ScopedSessionSandbox::new(...).await`; sync tests use `ScopedSessionSandbox::new_blocking(...)`. Guard is now `tokio::sync::OwnedMutexGuard<()>`.
- Added regression test `sandbox_lock_can_span_await_without_deadlocking` proving no deadlock across `.await` points.

Closes #754.

## Test plan

- [x] `cargo test -p cli-sub-agent sandbox_lock_can_span_await_without_deadlocking`
- [x] `cargo test -p cli-sub-agent`
- [x] `cargo test --workspace`
- [x] `just clippy`
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)