### PR TITLE
chore(commit): align PATTERN.md step numbering + split reviewer-metadata test (#966)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.455"
+version = "0.1.456"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.456"
+version = "0.1.457"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.455"
+version = "0.1.456"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.456"
+version = "0.1.457"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
@@ -279,6 +279,14 @@ fn commit_reviewer_guidance_schema_requires_regression_tests_for_timing_scenario
         !commit_pattern.contains("Risk Areas:") && !commit_workflow.contains("Risk Areas:"),
         "commit pattern/workflow should no longer require the old Risk Areas reviewer-guidance field"
     );
+}
+
+#[test]
+fn commit_workflow_step17_requires_ai_reviewer_metadata_marker() {
+    let commit_pattern =
+        std::fs::read_to_string(workspace_root().join("patterns/commit/PATTERN.md")).unwrap();
+    let commit_workflow =
+        std::fs::read_to_string(workspace_root().join("patterns/commit/workflow.toml")).unwrap();
 
     for content in [&commit_pattern, &commit_workflow] {
         assert!(
@@ -295,6 +303,43 @@ fn commit_reviewer_guidance_schema_requires_regression_tests_for_timing_scenario
         assert!(
             !content.contains("scripts/gen_commit_msg.sh --body"),
             "commit pattern/workflow step 17 must not synthesize a fallback commit body"
+        );
+        assert!(
+            content.contains("See patterns/commit/PATTERN.md step 17/18."),
+            "commit pattern/workflow step 17 must reference the renumbered PATTERN.md steps"
+        );
+        assert!(
+            content.contains(
+                "Commit body must include a descriptive summary before the AI Reviewer Metadata block."
+            ),
+            "commit pattern/workflow step 17 must require a descriptive summary before metadata"
+        );
+    }
+}
+
+#[test]
+fn commit_workflow_followup_step_hints_match_renumbered_pattern() {
+    let commit_pattern =
+        std::fs::read_to_string(workspace_root().join("patterns/commit/PATTERN.md")).unwrap();
+    let commit_workflow =
+        std::fs::read_to_string(workspace_root().join("patterns/commit/workflow.toml")).unwrap();
+
+    for content in [&commit_pattern, &commit_workflow] {
+        assert!(
+            content.contains("cumulative branch review (Step 21) or publish"),
+            "commit pattern/workflow must point commit follow-up hints at step 21"
+        );
+        assert!(
+            content.contains("push and create PR (Step 22)"),
+            "commit pattern/workflow must point publish follow-up hints at step 22"
+        );
+        assert!(
+            !content.contains("cumulative branch review (Step 18) or publish"),
+            "commit pattern/workflow must not retain the stale step-18 follow-up hint"
+        );
+        assert!(
+            !content.contains("push and create PR (Step 19)"),
+            "commit pattern/workflow must not retain the stale step-19 follow-up hint"
         );
     }
 }

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -537,6 +537,6 @@ echo '<!-- CSA:NEXT_STEP cmd="csa plan run --sa-mode true patterns/pr-bot/workfl
 ## Step 23: Fix Deferred Issues
 
 Fix deferred issues by priority (Critical > High > Medium).
-Each fix goes through full commit workflow (Steps 1-17).
+Each fix goes through full commit workflow (Steps 1-20).
 
 ## ENDIF

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -277,7 +277,7 @@ Run `review-loop` pattern on staged changes before final commit.
 
 ## ENDIF
 
-## Step 14: Generate Commit Message Parts
+## Step 17: Generate Commit Message Parts
 
 Tool: bash
 OnFail: abort
@@ -300,7 +300,7 @@ if [ -n "${COMMIT_BODY_RAW}" ] && [ "${COMMIT_BODY_RAW}" != '""' ]; then
   fi
 else
   echo "ERROR: Step 17 requires upstream COMMIT_BODY from the AI-generated commit body step." >&2
-  echo "See patterns/commit/PATTERN.md step 14/15." >&2
+  echo "See patterns/commit/PATTERN.md step 17/18." >&2
   exit 1
 fi
 
@@ -311,13 +311,13 @@ fi
 
 if [ -z "$(printf '%s' "${COMMIT_BODY_LOCAL}" | tr -d '[:space:]')" ]; then
   echo "ERROR: Step 17 requires non-empty upstream COMMIT_BODY from the AI-generated commit body step." >&2
-  echo "See patterns/commit/PATTERN.md step 14/15." >&2
+  echo "See patterns/commit/PATTERN.md step 17/18." >&2
   exit 1
 fi
 
 if ! printf '%s\n' "${COMMIT_BODY_LOCAL}" | grep -Fq -- '### AI Reviewer Metadata'; then
   echo "ERROR: Step 17: commit body missing required '### AI Reviewer Metadata' block" >&2
-  echo "See patterns/commit/PATTERN.md step 14/15." >&2
+  echo "See patterns/commit/PATTERN.md step 17/18." >&2
   exit 1
 fi
 
@@ -369,7 +369,7 @@ echo "CSA_VAR:COMMIT_BODY=$(printf '%s' "$COMMIT_BODY_LOCAL" | jq -Rs .)"
 printf '%s\n' "${COMMIT_SUBJECT_LOCAL}"
 ```
 
-## Step 15: Inject Spec Trailers
+## Step 18: Inject Spec Trailers
 
 Tool: bash
 OnFail: abort
@@ -416,7 +416,7 @@ echo "CSA_VAR:COMMIT_BODY=$(printf '%s' "$COMMIT_BODY_LOCAL" | jq -Rs .)"
 printf '%s\n' "${COMMIT_BODY_LOCAL}"
 ```
 
-## Step 16: Write Commit Message File
+## Step 19: Write Commit Message File
 
 Tool: bash
 OnFail: abort
@@ -445,7 +445,7 @@ echo "CSA_VAR:COMMIT_MESSAGE_FILE=$COMMIT_MESSAGE_FILE_LOCAL"
 cat "${COMMIT_MESSAGE_FILE_LOCAL}"
 ```
 
-## Step 17: Commit
+## Step 20: Commit
 
 Tool: bash
 OnFail: abort
@@ -461,12 +461,12 @@ fi
 
 trap 'rm -f "${COMMIT_MESSAGE_FILE_LOCAL}"' EXIT
 git commit -F "${COMMIT_MESSAGE_FILE_LOCAL}"
-echo '<!-- CSA:NEXT_STEP cmd="cumulative branch review (Step 18) or publish" required=true -->'
+echo '<!-- CSA:NEXT_STEP cmd="cumulative branch review (Step 21) or publish" required=true -->'
 ```
 
 ## IF NOT ${SKIP_PUBLISH} (Auto-Publish — standalone by default)
 
-## Step 18: Cumulative Branch Review
+## Step 21: Cumulative Branch Review
 
 Tool: csa
 Tier: tier-2-standard
@@ -479,7 +479,7 @@ This catches cross-commit issues that per-commit reviews might miss.
 set -euo pipefail
 bash scripts/csa/cumulative-review-batch.sh --default-branch main -- \
   csa review --range main...HEAD
-echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 19)" required=true -->'
+echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 22)" required=true -->'
 ```
 
 When global config sets `[review].batch_commits >= 2`, intermediate cumulative
@@ -487,7 +487,7 @@ reviews may be skipped until enough new commits have landed since the last
 passed `main...HEAD` review on this branch. Set `CSA_REVIEW_NOW=1` to force the
 review immediately and refresh the recorded HEAD.
 
-## Step 19: Auto PR Transaction
+## Step 22: Auto PR Transaction
 
 Tool: bash
 OnFail: abort
@@ -534,7 +534,7 @@ echo '<!-- CSA:NEXT_STEP cmd="csa plan run --sa-mode true patterns/pr-bot/workfl
 
 ## IF ${HAS_DEFERRED_ISSUES}
 
-## Step 20: Fix Deferred Issues
+## Step 23: Fix Deferred Issues
 
 Fix deferred issues by priority (Critical > High > Medium).
 Each fix goes through full commit workflow (Steps 1-17).

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -360,7 +360,7 @@ if [ -n "${COMMIT_BODY_RAW}" ] && [ "${COMMIT_BODY_RAW}" != '""' ]; then
   fi
 else
   echo "ERROR: Step 17 requires upstream COMMIT_BODY from the AI-generated commit body step." >&2
-  echo "See patterns/commit/PATTERN.md step 14/15." >&2
+  echo "See patterns/commit/PATTERN.md step 17/18." >&2
   exit 1
 fi
 
@@ -371,13 +371,13 @@ fi
 
 if [ -z "$(printf '%s' "${COMMIT_BODY_LOCAL}" | tr -d '[:space:]')" ]; then
   echo "ERROR: Step 17 requires non-empty upstream COMMIT_BODY from the AI-generated commit body step." >&2
-  echo "See patterns/commit/PATTERN.md step 14/15." >&2
+  echo "See patterns/commit/PATTERN.md step 17/18." >&2
   exit 1
 fi
 
 if ! printf '%s\n' "${COMMIT_BODY_LOCAL}" | grep -Fq -- '### AI Reviewer Metadata'; then
   echo "ERROR: Step 17: commit body missing required '### AI Reviewer Metadata' block" >&2
-  echo "See patterns/commit/PATTERN.md step 14/15." >&2
+  echo "See patterns/commit/PATTERN.md step 17/18." >&2
   exit 1
 fi
 
@@ -412,6 +412,16 @@ if ! printf '%s\n' "${timing_guidance}" | grep -Eiq '^(none|n/a|na|not applicabl
     echo "ERROR: Regression Tests Added must list concrete test names when Timing/Race Scenarios is not 'none'." >&2
     exit 1
   fi
+fi
+
+if ! printf '%s\n' "${COMMIT_BODY_LOCAL}" | awk '
+  BEGIN { found = 0; has_summary = 0 }
+  /^### AI Reviewer Metadata$/ { found = 1; next }
+  !found && $0 ~ /[^[:space:]]/ { has_summary = 1 }
+  END { exit !(found && has_summary) }
+'; then
+  echo "ERROR: Commit body must include a descriptive summary before the AI Reviewer Metadata block." >&2
+  exit 1
 fi
 
 echo "CSA_VAR:COMMIT_SUBJECT=$COMMIT_SUBJECT_LOCAL"
@@ -514,7 +524,7 @@ fi
 
 trap 'rm -f "${COMMIT_MESSAGE_FILE_LOCAL}"' EXIT
 git commit -F "${COMMIT_MESSAGE_FILE_LOCAL}"
-echo '<!-- CSA:NEXT_STEP cmd="cumulative branch review (Step 18) or publish" required=true -->'
+echo '<!-- CSA:NEXT_STEP cmd="cumulative branch review (Step 21) or publish" required=true -->'
 ```"""
 on_fail = "abort"
 
@@ -530,7 +540,7 @@ This catches cross-commit issues that per-commit reviews might miss.
 set -euo pipefail
 bash scripts/csa/cumulative-review-batch.sh --default-branch main -- \
   csa review --range main...HEAD
-echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 19)" required=true -->'
+echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 22)" required=true -->'
 ```"""
 tier = "tier-2-standard"
 on_fail = "abort"


### PR DESCRIPTION
## Summary

PR #965 (#730 fix) left two MEDIUM gemini-code-assist findings unaddressed:

- **Step numbering drift**: `patterns/commit/PATTERN.md` called the AI Reviewer Metadata enforcement section "Step 14" while `workflow.toml` implements it as `id = 17` (and the runtime error message references step 17). TOML id is runtime-authoritative; renumbered PATTERN.md Steps 14-20 → 17-23 so each heading aligns with its workflow.toml id. Error-message pointers (`See PATTERN.md step 17/18`) and CSA:NEXT_STEP hints (Step 21/22) updated to match.
- **Test extraction**: extracted AI-reviewer-metadata assertions from `commit_reviewer_guidance_schema_requires_regression_tests_for_timing_scenarios` into dedicated `commit_workflow_step17_requires_ai_reviewer_metadata_marker`, plus a `commit_workflow_followup_step_hints_match_renumbered_pattern` sanity test for the renumbering.

Also adds defensive validation in workflow.toml step 17 requiring a descriptive summary before the `### AI Reviewer Metadata` block (prevents metadata-only commits).

## Test plan

- [x] `cargo test -p cli-sub-agent --release commit_workflow -- --skip gate --skip lefthook` (4 passed)
- [x] `cargo test -p cli-sub-agent --release commit_reviewer_guidance_schema -- --skip gate --skip lefthook` (1 passed)
- [x] `just find-monolith-files` (clean)
- [x] `cargo build --release --workspace`

Closes #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)