### PR TITLE
fix(cli): is_csa_subprocess() recognizes CSA_DAEMON_SESSION_ID (#1024)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.493"
+version = "0.1.494"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.493"
+version = "0.1.494"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_helpers_atomic_commit.rs
+++ b/crates/cli-sub-agent/src/run_helpers_atomic_commit.rs
@@ -47,7 +47,10 @@ fn is_csa_subprocess() -> bool {
         .ok()
         .and_then(|s| s.parse::<u32>().ok())
         .map(|depth| depth > 0)
-        .unwrap_or_else(|| std::env::var_os("CSA_SESSION_ID").is_some())
+        .unwrap_or_else(|| {
+            std::env::var_os("CSA_SESSION_ID").is_some()
+                || std::env::var_os("CSA_DAEMON_SESSION_ID").is_some()
+        })
 }
 
 pub(crate) fn atomic_commit_discipline_preamble() -> &'static str {
@@ -67,4 +70,20 @@ pub(crate) fn prepend_atomic_commit_discipline_to_prompt(prompt: String) -> Stri
     }
 
     format!("{}\n\n{prompt}", atomic_commit_discipline_preamble())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_csa_subprocess;
+    use crate::test_env_lock::{ScopedEnvVarRestore, ScopedTestEnvVar};
+
+    #[test]
+    fn run_helpers_atomic_commit_daemon_session_id_alone_marks_csa_subprocess() {
+        let _daemon_guard =
+            ScopedTestEnvVar::set("CSA_DAEMON_SESSION_ID", "01KPTB1TSQ89AT5GVH8PCZ2SP4");
+        let _depth_guard = ScopedEnvVarRestore::unset("CSA_DEPTH");
+        let _session_guard = ScopedEnvVarRestore::unset("CSA_SESSION_ID");
+
+        assert!(is_csa_subprocess());
+    }
 }


### PR DESCRIPTION
## Summary

- PR #1023 added `is_csa_subprocess()` to gate the direct-git atomic-commit preamble, but the preamble is rendered in the `csa run --daemon-child` process which has only `CSA_DAEMON_SESSION_ID` set — not `CSA_DEPTH` / `CSA_SESSION_ID`.
- `CSA_DEPTH` IS set on the final tool process downstream (`pipeline_env.rs:64`, `transport_meta.rs:161`, `executor.rs:556`), but that's too late for preamble selection.
- Fix: `is_csa_subprocess()` now also accepts `CSA_DAEMON_SESSION_ID` as subprocess signal.
- Added unit test pinning the daemon-session-only case.

## Test plan

- [x] `cargo test -p cli-sub-agent run_helpers_atomic_commit` green
- [x] `just pre-commit` exit 0
- [x] Version bumped

Closes #1024. Refs #1021, PR #1023.