### PR TITLE
fix(csa-review): emit summary.md from reviewer output, not stale disk read (#776)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.446"
+version = "0.1.447"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.446"
+version = "0.1.447"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output_summary.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_summary.rs
@@ -53,13 +53,27 @@ pub(crate) fn ensure_review_summary_artifact(session_dir: &Path, output: &str) -
         .map_err(|error| anyhow::anyhow!("create {}: {error}", output_dir.display()))?;
     let summary_path = output_dir.join("summary.md");
     let summary = if current_run_has_summary_section(output) {
-        let Some(summary) = fs::read_to_string(&summary_path)
-            .ok()
+        let sanitized = sanitize_review_output(output);
+        let sections = parse_sections(&sanitized);
+        if let Some(summary) = sections
+            .iter()
+            .rev()
+            .find(|section| section.id == "summary")
+            .map(|section| extract_section_content(&sanitized, section))
             .filter(|summary| !summary.trim().is_empty())
-        else {
-            return Ok(());
-        };
-        summary
+        {
+            fs::write(&summary_path, &summary)
+                .map_err(|error| anyhow::anyhow!("write {}: {error}", summary_path.display()))?;
+            summary
+        } else {
+            let Some(summary) = fs::read_to_string(&summary_path)
+                .ok()
+                .filter(|summary| !summary.trim().is_empty())
+            else {
+                return Ok(());
+            };
+            summary
+        }
     } else {
         let Some(summary) = derive_review_result_summary(output) else {
             return Ok(());

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -422,6 +422,37 @@ fn ensure_review_summary_artifact_synthesizes_summary_from_details_only_output()
 }
 
 #[test]
+fn ensure_review_summary_artifact_writes_summary_md_when_section_emitted_without_prior_file() {
+    let session_id = "01TESTSUMMARYWRITE0000000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("review-summary-write-from-output", session_id);
+    let output = "<!-- CSA:SECTION:summary -->\nReview outcome: PASS.\n<!-- CSA:SECTION:summary:END -->\n\
+<!-- CSA:SECTION:details -->\nDetails go here\n<!-- CSA:SECTION:details:END -->\n";
+
+    ensure_review_summary_artifact(&session_dir, output).expect("write summary from output");
+
+    let summary_path = session_dir.join("output").join("summary.md");
+    assert!(summary_path.exists(), "summary.md must be written");
+    let contents = fs::read_to_string(&summary_path).expect("read summary");
+    assert!(
+        contents.contains("Review outcome: PASS."),
+        "got: {contents}"
+    );
+
+    let index = csa_session::load_output_index(&session_dir)
+        .expect("load output index")
+        .expect("index should exist");
+    let summary_entry = index
+        .sections
+        .iter()
+        .find(|section| section.id == "summary")
+        .expect("summary entry should exist");
+    assert_eq!(summary_entry.file_path.as_deref(), Some("summary.md"));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn ensure_review_summary_artifact_preserves_existing_summary_section() {
     let session_id = "01TESTSUMMARYKEEP0000000000";
     let (_env_lock, project_root, session_dir) =


### PR DESCRIPTION
## Summary

- `ensure_review_summary_artifact` previously tried to read `summary.md` from disk when the reviewer emitted a `<!-- CSA:SECTION:summary -->` block, assuming some earlier pipeline step wrote it. Nothing did, so the function silently returned without writing and `summary.md` was omitted from the artifact set despite the reviewer clearly providing a summary.
- Extract the summary section content directly from the reviewer output buffer via `parse_sections`/`extract_section_content`, then write it to `summary.md`. The no-section derive+write fallback is unchanged.
- `output/index.toml` stays in sync with the repaired summary entry.

Closes #776.

## Test plan

- [x] `cargo test -p cli-sub-agent ensure_review_summary_artifact`
- [x] `cargo test -p cli-sub-agent review_cmd_output`
- [x] `cargo test --workspace`
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)