### PR TITLE
test(csa): unify env-guard alias + reorder bwrap-skip under lock (#1006)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "chrono",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "chrono",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "axum",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "chrono",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "chrono",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.482"
+version = "0.1.483"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.482"
+version = "0.1.483"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -569,10 +569,8 @@ async fn handle_debate_marks_unavailable_when_all_tier_models_fail() {
 #[tokio::test]
 async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier_debate() {
     let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
-    let _available_guard = crate::test_env_lock::ScopedEnvVarRestore::set(
-        crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV,
-        "1",
-    );
+    let _available_guard =
+        EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
     let mut config = project_config_with_enabled_tools(&["codex", "gemini-cli"]);
     config.tools.get_mut("codex").unwrap().transport = Some(ToolTransport::Cli);
     config.tiers.insert(

--- a/crates/cli-sub-agent/src/review_cmd_tests_fix_fallback.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_fix_fallback.rs
@@ -6,13 +6,12 @@ use crate::test_session_sandbox::ScopedSessionSandbox;
 async fn handle_review_fix_loop_uses_effective_fallback_tool() {
     use std::os::unix::fs::PermissionsExt;
 
+    let project_dir = setup_git_repo();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     if which::which("bwrap").is_err() {
         eprintln!("skipping: bwrap not installed (CI gap, see #987)");
         return;
     }
-
-    let project_dir = setup_git_repo();
-    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let codex_count_path = project_dir.path().join("codex-count.txt");


### PR DESCRIPTION
## Summary

Two MEDIUMs aggregated from PR #1005 cloud gemini bot:

- Align fully-qualified `ScopedEnvVarRestore::set` in debate-side tier-fallback test with `EnvVarGuard` alias used nearby (style consistency).
- Move `which::which("bwrap")` skip-check INSIDE `TEST_ENV_LOCK`-holding scope so PATH reads can't race with parallel tests.

## Test plan

- [x] `just pre-commit` exit 0
- [x] `csa review` clean (session 01KPSJN2RTFKCEWYME1M6A9PC7, findings=[])

Closes #1006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)