### PR TITLE
test(csa-review): scope fake-script redirects to absolute paths (#984)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.462"
+version = "0.1.463"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.462"
+version = "0.1.463"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_execute_guard_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_guard_tests.rs
@@ -14,13 +14,16 @@ async fn execute_review_fails_when_repo_root_output_artifact_is_created() {
     let project_dir = setup_git_repo();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
+    let output_dir = project_dir.path().join("output");
+    let details_path = output_dir.join("details.md");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_opencode = bin_dir.join("opencode");
     std::fs::write(
         &fake_opencode,
-        "#!/bin/sh\n\
-mkdir -p output\n\
-printf 'repo-root leak\\n' > output/details.md\n\
+        &format!(
+            "#!/bin/sh\n\
+mkdir -p \"{}\"\n\
+printf 'repo-root leak\\n' > \"{}\"\n\
 printf '%s\\n' \
 '<!-- CSA:SECTION:summary -->' \
 'Review completed successfully.' \
@@ -31,6 +34,9 @@ printf '%s\\n' \
 '<!-- CSA:SECTION:details:END -->' \
 '' \
 'PASS'\n",
+            output_dir.display(),
+            details_path.display()
+        ),
     )
     .unwrap();
     let mut perms = std::fs::metadata(&fake_opencode).unwrap().permissions();
@@ -96,15 +102,21 @@ async fn execute_review_error_path_still_checks_artifact_contract() {
     let project_dir = setup_git_repo();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
+    let output_dir = project_dir.path().join("output");
+    let details_path = output_dir.join("details.md");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_opencode = bin_dir.join("opencode");
     std::fs::write(
         &fake_opencode,
-        "#!/bin/sh\n\
-mkdir -p output\n\
-printf 'repo-root leak\\n' > output/details.md\n\
+        &format!(
+            "#!/bin/sh\n\
+mkdir -p \"{}\"\n\
+printf 'repo-root leak\\n' > \"{}\"\n\
 printf 'review tool failed\\n' >&2\n\
 exit 7\n",
+            output_dir.display(),
+            details_path.display()
+        ),
     )
     .unwrap();
     let mut perms = std::fs::metadata(&fake_opencode).unwrap().permissions();
@@ -170,6 +182,8 @@ async fn execute_review_retry_path_still_checks_artifact_contract() {
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_gemini = bin_dir.join("gemini");
     let auth_log = project_dir.path().join("gemini-auth.log");
+    let output_dir = project_dir.path().join("output");
+    let details_path = output_dir.join("details.md");
     std::fs::write(
         &fake_gemini,
         format!(
@@ -180,8 +194,8 @@ if [ \"$1\" = \"--version\" ]; then\n\
 fi\n\
 if [ -n \"${{GEMINI_API_KEY:-}}\" ]; then\n\
   printf 'api_key\\n' >> \"{}\"\n\
-  mkdir -p output\n\
-  printf 'leak\\n' > output/details.md\n\
+  mkdir -p \"{}\"\n\
+  printf 'leak\\n' > \"{}\"\n\
   printf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS' '<!-- CSA:SECTION:summary:END -->'\n\
   printf '%s\\n' '<!-- CSA:SECTION:details -->' 'No issues found.' '<!-- CSA:SECTION:details:END -->'\n\
 else\n\
@@ -189,6 +203,8 @@ else\n\
   printf 'Opening authentication page\\nDo you want to continue? [Y/n]\\n'\n\
 fi\n",
             auth_log.display(),
+            output_dir.display(),
+            details_path.display(),
             auth_log.display()
         ),
     )
@@ -265,12 +281,14 @@ async fn execute_review_fails_when_repo_root_findings_artifact_is_created() {
     let project_dir = setup_git_repo();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
+    let findings_path = project_dir.path().join("review-findings.json");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_opencode = bin_dir.join("opencode");
     std::fs::write(
         &fake_opencode,
-        "#!/bin/sh\n\
-printf '{\"findings\":[]}\n' > review-findings.json\n\
+        &format!(
+            "#!/bin/sh\n\
+printf '{{\"findings\":[]}}\\n' > \"{}\"\n\
 printf '%s\\n' \
 '<!-- CSA:SECTION:summary -->' \
 'Review completed successfully.' \
@@ -281,6 +299,8 @@ printf '%s\\n' \
 '<!-- CSA:SECTION:details:END -->' \
 '' \
 'PASS'\n",
+            findings_path.display()
+        ),
     )
     .unwrap();
     let mut perms = std::fs::metadata(&fake_opencode).unwrap().permissions();

--- a/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
@@ -7,7 +7,7 @@ use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_config::{GlobalConfig, ProjectProfile, ToolRestrictions, global::GlobalToolConfig};
 use csa_core::types::ToolName;
 use csa_executor::PeakMemoryContext;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
 #[tokio::test]
@@ -17,11 +17,13 @@ async fn execute_review_reclassifies_complete_review_after_edit_restriction() {
     let project_dir = setup_git_repo();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
+    let tracked_path = project_dir.path().join("tracked.txt");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let fake_opencode = bin_dir.join("opencode");
     std::fs::write(
         &fake_opencode,
-        "#!/bin/sh\n\
+        &format!(
+            "#!/bin/sh\n\
 printf '%s\\n' \
 '<!-- CSA:SECTION:summary -->' \
 'Review completed successfully.' \
@@ -32,7 +34,9 @@ printf '%s\\n' \
 '<!-- CSA:SECTION:details:END -->' \
 '' \
 'PASS'\n\
-printf 'tool mutation\\n' >> tracked.txt\n",
+printf 'tool mutation\\n' >> \"{}\"\n",
+            tracked_path.display()
+        ),
     )
     .unwrap();
     let mut perms = std::fs::metadata(&fake_opencode).unwrap().permissions();
@@ -669,5 +673,99 @@ fn csa_review_patterns_do_not_use_relative_output_paths() {
         offenders.is_empty(),
         "found relative output/ paths in review pattern files:\n{}",
         offenders.join("\n")
+    );
+}
+
+fn collect_test_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read_dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_test_files(&path, files);
+            continue;
+        }
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with("_tests.rs"))
+        {
+            files.push(path);
+        }
+    }
+}
+
+fn contains_relative_redirect(line: &str) -> bool {
+    let redirect_positions = [" >> ", " > "]
+        .into_iter()
+        .filter_map(|needle| line.find(needle).map(|idx| (idx, needle.len())))
+        .collect::<Vec<_>>();
+    for (idx, needle_len) in redirect_positions {
+        let target = line[idx + needle_len..].trim_start();
+        let normalized_target = target.trim_start_matches('\\');
+        if normalized_target.starts_with("&")
+            || normalized_target.starts_with('"')
+            || normalized_target.starts_with('\'')
+            || normalized_target.starts_with('/')
+            || normalized_target.starts_with('{')
+            || normalized_target.starts_with("$")
+        {
+            continue;
+        }
+        return true;
+    }
+
+    if let Some(idx) = line.find(" tee ") {
+        let target = line[idx + " tee ".len()..].trim_start();
+        let normalized_target = target.trim_start_matches('\\');
+        if normalized_target.starts_with('&')
+            || normalized_target.starts_with('"')
+            || normalized_target.starts_with('\'')
+            || normalized_target.starts_with('/')
+            || normalized_target.starts_with('{')
+            || normalized_target.starts_with("$")
+        {
+            return false;
+        }
+        return true;
+    }
+
+    false
+}
+
+#[test]
+fn test_fake_tool_scripts_write_to_absolute_paths_only() {
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut test_files = Vec::new();
+    collect_test_files(&src_dir, &mut test_files);
+    let mut violations = Vec::new();
+
+    for path in test_files {
+        let content = std::fs::read_to_string(&path).expect("read test file");
+        let mut in_fake_script = false;
+        for (lineno, line) in content.lines().enumerate() {
+            if line.contains("#!/bin/sh") {
+                in_fake_script = true;
+            }
+            if in_fake_script
+                && (line.contains("printf") || line.contains("echo") || line.contains("tee "))
+                && contains_relative_redirect(line)
+            {
+                violations.push(format!(
+                    "{}:{}: {}",
+                    path.display(),
+                    lineno + 1,
+                    line.trim()
+                ));
+            }
+            if in_fake_script && line.trim_end().ends_with("\",") {
+                in_fake_script = false;
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "relative-path redirects in fake scripts:\n{}",
+        violations.join("\n")
     );
 }

--- a/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
@@ -695,20 +695,25 @@ fn collect_test_files(dir: &Path, files: &mut Vec<PathBuf>) {
 }
 
 fn contains_relative_redirect(line: &str) -> bool {
+    fn is_allowed_redirect_target(target: &str) -> bool {
+        let normalized_target = target.trim_start_matches('\\');
+        let stripped_target = normalized_target.trim_start_matches(['"', '\'']);
+        stripped_target.starts_with('&')
+            || stripped_target.starts_with('/')
+            || stripped_target.starts_with('{')
+            || stripped_target.starts_with('$')
+    }
+
     let redirect_positions = [" >> ", " > "]
         .into_iter()
-        .filter_map(|needle| line.find(needle).map(|idx| (idx, needle.len())))
+        .flat_map(|needle| {
+            line.match_indices(needle)
+                .map(move |(idx, _)| (idx, needle.len()))
+        })
         .collect::<Vec<_>>();
     for (idx, needle_len) in redirect_positions {
         let target = line[idx + needle_len..].trim_start();
-        let normalized_target = target.trim_start_matches('\\');
-        if normalized_target.starts_with("&")
-            || normalized_target.starts_with('"')
-            || normalized_target.starts_with('\'')
-            || normalized_target.starts_with('/')
-            || normalized_target.starts_with('{')
-            || normalized_target.starts_with("$")
-        {
+        if is_allowed_redirect_target(target) {
             continue;
         }
         return true;
@@ -716,14 +721,7 @@ fn contains_relative_redirect(line: &str) -> bool {
 
     if let Some(idx) = line.find(" tee ") {
         let target = line[idx + " tee ".len()..].trim_start();
-        let normalized_target = target.trim_start_matches('\\');
-        if normalized_target.starts_with('&')
-            || normalized_target.starts_with('"')
-            || normalized_target.starts_with('\'')
-            || normalized_target.starts_with('/')
-            || normalized_target.starts_with('{')
-            || normalized_target.starts_with("$")
-        {
+        if is_allowed_redirect_target(target) {
             return false;
         }
         return true;
@@ -743,6 +741,7 @@ fn test_fake_tool_scripts_write_to_absolute_paths_only() {
         let content = std::fs::read_to_string(&path).expect("read test file");
         let mut in_fake_script = false;
         for (lineno, line) in content.lines().enumerate() {
+            let trimmed_line = line.trim_end();
             if line.contains("#!/bin/sh") {
                 in_fake_script = true;
             }
@@ -757,7 +756,11 @@ fn test_fake_tool_scripts_write_to_absolute_paths_only() {
                     line.trim()
                 ));
             }
-            if in_fake_script && line.trim_end().ends_with("\",") {
+            if in_fake_script
+                && (trimmed_line.ends_with("\",")
+                    || trimmed_line.ends_with("\")")
+                    || trimmed_line.ends_with("\");"))
+            {
                 in_fake_script = false;
             }
         }
@@ -768,4 +771,31 @@ fn test_fake_tool_scripts_write_to_absolute_paths_only() {
         "relative-path redirects in fake scripts:\n{}",
         violations.join("\n")
     );
+}
+
+#[test]
+fn contains_relative_redirect_catches_multiple_redirects_per_line() {
+    assert!(contains_relative_redirect(
+        "printf 'a' > /abs/path; printf 'b' > rel/path"
+    ));
+}
+
+#[test]
+fn contains_relative_redirect_catches_quoted_relative_target() {
+    assert!(contains_relative_redirect("printf 'a' > \"tracked.txt\""));
+    assert!(contains_relative_redirect(
+        "printf 'a' >> 'output/details.md'"
+    ));
+}
+
+#[test]
+fn contains_relative_redirect_allows_quoted_absolute_target() {
+    assert!(!contains_relative_redirect("printf 'a' > \"/abs/path\""));
+    assert!(!contains_relative_redirect("printf 'a' > \"{TMPDIR}/x\""));
+}
+
+#[test]
+fn contains_relative_redirect_allows_interpolated_target() {
+    assert!(!contains_relative_redirect("printf 'a' >> {tracked}"));
+    assert!(!contains_relative_redirect("printf 'a' > ${TMPDIR}/x"));
 }


### PR DESCRIPTION
## Summary

- Fake shell scripts in `review_cmd_execute_tests.rs` and `review_cmd_execute_guard_tests.rs` used relative-path redirects (`>> tracked.txt`, `> review-findings.json`) that landed in the git-tracked repo root when the caller's cwd was inherited.
- Replace with absolute-path interpolation (`{TMPDIR}/tracked.txt` etc.) so scripts self-scope to the per-test TempDir.
- Add regression test `test_fake_tool_scripts_write_to_absolute_paths_only` that greps every `*_tests.rs` under `crates/cli-sub-agent/src/` for `printf/echo/tee` redirects whose target does NOT start with `/`, `{`, `"`, `'`, or `$`.

Test-only change — zero production code modified. 2 files, 131 LOC net. Closes #984.

## Test plan

- [x] `cargo test -p cli-sub-agent --release fake_tool_scripts` — 1 passed
- [x] `cargo build --release --workspace` — exit 0 (CSA session verified)
- [x] `git status` after full test run — clean (no stray `tracked.txt`, `review-findings.json`, or `output/` at repo root)
- [x] Grep `crates/cli-sub-agent/src/*_tests.rs` for relative redirects — regression test covers this

🤖 Generated with [Claude Code](https://claude.com/claude-code)