### PR TITLE
test(cli): assert config show renders [session_wait] override (#1012)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.486"
+version = "0.1.487"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.486"
+version = "0.1.487"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -301,6 +301,41 @@ fn config_show_exits_zero_after_init_full() {
 }
 
 #[test]
+fn config_show_renders_project_session_wait_override() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = csa_config::ProjectConfig::config_path(tmp.path());
+    std::fs::create_dir_all(config_path.parent().expect("config dir")).expect("create config dir");
+    std::fs::write(
+        &config_path,
+        r#"
+[project]
+name = "test-project"
+
+[session_wait]
+memory_warn_mb = 8192
+"#,
+    )
+    .expect("write config");
+
+    let project_root = tmp.path().display().to_string();
+    let output = csa_cmd(tmp.path())
+        .args(["config", "show", "--cd", &project_root])
+        .output()
+        .expect("failed to run csa config show --cd");
+
+    assert!(output.status.success(), "csa config show should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("[session_wait]"),
+        "should contain [session_wait] section"
+    );
+    assert!(
+        stdout.contains("memory_warn_mb = 8192"),
+        "should contain rendered session_wait override"
+    );
+}
+
+#[test]
 fn config_get_resolves_nested_resource_keys_from_effective_display_tree() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let config_path = csa_config::ProjectConfig::config_path(tmp.path());


### PR DESCRIPTION
## Summary

Followup regression-test gap from #1003 (PR #1011). Prior to this commit, the `csa config show` e2e coverage only checked broad section presence (`schema_version`, `[project]`, `[tools`); it never asserted that project-level `[session_wait]` overrides actually appeared in the effective display tree.

This adds a targeted e2e test that writes a project config with `memory_warn_mb = 8192` and asserts the rendered output contains both `[session_wait]` and `memory_warn_mb = 8192`.

Closes #1012.

## Review

Local review by csa-codex (session `01KPSQPGDJRSRPYSVW18WKH8VK`): verdict = **pass**, no findings.

## Test plan

- [x] `just bump-patch` → 0.1.487
- [x] `just pre-commit` exit 0
- [x] New e2e test in `tests/e2e.rs` covering `[session_wait]` visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)