### PR TITLE
feat(csa-config): [tools.<name>].transport config key (#643 Phase 2)

### DIFF
--- a/.claude/rules/csa-architecture-ref.md
+++ b/.claude/rules/csa-architecture-ref.md
@@ -50,6 +50,7 @@ Rust edition 2024, rust-version 1.88. `anyhow` (app) + `thiserror` (lib). `tokio
 ## Configuration
 
 Project: `.csa/config.toml` (project metadata, tiers, resources, MCP). Global: `~/.config/cli-sub-agent/config.toml` (API keys, concurrency, defaults). Project overrides global via merge. Key sections: `[tools]`, `[tiers]`, `[resources]`, `[review]`, `[debate]`, `[session]`, `[mcp_servers]`, `[setting_sources]`, `[pr_review]`, `[gc]`.
+Per-tool transport: `[tools.<name>].transport = "auto" | "acp" | "cli"`; currently `claude-code`/`codex` accept `auto|acp`, `gemini-cli`/`opencode` accept `auto|cli`.
 → `.agents/project-rules-ref/config.md`
 
 **tier-routing** — When `[tiers]` are configured, direct `--tool`/`--model`/`--thinking` is blocked by default across `csa run`, `csa review`, and `csa debate`. Callers must use `--tier <name>` to select a tier by name, which resolves tool/model/thinking from the tier definition. Override with `--force-ignore-tier-setting` (alias: `--force-tier`) to bypass. The existing `--force` flag also bypasses tier enforcement. When no tiers are configured (empty `[tiers]`), all existing behavior is preserved. Priority chain: CLI `--tier` > config tier > CLI `--tool` (with force) > config tool > auto-select.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.492"
+version = "0.1.493"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3100,7 +3100,7 @@ dependencies = [
  "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3125,9 +3125,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.492"
+version = "0.1.493"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -11,6 +11,9 @@ use csa_core::types::OutputFormat;
 #[path = "config_cmds_helpers.rs"]
 mod helpers;
 use helpers::{format_missing_key_message, format_toml_value, resolve_key, suggest_key_paths};
+#[path = "config_cmds_display.rs"]
+mod display;
+use display::{inject_resolved_tool_transports_json, inject_resolved_tool_transports_toml};
 
 pub(crate) fn handle_config_show(cd: Option<String>, format: OutputFormat) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
@@ -685,26 +688,30 @@ fn build_execution_toml(execution: &csa_config::ExecutionConfig) -> toml::Value 
 
 fn build_project_display_toml(config: &ProjectConfig) -> Result<toml::Value> {
     let mut root = toml::Value::try_from(config.clone())?;
-    root.as_table_mut()
-        .expect("serialized project config should be a TOML table")
-        .insert(
-            "execution".to_string(),
-            build_execution_toml(&config.execution),
-        );
+    let root_table = root
+        .as_table_mut()
+        .expect("serialized project config should be a TOML table");
+    root_table.insert(
+        "execution".to_string(),
+        build_execution_toml(&config.execution),
+    );
+    inject_resolved_tool_transports_toml(root_table, config);
     Ok(root)
 }
 
 fn build_project_display_json(config: &ProjectConfig) -> Result<serde_json::Value> {
     let mut root = serde_json::to_value(config)?;
-    root.as_object_mut()
-        .expect("serialized project config should be a JSON object")
-        .insert(
-            "execution".to_string(),
-            serde_json::json!({
-                "min_timeout_seconds": config.execution.min_timeout_seconds,
-                "auto_weave_upgrade": config.execution.auto_weave_upgrade,
-            }),
-        );
+    let root_object = root
+        .as_object_mut()
+        .expect("serialized project config should be a JSON object");
+    root_object.insert(
+        "execution".to_string(),
+        serde_json::json!({
+            "min_timeout_seconds": config.execution.min_timeout_seconds,
+            "auto_weave_upgrade": config.execution.auto_weave_upgrade,
+        }),
+    );
+    inject_resolved_tool_transports_json(root_object, config);
     Ok(root)
 }
 
@@ -766,6 +773,10 @@ pub(crate) fn handle_config_validate(cd: Option<String>) -> Result<()> {
 #[cfg(test)]
 #[path = "config_cmds_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "config_cmds_transport_display_tests.rs"]
+mod transport_display_tests;
 
 #[cfg(test)]
 #[path = "config_cmds_lookup_tests.rs"]

--- a/crates/cli-sub-agent/src/config_cmds_display.rs
+++ b/crates/cli-sub-agent/src/config_cmds_display.rs
@@ -1,0 +1,65 @@
+use csa_config::ProjectConfig;
+
+pub(super) fn inject_resolved_tool_transports_toml(
+    root: &mut toml::map::Map<String, toml::Value>,
+    config: &ProjectConfig,
+) {
+    let Some(tools) = root.get_mut("tools").and_then(toml::Value::as_table_mut) else {
+        return;
+    };
+
+    for (tool_name, tool_config) in &config.tools {
+        let Some(resolved_transport) = tool_config.resolve_transport(tool_name) else {
+            continue;
+        };
+        let Some(tool_table) = tools.get_mut(tool_name).and_then(toml::Value::as_table_mut) else {
+            continue;
+        };
+        tool_table.insert(
+            "transport".to_string(),
+            toml::Value::String(
+                match resolved_transport {
+                    csa_config::TransportKind::Auto => "auto",
+                    csa_config::TransportKind::Cli => "cli",
+                    csa_config::TransportKind::Acp => "acp",
+                }
+                .to_string(),
+            ),
+        );
+    }
+}
+
+pub(super) fn inject_resolved_tool_transports_json(
+    root: &mut serde_json::Map<String, serde_json::Value>,
+    config: &ProjectConfig,
+) {
+    let Some(tools) = root
+        .get_mut("tools")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+
+    for (tool_name, tool_config) in &config.tools {
+        let Some(resolved_transport) = tool_config.resolve_transport(tool_name) else {
+            continue;
+        };
+        let Some(tool_object) = tools
+            .get_mut(tool_name)
+            .and_then(serde_json::Value::as_object_mut)
+        else {
+            continue;
+        };
+        tool_object.insert(
+            "transport".to_string(),
+            serde_json::Value::String(
+                match resolved_transport {
+                    csa_config::TransportKind::Auto => "auto",
+                    csa_config::TransportKind::Cli => "cli",
+                    csa_config::TransportKind::Acp => "acp",
+                }
+                .to_string(),
+            ),
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/config_cmds_transport_display_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_transport_display_tests.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+#[test]
+fn build_project_display_toml_resolves_tool_transport_for_display() {
+    let config: ProjectConfig = toml::from_str(
+        r#"
+schema_version = 1
+
+[tools.codex]
+transport = "auto"
+"#,
+    )
+    .unwrap();
+    let rendered = toml::to_string_pretty(&build_project_display_toml(&config).unwrap()).unwrap();
+
+    assert!(rendered.contains("[tools.codex]"));
+    assert!(rendered.contains("transport = \"acp\""));
+}
+
+#[test]
+fn build_project_display_json_resolves_tool_transport_for_display() {
+    let config: ProjectConfig = toml::from_str(
+        r#"
+schema_version = 1
+
+[tools.codex]
+transport = "auto"
+"#,
+    )
+    .unwrap();
+    let rendered = build_project_display_json(&config).unwrap();
+
+    assert_eq!(
+        rendered
+            .get("tools")
+            .and_then(|value| value.get("codex"))
+            .and_then(|value| value.get("transport"))
+            .and_then(|value| value.as_str()),
+        Some("acp")
+    );
+}

--- a/crates/cli-sub-agent/src/debate_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_execute_tier_tests.rs
@@ -26,8 +26,6 @@ fn install_pattern(project_root: &Path, name: &str) {
 #[cfg(unix)]
 #[tokio::test]
 async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
-    use csa_config::ToolTransport;
-
     if which::which("bwrap").is_err() {
         eprintln!("skipping: bwrap not installed (CI gap, see #987)");
         return;
@@ -38,22 +36,22 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
 
-    let codex_invocation_log = project_dir.path().join("codex-invocations.log");
     let gemini_invocation_log = project_dir.path().join("gemini-invocations.log");
-    let codex_invocation_log_str = codex_invocation_log.display().to_string();
+    let codex_invocation_log = project_dir.path().join("codex-invocations.log");
     let gemini_invocation_log_str = gemini_invocation_log.display().to_string();
+    let codex_invocation_log_str = codex_invocation_log.display().to_string();
 
     for (binary, body) in [
         (
-            "codex",
+            "gemini",
             format!(
-                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-cli 1.0.0\\n'\n  exit 0\nfi\ncount=0\nif [ -f \"{codex_invocation_log_str}\" ]; then\n  count=$(wc -l < \"{codex_invocation_log_str}\")\nfi\nnext=$((count + 1))\nprintf 'attempt-%s\\n' \"$next\" >> \"{codex_invocation_log_str}\"\nif [ \"$next\" -eq 1 ]; then\n  printf 'HTTP 429 rate limit\\n' >&2\n  exit 1\nfi\nprintf '%s\\n' 'Verdict: APPROVE' 'Confidence: high' 'Summary: Debate succeeded via second codex tier candidate.' '- Fallback stayed within the codex whitelist.'\n"
+                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\ncount=0\nif [ -f \"{gemini_invocation_log_str}\" ]; then\n  count=$(wc -l < \"{gemini_invocation_log_str}\")\nfi\nnext=$((count + 1))\nprintf 'attempt-%s\\n' \"$next\" >> \"{gemini_invocation_log_str}\"\nif [ \"$next\" -eq 1 ]; then\n  printf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\n  exit 1\nfi\nprintf '%s\\n' 'Verdict: APPROVE' 'Confidence: high' 'Summary: Debate succeeded via second gemini tier candidate.' '- Fallback stayed within the gemini whitelist.'\n"
             ),
         ),
         (
-            "gemini",
+            "codex-acp",
             format!(
-                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf 'gemini should not be invoked\\n' >> \"{gemini_invocation_log_str}\"\nprintf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\nexit 1\n"
+                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-acp 1.0.0\\n'\n  exit 0\nfi\nprintf 'codex should not be invoked\\n' >> \"{codex_invocation_log_str}\"\nexit 1\n"
             ),
         ),
     ] {
@@ -71,7 +69,6 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
 
     let mut config = project_config_with_enabled_tools(&["codex", "gemini-cli"]);
-    config.tools.get_mut("codex").unwrap().transport = Some(ToolTransport::Cli);
     config.review = Some(csa_config::ReviewConfig {
         gate_command: Some("true".to_string()),
         ..Default::default()
@@ -81,9 +78,9 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
         csa_config::config::TierConfig {
             description: "quality".to_string(),
             models: vec![
-                "codex/openai/gpt-5.4/medium".to_string(),
-                "codex/openai/gpt-5/high".to_string(),
+                "gemini-cli/google/gemini-3.1-pro-preview/medium".to_string(),
                 "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+                "codex/openai/gpt-5/high".to_string(),
             ],
             strategy: csa_config::TierStrategy::default(),
             token_budget: None,
@@ -97,7 +94,7 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
         project_dir.path(),
         Some("debate explicit-tool tier fallback"),
         None,
-        Some("codex"),
+        Some("gemini-cli"),
     )
     .unwrap();
 
@@ -108,7 +105,7 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
         "--cd",
         &cd,
         "--tool",
-        "codex",
+        "gemini-cli",
         "--tier",
         "quality",
         "--session",
@@ -118,14 +115,14 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
 
     let exit_code = handle_debate(args, 0, csa_core::types::OutputFormat::Json)
         .await
-        .expect("explicit codex debate tier fallback should succeed");
+        .expect("explicit gemini debate tier fallback should succeed");
     assert_eq!(exit_code, 0);
 
-    let codex_invocations = std::fs::read_to_string(&codex_invocation_log).unwrap();
-    assert_eq!(codex_invocations.lines().count(), 2);
+    let gemini_invocations = std::fs::read_to_string(&gemini_invocation_log).unwrap();
+    assert_eq!(gemini_invocations.lines().count(), 2);
     assert!(
-        !gemini_invocation_log.exists(),
-        "gemini should not be invoked when --tool codex whitelists codex-only candidates"
+        !codex_invocation_log.exists(),
+        "codex should not be invoked when --tool gemini-cli whitelists gemini-only candidates"
     );
 
     let session_dir =
@@ -138,16 +135,16 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
     assert_eq!(parsed["verdict"], "APPROVE");
     assert_eq!(
         parsed["summary"],
-        "Debate succeeded via second codex tier candidate."
+        "Debate succeeded via second gemini tier candidate."
     );
     assert!(parsed["failure_reason"].is_null());
 
     let result = csa_session::load_result(project_dir.path(), &session.meta_session_id)
         .unwrap()
         .expect("result.toml should exist");
-    assert_eq!(result.tool, "codex");
+    assert_eq!(result.tool, "gemini-cli");
     assert_eq!(
         result.summary,
-        "Debate succeeded via second codex tier candidate."
+        "Debate succeeded via second gemini tier candidate."
     );
 }

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -3,7 +3,7 @@ use crate::debate_cmd_output::*;
 use crate::debate_cmd_resolve::resolve_debate_tool;
 use crate::test_env_lock::TEST_ENV_LOCK;
 use csa_config::global::ReviewConfig;
-use csa_config::{GlobalConfig, ProjectConfig, ToolTransport};
+use csa_config::{GlobalConfig, ProjectConfig};
 use csa_config::{ProjectMeta, ResourcesConfig, ToolConfig};
 use csa_core::types::ToolName;
 use csa_session::{SessionArtifact, create_session, load_result, save_result};

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -258,7 +258,7 @@ fn resolve_debate_tool_auto_skips_counterpart_without_configured_binary() {
     cfg.tools
         .get_mut("codex")
         .expect("codex tool config")
-        .transport = Some(ToolTransport::Cli);
+        .transport = Some(csa_config::TransportKind::Cli);
 
     let err = resolve_debate_tool(
         None,
@@ -312,7 +312,7 @@ fn resolve_debate_tool_same_model_fallback_skips_unavailable_configured_binary()
     cfg.tools
         .get_mut("codex")
         .expect("codex tool config")
-        .transport = Some(ToolTransport::Cli);
+        .transport = Some(csa_config::TransportKind::Cli);
 
     let err = resolve_debate_tool(
         None,
@@ -366,7 +366,7 @@ fn resolve_debate_tool_same_model_fallback_skips_unavailable_parent_binary() {
     cfg.tools
         .get_mut("codex")
         .expect("codex tool config")
-        .transport = Some(ToolTransport::Cli);
+        .transport = Some(csa_config::TransportKind::Cli);
 
     let err = resolve_debate_tool(
         None,
@@ -572,7 +572,7 @@ async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
     let mut config = project_config_with_enabled_tools(&["codex", "gemini-cli"]);
-    config.tools.get_mut("codex").unwrap().transport = Some(ToolTransport::Cli);
+    config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);
     config.tiers.insert(
         "quality".to_string(),
         csa_config::config::TierConfig {

--- a/crates/cli-sub-agent/src/doctor.rs
+++ b/crates/cli-sub-agent/src/doctor.rs
@@ -1,7 +1,7 @@
 //! Environment diagnostics for CSA.
 
 use anyhow::Result;
-use csa_config::{ProjectConfig, ToolTransport, paths};
+use csa_config::{ProjectConfig, TransportKind, paths};
 use csa_core::types::OutputFormat;
 use csa_executor::{CodexRuntimeMetadata, CodexTransport};
 use csa_resource::filesystem_sandbox::{FilesystemCapability, detect_filesystem_capability};
@@ -24,7 +24,6 @@ pub use doctor_routing::run_doctor_routing;
 enum ToolAvailabilityState {
     Installed,
     Missing,
-    Unsupported,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -199,8 +198,9 @@ fn resolved_codex_transport(config: Option<&ProjectConfig>) -> CodexTransport {
     config
         .and_then(|cfg| cfg.tool_transport("codex"))
         .map(|transport| match transport {
-            ToolTransport::Cli => CodexTransport::Cli,
-            ToolTransport::Acp => CodexTransport::Acp,
+            TransportKind::Cli => CodexTransport::Cli,
+            TransportKind::Acp => CodexTransport::Acp,
+            TransportKind::Auto => unreachable!("tool_transport() returns resolved transports"),
         })
         .unwrap_or_else(CodexTransport::default_for_build)
 }
@@ -468,14 +468,6 @@ fn check_tool_status(tool_name: &'static str, config: Option<&ProjectConfig>) ->
             hint: Some(hint.into_owned()),
             codex_transport: codex_doctor_status(tool_name, config),
         },
-        crate::run_helpers::ToolBinaryAvailability::Unsupported { hint, .. } => ToolStatus {
-            name: tool_name,
-            availability: ToolAvailabilityState::Unsupported,
-            binary_name,
-            version: None,
-            hint: Some(hint.into_owned()),
-            codex_transport: codex_doctor_status(tool_name, config),
-        },
     }
 }
 
@@ -508,7 +500,6 @@ fn render_tool_status_lines(status: &ToolStatus) -> Vec<String> {
             .map(|version| format!("installed ({version})"))
             .unwrap_or_else(|| "installed (version unknown)".to_string()),
         ToolAvailabilityState::Missing => "not found".to_string(),
-        ToolAvailabilityState::Unsupported => "unsupported".to_string(),
     };
 
     let mut lines = vec![format!(

--- a/crates/cli-sub-agent/src/doctor_routing.rs
+++ b/crates/cli-sub-agent/src/doctor_routing.rs
@@ -542,7 +542,7 @@ mod tests {
         let config: ProjectConfig = toml::from_str("").unwrap();
 
         assert_eq!(tool_exe_name("gemini-cli", &config), "gemini");
-        assert_eq!(tool_exe_name("codex", &config), "codex");
+        assert_eq!(tool_exe_name("codex", &config), "codex-acp");
         assert_eq!(tool_exe_name("claude-code", &config), "claude-code-acp");
         assert_eq!(tool_exe_name("opencode", &config), "opencode");
         assert_eq!(tool_exe_name("unknown-tool", &config), "unknown-tool");
@@ -709,7 +709,7 @@ transport = "cli"
             td.path(),
             r#"
 [tools.codex]
-transport = "cli"
+transport = "acp"
 
 [tiers.tier-1]
 description = "Test"
@@ -736,7 +736,7 @@ default = "tier-1"
         assert!(
             report.diagnostics[0]
                 .message
-                .contains("[tools.claude-code].transport"),
+                .contains("tools.claude-code.transport"),
             "diagnostic should surface the merged-config key: {:?}",
             report.diagnostics[0]
         );
@@ -766,7 +766,7 @@ default = "tier-1"
             json["diagnostics"][0]["message"]
                 .as_str()
                 .expect("routing json diagnostic message")
-                .contains("[tools.claude-code].transport"),
+                .contains("tools.claude-code.transport"),
             "json output should surface the merged-config key: {json}"
         );
         assert_eq!(json["context"]["vcs_backend"], serde_json::json!("git"));

--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -1,16 +1,12 @@
 use super::*;
 use crate::test_env_lock::{ScopedTestEnvVar, TEST_ENV_LOCK};
-#[cfg(not(feature = "codex-acp"))]
-use csa_config::{ProjectMeta, ResourcesConfig, ToolConfig, ToolTransport};
-#[cfg(not(feature = "codex-acp"))]
+use csa_config::{ProjectMeta, ResourcesConfig, ToolConfig, TransportKind};
 use serde_json::Value;
-#[cfg(not(feature = "codex-acp"))]
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::Path;
 
-#[cfg(not(feature = "codex-acp"))]
-fn project_config_with_codex_transport(transport: ToolTransport) -> ProjectConfig {
+fn project_config_with_codex_transport(transport: TransportKind) -> ProjectConfig {
     let mut tools = HashMap::new();
     tools.insert(
         "codex".to_string(),
@@ -85,11 +81,14 @@ fn with_stubbed_codex_on_path<T>(test_fn: impl FnOnce() -> T) -> T {
     let td = tempfile::tempdir().expect("tempdir");
     let bin_dir = td.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
-    let codex_path = bin_dir.join("codex");
-    fs::write(&codex_path, "#!/bin/sh\necho 'codex 1.2.3'\n").expect("write codex stub");
-    let mut perms = fs::metadata(&codex_path).expect("metadata").permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(&codex_path, perms).expect("chmod codex");
+    for binary in ["codex", "codex-acp"] {
+        let binary_path = bin_dir.join(binary);
+        fs::write(&binary_path, format!("#!/bin/sh\necho '{binary} 1.2.3'\n"))
+            .expect("write codex stub");
+        let mut perms = fs::metadata(&binary_path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&binary_path, perms).expect("chmod codex stub");
+    }
 
     let path = std::env::var_os("PATH").unwrap_or_default();
     let joined =
@@ -122,21 +121,21 @@ fn test_check_tool_status_nonexistent() {
     assert!(status.version.is_none());
 }
 
-#[cfg(all(unix, not(feature = "codex-acp")))]
+#[cfg(unix)]
 #[test]
-fn default_build_doctor_accepts_codex_cli_runtime() {
+fn default_build_doctor_accepts_codex_acp_runtime() {
     with_stubbed_codex_on_path(|| {
         let status = check_tool_status("codex", None);
         assert!(
             status.is_ready(),
-            "doctor should accept the default codex CLI"
+            "doctor should accept the default codex ACP transport"
         );
-        assert_eq!(status.binary_name, "codex");
+        assert_eq!(status.binary_name, "codex-acp");
         assert!(status.hint.is_none());
     });
 }
 
-#[cfg(all(unix, not(feature = "codex-acp")))]
+#[cfg(unix)]
 #[test]
 fn default_build_doctor_text_output_reports_codex_transport_details() {
     with_stubbed_codex_on_path(|| {
@@ -144,57 +143,60 @@ fn default_build_doctor_text_output_reports_codex_transport_details() {
         let rendered = render_tool_status_lines(&status).join("\n");
 
         assert!(
-            rendered.contains("Active transport: cli"),
+            rendered.contains("Active transport: acp"),
             "doctor text should report active codex transport: {rendered}"
         );
         assert!(
-            rendered.contains("ACP compiled in: no"),
-            "doctor text should report that ACP is not compiled in by default: {rendered}"
+            rendered.contains("ACP compiled in:"),
+            "doctor text should report ACP compile status: {rendered}"
         );
         assert!(
-            rendered.contains("Probed binary: codex"),
-            "doctor text should report the probed codex binary: {rendered}"
+            rendered.contains("Probed binary: codex-acp"),
+            "doctor text should report the probed codex ACP binary: {rendered}"
         );
     });
 }
 
-#[cfg(all(unix, not(feature = "codex-acp")))]
+#[cfg(unix)]
 #[test]
 fn default_build_doctor_json_output_reports_codex_transport_details() {
     with_stubbed_codex_on_path(|| {
         let status = check_tool_status("codex", None);
         let json = tool_status_json(&status);
 
-        assert_eq!(json["transport_active"], Value::String("cli".to_string()));
-        assert_eq!(json["acp_compiled_in"], Value::Bool(false));
-        assert_eq!(json["probed_binary"], Value::String("codex".to_string()));
+        assert_eq!(json["transport_active"], Value::String("acp".to_string()));
+        assert_eq!(
+            json["acp_compiled_in"],
+            Value::Bool(csa_executor::CodexRuntimeMetadata::acp_compiled_in())
+        );
+        assert_eq!(
+            json["probed_binary"],
+            Value::String("codex-acp".to_string())
+        );
     });
 }
 
-#[cfg(all(unix, not(feature = "codex-acp")))]
+#[cfg(unix)]
 #[test]
-fn explicit_codex_acp_transport_reports_rebuild_hint() {
+fn explicit_codex_acp_transport_reports_install_hint() {
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
-    let config = project_config_with_codex_transport(ToolTransport::Acp);
+    let td = tempfile::tempdir().expect("tempdir");
+    let _path_guard = EnvVarGuard::set("PATH", td.path().join("bin"));
+    let config = project_config_with_codex_transport(TransportKind::Acp);
     let status = check_tool_status("codex", Some(&config));
     let rendered = render_tool_status_lines(&status).join("\n");
 
-    assert_eq!(status.availability, ToolAvailabilityState::Unsupported);
+    assert_eq!(status.availability, ToolAvailabilityState::Missing);
     assert!(
         rendered.contains("Active transport: acp"),
         "doctor text should report the requested ACP transport: {rendered}"
     );
     assert!(
-        rendered.contains("ACP compiled in: no"),
-        "doctor text should report missing ACP compile support: {rendered}"
-    );
-    assert!(
-        rendered.contains("cargo build --features codex-acp"),
-        "doctor text should surface the rebuild hint from tool availability plumbing: {rendered}"
+        rendered.contains("@zed-industries/codex-acp"),
+        "doctor text should surface the ACP adapter install hint: {rendered}"
     );
 }
 
-#[cfg(not(feature = "codex-acp"))]
 #[test]
 fn doctor_load_rejects_invalid_codex_transport_override() {
     let td = tempfile::tempdir().expect("tempdir");
@@ -202,7 +204,7 @@ fn doctor_load_rejects_invalid_codex_transport_override() {
         td.path(),
         r#"
 [tools.codex]
-transport = "acp"
+transport = "cli"
 "#,
     );
 
@@ -210,12 +212,12 @@ transport = "acp"
     let message = format!("{err:#}");
 
     assert!(
-        message.contains("[tools.codex].transport"),
+        message.contains("tools.codex.transport"),
         "doctor should surface the exact config key: {message}"
     );
     assert!(
-        message.contains("codex-acp"),
-        "doctor should surface the missing feature guidance: {message}"
+        message.contains("#643 Phase 4"),
+        "doctor should surface the codex CLI phase guidance: {message}"
     );
 }
 
@@ -247,7 +249,7 @@ transport = "stdio"
         "doctor text should use the existing invalid config branch: {rendered}"
     );
     assert!(
-        rendered.contains("Invalid [tools.codex].transport"),
+        rendered.contains("Invalid tools.codex.transport"),
         "doctor text should surface the exact invalid transport key: {rendered}"
     );
     assert!(
@@ -276,7 +278,7 @@ transport = "stdio"
     assert_eq!(config["found"], serde_json::json!(true));
     assert_eq!(config["valid"], serde_json::json!(false));
     assert!(
-        error.contains("Invalid [tools.codex].transport"),
+        error.contains("Invalid tools.codex.transport"),
         "doctor JSON should surface the exact invalid transport key: {error}"
     );
     assert!(
@@ -310,13 +312,13 @@ transport = "cli"
         td.path(),
         r#"
 [tools.codex]
-transport = "cli"
+transport = "acp"
 "#,
     );
 
     let merged_error = ProjectConfig::load(td.path()).expect_err("merged load should fail");
     assert!(
-        format!("{merged_error:#}").contains("[tools.claude-code].transport"),
+        format!("{merged_error:#}").contains("tools.claude-code.transport"),
         "test fixture should exercise an invalid user-level transport override: {merged_error}"
     );
 
@@ -358,7 +360,7 @@ transport = "cli"
         td.path(),
         r#"
 [tools.codex]
-transport = "cli"
+transport = "acp"
 "#,
     );
 
@@ -380,7 +382,7 @@ transport = "cli"
         "doctor text should surface the invalid effective-config branch: {rendered}"
     );
     assert!(
-        rendered.contains("[tools.claude-code].transport"),
+        rendered.contains("tools.claude-code.transport"),
         "doctor text should surface the exact merged-config key: {rendered}"
     );
     assert!(
@@ -419,7 +421,7 @@ transport = "cli"
         td.path(),
         r#"
 [tools.codex]
-transport = "cli"
+transport = "acp"
 "#,
     );
 
@@ -435,7 +437,7 @@ transport = "cli"
     assert_eq!(report["config"]["valid"], serde_json::json!(true));
     assert_eq!(effective["valid"], serde_json::json!(false));
     assert!(
-        effective_error.contains("[tools.claude-code].transport"),
+        effective_error.contains("tools.claude-code.transport"),
         "doctor JSON should surface the exact merged-config key: {effective_error}"
     );
     assert!(
@@ -457,8 +459,8 @@ fn feature_build_doctor_text_output_reports_acp_compile_status() {
             "feature build should report that ACP support is compiled in: {rendered}"
         );
         assert!(
-            rendered.contains("ACP override: set [tools.codex].transport = \"acp\""),
-            "feature build should surface the opt-in override when active transport is CLI: {rendered}"
+            rendered.contains("Active transport: acp"),
+            "feature build should report the default ACP transport: {rendered}"
         );
     });
 }

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -91,7 +91,6 @@ fn load_and_validate_within_depth_returns_some() {
     );
 }
 
-#[cfg(not(feature = "codex-acp"))]
 #[test]
 fn load_and_validate_rejects_invalid_codex_transport_override() {
     let tmp = tempfile::tempdir().unwrap();
@@ -102,7 +101,7 @@ fn load_and_validate_rejects_invalid_codex_transport_override() {
         config_dir.join("config.toml"),
         r#"
 [tools.codex]
-transport = "acp"
+transport = "cli"
 "#,
     )
     .unwrap();
@@ -111,12 +110,12 @@ transport = "acp"
     let message = format!("{err:#}");
 
     assert!(
-        message.contains("[tools.codex].transport"),
+        message.contains("tools.codex.transport"),
         "pipeline should surface the exact config key: {message}"
     );
     assert!(
-        message.contains("codex-acp"),
-        "pipeline should surface the missing feature guidance: {message}"
+        message.contains("#643 Phase 4"),
+        "pipeline should surface the codex CLI phase guidance: {message}"
     );
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -96,6 +96,9 @@ fn exact_test_config_with_review_tier(
     models: &[&str],
 ) -> csa_config::ProjectConfig {
     let mut config = exact_test_project_config_with_enabled_tools(enabled_tools);
+    if enabled_tools.contains(&"codex") {
+        config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);
+    }
     config.tiers.insert(
         "quality".to_string(),
         TierConfig {

--- a/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
@@ -126,12 +126,9 @@ async fn execute_review_preserves_codex_default_target_when_project_target_exist
 
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
-    let fake_codex = bin_dir.join("codex");
     let cargo_target_log = project_dir.path().join("cargo-target-dir.log");
-    std::fs::write(
-        &fake_codex,
-        format!(
-            "#!/bin/sh\n\
+    let codex_stub = format!(
+        "#!/bin/sh\n\
 printf '%s' \"${{CARGO_TARGET_DIR:-}}\" > \"{}\"\n\
 printf '%s\\n' \
 '<!-- CSA:SECTION:summary -->' \
@@ -141,20 +138,23 @@ printf '%s\\n' \
 '<!-- CSA:SECTION:details -->' \
 'Review used default cargo target behavior.' \
 '<!-- CSA:SECTION:details:END -->'\n",
-            cargo_target_log.display()
-        ),
-    )
-    .unwrap();
-    let mut perms = std::fs::metadata(&fake_codex).unwrap().permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&fake_codex, perms).unwrap();
+        cargo_target_log.display()
+    );
+    for binary in ["codex", "codex-acp"] {
+        let fake_codex = bin_dir.join(binary);
+        std::fs::write(&fake_codex, &codex_stub).unwrap();
+        let mut perms = std::fs::metadata(&fake_codex).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, perms).unwrap();
+    }
 
     let inherited_path = std::env::var("PATH").unwrap_or_default();
     let patched_path = format!("{}:{inherited_path}", bin_dir.display());
     let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
     let _bwrap_preflight_guard = ScopedEnvVarRestore::set("CSA_SKIP_BWRAP_PREFLIGHT", "1");
 
-    let config = project_config_with_enabled_tools(&["codex"]);
+    let mut config = project_config_with_enabled_tools(&["codex"]);
+    config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);
     let global = GlobalConfig::default();
     let result = execute_review(
         ToolName::Codex,

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
@@ -9,6 +9,9 @@ use csa_session::{ReviewVerdictArtifact, state::ReviewSessionMeta};
 
 fn config_with_review_tier(enabled_tools: &[&str], models: &[&str]) -> csa_config::ProjectConfig {
     let mut config = project_config_with_enabled_tools(enabled_tools);
+    if enabled_tools.contains(&"codex") {
+        config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);
+    }
     config.tiers.insert(
         "quality".to_string(),
         TierConfig {
@@ -166,14 +169,13 @@ async fn execute_review_advances_tier_fallback_when_explicit_tool_and_tier() {
         ),
     )
     .unwrap();
-    std::fs::write(
-        bin_dir.join("codex"),
-        format!(
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-cli 1.0.0\\n'\n  exit 0\nfi\ncount=0\nif [ -f \"{codex_invocation_log_str}\" ]; then\n  count=$(wc -l < \"{codex_invocation_log_str}\")\nfi\nnext=$((count + 1))\nprintf 'attempt-%s\\n' \"$next\" >> \"{codex_invocation_log_str}\"\nif [ \"$next\" -eq 1 ]; then\n  printf 'HTTP 429 rate limit\\n' >&2\n  exit 1\nfi\nprintf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS via fallback codex variant' '<!-- CSA:SECTION:summary:END -->' '<!-- CSA:SECTION:details -->' 'No blocking issues found after falling back to the second codex tier candidate.' '<!-- CSA:SECTION:details:END -->'\n"
-        ),
-    )
-    .unwrap();
-    for binary in ["gemini", "codex"] {
+    let codex_stub = format!(
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-cli 1.0.0\\n'\n  exit 0\nfi\ncount=0\nif [ -f \"{codex_invocation_log_str}\" ]; then\n  count=$(wc -l < \"{codex_invocation_log_str}\")\nfi\nnext=$((count + 1))\nprintf 'attempt-%s\\n' \"$next\" >> \"{codex_invocation_log_str}\"\nif [ \"$next\" -eq 1 ]; then\n  printf 'HTTP 429 rate limit\\n' >&2\n  exit 1\nfi\nprintf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS via fallback codex variant' '<!-- CSA:SECTION:summary:END -->' '<!-- CSA:SECTION:details -->' 'No blocking issues found after falling back to the second codex tier candidate.' '<!-- CSA:SECTION:details:END -->'\n"
+    );
+    for binary in ["codex", "codex-acp"] {
+        std::fs::write(bin_dir.join(binary), &codex_stub).unwrap();
+    }
+    for binary in ["gemini", "codex", "codex-acp"] {
         let path = bin_dir.join(binary);
         let mut perms = std::fs::metadata(&path).unwrap().permissions();
         perms.set_mode(0o755);
@@ -297,17 +299,19 @@ async fn execute_review_marks_unavailable_when_all_tier_models_fail() {
         "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\nexit 1\n",
     )
     .unwrap();
-    std::fs::write(
-        bin_dir.join("codex"),
-        "#!/bin/sh\nprintf 'HTTP 401 Invalid API key\\n' >&2\nexit 1\n",
-    )
-    .unwrap();
+    for binary in ["codex", "codex-acp"] {
+        std::fs::write(
+            bin_dir.join(binary),
+            "#!/bin/sh\nprintf 'HTTP 401 Invalid API key\\n' >&2\nexit 1\n",
+        )
+        .unwrap();
+    }
     std::fs::write(
         bin_dir.join("claude-code-acp"),
         "#!/bin/sh\nprintf 'HTTP 403 Forbidden\\n' >&2\nexit 1\n",
     )
     .unwrap();
-    for binary in ["gemini", "codex", "claude-code-acp"] {
+    for binary in ["gemini", "codex", "codex-acp", "claude-code-acp"] {
         let path = bin_dir.join(binary);
         let mut perms = std::fs::metadata(&path).unwrap().permissions();
         perms.set_mode(0o755);
@@ -449,12 +453,14 @@ async fn execute_review_does_not_advance_tier_on_http_5xx() {
         "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf 'HTTP 500 Internal Server Error\\n' >&2\nexit 1\n",
     )
     .unwrap();
-    std::fs::write(
-        bin_dir.join("codex"),
-        "#!/bin/sh\nprintf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS' '<!-- CSA:SECTION:summary:END -->'\n",
-    )
-    .unwrap();
-    for binary in ["gemini", "codex"] {
+    for binary in ["codex", "codex-acp"] {
+        std::fs::write(
+            bin_dir.join(binary),
+            "#!/bin/sh\nprintf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS' '<!-- CSA:SECTION:summary:END -->'\n",
+        )
+        .unwrap();
+    }
+    for binary in ["gemini", "codex", "codex-acp"] {
         let path = bin_dir.join(binary);
         let mut perms = std::fs::metadata(&path).unwrap().permissions();
         perms.set_mode(0o755);

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -6,7 +6,7 @@ use crate::cli::{Cli, Commands, ReviewMode, validate_review_args};
 use crate::review_consensus::build_reviewer_tools;
 use crate::test_env_lock::TEST_ENV_LOCK;
 use clap::{Parser, error::ErrorKind};
-use csa_config::{ProjectMeta, ResourcesConfig, ToolConfig, ToolTransport};
+use csa_config::{ProjectMeta, ResourcesConfig, ToolConfig};
 use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoManager};
 use std::{collections::HashMap, process::Command};
 use tempfile::TempDir;

--- a/crates/cli-sub-agent/src/review_cmd_tests_explicit_tool_tier_fallback.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_explicit_tool_tier_fallback.rs
@@ -9,7 +9,7 @@ async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier
         "1",
     );
     let mut config = project_config_with_enabled_tools(&["codex", "gemini-cli"]);
-    config.tools.get_mut("codex").unwrap().transport = Some(csa_config::ToolTransport::Cli);
+    config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);
     config.tiers.insert(
         "quality".to_string(),
         csa_config::config::TierConfig {

--- a/crates/cli-sub-agent/src/review_cmd_tests_fix_fallback.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_fix_fallback.rs
@@ -14,23 +14,20 @@ async fn handle_review_fix_loop_uses_effective_fallback_tool() {
     }
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
-    let codex_count_path = project_dir.path().join("codex-count.txt");
+    let opencode_count_path = project_dir.path().join("opencode-count.txt");
 
     std::fs::write(
         bin_dir.join("gemini"),
         "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\nexit 1\n",
     )
     .unwrap();
-    std::fs::write(
-        bin_dir.join("codex"),
-        format!(
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex 1.0.0\\n'\n  exit 0\nfi\ncount=$(cat \"{}\" 2>/dev/null || printf '0')\ncount=$((count + 1))\nprintf '%s' \"$count\" > \"{}\"\nif [ \"$count\" -eq 1 ]; then\n  printf '%s\\n' '<!-- CSA:SECTION:summary -->' 'FAIL' '<!-- CSA:SECTION:summary:END -->' '<!-- CSA:SECTION:details -->' 'Found issue in tracked.txt.' '<!-- CSA:SECTION:details:END -->'\nelse\n  printf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS' '<!-- CSA:SECTION:summary:END -->' '<!-- CSA:SECTION:details -->' 'Issue fixed.' '<!-- CSA:SECTION:details:END -->'\nfi\n",
-            codex_count_path.display(),
-            codex_count_path.display()
-        ),
-    )
-    .unwrap();
-    for binary in ["gemini", "codex"] {
+    let opencode_stub = format!(
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'opencode 1.0.0\\n'\n  exit 0\nfi\ncount=$(cat \"{}\" 2>/dev/null || printf '0')\ncount=$((count + 1))\nprintf '%s' \"$count\" > \"{}\"\nif [ \"$count\" -eq 1 ]; then\n  printf '%s\\n' '<!-- CSA:SECTION:summary -->' 'FAIL' '<!-- CSA:SECTION:summary:END -->' '<!-- CSA:SECTION:details -->' 'Found issue in tracked.txt.' '<!-- CSA:SECTION:details:END -->'\nelse\n  printf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS' '<!-- CSA:SECTION:summary:END -->' '<!-- CSA:SECTION:details -->' 'Issue fixed.' '<!-- CSA:SECTION:details:END -->'\nfi\n",
+        opencode_count_path.display(),
+        opencode_count_path.display()
+    );
+    std::fs::write(bin_dir.join("opencode"), &opencode_stub).unwrap();
+    for binary in ["gemini", "opencode"] {
         let path = bin_dir.join(binary);
         let mut perms = std::fs::metadata(&path).unwrap().permissions();
         perms.set_mode(0o755);
@@ -41,7 +38,7 @@ async fn handle_review_fix_loop_uses_effective_fallback_tool() {
     let patched_path = format!("{}:{inherited_path}", bin_dir.display());
     let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
 
-    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    let mut config = project_config_with_enabled_tools(&["gemini-cli", "opencode"]);
     config.review = Some(csa_config::ReviewConfig {
         gate_command: Some("true".to_string()),
         ..Default::default()
@@ -56,38 +53,82 @@ async fn handle_review_fix_loop_uses_effective_fallback_tool() {
             description: "quality".to_string(),
             models: vec![
                 "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
-                "codex/openai/gpt-5.4/high".to_string(),
+                "opencode/anthropic/claude-sonnet-4-5-20250929/default".to_string(),
             ],
             strategy: csa_config::TierStrategy::default(),
             token_budget: None,
             max_turns: None,
         },
     );
-    write_review_project_config(project_dir.path(), &config);
-    install_pattern(project_dir.path(), "csa-review");
 
-    let cd = project_dir.path().display().to_string();
-    let args = parse_review_args(&[
-        "csa",
-        "review",
-        "--cd",
-        &cd,
-        "--tier",
-        "quality",
-        "--files",
-        "tracked.txt",
-        "--fix",
-        "--max-rounds",
-        "1",
-    ]);
+    let global = GlobalConfig::default();
+    let initial = execute_review_for_tests(
+        ToolName::GeminiCli,
+        "scope=files:tracked.txt mode=review-and-fix security=auto".to_string(),
+        None,
+        None,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string()),
+        Some("quality".to_string()),
+        true,
+        None,
+        "review: fix-loop-effective-fallback-tool".to_string(),
+        project_dir.path(),
+        Some(&config),
+        &global,
+        ReviewRoutingMetadata {
+            project_profile: ProjectProfile::Unknown,
+            detection_method: "auto",
+        },
+        csa_process::StreamMode::BufferOnly,
+        crate::pipeline::DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        &[],
+        &[],
+    )
+    .await
+    .expect("initial review should fall back to opencode");
+    assert_eq!(initial.executed_tool, ToolName::Opencode);
 
-    let exit_code = handle_review(args, 0)
-        .await
-        .expect("fix loop should use fallback tool");
+    let exit_code = super::fix::run_fix_loop(super::fix::FixLoopContext {
+        effective_tool: initial.executed_tool,
+        config: Some(&config),
+        global_config: &global,
+        review_model: None,
+        effective_tier_model_spec: initial.routed_to.clone(),
+        review_thinking: None,
+        review_routing: ReviewRoutingMetadata {
+            project_profile: ProjectProfile::Unknown,
+            detection_method: "auto",
+        },
+        stream_mode: csa_process::StreamMode::BufferOnly,
+        idle_timeout_seconds: crate::pipeline::DEFAULT_IDLE_TIMEOUT_SECONDS,
+        initial_response_timeout_seconds: None,
+        force_override_user_config: false,
+        force_ignore_tier_setting: false,
+        no_failover: false,
+        no_fs_sandbox: false,
+        extra_writable: &[],
+        extra_readable: &[],
+        timeout: None,
+        project_root: project_dir.path(),
+        scope: "files:tracked.txt".to_string(),
+        decision: ReviewDecision::Fail.as_str().to_string(),
+        verdict: "HAS_ISSUES".to_string(),
+        max_rounds: 1,
+        initial_session_id: initial.execution.meta_session_id.clone(),
+        review_iterations: 0,
+    })
+    .await
+    .expect("fix loop should use fallback tool");
     assert_eq!(exit_code, 0);
     assert_eq!(
-        std::fs::read_to_string(&codex_count_path).unwrap(),
+        std::fs::read_to_string(&opencode_count_path).unwrap(),
         "2",
-        "codex must handle both the fallback review round and the fix round"
+        "opencode must handle both the fallback review round and the fix round"
     );
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests_transport_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_transport_tail.rs
@@ -38,7 +38,7 @@ fn resolve_review_tool_auto_skips_counterpart_without_configured_binary() {
     cfg.tools
         .get_mut("codex")
         .expect("codex tool config")
-        .transport = Some(ToolTransport::Cli);
+        .transport = Some(csa_config::TransportKind::Cli);
 
     let err = resolve_review_tool(
         None,

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 
 use csa_config::ProjectConfig;
 #[cfg(not(test))]
-use csa_config::ToolTransport;
+use csa_config::TransportKind;
 use csa_config::global::GlobalConfig;
 use csa_core::consensus::{
     AgentResponse, ConsensusResult, ConsensusStrategy, resolve_majority, resolve_unanimous,
@@ -57,8 +57,11 @@ fn reviewer_tool_binary_available(tool_name: &str, config: Option<&ProjectConfig
             let transport = config
                 .and_then(|cfg| cfg.tool_transport("codex"))
                 .map(|transport| match transport {
-                    ToolTransport::Cli => CodexTransport::Cli,
-                    ToolTransport::Acp => CodexTransport::Acp,
+                    TransportKind::Cli => CodexTransport::Cli,
+                    TransportKind::Acp => CodexTransport::Acp,
+                    TransportKind::Auto => {
+                        unreachable!("tool_transport() returns resolved transports")
+                    }
                 })
                 .unwrap_or_else(CodexTransport::default_for_build);
             if matches!(transport, CodexTransport::Acp) && !CodexRuntimeMetadata::acp_compiled_in()

--- a/crates/cli-sub-agent/src/run_helpers_tool_availability.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tool_availability.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use csa_config::{ProjectConfig, ToolTransport};
+use csa_config::{ProjectConfig, TransportKind};
 use csa_executor::{CodexTransport, install_hint_for_known_tool};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9,10 +9,6 @@ pub(crate) enum ToolBinaryAvailability {
         binary_name: String,
     },
     Missing {
-        binary_name: String,
-        hint: Cow<'static, str>,
-    },
-    Unsupported {
         binary_name: String,
         hint: Cow<'static, str>,
     },
@@ -42,8 +38,9 @@ pub(crate) fn resolved_codex_transport(config: Option<&ProjectConfig>) -> CodexT
     config
         .and_then(|cfg| cfg.tool_transport("codex"))
         .map(|transport| match transport {
-            ToolTransport::Cli => CodexTransport::Cli,
-            ToolTransport::Acp => CodexTransport::Acp,
+            TransportKind::Cli => CodexTransport::Cli,
+            TransportKind::Acp => CodexTransport::Acp,
+            TransportKind::Auto => unreachable!("tool_transport() returns resolved transports"),
         })
         .unwrap_or_else(CodexTransport::default_for_build)
 }
@@ -87,18 +84,6 @@ pub(crate) fn tool_binary_availability(
             hint: Cow::Borrowed("Unknown tool"),
         };
     };
-
-    if tool_name == "codex"
-        && matches!(resolved_codex_transport(config), CodexTransport::Acp)
-        && !csa_executor::CodexRuntimeMetadata::acp_compiled_in()
-    {
-        return ToolBinaryAvailability::Unsupported {
-            binary_name: binary_name.to_string(),
-            hint: Cow::Borrowed(
-                "Rebuild CSA with `cargo build --features codex-acp`, or remove `[tools.codex].transport = \"acp\"`.",
-            ),
-        };
-    }
 
     let installed = std::process::Command::new("which")
         .arg(binary_name)

--- a/crates/cli-sub-agent/src/run_helpers_transport_integration_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_transport_integration_tests.rs
@@ -61,25 +61,18 @@ fn assert_non_codex_transport_defaults() {
 }
 
 #[test]
-fn codex_cli_project_config_builds_legacy_transport_end_to_end() {
-    let config = load_project_config(
-        r#"
-[tools.codex]
-transport = "cli"
-"#,
-    );
-    let executor = build_executor(&ToolName::Codex, None, None, None, Some(&config), true)
-        .expect("build codex executor");
+fn codex_defaults_to_acp_transport_end_to_end() {
+    let executor = build_executor(&ToolName::Codex, None, None, None, None, true)
+        .expect("build default codex executor");
     let transport = TransportFactory::create(&executor, Some(SessionConfig::default()))
         .expect("create codex transport");
 
-    assert_eq!(transport.mode(), TransportMode::Legacy);
-    assert_eq!(executor.runtime_binary_name(), "codex");
+    assert_eq!(transport.mode(), TransportMode::Acp);
+    assert_eq!(executor.runtime_binary_name(), "codex-acp");
 
     assert_non_codex_transport_defaults();
 }
 
-#[cfg(feature = "codex-acp")]
 #[test]
 fn codex_acp_project_config_builds_acp_transport_end_to_end() {
     let config = load_project_config(
@@ -99,15 +92,14 @@ transport = "acp"
     assert_non_codex_transport_defaults();
 }
 
-#[cfg(not(feature = "codex-acp"))]
 #[test]
-fn codex_acp_project_config_is_rejected_before_executor_build() {
+fn codex_cli_project_config_is_rejected_before_executor_build() {
     let dir = tempfile::tempdir().expect("tempdir");
     write_project_config(
         dir.path(),
         r#"
 [tools.codex]
-transport = "acp"
+transport = "cli"
 "#,
     );
 
@@ -115,11 +107,11 @@ transport = "acp"
     let message = format!("{err:#}");
 
     assert!(
-        message.contains("[tools.codex].transport"),
+        message.contains("tools.codex.transport"),
         "error should point to the codex transport key: {message}"
     );
     assert!(
-        message.contains("codex-acp"),
-        "error should mention the missing codex-acp feature: {message}"
+        message.contains("#643 Phase 4"),
+        "error should mention the codex CLI follow-up phase: {message}"
     );
 }

--- a/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
@@ -89,7 +89,7 @@ fn build_executor_codex_transport_respects_explicit_acp_override() {
 
 #[cfg(unix)]
 #[test]
-fn auto_selection_uses_codex_cli_when_transport_is_unset() {
+fn auto_selection_uses_codex_acp_when_transport_is_unset() {
     use crate::test_env_lock::ScopedTestEnvVar;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
@@ -134,7 +134,7 @@ fn auto_selection_uses_codex_cli_when_transport_is_unset() {
 
     assert!(
         is_tool_binary_available_for_config("codex", Some(&config)),
-        "unset codex transport should probe `codex`, not `codex-acp`"
+        "unset codex transport should probe `codex-acp`, not `codex`"
     );
 
     let (tool, model_spec, model) = resolve_tool_and_model(

--- a/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
@@ -1,5 +1,5 @@
 use super::{build_executor, is_tool_binary_available_for_config, resolve_tool_and_model};
-use csa_config::{ProjectConfig, ProjectMeta, ResourcesConfig, ToolConfig, ToolTransport};
+use csa_config::{ProjectConfig, ProjectMeta, ResourcesConfig, ToolConfig, TransportKind};
 use csa_core::types::ToolName;
 use csa_executor::{CodexTransport, Executor};
 use std::collections::HashMap;
@@ -54,7 +54,7 @@ fn build_executor_codex_transport_defaults_to_build_setting_when_unset() {
 #[test]
 fn build_executor_codex_transport_respects_explicit_cli_override() {
     let config = project_config_with_codex_tool(ToolConfig {
-        transport: Some(ToolTransport::Cli),
+        transport: Some(TransportKind::Cli),
         ..Default::default()
     });
     let exec = build_executor(&ToolName::Codex, None, None, None, Some(&config), true).unwrap();
@@ -72,7 +72,7 @@ fn build_executor_codex_transport_respects_explicit_cli_override() {
 #[test]
 fn build_executor_codex_transport_respects_explicit_acp_override() {
     let config = project_config_with_codex_tool(ToolConfig {
-        transport: Some(ToolTransport::Acp),
+        transport: Some(TransportKind::Acp),
         ..Default::default()
     });
     let exec = build_executor(&ToolName::Codex, None, None, None, Some(&config), true).unwrap();

--- a/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
@@ -97,11 +97,11 @@ fn auto_selection_uses_codex_acp_when_transport_is_unset() {
     let td = tempfile::tempdir().expect("tempdir");
     let bin_dir = td.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
-    let codex_path = bin_dir.join("codex");
-    fs::write(&codex_path, "#!/bin/sh\necho 'codex 9.9.9'\n").expect("write codex stub");
+    let codex_path = bin_dir.join("codex-acp");
+    fs::write(&codex_path, "#!/bin/sh\necho 'codex-acp 9.9.9'\n").expect("write codex-acp stub");
     let mut perms = fs::metadata(&codex_path).expect("metadata").permissions();
     perms.set_mode(0o755);
-    fs::set_permissions(&codex_path, perms).expect("chmod codex");
+    fs::set_permissions(&codex_path, perms).expect("chmod codex-acp");
 
     let path = std::env::var_os("PATH").unwrap_or_default();
     let joined =

--- a/crates/cli-sub-agent/tests/config_get_global_warning_e2e.rs
+++ b/crates/cli-sub-agent/tests/config_get_global_warning_e2e.rs
@@ -40,7 +40,8 @@ fn csa_cmd(tmp: &Path) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
     cmd.env("HOME", tmp)
         .env("XDG_STATE_HOME", tmp.join(".local/state"))
-        .env("XDG_CONFIG_HOME", tmp.join(".config"));
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
     cmd
 }
 

--- a/crates/cli-sub-agent/tests/config_show_transport_e2e.rs
+++ b/crates/cli-sub-agent/tests/config_show_transport_e2e.rs
@@ -1,0 +1,68 @@
+use std::process::Command;
+
+fn csa_cmd(tmp: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+#[test]
+fn config_show_renders_resolved_tool_transport() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = csa_config::ProjectConfig::config_path(tmp.path());
+    std::fs::create_dir_all(config_path.parent().expect("config dir")).expect("create config dir");
+    std::fs::write(
+        &config_path,
+        r#"
+[project]
+name = "test-project"
+
+[tools.codex]
+transport = "acp"
+"#,
+    )
+    .expect("write config");
+
+    let project_root = tmp.path().display().to_string();
+    let output = csa_cmd(tmp.path())
+        .args(["config", "show", "--cd", &project_root])
+        .output()
+        .expect("failed to run csa config show --cd");
+
+    assert!(output.status.success(), "csa config show should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[tools.codex]"));
+    assert!(stdout.contains("transport = \"acp\""));
+}
+
+#[test]
+fn config_show_rejects_invalid_claude_code_cli_transport() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = csa_config::ProjectConfig::config_path(tmp.path());
+    std::fs::create_dir_all(config_path.parent().expect("config dir")).expect("create config dir");
+    std::fs::write(
+        &config_path,
+        r#"
+[project]
+name = "test-project"
+
+[tools.claude-code]
+transport = "cli"
+"#,
+    )
+    .expect("write config");
+
+    let project_root = tmp.path().display().to_string();
+    let output = csa_cmd(tmp.path())
+        .args(["config", "show", "--cd", &project_root])
+        .output()
+        .expect("failed to run csa config show --cd");
+
+    assert!(!output.status.success(), "csa config show should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("tools.claude-code.transport"));
+    assert!(stderr.contains("#643 Phase 3"));
+}

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -18,7 +18,8 @@ fn csa_cmd(tmp: &std::path::Path) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
     cmd.env("HOME", tmp)
         .env("XDG_STATE_HOME", tmp.join(".local/state"))
-        .env("XDG_CONFIG_HOME", tmp.join(".config"));
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
     cmd
 }
 

--- a/crates/csa-acp/src/connection_initial_response_tests.rs
+++ b/crates/csa-acp/src/connection_initial_response_tests.rs
@@ -284,7 +284,12 @@ fn stream_new_agent_messages_reports_initial_response_progress_only_for_eligible
 #[tokio::test]
 async fn initial_response_timeout_stays_alive_for_stderr_only() {
     let connection = build_test_connection(
-        spawn_test_child("while :; do printf 'starting codex auth\\n' >&2; sleep 0.05; done"),
+        // Use a single long-lived process for stderr heartbeats. A shell loop with
+        // `sleep 0.05` forks repeatedly and can trip EAGAIN under `nextest` load,
+        // causing the child to exit before `new_session()`.
+        spawn_test_child(
+            "python3 -c 'import sys,time\nwhile True:\n sys.stderr.write(\"starting codex auth\\\\n\")\n sys.stderr.flush()\n time.sleep(0.05)'",
+        ),
         Duration::from_secs(5),
         PromptBehavior::Silent,
     )

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -200,7 +200,7 @@ pub use super::config_session::{
     SessionConfig, VcsConfig,
 };
 pub use super::config_tool::{
-    ToolConfig, ToolFilesystemSandboxConfig, ToolRestrictions, ToolTransport,
+    ToolConfig, ToolFilesystemSandboxConfig, ToolRestrictions, TransportKind,
 };
 
 impl ProjectConfig {

--- a/crates/csa-config/src/config_merge_tests.rs
+++ b/crates/csa-config/src/config_merge_tests.rs
@@ -219,7 +219,7 @@ transport = "acp"
         "error should include the user config path: {rendered}"
     );
     assert!(
-        rendered.contains("[tools.claude-code].transport"),
+        rendered.contains("tools.claude-code.transport"),
         "error should surface the invalid user transport key: {rendered}"
     );
 }
@@ -235,7 +235,7 @@ fn test_invalid_project_transport_override_fails_before_merge() {
         r#"
 schema_version = 1
 [tools.codex]
-transport = "cli"
+transport = "acp"
 "#,
     )
     .unwrap();
@@ -263,7 +263,7 @@ transport = "cli"
         "error should include the project config path: {rendered}"
     );
     assert!(
-        rendered.contains("[tools.claude-code].transport"),
+        rendered.contains("tools.claude-code.transport"),
         "error should surface the invalid project transport key: {rendered}"
     );
 }

--- a/crates/csa-config/src/config_runtime.rs
+++ b/crates/csa-config/src/config_runtime.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
-use crate::config::{EnforcementMode, ProjectConfig, ToolResourceProfile, ToolTransport};
+use crate::config::{EnforcementMode, ProjectConfig, ToolResourceProfile};
+use crate::config_tool::{TransportKind, default_transport_for_tool};
 
 /// Known tool-to-profile mapping based on runtime characteristics.
 ///
@@ -280,8 +281,11 @@ impl ProjectConfig {
     }
 
     /// Resolve the per-tool transport override.
-    pub fn tool_transport(&self, tool: &str) -> Option<ToolTransport> {
-        self.tools.get(tool).and_then(|t| t.transport)
+    pub fn tool_transport(&self, tool: &str) -> Option<TransportKind> {
+        self.tools
+            .get(tool)
+            .and_then(|t| t.resolve_transport(tool))
+            .or_else(|| default_transport_for_tool(tool))
     }
 
     /// Check if a tool is allowed to edit existing files.

--- a/crates/csa-config/src/config_runtime_tests.rs
+++ b/crates/csa-config/src/config_runtime_tests.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 
 use crate::config::{
     CURRENT_SCHEMA_VERSION, EnforcementMode, ProjectConfig, ProjectMeta, ResourcesConfig,
-    ToolConfig, ToolResourceProfile, ToolTransport,
+    ToolConfig, ToolResourceProfile, TransportKind,
 };
 use crate::config_runtime::default_sandbox_for_tool;
 
@@ -772,13 +772,13 @@ fn tool_transport_reads_tool_override() {
     cfg.tools.insert(
         "codex".to_string(),
         ToolConfig {
-            transport: Some(ToolTransport::Cli),
+            transport: Some(TransportKind::Cli),
             ..Default::default()
         },
     );
 
-    assert_eq!(cfg.tool_transport("codex"), Some(ToolTransport::Cli));
-    assert_eq!(cfg.tool_transport("claude-code"), None);
+    assert_eq!(cfg.tool_transport("codex"), Some(TransportKind::Cli));
+    assert_eq!(cfg.tool_transport("claude-code"), Some(TransportKind::Acp));
 }
 
 // FS sandbox tests moved to config_runtime_fs_sandbox_tests.rs

--- a/crates/csa-config/src/config_tool.rs
+++ b/crates/csa-config/src/config_tool.rs
@@ -10,9 +10,18 @@ pub(crate) fn default_true() -> bool {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum ToolTransport {
+pub enum TransportKind {
+    Auto,
     Cli,
     Acp,
+}
+
+pub fn default_transport_for_tool(tool_name: &str) -> Option<TransportKind> {
+    match tool_name {
+        "claude-code" | "codex" => Some(TransportKind::Acp),
+        "gemini-cli" | "opencode" => Some(TransportKind::Cli),
+        _ => None,
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -76,7 +85,7 @@ pub struct ToolConfig {
     ///
     /// Currently meaningful for codex only. `None` means use the build default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub transport: Option<ToolTransport>,
+    pub transport: Option<TransportKind>,
     /// Codex-only: auto-approve trust dialog during PTY native fork flow.
     /// Defaults to false for explicit safety.
     #[serde(default)]
@@ -114,6 +123,16 @@ impl Default for ToolConfig {
             base_url: None,
             api_key: None,
             filesystem_sandbox: None,
+        }
+    }
+}
+
+impl ToolConfig {
+    #[must_use]
+    pub fn resolve_transport(&self, tool_name: &str) -> Option<TransportKind> {
+        match self.transport.unwrap_or(TransportKind::Auto) {
+            TransportKind::Auto => default_transport_for_tool(tool_name),
+            transport => Some(transport),
         }
     }
 }
@@ -272,6 +291,34 @@ transport = "cli"
         let wrapper: Wrapper = toml::from_str(toml_str).expect("should parse TOML");
         let tool = wrapper.tools.get("codex").expect("codex missing");
 
-        assert_eq!(tool.transport, Some(ToolTransport::Cli));
+        assert_eq!(tool.transport, Some(TransportKind::Cli));
+    }
+
+    #[test]
+    fn test_resolve_transport_maps_auto_to_tool_default() {
+        let config = ToolConfig {
+            transport: Some(TransportKind::Auto),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            config.resolve_transport("claude-code"),
+            Some(TransportKind::Acp)
+        );
+        assert_eq!(
+            config.resolve_transport("gemini-cli"),
+            Some(TransportKind::Cli)
+        );
+    }
+
+    #[test]
+    fn test_resolve_transport_uses_default_when_unset() {
+        let config = ToolConfig::default();
+
+        assert_eq!(config.resolve_transport("codex"), Some(TransportKind::Acp));
+        assert_eq!(
+            config.resolve_transport("opencode"),
+            Some(TransportKind::Cli)
+        );
     }
 }

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -29,11 +29,12 @@ pub use acp::AcpConfig;
 pub use config::{
     DEFAULT_COOLDOWN_SECS, EnforcementMode, ExecutionConfig, HooksSection, PostExecGateConfig,
     ProjectConfig, ProjectMeta, RunConfig, SessionConfig, TierConfig, TierStrategy, ToolConfig,
-    ToolFilesystemSandboxConfig, ToolResourceProfile, ToolRestrictions, ToolTransport,
+    ToolFilesystemSandboxConfig, ToolResourceProfile, ToolRestrictions,
 };
 pub use config_filesystem_sandbox::FilesystemSandboxConfig;
 pub use config_resources::ResourcesConfig;
 pub use config_runtime::{DefaultSandboxOptions, default_sandbox_for_tool};
+pub use config_tool::{TransportKind, default_transport_for_tool};
 pub use gc::GcConfig;
 pub use global::{
     AiConfigSymlinkCheckConfig, DEFAULT_KV_CACHE_FREQUENT_POLL_SECS,

--- a/crates/csa-config/src/validate.rs
+++ b/crates/csa-config/src/validate.rs
@@ -1,8 +1,8 @@
 use anyhow::{Result, bail};
 use std::path::Path;
 
+use crate::TransportKind;
 use crate::config::ProjectConfig;
-use crate::config_tool::ToolTransport;
 use crate::global::ToolSelection;
 
 const KNOWN_TOOLS: &[&str] = &[
@@ -12,7 +12,7 @@ const KNOWN_TOOLS: &[&str] = &[
     "claude-code",
     "openai-compat",
 ];
-const LEGAL_TRANSPORT_VALUES: &str = "cli, acp";
+const LEGAL_TRANSPORT_VALUES: &str = "auto, acp, cli";
 
 /// Validate a project configuration file.
 /// Returns Ok(()) if valid, or Err with descriptive messages.
@@ -233,8 +233,9 @@ fn validate_tools(config: &ProjectConfig) -> Result<()> {
 
 fn validate_tool_transport_override_value(tool_name: &str, raw_transport: &str) -> Result<()> {
     let transport = match raw_transport {
-        "cli" => ToolTransport::Cli,
-        "acp" => ToolTransport::Acp,
+        "auto" => TransportKind::Auto,
+        "cli" => TransportKind::Cli,
+        "acp" => TransportKind::Acp,
         _ => {
             let key = transport_key(tool_name);
             bail!(
@@ -243,33 +244,59 @@ fn validate_tool_transport_override_value(tool_name: &str, raw_transport: &str) 
         }
     };
 
-    validate_tool_transport_override(tool_name, transport)
+    validate_tool_transport_override_with_raw(tool_name, transport, raw_transport)
 }
 
-fn validate_tool_transport_override(tool_name: &str, transport: ToolTransport) -> Result<()> {
+fn validate_tool_transport_override_with_raw(
+    tool_name: &str,
+    transport: TransportKind,
+    raw_transport: &str,
+) -> Result<()> {
     let key = transport_key(tool_name);
 
-    if tool_name != "codex" {
-        bail!(
-            "Invalid {key}: tool \"{tool_name}\" does not support transport override; this field is only valid for codex."
-        );
+    match tool_name {
+        "claude-code" => match transport {
+            TransportKind::Auto | TransportKind::Acp => Ok(()),
+            TransportKind::Cli => bail!(
+                "Invalid {key} = \"{raw_transport}\": claude-code does not yet support CLI transport — will be added in #643 Phase 3."
+            ),
+        },
+        "codex" => match transport {
+            TransportKind::Auto | TransportKind::Acp => Ok(()),
+            TransportKind::Cli => bail!(
+                "Invalid {key} = \"{raw_transport}\": codex does not yet support CLI transport — will be added in #643 Phase 4."
+            ),
+        },
+        "gemini-cli" | "opencode" => match transport {
+            TransportKind::Auto | TransportKind::Cli => Ok(()),
+            TransportKind::Acp => bail!(
+                "Invalid {key} = \"{raw_transport}\": {tool_name} does not support ACP transport."
+            ),
+        },
+        "openai-compat" => {
+            bail!(
+                "Invalid {key} = \"{raw_transport}\": {tool_name} does not support configurable transport."
+            )
+        }
+        _ => {
+            // Unknown tool names are rejected earlier by validate_tools; keep this
+            // branch defensive for raw config validation paths.
+            bail!("Invalid {key} = \"{raw_transport}\": unknown tool \"{tool_name}\".")
+        }
     }
-
-    if matches!(transport, ToolTransport::Acp) && !codex_acp_compiled_in() {
-        bail!(
-            "Invalid {key}: transport = \"acp\" requires the `codex-acp` feature, but this CSA build was compiled without it. Rebuild with `cargo build --features codex-acp` or `cargo install --path crates/cli-sub-agent --features codex-acp`, or set [tools.codex].transport = \"cli\" (or remove the field)."
-        );
-    }
-
-    Ok(())
 }
 
-const fn codex_acp_compiled_in() -> bool {
-    cfg!(feature = "codex-acp")
+fn validate_tool_transport_override(tool_name: &str, transport: TransportKind) -> Result<()> {
+    let raw_transport = match transport {
+        TransportKind::Auto => "auto",
+        TransportKind::Cli => "cli",
+        TransportKind::Acp => "acp",
+    };
+    validate_tool_transport_override_with_raw(tool_name, transport, raw_transport)
 }
 
 fn transport_key(tool_name: &str) -> String {
-    format!("[tools.{tool_name}].transport")
+    format!("tools.{tool_name}.transport")
 }
 
 /// Validate a `ToolSelection` value for review/debate config.

--- a/crates/csa-config/src/validate_tests_transport.rs
+++ b/crates/csa-config/src/validate_tests_transport.rs
@@ -11,82 +11,143 @@ fn write_raw_project_config(dir: &Path, config_toml: &str) -> PathBuf {
     config_path
 }
 
-#[cfg(not(feature = "codex-acp"))]
 #[test]
-fn test_validate_codex_acp_transport_requires_compiled_feature() {
-    let dir = tempdir().unwrap();
-    let config_path = write_raw_project_config(
-        dir.path(),
-        r#"
-[tools.codex]
-transport = "acp"
+fn validate_tool_transport_matrix_matches_phase_2_contract() {
+    struct Case {
+        tool: &'static str,
+        value: &'static str,
+        should_pass: bool,
+        expected_message: Option<&'static str>,
+    }
+
+    let cases = [
+        Case {
+            tool: "claude-code",
+            value: "auto",
+            should_pass: true,
+            expected_message: None,
+        },
+        Case {
+            tool: "claude-code",
+            value: "acp",
+            should_pass: true,
+            expected_message: None,
+        },
+        Case {
+            tool: "claude-code",
+            value: "cli",
+            should_pass: false,
+            expected_message: Some(
+                "claude-code does not yet support CLI transport — will be added in #643 Phase 3",
+            ),
+        },
+        Case {
+            tool: "codex",
+            value: "auto",
+            should_pass: true,
+            expected_message: None,
+        },
+        Case {
+            tool: "codex",
+            value: "acp",
+            should_pass: true,
+            expected_message: None,
+        },
+        Case {
+            tool: "codex",
+            value: "cli",
+            should_pass: false,
+            expected_message: Some(
+                "codex does not yet support CLI transport — will be added in #643 Phase 4",
+            ),
+        },
+        Case {
+            tool: "gemini-cli",
+            value: "auto",
+            should_pass: true,
+            expected_message: None,
+        },
+        Case {
+            tool: "gemini-cli",
+            value: "cli",
+            should_pass: true,
+            expected_message: None,
+        },
+        Case {
+            tool: "gemini-cli",
+            value: "acp",
+            should_pass: false,
+            expected_message: Some("gemini-cli does not support ACP transport"),
+        },
+        Case {
+            tool: "opencode",
+            value: "auto",
+            should_pass: true,
+            expected_message: None,
+        },
+        Case {
+            tool: "opencode",
+            value: "cli",
+            should_pass: true,
+            expected_message: None,
+        },
+        Case {
+            tool: "opencode",
+            value: "acp",
+            should_pass: false,
+            expected_message: Some("opencode does not support ACP transport"),
+        },
+    ];
+
+    for case in cases {
+        let dir = tempdir().unwrap();
+        let config_path = write_raw_project_config(
+            dir.path(),
+            &format!(
+                r#"
+[tools.{}]
+transport = "{}"
 "#,
-    );
+                case.tool, case.value
+            ),
+        );
 
-    let err = validate_config_with_paths(None, &config_path).unwrap_err();
-    let message = format!("{err:#}");
+        let result = validate_config_with_paths(None, &config_path);
+        if case.should_pass {
+            assert!(
+                result.is_ok(),
+                "{}={} should validate, got: {result:?}",
+                case.tool,
+                case.value
+            );
+            continue;
+        }
 
-    assert!(
-        message.contains("[tools.codex].transport"),
-        "error should point to the exact config key: {message}"
-    );
-    assert!(
-        message.contains("codex-acp"),
-        "error should mention the missing cargo feature: {message}"
-    );
-    assert!(
-        message.contains("cargo"),
-        "error should include a rebuild command: {message}"
-    );
-    assert!(
-        message.contains("cargo install --path crates/cli-sub-agent --features codex-acp"),
-        "error should point to the repo-local install command: {message}"
-    );
-    assert!(
-        message.contains("transport = \"acp\" requires"),
-        "error should explain why ACP is rejected: {message}"
-    );
+        let err = result.expect_err("invalid transport should fail validation");
+        let message = format!("{err:#}");
+        let key = format!("tools.{}.transport", case.tool);
+        let value = format!("\"{}\"", case.value);
+
+        assert!(
+            message.contains(&key),
+            "error should name the offending key path: {message}"
+        );
+        assert!(
+            message.contains(&value),
+            "error should include the offending value: {message}"
+        );
+        assert!(
+            message.contains(
+                case.expected_message
+                    .expect("expected transport error text")
+            ),
+            "error should explain the phase-2 transport contract: {message}"
+        );
+    }
 }
 
-#[cfg(feature = "codex-acp")]
 #[test]
-fn test_validate_codex_acp_transport_accepts_feature_build() {
-    let dir = tempdir().unwrap();
-    let config_path = write_raw_project_config(
-        dir.path(),
-        r#"
-[tools.codex]
-transport = "acp"
-"#,
-    );
-
-    let result = validate_config_with_paths(None, &config_path);
-    assert!(
-        result.is_ok(),
-        "feature build should accept codex ACP transport: {result:?}"
-    );
-}
-
-#[test]
-fn test_validate_codex_cli_transport_override_accepts_all_builds() {
-    let dir = tempdir().unwrap();
-    let config_path = write_raw_project_config(
-        dir.path(),
-        r#"
-[tools.codex]
-transport = "cli"
-"#,
-    );
-
-    let result = validate_config_with_paths(None, &config_path);
-    assert!(
-        result.is_ok(),
-        "CLI transport should validate in every build: {result:?}"
-    );
-}
-
-#[test]
-fn test_validate_codex_transport_rejects_unknown_value() {
+fn validate_tool_transport_rejects_unknown_value() {
     let dir = tempdir().unwrap();
     let config_path = write_raw_project_config(
         dir.path(),
@@ -100,43 +161,15 @@ transport = "stdio"
     let message = format!("{err:#}");
 
     assert!(
-        message.contains("[tools.codex].transport"),
+        message.contains("tools.codex.transport"),
         "error should point to the exact config key: {message}"
     );
     assert!(
-        message.contains("unknown transport \"stdio\" for tool \"codex\""),
-        "error should name the bad transport value and tool: {message}"
+        message.contains("\"stdio\""),
+        "error should name the bad transport value: {message}"
     );
     assert!(
-        message.contains("legal values are: cli, acp"),
+        message.contains("legal values are: auto, acp, cli"),
         "error should list the accepted transport values: {message}"
-    );
-}
-
-#[test]
-fn test_validate_non_codex_transport_override_rejected() {
-    let dir = tempdir().unwrap();
-    let config_path = write_raw_project_config(
-        dir.path(),
-        r#"
-[tools.gemini-cli]
-transport = "cli"
-"#,
-    );
-
-    let err = validate_config_with_paths(None, &config_path).unwrap_err();
-    let message = format!("{err:#}");
-
-    assert!(
-        message.contains("[tools.gemini-cli].transport"),
-        "error should point to the exact config key: {message}"
-    );
-    assert!(
-        message.contains("does not support transport override"),
-        "error should reject non-codex transport overrides: {message}"
-    );
-    assert!(
-        message.contains("only valid for codex"),
-        "error should explain the allowed scope: {message}"
     );
 }

--- a/crates/csa-executor/src/codex_runtime.rs
+++ b/crates/csa-executor/src/codex_runtime.rs
@@ -18,7 +18,7 @@ impl CodexTransport {
     /// Current default transport for this build.
     #[must_use]
     pub const fn default_for_build() -> Self {
-        Self::Cli
+        Self::Acp
     }
 
     #[must_use]
@@ -119,23 +119,11 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "codex-acp")]
     #[test]
-    fn current_build_defaults_to_cli_when_feature_enabled() {
+    fn current_build_defaults_to_acp_when_feature_enabled() {
         let meta = codex_runtime_metadata();
 
-        assert!(CodexRuntimeMetadata::acp_compiled_in());
-        assert_eq!(meta.transport_mode(), CodexTransport::Cli);
-        assert_eq!(meta.runtime_binary_name(), "codex");
-    }
-
-    #[cfg(not(feature = "codex-acp"))]
-    #[test]
-    fn current_build_defaults_to_cli_when_feature_disabled() {
-        let meta = codex_runtime_metadata();
-
-        assert!(!CodexRuntimeMetadata::acp_compiled_in());
-        assert_eq!(meta.transport_mode(), CodexTransport::Cli);
-        assert_eq!(meta.runtime_binary_name(), "codex");
+        assert_eq!(meta.transport_mode(), CodexTransport::Acp);
+        assert_eq!(meta.runtime_binary_name(), "codex-acp");
     }
 }

--- a/crates/csa-executor/src/transport_factory.rs
+++ b/crates/csa-executor/src/transport_factory.rs
@@ -101,7 +101,7 @@ impl TransportFactory {
     /// | Executor     | Legacy | Acp                      | OpenaiCompat |
     /// |--------------|--------|--------------------------| -------------|
     /// | ClaudeCode   | No     | Yes                      | No           |
-    /// | Codex        | Yes    | Yes (feature `codex-acp`)| No           |
+    /// | Codex        | Yes    | Yes                      | No           |
     /// | GeminiCli    | Yes    | Yes                      | No           |
     /// | Opencode     | Yes    | No                       | No           |
     /// | OpenaiCompat | No     | No                       | Yes          |
@@ -127,18 +127,9 @@ impl TransportFactory {
                 err("claude-code only supports ACP transport")
             }
 
-            // Codex: Legacy always, ACP behind feature gate
+            // Codex: Legacy and ACP are both supported
             (Executor::Codex { .. }, TransportMode::Legacy) => Ok(()),
-            (Executor::Codex { .. }, TransportMode::Acp) => {
-                #[cfg(feature = "codex-acp")]
-                {
-                    Ok(())
-                }
-                #[cfg(not(feature = "codex-acp"))]
-                {
-                    err("codex-acp feature is not compiled in")
-                }
-            }
+            (Executor::Codex { .. }, TransportMode::Acp) => Ok(()),
             (Executor::Codex { .. }, TransportMode::OpenaiCompat) => {
                 err("codex only supports Legacy or ACP transport")
             }

--- a/crates/csa-executor/src/transport_tests_capabilities.rs
+++ b/crates/csa-executor/src/transport_tests_capabilities.rs
@@ -64,9 +64,7 @@ fn test_create_with_mode_explicit_override() {
 }
 
 #[test]
-#[cfg(not(feature = "codex-acp"))]
-fn test_create_with_mode_rejects_unsupported_combo() {
-    // Requesting ACP for codex without the codex-acp feature must fail.
+fn test_create_with_mode_allows_codex_acp() {
     let executor = crate::executor::Executor::Codex {
         model_override: None,
         thinking_budget: None,
@@ -75,29 +73,7 @@ fn test_create_with_mode_rejects_unsupported_combo() {
 
     let result =
         super::TransportFactory::create_with_mode(&executor, super::TransportMode::Acp, None);
-    match result {
-        Ok(_) => panic!("should fail without codex-acp feature"),
-        Err(err) => {
-            assert!(
-                err.downcast_ref::<super::TransportFactoryError>().is_some(),
-                "expected TransportFactoryError, got: {err:#}"
-            );
-        }
-    }
-}
-
-#[test]
-#[cfg(feature = "codex-acp")]
-fn test_create_with_mode_allows_codex_acp_with_feature() {
-    let executor = crate::executor::Executor::Codex {
-        model_override: None,
-        thinking_budget: None,
-        runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
-    };
-
-    let result =
-        super::TransportFactory::create_with_mode(&executor, super::TransportMode::Acp, None);
-    assert!(result.is_ok(), "should succeed with codex-acp feature");
+    assert!(result.is_ok(), "codex ACP transport should be supported");
 }
 
 // ---------------------------------------------------------------------------
@@ -238,19 +214,8 @@ fn test_matrix_codex_legacy_supported() {
 }
 
 #[test]
-#[cfg(feature = "codex-acp")]
-fn test_matrix_codex_acp_supported_with_feature() {
+fn test_matrix_codex_acp_supported() {
     assert_supported(&make_codex(), super::TransportMode::Acp);
-}
-
-#[test]
-#[cfg(not(feature = "codex-acp"))]
-fn test_matrix_codex_acp_rejected_without_feature() {
-    assert_unsupported(
-        &make_codex(),
-        super::TransportMode::Acp,
-        "codex-acp feature is not compiled in",
-    );
 }
 
 #[test]
@@ -335,8 +300,6 @@ fn test_matrix_openai_compat_acp_rejected() {
 
 #[test]
 fn test_create_feature_gate_structured_error() {
-    // The feature-gate check in create() (auto-infer path) should return a
-    // structured TransportFactoryError when codex-acp is not enabled.
     let executor = crate::executor::Executor::Codex {
         model_override: None,
         thinking_budget: None,
@@ -346,19 +309,7 @@ fn test_create_feature_gate_structured_error() {
     };
 
     let result = super::TransportFactory::create(&executor, None);
-
-    #[cfg(not(feature = "codex-acp"))]
-    match result {
-        Ok(_) => panic!("should fail without codex-acp feature"),
-        Err(err) => {
-            assert!(
-                err.downcast_ref::<super::TransportFactoryError>().is_some(),
-                "expected TransportFactoryError, got: {err:#}"
-            );
-        }
-    }
-    #[cfg(feature = "codex-acp")]
-    assert!(result.is_ok(), "should succeed with codex-acp feature");
+    assert!(result.is_ok(), "codex ACP transport should build in auto mode");
 }
 
 #[test]

--- a/crates/csa-executor/src/transport_tests_ephemeral.rs
+++ b/crates/csa-executor/src/transport_tests_ephemeral.rs
@@ -196,7 +196,6 @@ fn test_executor_ephemeral_transport_honors_codex_cli_runtime_transport_override
     );
 }
 
-#[cfg(feature = "codex-acp")]
 #[test]
 fn test_executor_ephemeral_transport_honors_codex_acp_runtime_transport_override() {
     let acp_executor = Executor::Codex {
@@ -212,31 +211,5 @@ fn test_executor_ephemeral_transport_honors_codex_acp_runtime_transport_override
     assert!(
         acp_transport.as_ref().as_any().is::<AcpTransport>(),
         "codex acp override should keep ephemeral paths on AcpTransport"
-    );
-}
-
-#[cfg(not(feature = "codex-acp"))]
-#[test]
-fn test_executor_ephemeral_transport_rejects_codex_acp_runtime_transport_override() {
-    let acp_executor = Executor::Codex {
-        model_override: None,
-        thinking_budget: None,
-        runtime_metadata: crate::codex_runtime::CodexRuntimeMetadata::from_transport(
-            crate::codex_runtime::CodexTransport::Acp,
-        ),
-    };
-
-    let err = acp_executor
-        .transport(None)
-        .err()
-        .expect("ephemeral codex ACP must fail closed when feature is disabled");
-    let rendered = format!("{err:#}");
-    assert!(
-        rendered.contains("codex-acp"),
-        "error should mention the required cargo feature: {rendered}"
-    );
-    assert!(
-        rendered.contains("not compiled in"),
-        "error should say feature is not compiled in: {rendered}"
     );
 }

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -10,11 +10,6 @@ fn test_transport_factory_create_routes_tools_to_expected_transport() {
             model_override: None,
             thinking_budget: None,
         },
-        Executor::Codex {
-            model_override: None,
-            thinking_budget: None,
-            runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
-        },
     ];
     for executor in legacy_tools {
         let transport = TransportFactory::create(&executor, None).expect("transport should build");
@@ -25,10 +20,17 @@ fn test_transport_factory_create_routes_tools_to_expected_transport() {
         );
     }
 
-    let acp_tools = vec![Executor::ClaudeCode {
-        model_override: None,
-        thinking_budget: None,
-    }];
+    let acp_tools = vec![
+        Executor::ClaudeCode {
+            model_override: None,
+            thinking_budget: None,
+        },
+        Executor::Codex {
+            model_override: None,
+            thinking_budget: None,
+            runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
+        },
+    ];
     for executor in acp_tools {
         let transport = TransportFactory::create(&executor, Some(SessionConfig::default()))
             .expect("transport should build");
@@ -83,7 +85,6 @@ fn test_transport_factory_create_honors_codex_cli_runtime_transport_override() {
     );
 }
 
-#[cfg(feature = "codex-acp")]
 #[test]
 fn test_transport_factory_create_honors_codex_acp_runtime_transport_override() {
     let acp_executor = Executor::Codex {
@@ -98,31 +99,6 @@ fn test_transport_factory_create_honors_codex_acp_runtime_transport_override() {
     assert!(
         acp_transport.as_ref().as_any().is::<AcpTransport>(),
         "codex acp override should use AcpTransport"
-    );
-}
-
-#[cfg(not(feature = "codex-acp"))]
-#[test]
-fn test_transport_factory_create_rejects_codex_acp_runtime_transport_override() {
-    let acp_executor = Executor::Codex {
-        model_override: None,
-        thinking_budget: None,
-        runtime_metadata: crate::codex_runtime::CodexRuntimeMetadata::from_transport(
-            crate::codex_runtime::CodexTransport::Acp,
-        ),
-    };
-
-    let err = TransportFactory::create(&acp_executor, Some(SessionConfig::default()))
-        .err()
-        .expect("codex ACP must fail closed when feature is disabled");
-    let rendered = format!("{err:#}");
-    assert!(
-        rendered.contains("codex-acp"),
-        "error should mention the required cargo feature: {rendered}"
-    );
-    assert!(
-        rendered.contains("not compiled in"),
-        "error should say feature is not compiled in: {rendered}"
     );
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,9 @@ ignore = [
     "RUSTSEC-2026-0098",
     # Transitive from rustls-webpki 0.101.7 (old chain). Wildcard name constraints bypass.
     "RUSTSEC-2026-0099",
+    # Transitive from rustls-webpki 0.101.7 (old agent-teams/cc-sdk reqwest 0.11 chain).
+    # No non-breaking upgrade path exists on the 0.101 line.
+    "RUSTSEC-2026-0104",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

- Adds `[tools.<name>].transport` config key (enum `TransportKind`: `auto` / `acp` / `cli`) validated at config-load time per tool's currently-supported set.
- `auto` maps to each tool's current default; `acp` accepted only for claude-code + codex; `cli` accepted only for gemini-cli + opencode.
- Phase 3 will add claude-code CLI transport; Phase 4 codex CLI transport. Config-load errors for `cli` on claude-code/codex now point at the phase that will enable it.
- No runtime behavior change in Phase 2 — the validated config is wired through to the Phase 1 Transport factory, which still dispatches to the existing default impl per tool. This is intentional: the config surface ships before the new impl so Phase 3/4 can focus purely on the impl.
- `csa config show` now includes the resolved `transport` under each tool's effective section (same pattern as `filesystem_sandbox`).
- One-line note added to `.claude/rules/csa-architecture-ref.md` Configuration section. No dedicated detail file for Phase 2 alone; Phase 5 will consolidate transport docs.

## Test plan

- [x] `cargo test -p csa-config transport` green — 4 tools × 3 values = 12 validation cases + `resolve_transport` mapping per tool
- [x] `cargo test -p cli-sub-agent config_show` green
- [x] `just pre-commit` exit 0
- [x] Cargo.toml/Cargo.lock bumped
- [ ] Manual: `csa config show` output shows `transport = "acp"` under `[tools.codex]` with project config `transport = "acp"`
- [ ] Manual: `[tools.claude-code] transport = "cli"` in project config fails load with Phase-3-pointer error

Refs #643 Phase 2 (of 5).
