### PR TITLE
docs(csa-review): use "convergence" for exhaustion semantics (#998)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "chrono",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "axum",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "chrono",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "chrono",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.480"
+version = "0.1.481"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.480"
+version = "0.1.481"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/csa-review/PATTERN.md
+++ b/patterns/csa-review/PATTERN.md
@@ -141,7 +141,7 @@ Its post-fix state is **asymmetric**:
 
 - On **successful `csa review --fix` convergence** (gate passed + non-empty output),
   the file is overwritten with an empty findings list — an explicit "clean" signal.
-- On **`csa review --fix` exhaustion** (fix rounds end without gate pass), the
+- On **`csa review --fix` exhaustion** (fix rounds end without convergence), the
   pre-fix findings are preserved — the last review phase's findings remain
   authoritative.
 - To re-verify after exhaustion, run a fresh `csa review` phase.


### PR DESCRIPTION
## Summary

- Replace "gate pass" with "convergence" in the exhaustion bullet of `patterns/csa-review/PATTERN.md` so it correctly covers both the gate-fail and `fix_empty == true` cases.

## Test plan

- [x] `just pre-commit` exit 0
- [x] `csa review` clean (session 01KPSG00B4E67N5S52B4CJKDMG, findings=[])

Closes #998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)