### PR TITLE
feat(cli-sub-agent): preflight AI-config symlink integrity check (#741)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.452"
+version = "0.1.453"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.452"
+version = "0.1.453"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
@@ -349,6 +349,7 @@ mod tests {
             memory: Default::default(),
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         }
@@ -595,6 +596,7 @@ mod tests {
             memory: Default::default(),
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         };

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -78,6 +78,7 @@ fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/cli-sub-agent/src/debate_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tier_tests.rs
@@ -47,6 +47,7 @@ fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -37,6 +37,7 @@ fn project_config_with_codex_transport(transport: ToolTransport) -> ProjectConfi
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -37,6 +37,7 @@ mod pipeline_transcript;
 mod plan_cmd;
 mod plan_condition;
 mod plan_display;
+mod preflight_symlink;
 mod process_tree;
 mod review_cmd;
 mod review_consensus;

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -496,3 +496,7 @@ mod thinking_tests;
 #[cfg(test)]
 #[path = "pipeline_tests_prompt_guard.rs"]
 mod prompt_guard_tests;
+
+#[cfg(test)]
+#[path = "pipeline_tests_preflight.rs"]
+mod preflight_tests;

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -181,6 +181,17 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     {
         return Err(csa_core::error::AppError::ParentSessionViolation.into());
     }
+    if session_arg.is_none() {
+        let preflight_check_config = config
+            .map(|cfg| &cfg.preflight.ai_config_symlink_check)
+            .or_else(|| global_config.map(|cfg| &cfg.preflight.ai_config_symlink_check));
+        if let Some(preflight_check_config) = preflight_check_config {
+            crate::preflight_symlink::run_ai_config_symlink_check(
+                project_root,
+                preflight_check_config,
+            )?;
+        }
+    }
     let memory_project_key = resolve_memory_project_key(project_root);
     let cd = crate::pipeline_env::resolve_cooldown_seconds(config);
     let depth = crate::pipeline_env::current_csa_depth();

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -155,6 +155,7 @@ fn resolve_idle_timeout_prefers_cli_override() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -267,6 +268,7 @@ fn resolve_idle_timeout_uses_config_then_default() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -304,6 +306,7 @@ fn resolve_liveness_dead_seconds_uses_config_then_default() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -448,6 +451,7 @@ fn test_config_with_node_heap_limit(node_heap_limit_mb: Option<u64>) -> ProjectC
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }
@@ -637,6 +641,7 @@ fn config_with_tier_for_tool(_tool_prefix: &str, model_spec: &str) -> ProjectCon
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/cli-sub-agent/src/pipeline_tests_initial_response.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_initial_response.rs
@@ -36,6 +36,7 @@ fn test_resolve_initial_response_timeout_cli_override_over_config() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -77,6 +78,7 @@ fn test_resolve_initial_response_timeout_config_zero_disables() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -118,6 +120,7 @@ fn test_resolve_initial_response_timeout_uses_config_value() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -163,6 +166,7 @@ fn test_resolve_initial_response_timeout_for_tool_disabled_when_idle_timeout_exp
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -196,6 +200,7 @@ fn test_resolve_initial_response_timeout_for_tool_kept_when_both_explicit() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -229,6 +234,7 @@ fn test_resolve_initial_response_timeout_for_tool_falls_through_without_idle_tim
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -261,6 +267,7 @@ fn test_resolve_initial_response_timeout_for_codex_defaults_to_300_without_overr
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -293,6 +300,7 @@ fn test_resolve_initial_response_timeout_for_gemini_cli_default() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -322,6 +330,7 @@ fn test_resolve_initial_response_timeout_for_non_codex_cli_zero_disables_watchdo
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -360,6 +369,7 @@ fn test_resolve_initial_response_timeout_gemini_cli_honors_override() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -397,6 +407,7 @@ fn test_resolve_initial_response_timeout_gemini_cli_disable() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -429,6 +440,7 @@ fn test_resolve_initial_response_timeout_for_unknown_tool_uses_global_default() 
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -458,6 +470,7 @@ fn test_resolve_initial_response_timeout_for_non_codex_positive_override_passes_
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -490,6 +503,7 @@ fn test_resolve_initial_response_timeout_for_codex_uses_explicit_resource_timeou
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -527,6 +541,7 @@ fn test_resolve_initial_response_timeout_for_codex_uses_tool_override() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -567,6 +582,7 @@ fn test_resolve_initial_response_timeout_for_codex_tool_override_beats_resource_
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -596,6 +612,7 @@ fn test_resolve_initial_response_timeout_for_codex_cli_zero_disables_watchdog() 
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -634,6 +651,7 @@ fn test_resolve_initial_response_timeout_for_codex_tool_zero_disables() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -667,6 +685,7 @@ fn test_resolve_initial_response_timeout_for_codex_global_zero_disables() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -697,6 +716,7 @@ fn test_resolve_initial_response_timeout_for_codex_respects_explicit_idle_overri
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/cli-sub-agent/src/pipeline_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_preflight.rs
@@ -1,0 +1,87 @@
+use super::*;
+use std::collections::HashMap;
+
+use csa_config::config::CURRENT_SCHEMA_VERSION;
+use csa_config::{ProjectMeta, ResourcesConfig};
+
+use crate::test_session_sandbox::ScopedSessionSandbox;
+
+#[tokio::test]
+async fn execute_with_session_and_meta_fails_preflight_before_creating_session() {
+    let temp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    std::fs::write(temp.path().join("AGENTS.md"), "not a symlink").unwrap();
+
+    let config = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        execution: Default::default(),
+        preflight: csa_config::PreflightConfig {
+            ai_config_symlink_check: csa_config::AiConfigSymlinkCheckConfig {
+                enabled: true,
+                ..Default::default()
+            },
+        },
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+    let executor = Executor::Opencode {
+        model_override: None,
+        agent: None,
+        thinking_budget: None,
+    };
+
+    let err = match execute_with_session_and_meta(
+        &executor,
+        &ToolName::Opencode,
+        "review prompt",
+        csa_core::types::OutputFormat::Json,
+        None,
+        Some("preflight-fail".to_string()),
+        None,
+        temp.path(),
+        Some(&config),
+        None,
+        Some("run"),
+        None,
+        None,
+        csa_process::StreamMode::BufferOnly,
+        DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        None,
+        None,
+        None,
+        false,
+        false,
+        &[],
+        &[],
+    )
+    .await
+    {
+        Ok(_) => panic!("preflight should fail"),
+        Err(err) => err,
+    };
+
+    let message = err.to_string();
+    assert!(message.contains("preflight: AI-config symlink integrity check failed"));
+    assert!(message.contains("AGENTS.md"));
+
+    let sessions = csa_session::list_sessions(temp.path(), None).unwrap();
+    assert!(
+        sessions.is_empty(),
+        "preflight failure must not create session"
+    );
+}

--- a/crates/cli-sub-agent/src/pipeline_tests_prompt_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_prompt_guard.rs
@@ -161,6 +161,7 @@ fn anti_recursion_guard_honors_custom_max_recursion_depth() {
             memory: Default::default(),
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         }

--- a/crates/cli-sub-agent/src/pipeline_tests_tail.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_tail.rs
@@ -21,6 +21,7 @@ async fn build_and_validate_executor_no_tiers_both_flags_equivalent() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/cli-sub-agent/src/pipeline_tests_thinking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_thinking.rs
@@ -47,6 +47,7 @@ fn config_with_single_tier_model(
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }
@@ -81,6 +82,7 @@ async fn thinking_lock_project_config_overrides_cli_thinking() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -180,6 +182,7 @@ async fn thinking_lock_project_overrides_global() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -339,6 +342,7 @@ async fn project_default_thinking_applies_when_cli_absent() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -408,6 +412,7 @@ async fn project_default_model_is_checked_against_tiers_when_enabled() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -475,6 +480,7 @@ async fn project_default_model_is_ignored_when_tool_defaults_disabled() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/cli-sub-agent/src/pipeline_transcript.rs
+++ b/crates/cli-sub-agent/src/pipeline_transcript.rs
@@ -82,6 +82,7 @@ mod tests {
             memory: Default::default(),
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         }

--- a/crates/cli-sub-agent/src/preflight_symlink.rs
+++ b/crates/cli-sub-agent/src/preflight_symlink.rs
@@ -1,0 +1,230 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+use csa_config::AiConfigSymlinkCheckConfig;
+
+const DEFAULT_AI_CONFIG_SYMLINK_PATHS: &[&str] = &[
+    "AGENTS.md",
+    "GEMINI.md",
+    "CLAUDE.md",
+    ".claude/rules/AGENTS.md",
+    ".agents/project-rules-ref",
+    ".agents/rules-ref",
+];
+
+pub fn run_ai_config_symlink_check(
+    project_root: &Path,
+    config: &AiConfigSymlinkCheckConfig,
+) -> Result<()> {
+    if !config.enabled {
+        return Ok(());
+    }
+
+    let violations: Vec<String> = if let Some(configured_paths) = config.paths.as_ref() {
+        configured_paths
+            .iter()
+            .filter_map(|relative_path| validate_one_path(project_root, relative_path, config))
+            .collect()
+    } else {
+        DEFAULT_AI_CONFIG_SYMLINK_PATHS
+            .iter()
+            .filter_map(|relative_path| validate_one_path(project_root, relative_path, config))
+            .collect()
+    };
+
+    if violations.is_empty() {
+        return Ok(());
+    }
+
+    let mut message = String::from("preflight: AI-config symlink integrity check failed\n");
+    for violation in violations {
+        message.push_str("  ");
+        message.push_str(&violation);
+        message.push('\n');
+    }
+    message.push_str(
+        "\nThese paths must be symlinks into your rules/drafts repo (see AGENTS.md Rule 036).\n\
+Fix by re-creating the symlinks:\n  ln -sf <target> <path>\n\n\
+To disable this check, set `preflight.ai_config_symlink_check.enabled = false` in\n\
+~/.config/cli-sub-agent/config.toml or the project .csa/config.toml.",
+    );
+
+    Err(anyhow!(message))
+}
+
+fn validate_one_path(
+    project_root: &Path,
+    relative_path: &str,
+    config: &AiConfigSymlinkCheckConfig,
+) -> Option<String> {
+    let full_path = project_root.join(relative_path);
+    let metadata = match fs::symlink_metadata(&full_path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(err) => {
+            return Some(format!("{relative_path:<32} failed to inspect path: {err}"));
+        }
+    };
+
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        if !config.treat_broken_symlink_as_error {
+            return None;
+        }
+
+        if let Err(err) = fs::metadata(&full_path) {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                let resolved_target = describe_symlink_target(&full_path);
+                return Some(format!(
+                    "{relative_path:<32} broken symlink: target '{resolved_target}' does not exist"
+                ));
+            }
+            return Some(format!(
+                "{relative_path:<32} failed to inspect symlink target: {err}"
+            ));
+        }
+        return None;
+    }
+
+    if file_type.is_file() {
+        return Some(format!(
+            "{relative_path:<32} is a regular file, expected symlink"
+        ));
+    }
+
+    if file_type.is_dir() {
+        return Some(format!(
+            "{relative_path:<32} is a regular directory, expected symlink"
+        ));
+    }
+
+    Some(format!(
+        "{relative_path:<32} is not a symlink, expected symlink"
+    ))
+}
+
+fn describe_symlink_target(path: &Path) -> String {
+    match fs::read_link(path) {
+        Ok(target) => resolve_symlink_target(path, &target).display().to_string(),
+        Err(err) => format!("<unreadable symlink target: {err}>"),
+    }
+}
+
+fn resolve_symlink_target(link_path: &Path, target: &Path) -> PathBuf {
+    if target.is_absolute() {
+        return target.to_path_buf();
+    }
+
+    link_path
+        .parent()
+        .map(|parent| parent.join(target))
+        .unwrap_or_else(|| target.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_never_fails() {
+        let d = tempfile::tempdir().unwrap();
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        run_ai_config_symlink_check(d.path(), &cfg).expect("disabled should return Ok");
+    }
+
+    #[test]
+    fn enabled_with_no_paths_present_returns_ok() {
+        let d = tempfile::tempdir().unwrap();
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        run_ai_config_symlink_check(d.path(), &cfg).expect("missing files are ok");
+    }
+
+    #[test]
+    fn regular_file_at_ai_config_path_is_violation() {
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(d.path().join("AGENTS.md"), "content").unwrap();
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let err = run_ai_config_symlink_check(d.path(), &cfg).expect_err("should fail");
+        assert!(err.to_string().contains("AGENTS.md"), "got: {err}");
+        assert!(err.to_string().contains("regular file"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn valid_symlink_passes() {
+        let d = tempfile::tempdir().unwrap();
+        let target = d.path().join("real.md");
+        std::fs::write(&target, "content").unwrap();
+        std::os::unix::fs::symlink(&target, d.path().join("AGENTS.md")).unwrap();
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        run_ai_config_symlink_check(d.path(), &cfg).expect("valid symlink ok");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn broken_symlink_fails_when_treated_as_error() {
+        let d = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink("/nonexistent/nowhere", d.path().join("AGENTS.md")).unwrap();
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let err = run_ai_config_symlink_check(d.path(), &cfg).expect_err("broken -> err");
+        assert!(err.to_string().contains("broken symlink"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn broken_symlink_passes_when_configured_to_ignore() {
+        let d = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink("/nonexistent", d.path().join("AGENTS.md")).unwrap();
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: true,
+            treat_broken_symlink_as_error: false,
+            ..Default::default()
+        };
+        run_ai_config_symlink_check(d.path(), &cfg).expect("ignored broken -> ok");
+    }
+
+    #[test]
+    fn custom_path_list_overrides_defaults() {
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(d.path().join("CUSTOM.md"), "content").unwrap();
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: true,
+            paths: Some(vec!["CUSTOM.md".to_string()]),
+            ..Default::default()
+        };
+        let err = run_ai_config_symlink_check(d.path(), &cfg).expect_err("custom path flagged");
+        assert!(err.to_string().contains("CUSTOM.md"), "got: {err}");
+        assert!(
+            !err.to_string()
+                .contains("AGENTS.md                        is "),
+            "got: {err}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn disabled_returns_ok_on_windows() {
+        let d = tempfile::tempdir().unwrap();
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        run_ai_config_symlink_check(d.path(), &cfg).expect("disabled should return Ok");
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_reviewers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers.rs
@@ -280,6 +280,7 @@ mod tests {
             memory: Default::default(),
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         }

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -62,6 +62,7 @@ pub(super) fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
@@ -40,6 +40,7 @@ fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -48,6 +48,7 @@ fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
@@ -52,6 +52,7 @@ fn make_named_failover_config(tier_name: &str, models: &[&str]) -> ProjectConfig
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -601,6 +601,7 @@ mod tests {
             memory: Default::default(),
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         }

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -44,6 +44,7 @@ fn run_config_with_tier(
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -43,6 +43,7 @@ fn run_config_with_tier(
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
@@ -657,6 +657,7 @@ mod tests {
             memory: Default::default(),
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         }

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection_model_spec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection_model_spec_tests.rs
@@ -51,6 +51,7 @@ fn resolve_tool_by_strategy_model_spec_disables_default_tier_and_runtime_fallbac
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/cli-sub-agent/src/run_helpers_model_spec_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_model_spec_tests.rs
@@ -52,6 +52,7 @@ fn project_config_with_tier_tools(tools: &[&str]) -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/cli-sub-agent/src/run_helpers_override_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_override_tests.rs
@@ -22,6 +22,7 @@ fn resolve_tool_and_model_model_spec_preserves_explicit_model_override() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/cli-sub-agent/src/run_helpers_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tests.rs
@@ -195,6 +195,7 @@ fn mutating_skill_contract_routes_default_tier_away_from_restricted_tool() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -353,6 +354,7 @@ fn build_executor_uses_project_tool_defaults_when_cli_missing() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -391,6 +393,7 @@ fn build_executor_ignores_project_tool_defaults_when_disabled() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -435,6 +438,7 @@ fn build_executor_cli_overrides_project_tool_defaults() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -678,6 +682,7 @@ fn build_executor_model_spec_overrides_both() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
@@ -40,6 +40,7 @@ fn resolve_tool_and_model_disabled_tool_explicit_errors() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -93,6 +94,7 @@ fn resolve_tool_and_model_disabled_tool_with_override_succeeds() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -146,6 +148,7 @@ fn resolve_tool_and_model_disabled_tool_model_spec_errors() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -215,6 +218,7 @@ fn config_with_tier(tier_name: &str, models: Vec<&str>, enabled_tools: &[&str]) 
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }
@@ -486,6 +490,7 @@ fn resolve_tool_and_model_no_tiers_allows_direct_tool() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
@@ -25,6 +25,7 @@ fn project_config_with_codex_tool(tool_config: ToolConfig) -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -74,6 +74,7 @@ fn write_project_config_with_tier(project_root: &Path) {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -11,7 +11,7 @@ use crate::config_merge::{
     warn_deprecated_keys,
 };
 pub use crate::config_resources::ResourcesConfig;
-use crate::global::{PreferencesConfig, ReviewConfig};
+use crate::global::{PreferencesConfig, PreflightConfig, ReviewConfig};
 use crate::memory::MemoryConfig;
 use crate::paths;
 
@@ -142,10 +142,16 @@ pub struct ProjectConfig {
     /// Execution tuning knobs (timeout floors, etc.).
     #[serde(default, skip_serializing_if = "ExecutionConfig::is_default")]
     pub execution: ExecutionConfig,
+    #[serde(default, skip_serializing_if = "preflight_is_default")]
+    pub preflight: PreflightConfig,
     #[serde(default, skip_serializing_if = "VcsConfig::is_default")]
     pub vcs: VcsConfig,
     #[serde(default, skip_serializing_if = "FilesystemSandboxConfig::is_default")]
     pub filesystem_sandbox: FilesystemSandboxConfig,
+}
+
+fn preflight_is_default(config: &PreflightConfig) -> bool {
+    config.ai_config_symlink_check.is_default()
 }
 
 fn default_schema_version() -> u32 {
@@ -653,6 +659,9 @@ mod merge_tests;
 #[cfg(test)]
 #[path = "config_merge_tests_tail.rs"]
 mod merge_tests_tail;
+#[cfg(test)]
+#[path = "config_tests_preflight.rs"]
+mod preflight_tests;
 #[cfg(test)]
 #[path = "config_tests.rs"]
 mod tests;

--- a/crates/csa-config/src/config_runtime_fs_sandbox_tests.rs
+++ b/crates/csa-config/src/config_runtime_fs_sandbox_tests.rs
@@ -30,6 +30,7 @@ fn empty_config() -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/csa-config/src/config_runtime_tests.rs
+++ b/crates/csa-config/src/config_runtime_tests.rs
@@ -30,6 +30,7 @@ fn empty_config() -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/csa-config/src/config_runtime_timeout_tests.rs
+++ b/crates/csa-config/src/config_runtime_timeout_tests.rs
@@ -25,6 +25,7 @@ fn empty_config() -> ProjectConfig {
         preferences: None,
         hooks: HooksSection::default(),
         execution: ExecutionConfig::default(),
+        preflight: Default::default(),
         vcs: VcsConfig::default(),
         filesystem_sandbox: FilesystemSandboxConfig::default(),
     }

--- a/crates/csa-config/src/config_tests.rs
+++ b/crates/csa-config/src/config_tests.rs
@@ -47,6 +47,7 @@ fn test_save_and_load_roundtrip() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -97,6 +98,7 @@ fn test_save_and_load_roundtrip_with_review_override() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -140,6 +142,7 @@ fn test_is_tool_enabled_configured_enabled() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -181,6 +184,7 @@ fn test_is_tool_enabled_configured_disabled() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -211,6 +215,7 @@ fn test_is_tool_enabled_unconfigured_defaults_to_true() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -257,6 +262,7 @@ fn test_is_tool_configured_in_tiers_detects_presence() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -317,6 +323,7 @@ fn test_is_tool_auto_selectable_requires_enabled_and_tier_membership() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -363,6 +370,7 @@ fn test_can_tool_edit_existing_with_restrictions_false() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -396,6 +404,7 @@ fn test_can_tool_edit_existing_without_restrictions() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -426,6 +435,7 @@ fn test_can_tool_edit_existing_unconfigured_defaults_to_true() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -510,6 +520,7 @@ fn test_max_recursion_depth_override() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -641,6 +652,7 @@ fn test_schema_version_current_is_ok() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -672,6 +684,7 @@ fn test_schema_version_older_is_ok() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -702,6 +715,7 @@ fn test_schema_version_newer_fails() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -763,6 +777,7 @@ fn test_enforce_tool_enabled_disabled_tool_returns_error() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/csa-config/src/config_tests_preflight.rs
+++ b/crates/csa-config/src/config_tests_preflight.rs
@@ -1,0 +1,69 @@
+use super::*;
+use tempfile::tempdir;
+
+#[test]
+fn test_preflight_ai_config_symlink_check_defaults() {
+    let config: ProjectConfig = toml::from_str(
+        r#"
+schema_version = 2
+
+[project]
+name = "test"
+"#,
+    )
+    .expect("parse config");
+
+    assert!(!config.preflight.ai_config_symlink_check.enabled);
+    assert!(config.preflight.ai_config_symlink_check.paths.is_none());
+    assert!(
+        config
+            .preflight
+            .ai_config_symlink_check
+            .treat_broken_symlink_as_error
+    );
+}
+
+#[test]
+fn test_project_preflight_overrides_global_merge() {
+    let dir = tempdir().unwrap();
+    let user_config = dir.path().join("user.toml");
+    let project_dir = dir.path().join(".csa");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    let project_config = project_dir.join("config.toml");
+
+    std::fs::write(
+        &user_config,
+        r#"
+[preflight.ai_config_symlink_check]
+enabled = true
+treat_broken_symlink_as_error = true
+paths = ["AGENTS.md", "CLAUDE.md"]
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &project_config,
+        r#"
+[preflight.ai_config_symlink_check]
+paths = ["CUSTOM.md"]
+treat_broken_symlink_as_error = false
+"#,
+    )
+    .unwrap();
+
+    let merged = ProjectConfig::load_with_paths(Some(&user_config), &project_config)
+        .expect("load merged")
+        .expect("config present");
+
+    assert!(merged.preflight.ai_config_symlink_check.enabled);
+    assert_eq!(
+        merged.preflight.ai_config_symlink_check.paths,
+        Some(vec!["CUSTOM.md".to_string()])
+    );
+    assert!(
+        !merged
+            .preflight
+            .ai_config_symlink_check
+            .treat_broken_symlink_as_error
+    );
+}

--- a/crates/csa-config/src/config_tests_tail.rs
+++ b/crates/csa-config/src/config_tests_tail.rs
@@ -22,6 +22,7 @@ fn test_enforce_tool_enabled_enabled_tool_returns_ok() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -48,6 +49,7 @@ fn test_enforce_tool_enabled_unconfigured_tool_returns_ok() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -83,6 +85,7 @@ fn test_enforce_tool_enabled_force_override_bypasses_disabled() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/csa-config/src/config_tests_tier.rs
+++ b/crates/csa-config/src/config_tests_tier.rs
@@ -46,6 +46,7 @@ fn test_resolve_tier_default_selection() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -96,6 +97,7 @@ fn test_resolve_tier_fallback_to_tier3() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -162,6 +164,7 @@ fn test_resolve_tier_skips_disabled_tools() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -206,6 +209,7 @@ fn test_resolve_alias() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -264,6 +268,7 @@ fn enabled_tier_models_returns_all_when_no_tools_disabled() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -319,6 +324,7 @@ fn enabled_tier_models_excludes_disabled_tool() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -349,6 +355,7 @@ fn enabled_tier_models_returns_empty_for_unknown_tier() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -407,6 +414,7 @@ fn enabled_tier_models_returns_empty_when_all_tools_disabled() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -467,6 +475,7 @@ fn filtered_skips_restricted_tool_when_needs_edit() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -531,6 +540,7 @@ fn filtered_returns_none_when_all_restricted_and_needs_edit() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/csa-config/src/config_tests_tier_selector.rs
+++ b/crates/csa-config/src/config_tests_tier_selector.rs
@@ -33,6 +33,7 @@ fn test_resolve_tier_selector_direct_tier() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -77,6 +78,7 @@ fn test_resolve_tier_selector_alias() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -133,6 +135,7 @@ fn test_resolve_tier_selector_direct_wins_on_collision() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -163,6 +166,7 @@ fn test_resolve_tier_selector_nonexistent() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -192,6 +196,7 @@ fn test_resolve_tier_selector_alias_to_nonexistent_tier() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -241,6 +246,7 @@ fn test_resolve_tier_selector_prefix_unique() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -295,6 +301,7 @@ fn test_resolve_tier_selector_prefix_ambiguous() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -337,6 +344,7 @@ fn test_resolve_tier_selector_exact_wins_over_prefix() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -385,6 +393,7 @@ fn test_suggest_tier_prefix() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -432,6 +441,7 @@ fn test_suggest_tier_substring() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -469,6 +479,7 @@ fn test_suggest_tier_no_match() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -511,6 +522,7 @@ fn test_resolve_tier_selector_empty_string_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/csa-config/src/config_tests_tier_whitelist.rs
+++ b/crates/csa-config/src/config_tests_tier_whitelist.rs
@@ -31,6 +31,7 @@ fn config_with_tiers(tier_models: &[&str]) -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }
@@ -388,6 +389,7 @@ fn config_with_multi_tiers() -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -50,6 +50,9 @@ pub struct GlobalConfig {
     /// KV cache-aware polling defaults used by orchestration workflows.
     #[serde(default)]
     pub kv_cache: KvCacheConfig,
+    /// Pre-flight repository integrity checks before session spawn.
+    #[serde(default)]
+    pub preflight: PreflightConfig,
     /// ACP transport overrides; project-level `[acp]` takes precedence.
     #[serde(default, skip_serializing_if = "crate::AcpConfig::is_default")]
     pub acp: crate::AcpConfig,
@@ -59,6 +62,47 @@ pub struct GlobalConfig {
         skip_serializing_if = "crate::config_filesystem_sandbox::FilesystemSandboxConfig::is_default"
     )]
     pub filesystem_sandbox: crate::config_filesystem_sandbox::FilesystemSandboxConfig,
+}
+
+/// Pre-flight checks that run before session creation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PreflightConfig {
+    #[serde(
+        default,
+        skip_serializing_if = "AiConfigSymlinkCheckConfig::is_default"
+    )]
+    pub ai_config_symlink_check: AiConfigSymlinkCheckConfig,
+}
+
+/// Configuration for AI-config symlink integrity validation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiConfigSymlinkCheckConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paths: Option<Vec<String>>,
+    #[serde(default = "default_broken_as_error")]
+    pub treat_broken_symlink_as_error: bool,
+}
+
+const fn default_broken_as_error() -> bool {
+    true
+}
+
+impl Default for AiConfigSymlinkCheckConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            paths: None,
+            treat_broken_symlink_as_error: default_broken_as_error(),
+        }
+    }
+}
+
+impl AiConfigSymlinkCheckConfig {
+    pub fn is_default(&self) -> bool {
+        !self.enabled && self.paths.is_none() && self.treat_broken_symlink_as_error
+    }
 }
 
 /// User preferences for tool selection and routing.

--- a/crates/csa-config/src/global_tests_priority.rs
+++ b/crates/csa-config/src/global_tests_priority.rs
@@ -145,6 +145,7 @@ fn project_config_with_preferences(prefs: Option<PreferencesConfig>) -> crate::P
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/csa-config/src/init.rs
+++ b/crates/csa-config/src/init.rs
@@ -244,6 +244,7 @@ pub fn init_project(
             preferences: None,
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         }
@@ -273,6 +274,7 @@ pub fn init_project(
             preferences: None,
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         }

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -36,9 +36,10 @@ pub use config_resources::ResourcesConfig;
 pub use config_runtime::{DefaultSandboxOptions, default_sandbox_for_tool};
 pub use gc::GcConfig;
 pub use global::{
-    DEFAULT_KV_CACHE_FREQUENT_POLL_SECS, DEFAULT_KV_CACHE_LONG_POLL_SECS, ExecutionEnvOptions,
-    GateMode, GateStep, GlobalConfig, GlobalMcpConfig, KvCacheConfig, KvCacheValueSource,
-    LEGACY_SESSION_WAIT_FALLBACK_SECS, ResolvedKvCacheValue, ReviewConfig, ToolSelection,
+    AiConfigSymlinkCheckConfig, DEFAULT_KV_CACHE_FREQUENT_POLL_SECS,
+    DEFAULT_KV_CACHE_LONG_POLL_SECS, ExecutionEnvOptions, GateMode, GateStep, GlobalConfig,
+    GlobalMcpConfig, KvCacheConfig, KvCacheValueSource, LEGACY_SESSION_WAIT_FALLBACK_SECS,
+    PreflightConfig, ResolvedKvCacheValue, ReviewConfig, ToolSelection,
 };
 pub use init::{detect_installed_tools, init_project};
 pub use mcp::{McpFilter, McpRegistry, McpServerConfig, McpTransport};

--- a/crates/csa-config/src/validate_tests.rs
+++ b/crates/csa-config/src/validate_tests.rs
@@ -53,6 +53,7 @@ fn test_validate_config_succeeds_on_valid() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -89,6 +90,7 @@ fn test_validate_config_fails_on_empty_name() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -129,6 +131,7 @@ fn test_validate_config_fails_on_unknown_tool() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -170,6 +173,7 @@ fn test_validate_config_fails_on_zero_idle_timeout() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -215,6 +219,7 @@ fn test_validate_config_fails_on_invalid_review_tool() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -270,6 +275,7 @@ fn test_validate_config_fails_on_invalid_model_spec() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -328,6 +334,7 @@ fn test_validate_config_fails_on_invalid_tier_mapping() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -395,6 +402,7 @@ fn test_validate_config_fails_on_empty_models() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -453,6 +461,7 @@ fn test_validate_config_accepts_custom_tier_names() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -492,6 +501,7 @@ fn test_validate_config_fails_on_invalid_debate_tool() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -534,6 +544,7 @@ fn test_validate_max_recursion_depth_boundary_20() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -569,6 +580,7 @@ fn test_validate_max_recursion_depth_boundary_21() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/csa-config/src/validate_tests_preferences.rs
+++ b/crates/csa-config/src/validate_tests_preferences.rs
@@ -28,6 +28,7 @@ fn test_validate_config_warns_but_passes_on_unknown_tool_priority() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };

--- a/crates/csa-config/src/validate_tests_sandbox.rs
+++ b/crates/csa-config/src/validate_tests_sandbox.rs
@@ -28,6 +28,7 @@ fn test_validate_liveness_dead_seconds_zero_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -72,6 +73,7 @@ fn test_validate_memory_max_mb_too_low() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -116,6 +118,7 @@ fn test_validate_memory_max_mb_at_minimum() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -154,6 +157,7 @@ fn test_validate_pids_max_too_low() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -198,6 +202,7 @@ fn test_validate_pids_max_at_minimum() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -236,6 +241,7 @@ fn test_validate_node_heap_limit_mb_too_low_in_resources() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -286,6 +292,7 @@ fn test_validate_per_tool_required_enforcement_without_memory_fails() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -339,6 +346,7 @@ fn test_validate_per_tool_required_enforcement_with_tool_memory_passes() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -386,6 +394,7 @@ fn test_validate_per_tool_required_enforcement_with_global_memory_passes() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -433,6 +442,7 @@ fn test_validate_node_heap_limit_mb_too_low_in_tool() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -477,6 +487,7 @@ fn test_validate_soft_limit_percent_zero_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -521,6 +532,7 @@ fn test_validate_soft_limit_percent_over_100_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -565,6 +577,7 @@ fn test_validate_soft_limit_percent_valid() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -603,6 +616,7 @@ fn test_validate_memory_monitor_interval_zero_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -647,6 +661,7 @@ fn test_validate_memory_monitor_interval_valid() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };

--- a/crates/csa-config/src/validate_tests_tail.rs
+++ b/crates/csa-config/src/validate_tests_tail.rs
@@ -47,6 +47,7 @@ fn test_validate_model_spec_two_parts() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -101,6 +102,7 @@ fn test_validate_model_spec_five_parts() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -145,6 +147,7 @@ fn test_validate_review_tool_auto_accepted() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -183,6 +186,7 @@ fn test_validate_review_batch_commits_zero_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -228,6 +232,7 @@ fn test_validate_all_known_review_tools_accepted() {
             memory: Default::default(),
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         };
@@ -272,6 +277,7 @@ fn test_validate_all_known_debate_tools_accepted() {
             memory: Default::default(),
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         };
@@ -316,6 +322,7 @@ fn test_validate_all_four_known_tools_accepted() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -351,6 +358,7 @@ fn test_validate_no_review_no_debate_is_ok() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };
@@ -386,6 +394,7 @@ fn test_validate_max_recursion_depth_zero() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };

--- a/crates/csa-config/src/validate_tests_tiers.rs
+++ b/crates/csa-config/src/validate_tests_tiers.rs
@@ -63,6 +63,7 @@ fn test_validate_multiple_tiers_all_valid() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -114,6 +115,7 @@ fn test_validate_tier_with_multiple_models_all_valid() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -165,6 +167,7 @@ fn test_validate_tier_with_one_bad_model_in_list() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -219,6 +222,7 @@ fn test_validate_tier_token_budget_zero_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -268,6 +272,7 @@ fn test_validate_tier_max_turns_zero_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -317,6 +322,7 @@ fn test_validate_tier_with_valid_budget_and_turns() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -365,6 +371,7 @@ fn test_validate_tier_model_spec_unknown_tool_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -418,6 +425,7 @@ fn test_validate_tier_model_spec_known_tool_accepted() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -456,6 +464,7 @@ fn test_validate_review_tier_unknown_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -499,6 +508,7 @@ fn test_validate_debate_tier_unknown_rejected() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };
@@ -555,6 +565,7 @@ fn test_validate_review_tier_valid_accepted() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
     };

--- a/crates/csa-scheduler/src/failover_tests.rs
+++ b/crates/csa-scheduler/src/failover_tests.rs
@@ -52,6 +52,7 @@ fn make_config(models: Vec<&str>, disabled: Vec<&str>) -> ProjectConfig {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }
@@ -168,6 +169,7 @@ fn make_multi_tier_config(
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }

--- a/crates/csa-scheduler/src/rotation.rs
+++ b/crates/csa-scheduler/src/rotation.rs
@@ -308,6 +308,7 @@ mod tests {
             memory: Default::default(),
             hooks: Default::default(),
             execution: Default::default(),
+            preflight: Default::default(),
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         }

--- a/crates/csa-scheduler/src/rotation_tests_tail.rs
+++ b/crates/csa-scheduler/src/rotation_tests_tail.rs
@@ -98,6 +98,7 @@ fn make_config_with_strategy(
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }
@@ -154,6 +155,7 @@ fn make_config_with_restrictions(models: Vec<&str>, restricted_tools: Vec<&str>)
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }
@@ -374,6 +376,7 @@ fn test_resolve_tier_name_missing_tier_returns_none() {
         memory: Default::default(),
         hooks: Default::default(),
         execution: Default::default(),
+        preflight: Default::default(),
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     };


### PR DESCRIPTION
## Summary

Adds an opt-in pre-flight check that runs before session spawn (`csa run` / `csa review` / `csa debate`). Verifies that a configurable list of AI-configuration paths (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.claude/rules/AGENTS.md`, `.agents/project-rules-ref`, `.agents/rules-ref`) are symlinks (not regular files) and that their targets resolve. On any violation, CSA fails fast with a per-path diagnostic pointing at AGENTS.md Rule 036.

Config lives at `preflight.ai_config_symlink_check` in global or project TOML (`enabled`, `paths`, `treat_broken_symlink_as_error`). **Default is disabled** — new installs aren't forced into the check; the user opts in explicitly when their repo has symlinked AI-config.

Closes #741.

## Test plan

- [x] `cargo build --release --workspace` exit 0
- [x] `cargo test -p cli-sub-agent --release preflight_symlink -- --skip gate --skip lefthook` (7 passed)
- [x] `cargo test -p csa-config --release preflight` (2 passed)
- [x] `just find-monolith-files` exit 0
- [x] Wire-in asserted: preflight failure does NOT create session directory (integration test in pipeline_tests_preflight.rs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)