### PR TITLE
chore(csa-todo): preserve CRLF line endings in sync_todo_heading (#969)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.454"
+version = "0.1.455"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.454"
+version = "0.1.455"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-todo/src/lib.rs
+++ b/crates/csa-todo/src/lib.rs
@@ -504,6 +504,9 @@ fn sync_todo_heading(content: &str, title: &str) -> String {
         let line = segment.strip_suffix('\n').unwrap_or(segment);
         if !replaced && (line.starts_with("# ") || line.starts_with("## ")) {
             updated.push_str(&replacement);
+            if line.ends_with('\r') {
+                updated.push('\r');
+            }
             if segment.ends_with('\n') {
                 updated.push('\n');
             }

--- a/crates/csa-todo/src/lib_tests.rs
+++ b/crates/csa-todo/src/lib_tests.rs
@@ -235,6 +235,27 @@ fn test_update_title_syncs_todo_md_heading() {
 }
 
 #[test]
+fn test_update_title_syncs_todo_md_heading_preserving_crlf() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+    let plan = manager.create("Old Title", None).unwrap();
+    std::fs::write(plan.todo_md_path(), "# Old Title\r\n\r\nBody line\r\n").unwrap();
+
+    let updated = manager.update_title(&plan.timestamp, "New Title").unwrap();
+    assert_eq!(updated.metadata.title, "New Title");
+
+    let todo_content = std::fs::read_to_string(plan.todo_md_path()).unwrap();
+    assert_eq!(todo_content, "# New Title\r\n\r\nBody line\r\n");
+}
+
+#[test]
+fn test_sync_todo_heading_preserves_lf_line_endings() {
+    let updated = sync_todo_heading("# Old Title\n\nbody\n", "New Title");
+    assert_eq!(updated, "# New Title\n\nbody\n");
+}
+
+#[test]
 fn test_update_title_inserts_heading_when_missing() {
     let dir = tempdir().unwrap();
     let manager = TodoManager::with_base_dir(dir.path().to_path_buf());


### PR DESCRIPTION
## Summary

- `sync_todo_heading` split on `\n` and re-emitted the heading line with just `\n`, dropping `\r` in CRLF (`\r\n`) pairs
- On Windows or on files edited with a CRLF editor, `csa todo update --title` silently rewrote the heading's line terminator
- Fix: detect the original heading line's trailing `\r` and reattach it when emitting the new heading; other lines untouched so existing line-ending style round-trips unchanged

## Test plan

- [x] `cargo test -p csa-todo --release sync_todo_heading -- --skip gate --skip lefthook` — added `test_update_title_syncs_todo_md_heading_preserving_crlf` and `test_sync_todo_heading_preserves_lf_line_endings`
- [x] `cargo build --release --workspace`
- [x] `just find-monolith-files`

Closes #969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)