### PR TITLE
fix(csa-executor): port degraded-MCP preflight+retry to Gemini ACP path (#840)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "chrono",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "axum",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "chrono",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "chrono",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.478"
+version = "0.1.479"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.478"
+version = "0.1.479"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -31,11 +31,12 @@ mod transport_gemini_helpers;
 #[cfg(test)]
 use transport_gemini_helpers::format_gemini_retry_report;
 use transport_gemini_helpers::{
-    GeminiRetryPhase, annotate_gemini_retry_error, append_gemini_retry_report,
-    apply_gemini_acp_initial_stall_summary, apply_gemini_legacy_initial_stall_summary,
-    apply_gemini_mcp_warning_summary, apply_gemini_sandbox_runtime_env_overrides,
-    classify_gemini_acp_init_failure, classify_gemini_acp_initial_stall,
-    classify_gemini_legacy_initial_stall, classify_gemini_oauth_prompt_result, classify_join_error,
+    GeminiAcpInitFailureClassification, GeminiRetryPhase, annotate_gemini_retry_error,
+    append_gemini_retry_report, apply_gemini_acp_initial_stall_summary,
+    apply_gemini_legacy_initial_stall_summary, apply_gemini_mcp_warning_summary,
+    apply_gemini_sandbox_runtime_env_overrides, classify_gemini_acp_init_failure,
+    classify_gemini_acp_initial_stall, classify_gemini_legacy_initial_stall,
+    classify_gemini_oauth_prompt_result, classify_join_error,
     ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure,
     gemini_acp_initial_response_timeout_seconds, gemini_phase_desc,
     gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure, is_gemini_mcp_issue_result,
@@ -52,8 +53,8 @@ use transport_gemini_acp_runtime::{
 #[path = "transport_gemini_mcp_diagnostic.rs"]
 mod transport_gemini_mcp_diagnostic;
 use transport_gemini_mcp_diagnostic::{
-    diagnose_mcp_init_failure, disable_mcp_servers_in_runtime, format_mcp_init_warning_summary,
-    gemini_allow_degraded_mcp,
+    McpInitDiagnostic, diagnose_mcp_init_failure, disable_mcp_servers_in_runtime,
+    format_mcp_init_warning_summary, gemini_allow_degraded_mcp,
 };
 #[path = "transport_acp_crash_retry.rs"]
 mod transport_acp_crash_retry;
@@ -393,6 +394,8 @@ impl AcpTransport {
     }
 }
 
+include!("transport_acp_spawn.rs");
+
 impl AcpTransport {
     /// Execute a single ACP attempt with the given args and env.
     ///
@@ -494,156 +497,66 @@ impl AcpTransport {
         let output_spool = options.output_spool.map(std::path::Path::to_path_buf);
         let output_spool_max_bytes = options.output_spool_max_bytes;
         let output_spool_keep_rotated = options.output_spool_keep_rotated;
-        let output =
-            tokio::task::spawn_blocking(move || -> Result<csa_acp::transport::AcpOutput> {
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|e| anyhow!("failed to build ACP runtime: {e}"))?;
+        let spawn_request = AcpPromptRunRequest {
+            tool_name: self.tool_name.clone(),
+            acp_command,
+            acp_args,
+            prompt,
+            working_dir,
+            env,
+            system_prompt,
+            resume_session_id,
+            session_meta,
+            sandbox_plan,
+            sandbox_tool_name,
+            sandbox_session_id,
+            sandbox_best_effort,
+            idle_timeout_seconds,
+            initial_response_timeout_seconds,
+            acp_init_timeout_seconds,
+            termination_grace_period_seconds,
+            stream_stdout_to_stderr,
+            output_spool,
+            output_spool_max_bytes,
+            output_spool_keep_rotated,
+            acp_payload_debug_path,
+            gemini_classification_env,
+            gemini_env_allowlist_applied,
+            memory_max_mb: options
+                .sandbox
+                .and_then(|sandbox| sandbox.isolation_plan.memory_max_mb),
+        };
 
-                if let Some(ref plan) = sandbox_plan {
-                    let tool_name = sandbox_tool_name.as_deref().unwrap_or("");
-                    let sess_id = sandbox_session_id.as_deref().unwrap_or("");
-                    let sr = rt.block_on(run_acp_sandboxed(
-                        &acp_command,
-                        &acp_args,
-                        &working_dir,
-                        &env,
-                        system_prompt.as_deref(),
-                        resume_session_id.as_deref(),
-                        session_meta.clone(),
-                        &prompt,
-                        std::time::Duration::from_secs(idle_timeout_seconds),
-                        initial_response_timeout_seconds
-                            .map(std::time::Duration::from_secs),
-                        std::time::Duration::from_secs(acp_init_timeout_seconds),
-                        std::time::Duration::from_secs(termination_grace_period_seconds),
-                        plan,
-                        tool_name,
-                        sess_id,
-                        stream_stdout_to_stderr,
-                        output_spool.as_deref(),
-                        output_spool_max_bytes,
-                        output_spool_keep_rotated,
-                    ));
-                    match sr.result {
-                        Ok(mut output) => {
-                            output.peak_memory_mb = output.peak_memory_mb.or(sr.peak_memory_mb);
-                            Ok(output)
-                        }
-                        Err(e) if sandbox_best_effort && sr.sandbox_spawn_failed => {
-                            tracing::warn!(
-                                "ACP sandbox spawn failed in best-effort mode, falling back to unsandboxed: {e}"
-                            );
-                            rt.block_on(csa_acp::transport::run_prompt_with_io(
-                                &acp_command,
-                                &acp_args,
-                                &working_dir,
-                                &env,
-                                csa_acp::transport::AcpSessionStart {
-                                    system_prompt: system_prompt.as_deref(),
-                                    resume_session_id: resume_session_id.as_deref(),
-                                    meta: session_meta.clone(),
-                                    ..Default::default()
-                                },
-                                &prompt,
-                                csa_acp::transport::AcpRunOptions {
-                                    idle_timeout: std::time::Duration::from_secs(
-                                        idle_timeout_seconds,
-                                    ),
-                                    initial_response_timeout: initial_response_timeout_seconds
-                                        .map(std::time::Duration::from_secs),
-                                    init_timeout: std::time::Duration::from_secs(
-                                        acp_init_timeout_seconds,
-                                    ),
-                                    termination_grace_period: std::time::Duration::from_secs(
-                                        termination_grace_period_seconds,
-                                    ),
-                                    io: csa_acp::transport::AcpOutputIoOptions {
-                                        stream_stdout_to_stderr,
-                                        output_spool: output_spool.as_deref(),
-                                        spool_max_bytes: output_spool_max_bytes,
-                                        keep_rotated_spool: output_spool_keep_rotated,
-                                    },
-                                },
-                            ))
-                            .map_err(|e| anyhow!("ACP transport (unsandboxed fallback) failed: {e}"))
-                        }
-                        Err(e) => Err(PeakMemoryContext(sr.peak_memory_mb)
-                            .into_anyhow(format!("sandboxed ACP: {e}"))),
-                    }
-                } else {
-                    rt.block_on(csa_acp::transport::run_prompt_with_io(
-                        &acp_command,
-                        &acp_args,
-                        &working_dir,
-                        &env,
-                        csa_acp::transport::AcpSessionStart {
-                            system_prompt: system_prompt.as_deref(),
-                            resume_session_id: resume_session_id.as_deref(),
-                            meta: session_meta.clone(),
-                            ..Default::default()
-                        },
-                        &prompt,
-                        csa_acp::transport::AcpRunOptions {
-                            idle_timeout: std::time::Duration::from_secs(idle_timeout_seconds),
-                            initial_response_timeout: initial_response_timeout_seconds
-                                .map(std::time::Duration::from_secs),
-                            init_timeout: std::time::Duration::from_secs(
-                                acp_init_timeout_seconds,
-                            ),
-                            termination_grace_period: std::time::Duration::from_secs(
-                                termination_grace_period_seconds,
-                            ),
-                            io: csa_acp::transport::AcpOutputIoOptions {
-                                stream_stdout_to_stderr,
-                                output_spool: output_spool.as_deref(),
-                                spool_max_bytes: output_spool_max_bytes,
-                                keep_rotated_spool: output_spool_keep_rotated,
-                            },
-                        },
-                    ))
-                    .map_err(|e| anyhow!("ACP transport failed: {e}"))
-                }
-            })
-            .await
-            .map_err(classify_join_error)?
-            .map_err(|error| {
-                if self.tool_name == "gemini-cli" {
+        let (output, gemini_warning_summary) = if self.tool_name == "gemini-cli" {
+            let runtime_home = gemini_runtime_home
+                .clone()
+                .expect("gemini runtime home should exist for ACP execution");
+            let path_override = spawn_request.env.get("PATH").map(std::ffi::OsString::from);
+            let outcome = Self::execute_gemini_acp_with_degraded_mcp_retry(
+                &runtime_home,
+                path_override,
+                gemini_allow_degraded_mcp(&spawn_request.env),
+                || Self::run_acp_prompt(spawn_request.clone()),
+                diagnose_mcp_init_failure,
+                disable_mcp_servers_in_runtime,
+                |error| {
                     let error_display = format!("{error:#}");
-                    if is_gemini_acp_init_failure(&error_display) {
-                        let memory_max_mb = options
-                            .sandbox
-                            .and_then(|sandbox| sandbox.isolation_plan.memory_max_mb);
-                        let classification = classify_gemini_acp_init_failure(
+                    is_gemini_acp_init_failure(&error_display).then(|| {
+                        classify_gemini_acp_init_failure(
                             &error_display,
-                            gemini_classification_env
+                            spawn_request
+                                .gemini_classification_env
                                 .as_ref()
                                 .expect("gemini classification env"),
-                        );
-                        tracing::warn!(
-                            classified_reason = classification.code,
-                            memory_max_mb,
-                            env_allowlist_applied = %gemini_env_allowlist_applied,
-                            missing_env_vars = %classification.missing_env_vars.join(","),
-                            "classified gemini ACP initialization failure"
-                        );
-                        return format_gemini_acp_init_failure(
-                            &classification,
-                            error,
-                            memory_max_mb,
-                        );
-                    }
-                }
-                if let Some(path) = acp_payload_debug_path.as_deref() {
-                    error.context(format!(
-                        "ACP payload debug written to {}",
-                        path.display()
-                    ))
-                } else {
-                    error
-                }
-            })?;
+                        )
+                    })
+                },
+            )
+            .await?;
+            (outcome.value, outcome.warning_summary)
+        } else {
+            (Self::run_acp_prompt(spawn_request).await?, None)
+        };
         let mut execution = ExecutionResult {
             summary: build_summary(&output.output, &output.stderr, output.exit_code),
             output: output.output,
@@ -651,6 +564,9 @@ impl AcpTransport {
             exit_code: output.exit_code,
             peak_memory_mb: output.peak_memory_mb,
         };
+        if let Some(warning_summary) = gemini_warning_summary.as_deref() {
+            apply_gemini_mcp_warning_summary(&mut execution, warning_summary);
+        }
         if let Some(classification) = (self.tool_name == "gemini-cli")
             .then(|| {
                 classify_gemini_acp_initial_stall(&execution, initial_response_timeout_seconds)

--- a/crates/csa-executor/src/transport_acp_spawn.rs
+++ b/crates/csa-executor/src/transport_acp_spawn.rs
@@ -1,0 +1,305 @@
+#[derive(Clone)]
+struct AcpPromptRunRequest {
+    tool_name: String,
+    acp_command: String,
+    acp_args: Vec<String>,
+    prompt: String,
+    working_dir: std::path::PathBuf,
+    env: HashMap<String, String>,
+    system_prompt: Option<String>,
+    resume_session_id: Option<String>,
+    session_meta: Option<serde_json::Map<String, serde_json::Value>>,
+    sandbox_plan: Option<csa_resource::isolation_plan::IsolationPlan>,
+    sandbox_tool_name: Option<String>,
+    sandbox_session_id: Option<String>,
+    sandbox_best_effort: bool,
+    idle_timeout_seconds: u64,
+    initial_response_timeout_seconds: Option<u64>,
+    acp_init_timeout_seconds: u64,
+    termination_grace_period_seconds: u64,
+    stream_stdout_to_stderr: bool,
+    output_spool: Option<std::path::PathBuf>,
+    output_spool_max_bytes: u64,
+    output_spool_keep_rotated: bool,
+    acp_payload_debug_path: Option<std::path::PathBuf>,
+    gemini_classification_env: Option<HashMap<String, String>>,
+    gemini_env_allowlist_applied: String,
+    memory_max_mb: Option<u64>,
+}
+
+#[derive(Debug)]
+struct GeminiAcpMcpRetryOutcome<T> {
+    value: T,
+    warning_summary: Option<String>,
+}
+
+impl AcpTransport {
+    async fn run_acp_prompt(
+        request: AcpPromptRunRequest,
+    ) -> Result<csa_acp::transport::AcpOutput> {
+        let classify_request = request.clone();
+        let output =
+            tokio::task::spawn_blocking(move || -> Result<csa_acp::transport::AcpOutput> {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| anyhow!("failed to build ACP runtime: {e}"))?;
+
+                if let Some(ref plan) = request.sandbox_plan {
+                    let tool_name = request.sandbox_tool_name.as_deref().unwrap_or("");
+                    let sess_id = request.sandbox_session_id.as_deref().unwrap_or("");
+                    let sr = rt.block_on(run_acp_sandboxed(
+                        &request.acp_command,
+                        &request.acp_args,
+                        &request.working_dir,
+                        &request.env,
+                        request.system_prompt.as_deref(),
+                        request.resume_session_id.as_deref(),
+                        request.session_meta.clone(),
+                        &request.prompt,
+                        std::time::Duration::from_secs(request.idle_timeout_seconds),
+                        request
+                            .initial_response_timeout_seconds
+                            .map(std::time::Duration::from_secs),
+                        std::time::Duration::from_secs(request.acp_init_timeout_seconds),
+                        std::time::Duration::from_secs(
+                            request.termination_grace_period_seconds,
+                        ),
+                        plan,
+                        tool_name,
+                        sess_id,
+                        request.stream_stdout_to_stderr,
+                        request.output_spool.as_deref(),
+                        request.output_spool_max_bytes,
+                        request.output_spool_keep_rotated,
+                    ));
+                    match sr {
+                        transport_meta::AcpSandboxedResult {
+                            result: Ok(mut output),
+                            peak_memory_mb,
+                            ..
+                        } => {
+                            output.peak_memory_mb = output.peak_memory_mb.or(peak_memory_mb);
+                            Ok(output)
+                        }
+                        transport_meta::AcpSandboxedResult {
+                            result: Err(e),
+                            sandbox_spawn_failed: true,
+                            ..
+                        } if request.sandbox_best_effort => {
+                            tracing::warn!(
+                                "sandboxed ACP spawn failed in best-effort mode, retrying unsandboxed: {e:#}"
+                            );
+                            rt.block_on(csa_acp::transport::run_prompt_with_io(
+                                &request.acp_command,
+                                &request.acp_args,
+                                &request.working_dir,
+                                &request.env,
+                                csa_acp::transport::AcpSessionStart {
+                                    system_prompt: request.system_prompt.as_deref(),
+                                    resume_session_id: request.resume_session_id.as_deref(),
+                                    meta: request.session_meta.clone(),
+                                    ..Default::default()
+                                },
+                                &request.prompt,
+                                csa_acp::transport::AcpRunOptions {
+                                    idle_timeout: std::time::Duration::from_secs(
+                                        request.idle_timeout_seconds,
+                                    ),
+                                    initial_response_timeout: request
+                                        .initial_response_timeout_seconds
+                                        .map(std::time::Duration::from_secs),
+                                    init_timeout: std::time::Duration::from_secs(
+                                        request.acp_init_timeout_seconds,
+                                    ),
+                                    termination_grace_period: std::time::Duration::from_secs(
+                                        request.termination_grace_period_seconds,
+                                    ),
+                                    io: csa_acp::transport::AcpOutputIoOptions {
+                                        stream_stdout_to_stderr: request.stream_stdout_to_stderr,
+                                        output_spool: request.output_spool.as_deref(),
+                                        spool_max_bytes: request.output_spool_max_bytes,
+                                        keep_rotated_spool: request.output_spool_keep_rotated,
+                                    },
+                                },
+                            ))
+                            .map_err(|e| anyhow!("ACP transport (unsandboxed fallback) failed: {e}"))
+                        }
+                        transport_meta::AcpSandboxedResult {
+                            result: Err(e),
+                            peak_memory_mb,
+                            ..
+                        } => Err(PeakMemoryContext(peak_memory_mb)
+                            .into_anyhow(format!("sandboxed ACP: {e}"))),
+                    }
+                } else {
+                    rt.block_on(csa_acp::transport::run_prompt_with_io(
+                        &request.acp_command,
+                        &request.acp_args,
+                        &request.working_dir,
+                        &request.env,
+                        csa_acp::transport::AcpSessionStart {
+                            system_prompt: request.system_prompt.as_deref(),
+                            resume_session_id: request.resume_session_id.as_deref(),
+                            meta: request.session_meta.clone(),
+                            ..Default::default()
+                        },
+                        &request.prompt,
+                        csa_acp::transport::AcpRunOptions {
+                            idle_timeout: std::time::Duration::from_secs(
+                                request.idle_timeout_seconds,
+                            ),
+                            initial_response_timeout: request
+                                .initial_response_timeout_seconds
+                                .map(std::time::Duration::from_secs),
+                            init_timeout: std::time::Duration::from_secs(
+                                request.acp_init_timeout_seconds,
+                            ),
+                            termination_grace_period: std::time::Duration::from_secs(
+                                request.termination_grace_period_seconds,
+                            ),
+                            io: csa_acp::transport::AcpOutputIoOptions {
+                                stream_stdout_to_stderr: request.stream_stdout_to_stderr,
+                                output_spool: request.output_spool.as_deref(),
+                                spool_max_bytes: request.output_spool_max_bytes,
+                                keep_rotated_spool: request.output_spool_keep_rotated,
+                            },
+                        },
+                    ))
+                    .map_err(|e| anyhow!("ACP transport failed: {e}"))
+                }
+            })
+            .await
+            .map_err(classify_join_error)?
+            .map_err(|error| {
+                if classify_request.tool_name == "gemini-cli" {
+                    let error_display = format!("{error:#}");
+                    if is_gemini_acp_init_failure(&error_display) {
+                        let classification = classify_gemini_acp_init_failure(
+                            &error_display,
+                            classify_request
+                                .gemini_classification_env
+                                .as_ref()
+                                .expect("gemini classification env"),
+                        );
+                        tracing::warn!(
+                            classified_reason = classification.code,
+                            memory_max_mb = classify_request.memory_max_mb,
+                            env_allowlist_applied = %classify_request.gemini_env_allowlist_applied,
+                            missing_env_vars = %classification.missing_env_vars.join(","),
+                            "classified gemini ACP initialization failure"
+                        );
+                        return format_gemini_acp_init_failure(
+                            &classification,
+                            error,
+                            classify_request.memory_max_mb,
+                        );
+                    }
+                }
+                if let Some(path) = classify_request.acp_payload_debug_path.as_deref() {
+                    error.context(format!(
+                        "ACP payload debug written to {}",
+                        path.display()
+                    ))
+                } else {
+                    error
+                }
+            })?;
+
+        Ok(output)
+    }
+
+    fn degraded_mcp_retry_hint(diagnostic: &McpInitDiagnostic, disable_all: bool) -> String {
+        if diagnostic.unhealthy_servers.is_empty() {
+            format!(
+                "Gemini ACP degraded-MCP retry (#840) disabled all configured MCP servers after generic init crash (disable_all={disable_all})"
+            )
+        } else {
+            format!(
+                "Gemini ACP degraded-MCP retry (#840) followed unhealthy MCP servers: {}",
+                diagnostic.unhealthy_servers.join(", ")
+            )
+        }
+    }
+
+    async fn execute_gemini_acp_with_degraded_mcp_retry<
+        T,
+        Spawn,
+        SpawnFut,
+        Diagnose,
+        Disable,
+        Classify,
+    >(
+        runtime_home: &Path,
+        path_override: Option<std::ffi::OsString>,
+        allow_degraded_mcp: bool,
+        mut spawn_once: Spawn,
+        diagnose: Diagnose,
+        disable: Disable,
+        classify_init_failure: Classify,
+    ) -> Result<GeminiAcpMcpRetryOutcome<T>>
+    where
+        Spawn: FnMut() -> SpawnFut,
+        SpawnFut: std::future::Future<Output = Result<T>>,
+        Diagnose: Fn(&Path, Option<&std::ffi::OsStr>) -> McpInitDiagnostic,
+        Disable: Fn(&Path, &McpInitDiagnostic, bool) -> Result<()>,
+        Classify: Fn(&anyhow::Error) -> Option<GeminiAcpInitFailureClassification>,
+    {
+        let issue_url = "https://github.com/RyderFreeman4Logos/cli-sub-agent/issues/840";
+        let mut warning_summary = None;
+        let preflight = diagnose(runtime_home, path_override.as_deref());
+        let mut already_degraded = false;
+
+        if allow_degraded_mcp && !preflight.unhealthy_servers.is_empty() {
+            disable(runtime_home, &preflight, false)?;
+            warning_summary = Some(format_mcp_init_warning_summary(&preflight, false));
+            already_degraded = true;
+            tracing::warn!(
+                issue = issue_url,
+                unhealthy_servers = %preflight.unhealthy_servers.join(","),
+                "gemini-cli ACP preflight found unhealthy MCP servers; degrading mirrored runtime before spawn"
+            );
+        }
+
+        match spawn_once().await {
+            Ok(value) => Ok(GeminiAcpMcpRetryOutcome {
+                value,
+                warning_summary,
+            }),
+            Err(error) if !allow_degraded_mcp || already_degraded => Err(error),
+            Err(error) => {
+                let Some(classification) = classify_init_failure(&error) else {
+                    return Err(error);
+                };
+                if classification.code != "gemini_acp_init_handshake_timeout" {
+                    return Err(error);
+                }
+
+                let diagnostic = diagnose(runtime_home, path_override.as_deref());
+                let disable_all = diagnostic.unhealthy_servers.is_empty();
+                disable(runtime_home, &diagnostic, disable_all)?;
+                warning_summary =
+                    Some(format_mcp_init_warning_summary(&diagnostic, disable_all));
+                tracing::warn!(
+                    issue = issue_url,
+                    unhealthy_servers = %if diagnostic.unhealthy_servers.is_empty() {
+                        "unknown".to_string()
+                    } else {
+                        diagnostic.unhealthy_servers.join(",")
+                    },
+                    disable_all,
+                    "gemini-cli ACP init crash matched generic bucket; retrying once with degraded MCP"
+                );
+
+                match spawn_once().await {
+                    Ok(value) => Ok(GeminiAcpMcpRetryOutcome {
+                        value,
+                        warning_summary,
+                    }),
+                    Err(retry_error) => Err(retry_error
+                        .context(Self::degraded_mcp_retry_hint(&diagnostic, disable_all))),
+                }
+            }
+        }
+    }
+}

--- a/crates/csa-executor/src/transport_tests_gemini_acp_mcp_retry.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_acp_mcp_retry.rs
@@ -1,0 +1,258 @@
+#[tokio::test]
+async fn test_gemini_acp_falls_back_to_degraded_mcp_when_preflight_detects_unhealthy() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime_home = temp.path().join("runtime-home");
+    write_gemini_settings(&runtime_home, "missing-mcp-command");
+
+    let steps = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let observed_settings = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+    let settings_path = runtime_home.join(".gemini/settings.json");
+
+    let outcome = AcpTransport::execute_gemini_acp_with_degraded_mcp_retry(
+        &runtime_home,
+        Some(std::ffi::OsString::from("/prepared/bin")),
+        true,
+        {
+            let steps = std::sync::Arc::clone(&steps);
+            let observed_settings = std::sync::Arc::clone(&observed_settings);
+            let settings_path = settings_path.clone();
+            move || {
+                let steps = std::sync::Arc::clone(&steps);
+                let observed_settings = std::sync::Arc::clone(&observed_settings);
+                let settings_path = settings_path.clone();
+                async move {
+                    steps.lock().expect("steps lock").push("spawn".to_string());
+                    *observed_settings.lock().expect("settings lock") = Some(
+                        std::fs::read_to_string(&settings_path)
+                            .expect("spawn should see runtime settings"),
+                    );
+                    Ok::<_, anyhow::Error>("spawned".to_string())
+                }
+            }
+        },
+        {
+            let steps = std::sync::Arc::clone(&steps);
+            move |_, _| {
+                steps.lock().expect("steps lock").push("diagnose".to_string());
+                McpInitDiagnostic {
+                    unhealthy_servers: vec!["broken-mcp".to_string()],
+                    ..Default::default()
+                }
+            }
+        },
+        {
+            let steps = std::sync::Arc::clone(&steps);
+            move |path, diagnostic, disable_all| {
+                steps.lock().expect("steps lock").push(format!(
+                    "disable:{disable_all}:{}",
+                    diagnostic.unhealthy_servers.join(",")
+                ));
+                disable_mcp_servers_in_runtime(path, diagnostic, disable_all)
+            }
+        },
+        |_| None,
+    )
+    .await
+    .expect("preflight unhealthy MCP should degrade before first spawn");
+
+    assert_eq!(
+        steps.lock().expect("steps lock").clone(),
+        vec![
+            "diagnose".to_string(),
+            "disable:false:broken-mcp".to_string(),
+            "spawn".to_string(),
+        ]
+    );
+    assert!(
+        observed_settings
+            .lock()
+            .expect("settings lock")
+            .as_deref()
+            .is_some_and(|settings| settings.contains(r#""mcpServers": {}"#)),
+        "spawn should observe a degraded runtime settings file"
+    );
+    assert!(
+        outcome
+            .warning_summary
+            .as_deref()
+            .is_some_and(|summary| summary.contains("broken-mcp")),
+        "warning summary should name the unhealthy server: {:?}",
+        outcome.warning_summary
+    );
+}
+
+#[tokio::test]
+async fn test_gemini_acp_retries_with_degraded_mcp_on_generic_init_crash() {
+    async fn run_case(second_spawn_succeeds: bool) -> Result<GeminiAcpMcpRetryOutcome<String>> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime_home = temp.path().join("runtime-home");
+        write_gemini_settings(&runtime_home, "missing-mcp-command");
+
+        let diagnose_calls = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+        let disable_calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let spawn_calls = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+        let settings_after_retry = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+        let settings_path = runtime_home.join(".gemini/settings.json");
+
+        AcpTransport::execute_gemini_acp_with_degraded_mcp_retry(
+            &runtime_home,
+            Some(std::ffi::OsString::from("/prepared/bin")),
+            true,
+            {
+                let spawn_calls = std::sync::Arc::clone(&spawn_calls);
+                let settings_after_retry = std::sync::Arc::clone(&settings_after_retry);
+                let settings_path = settings_path.clone();
+                move || {
+                    let spawn_calls = std::sync::Arc::clone(&spawn_calls);
+                    let settings_after_retry = std::sync::Arc::clone(&settings_after_retry);
+                    let settings_path = settings_path.clone();
+                    async move {
+                        let mut call_count = spawn_calls.lock().expect("spawn calls lock");
+                        *call_count += 1;
+                        if *call_count == 1 {
+                            return Err(anyhow::anyhow!("first generic init crash"));
+                        }
+
+                        *settings_after_retry.lock().expect("settings lock") = Some(
+                            std::fs::read_to_string(&settings_path)
+                                .expect("retry spawn should read runtime settings"),
+                        );
+                        if second_spawn_succeeds {
+                            Ok::<_, anyhow::Error>("recovered".to_string())
+                        } else {
+                            Err(anyhow::anyhow!("second generic init crash"))
+                        }
+                    }
+                }
+            },
+            {
+                let diagnose_calls = std::sync::Arc::clone(&diagnose_calls);
+                move |_, _| {
+                    let mut call_count = diagnose_calls.lock().expect("diagnose calls lock");
+                    *call_count += 1;
+                    if *call_count == 1 {
+                        McpInitDiagnostic::default()
+                    } else {
+                        McpInitDiagnostic {
+                            unhealthy_servers: vec!["broken-mcp".to_string()],
+                            ..Default::default()
+                        }
+                    }
+                }
+            },
+            {
+                let disable_calls = std::sync::Arc::clone(&disable_calls);
+                move |path, diagnostic, disable_all| {
+                    disable_calls.lock().expect("disable calls lock").push(format!(
+                        "disable:{disable_all}:{}",
+                        diagnostic.unhealthy_servers.join(",")
+                    ));
+                    disable_mcp_servers_in_runtime(path, diagnostic, disable_all)
+                }
+            },
+            |_| {
+                Some(GeminiAcpInitFailureClassification {
+                    code: "gemini_acp_init_handshake_timeout",
+                    missing_env_vars: Vec::new(),
+                })
+            },
+        )
+        .await
+        .inspect(|_| {
+            assert_eq!(
+                *spawn_calls.lock().expect("spawn calls lock"),
+                2,
+                "generic init crash should trigger exactly one degraded retry"
+            );
+            assert_eq!(
+                disable_calls.lock().expect("disable calls lock").as_slice(),
+                ["disable:false:broken-mcp"],
+                "degraded retry should disable the diagnosed unhealthy server"
+            );
+            assert!(
+                settings_after_retry
+                    .lock()
+                    .expect("settings lock")
+                    .as_deref()
+                    .is_some_and(|settings| settings.contains(r#""mcpServers": {}"#)),
+                "retry spawn should observe the degraded runtime settings"
+            );
+        })
+    }
+
+    let success = run_case(true)
+        .await
+        .expect("generic init crash should recover after degraded retry");
+    assert!(
+        success
+            .warning_summary
+            .as_deref()
+            .is_some_and(|summary| summary.contains("broken-mcp")),
+        "warning summary should name the retried unhealthy server: {:?}",
+        success.warning_summary
+    );
+
+    let error = run_case(false)
+        .await
+        .expect_err("second degraded retry failure should surface unhealthy server hint");
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("broken-mcp"),
+        "second-round failure should include unhealthy server hint: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn test_gemini_acp_no_retry_when_first_spawn_succeeds() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime_home = temp.path().join("runtime-home");
+    write_gemini_settings(&runtime_home, "missing-mcp-command");
+
+    let diagnose_calls = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+    let disable_calls = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+    let spawn_calls = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+
+    let outcome = AcpTransport::execute_gemini_acp_with_degraded_mcp_retry(
+        &runtime_home,
+        Some(std::ffi::OsString::from("/prepared/bin")),
+        true,
+        {
+            let spawn_calls = std::sync::Arc::clone(&spawn_calls);
+            move || {
+                let spawn_calls = std::sync::Arc::clone(&spawn_calls);
+                async move {
+                    *spawn_calls.lock().expect("spawn calls lock") += 1;
+                    Ok::<_, anyhow::Error>("ok".to_string())
+                }
+            }
+        },
+        {
+            let diagnose_calls = std::sync::Arc::clone(&diagnose_calls);
+            move |_, _| {
+                *diagnose_calls.lock().expect("diagnose calls lock") += 1;
+                McpInitDiagnostic::default()
+            }
+        },
+        {
+            let disable_calls = std::sync::Arc::clone(&disable_calls);
+            move |_, _, _| {
+                *disable_calls.lock().expect("disable calls lock") += 1;
+                Ok(())
+            }
+        },
+        |_| {
+            Some(GeminiAcpInitFailureClassification {
+                code: "gemini_acp_init_handshake_timeout",
+                missing_env_vars: Vec::new(),
+            })
+        },
+    )
+    .await
+    .expect("first spawn success should return directly");
+
+    assert_eq!(outcome.value, "ok");
+    assert!(outcome.warning_summary.is_none());
+    assert_eq!(*diagnose_calls.lock().expect("diagnose calls lock"), 1);
+    assert_eq!(*disable_calls.lock().expect("disable calls lock"), 0);
+    assert_eq!(*spawn_calls.lock().expect("spawn calls lock"), 1);
+}

--- a/crates/csa-executor/src/transport_tests_mod.rs
+++ b/crates/csa-executor/src/transport_tests_mod.rs
@@ -7,6 +7,7 @@ include!("transport_tests_tail.rs");
 include!("transport_tests_ephemeral.rs");
 include!("transport_tests_gemini_fallback.rs");
 include!("transport_tests_gemini_init_classification.rs");
+include!("transport_tests_gemini_acp_mcp_retry.rs");
 include!("transport_tests_gemini_oauth_prompt.rs");
 include!("transport_tests_extra.rs");
 include!("transport_tests_codex_acp_stall.rs");


### PR DESCRIPTION
## Summary

Fixes #840.

Gemini ACP sessions die pre-handshake when MCP extension startup fails. The ACP spawn path had no degraded-MCP fallback, so a broken MCP extension blocked the entire session. Legacy Gemini transport already handles this with a two-stage pattern (`diagnose_mcp_init_failure` → `disable_mcp_servers_in_runtime` → retry). This PR ports that pattern to the Gemini ACP path.

## Behavior

- After `prepare_gemini_acp_runtime()` resolves the runtime home, run `diagnose_mcp_init_failure`. On unhealthy MCP, degrade the mirrored settings immediately and spawn once with MCP disabled.
- On healthy preflight: if the first spawn returns the generic init-crash classification (`gemini_acp_init_handshake_timeout`), retry once with MCP disabled. Unhealthy-server hint is surfaced in the final error message.
- The degraded-MCP retry sits BEFORE the existing OAuth/rate-limit retry loop — they compose cleanly.
- Only mirrored session runtime settings are modified; user's on-disk `~/.gemini/` config untouched.

## RECON context

RECON session `01KPRHFS7HD9SPM0BGDWRXTVET` mapped the 4 candidate causes:

| Cause | Confidence | Evidence |
|-------|-----------|----------|
| **MCP extension startup** | medium-high | ACP spawn lacks the degraded-MCP guard legacy already needs; MCP failures are common on affected hosts. |
| Env stripping / auth env loss | medium | `GEMINI_API_KEY` forwarded via extra_env; no forwarding for `GOOGLE_APPLICATION_CREDENTIALS` etc, but preserved crash samples don't show auth text. |
| Upstream handshake drift | medium-low | Two historical turn_count=0 crashes match the generic bucket; newer failures mostly 120s stalls. |
| Memory pressure | low | All live samples show `memory_max_mb=16384`; no OOM markers in stderr. |

This PR addresses the primary (MCP) cause. Env-forwarding widening is a separate followup if this doesn't clear the crash.

## Test plan

- [x] `cargo check --workspace --all-features` passes.
- [x] `cargo test -p csa-executor` passes (including 3 new tests: unhealthy-MCP preflight degradation, healthy-preflight + retry-on-generic-init-crash, happy-path no-retry).
- [x] `just clippy` — no new warnings.
- [x] `just pre-commit` — exit 0.
- [ ] Cloud `/gemini review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)