### PR TITLE
chore(run_cmd): use filesystem_sandbox_active helper + defer I/O (#974)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.457"
+version = "0.1.458"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.457"
+version = "0.1.458"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -30,6 +30,26 @@ impl Drop for CurrentDirGuard {
     }
 }
 
+#[test]
+fn test_filesystem_sandbox_active_helper() {
+    let active = csa_session::SandboxInfo {
+        mode: "cgroup".to_string(),
+        memory_max_mb: None,
+        filesystem_mode: Some("bwrap".to_string()),
+        readonly_project_root: None,
+    };
+    let inactive = csa_session::SandboxInfo {
+        mode: "cgroup".to_string(),
+        memory_max_mb: None,
+        filesystem_mode: Some("none".to_string()),
+        readonly_project_root: None,
+    };
+
+    assert!(filesystem_sandbox_active(Some(&active)));
+    assert!(!filesystem_sandbox_active(None));
+    assert!(!filesystem_sandbox_active(Some(&inactive)));
+}
+
 /// Heavyweight tools (claude-code) with no project config should get setting_sources=Some(vec![]).
 #[test]
 fn test_none_config_sets_setting_sources_for_heavyweight() {

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -500,12 +500,6 @@ pub(crate) async fn handle_run(
     let current_tool = loop_outcome.current_tool;
     let executed_session_id = loop_outcome.executed_session_id;
     let fork_resolution = loop_outcome.fork_resolution;
-    let fs_sandbox_active = executed_session_id
-        .as_deref()
-        .and_then(|sid| csa_session::load_session(&project_root, sid).ok())
-        .and_then(|session| session.sandbox_info)
-        .and_then(|info| info.filesystem_mode)
-        .is_some_and(|mode| mode != "none");
 
     if fork_call {
         let parent_session_id = fork_call_parent_session_id
@@ -541,14 +535,30 @@ pub(crate) async fn handle_run(
             print!("{}", result.output);
             if result.exit_code != 0
                 && let Some(ref sid) = executed_session_id
-                && let Some(hint) = crate::error_hints::sandbox_fs_denial_hint(
+                && crate::error_hints::sandbox_fs_denial_hint(
+                    &result.stderr_output,
+                    &result.output,
+                    true,
+                    sid,
+                )
+                .is_some()
+            {
+                let fs_sandbox_active = csa_session::load_session(&project_root, sid)
+                    .ok()
+                    .and_then(|session| {
+                        session.sandbox_info.as_ref().map(|info| {
+                            crate::pipeline_sandbox::filesystem_sandbox_active(Some(info))
+                        })
+                    })
+                    .unwrap_or(false);
+                if let Some(hint) = crate::error_hints::sandbox_fs_denial_hint(
                     &result.stderr_output,
                     &result.output,
                     fs_sandbox_active,
                     sid,
-                )
-            {
-                eprintln!("{hint}");
+                ) {
+                    eprintln!("{hint}");
+                }
             }
         }
         OutputFormat::Json => {


### PR DESCRIPTION
## Summary

PR #973 / #962 followup — two non-blocking refactor findings:

- **MEDIUM**: `run_cmd_execute.rs` inlined the same `.and_then(|session| session.sandbox_info).and_then(|info| info.filesystem_mode).is_some_and(...)` chain that `pipeline_sandbox::filesystem_sandbox_active()` already encapsulates. Replaced with helper call.
- **P2**: `load_session` ran unconditionally on every non-zero exit in the Text output format. Moved the session-load + fs-sandbox-active computation inside the hint-emit conditional so no session I/O happens when stderr has no denial marker.

Zero behavior change. Stale-sandbox_info on resumed sessions (third review point) intentionally out of scope — remains conservative fail-suppress.

## Test plan

- [x] `cargo test -p cli-sub-agent --release error_hints:: -- --skip gate --skip lefthook` (15 passed)
- [x] `cargo test -p cli-sub-agent --release filesystem_sandbox_active -- --skip gate --skip lefthook`
- [x] `just find-monolith-files` (clean)
- [x] `cargo build --release --workspace`

Closes #974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)