### PR TITLE
fix(cli): #1021 CSA-subprocess-aware atomic-commit preamble

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.491"
+version = "0.1.492"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.491"
+version = "0.1.492"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
@@ -52,17 +52,30 @@ fn make_test_config() -> ProjectConfig {
     }
 }
 
+fn atomic_commit_block<'a>(prompt: &'a str, user_task_marker: &str) -> &'a str {
+    let preamble_start = prompt
+        .find("<atomic-commit-discipline>")
+        .expect("preamble must exist");
+    let user_task_pos = prompt
+        .find(user_task_marker)
+        .expect("user task marker must exist");
+    &prompt[preamble_start..user_task_pos]
+}
+
 #[test]
 fn finalize_prompt_text_prepends_atomic_commit_preamble() {
     let tmp = TempDir::new().expect("tempdir");
-    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let mut sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    sandbox.track_env("CSA_DEPTH");
+    sandbox.track_env("CSA_SESSION_ID");
+    // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for the full test.
+    unsafe {
+        std::env::remove_var("CSA_DEPTH");
+        std::env::remove_var("CSA_SESSION_ID");
+    }
 
     let result = finalize_prompt_text(tmp.path(), "user task".to_string(), None).expect("finalize");
-    let preamble_start = result
-        .find("<atomic-commit-discipline>")
-        .expect("preamble must exist");
-    let user_task_pos = result.find("user task").expect("user task must exist");
-    let preamble_body = &result[preamble_start..user_task_pos];
+    let preamble_body = atomic_commit_block(&result, "user task");
 
     assert!(
         result.contains("<atomic-commit-discipline>"),
@@ -82,8 +95,118 @@ fn finalize_prompt_text_prepends_atomic_commit_preamble() {
         "preamble must not instruct manual git add; got: {preamble_body}"
     );
     assert!(
-        preamble_start < user_task_pos,
+        result.find("<atomic-commit-discipline>").unwrap() < result.find("user task").unwrap(),
         "preamble must come BEFORE the user prompt"
+    );
+}
+
+#[test]
+fn finalize_prompt_text_uses_subprocess_atomic_commit_preamble_when_csa_depth_positive() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    sandbox.track_env("CSA_DEPTH");
+    sandbox.track_env("CSA_SESSION_ID");
+    // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for the full test.
+    unsafe {
+        std::env::set_var("CSA_DEPTH", "1");
+        std::env::remove_var("CSA_SESSION_ID");
+    }
+
+    let result =
+        finalize_prompt_text(tmp.path(), "subprocess task".to_string(), None).expect("finalize");
+    let preamble_body = atomic_commit_block(&result, "subprocess task");
+
+    assert!(
+        preamble_body.contains("git commit -m"),
+        "subprocess preamble must instruct direct git commit; got: {preamble_body}"
+    );
+    assert!(
+        preamble_body.contains("git add"),
+        "subprocess preamble must instruct direct git add; got: {preamble_body}"
+    );
+    assert!(
+        !preamble_body.contains("/commit"),
+        "subprocess preamble must not reference /commit; got: {preamble_body}"
+    );
+}
+
+#[test]
+fn finalize_prompt_text_uses_main_agent_preamble_when_csa_depth_missing() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    sandbox.track_env("CSA_DEPTH");
+    sandbox.track_env("CSA_SESSION_ID");
+    // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for the full test.
+    unsafe {
+        std::env::remove_var("CSA_DEPTH");
+        std::env::remove_var("CSA_SESSION_ID");
+    }
+
+    let result =
+        finalize_prompt_text(tmp.path(), "main agent task".to_string(), None).expect("finalize");
+    let preamble_body = atomic_commit_block(&result, "main agent task");
+
+    assert!(
+        preamble_body.contains("/commit"),
+        "main-agent preamble must reference /commit; got: {preamble_body}"
+    );
+    assert!(
+        !preamble_body.contains("git commit -m"),
+        "main-agent preamble must not instruct manual git commit; got: {preamble_body}"
+    );
+}
+
+#[test]
+fn finalize_prompt_text_uses_main_agent_preamble_when_csa_depth_zero() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    sandbox.track_env("CSA_DEPTH");
+    sandbox.track_env("CSA_SESSION_ID");
+    // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for the full test.
+    unsafe {
+        std::env::set_var("CSA_DEPTH", "0");
+        std::env::remove_var("CSA_SESSION_ID");
+    }
+
+    let result =
+        finalize_prompt_text(tmp.path(), "depth zero task".to_string(), None).expect("finalize");
+    let preamble_body = atomic_commit_block(&result, "depth zero task");
+
+    assert!(
+        preamble_body.contains("/commit"),
+        "CSA_DEPTH=0 must still use main-agent /commit instructions; got: {preamble_body}"
+    );
+    assert!(
+        !preamble_body.contains("git commit -m"),
+        "CSA_DEPTH=0 must not use subprocess git commit instructions; got: {preamble_body}"
+    );
+}
+
+#[test]
+fn finalize_prompt_text_uses_subprocess_preamble_when_only_session_id_is_set() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mut sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    sandbox.track_env("CSA_DEPTH");
+    sandbox.track_env("CSA_SESSION_ID");
+    // Treat CSA_SESSION_ID alone as subprocess so detached child contexts still avoid the
+    // unavailable /commit slash-command path.
+    // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for the full test.
+    unsafe {
+        std::env::remove_var("CSA_DEPTH");
+        std::env::set_var("CSA_SESSION_ID", "01KPSX30G8HRHM5RHGBDB2XPSA");
+    }
+
+    let result =
+        finalize_prompt_text(tmp.path(), "session-id task".to_string(), None).expect("finalize");
+    let preamble_body = atomic_commit_block(&result, "session-id task");
+
+    assert!(
+        preamble_body.contains("git commit -m"),
+        "CSA_SESSION_ID fallback must use subprocess git commit instructions; got: {preamble_body}"
+    );
+    assert!(
+        !preamble_body.contains("/commit"),
+        "CSA_SESSION_ID fallback must not reference /commit; got: {preamble_body}"
     );
 }
 
@@ -169,7 +292,7 @@ fn finalize_prompt_text_prepends_review_context_for_skill_only_prompt() {
     let expected_review_context_prefix = format!(
         "<csa-review-context session=\"{session_id}\">\n<!-- summary.md -->\nSummary line\n"
     );
-    assert!(prompt_text.starts_with(crate::run_helpers::ATOMIC_COMMIT_DISCIPLINE_PREAMBLE));
+    assert!(prompt_text.starts_with(crate::run_helpers::atomic_commit_discipline_preamble()));
     let review_context_pos = prompt_text
         .find(&expected_review_context_prefix)
         .expect("review context should appear");

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -8,6 +8,8 @@ use csa_core::types::ToolName;
 use csa_executor::{Executor, ModelSpec, ThinkingBudget};
 use csa_session::TokenUsage;
 
+#[path = "run_helpers_atomic_commit.rs"]
+mod atomic_commit;
 #[path = "run_helpers_edit_requirement.rs"]
 mod edit_requirement;
 #[path = "run_helpers_inline_review_context.rs"]
@@ -19,6 +21,9 @@ mod routing_conflict;
 #[path = "run_helpers_tool_availability.rs"]
 mod tool_availability;
 
+#[cfg(test)]
+pub(crate) use atomic_commit::atomic_commit_discipline_preamble;
+pub(crate) use atomic_commit::prepend_atomic_commit_discipline_to_prompt;
 pub(crate) use edit_requirement::{infer_task_edit_requirement, resolve_task_edit_requirement};
 pub(crate) use inline_review_context::prepend_review_context_to_prompt;
 pub(crate) use prompt::{read_prompt, resolve_positional_stdin_sentinel};
@@ -27,37 +32,6 @@ pub(crate) use tool_availability::{
     ToolBinaryAvailability, is_tool_binary_available_for_config, resolved_tool_binary_name,
     tool_binary_availability,
 };
-
-pub(crate) const ATOMIC_COMMIT_DISCIPLINE_PREAMBLE: &str = r#"<atomic-commit-discipline>
-When this task involves multiple independent logical changes (different
-files, different concerns, different issue references), finish each
-logical change with its own commit before starting the next. Never
-batch unrelated logical changes into one commit.
-
-For EACH logical change:
-  1. Make the code edits for that change only.
-  2. Invoke the `/commit` skill to handle staging, pre-commit gates,
-     two-layer review, and conventional-commit message generation.
-     Do NOT run manual Git staging, commit, or push commands —
-     those are forbidden by AGENTS.md rule 015. The `/commit`
-     skill is the only sanctioned commit path.
-  3. Verify the working tree is clean (post-skill) before starting
-     the next logical change.
-
-If a single logical change must touch multiple unrelated files,
-explain the grouping to `/commit` (it surfaces in the commit body).
-</atomic-commit-discipline>"#;
-
-pub(crate) fn prepend_atomic_commit_discipline_to_prompt(prompt: String) -> String {
-    if prompt.contains("<atomic-commit-discipline>")
-        || prompt.starts_with("# REVIEW:")
-        || prompt.starts_with("# DEBATE:")
-    {
-        return prompt;
-    }
-
-    format!("{ATOMIC_COMMIT_DISCIPLINE_PREAMBLE}\n\n{prompt}")
-}
 
 #[cfg(test)]
 pub(crate) const TEST_SKIP_TOOL_AVAILABILITY_CHECK_ENV: &str =

--- a/crates/cli-sub-agent/src/run_helpers_atomic_commit.rs
+++ b/crates/cli-sub-agent/src/run_helpers_atomic_commit.rs
@@ -1,0 +1,70 @@
+pub(crate) const ATOMIC_COMMIT_DISCIPLINE_PREAMBLE: &str = r#"<atomic-commit-discipline>
+When this task involves multiple independent logical changes (different
+files, different concerns, different issue references), finish each
+logical change with its own commit before starting the next. Never
+batch unrelated logical changes into one commit.
+
+For EACH logical change:
+  1. Make the code edits for that change only.
+  2. Invoke the `/commit` skill to handle staging, pre-commit gates,
+     two-layer review, and conventional-commit message generation.
+     Do NOT run manual Git staging, commit, or push commands —
+     those are forbidden by AGENTS.md rule 015. The `/commit`
+     skill is the only sanctioned commit path.
+  3. Verify the working tree is clean (post-skill) before starting
+     the next logical change.
+
+If a single logical change must touch multiple unrelated files,
+explain the grouping to `/commit` (it surfaces in the commit body).
+</atomic-commit-discipline>"#;
+
+const ATOMIC_COMMIT_DISCIPLINE_SUBPROCESS_PREAMBLE: &str = r#"<atomic-commit-discipline>
+When this task involves multiple independent logical changes (different
+files, different concerns, different issue references), finish each
+logical change with its own commit before starting the next. Never
+batch unrelated logical changes into one commit.
+
+For EACH logical change:
+  1. Make the code edits for that change only.
+  2. Stage the specific files for that change: `git add <path> [<path>...]`.
+     Avoid `git add -A` (may catch forbidden files per AGENTS.md 036).
+  3. Commit with a Conventional Commits message:
+     `git commit -m "type(scope): summary" -m "body"`.
+  4. Verify the working tree reflects the intended state before
+     starting the next logical change.
+
+NOTE: In interactive Claude Code sessions the commit skill handles
+staging, pre-commit gates, two-layer review, and message generation.
+That skill is NOT available in this CSA subprocess context, so direct
+`git add` + `git commit -m` is the sanctioned path here.
+
+If a single logical change must touch multiple unrelated files,
+mention the grouping in the commit body.
+</atomic-commit-discipline>"#;
+
+fn is_csa_subprocess() -> bool {
+    std::env::var("CSA_DEPTH")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .map(|depth| depth > 0)
+        .unwrap_or_else(|| std::env::var_os("CSA_SESSION_ID").is_some())
+}
+
+pub(crate) fn atomic_commit_discipline_preamble() -> &'static str {
+    if is_csa_subprocess() {
+        ATOMIC_COMMIT_DISCIPLINE_SUBPROCESS_PREAMBLE
+    } else {
+        ATOMIC_COMMIT_DISCIPLINE_PREAMBLE
+    }
+}
+
+pub(crate) fn prepend_atomic_commit_discipline_to_prompt(prompt: String) -> String {
+    if prompt.contains("<atomic-commit-discipline>")
+        || prompt.starts_with("# REVIEW:")
+        || prompt.starts_with("# DEBATE:")
+    {
+        return prompt;
+    }
+
+    format!("{}\n\n{prompt}", atomic_commit_discipline_preamble())
+}


### PR DESCRIPTION
## Summary

- Fix for #1021: atomic-commit preamble added by #717 (PR #1020) tells employee agents to invoke the `/commit` slash-command skill, which is NOT available in CSA subprocess context.
- Symptom: codex session completes exit 0 with everything staged but NO commit — it follows the preamble, tries `/commit`, finds it missing, and exits. Layer 0 orchestrator has to rescue with an explicit override clause.
- Detects CSA subprocess context via `CSA_DEPTH > 0`. When subprocess, emits an alternate preamble variant that instructs direct `git add` + `git commit -m` with a NOTE explaining why `/commit` is unavailable. When main-agent context, keeps the existing #717 preamble verbatim.
- Discipline (one commit per logical change) preserved in both variants — only the mechanism-string differs.
- Unit tests pin the env-conditional dispatch so the split can't regress.

## Test plan

- [x] `cargo test -p cli-sub-agent finalize_prompt_text` green — both #717 tests (no CSA_DEPTH → main-agent variant) and new tests (CSA_DEPTH=1 → subprocess variant)
- [x] `just pre-commit` exit 0
- [ ] Dispatch any `csa run --sa-mode true` employee session and verify it self-commits directly (no manual rescue needed)

Closes #1021.
