### PR TITLE
feat(cli-sub-agent): emit --fork-from recovery hint on sandbox fs denial (#685)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.447"
+version = "0.1.448"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.447"
+version = "0.1.448"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/error_hints.rs
+++ b/crates/cli-sub-agent/src/error_hints.rs
@@ -3,6 +3,8 @@
 //! Inspired by xurl's `user_facing_error()` pattern: match on error type/message
 //! and return actionable fix suggestions with concrete commands.
 
+use std::path::Path;
+
 use anyhow::Error;
 use csa_core::error::AppError;
 
@@ -20,6 +22,15 @@ const HINT_SESSION_NOT_FOUND: &str = "hint: list available sessions with 'csa se
 const HINT_CONFIG_ERROR: &str =
     "hint: validate config with 'csa config validate' or reinitialize with 'csa init'";
 const HINT_GEMINI_RUNTIME_HOME: &str = "hint: Gemini ACP needs a writable runtime home; current builds pin TMPDIR to a writable sandbox temp dir (private /tmp in bwrap, session tmp elsewhere) and seed under CSA session state, but older builds may still need re-run with TMPDIR=/tmp";
+const SANDBOX_FS_DENIAL_MARKERS: [&str; 7] = [
+    "read-only file system",
+    "permission denied",
+    "operation not permitted",
+    "eacces",
+    "eperm",
+    "errno 13",
+    "errno 30",
+];
 
 pub fn suggest_fix(err: &Error) -> Option<String> {
     for cause in err.chain() {
@@ -98,6 +109,82 @@ pub fn suggest_fix(err: &Error) -> Option<String> {
     }
 
     None
+}
+
+pub(crate) fn sandbox_fs_denial_hint(
+    stderr: &str,
+    stdout: &str,
+    session_id: &str,
+) -> Option<String> {
+    let combined_lower = format!("{stderr}\n{stdout}").to_ascii_lowercase();
+    if !SANDBOX_FS_DENIAL_MARKERS
+        .iter()
+        .any(|marker| combined_lower.contains(marker))
+    {
+        return None;
+    }
+
+    let path_hint = extract_denied_path(stderr)
+        .or_else(|| extract_denied_path(stdout))
+        .map(|path| {
+            let suggested = Path::new(&path)
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .map(|parent| parent.display().to_string())
+                .unwrap_or(path);
+            format!("--extra-writable {suggested}")
+        })
+        .unwrap_or_else(|| "--extra-writable /path/to/needed/dir".to_string());
+
+    Some(format!(
+        "hint: sandbox filesystem write denied. To continue from this session's partial work rather than re-running from scratch, run:\n  csa run --fork-from {session_id} {path_hint} --prompt-file <continuation prompt>"
+    ))
+}
+
+pub(crate) fn append_sandbox_fs_denial_hint(
+    stderr_output: &mut String,
+    stdout: &str,
+    session_id: &str,
+) {
+    let Some(hint) = sandbox_fs_denial_hint(stderr_output, stdout, session_id) else {
+        return;
+    };
+    if stderr_output.contains(&hint) {
+        return;
+    }
+    if !stderr_output.is_empty() && !stderr_output.ends_with('\n') {
+        stderr_output.push('\n');
+    }
+    stderr_output.push_str(&hint);
+    stderr_output.push('\n');
+}
+
+fn extract_denied_path(text: &str) -> Option<String> {
+    for line in text.lines() {
+        let lower = line.to_ascii_lowercase();
+        if !SANDBOX_FS_DENIAL_MARKERS
+            .iter()
+            .take(3)
+            .any(|marker| lower.contains(marker))
+        {
+            continue;
+        }
+
+        if let Some(path) = extract_quoted_path(line, ": '", '\'') {
+            return Some(path);
+        }
+        if let Some(path) = extract_quoted_path(line, ": \"", '"') {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn extract_quoted_path(line: &str, marker: &str, quote: char) -> Option<String> {
+    let start = line.rfind(marker)?;
+    let rest = &line[start + marker.len()..];
+    let end = rest.find(quote)?;
+    Some(rest[..end].to_string())
 }
 
 fn tool_install_hint(tool_name: &str) -> Option<&'static str> {
@@ -199,5 +286,41 @@ mod tests {
     fn test_no_hint_for_generic_error() {
         let err = anyhow::anyhow!("something failed");
         assert_eq!(suggest_fix(&err), None);
+    }
+
+    #[test]
+    fn sandbox_fs_denial_hint_fires_on_read_only_error() {
+        let stderr = "OSError: [Errno 30] Read-only file system: '/home/obj/.claude-mem/settings.json.tmp.1234'";
+        let hint = sandbox_fs_denial_hint(stderr, "", "01KTEST123").unwrap();
+        assert!(hint.contains("--fork-from 01KTEST123"), "got: {hint}");
+        assert!(
+            hint.contains("--extra-writable /home/obj/.claude-mem"),
+            "got: {hint}"
+        );
+        assert!(hint.contains("--prompt-file"), "got: {hint}");
+    }
+
+    #[test]
+    fn sandbox_fs_denial_hint_fires_on_permission_denied() {
+        let stderr = "PermissionError: [Errno 13] Permission denied: '/etc/foo'";
+        let hint = sandbox_fs_denial_hint(stderr, "", "01KTEST123").unwrap();
+        assert!(hint.contains("--extra-writable /etc"), "got: {hint}");
+    }
+
+    #[test]
+    fn sandbox_fs_denial_hint_is_none_for_unrelated_failure() {
+        let stderr = "Error: connection refused";
+        let hint = sandbox_fs_denial_hint(stderr, "", "01KTEST123");
+        assert!(hint.is_none());
+    }
+
+    #[test]
+    fn sandbox_fs_denial_hint_generic_path_fallback_when_no_parse() {
+        let stderr = "bash: cannot create file: Read-only file system";
+        let hint = sandbox_fs_denial_hint(stderr, "", "01KTEST123").unwrap();
+        assert!(
+            hint.contains("--extra-writable /path/to/needed/dir"),
+            "got: {hint}"
+        );
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -86,7 +86,6 @@ pub(crate) async fn execute_with_session(
         extra_readable,
     )
     .await?;
-
     Ok(execution.execution)
 }
 #[allow(clippy::too_many_arguments)]
@@ -182,14 +181,12 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         return Err(csa_core::error::AppError::ParentSessionViolation.into());
     }
     let memory_project_key = resolve_memory_project_key(project_root);
-
     let cd = crate::pipeline_env::resolve_cooldown_seconds(config);
     let depth = crate::pipeline_env::current_csa_depth();
     if let Some(wait) = compute_cooldown_wait(project_root, cd, &session_arg, &parent, depth) {
         info!("Cooldown: sleeping {wait:?} before new session");
         tokio::time::sleep(wait).await;
     }
-
     let mut resolved_provider_session_id: Option<String> = None;
     let mut session = if let Some(ref session_id) = session_arg {
         let resolution =
@@ -247,7 +244,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         }
         new_session
     };
-
     if session_arg.is_some() && session.phase == csa_session::SessionPhase::Available {
         if let Err(e) = session.apply_phase_event(csa_session::PhaseEvent::Resumed) {
             warn!(session = %session.meta_session_id, error = %e, "Skipping phase transition on resume");
@@ -262,7 +258,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     } else {
         None
     };
-
     let (_log_writer, _log_guard) = match csa_executor::create_session_log_writer(&session_dir) {
         Ok(pair) => pair,
         Err(e) => {
@@ -703,13 +698,19 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         }
         result.exit_code = 1;
     }
+    if result.exit_code != 0 {
+        crate::error_hints::append_sandbox_fs_denial_hint(
+            &mut result.stderr_output,
+            &result.output,
+            &session.meta_session_id,
+        );
+    }
     // Post-run git snapshot for commit guard + changed_paths hook vars.
     let post_run_workspace = if is_git {
         crate::run_cmd::capture_git_workspace_snapshot(project_root, require_commit_on_mutation)
     } else {
         None
     };
-
     let pre_fingerprints = pre_run_workspace
         .as_ref()
         .map(session_exec_audit::snapshot_to_fingerprints);

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -533,6 +533,16 @@ pub(crate) async fn handle_run(
     match output_format {
         OutputFormat::Text => {
             print!("{}", result.output);
+            if result.exit_code != 0
+                && let Some(ref sid) = executed_session_id
+                && let Some(hint) = crate::error_hints::sandbox_fs_denial_hint(
+                    &result.stderr_output,
+                    &result.output,
+                    sid,
+                )
+            {
+                eprintln!("{hint}");
+            }
         }
         OutputFormat::Json => {
             let json = serde_json::to_string_pretty(&result)?;


### PR DESCRIPTION
## Summary

- When a `csa run` session fails with a filesystem sandbox denial pattern (Read-only file system, Permission denied, Operation not permitted, EACCES/EPERM/Errno 13/Errno 30), emit a hint pointing the caller at `csa run --fork-from <SID> --extra-writable <parent> --prompt-file <continuation>` so the partial work (discovery, reads, setup) done before the denial is preserved.
- Best-effort parses the denied path out of standard OSError/PermissionError line shapes and suggests its parent as `--extra-writable`; falls back to a generic placeholder when no path is recoverable.

Closes #685.
Followup tracked in #962 (gate hint on fs-sandbox-active telemetry).

## Test plan

- [x] `cargo test -p cli-sub-agent sandbox_fs_denial_hint`
- [x] `cargo test -p cli-sub-agent error_hints`
- [x] `cargo test --workspace`
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)