### PR TITLE
feat(session): show session start time + elapsed duration in list (#696)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.448"
+version = "0.1.449"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.448"
+version = "0.1.449"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -28,8 +28,9 @@ mod list;
 #[cfg(test)]
 use list::status_from_phase_and_result;
 use list::{
-    resolve_session_status, select_sessions_for_list, select_sessions_for_list_all_projects,
-    session_to_json, truncate_with_ellipsis,
+    format_elapsed, format_started_at, resolve_session_status, select_sessions_for_list,
+    select_sessions_for_list_all_projects, session_created_at, session_to_json,
+    truncate_with_ellipsis,
 };
 
 #[path = "session_cmds_reconcile.rs"]
@@ -148,8 +149,10 @@ pub(crate) fn handle_session_list(
                 // Print table header
                 if all_projects {
                     println!(
-                        "{:<11}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<30}  TOKENS",
+                        "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<30}  TOKENS",
                         "SESSION",
+                        "STARTED",
+                        "ELAPSED",
                         "LAST ACCESSED",
                         "STATUS",
                         "DESCRIPTION",
@@ -157,19 +160,28 @@ pub(crate) fn handle_session_list(
                         "BRANCH",
                         "PROJECT"
                     );
-                    println!("{}", "-".repeat(160));
+                    println!("{}", "-".repeat(192));
                 } else {
                     println!(
-                        "{:<11}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  TOKENS",
-                        "SESSION", "LAST ACCESSED", "STATUS", "DESCRIPTION", "TOOLS", "BRANCH"
+                        "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  TOKENS",
+                        "SESSION",
+                        "STARTED",
+                        "ELAPSED",
+                        "LAST ACCESSED",
+                        "STATUS",
+                        "DESCRIPTION",
+                        "TOOLS",
+                        "BRANCH"
                     );
-                    println!("{}", "-".repeat(130));
+                    println!("{}", "-".repeat(162));
                 }
                 for session in sessions {
                     // Truncate ULID to 11 chars for readability
                     let short_id =
                         &session.meta_session_id[..11.min(session.meta_session_id.len())];
                     let status_str = resolve_session_status(&session);
+                    let started_str = format_started_at(session_created_at(&session));
+                    let elapsed_str = format_elapsed(&session, &status_str, chrono::Utc::now());
                     let desc = session
                         .description
                         .as_deref()
@@ -231,8 +243,10 @@ pub(crate) fn handle_session_list(
                     if all_projects {
                         let project_display = truncate_with_ellipsis(&session.project_path, 30);
                         println!(
-                            "{:<11}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<30}  {}{}{}",
+                            "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<30}  {}{}{}",
                             short_id,
+                            started_str,
+                            elapsed_str,
                             session
                                 .last_accessed
                                 .with_timezone(&chrono::Local)
@@ -248,8 +262,10 @@ pub(crate) fn handle_session_list(
                         );
                     } else {
                         println!(
-                            "{:<11}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {}{}{}",
+                            "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {}{}{}",
                             short_id,
+                            started_str,
+                            elapsed_str,
                             session
                                 .last_accessed
                                 .with_timezone(&chrono::Local)

--- a/crates/cli-sub-agent/src/session_cmds_list.rs
+++ b/crates/cli-sub-agent/src/session_cmds_list.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
+use chrono::{DateTime, Duration, Local, Utc};
 use std::path::Path;
 
+#[cfg(test)]
+use csa_session::decode_session_created_at;
 use csa_session::{MetaSessionState, SessionPhase, SessionResult, list_sessions, load_result};
 
 use super::{ensure_terminal_result_for_dead_active_session, retire_if_dead_with_result};
@@ -22,6 +25,65 @@ pub(super) fn truncate_with_ellipsis(input: &str, max_chars: usize) -> String {
         .unwrap_or(input.len());
 
     format!("{}...", &input[..end])
+}
+
+pub(super) fn session_created_at(session: &MetaSessionState) -> DateTime<Utc> {
+    session
+        .created_at
+        .with_timezone(&Utc)
+        .min(session.last_accessed)
+}
+
+pub(super) fn format_started_at(created_at: DateTime<Utc>) -> String {
+    created_at
+        .with_timezone(&Local)
+        .format("%Y-%m-%d %H:%M")
+        .to_string()
+}
+
+pub(super) fn format_compact_duration(duration: Duration) -> String {
+    let secs = duration.num_seconds().max(0);
+    let days = secs / 86_400;
+    let hours = (secs % 86_400) / 3_600;
+    let minutes = (secs % 3_600) / 60;
+    let seconds = secs % 60;
+
+    if days > 0 {
+        if hours > 0 {
+            format!("{days}d{hours}h")
+        } else {
+            format!("{days}d")
+        }
+    } else if hours > 0 {
+        if minutes > 0 {
+            format!("{hours}h{minutes}m")
+        } else {
+            format!("{hours}h")
+        }
+    } else if minutes > 0 {
+        format!("{minutes}m")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+pub(super) fn format_elapsed(
+    session: &MetaSessionState,
+    resolved_status: &str,
+    now: DateTime<Utc>,
+) -> String {
+    let created_at = session_created_at(session);
+    let end = if resolved_status == "Active" {
+        now
+    } else {
+        session.last_accessed.max(created_at)
+    };
+    format_compact_duration(end - created_at)
+}
+
+#[cfg(test)]
+pub(super) fn decode_ulid_created_at(session_id: &str) -> Result<DateTime<Utc>> {
+    decode_session_created_at(session_id)
 }
 
 pub(super) fn phase_label(phase: &SessionPhase) -> &'static str {
@@ -131,12 +193,17 @@ pub(super) fn select_sessions_for_list_all_projects(
 }
 
 pub(super) fn session_to_json(session: &MetaSessionState) -> serde_json::Value {
+    let status = resolve_session_status(session);
+    let created_at = session_created_at(session);
+    let now = Utc::now();
     let mut value = serde_json::json!({
         "session_id": session.meta_session_id,
+        "started_at": created_at,
         "last_accessed": session.last_accessed,
+        "elapsed": format_elapsed(session, &status, now),
         "description": session.description.as_deref().unwrap_or(""),
         "tools": session.tools.keys().collect::<Vec<_>>(),
-        "status": resolve_session_status(session),
+        "status": status,
         "phase": format!("{:?}", session.phase),
         "branch": session.branch,
         "task_type": session.task_context.task_type,

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -216,20 +216,6 @@ fn sample_session_state() -> MetaSessionState {
 }
 
 #[test]
-fn session_to_json_includes_branch_and_task_type() {
-    let session = sample_session_state();
-    let value = session_to_json(&session);
-    assert_eq!(
-        value.get("branch").and_then(|v| v.as_str()),
-        Some("feature/x")
-    );
-    assert_eq!(
-        value.get("task_type").and_then(|v| v.as_str()),
-        Some("plan")
-    );
-}
-
-#[test]
 fn session_list_branch_filter_returns_matching_sessions() {
     let td = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new_blocking(&td);
@@ -792,6 +778,8 @@ fn session_to_json_includes_depth_and_parent() {
 
 #[path = "session_cmds_tests_daemon_pid_tail.rs"]
 mod daemon_pid_tail_tests;
+#[path = "session_cmds_tests_list_format.rs"]
+mod list_format_tests;
 #[path = "session_cmds_tests_tail.rs"]
 mod tail_tests;
 #[path = "session_cmds_tests_tail_recovery.rs"]

--- a/crates/cli-sub-agent/src/session_cmds_tests_list_format.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_list_format.rs
@@ -1,0 +1,82 @@
+use super::super::list::{
+    decode_ulid_created_at, format_compact_duration, format_elapsed, session_created_at,
+};
+use super::{sample_session_state, session_to_json};
+use chrono::{Duration, Utc};
+use csa_session::SessionPhase;
+
+#[test]
+fn format_compact_duration_basics() {
+    assert_eq!(format_compact_duration(Duration::seconds(0)), "0s");
+    assert_eq!(format_compact_duration(Duration::seconds(45)), "45s");
+    assert_eq!(format_compact_duration(Duration::seconds(60)), "1m");
+    assert_eq!(
+        format_compact_duration(Duration::seconds(3 * 60 + 20)),
+        "3m"
+    );
+    assert_eq!(format_compact_duration(Duration::seconds(3_600)), "1h");
+    assert_eq!(
+        format_compact_duration(Duration::seconds(3_600 + 23 * 60)),
+        "1h23m"
+    );
+    assert_eq!(format_compact_duration(Duration::seconds(86_400)), "1d");
+    assert_eq!(
+        format_compact_duration(Duration::seconds(2 * 86_400 + 4 * 3_600)),
+        "2d4h"
+    );
+}
+
+#[test]
+fn active_session_elapsed_uses_now_minus_created() {
+    let mut session = sample_session_state();
+    let now = Utc::now();
+    session.phase = SessionPhase::Active;
+    session.created_at = now - Duration::minutes(5);
+    session.last_accessed = now - Duration::minutes(1);
+
+    let elapsed = format_elapsed(&session, "Active", now);
+
+    assert_eq!(elapsed, "5m");
+}
+
+#[test]
+fn retired_session_elapsed_uses_last_accessed_minus_created() {
+    let mut session = sample_session_state();
+    let now = Utc::now();
+    session.phase = SessionPhase::Retired;
+    session.created_at = now - Duration::hours(2);
+    session.last_accessed = now;
+
+    let elapsed = format_elapsed(&session, "Retired", now + Duration::minutes(30));
+
+    assert_eq!(elapsed, "2h");
+}
+
+#[test]
+fn created_at_fallback_decodes_from_ulid_when_metadata_missing() {
+    let ulid = ulid::Ulid::new();
+    let decoded = decode_ulid_created_at(&ulid.to_string()).expect("decode");
+    let now = Utc::now();
+
+    assert!((now.timestamp_millis() - decoded.timestamp_millis()).abs() < 5_000);
+}
+
+#[test]
+fn session_to_json_includes_started_at_and_elapsed() {
+    let session = sample_session_state();
+    let value = session_to_json(&session);
+
+    assert_eq!(
+        value.get("started_at"),
+        Some(&serde_json::json!(session_created_at(&session)))
+    );
+    assert_eq!(value.get("elapsed").and_then(|v| v.as_str()), Some("0s"));
+    assert_eq!(
+        value.get("branch").and_then(|v| v.as_str()),
+        Some("feature/x")
+    );
+    assert_eq!(
+        value.get("task_type").and_then(|v| v.as_str()),
+        Some("plan")
+    );
+}

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -79,8 +79,8 @@ pub use vcs_backends::{GitBackend, JjBackend, create_vcs_backend};
 pub use manager::{
     CONTRACT_RESULT_ARTIFACT_PATH, LEGACY_USER_RESULT_ARTIFACT_PATH, RESULT_TOML_PATH_CONTRACT_ENV,
     RepoWriteAudit, SaveOptions, clear_manager_sidecar, complete_session, compute_repo_write_audit,
-    contract_result_path, create_session, create_session_fresh, delete_session,
-    delete_session_from_root, detect_git_head, find_sessions, get_session_dir,
+    contract_result_path, create_session, create_session_fresh, decode_session_created_at,
+    delete_session, delete_session_from_root, detect_git_head, find_sessions, get_session_dir,
     get_session_dir_global, get_session_root, legacy_user_result_path,
     list_all_project_session_roots, list_all_sessions, list_all_sessions_all_projects,
     list_artifacts, list_sessions, list_sessions_from_root, list_sessions_from_root_readonly,

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -11,12 +11,19 @@ use std::process::Command;
 
 #[path = "manager_audit.rs"]
 mod manager_audit;
+#[path = "manager_daemon.rs"]
+mod manager_daemon;
+#[path = "manager_legacy.rs"]
+mod manager_legacy;
 #[path = "manager_paths.rs"]
 mod manager_paths;
 #[path = "manager_result.rs"]
 mod manager_result;
 
 pub use manager_audit::{RepoWriteAudit, compute_repo_write_audit, write_audit_warning_artifact};
+pub use manager_daemon::ResumeSessionResolution;
+use manager_daemon::{SessionIdStrategy, preassigned_daemon_session_id};
+pub use manager_legacy::decode_session_created_at;
 #[cfg(test)]
 use manager_paths::project_storage_key_from_path;
 pub use manager_paths::{get_session_dir, get_session_root};
@@ -38,30 +45,6 @@ const STATE_FILE_NAME: &str = "state.toml";
 const DAEMON_SESSION_ID_ENV: &str = "CSA_DAEMON_SESSION_ID";
 const DAEMON_SESSION_DIR_ENV: &str = "CSA_DAEMON_SESSION_DIR";
 const DAEMON_PROJECT_ROOT_ENV: &str = "CSA_DAEMON_PROJECT_ROOT";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SessionIdStrategy {
-    DaemonAware,
-    Fresh,
-}
-
-fn preassigned_daemon_session_id() -> Option<String> {
-    let session_id = std::env::var(DAEMON_SESSION_ID_ENV)
-        .ok()
-        .filter(|value| !value.is_empty())?;
-    let has_daemon_context = std::env::var_os(DAEMON_SESSION_DIR_ENV).is_some()
-        || std::env::var_os(DAEMON_PROJECT_ROOT_ENV).is_some();
-    has_daemon_context.then_some(session_id)
-}
-
-/// Resolved identifiers for resuming a tool session.
-#[derive(Debug, Clone)]
-pub struct ResumeSessionResolution {
-    /// Fully resolved CSA meta session ID (ULID).
-    pub meta_session_id: String,
-    /// Provider-native session ID for the requested tool, if present in state.
-    pub provider_session_id: Option<String>,
-}
 
 /// Create a new session. If `parent_id` is provided, this session is a child
 /// of that parent with `depth = parent.depth + 1`. If `tool` is provided,
@@ -349,8 +332,18 @@ pub(crate) fn load_session_in(base_dir: &Path, session_id: &str) -> Result<MetaS
     let contents = fs::read_to_string(&state_path)
         .with_context(|| format!("Failed to read state file: {}", state_path.display()))?;
 
-    let state: MetaSessionState = toml::from_str(&contents)
-        .with_context(|| format!("Failed to parse state file: {}", state_path.display()))?;
+    let state: MetaSessionState = match toml::from_str(&contents) {
+        Ok(state) => state,
+        Err(primary_err) => {
+            manager_legacy::load_session_with_created_at_fallback(&contents, session_id)
+                .with_context(|| format!("Failed to parse state file: {}", state_path.display()))
+                .or_else(|_| {
+                    Err(primary_err).with_context(|| {
+                        format!("Failed to parse state file: {}", state_path.display())
+                    })
+                })?
+        }
+    };
 
     Ok(state)
 }

--- a/crates/csa-session/src/manager_daemon.rs
+++ b/crates/csa-session/src/manager_daemon.rs
@@ -1,0 +1,23 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionIdStrategy {
+    DaemonAware,
+    Fresh,
+}
+
+pub(crate) fn preassigned_daemon_session_id() -> Option<String> {
+    let session_id = std::env::var(super::DAEMON_SESSION_ID_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())?;
+    let has_daemon_context = std::env::var_os(super::DAEMON_SESSION_DIR_ENV).is_some()
+        || std::env::var_os(super::DAEMON_PROJECT_ROOT_ENV).is_some();
+    has_daemon_context.then_some(session_id)
+}
+
+/// Resolved identifiers for resuming a tool session.
+#[derive(Debug, Clone)]
+pub struct ResumeSessionResolution {
+    /// Fully resolved CSA meta session ID (ULID).
+    pub meta_session_id: String,
+    /// Provider-native session ID for the requested tool, if present in state.
+    pub provider_session_id: Option<String>,
+}

--- a/crates/csa-session/src/manager_legacy.rs
+++ b/crates/csa-session/src/manager_legacy.rs
@@ -1,0 +1,35 @@
+use crate::state::MetaSessionState;
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+
+pub(crate) fn load_session_with_created_at_fallback(
+    contents: &str,
+    session_id: &str,
+) -> Result<MetaSessionState> {
+    let mut value: toml::Value = toml::from_str(contents)?;
+    let Some(table) = value.as_table_mut() else {
+        bail!("Session state is not a TOML table");
+    };
+
+    if table.contains_key("created_at") {
+        bail!("Session state already has created_at");
+    }
+
+    table.insert(
+        "created_at".to_string(),
+        toml::Value::String(decode_session_created_at(session_id)?.to_rfc3339()),
+    );
+
+    value
+        .try_into::<MetaSessionState>()
+        .context("Failed to parse session state after ULID created_at fallback")
+}
+
+pub fn decode_session_created_at(session_id: &str) -> Result<DateTime<Utc>> {
+    let ulid = ulid::Ulid::from_string(session_id)
+        .with_context(|| format!("Invalid session ULID: {session_id}"))?;
+    let timestamp_ms = i64::try_from(ulid.timestamp_ms())
+        .context("ULID timestamp exceeds supported chrono range")?;
+    DateTime::from_timestamp_millis(timestamp_ms)
+        .context("ULID timestamp is outside chrono supported range")
+}

--- a/crates/csa-session/src/manager_tests.rs
+++ b/crates/csa-session/src/manager_tests.rs
@@ -120,6 +120,27 @@ fn test_load_session() {
 }
 
 #[test]
+fn test_load_session_falls_back_to_ulid_when_created_at_missing() {
+    let td = tempdir().unwrap();
+    let created = create_session_in(td.path(), td.path(), Some("Legacy"), None, None).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &created.meta_session_id);
+    let state_path = session_dir.join(STATE_FILE_NAME);
+    let original = std::fs::read_to_string(&state_path).unwrap();
+    let filtered = original
+        .lines()
+        .filter(|line| !line.starts_with("created_at = "))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&state_path, format!("{filtered}\n")).unwrap();
+
+    let loaded = load_session_in(td.path(), &created.meta_session_id).unwrap();
+    let decoded = decode_session_created_at(&created.meta_session_id).unwrap();
+
+    assert_eq!(loaded.meta_session_id, created.meta_session_id);
+    assert_eq!(loaded.created_at, decoded);
+}
+
+#[test]
 fn test_delete_session() {
     let td = tempdir().unwrap();
     let state = create_session_in(td.path(), td.path(), None, None, None).unwrap();


### PR DESCRIPTION
## Summary

- `csa session list` previously only exposed `LAST ACCESSED`. When monitoring concurrent sessions it was hard to tell when each one started or whether a slow session was stuck.
- Add `STARTED` and `ELAPSED` columns. `STARTED` comes from session metadata or falls back to the ULID-encoded creation timestamp. `ELAPSED` is compact (`45s` / `3m` / `1h23m` / `2d4h`) and uses wall-clock-vs-now for active sessions, last-accessed-minus-created for terminal phases.

Closes #696.

## Test plan

- [x] `cargo test -p cli-sub-agent session`
- [x] `cargo test --workspace`
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)