### PR TITLE
test(csa-review): skip execute_review_* tier tests when bwrap missing (#987)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.464"
+version = "0.1.465"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.464"
+version = "0.1.465"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -243,6 +243,11 @@ fn persist_verdict_refreshes_on_fix_reuse_session() {
 #[cfg(unix)]
 #[tokio::test]
 async fn execute_review_marks_unavailable_when_all_tier_models_fail() {
+    if which::which("bwrap").is_err() {
+        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
+        return;
+    }
+
     let project_dir = exact_test_setup_git_repo();
     let _sandbox = test_session_sandbox::ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
@@ -321,6 +326,11 @@ async fn execute_review_marks_unavailable_when_all_tier_models_fail() {
 #[cfg(unix)]
 #[tokio::test]
 async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metadata() {
+    if which::which("bwrap").is_err() {
+        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
+        return;
+    }
+
     let project_dir = exact_test_setup_git_repo();
     let _sandbox = test_session_sandbox::ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
@@ -28,6 +28,11 @@ async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metad
     use crate::review_cmd::output::persist_review_verdict;
     use std::os::unix::fs::PermissionsExt;
 
+    if which::which("bwrap").is_err() {
+        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
+        return;
+    }
+
     let project_dir = setup_git_repo();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
@@ -137,6 +142,11 @@ async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metad
 #[tokio::test]
 async fn execute_review_marks_unavailable_when_all_tier_models_fail() {
     use std::os::unix::fs::PermissionsExt;
+
+    if which::which("bwrap").is_err() {
+        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
+        return;
+    }
 
     let project_dir = setup_git_repo();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;


### PR DESCRIPTION
## Summary

Two tier-fallback tests added in #982 (PR #985) invoke real codex preflight, which hard-fails on GitHub Actions workers where bubblewrap isn't installed. `ubuntu-latest` sometimes, `macos-latest` always (bwrap is Linux-only).

Add a `which::which("bwrap").is_err()` skip guard at the top of each affected test so CI runners without bubblewrap skip cleanly instead of panicking on preflight failure. Mirrors the CLAUDE.md lessons-learned (#642) guidance for CI environment-conditional tests.

## Changes

- `crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs` — skip guard at tier tests
- `crates/cli-sub-agent/src/review_cmd_exact_tests.rs` — skip guard at exact test
- `Cargo.toml` / `Cargo.lock` — workspace version 0.1.464 → 0.1.465 (CI gate)

Net: +37 -17 across 4 files.

## Test plan

- [x] `cargo test -p cli-sub-agent --release -- --skip gate --skip lefthook` — full suite, 0 failed
- [x] `just pre-commit` — clean
- [x] Two named tests still pass when bwrap is installed (local)
- [x] On CI runners without bwrap, tests now `eprintln` + early-return cleanly

## Followup

- #989 — end-to-end `execute_review` call-site test for #986 (separate PR track)

Closes #987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)