### PR TITLE
chore(csa-executor): HashMap::entry for MISE_TRUSTED_CONFIG_PATHS (#1001)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "chrono",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "axum",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "chrono",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "chrono",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.479"
+version = "0.1.480"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.479"
+version = "0.1.480"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -96,12 +96,12 @@ pub(crate) fn prepare_gemini_acp_runtime(
     // Preserve explicit trust state from the inherited environment only.
     // Do not synthesize trust from project-local mise.toml, because that would
     // elevate repo-controlled input into trusted execution state. See #972.
-    let inherited_trusted = env
-        .get("MISE_TRUSTED_CONFIG_PATHS")
-        .cloned()
-        .or_else(|| std::env::var("MISE_TRUSTED_CONFIG_PATHS").ok());
-    if let Some(trusted) = inherited_trusted {
-        env.insert("MISE_TRUSTED_CONFIG_PATHS".to_string(), trusted);
+    if std::env::var("MISE_TRUSTED_CONFIG_PATHS").is_ok() {
+        env.entry("MISE_TRUSTED_CONFIG_PATHS".to_string())
+            .or_insert_with(|| {
+                std::env::var("MISE_TRUSTED_CONFIG_PATHS")
+                    .expect("MISE_TRUSTED_CONFIG_PATHS existence checked above")
+            });
     }
 
     let inherited_path = env


### PR DESCRIPTION
## Summary

- Rewrite the MISE_TRUSTED_CONFIG_PATHS env forwarder in `transport_gemini_acp_runtime.rs` using `HashMap::entry().or_insert_with()` for idiomatic clarity.
- Pure refactor — semantics preserved across all 4 cases (env has/absent × std::env has/absent).

## Test plan

- [x] `just pre-commit` exit 0
- [x] `csa review --range main...HEAD` clean (session 01KPSF1JPQE4CJXMY43GC8JJS6, findings=[])

Closes #1001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)