### PR TITLE
fix(pr-bot): route to Merge Without Bot on gemini quota exhaustion (#1019)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.494"
+version = "0.1.495"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.494"
+version = "0.1.495"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -329,14 +329,21 @@ Before triggering the bot, consult the persisted quota cache at
 `${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/pr_review/cloud_bot_quota.toml`.
 If the configured bot is still inside a recorded quota-exhaustion window and
 `CSA_PR_BOT_FORCE` is not set, skip the bot path and route directly to Step 6a.
+Also inspect the latest configured-bot PR comment; if that newest comment
+already signals quota exhaustion, record the 24h window and take the same
+Step 6a fallback path without entering Step 5.
 
 ```bash
 set -euo pipefail
 if [ -n "${CSA_WORKFLOW_DIR:-}" ]; then
   CSA_HELPER_DIR="${CSA_WORKFLOW_DIR}/scripts/csa"
+  PR_BOT_QUOTA_CACHE_SCRIPT="${CSA_WORKFLOW_DIR}/scripts/pr-bot-quota-cache.sh"
 else
   CSA_HELPER_DIR="patterns/pr-bot/scripts/csa"
+  PR_BOT_QUOTA_CACHE_SCRIPT="patterns/pr-bot/scripts/pr-bot-quota-cache.sh"
 fi
+# shellcheck source=patterns/pr-bot/scripts/pr-bot-quota-cache.sh
+. "${PR_BOT_QUOTA_CACHE_SCRIPT}"
 CLOUD_BOT=$(csa config get pr_review.cloud_bot --default true)
 CLOUD_BOT_NAME=$(csa config get pr_review.cloud_bot_name --default gemini-code-assist)
 CLOUD_BOT_TRIGGER=$(csa config get pr_review.cloud_bot_trigger --default auto)
@@ -400,6 +407,10 @@ quota_clear_section() {
   fi
   mv "${tmp_file}" "${CLOUD_BOT_QUOTA_CACHE_FILE}"
 }
+query_latest_bot_comment_json() {
+  gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" 2>/dev/null \
+    | jq -c '[.[] | .[] | select((.user.login // "") == "'"${CLOUD_BOT_LOGIN}"'")] | sort_by(.created_at) | last // empty'
+}
 if [ "${CLOUD_BOT}" = "true" ]; then
   CLOUD_BOT_QUOTA_EXHAUSTED_AT="$(quota_read_field exhausted_at)"
   CLOUD_BOT_QUOTA_EXPECTED_RESET_AT="$(quota_read_field expected_reset_at)"
@@ -417,6 +428,30 @@ if [ "${CLOUD_BOT}" = "true" ]; then
       quota_clear_section
       CLOUD_BOT_QUOTA_EXHAUSTED_AT=""
       CLOUD_BOT_QUOTA_EXPECTED_RESET_AT=""
+    fi
+  fi
+fi
+if [ "${CLOUD_BOT}" = "true" ] \
+  && [ "${CLOUD_BOT_SKIPPED}" != "true" ] \
+  && [ "${CSA_PR_BOT_FORCE:-0}" != "1" ]
+then
+  set +e
+  LATEST_BOT_COMMENT_JSON="$(query_latest_bot_comment_json)"
+  LATEST_BOT_COMMENT_RC=$?
+  set -e
+  if [ "${LATEST_BOT_COMMENT_RC}" -eq 0 ] && [ -n "${LATEST_BOT_COMMENT_JSON}" ]; then
+    LATEST_BOT_COMMENT_BODY="$(printf '%s\n' "${LATEST_BOT_COMMENT_JSON}" | jq -r '.body // ""')"
+    if quota_comment_indicates_exhaustion "${LATEST_BOT_COMMENT_BODY}" "${CLOUD_BOT_LOGIN}" "${CLOUD_BOT_NAME}"; then
+      LATEST_BOT_COMMENT_CREATED_AT="$(printf '%s\n' "${LATEST_BOT_COMMENT_JSON}" | jq -r '.created_at // ""')"
+      QUOTA_NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      QUOTA_EXPECTED_RESET_AT="$(compute_quota_expected_reset_at)"
+      QUOTA_CACHE_FILE="${CLOUD_BOT_QUOTA_CACHE_FILE}" \
+      BOT_NAME="${CLOUD_BOT_NAME}" \
+      PR_NUMBER="${PR_NUM}" \
+      write_quota_cache "${QUOTA_NOW_UTC}" "${QUOTA_EXPECTED_RESET_AT}" "cloud_bot_quota_exhausted" "${LATEST_BOT_COMMENT_BODY}"
+      CLOUD_BOT_SKIPPED=true
+      CLOUD_BOT_SKIP_KIND="quota_exhausted"
+      CLOUD_BOT_SKIP_REASON="latest ${CLOUD_BOT_NAME} comment indicates quota exhaustion at ${LATEST_BOT_COMMENT_CREATED_AT:-unknown}"
     fi
   fi
 fi
@@ -524,11 +559,13 @@ or aborting on resume/rerun.
 If bot times out, **ABORT the workflow** — user must decide next action.
 Also detects non-target bot comments (e.g., codex auto-review when
 configured bot is gemini-code-assist) and includes them with a quota warning.
-If a bot issue comment contains `daily quota limit` (case-insensitive), record
-the 24h quota window in the cache file, mark the bot unavailable, and continue
-through the Step 6a merge-without-bot path instead of spending another wait cycle.
-This applies both to the polling helper path and to the later Step 5
-post-verification quota-comment check.
+If the most recent issue comment from the configured bot indicates quota
+exhaustion (`daily quota limit`, `resource exhausted`, gemini `try again
+later`, or generic quota/rate-limit wording), record the 24h quota window in
+the cache file, mark the bot unavailable, and continue through the Step 6a
+merge-without-bot path instead of spending another wait cycle. This applies
+both to the polling helper path and to the later Step 5 post-verification
+latest-comment check.
 
 ```bash
 set -euo pipefail
@@ -761,30 +798,35 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     REVIEW_EVENT_COUNT="$(echo "${REVIEW_EVENT_RAW}" | awk '{s+=$1} END {print s+0}')"
   fi
   # Helper: check for setup/configuration messages before marking unavailable
-  check_quota_message_step5() {
+  query_latest_bot_comment_json_step5() {
+    gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" 2>/dev/null \
+      | jq -c '[.[] | .[] | select((.user.login // "") == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${BOT_REVIEW_WINDOW_START}"'")] | sort_by(.created_at) | last // empty'
+  }
+
+  check_latest_quota_comment_step5() {
     set +e
+    local latest_bot_comment_json
     local quota_body
     local quota_now_utc
     local quota_expected_reset_at
-    quota_body="$(
-      gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
-        | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select((.body // "") | test("daily quota limit"; "i"))] | .[0].body // ""' \
-        2>/dev/null
-    )"
+    latest_bot_comment_json="$(query_latest_bot_comment_json_step5)"
     set -e
-    if [ -n "${quota_body}" ]; then
-      echo "Quota exhaustion detected from cloud bot comment during post-poll verification." >&2
-      quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-      quota_expected_reset_at="$(compute_quota_expected_reset_at)"
-      QUOTA_CACHE_FILE="${CLOUD_BOT_QUOTA_CACHE_FILE}" \
-      BOT_NAME="${CLOUD_BOT_NAME}" \
-      PR_NUMBER="${PR_NUM}" \
-      write_quota_cache "${quota_now_utc}" "${quota_expected_reset_at}" "cloud_bot_quota_exhausted" "${quota_body}"
-      CLOUD_BOT_SKIPPED=true
-      CLOUD_BOT_SKIP_KIND="quota_exhausted"
-      CLOUD_BOT_SKIP_REASON="quota exhausted detected on PR #${PR_NUM}"
-      BOT_UNAVAILABLE=true
-      return 0
+    if [ -n "${latest_bot_comment_json}" ]; then
+      quota_body="$(printf '%s\n' "${latest_bot_comment_json}" | jq -r '.body // ""')"
+      if quota_comment_indicates_exhaustion "${quota_body}" "${CLOUD_BOT_LOGIN}" "${CLOUD_BOT_NAME}"; then
+        echo "Quota exhaustion detected from latest cloud bot comment during post-poll verification." >&2
+        quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        quota_expected_reset_at="$(compute_quota_expected_reset_at)"
+        QUOTA_CACHE_FILE="${CLOUD_BOT_QUOTA_CACHE_FILE}" \
+        BOT_NAME="${CLOUD_BOT_NAME}" \
+        PR_NUMBER="${PR_NUM}" \
+        write_quota_cache "${quota_now_utc}" "${quota_expected_reset_at}" "cloud_bot_quota_exhausted" "${quota_body}"
+        CLOUD_BOT_SKIPPED=true
+        CLOUD_BOT_SKIP_KIND="quota_exhausted"
+        CLOUD_BOT_SKIP_REASON="latest ${CLOUD_BOT_NAME} comment indicates quota exhaustion on PR #${PR_NUM}"
+        BOT_UNAVAILABLE=true
+        return 0
+      fi
     fi
     return 1
   }
@@ -811,7 +853,7 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
 
   if [ "${REVIEW_EVENT_RC}" -ne 0 ]; then
     echo "WARN: Failed to query review events (rc=${REVIEW_EVENT_RC})." >&2
-    check_quota_message_step5 || _check_setup_message_step5 || {
+    check_latest_quota_comment_step5 || _check_setup_message_step5 || {
       echo "Treating as bot unavailable — API failure with no setup message." >&2
       BOT_UNAVAILABLE=true
     }
@@ -857,7 +899,7 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
       BOT_HAS_ISSUES=true
     elif [ "${REVIEW_EVENT_COUNT:-0}" -eq 0 ]; then
       echo "WARN: No current-HEAD review event or inline comments for HEAD ${CURRENT_SHA} since ${BOT_REVIEW_WINDOW_START}." >&2
-      check_quota_message_step5 || _check_setup_message_step5 || {
+      check_latest_quota_comment_step5 || _check_setup_message_step5 || {
         echo "Treating as bot unavailable — no positive signal (neither review event nor comments)." >&2
         BOT_UNAVAILABLE=true
       }
@@ -1835,6 +1877,8 @@ guarantees `FALLBACK_REVIEW_HAS_ISSUES=false` before reaching this point.
 This step executes in either of these cases:
 - `cloud_bot=false` (no cloud bot path)
 - `cloud_bot=true`, bot is skipped due to cached quota exhaustion, and fallback local review is clean
+Note: this Step 6a path now also covers the latest-comment quota fallback once
+the workflow records the quota window.
 
 **MANDATORY**: Before merging, leave a PR comment explaining the merge rationale.
 This step has two audit-trail cases:
@@ -1875,7 +1919,7 @@ elif [ "${MERGE_WITHOUT_BOT_REASON_KIND:-}" = "cloud_bot_quota_exhausted" ]; the
     printf '%s\n' \
       '## Merge audit trail — cloud bot skipped (quota exhausted)' \
       '' \
-      "Configured cloud bot \`${CLOUD_BOT_NAME}\` is quota-exhausted (detected at \`${CLOUD_BOT_QUOTA_EXHAUSTED_AT:-unknown}\`, expected reset \`${CLOUD_BOT_QUOTA_EXPECTED_RESET_AT:-unknown}\`). Per pr-bot Step 4 auto-skip, routing directly to bot-unavailable + local-review-clean merge path." \
+      "Configured cloud bot \`${CLOUD_BOT_NAME}\` is quota-exhausted (detected at \`${CLOUD_BOT_QUOTA_EXHAUSTED_AT:-unknown}\`, expected reset \`${CLOUD_BOT_QUOTA_EXPECTED_RESET_AT:-unknown}\`). Per pr-bot quota fallback, routing to the bot-unavailable + local-review-clean merge path." \
       '' \
       "**Local pre-merge review verdict**: CLEAN (session \`${LOCAL_REVIEW_SESSION_ID:-unknown}\`)" \
       '' \

--- a/patterns/pr-bot/scripts/pr-bot-quota-cache.sh
+++ b/patterns/pr-bot/scripts/pr-bot-quota-cache.sh
@@ -8,6 +8,30 @@ compute_quota_expected_reset_at() {
   date -u -d '+24 hours' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+24H +%Y-%m-%dT%H:%M:%SZ
 }
 
+quota_comment_indicates_exhaustion() {
+  local comment_body="${1:-}"
+  local bot_login="${2:-${BOT_LOGIN:-${CLOUD_BOT_LOGIN:-}}}"
+  local bot_name="${3:-${BOT_NAME:-${CLOUD_BOT_NAME:-${CSA_PR_BOT_NAME:-}}}}"
+
+  if [ -z "${comment_body}" ]; then
+    return 1
+  fi
+
+  if printf '%s\n' "${comment_body}" | grep -Eqi 'daily quota limit|resource exhausted|quota|exhausted|rate.{0,3}limit.{0,20}exceed'; then
+    return 0
+  fi
+
+  if {
+    [ "${bot_name}" = "gemini-code-assist" ] \
+      || [ "${bot_login}" = "gemini-code-assist" ] \
+      || [ "${bot_login}" = "gemini-code-assist[bot]" ];
+  } && printf '%s\n' "${comment_body}" | grep -qi 'try again later'; then
+    return 0
+  fi
+
+  return 1
+}
+
 write_quota_cache() {
   local exhausted_at="$1"
   local expected_reset_at="$2"

--- a/patterns/pr-bot/scripts/pr-bot-wait.sh
+++ b/patterns/pr-bot/scripts/pr-bot-wait.sh
@@ -192,13 +192,12 @@ while [ "${elapsed}" -le "${TIMEOUT_SEC}" ]; do
   fi
 
   comments_json="$(gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100")"
-  quota_comment_json="$(
+  latest_bot_comment_json="$(
     if [ -n "${BOT_LOGIN}" ]; then
       printf '%s\n' "${comments_json}" | jq -c --arg login "${BOT_LOGIN}" --arg push_time "${PUSH_TIME}" '
         [ .[] | .[]
           | select((.user.login // "") == $login)
           | select($push_time == "" or (.created_at // "") > $push_time)
-          | select((.body // "") | test("daily quota limit"; "i"))
         ]
         | sort_by(.created_at)
         | last // empty
@@ -208,65 +207,41 @@ while [ "${elapsed}" -le "${TIMEOUT_SEC}" ]; do
         [ .[] | .[]
           | select((.user.type // "") == "Bot" or ((.user.login // "") | test("\\[bot\\]$")))
           | select($push_time == "" or (.created_at // "") > $push_time)
-          | select((.body // "") | test("daily quota limit"; "i"))
         ]
         | sort_by(.created_at)
         | last // empty
       ' || true
     fi
   )"
-  if [ -n "${quota_comment_json}" ]; then
-    quota_body="$(printf '%s\n' "${quota_comment_json}" | jq -r '.body // ""')"
-    quota_preview="$(quota_cache_preview_body "${quota_body}")"
-    quota_created_at="$(printf '%s\n' "${quota_comment_json}" | jq -r '.created_at // ""')"
-    quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    quota_expected_reset_at="$(compute_quota_expected_reset_at)"
-    write_quota_cache "${quota_now_utc}" "${quota_expected_reset_at}" "cloud_bot_quota_exhausted" "${quota_body}"
-    result_json="$(
-      jq -n \
-        --argjson pr "${PR_NUMBER}" \
-        --argjson elapsed "${elapsed}" \
-        --arg preview "${quota_preview}" \
-        --arg created_at "${quota_created_at}" \
-        --arg exhausted_at "${QUOTA_EXHAUSTED_AT}" \
-        --arg expected_reset_at "${QUOTA_EXPECTED_RESET_AT}" \
-        '{status:"quota_exhausted", pr:$pr, elapsed_seconds:$elapsed, exhausted_at:$exhausted_at, expected_reset_at:$expected_reset_at, comment:{preview:$preview, created_at:$created_at}}'
-    )"
-    write_output "${result_json}"
-    exit 0
-  fi
+  if [ -n "${latest_bot_comment_json}" ]; then
+    latest_comment_body="$(printf '%s\n' "${latest_bot_comment_json}" | jq -r '.body // ""')"
+    latest_comment_created_at="$(printf '%s\n' "${latest_bot_comment_json}" | jq -r '.created_at // ""')"
+    if quota_comment_indicates_exhaustion "${latest_comment_body}" "${BOT_LOGIN}" "${BOT_NAME}"; then
+      quota_preview="$(quota_cache_preview_body "${latest_comment_body}")"
+      quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      quota_expected_reset_at="$(compute_quota_expected_reset_at)"
+      write_quota_cache "${quota_now_utc}" "${quota_expected_reset_at}" "cloud_bot_quota_exhausted" "${latest_comment_body}"
+      result_json="$(
+        jq -n \
+          --argjson pr "${PR_NUMBER}" \
+          --argjson elapsed "${elapsed}" \
+          --arg preview "${quota_preview}" \
+          --arg created_at "${latest_comment_created_at}" \
+          --arg exhausted_at "${QUOTA_EXHAUSTED_AT}" \
+          --arg expected_reset_at "${QUOTA_EXPECTED_RESET_AT}" \
+          '{status:"quota_exhausted", pr:$pr, elapsed_seconds:$elapsed, exhausted_at:$exhausted_at, expected_reset_at:$expected_reset_at, comment:{preview:$preview, created_at:$created_at}}'
+      )"
+      write_output "${result_json}"
+      exit 0
+    fi
 
-  reply_comment_json="$(
-    if [ -n "${BOT_LOGIN}" ]; then
-      printf '%s\n' "${comments_json}" | jq -c --arg login "${BOT_LOGIN}" --arg push_time "${PUSH_TIME}" '
-        [ .[] | .[]
-          | select((.user.login // "") == $login)
-          | select($push_time == "" or (.created_at // "") > $push_time)
-        ]
-        | sort_by(.created_at)
-        | last // empty
-      ' || true
-    else
-      printf '%s\n' "${comments_json}" | jq -c --arg push_time "${PUSH_TIME}" '
-        [ .[] | .[]
-          | select((.user.type // "") == "Bot" or ((.user.login // "") | test("\\[bot\\]$")))
-          | select($push_time == "" or (.created_at // "") > $push_time)
-        ]
-        | sort_by(.created_at)
-        | last // empty
-      ' || true
-    fi
-  )"
-  if [ -n "${reply_comment_json}" ]; then
-    reply_body="$(printf '%s\n' "${reply_comment_json}" | jq -r '.body // ""')"
-    reply_preview="$(preview_body "${reply_body}")"
-    reply_created_at="$(printf '%s\n' "${reply_comment_json}" | jq -r '.created_at // ""')"
+    reply_preview="$(quota_cache_preview_body "${latest_comment_body}")"
     result_json="$(
       jq -n \
         --argjson pr "${PR_NUMBER}" \
         --argjson elapsed "${elapsed}" \
         --arg preview "${reply_preview}" \
-        --arg created_at "${reply_created_at}" \
+        --arg created_at "${latest_comment_created_at}" \
         '{status:"replied", pr:$pr, elapsed_seconds:$elapsed, comment:{preview:$preview, created_at:$created_at}}'
     )"
     write_output "${result_json}"

--- a/patterns/pr-bot/tests/quota-fallback-reproducer.md
+++ b/patterns/pr-bot/tests/quota-fallback-reproducer.md
@@ -1,0 +1,43 @@
+# pr-bot quota fallback reproducer
+
+This reproducer simulates gemini cloud-bot quota exhaustion without burning
+real quota.
+
+## Goal
+
+Verify that `patterns/pr-bot/workflow.toml` routes to Step 6a when the latest
+`gemini-code-assist[bot]` PR comment indicates quota exhaustion.
+
+## Preconditions
+
+- Work on a disposable test PR.
+- `pr_review.cloud_bot=true`
+- `pr_review.cloud_bot_name=gemini-code-assist`
+- `pr_review.cloud_bot_login=gemini-code-assist[bot]`
+- `gh` auth is already working for the repo.
+
+## Simulation Steps
+
+1. Create a temporary `gh` wrapper earlier on `PATH`.
+2. Let the wrapper pass through every command except
+   `gh api repos/<owner>/<repo>/issues/<PR>/comments?per_page=100`.
+3. For that comments endpoint, return JSON whose newest
+   `gemini-code-assist[bot]` comment body is one of:
+   - `Daily quota limit reached for today.`
+   - `Resource exhausted. Try again later.`
+   - `Rate limit exceeded, try again later.`
+4. Run `csa plan run patterns/pr-bot/workflow.toml` against the test PR.
+
+## Expected Result
+
+- Step 4a or Step 5 logs that the latest gemini comment indicates quota
+  exhaustion.
+- `CLOUD_BOT_SKIP_KIND=quota_exhausted`
+- `MERGE_WITHOUT_BOT_REASON_KIND=cloud_bot_quota_exhausted`
+- The workflow does not stop waiting for another bot response.
+- The workflow follows the Step 6a merge-without-bot path.
+
+## Control Check
+
+Change the stubbed newest bot comment body to a normal non-quota message, then
+rerun the workflow. The Step 5 trigger-and-wait path should execute normally.

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -769,14 +769,21 @@ Before triggering the bot, consult the persisted quota cache at
 `${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/pr_review/cloud_bot_quota.toml`.
 If the configured bot is still inside a recorded quota-exhaustion window and
 `CSA_PR_BOT_FORCE` is not set, skip the bot path and route directly to Step 6a.
+Also inspect the latest configured-bot PR comment; if that newest comment
+already signals quota exhaustion, record the 24h window and take the same
+Step 6a fallback path without entering Step 5.
 
 ```bash
 set -euo pipefail
 if [ -n "${CSA_WORKFLOW_DIR:-}" ]; then
   CSA_HELPER_DIR="${CSA_WORKFLOW_DIR}/scripts/csa"
+  PR_BOT_QUOTA_CACHE_SCRIPT="${CSA_WORKFLOW_DIR}/scripts/pr-bot-quota-cache.sh"
 else
   CSA_HELPER_DIR="patterns/pr-bot/scripts/csa"
+  PR_BOT_QUOTA_CACHE_SCRIPT="patterns/pr-bot/scripts/pr-bot-quota-cache.sh"
 fi
+# shellcheck source=patterns/pr-bot/scripts/pr-bot-quota-cache.sh
+. "${PR_BOT_QUOTA_CACHE_SCRIPT}"
 CLOUD_BOT=$(csa config get pr_review.cloud_bot --default true)
 CLOUD_BOT_NAME=$(csa config get pr_review.cloud_bot_name --default gemini-code-assist)
 CLOUD_BOT_TRIGGER=$(csa config get pr_review.cloud_bot_trigger --default auto)
@@ -840,6 +847,10 @@ quota_clear_section() {
   fi
   mv "${tmp_file}" "${CLOUD_BOT_QUOTA_CACHE_FILE}"
 }
+query_latest_bot_comment_json() {
+  gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" 2>/dev/null \
+    | jq -c '[.[] | .[] | select((.user.login // "") == "'"${CLOUD_BOT_LOGIN}"'")] | sort_by(.created_at) | last // empty'
+}
 if [ "${CLOUD_BOT}" = "true" ]; then
   CLOUD_BOT_QUOTA_EXHAUSTED_AT="$(quota_read_field exhausted_at)"
   CLOUD_BOT_QUOTA_EXPECTED_RESET_AT="$(quota_read_field expected_reset_at)"
@@ -857,6 +868,30 @@ if [ "${CLOUD_BOT}" = "true" ]; then
       quota_clear_section
       CLOUD_BOT_QUOTA_EXHAUSTED_AT=""
       CLOUD_BOT_QUOTA_EXPECTED_RESET_AT=""
+    fi
+  fi
+fi
+if [ "${CLOUD_BOT}" = "true" ] \
+  && [ "${CLOUD_BOT_SKIPPED}" != "true" ] \
+  && [ "${CSA_PR_BOT_FORCE:-0}" != "1" ]
+then
+  set +e
+  LATEST_BOT_COMMENT_JSON="$(query_latest_bot_comment_json)"
+  LATEST_BOT_COMMENT_RC=$?
+  set -e
+  if [ "${LATEST_BOT_COMMENT_RC}" -eq 0 ] && [ -n "${LATEST_BOT_COMMENT_JSON}" ]; then
+    LATEST_BOT_COMMENT_BODY="$(printf '%s\n' "${LATEST_BOT_COMMENT_JSON}" | jq -r '.body // ""')"
+    if quota_comment_indicates_exhaustion "${LATEST_BOT_COMMENT_BODY}" "${CLOUD_BOT_LOGIN}" "${CLOUD_BOT_NAME}"; then
+      LATEST_BOT_COMMENT_CREATED_AT="$(printf '%s\n' "${LATEST_BOT_COMMENT_JSON}" | jq -r '.created_at // ""')"
+      QUOTA_NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      QUOTA_EXPECTED_RESET_AT="$(compute_quota_expected_reset_at)"
+      QUOTA_CACHE_FILE="${CLOUD_BOT_QUOTA_CACHE_FILE}" \
+      BOT_NAME="${CLOUD_BOT_NAME}" \
+      PR_NUMBER="${PR_NUM}" \
+      write_quota_cache "${QUOTA_NOW_UTC}" "${QUOTA_EXPECTED_RESET_AT}" "cloud_bot_quota_exhausted" "${LATEST_BOT_COMMENT_BODY}"
+      CLOUD_BOT_SKIPPED=true
+      CLOUD_BOT_SKIP_KIND="quota_exhausted"
+      CLOUD_BOT_SKIP_REASON="latest ${CLOUD_BOT_NAME} comment indicates quota exhaustion at ${LATEST_BOT_COMMENT_CREATED_AT:-unknown}"
     fi
   fi
 fi
@@ -963,11 +998,13 @@ or aborting on resume/rerun.
 If bot times out, **ABORT the workflow** — user must decide next action.
 Also detects non-target bot comments (e.g., codex auto-review when
 configured bot is gemini-code-assist) and includes them with a quota warning.
-If a bot issue comment contains `daily quota limit` (case-insensitive), record
-the 24h quota window in the cache file, mark the bot unavailable, and continue
-through the Step 6a merge-without-bot path instead of spending another wait cycle.
-This applies both to the polling helper path and to the later Step 5
-post-verification quota-comment check.
+If the most recent issue comment from the configured bot indicates quota
+exhaustion (`daily quota limit`, `resource exhausted`, gemini `try again
+later`, or generic quota/rate-limit wording), record the 24h quota window in
+the cache file, mark the bot unavailable, and continue through the Step 6a
+merge-without-bot path instead of spending another wait cycle. This applies
+both to the polling helper path and to the later Step 5 post-verification
+latest-comment check.
 
 ```bash
 set -euo pipefail
@@ -1200,30 +1237,35 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     REVIEW_EVENT_COUNT="$(echo "${REVIEW_EVENT_RAW}" | awk '{s+=$1} END {print s+0}')"
   fi
   # Helper: check for setup/configuration messages before marking unavailable
-  check_quota_message_step5() {
+  query_latest_bot_comment_json_step5() {
+    gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" 2>/dev/null \
+      | jq -c '[.[] | .[] | select((.user.login // "") == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${BOT_REVIEW_WINDOW_START}"'")] | sort_by(.created_at) | last // empty'
+  }
+
+  check_latest_quota_comment_step5() {
     set +e
+    local latest_bot_comment_json
     local quota_body
     local quota_now_utc
     local quota_expected_reset_at
-    quota_body="$(
-      gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
-        | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${BOT_REVIEW_WINDOW_START}"'") | select((.body // "") | test("daily quota limit"; "i"))] | .[0].body // ""' \
-        2>/dev/null
-    )"
+    latest_bot_comment_json="$(query_latest_bot_comment_json_step5)"
     set -e
-    if [ -n "${quota_body}" ]; then
-      echo "Quota exhaustion detected from cloud bot comment during post-poll verification." >&2
-      quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-      quota_expected_reset_at="$(compute_quota_expected_reset_at)"
-      QUOTA_CACHE_FILE="${CLOUD_BOT_QUOTA_CACHE_FILE}" \
-      BOT_NAME="${CLOUD_BOT_NAME}" \
-      PR_NUMBER="${PR_NUM}" \
-      write_quota_cache "${quota_now_utc}" "${quota_expected_reset_at}" "cloud_bot_quota_exhausted" "${quota_body}"
-      CLOUD_BOT_SKIPPED=true
-      CLOUD_BOT_SKIP_KIND="quota_exhausted"
-      CLOUD_BOT_SKIP_REASON="quota exhausted detected on PR #${PR_NUM}"
-      BOT_UNAVAILABLE=true
-      return 0
+    if [ -n "${latest_bot_comment_json}" ]; then
+      quota_body="$(printf '%s\n' "${latest_bot_comment_json}" | jq -r '.body // ""')"
+      if quota_comment_indicates_exhaustion "${quota_body}" "${CLOUD_BOT_LOGIN}" "${CLOUD_BOT_NAME}"; then
+        echo "Quota exhaustion detected from latest cloud bot comment during post-poll verification." >&2
+        quota_now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        quota_expected_reset_at="$(compute_quota_expected_reset_at)"
+        QUOTA_CACHE_FILE="${CLOUD_BOT_QUOTA_CACHE_FILE}" \
+        BOT_NAME="${CLOUD_BOT_NAME}" \
+        PR_NUMBER="${PR_NUM}" \
+        write_quota_cache "${quota_now_utc}" "${quota_expected_reset_at}" "cloud_bot_quota_exhausted" "${quota_body}"
+        CLOUD_BOT_SKIPPED=true
+        CLOUD_BOT_SKIP_KIND="quota_exhausted"
+        CLOUD_BOT_SKIP_REASON="latest ${CLOUD_BOT_NAME} comment indicates quota exhaustion on PR #${PR_NUM}"
+        BOT_UNAVAILABLE=true
+        return 0
+      fi
     fi
     return 1
   }
@@ -1250,7 +1292,7 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
 
   if [ "${REVIEW_EVENT_RC}" -ne 0 ]; then
     echo "WARN: Failed to query review events (rc=${REVIEW_EVENT_RC})." >&2
-    check_quota_message_step5 || _check_setup_message_step5 || {
+    check_latest_quota_comment_step5 || _check_setup_message_step5 || {
       echo "Treating as bot unavailable — API failure with no setup message." >&2
       BOT_UNAVAILABLE=true
     }
@@ -1296,7 +1338,7 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
       BOT_HAS_ISSUES=true
     elif [ "${REVIEW_EVENT_COUNT:-0}" -eq 0 ]; then
       echo "WARN: No current-HEAD review event or inline comments for HEAD ${CURRENT_SHA} since ${BOT_REVIEW_WINDOW_START}." >&2
-      check_quota_message_step5 || _check_setup_message_step5 || {
+      check_latest_quota_comment_step5 || _check_setup_message_step5 || {
         echo "Treating as bot unavailable — no positive signal (neither review event nor comments)." >&2
         BOT_UNAVAILABLE=true
       }
@@ -2256,6 +2298,8 @@ guarantees `FALLBACK_REVIEW_HAS_ISSUES=false` before reaching this point.
 This step executes in either of these cases:
 - `cloud_bot=false` (no cloud bot path)
 - `cloud_bot=true`, bot is skipped due to cached quota exhaustion, and fallback local review is clean
+Note: this Step 6a path now also covers the latest-comment quota fallback once
+the workflow records the quota window.
 
 **MANDATORY**: Before merging, leave a PR comment explaining the merge rationale.
 This step has two audit-trail cases:
@@ -2296,7 +2340,7 @@ elif [ "${MERGE_WITHOUT_BOT_REASON_KIND:-}" = "cloud_bot_quota_exhausted" ]; the
     printf '%s\n' \
       '## Merge audit trail — cloud bot skipped (quota exhausted)' \
       '' \
-      "Configured cloud bot \`${CLOUD_BOT_NAME}\` is quota-exhausted (detected at \`${CLOUD_BOT_QUOTA_EXHAUSTED_AT:-unknown}\`, expected reset \`${CLOUD_BOT_QUOTA_EXPECTED_RESET_AT:-unknown}\`). Per pr-bot Step 4 auto-skip, routing directly to bot-unavailable + local-review-clean merge path." \
+      "Configured cloud bot \`${CLOUD_BOT_NAME}\` is quota-exhausted (detected at \`${CLOUD_BOT_QUOTA_EXHAUSTED_AT:-unknown}\`, expected reset \`${CLOUD_BOT_QUOTA_EXPECTED_RESET_AT:-unknown}\`). Per pr-bot quota fallback, routing to the bot-unavailable + local-review-clean merge path." \
       '' \
       "**Local pre-merge review verdict**: CLEAN (session \`${LOCAL_REVIEW_SESSION_ID:-unknown}\`)" \
       '' \


### PR DESCRIPTION
## Summary

- When gemini-code-assist cloud bot signals quota exhaustion in its most recent PR comment, pr-bot now routes to the existing Step 6a "Merge Without Bot" path instead of halting Step 7 on "awaiting user action".
- Observed nightly burn: PRs #1018, #1022, #1023, #1025, #1026 all required Layer 0 manual merge rescue while gemini quota was exhausted.
- Quota-exhaustion detection: regex match on the latest gemini-code-assist comment body against `(?i)(quota|exhausted|rate.{0,3}limit.{0,20}exceed)`. Non-quota Step 7 flow unchanged.
- PATTERN.md + workflow.toml synced per AGENTS.md rule 027.

## Test plan

- [x] `weave compile patterns/pr-bot/workflow.toml` exit 0
- [x] `just pre-commit` exit 0
- [x] Version bumped
- [x] Manual-reproduction doc added

Closes #1019.