### PR TITLE
fix(csa-review,csa-debate): tier fallback respects whitelist on explicit --tool (#986)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.463"
+version = "0.1.464"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.463"
+version = "0.1.464"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -303,7 +303,7 @@ pub(crate) async fn handle_debate(
         resolved_model_spec.as_deref(),
         resolved_tier_name.as_deref(),
         config.as_ref(),
-        tier_active && args.tool.is_none(),
+        tier_active,
         tier_filter.as_ref(),
     );
     let mut execution = None;

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -566,6 +566,48 @@ async fn handle_debate_marks_unavailable_when_all_tier_models_fail() {
     assert!(failure_reason.contains("gemini-cli/google/gemini-2.5-pro/medium=QUOTA_EXHAUSTED"));
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier_debate() {
+    let mut config = project_config_with_enabled_tools(&["codex", "gemini-cli"]);
+    config.tools.get_mut("codex").unwrap().transport = Some(ToolTransport::Cli);
+    config.tiers.insert(
+        "quality".to_string(),
+        csa_config::config::TierConfig {
+            description: "quality".to_string(),
+            models: vec![
+                "codex/openai/gpt-5.4/medium".to_string(),
+                "codex/openai/gpt-5/high".to_string(),
+                "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+            ],
+            strategy: csa_config::TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    let candidates = crate::tier_model_fallback::ordered_tier_candidates(
+        ToolName::Codex,
+        Some("codex/openai/gpt-5.4/medium"),
+        Some("quality"),
+        Some(&config),
+        true,
+        Some(&crate::tier_model_fallback::TierFilter::whitelist([
+            "codex",
+        ])),
+    );
+
+    assert_eq!(
+        candidates,
+        vec![
+            (
+                ToolName::Codex,
+                Some("codex/openai/gpt-5.4/medium".to_string()),
+            ),
+            (ToolName::Codex, Some("codex/openai/gpt-5/high".to_string())),
+        ]
+    );
+}
+
 // --- CLI parse tests for --rounds flag (#138) ---
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -366,7 +366,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             review_model.clone(),
             resolved_model_spec.clone(),
             resolved_tier_name.clone(),
-            tier_active && args.tool.is_none(),
+            tier_active,
             tier_filter.clone(),
             review_thinking.clone(),
             review_description.clone(),

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -633,3 +633,7 @@ mod guard_tests;
 #[cfg(test)]
 #[path = "review_cmd_execute_tier_tests.rs"]
 mod tier_tests;
+
+#[cfg(test)]
+#[path = "review_cmd_execute_redirect_guard_tests.rs"]
+mod redirect_guard_tests;

--- a/crates/cli-sub-agent/src/review_cmd_execute_redirect_guard_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_redirect_guard_tests.rs
@@ -1,0 +1,28 @@
+use super::tests::contains_relative_redirect;
+
+#[test]
+fn contains_relative_redirect_catches_multiple_redirects_per_line() {
+    assert!(contains_relative_redirect(
+        "printf 'a' > /abs/path; printf 'b' > rel/path"
+    ));
+}
+
+#[test]
+fn contains_relative_redirect_catches_quoted_relative_target() {
+    assert!(contains_relative_redirect("printf 'a' > \"tracked.txt\""));
+    assert!(contains_relative_redirect(
+        "printf 'a' >> 'output/details.md'"
+    ));
+}
+
+#[test]
+fn contains_relative_redirect_allows_quoted_absolute_target() {
+    assert!(!contains_relative_redirect("printf 'a' > \"/abs/path\""));
+    assert!(!contains_relative_redirect("printf 'a' > \"{TMPDIR}/x\""));
+}
+
+#[test]
+fn contains_relative_redirect_allows_interpolated_target() {
+    assert!(!contains_relative_redirect("printf 'a' >> {tracked}"));
+    assert!(!contains_relative_redirect("printf 'a' > ${TMPDIR}/x"));
+}

--- a/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
@@ -694,7 +694,7 @@ fn collect_test_files(dir: &Path, files: &mut Vec<PathBuf>) {
     }
 }
 
-fn contains_relative_redirect(line: &str) -> bool {
+pub(super) fn contains_relative_redirect(line: &str) -> bool {
     fn is_allowed_redirect_target(target: &str) -> bool {
         let normalized_target = target.trim_start_matches('\\');
         let stripped_target = normalized_target.trim_start_matches(['"', '\'']);
@@ -771,31 +771,4 @@ fn test_fake_tool_scripts_write_to_absolute_paths_only() {
         "relative-path redirects in fake scripts:\n{}",
         violations.join("\n")
     );
-}
-
-#[test]
-fn contains_relative_redirect_catches_multiple_redirects_per_line() {
-    assert!(contains_relative_redirect(
-        "printf 'a' > /abs/path; printf 'b' > rel/path"
-    ));
-}
-
-#[test]
-fn contains_relative_redirect_catches_quoted_relative_target() {
-    assert!(contains_relative_redirect("printf 'a' > \"tracked.txt\""));
-    assert!(contains_relative_redirect(
-        "printf 'a' >> 'output/details.md'"
-    ));
-}
-
-#[test]
-fn contains_relative_redirect_allows_quoted_absolute_target() {
-    assert!(!contains_relative_redirect("printf 'a' > \"/abs/path\""));
-    assert!(!contains_relative_redirect("printf 'a' > \"{TMPDIR}/x\""));
-}
-
-#[test]
-fn contains_relative_redirect_allows_interpolated_target() {
-    assert!(!contains_relative_redirect("printf 'a' >> {tracked}"));
-    assert!(!contains_relative_redirect("printf 'a' > ${TMPDIR}/x"));
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -769,6 +769,8 @@ fn has_structured_review_content_requires_non_empty_sections() {
 
 #[path = "review_cmd_bug_class_tests.rs"]
 mod bug_class_tests;
+#[path = "review_cmd_tests_explicit_tool_tier_fallback.rs"]
+mod explicit_tool_tier_fallback_tests;
 #[path = "review_cmd_tests_no_failover.rs"]
 mod no_failover_tests;
 #[path = "review_cmd_tests_tail.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_tests_explicit_tool_tier_fallback.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_explicit_tool_tier_fallback.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+#[cfg(unix)]
+#[tokio::test]
+async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier() {
+    let mut config = project_config_with_enabled_tools(&["codex", "gemini-cli"]);
+    config.tools.get_mut("codex").unwrap().transport = Some(csa_config::ToolTransport::Cli);
+    config.tiers.insert(
+        "quality".to_string(),
+        csa_config::config::TierConfig {
+            description: "quality".to_string(),
+            models: vec![
+                "codex/openai/gpt-5.4/medium".to_string(),
+                "codex/openai/gpt-5/high".to_string(),
+                "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+            ],
+            strategy: csa_config::TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    let candidates = crate::tier_model_fallback::ordered_tier_candidates(
+        csa_core::types::ToolName::Codex,
+        Some("codex/openai/gpt-5.4/medium"),
+        Some("quality"),
+        Some(&config),
+        true,
+        Some(&crate::tier_model_fallback::TierFilter::whitelist([
+            "codex",
+        ])),
+    );
+
+    assert_eq!(
+        candidates,
+        vec![
+            (
+                csa_core::types::ToolName::Codex,
+                Some("codex/openai/gpt-5.4/medium".to_string()),
+            ),
+            (
+                csa_core::types::ToolName::Codex,
+                Some("codex/openai/gpt-5/high".to_string()),
+            ),
+        ]
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -620,7 +620,6 @@ async fn execute_review_ignores_inherited_csa_session_id_without_explicit_sessio
     let inherited_path = std::env::var("PATH").unwrap_or_default();
     let patched_path = format!("{}:{inherited_path}", bin_dir.display());
     let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
-
     let global = GlobalConfig::default();
     let result = execute_review(
         ToolName::Opencode,


### PR DESCRIPTION
## Summary

Fix outer short-circuit in review/debate dispatch that disabled tier fallback whenever `--tool` was passed, even when `TierFilter::whitelist` narrowed candidates to multiple variants of that tool.

`csa review --tool codex --tier quality` previously died on the first 401/403/429 instead of advancing to the next codex variant in the tier. This defeated the main #982 quota/auth fallback contract for the explicit-tool invocation pattern.

## The fix

Drop `args.tool.is_none()` from `tier_fallback_enabled`:

- `crates/cli-sub-agent/src/review_cmd.rs:366` — `tier_active && args.tool.is_none()` → `tier_active`
- `crates/cli-sub-agent/src/debate_cmd.rs:303` — same

`tier_filter` already whitelists the explicit tool variant, so fallback naturally becomes a no-op when the filter narrows candidates to 1, and iterates otherwise.

## Tests added

- `tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier` (review)
- `tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier_debate` (debate)

Plus a new `review_cmd_execute_redirect_guard_tests` module that promotes `contains_relative_redirect` to `pub(super)` so multiple test modules can share the heuristic. Four extra unit tests cover multi-redirect lines, quoted-relative, quoted-absolute, and interpolated targets (carried over from #984 round-2 work).

## Followup

- #989 — add true end-to-end `execute_review` test (P2, filed as review followup — the helper-level test wouldn't have failed pre-fix).
- #987 — CI bubblewrap gap (pre-existing from #982 PR, unrelated to this change).

## Test plan

- [x] `just pre-commit` clean
- [x] `cargo test -p cli-sub-agent --release` full suite
- [x] `csa review --range main...HEAD --tier tier-4-critical` — zero HIGH/CRITICAL findings (1 P2 filed as #989)

🤖 Generated with [Claude Code](https://claude.com/claude-code)