### PR TITLE
fix(csa-session): envelope-gated sidecar overlay (#956, #957)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "chrono",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4485,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.466"
+version = "0.1.467"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.466"
+version = "0.1.467"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -129,6 +129,9 @@ pub(crate) fn save_result_in(
         // envelope first so it never points at a sidecar that was deleted
         // before the new envelope became durable.
         if let Err(err) = clear_manager_sidecar(&session_dir) {
+            // NOTE: stale sidecar on disk is harmless. load_result_in gates the overlay
+            // on envelope.artifacts containing CONTRACT_RESULT_ARTIFACT_PATH (#956 Option A),
+            // so even if the unlink fails, the stale sidecar will be ignored on reload.
             tracing::warn!(
                 path = %contract_result_path(&session_dir).display(),
                 error = %err,
@@ -389,6 +392,9 @@ fn is_sensitive_key(key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::redact_result_sidecar_value;
+    use super::*;
+    use chrono::Utc;
+    use tempfile::tempdir;
 
     #[test]
     fn manager_result_redaction_preserves_toml_datetime_values() {
@@ -430,6 +436,83 @@ mod tests {
         assert!(!payload.contains("top-secret"));
         assert!(payload.contains("[REDACTED]"));
     }
+
+    #[test]
+    fn load_result_in_ignores_orphaned_sidecar() {
+        let td = tempdir().expect("tempdir");
+        let session_id = crate::validate::new_session_id();
+        let session_dir = super::super::get_session_dir_in(td.path(), &session_id);
+        std::fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+        let result_path = session_dir.join(RESULT_FILE_NAME);
+
+        let now = Utc::now();
+        let turn_1_result = SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "turn 1".to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            events_count: 1,
+            artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
+            peak_memory_mb: None,
+            manager_fields: crate::result::SessionManagerFields {
+                report: Some(
+                    toml::toml! {
+                        [repo_write_audit]
+                        added = ["turn-1.txt"]
+                    }
+                    .into(),
+                ),
+                ..Default::default()
+            },
+        };
+        save_result_in(
+            td.path(),
+            &session_id,
+            &turn_1_result,
+            SaveOptions::default(),
+        )
+        .expect("save turn 1");
+
+        let turn_2_result = SessionResult {
+            summary: "turn 2".to_string(),
+            manager_fields: Default::default(),
+            ..turn_1_result
+        };
+        save_result_in(
+            td.path(),
+            &session_id,
+            &turn_2_result,
+            SaveOptions::default(),
+        )
+        .expect("save turn 2");
+
+        let mut turn_2_envelope: SessionResult =
+            toml::from_str(&std::fs::read_to_string(&result_path).expect("read turn 2 envelope"))
+                .expect("parse turn 2 envelope");
+        turn_2_envelope
+            .artifacts
+            .retain(|artifact| artifact.path != CONTRACT_RESULT_ARTIFACT_PATH);
+        let contents =
+            toml::to_string_pretty(&turn_2_envelope).expect("serialize orphaned envelope");
+        write_file_atomically(&result_path, &contents).expect("persist orphaned envelope");
+
+        let reloaded = load_result_in(td.path(), &session_id)
+            .expect("load result")
+            .expect("result should exist");
+        assert!(
+            reloaded
+                .artifacts
+                .iter()
+                .all(|artifact| artifact.path != CONTRACT_RESULT_ARTIFACT_PATH),
+            "turn 2 envelope must not advertise the manager sidecar"
+        );
+        assert!(
+            reloaded.manager_fields.as_sidecar().is_none(),
+            "orphaned sidecar must not leak prior manager fields into turn 2"
+        );
+    }
 }
 
 /// Load a session result
@@ -458,7 +541,15 @@ pub(crate) fn load_result_in(base_dir: &Path, session_id: &str) -> Result<Option
         .with_context(|| format!("Failed to read result: {}", result_path.display()))?;
     let mut result: SessionResult = toml::from_str(&contents)
         .with_context(|| format!("Failed to parse result: {}", result_path.display()))?;
-    let manager_sidecar = load_optional_result_sidecar(&session_dir, CONTRACT_RESULT_ARTIFACT_PATH)
+    let envelope_references_manager_sidecar = result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.path == CONTRACT_RESULT_ARTIFACT_PATH);
+    if envelope_references_manager_sidecar {
+        let manager_sidecar = load_optional_result_sidecar(
+            &session_dir,
+            CONTRACT_RESULT_ARTIFACT_PATH,
+        )
         .unwrap_or_else(|error| {
             tracing::warn!(
                 target: "csa-session.load_result",
@@ -468,8 +559,9 @@ pub(crate) fn load_result_in(base_dir: &Path, session_id: &str) -> Result<Option
             );
             None
         });
-    if let Some(sidecar) = manager_sidecar {
-        result.manager_fields = crate::result::SessionManagerFields::from_sidecar(&sidecar);
+        if let Some(sidecar) = manager_sidecar {
+            result.manager_fields = crate::result::SessionManagerFields::from_sidecar(&sidecar);
+        }
     }
     Ok(Some(result))
 }
@@ -482,9 +574,18 @@ pub(crate) fn load_result_view_in(
         return Ok(None);
     };
     let session_dir = super::get_session_dir_in(base_dir, session_id);
+    let manager_sidecar = if envelope
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.path == CONTRACT_RESULT_ARTIFACT_PATH)
+    {
+        load_optional_result_sidecar(&session_dir, CONTRACT_RESULT_ARTIFACT_PATH)?
+    } else {
+        None
+    };
     Ok(Some(SessionResultView {
         envelope,
-        manager_sidecar: load_optional_result_sidecar(&session_dir, CONTRACT_RESULT_ARTIFACT_PATH)?,
+        manager_sidecar,
         legacy_sidecar: load_optional_result_sidecar(
             &session_dir,
             LEGACY_USER_RESULT_ARTIFACT_PATH,

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -45,7 +45,7 @@ impl io::Write for SharedLogWriter {
 }
 
 #[test]
-fn test_load_result_view_surfaces_manager_and_legacy_sidecars() {
+fn test_load_result_view_ignores_orphaned_manager_sidecar() {
     let td = tempdir().unwrap();
     let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
     let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
@@ -86,14 +86,7 @@ fn test_load_result_view_surfaces_manager_and_legacy_sidecars() {
         .unwrap()
         .expect("result view should exist");
     assert_eq!(loaded.envelope.summary, "runtime summary");
-    assert_eq!(
-        loaded.manager_sidecar.as_ref().and_then(|value| value.get("report")),
-        Some(&toml::Value::Table(
-            [("summary".to_string(), toml::Value::String("manager-visible".to_string()))]
-                .into_iter()
-                .collect()
-        ))
-    );
+    assert!(loaded.manager_sidecar.is_none());
     assert_eq!(
         loaded.legacy_sidecar.as_ref().and_then(|value| value.get("artifacts")),
         Some(&toml::Value::Table(
@@ -123,14 +116,6 @@ fn test_load_result_merges_manager_sidecar_sections_into_runtime_result() {
         peak_memory_mb: None,
         manager_fields: Default::default(),
     };
-    save_result_in(
-        td.path(),
-        &state.meta_session_id,
-        &runtime_result,
-        crate::SaveOptions::default(),
-    )
-    .unwrap();
-
     std::fs::write(
         session_dir.join(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
         r#"
@@ -158,6 +143,13 @@ questions = ["Question 1", "Question 2"]
 [artifacts]
 count = 2
 "#,
+    )
+    .unwrap();
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &runtime_result,
+        crate::SaveOptions::default(),
     )
     .unwrap();
 
@@ -239,14 +231,6 @@ fn test_manager_sidecar_roundtrip_preserves_full_sa_schema() {
         peak_memory_mb: None,
         manager_fields: Default::default(),
     };
-    save_result_in(
-        td.path(),
-        &state.meta_session_id,
-        &runtime_result,
-        crate::SaveOptions::default(),
-    )
-    .unwrap();
-
     let input_sidecar = toml::Value::Table(toml::toml! {
         [result]
         status = "needs_clarification"
@@ -286,6 +270,13 @@ fn test_manager_sidecar_roundtrip_preserves_full_sa_schema() {
     std::fs::write(
         session_dir.join(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
         &input_sidecar_str,
+    )
+    .unwrap();
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &runtime_result,
+        crate::SaveOptions::default(),
     )
     .unwrap();
 
@@ -535,17 +526,16 @@ fn test_load_result_with_malformed_manager_sidecar_is_non_fatal() {
         peak_memory_mb: None,
         manager_fields: Default::default(),
     };
+    std::fs::write(
+        session_dir.join(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        "not = [valid toml",
+    )
+    .unwrap();
     save_result_in(
         td.path(),
         &state.meta_session_id,
         &runtime_result,
         crate::SaveOptions::default(),
-    )
-    .unwrap();
-
-    std::fs::write(
-        session_dir.join(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
-        "not = [valid toml",
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary

- Closes #956: `load_result_in` now overlays `output/result.toml` onto `manager_fields` only when `envelope.artifacts` contains `CONTRACT_RESULT_ARTIFACT_PATH`. Prevents stale sidecar leaking across turns when envelope does not reference it.
- Closes #957: `save_result_in`'s `clear_manager_sidecar` unlink failure swallow is now safe — load-side gate defends correctness. NOTE comment references the invariant.
- Extends the gate to `load_result_view_in` so `csa session result` does not surface orphan sidecar data either (surfaced by codex review R1).

## Design decision (user-approved 2026-04-21)

- #956 Option A (envelope-gated overlay). Circuit-broken 3rd-flip design ping-pong per CLAUDE.md lesson #821.
- #957 Option B (swallow unlink, rely on #956 load-gate).

See issue comments on #956 / #957 for rationale.

## Test plan

- [x] `cargo test -p csa-session` — new `load_result_in_ignores_orphaned_sidecar` + flipped view-path assertion both pass.
- [x] `just pre-commit` — green.
- [x] `csa review --range main...HEAD` with codex/openai/gpt-5.4/high — verdict PASS, 0 findings after R2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)