### PR TITLE
fix(cli): treat `-` positional as stdin sentinel for csa run (#993)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "chrono",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "axum",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "chrono",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "chrono",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.481"
+version = "0.1.482"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.481"
+version = "0.1.482"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -164,7 +164,8 @@ pub(crate) async fn handle_debate(
     }
 
     // 3. Read question (from --prompt-file, positional arg, --topic, or stdin)
-    let effective_question = args.question.or(args.topic);
+    let effective_question =
+        crate::run_helpers::resolve_positional_stdin_sentinel(args.question)?.or(args.topic);
     let mut question = resolve_prompt_with_file(effective_question, args.prompt_file.as_deref())?;
     if let Some(ctx) = &args.context {
         question = format!("<debate-context>\n{ctx}\n</debate-context>\n\n{question}");

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -187,7 +187,7 @@ pub(crate) async fn handle_run(
     // resolution may override it).  This drives tier enforcement: explicit
     // --tool (including --tool auto) is blocked when tiers are configured.
     let user_explicit_tool = tool.is_some();
-    let prompt = prompt.or(prompt_flag);
+    let prompt = crate::run_helpers::resolve_positional_stdin_sentinel(prompt)?.or(prompt_flag);
 
     // Resolve --prompt-file into the prompt if provided.
     let prompt = if prompt_file.is_some() {

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -1,7 +1,6 @@
 //! Helper functions for `csa run`: tool resolution, executor building, token parsing.
 
 use anyhow::{Context, Result};
-use std::io::Read;
 use std::path::Path;
 
 use csa_config::{GlobalConfig, ProjectConfig};
@@ -11,12 +10,15 @@ use csa_session::TokenUsage;
 
 #[path = "run_helpers_edit_requirement.rs"]
 mod edit_requirement;
+#[path = "run_helpers_prompt.rs"]
+mod prompt;
 #[path = "run_helpers_routing_conflict.rs"]
 mod routing_conflict;
 #[path = "run_helpers_tool_availability.rs"]
 mod tool_availability;
 
 pub(crate) use edit_requirement::{infer_task_edit_requirement, resolve_task_edit_requirement};
+pub(crate) use prompt::{read_prompt, resolve_positional_stdin_sentinel};
 pub(crate) use routing_conflict::{is_routing_conflict, routing_conflict_error};
 pub(crate) use tool_availability::{
     ToolBinaryAvailability, is_tool_binary_available_for_config, resolved_tool_binary_name,
@@ -550,35 +552,6 @@ pub(crate) fn resolve_prompt_with_file(
         return Ok(content);
     }
     read_prompt(prompt)
-}
-
-/// Read prompt from CLI argument or stdin.
-pub(crate) fn read_prompt(prompt: Option<String>) -> Result<String> {
-    if let Some(p) = prompt {
-        if p.trim().is_empty() {
-            anyhow::bail!(
-                "Empty prompt provided. Usage:\n  csa run --sa-mode <true|false> --tool <tool> \"your prompt here\"\n  echo \"prompt\" | csa run --sa-mode <true|false> --tool <tool>"
-            );
-        }
-        Ok(p)
-    } else {
-        // No prompt argument: read from stdin
-        use std::io::IsTerminal;
-        if std::io::stdin().is_terminal() {
-            anyhow::bail!(
-                "No prompt provided and stdin is a terminal.\n\n\
-                 Usage:\n  \
-                 csa run --sa-mode <true|false> --tool <tool> \"your prompt here\"\n  \
-                 echo \"prompt\" | csa run --sa-mode <true|false> --tool <tool>"
-            );
-        }
-        let mut buffer = String::new();
-        std::io::stdin().read_to_string(&mut buffer)?;
-        if buffer.trim().is_empty() {
-            anyhow::bail!("Empty prompt from stdin. Provide a non-empty prompt.");
-        }
-        Ok(buffer)
-    }
 }
 
 /// Result of resolving a tool from a tier's models list.

--- a/crates/cli-sub-agent/src/run_helpers_prompt.rs
+++ b/crates/cli-sub-agent/src/run_helpers_prompt.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+use std::io::{IsTerminal, Read};
+
+pub(crate) fn resolve_positional_stdin_sentinel(prompt: Option<String>) -> Result<Option<String>> {
+    let mut stdin = std::io::stdin();
+    resolve_positional_stdin_sentinel_from_reader(prompt, stdin.is_terminal(), &mut stdin)
+}
+
+#[cfg(test)]
+pub(crate) fn resolve_positional_stdin_sentinel_from_reader<R: Read>(
+    prompt: Option<String>,
+    stdin_is_terminal: bool,
+    reader: &mut R,
+) -> Result<Option<String>> {
+    match prompt.as_deref() {
+        Some("-") => read_prompt_from_reader(None, stdin_is_terminal, reader).map(Some),
+        _ => Ok(prompt),
+    }
+}
+
+#[cfg(not(test))]
+fn resolve_positional_stdin_sentinel_from_reader<R: Read>(
+    prompt: Option<String>,
+    stdin_is_terminal: bool,
+    reader: &mut R,
+) -> Result<Option<String>> {
+    match prompt.as_deref() {
+        Some("-") => read_prompt_from_reader(None, stdin_is_terminal, reader).map(Some),
+        _ => Ok(prompt),
+    }
+}
+
+pub(crate) fn read_prompt(prompt: Option<String>) -> Result<String> {
+    let mut stdin = std::io::stdin();
+    read_prompt_from_reader(prompt, stdin.is_terminal(), &mut stdin)
+}
+
+fn read_prompt_from_reader<R: Read>(
+    prompt: Option<String>,
+    stdin_is_terminal: bool,
+    reader: &mut R,
+) -> Result<String> {
+    if let Some(p) = prompt {
+        if p.trim().is_empty() {
+            anyhow::bail!(
+                "Empty prompt provided. Usage:\n  csa run --sa-mode <true|false> --tool <tool> \"your prompt here\"\n  echo \"prompt\" | csa run --sa-mode <true|false> --tool <tool>"
+            );
+        }
+        Ok(p)
+    } else {
+        if stdin_is_terminal {
+            anyhow::bail!(
+                "No prompt provided and stdin is a terminal.\n\n\
+                 Usage:\n  \
+                 csa run --sa-mode <true|false> --tool <tool> \"your prompt here\"\n  \
+                 echo \"prompt\" | csa run --sa-mode <true|false> --tool <tool>"
+            );
+        }
+        let mut buffer = String::new();
+        reader.read_to_string(&mut buffer)?;
+        if buffer.trim().is_empty() {
+            anyhow::bail!("Empty prompt from stdin. Provide a non-empty prompt.");
+        }
+        Ok(buffer)
+    }
+}

--- a/crates/cli-sub-agent/src/run_helpers_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tests.rs
@@ -777,3 +777,22 @@ fn resolve_prompt_with_file_falls_through_to_positional() {
     let result = super::resolve_prompt_with_file(Some("hello".to_string()), None).unwrap();
     assert_eq!(result, "hello");
 }
+
+#[test]
+fn resolve_positional_stdin_sentinel_preserves_non_sentinel_prompt() {
+    let result =
+        super::resolve_positional_stdin_sentinel(Some("literal prompt".to_string())).unwrap();
+    assert_eq!(result, Some("literal prompt".to_string()));
+}
+
+#[test]
+fn resolve_positional_stdin_sentinel_reads_from_stdin_for_dash() {
+    let mut stdin = std::io::Cursor::new("prompt from stdin");
+    let result = super::prompt::resolve_positional_stdin_sentinel_from_reader(
+        Some("-".to_string()),
+        false,
+        &mut stdin,
+    )
+    .unwrap();
+    assert_eq!(result, Some("prompt from stdin".to_string()));
+}


### PR DESCRIPTION
## Summary

- `csa run ... -` previously treated `-` as a literal prompt, silently dropping piped stdin
- Align with Unix convention: `cat -`, `jq . -`, `codex exec -` — all read from stdin on `-`
- Same sentinel applied to `debate_cmd` positional prompt
- Extracted the sentinel resolution into `run_helpers_prompt.rs` with unit test coverage

## Test plan

- [x] `just pre-commit` exit 0
- [x] `csa review` clean (session 01KPSHDSNXX0FEDM1KXEAV7S8V, findings=[])

Closes #993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)