### PR TITLE
fix(cli): inline review context also prepends in --skill mode (#1014)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.485"
+version = "0.1.486"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.485"
+version = "0.1.486"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from `run_cmd.rs` to keep module sizes manageable.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use anyhow::Result;
@@ -56,6 +56,18 @@ fn resolve_run_tier_context(
         tier_auto_select,
         failover_on_crash_enabled,
         resolved_tier_name,
+    )
+}
+
+fn finalize_prompt_text(
+    project_root: &Path,
+    prompt_text: String,
+    inline_context_from_review_session: Option<&str>,
+) -> Result<String> {
+    crate::run_helpers::prepend_review_context_to_prompt(
+        project_root,
+        prompt_text,
+        inline_context_from_review_session,
     )
 }
 
@@ -199,20 +211,6 @@ pub(crate) async fn handle_run(
     } else {
         prompt
     };
-    let prompt = if inline_context_from_review_session.is_some() && skill.is_none() {
-        Some(crate::run_helpers::read_prompt(prompt)?)
-    } else {
-        prompt
-    };
-    let prompt = prompt
-        .map(|prompt| {
-            crate::run_helpers::prepend_review_context_to_prompt(
-                &project_root,
-                prompt,
-                inline_context_from_review_session.as_deref(),
-            )
-        })
-        .transpose()?;
 
     let skill_res = resolve_skill_and_prompt(
         skill.as_deref(),
@@ -222,7 +220,11 @@ pub(crate) async fn handle_run(
         thinking,
         &project_root,
     )?;
-    let prompt_text = skill_res.prompt_text;
+    let prompt_text = finalize_prompt_text(
+        &project_root,
+        skill_res.prompt_text,
+        inline_context_from_review_session.as_deref(),
+    )?;
     let resolved_skill = skill_res.resolved_skill;
     let skill_agent = resolved_skill.as_ref().and_then(|sk| sk.agent_config());
     let thinking = skill_res.thinking;
@@ -591,10 +593,14 @@ mod pre_exec_tests;
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_run_tier_context;
+    use super::{finalize_prompt_text, resolve_run_tier_context};
+    use crate::run_cmd_tool_selection::resolve_skill_and_prompt;
+    use crate::test_session_sandbox::ScopedSessionSandbox;
     use chrono::Utc;
     use csa_config::{ProjectConfig, ProjectMeta, TierConfig, TierStrategy};
     use std::collections::HashMap;
+    use std::fs;
+    use tempfile::TempDir;
 
     fn make_test_config() -> ProjectConfig {
         let mut tiers = HashMap::new();
@@ -638,6 +644,40 @@ mod tests {
             vcs: Default::default(),
             filesystem_sandbox: Default::default(),
         }
+    }
+
+    #[test]
+    fn finalize_prompt_text_prepends_review_context_for_skill_only_prompt() {
+        let tmp = TempDir::new().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+        let skill_dir = tmp.path().join(".csa").join("skills").join("demo");
+        fs::create_dir_all(&skill_dir).expect("create skill dir");
+        fs::write(skill_dir.join("SKILL.md"), "demo skill body").expect("write SKILL.md");
+
+        let session_id = "01KAS6M5XG7V4M4M6YDRS7P8R4";
+        let session_dir =
+            csa_session::get_session_dir(tmp.path(), session_id).expect("session dir");
+        fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+        fs::write(
+            session_dir.join("output").join("summary.md"),
+            "Summary line\n",
+        )
+        .expect("write summary");
+
+        let skill_resolution =
+            resolve_skill_and_prompt(Some("demo"), None, None, None, None, tmp.path())
+                .expect("resolve skill prompt");
+
+        let prompt_text =
+            finalize_prompt_text(tmp.path(), skill_resolution.prompt_text, Some(session_id))
+                .expect("finalize prompt text");
+
+        assert!(prompt_text.starts_with(&format!(
+            "<csa-review-context session=\"{session_id}\">\n<!-- summary.md -->\nSummary line\n"
+        )));
+        assert!(prompt_text.contains("<original-prompt>\n<skill-mode>executor</skill-mode>\n"));
+        assert!(prompt_text.contains("demo skill body"));
+        assert!(prompt_text.ends_with("</original-prompt>\n"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Followup MEDIUM from PR #1013 (#769). The `--inline-context-from-review-session` flag was wired to only prepend review context for bare user prompts. In `--skill <name>` mode without a user prompt, the skill-supplied prompt bypassed the prepend step, silently dropping the review context.

This moves the inline review-context wrapping to post-skill prompt resolution, so the flag behaves consistently regardless of prompt source.

Closes #1014.

## Review

Local review by csa-codex (session `01KPSQ29GC5GMBAZJBR9T5D94D`): verdict = **pass**, no findings.

## Test plan

- [x] `just bump-patch` → 0.1.486
- [x] `just pre-commit` exit 0
- [x] New regression test `finalize_prompt_text_prepends_review_context_for_skill_only_prompt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)