### PR TITLE
fix(cli): todo update --title syncs TODO.md; session list --tree rejects filter flags (#703)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.451"
+version = "0.1.452"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.451"
+version = "0.1.452"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -17,7 +17,7 @@ pub enum SessionCommands {
         #[arg(long)]
         tool: Option<String>,
 
-        /// Show tree structure
+        /// Show tree structure (incompatible with --limit/--since/--status)
         #[arg(long)]
         tree: bool,
 

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -85,6 +85,10 @@ pub(crate) fn handle_session_list(
     filters: SessionListFilters,
     format: OutputFormat,
 ) -> Result<()> {
+    if tree && (filters.limit.is_some() || filters.since.is_some() || filters.status.is_some()) {
+        anyhow::bail!("--tree is incompatible with --limit/--since/--status (not yet supported)");
+    }
+
     let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
     let tool_filter: Option<Vec<&str>> = tool.as_ref().map(|t| t.split(',').collect());
 

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -4,8 +4,8 @@ use super::{
     display_log_files, ensure_terminal_result_for_dead_active_session,
     ensure_terminal_result_for_dead_active_session_with_before_write,
     filter_sessions_by_csa_version, handle_session_is_alive, handle_session_kill,
-    handle_session_wait, print_content_with_tail, select_sessions_for_list, session_to_json,
-    status_from_phase_and_result, truncate_with_ellipsis,
+    handle_session_list, handle_session_wait, print_content_with_tail, select_sessions_for_list,
+    session_to_json, status_from_phase_and_result, truncate_with_ellipsis,
 };
 use crate::cli::{Cli, Commands, SessionCommands};
 use crate::session_cmds_daemon::{
@@ -14,7 +14,7 @@ use crate::session_cmds_daemon::{
 use crate::test_env_lock::TEST_ENV_LOCK;
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use chrono::Utc;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use csa_session::{
     ContextStatus, Genealogy, MetaSessionState, SessionPhase, SessionResult, TaskContext,
     TokenUsage, create_session, delete_session, get_session_dir, get_session_root, load_result,
@@ -292,6 +292,70 @@ fn session_list_cli_parses_csa_version_filter() {
         }
         _ => panic!("expected session list command"),
     }
+}
+
+#[test]
+fn session_list_cli_help_mentions_tree_filter_incompatibility() {
+    let mut list_cmd = Cli::command()
+        .find_subcommand("session")
+        .expect("session command")
+        .find_subcommand("list")
+        .expect("session list command")
+        .clone();
+    let help = list_cmd.render_long_help().to_string();
+
+    assert!(help.contains("incompatible with --limit/--since/--status"));
+}
+
+#[test]
+fn session_list_tree_rejects_limit_flag() {
+    let td = tempdir().unwrap();
+    let err = handle_session_list(
+        Some(td.path().display().to_string()),
+        None,
+        None,
+        true,
+        false,
+        super::SessionListFilters {
+            limit: Some(10),
+            since: None,
+            status: None,
+            csa_version: None,
+            show_version: false,
+        },
+        csa_core::types::OutputFormat::Text,
+    )
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("--tree is incompatible"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn session_list_tree_accepts_no_filters() {
+    let td = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
+    let project = td.path();
+    let _session = create_session(project, Some("Tree session"), None, None).unwrap();
+
+    handle_session_list(
+        Some(project.display().to_string()),
+        None,
+        None,
+        true,
+        false,
+        super::SessionListFilters {
+            limit: None,
+            since: None,
+            status: None,
+            csa_version: None,
+            show_version: false,
+        },
+        csa_core::types::OutputFormat::Text,
+    )
+    .expect("tree listing without filters should succeed");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/todo_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_cmd.rs
@@ -455,10 +455,13 @@ pub(crate) fn handle_update(
     let mut changed_fields: Vec<&str> = Vec::new();
     let mut changed_files: Vec<String> = Vec::new();
 
-    if let Some(ref new_title) = title {
+    if let Some(ref new_title) = title
+        && plan.metadata.title != *new_title
+    {
         manager.update_title(&timestamp, new_title)?;
         changed_fields.push("title");
         changed_files.push(format!("{timestamp}/metadata.toml"));
+        changed_files.push(format!("{timestamp}/TODO.md"));
     }
 
     if let Some(new_status) = parsed_status

--- a/crates/csa-todo/src/lib.rs
+++ b/crates/csa-todo/src/lib.rs
@@ -210,8 +210,21 @@ impl TodoManager {
     pub fn update_title(&self, timestamp: &str, title: &str) -> Result<TodoPlan> {
         self.with_write_lock(|| {
             let mut plan = self.load_inner(timestamp)?;
+            if plan.metadata.title == title {
+                return Ok(plan);
+            }
+
+            let todo_path = plan.todo_md_path();
+            let content = std::fs::read_to_string(&todo_path).with_context(|| {
+                format!("Failed to read TODO markdown: {}", todo_path.display())
+            })?;
+            let updated_content = sync_todo_heading(&content, title);
+
             plan.metadata.title = title.to_string();
             plan.metadata.updated_at = Utc::now();
+            if updated_content != content {
+                atomic_write(&todo_path, updated_content.as_bytes())?;
+            }
             self.write_metadata(&plan)?;
             Ok(plan)
         })
@@ -480,6 +493,36 @@ fn atomic_write(target: &Path, data: &[u8]) -> Result<()> {
         .with_context(|| format!("Failed to persist to {}", target.display()))?;
 
     Ok(())
+}
+
+fn sync_todo_heading(content: &str, title: &str) -> String {
+    let replacement = format!("# {title}");
+    let mut updated = String::with_capacity(content.len().max(replacement.len()) + 2);
+    let mut replaced = false;
+
+    for segment in content.split_inclusive('\n') {
+        let line = segment.strip_suffix('\n').unwrap_or(segment);
+        if !replaced && (line.starts_with("# ") || line.starts_with("## ")) {
+            updated.push_str(&replacement);
+            if segment.ends_with('\n') {
+                updated.push('\n');
+            }
+            replaced = true;
+            continue;
+        }
+
+        updated.push_str(segment);
+    }
+
+    if replaced {
+        return updated;
+    }
+
+    if content.is_empty() {
+        format!("{replacement}\n")
+    } else {
+        format!("{replacement}\n\n{content}")
+    }
 }
 
 pub mod dag;

--- a/crates/csa-todo/src/lib_tests.rs
+++ b/crates/csa-todo/src/lib_tests.rs
@@ -215,6 +215,42 @@ fn test_write_todo_md() {
 }
 
 #[test]
+fn test_update_title_syncs_todo_md_heading() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+    let plan = manager.create("Old Title", None).unwrap();
+    manager
+        .write_todo_md(&plan.timestamp, "# Old Title\n\nBody line\n")
+        .unwrap();
+
+    let updated = manager.update_title(&plan.timestamp, "New Title").unwrap();
+    assert_eq!(updated.metadata.title, "New Title");
+
+    let reloaded = manager.load(&plan.timestamp).unwrap();
+    assert_eq!(reloaded.metadata.title, "New Title");
+
+    let todo_content = std::fs::read_to_string(plan.todo_md_path()).unwrap();
+    assert_eq!(todo_content, "# New Title\n\nBody line\n");
+}
+
+#[test]
+fn test_update_title_inserts_heading_when_missing() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+    let plan = manager.create("Old Title", None).unwrap();
+    manager
+        .write_todo_md(&plan.timestamp, "Body without heading\n")
+        .unwrap();
+
+    manager.update_title(&plan.timestamp, "New Title").unwrap();
+
+    let todo_content = std::fs::read_to_string(plan.todo_md_path()).unwrap();
+    assert_eq!(todo_content, "# New Title\n\nBody without heading\n");
+}
+
+#[test]
 fn test_metadata_serialization() {
     let metadata = TodoMetadata {
         branch: Some("feat/test".to_string()),


### PR DESCRIPTION
## Summary

Two CLI ergonomic papercuts:

- `csa todo update <ts> --title "new"` previously only updated `metadata.toml`; `csa todo show` kept rendering the stale title from TODO.md's first heading. Now the first Markdown heading in TODO.md is rewritten to match (and inserted if absent).
- `csa session list --tree --limit/--since/--status` silently returned unfiltered output because the tree renderer short-circuited before filter application. The handler now rejects the combination with a clear error; tree-aware filtering can land as a followup.

## Test plan

- [x] New tests cover title sync (metadata ↔ TODO.md heading) + heading insertion when missing
- [x] New tests cover tree + filter flag rejection
- [x] `cargo test -p cli-sub-agent --release -- --skip gate --skip lefthook` exit 0

Closes #703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)