### PR TITLE
test(csa-review,csa-debate): end-to-end tier fallback with explicit --tool (#989)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.465"
+version = "0.1.466"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.465"
+version = "0.1.466"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_execute_tier_tests.rs
@@ -1,0 +1,153 @@
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use std::path::Path;
+use tempfile::tempdir;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+fn write_debate_project_config(project_root: &Path, config: &ProjectConfig) {
+    let config_path = ProjectConfig::config_path(project_root);
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(config_path, toml::to_string_pretty(config).unwrap()).unwrap();
+}
+
+fn install_pattern(project_root: &Path, name: &str) {
+    let skill_dir = project_root
+        .join(".csa")
+        .join("patterns")
+        .join(name)
+        .join("skills")
+        .join(name);
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(skill_dir.join("SKILL.md"), "# test pattern\n").unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
+    use csa_config::ToolTransport;
+
+    if which::which("bwrap").is_err() {
+        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
+        return;
+    }
+
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    let bin_dir = project_dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+
+    let codex_invocation_log = project_dir.path().join("codex-invocations.log");
+    let gemini_invocation_log = project_dir.path().join("gemini-invocations.log");
+    let codex_invocation_log_str = codex_invocation_log.display().to_string();
+    let gemini_invocation_log_str = gemini_invocation_log.display().to_string();
+
+    for (binary, body) in [
+        (
+            "codex",
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-cli 1.0.0\\n'\n  exit 0\nfi\ncount=0\nif [ -f \"{codex_invocation_log_str}\" ]; then\n  count=$(wc -l < \"{codex_invocation_log_str}\")\nfi\nnext=$((count + 1))\nprintf 'attempt-%s\\n' \"$next\" >> \"{codex_invocation_log_str}\"\nif [ \"$next\" -eq 1 ]; then\n  printf 'HTTP 429 rate limit\\n' >&2\n  exit 1\nfi\nprintf '%s\\n' 'Verdict: APPROVE' 'Confidence: high' 'Summary: Debate succeeded via second codex tier candidate.' '- Fallback stayed within the codex whitelist.'\n"
+            ),
+        ),
+        (
+            "gemini",
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf 'gemini should not be invoked\\n' >> \"{gemini_invocation_log_str}\"\nprintf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\nexit 1\n"
+            ),
+        ),
+    ] {
+        let path = bin_dir.join(binary);
+        std::fs::write(&path, body).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+    }
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+    let _path_guard = EnvVarGuard::set("PATH", &patched_path);
+    let _available_guard =
+        EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+
+    let mut config = project_config_with_enabled_tools(&["codex", "gemini-cli"]);
+    config.tools.get_mut("codex").unwrap().transport = Some(ToolTransport::Cli);
+    config.review = Some(csa_config::ReviewConfig {
+        gate_command: Some("true".to_string()),
+        ..Default::default()
+    });
+    config.tiers.insert(
+        "quality".to_string(),
+        csa_config::config::TierConfig {
+            description: "quality".to_string(),
+            models: vec![
+                "codex/openai/gpt-5.4/medium".to_string(),
+                "codex/openai/gpt-5/high".to_string(),
+                "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+            ],
+            strategy: csa_config::TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    write_debate_project_config(project_dir.path(), &config);
+    install_pattern(project_dir.path(), "debate");
+
+    let session = csa_session::create_session(
+        project_dir.path(),
+        Some("debate explicit-tool tier fallback"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+
+    let cd = project_dir.path().display().to_string();
+    let args = parse_debate_args(&[
+        "csa",
+        "debate",
+        "--cd",
+        &cd,
+        "--tool",
+        "codex",
+        "--tier",
+        "quality",
+        "--session",
+        &session.meta_session_id,
+        "Should we ship this migration?",
+    ]);
+
+    let exit_code = handle_debate(args, 0, csa_core::types::OutputFormat::Json)
+        .await
+        .expect("explicit codex debate tier fallback should succeed");
+    assert_eq!(exit_code, 0);
+
+    let codex_invocations = std::fs::read_to_string(&codex_invocation_log).unwrap();
+    assert_eq!(codex_invocations.lines().count(), 2);
+    assert!(
+        !gemini_invocation_log.exists(),
+        "gemini should not be invoked when --tool codex whitelists codex-only candidates"
+    );
+
+    let session_dir =
+        csa_session::get_session_dir(project_dir.path(), &session.meta_session_id).unwrap();
+    let verdict_path = session_dir.join("output").join("debate-verdict.json");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&verdict_path).unwrap()).unwrap();
+
+    assert_ne!(parsed["decision"], "unavailable");
+    assert_eq!(parsed["verdict"], "APPROVE");
+    assert_eq!(
+        parsed["summary"],
+        "Debate succeeded via second codex tier candidate."
+    );
+    assert!(parsed["failure_reason"].is_null());
+
+    let result = csa_session::load_result(project_dir.path(), &session.meta_session_id)
+        .unwrap()
+        .expect("result.toml should exist");
+    assert_eq!(result.tool, "codex");
+    assert_eq!(
+        result.summary,
+        "Debate succeeded via second codex tier candidate."
+    );
+}

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -745,5 +745,8 @@ fn debate_cli_rejects_zero_idle_timeout() {
 #[path = "debate_cmd_tier_tests.rs"]
 mod tier_tests;
 
+#[path = "debate_cmd_execute_tier_tests.rs"]
+mod execute_tier_tests;
+
 #[path = "debate_cmd_tests_tail.rs"]
 mod tests_tail;

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -421,7 +421,6 @@ async fn handle_debate_persists_result_for_direct_tool_tier_rejection() {
     );
     write_debate_project_config(project_dir.path(), &config);
     install_pattern(project_dir.path(), "debate");
-
     let cd = project_dir.path().display().to_string();
     let args = parse_debate_args(&[
         "csa",

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
@@ -140,6 +140,145 @@ async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metad
 
 #[cfg(unix)]
 #[tokio::test]
+async fn execute_review_advances_tier_fallback_when_explicit_tool_and_tier() {
+    use crate::review_cmd::output::persist_review_verdict;
+    use std::os::unix::fs::PermissionsExt;
+
+    if which::which("bwrap").is_err() {
+        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
+        return;
+    }
+
+    let project_dir = setup_git_repo();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    let bin_dir = project_dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+
+    let codex_invocation_log = project_dir.path().join("codex-invocations.log");
+    let gemini_invocation_log = project_dir.path().join("gemini-invocations.log");
+    let codex_invocation_log_str = codex_invocation_log.display().to_string();
+    let gemini_invocation_log_str = gemini_invocation_log.display().to_string();
+
+    std::fs::write(
+        bin_dir.join("gemini"),
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf 'gemini should not be invoked\\n' >> \"{gemini_invocation_log_str}\"\nprintf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\nexit 1\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        bin_dir.join("codex"),
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-cli 1.0.0\\n'\n  exit 0\nfi\ncount=0\nif [ -f \"{codex_invocation_log_str}\" ]; then\n  count=$(wc -l < \"{codex_invocation_log_str}\")\nfi\nnext=$((count + 1))\nprintf 'attempt-%s\\n' \"$next\" >> \"{codex_invocation_log_str}\"\nif [ \"$next\" -eq 1 ]; then\n  printf 'HTTP 429 rate limit\\n' >&2\n  exit 1\nfi\nprintf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS via fallback codex variant' '<!-- CSA:SECTION:summary:END -->' '<!-- CSA:SECTION:details -->' 'No blocking issues found after falling back to the second codex tier candidate.' '<!-- CSA:SECTION:details:END -->'\n"
+        ),
+    )
+    .unwrap();
+    for binary in ["gemini", "codex"] {
+        let path = bin_dir.join(binary);
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+    let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
+
+    let config = config_with_review_tier(
+        &["codex", "gemini-cli"],
+        &[
+            "codex/openai/gpt-5.4/medium",
+            "codex/openai/gpt-5/high",
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        ],
+    );
+    let global = GlobalConfig::default();
+
+    let result = execute_review(
+        ToolName::Codex,
+        "scope=uncommitted mode=review-only security=auto".to_string(),
+        None,
+        None,
+        Some("codex/openai/gpt-5.4/medium".to_string()),
+        Some("quality".to_string()),
+        true,
+        None,
+        "review: explicit-tool-tier-fallback".to_string(),
+        project_dir.path(),
+        Some(&config),
+        &global,
+        ReviewRoutingMetadata {
+            project_profile: ProjectProfile::Unknown,
+            detection_method: "auto",
+        },
+        csa_process::StreamMode::BufferOnly,
+        crate::pipeline::DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        &[],
+        &[],
+    )
+    .await
+    .expect("explicit codex tier fallback should succeed");
+
+    assert_ne!(result.forced_decision, Some(ReviewDecision::Unavailable));
+    assert_eq!(result.executed_tool, ToolName::Codex);
+    assert_eq!(result.routed_to.as_deref(), Some("codex/openai/gpt-5/high"));
+    assert_eq!(result.primary_failure.as_deref(), Some("HTTP 429"));
+
+    let codex_invocations = std::fs::read_to_string(&codex_invocation_log).unwrap();
+    assert_eq!(codex_invocations.lines().count(), 2);
+    assert!(
+        !gemini_invocation_log.exists(),
+        "gemini should not be invoked when --tool codex whitelists codex-only candidates"
+    );
+
+    let meta = ReviewSessionMeta {
+        session_id: result.execution.meta_session_id.clone(),
+        head_sha: String::new(),
+        decision: ReviewDecision::Pass.as_str().to_string(),
+        verdict: "CLEAN".to_string(),
+        status_reason: None,
+        routed_to: result.routed_to.clone(),
+        primary_failure: result.primary_failure.clone(),
+        failure_reason: result.failure_reason.clone(),
+        tool: result.executed_tool.as_str().to_string(),
+        scope: "uncommitted".to_string(),
+        exit_code: 0,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+    };
+    let session_dir =
+        csa_session::get_session_dir(project_dir.path(), &result.execution.meta_session_id)
+            .unwrap();
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    if verdict_path.exists() {
+        std::fs::remove_file(&verdict_path).unwrap();
+    }
+    persist_review_verdict(project_dir.path(), &meta, &[], Vec::new());
+
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&std::fs::read_to_string(&verdict_path).unwrap()).unwrap();
+    assert_eq!(
+        artifact.routed_to.as_deref(),
+        Some("codex/openai/gpt-5/high")
+    );
+    assert_eq!(artifact.primary_failure.as_deref(), Some("HTTP 429"));
+
+    let result_toml = std::fs::read_to_string(session_dir.join("result.toml")).unwrap();
+    assert!(result_toml.contains("tool = \"codex\""));
+    assert!(result_toml.contains("PASS via fallback codex variant"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn execute_review_marks_unavailable_when_all_tier_models_fail() {
     use std::os::unix::fs::PermissionsExt;
 


### PR DESCRIPTION
## Summary

P2 followup from #986 PR #990 review. The regression test landed in #990 exercised the `ordered_tier_candidates` helper — which was already correct before #986's fix. So the test wouldn't have failed pre-fix.

This PR adds true end-to-end `execute_review` / `execute_debate` tests that verify the dispatch call-site actually iterates whitelisted tier candidates when `--tool codex --tier quality` is explicit. Guards the regression path directly.

## Tests

- `execute_review_advances_tier_fallback_when_explicit_tool_and_tier`
- `execute_debate_advances_tier_fallback_when_explicit_tool_and_tier`

Scenario: 3-model tier (codex/gpt-5.4/medium + codex/gpt-5/high + gemini). First codex returns classified 429, second succeeds. Asserts gemini is NOT invoked (whitelist respected).

Both tests include the `#987` bwrap skip guard.

## Scope

Test-only. No production code modified.

## Test plan

- [x] `cargo test -p cli-sub-agent --release execute_review_advances_tier_fallback_when_explicit_tool_and_tier -- --exact`
- [x] `cargo test -p cli-sub-agent --release execute_debate_advances_tier_fallback_when_explicit_tool_and_tier -- --exact`
- [x] Full `cargo test -p cli-sub-agent --release -- --skip gate --skip lefthook`

Closes #989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)