### PR TITLE
fix(pr-bot): re-enable Step 10.5 with AI Reviewer Metadata rollup (#662)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.495"
+version = "0.1.496"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.495"
+version = "0.1.496"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -1698,169 +1698,43 @@ No issues found by bot. Proceed to merge.
 This step only runs when the cloud bot is enabled, reachable, has reported no
 issues, and the review loop has not hit the round limit.
 
-## Step 10.5: Rebase for Clean History (DISABLED)
+## Step 10.5: Rebase for Clean History
 
 > **Layer**: 0 (Orchestrator) -- git history cleanup before merge.
-> **Status**: Disabled. With `--merge` (not `--squash`), rebase destroys the
-> per-commit audit trail instead of cleaning it up.
-> Squash merges are forbidden for audit reasons.
 
 Tool: bash
-Condition: false
+Condition: (${CLOUD_BOT}) && !(${BOT_UNAVAILABLE}) && !(${BOT_HAS_ISSUES}) && !(${ROUND_LIMIT_REACHED}) && (${FIXES_ACCUMULATED})
 
 Reorganize accumulated fix commits into logical groups (source, patterns, other)
-before merging. Skip if <= 3 commits.
+before merging, but only when the branch meets the audit guard:
+- branch has 3+ commits since `${DEFAULT_BRANCH}`
+- every original commit carries explicit review metadata with `verdict=Pass`
+  (legacy `Review: ... summary=PASS|CLEAN` is also accepted)
 
-After rebase: backup branch, soft reset to merge-base, dynamic file grouping,
-force-push with lease, trigger final `@${CLOUD_BOT_NAME} review`, then delegate the long
-wait/fix/review loop to a single CSA-managed step.
+When the guard passes, Step 10.5:
+- creates/refreshes `backup-${PR_NUM}-pre-rebase`
+- soft-resets to the merge-base
+- rebuilds logical commits
+- preserves the current commit's `### AI Reviewer Metadata` block
+- appends an additive `## AI Reviewer Metadata Rollup` block naming the
+  original SHAs + verdict/tool/round metadata
+- force-pushes with `--force-with-lease`
+- triggers one final `@${CLOUD_BOT_NAME}` review on the rebased HEAD
+- blocks merge until the delegated post-rebase review gate returns
+  `REBASE_GATE=PASS`
 
-**Post-rebase review gate** (BLOCKING):
-- CSA delegated step handles both paths:
-  - Bot responds with P0/P1/P2 badges → CSA runs bounded fix/review retries (max 3 rounds), using the same configurable wait policy for each trigger (`cloud_bot_wait_seconds` quiet wait + `cloud_bot_poll_max_seconds` polling).
-  - Bot times out → CSA runs fallback `csa review --range "${DEFAULT_BRANCH}...HEAD"` and bounded fix/review retries (max 3 rounds).
-- CSA daemon + session wait (configured by `cloud_bot_wait_seconds` + `cloud_bot_poll_max_seconds`, defaults: `kv_cache.frequent_poll_seconds = 60` and `kv_cache.long_poll_seconds = 240`) enforces the hard timeout.
-- delegated execution failures are hard failures (no `|| true` silent downgrade).
-- On delegated gate failure (timeout, non-zero, or non-PASS marker), set `REBASE_REVIEW_HAS_ISSUES=true` (and `FALLBACK_REVIEW_HAS_ISSUES=true` when appropriate), then block merge.
-- On success, both `REBASE_REVIEW_HAS_ISSUES` and `FALLBACK_REVIEW_HAS_ISSUES` must be false.
-
-This step is disabled unconditionally. Keep the implementation text only as
-historical context; the workflow condition is `false` so the rebase path never
-executes.
+When the guard does not pass, the step logs the skip reason and the workflow
+falls back to the existing clean-branch path (Step 11 / Step 12).
 
 ```bash
 set -euo pipefail
 if [ -n "${CSA_WORKFLOW_DIR:-}" ]; then
-  CSA_HELPER_DIR="${CSA_WORKFLOW_DIR}/scripts/csa"
+  REBASE_SCRIPT="${CSA_WORKFLOW_DIR}/scripts/rebase-with-rollup.sh"
 else
-  CSA_HELPER_DIR="patterns/pr-bot/scripts/csa"
+  REBASE_SCRIPT="patterns/pr-bot/scripts/rebase-with-rollup.sh"
 fi
 
-COMMIT_COUNT=$(git rev-list --count "${DEFAULT_BRANCH}..HEAD")
-if [ "${COMMIT_COUNT}" -gt 3 ]; then
-  git branch -f "backup-${PR_NUM}-pre-rebase" HEAD
-
-  MERGE_BASE=$(git merge-base "${DEFAULT_BRANCH}" HEAD)
-  git reset --soft $MERGE_BASE
-
-  git reset HEAD .
-  git diff --name-only -z HEAD | { grep -zE '^(src/|crates/|lib/|bin/)' || true; } | xargs -0 --no-run-if-empty git add --
-  if ! git diff --cached --quiet; then
-    git commit -m "feat(scope): primary implementation changes"
-  fi
-
-  git diff --name-only -z HEAD | { grep -zE '^(patterns/|\.claude/)' || true; } | xargs -0 --no-run-if-empty git add --
-  if ! git diff --cached --quiet; then
-    git commit -m "fix(scope): pattern and skill updates"
-  fi
-
-  git add -A
-  if ! git diff --cached --quiet; then
-    git commit -m "chore(scope): config and documentation updates"
-  fi
-
-  NEW_COMMIT_COUNT=$(git rev-list --count ${MERGE_BASE}..HEAD)
-  if [ "${NEW_COMMIT_COUNT}" -eq 0 ]; then
-    echo "ERROR: No replacement commits after soft reset. Restoring backup."
-    git reset --hard "backup-${PR_NUM}-pre-rebase"
-    exit 1
-  fi
-
-  git push --force-with-lease
-  REBASE_CURRENT_SHA="$(git rev-parse HEAD)"
-  REBASE_TRIGGER_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  # ALWAYS trigger explicitly — force-push doesn't auto-review (#506)
-  REBASE_TRIGGER_BODY="${CLOUD_BOT_RETRIGGER_CMD}
-
-<!-- csa-retrigger:post-rebase:${REBASE_CURRENT_SHA}:${REBASE_TRIGGER_TS} -->"
-  gh pr comment "${PR_NUM}" --repo "${REPO}" --body "${REBASE_TRIGGER_BODY}"
-  echo "Triggered post-rebase review via '${CLOUD_BOT_RETRIGGER_CMD}' for HEAD ${REBASE_CURRENT_SHA}."
-
-  # POST_REBASE_TIMEOUT is pre-computed in Step 4a.
-  set +e
-  GATE_SID="$(csa run --sa-mode true --tier tier-1 --timeout ${POST_REBASE_TIMEOUT} --idle-timeout ${POST_REBASE_TIMEOUT} "Bounded post-rebase gate task only. Do NOT invoke pr-bot skill or any full PR workflow. Operate on PR #${PR_NUM} in repo ${REPO} (branch ${WORKFLOW_BRANCH}). Complete the post-rebase review gate end-to-end. For each cloud bot trigger, wait ${CLOUD_BOT_WAIT_SECONDS} seconds quietly, then poll up to ${CLOUD_BOT_POLL_MAX_SECONDS} seconds for a response. If response contains P0/P1/P2 findings, iteratively fix/commit/push/re-trigger and re-check with the same wait policy (max 3 rounds). If bot times out, abort and report to user; return exactly one marker line REBASE_GATE=PASS when clean, otherwise REBASE_GATE=FAIL and exit non-zero.")"
-  DAEMON_RC=$?
-  set -e
-  if [ "${DAEMON_RC}" -ne 0 ] || [ -z "${GATE_SID}" ]; then
-    REBASE_REVIEW_HAS_ISSUES=true
-    FALLBACK_REVIEW_HAS_ISSUES=true
-    echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-    echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-    echo "ERROR: Failed to launch daemon for post-rebase gate (rc=${DAEMON_RC})." >&2
-    exit 1
-  fi
-  set +e
-  GATE_RESULT="$(bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "${GATE_SID}")"
-  GATE_RC=$?
-  set -e
-  if [ "${GATE_RC}" -ne 0 ]; then
-    REBASE_REVIEW_HAS_ISSUES=true
-    FALLBACK_REVIEW_HAS_ISSUES=true
-    echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-    echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-    echo "ERROR: Post-rebase delegated gate failed (rc=${GATE_RC})." >&2
-    exit 1
-  fi
-
-  GATE_MARKER="$(
-    printf '%s\n' "${GATE_RESULT}" \
-      | grep -E '^[[:space:]]*REBASE_GATE=(PASS|FAIL)[[:space:]]*$' \
-      | tail -n 1 \
-      | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
-      || true
-  )"
-  if [ "${GATE_MARKER}" != "REBASE_GATE=PASS" ]; then
-    REBASE_REVIEW_HAS_ISSUES=true
-    FALLBACK_REVIEW_HAS_ISSUES=true
-    echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-    echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-    echo "ERROR: Post-rebase review gate failed."
-    exit 1
-  fi
-
-  BOT_SETTLE_SECS="${BOT_SETTLE_SECS:-20}"
-  sleep "${BOT_SETTLE_SECS}"
-  set +e
-  LATE_ACTIONABLE_COUNT="$(
-    gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/comments" \
-      | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at > "'"${REBASE_TRIGGER_TS}"'") | select((.body | test("P0|P1|P2"))) ] | length' \
-      2>/dev/null
-  )"
-  LATE_ACTIONABLE_RC=$?
-  set -e
-  if [ "${LATE_ACTIONABLE_RC}" -ne 0 ]; then
-    REBASE_REVIEW_HAS_ISSUES=true
-    FALLBACK_REVIEW_HAS_ISSUES=true
-    echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-    echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-    echo "ERROR: Failed to query post-rebase actionable bot comments (rc=${LATE_ACTIONABLE_RC})." >&2
-    exit 1
-  fi
-  case "${LATE_ACTIONABLE_COUNT:-}" in
-    ''|*[!0-9]*)
-      REBASE_REVIEW_HAS_ISSUES=true
-      FALLBACK_REVIEW_HAS_ISSUES=true
-      echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-      echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-      echo "ERROR: Invalid post-rebase actionable comment count from GitHub API: '${LATE_ACTIONABLE_COUNT}'." >&2
-      exit 1
-      ;;
-  esac
-  if [ "${LATE_ACTIONABLE_COUNT}" -gt 0 ]; then
-    REBASE_REVIEW_HAS_ISSUES=true
-    FALLBACK_REVIEW_HAS_ISSUES=true
-    echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-    echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-    echo "ERROR: Detected ${LATE_ACTIONABLE_COUNT} actionable bot comment(s) after post-rebase trigger window." >&2
-    exit 1
-  fi
-
-  REBASE_REVIEW_HAS_ISSUES=false
-  FALLBACK_REVIEW_HAS_ISSUES=false
-  echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-  echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-  git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
-fi
+bash "${REBASE_SCRIPT}"
 ```
 
 ## IF !(${CLOUD_BOT}) || ((${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && !(${FALLBACK_REVIEW_HAS_ISSUES}))
@@ -1960,7 +1834,7 @@ echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged without bot" requi
 
 ## IF !(${BOT_UNAVAILABLE})
 
-## IF ${FIXES_ACCUMULATED}
+## IF ${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED})
 
 ## Step 11: Clean Resubmission (if needed)
 
@@ -2024,14 +1898,14 @@ echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false --
 
 ## ELSE
 
-## Step 12b: Final Merge (Direct)
+## Step 12b: Final Merge (Direct or Post-Rebase)
 
 > **Layer**: 0 (Orchestrator) -- direct merge, no code analysis needed.
 
 Tool: bash
 OnFail: abort
 
-First-pass clean review: merge the existing PR directly.
+First-pass clean review or Step 10.5 post-rebase success: merge the existing PR directly.
 
 ```bash
 # --- Hard gate: unconditional pre-merge check ---

--- a/patterns/pr-bot/references/rebase-clean-history.md
+++ b/patterns/pr-bot/references/rebase-clean-history.md
@@ -2,232 +2,119 @@
 
 > **Layer**: 0 (Orchestrator) -- git history cleanup before merge.
 
-Tool: bash
+Tool: bash helper (`patterns/pr-bot/scripts/rebase-with-rollup.sh`)
 
-When the branch has accumulated fix commits from review iterations,
-reorganize them into logical groups before merging.
+## Intent
 
-**Skip this step if**:
-- The branch has <= 3 commits (already clean enough)
-- All commits already follow a logical grouping
+When a PR branch has accumulated multiple fix commits across review rounds, Step
+10.5 rewrites the branch into a smaller set of logical commits before merge,
+then forces one more bot review on the compressed history.
 
-```bash
-COMMIT_COUNT=$(git rev-list --count main..HEAD)
-if [ "${COMMIT_COUNT}" -gt 3 ]; then
-  # 1. Create backup branch (idempotent: -f overwrites if exists from prior run)
-  git branch -f "backup-${PR_NUM}-pre-rebase" HEAD
+This path exists to catch regressions that only appear after the fix chain is
+compacted. It must not destroy auditability, so the rebased commits preserve the
+current commit's AI Reviewer Metadata block and append a rollup trailer for the
+original commits they consolidate.
 
-  # 2. Soft reset to merge-base (not local main tip, which may have advanced)
-  MERGE_BASE=$(git merge-base main HEAD)
-  git reset --soft $MERGE_BASE
+## Guard
 
-  # 3. Create logical commits by selectively staging files per phase/concern
-  #    After soft reset, ALL changes are staged in the index. We must unstage
-  #    everything first, then selectively re-stage and commit per logical group.
-  #
-  #    The orchestrator (Layer 0) delegates this to a Layer 1 executor:
-  #    a) Unstage all changes: git reset HEAD .
-  #    b) Discover changed files dynamically via git diff
-  #    c) For each logical group: git add <files> && git commit
-  #    d) Verify all changes are committed: git status --porcelain is empty
-  #
-  #    Dynamic grouping: discover actual changed paths instead of hard-coding
-  #    directory names (which fail with pathspec errors on repos without them).
-  git reset HEAD .
-  CHANGED_FILES=$(git diff --name-only HEAD)
+Step 10.5 is eligible only when all of the following are true:
 
-  # Group 1: Source code (any file under directories containing code)
-  SOURCE_FILES=$(echo "${CHANGED_FILES}" | grep -E '^(src/|crates/|lib/|bin/)' || true)
-  if [ -n "${SOURCE_FILES}" ]; then
-    echo "${SOURCE_FILES}" | xargs git add --
-    if ! git diff --cached --quiet; then
-      git commit -m "feat(scope): primary implementation changes"
-    fi
-  fi
+- `FIXES_ACCUMULATED=true`
+- branch has 3+ commits since `${DEFAULT_BRANCH}`
+- every original commit carries explicit Pass review metadata
 
-  # Group 2: Patterns, skills, and workflow definitions
-  PATTERN_FILES=$(echo "${CHANGED_FILES}" | grep -E '^(patterns/|\.claude/)' || true)
-  if [ -n "${PATTERN_FILES}" ]; then
-    echo "${PATTERN_FILES}" | xargs git add --
-    if ! git diff --cached --quiet; then
-      git commit -m "fix(scope): pattern and skill updates"
-    fi
-  fi
+If any original commit has `Fail` metadata, or if a commit lacks explicit pass
+metadata, Step 10.5 logs a skip reason and the workflow falls back to the
+existing clean-branch path (Step 11 / Step 12).
 
-  # Group 3: Everything else (config, docs, tests, etc.)
-  git add -A
-  if ! git diff --cached --quiet; then
-    git commit -m "chore(scope): config and documentation updates"
-  fi
-  #
-  #    IMPORTANT: Each commit is guarded by `git diff --cached --quiet` to skip
-  #    empty groups without halting the script. Groups are discovered dynamically
-  #    from actual changed files, so repos without src/ or crates/ directories
-  #    will not trigger pathspec errors.
+### Accepted Pass Metadata
 
-  # 4. Verify replacement commits exist before force pushing
-  NEW_COMMIT_COUNT=$(git rev-list --count ${MERGE_BASE}..HEAD)
-  if [ "${NEW_COMMIT_COUNT}" -eq 0 ]; then
-    echo "ERROR: No replacement commits created after soft reset. Aborting push."
-    echo "Restoring from backup branch."
-    git reset --hard "backup-${PR_NUM}-pre-rebase"
-    exit 1
-  fi
+Preferred explicit format:
 
-  # 5. Force push
-  git push --force-with-lease
-
-  # 6. Trigger one final @${CLOUD_BOT_NAME} review to verify rebased code
-  gh pr comment "${PR_NUM}" --repo "${REPO}" --body "@${CLOUD_BOT_NAME} review"
-
-  # 7. Poll for bot response (reuse Step 5 polling logic)
-  REBASE_BOT_OK=false
-  POLL_INTERVAL=30
-  MAX_WAIT=$(csa config get pr_review.cloud_bot_poll_max_seconds --default "$(csa config get kv_cache.long_poll_seconds --default 240)")
-  WAITED=0
-  while [ "${WAITED}" -lt "${MAX_WAIT}" ]; do
-    sleep "${POLL_INTERVAL}"
-    WAITED=$((WAITED + POLL_INTERVAL))
-    BOT_REPLY=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" \
-      --jq "[.[] | select(.user.type == \"Bot\" or .user.type == \"Bot\") | select(.created_at > \"$(git log -1 --format=%cI HEAD)\")] | length" 2>/dev/null || echo "0")
-    if [ "${BOT_REPLY}" -gt 0 ] 2>/dev/null; then
-      REBASE_BOT_OK=true
-      break
-    fi
-    echo "Post-rebase poll... ${WAITED}s / ${MAX_WAIT}s"
-  done
-
-  # 8. BLOCKING: Evaluate final review result before merge
-  #    The orchestrator MUST NOT proceed to merge until this gate passes.
-  if [ "${REBASE_BOT_OK}" = "true" ]; then
-    echo "Post-rebase review received. Evaluating..."
-    # Orchestrator classifies the final bot response using Step 7 logic.
-    # Extract bot comments posted after the force-push and check for actionable issues.
-    #
-    # Detection uses P0/P1/P2 badge presence (e.g., "**P0**", "**P1**", "**P2**") instead of
-    # raw keyword grep. The bot always emits P0/P1/P2 severity badges for real issues;
-    # keyword matching ("issue|error|fix|warning|problem") misclassifies clean
-    # summaries like "No issues found" because they contain "issue".
-    REBASE_BOT_ISSUES=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" \
-      --jq "[.[] | select(.user.type == \"Bot\" or .user.type == \"Bot\") | select(.created_at > \"$(git log -1 --format=%cI HEAD)\") | select(.body | test(\"\\*\\*P[012]\\*\\*\"))] | length" 2>/dev/null || echo "0")
-
-    if [ "${REBASE_BOT_ISSUES}" -gt 0 ] 2>/dev/null; then
-      echo "BLOCKED: Post-rebase review found ${REBASE_BOT_ISSUES} actionable comment(s)."
-      echo "Routing to inline fix cycle. Merge is blocked."
-      REBASE_REVIEW_HAS_ISSUES=true
-      # NOTE: We do NOT set BOT_HAS_ISSUES=true here because we are already
-      # past the BOT_HAS_ISSUES branch point — setting it would have no effect
-      # on control flow. Instead, a dedicated fix cycle runs inline below.
-      # FORBIDDEN: Falling through to merge from this path.
-
-      # --- Inline post-rebase fix cycle ---
-      REBASE_FIX_ROUND=0
-      REBASE_FIX_MAX=3
-      while [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ] && [ "${REBASE_FIX_ROUND}" -lt "${REBASE_FIX_MAX}" ]; do
-        REBASE_FIX_ROUND=$((REBASE_FIX_ROUND + 1))
-        echo "Post-rebase fix round ${REBASE_FIX_ROUND}/${REBASE_FIX_MAX}"
-
-        # 1. Fix issues found by post-rebase bot review
-        csa run "Fix the issues found by the post-rebase bot review on PR #${PR_NUM}. Read the bot comments and apply fixes. Commit the fixes."
-
-        # 2. Push fixes and re-trigger bot review
-        git push origin "${WORKFLOW_BRANCH}"
-        gh pr comment "${PR_NUM}" --repo "${REPO}" --body "@${CLOUD_BOT_NAME} review"
-
-        # 3. Poll for new bot response
-        REFIX_BOT_OK=false
-        REFIX_WAITED=0
-        while [ "${REFIX_WAITED}" -lt "${MAX_WAIT}" ]; do
-          sleep "${POLL_INTERVAL}"
-          REFIX_WAITED=$((REFIX_WAITED + POLL_INTERVAL))
-          REFIX_REPLY=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" \
-            --jq "[.[] | select(.user.type == \"Bot\" or .user.type == \"Bot\") | select(.created_at > \"$(git log -1 --format=%cI HEAD)\")] | length" 2>/dev/null || echo "0")
-          if [ "${REFIX_REPLY}" -gt 0 ] 2>/dev/null; then
-            REFIX_BOT_OK=true
-            break
-          fi
-        done
-
-        # 4. Evaluate result
-        if [ "${REFIX_BOT_OK}" = "true" ]; then
-          REFIX_ISSUES=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" \
-            --jq "[.[] | select(.user.type == \"Bot\" or .user.type == \"Bot\") | select(.created_at > \"$(git log -1 --format=%cI HEAD)\") | select(.body | test(\"\\*\\*P[012]\\*\\*\"))] | length" 2>/dev/null || echo "0")
-          if [ "${REFIX_ISSUES}" -eq 0 ] 2>/dev/null; then
-            echo "Post-rebase review now passes after fix round ${REBASE_FIX_ROUND}."
-            REBASE_REVIEW_HAS_ISSUES=false
-          else
-            echo "Post-rebase review still has ${REFIX_ISSUES} issue(s) after round ${REBASE_FIX_ROUND}."
-          fi
-        else
-          # Bot timed out during fix cycle — fall back to local review
-          if csa review --range main...HEAD 2>/dev/null; then
-            echo "Local fallback review passes after fix round ${REBASE_FIX_ROUND}."
-            REBASE_REVIEW_HAS_ISSUES=false
-          else
-            echo "Local fallback review still has issues after round ${REBASE_FIX_ROUND}."
-          fi
-        fi
-      done
-
-      if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
-        echo "ERROR: Post-rebase review still failing after ${REBASE_FIX_MAX} fix rounds. Aborting."
-        exit 1
-      fi
-      echo "REBASE_FIXED: Post-rebase issues resolved. Proceeding to merge."
-    else
-      echo "Post-rebase review is clean. Proceeding to merge."
-      REBASE_REVIEW_HAS_ISSUES=false
-      # Fall through to merge (Step 12/12b).
-    fi
-  else
-    echo "Post-rebase bot timed out. Falling back to local review."
-    if csa review --range main...HEAD 2>/dev/null; then
-      # Audit trail: explain why merging without post-rebase bot review.
-      gh pr comment "${PR_NUM}" --repo "${REPO}" --body \
-        "**Merge rationale**: Post-rebase cloud bot timed out. Local \`csa review --range main...HEAD\` passed CLEAN. Proceeding to merge with local review as the review layer."
-    else
-      echo "BLOCKED: Post-rebase fallback review found issues."
-      FALLBACK_REVIEW_HAS_ISSUES=true
-    fi
-    # Gate: fallback review failure blocks merge, routes to inline fix cycle.
-    # This check is unconditional — runs whether csa review passed or failed.
-    if [ "${FALLBACK_REVIEW_HAS_ISSUES}" = "true" ]; then
-      # NOTE: We do NOT set BOT_HAS_ISSUES=true here because we are already
-      # past the BOT_HAS_ISSUES branch point — setting it would have no effect.
-      # Instead, a dedicated fix cycle runs inline below.
-
-      # --- Inline post-rebase fallback fix cycle ---
-      REBASE_FB_FIX_ROUND=0
-      REBASE_FB_FIX_MAX=3
-      while [ "${FALLBACK_REVIEW_HAS_ISSUES}" = "true" ] && [ "${REBASE_FB_FIX_ROUND}" -lt "${REBASE_FB_FIX_MAX}" ]; do
-        REBASE_FB_FIX_ROUND=$((REBASE_FB_FIX_ROUND + 1))
-        echo "Post-rebase fallback fix round ${REBASE_FB_FIX_ROUND}/${REBASE_FB_FIX_MAX}"
-
-        # 1. Fix issues found by local review
-        csa run "Fix the issues found by csa review --range main...HEAD. Read the review output and apply fixes. Commit the fixes."
-
-        # 2. Re-run local review to verify fixes
-        if csa review --range main...HEAD 2>/dev/null; then
-          echo "Post-rebase fallback review now passes after fix round ${REBASE_FB_FIX_ROUND}."
-          FALLBACK_REVIEW_HAS_ISSUES=false
-        else
-          echo "Post-rebase fallback review still has issues after round ${REBASE_FB_FIX_ROUND}."
-        fi
-      done
-
-      if [ "${FALLBACK_REVIEW_HAS_ISSUES}" = "true" ]; then
-        echo "ERROR: Post-rebase fallback review still failing after ${REBASE_FB_FIX_MAX} fix rounds. Aborting."
-        exit 1
-      fi
-      # Push fallback fix commits so remote PR head includes them.
-      # Without this, gh pr merge merges stale remote HEAD and drops fixes.
-      git push origin "${WORKFLOW_BRANCH}"
-
-      # Audit trail: explain why merging without post-rebase bot review.
-      gh pr comment "${PR_NUM}" --repo "${REPO}" --body \
-        "**Merge rationale**: Post-rebase cloud bot timed out. Local \`csa review --range main...HEAD\` passed CLEAN after ${REBASE_FB_FIX_ROUND} fix round(s). Proceeding to merge with local review as the review layer."
-      echo "REBASE_FALLBACK_FIXED: Post-rebase fallback issues resolved. Proceeding to merge."
-    fi
-  fi
-fi
+```text
+verdict=Pass
+tool=codex
+round=3
 ```
+
+Legacy compatibility format accepted by the guard:
+
+```text
+Review: codex session 01ABC... (status=success, summary=PASS)
+Review: gemini-cli session 01DEF... (status=success, summary=CLEAN)
+```
+
+`summary=FAIL` (or `verdict=Fail`) blocks compression. A commit with no explicit
+pass marker is treated as non-eligible and causes a skip.
+
+## Rollup Trailer Format
+
+Each rebased logical commit keeps its normal `### AI Reviewer Metadata` block,
+then appends:
+
+```text
+## AI Reviewer Metadata Rollup
+
+This commit consolidates review history from:
+- <short-sha> verdict=<Pass|Fail|Skip|Uncertain> tool=<tool> round=<n> (<subject>)
+- ...
+```
+
+Format rules:
+
+- heading is `## AI Reviewer Metadata Rollup`
+- entries use 7-character short SHAs
+- `verdict=` is mandatory in the rollup entry
+- `tool=` is mandatory in the rollup entry (`unknown` if not detectable)
+- `round=` is included only when detectable from the original commit subject/body
+- subject is the original commit subject in parentheses for fast scanning
+
+The rollup is additive. It does not replace the current logical commit's own AI
+Reviewer Metadata block.
+
+## Logical Grouping
+
+After a soft reset to the merge-base, the helper rebuilds at most three logical
+commits:
+
+1. Source files: `src/`, `crates/`, `lib/`, `bin/`
+2. Patterns / agent workflow files: `patterns/`, `.claude/`
+3. Everything else: docs, config, tests, lockfiles, etc.
+
+For each group:
+
+1. Stage matching files.
+2. Generate the current commit subject/body via `scripts/gen_commit_msg.sh`.
+3. Append the rollup trailer for the original commits that touched that group.
+4. Commit.
+
+## Post-Rebase Review Gate
+
+After the rewrite:
+
+1. Create/update `backup-${PR_NUM}-pre-rebase`
+2. `git push --force-with-lease "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"`
+3. Post an explicit `@${CLOUD_BOT_NAME}` retrigger comment for the new HEAD
+4. Launch the bounded delegated post-rebase gate
+5. Require the delegated session to emit `REBASE_GATE=PASS`
+6. Re-check late actionable bot comments before allowing merge
+
+On success:
+
+- `REBASE_CLEAN_HISTORY_APPLIED=true`
+- `REBASE_REVIEW_HAS_ISSUES=false`
+- `FALLBACK_REVIEW_HAS_ISSUES=false`
+
+On delegated gate failure or late actionable comments:
+
+- `REBASE_REVIEW_HAS_ISSUES=true`
+- `FALLBACK_REVIEW_HAS_ISSUES=true`
+- workflow aborts
+
+## Routing After Step 10.5
+
+- If Step 10.5 applies successfully: skip Step 11 / Step 12 clean-branch
+  resubmission and go straight to the direct merge path.
+- If Step 10.5 skips: keep the old clean-branch path unchanged.
+- If Step 10.5 fails after rewriting: abort and preserve the rewritten branch
+  plus the `backup-${PR_NUM}-pre-rebase` backup branch for audit.

--- a/patterns/pr-bot/scripts/rebase-with-rollup.sh
+++ b/patterns/pr-bot/scripts/rebase-with-rollup.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+COMMIT_MSG_SCRIPT="${ROOT_DIR}/scripts/gen_commit_msg.sh"
+
+if [ -n "${CSA_WORKFLOW_DIR:-}" ]; then
+  CSA_HELPER_DIR="${CSA_WORKFLOW_DIR}/scripts/csa"
+else
+  CSA_HELPER_DIR="${ROOT_DIR}/patterns/pr-bot/scripts/csa"
+fi
+
+emit_var() {
+  printf 'CSA_VAR:%s=%s\n' "$1" "$2"
+}
+
+emit_skip() {
+  local reason="$1"
+
+  echo "Skipping Step 10.5: ${reason}"
+  emit_var "REBASE_CLEAN_HISTORY_APPLIED" "false"
+  exit 0
+}
+
+normalize_verdict() {
+  local raw="${1:-}"
+
+  case "$(printf '%s' "${raw}" | tr '[:lower:]' '[:upper:]')" in
+    PASS|CLEAN)
+      printf 'Pass\n'
+      ;;
+    FAIL|HAS_ISSUES)
+      printf 'Fail\n'
+      ;;
+    SKIP)
+      printf 'Skip\n'
+      ;;
+    UNCERTAIN)
+      printf 'Uncertain\n'
+      ;;
+    *)
+      printf '\n'
+      ;;
+  esac
+}
+
+extract_commit_verdict() {
+  local message="$1"
+  local raw=""
+
+  raw="$(
+    printf '%s\n' "${message}" \
+      | grep -oiE 'verdict=(pass|fail|skip|uncertain|clean|has_issues)' \
+      | head -n 1 \
+      | cut -d= -f2 \
+      || true
+  )"
+  if [ -z "${raw}" ]; then
+    raw="$(
+      printf '%s\n' "${message}" \
+        | grep -oiE 'summary=(pass|fail|skip|uncertain|clean|has_issues)' \
+        | head -n 1 \
+        | cut -d= -f2 \
+        || true
+    )"
+  fi
+
+  normalize_verdict "${raw}"
+}
+
+extract_commit_tool() {
+  local message="$1"
+  local tool=""
+
+  tool="$(
+    printf '%s\n' "${message}" \
+      | grep -oiE 'tool=[A-Za-z0-9._-]+' \
+      | head -n 1 \
+      | cut -d= -f2 \
+      || true
+  )"
+  if [ -z "${tool}" ]; then
+    tool="$(
+      printf '%s\n' "${message}" \
+        | sed -nE 's/^Review: ([^ ]+) session.*/\1/p' \
+        | head -n 1 \
+        || true
+    )"
+  fi
+  if [ -z "${tool}" ]; then
+    tool="unknown"
+  fi
+
+  printf '%s\n' "${tool}"
+}
+
+extract_commit_round() {
+  local subject="$1"
+  local message="$2"
+
+  printf '%s\n%s\n' "${subject}" "${message}" \
+    | grep -oiE 'round[[:space:]]*[:=#-]?[[:space:]]*[0-9]+' \
+    | head -n 1 \
+    | grep -oE '[0-9]+' \
+    || true
+}
+
+file_belongs_to_group() {
+  local group="$1"
+  local file="$2"
+
+  case "${group}" in
+    source)
+      printf '%s\n' "${file}" | grep -Eq '^(src/|crates/|lib/|bin/)'
+      ;;
+    patterns)
+      printf '%s\n' "${file}" | grep -Eq '^(patterns/|\.claude/)'
+      ;;
+    other)
+      ! printf '%s\n' "${file}" | grep -Eq '^(src/|crates/|lib/|bin/|patterns/|\.claude/)'
+      ;;
+    *)
+      echo "ERROR: unknown rebase group '${group}'." >&2
+      exit 1
+      ;;
+  esac
+}
+
+commit_touches_group() {
+  local sha="$1"
+  local group="$2"
+  local file=""
+
+  while IFS= read -r -d '' file; do
+    if file_belongs_to_group "${group}" "${file}"; then
+      return 0
+    fi
+  done < <(git diff-tree --no-commit-id --name-only -r -z "${sha}")
+
+  return 1
+}
+
+stage_group_files() {
+  local group="$1"
+  local file=""
+
+  mapfile -d '' -t changed_files < <(git diff --name-only -z HEAD)
+  for file in "${changed_files[@]}"; do
+    if file_belongs_to_group "${group}" "${file}"; then
+      git add -- "${file}"
+    fi
+  done
+}
+
+build_rollup_block() {
+  local group="$1"
+  local sha=""
+  local subject=""
+  local message=""
+  local verdict=""
+  local tool=""
+  local round=""
+  local short_sha=""
+  local entry=""
+
+  printf '## AI Reviewer Metadata Rollup\n\n'
+  printf 'This commit consolidates review history from:\n'
+  for sha in "${ORIGINAL_COMMITS[@]}"; do
+    if ! commit_touches_group "${sha}" "${group}"; then
+      continue
+    fi
+
+    subject="$(git show -s --format=%s "${sha}")"
+    message="$(git show -s --format=%B "${sha}")"
+    verdict="$(extract_commit_verdict "${message}")"
+    tool="$(extract_commit_tool "${message}")"
+    round="$(extract_commit_round "${subject}" "${message}")"
+    short_sha="$(git rev-parse --short=7 "${sha}")"
+
+    entry="- ${short_sha} verdict=${verdict} tool=${tool}"
+    if [ -n "${round}" ]; then
+      entry="${entry} round=${round}"
+    fi
+    entry="${entry} (${subject})"
+    printf '%s\n' "${entry}"
+  done
+}
+
+create_group_commit() {
+  local group="$1"
+  local commit_subject=""
+  local commit_body=""
+  local rollup_block=""
+
+  if git diff --cached --quiet; then
+    return 0
+  fi
+
+  commit_subject="$("${COMMIT_MSG_SCRIPT}" --subject)"
+  commit_body="$("${COMMIT_MSG_SCRIPT}" --body)"
+  rollup_block="$(build_rollup_block "${group}")"
+  commit_body="${commit_body}
+
+${rollup_block}"
+
+  git commit -m "${commit_subject}" -m "${commit_body}"
+}
+
+validate_all_commits_pass() {
+  local sha=""
+  local subject=""
+  local message=""
+  local verdict=""
+  local short_sha=""
+
+  for sha in "${ORIGINAL_COMMITS[@]}"; do
+    subject="$(git show -s --format=%s "${sha}")"
+    message="$(git show -s --format=%B "${sha}")"
+    verdict="$(extract_commit_verdict "${message}")"
+    short_sha="$(git rev-parse --short=7 "${sha}")"
+
+    if [ "${verdict}" = "Fail" ]; then
+      emit_skip "commit ${short_sha} (${subject}) has verdict=Fail; preserve the full fix chain for audit."
+    fi
+    if [ "${verdict}" != "Pass" ]; then
+      emit_skip "commit ${short_sha} (${subject}) does not carry explicit verdict=Pass metadata."
+    fi
+  done
+}
+
+REBASE_PUSHED=false
+BACKUP_BRANCH="backup-${PR_NUM}-pre-rebase"
+ORIGINAL_HEAD="$(git rev-parse HEAD)"
+MERGE_BASE="$(git merge-base "${DEFAULT_BRANCH}" "${ORIGINAL_HEAD}")"
+mapfile -t ORIGINAL_COMMITS < <(git rev-list --reverse "${MERGE_BASE}..${ORIGINAL_HEAD}")
+COMMIT_COUNT="${#ORIGINAL_COMMITS[@]}"
+
+restore_pre_push_state() {
+  local exit_code="$1"
+
+  if [ "${exit_code}" -ne 0 ] && [ "${REBASE_PUSHED}" != "true" ] && git show-ref --verify --quiet "refs/heads/${BACKUP_BRANCH}"; then
+    git reset --hard "${BACKUP_BRANCH}" >/dev/null 2>&1 || true
+  fi
+}
+
+trap 'restore_pre_push_state "$?"' EXIT
+
+if [ "${COMMIT_COUNT}" -lt 3 ]; then
+  emit_skip "branch has ${COMMIT_COUNT} commit(s); Step 10.5 only fires at 3+ commits."
+fi
+
+validate_all_commits_pass
+
+git branch -f "${BACKUP_BRANCH}" "${ORIGINAL_HEAD}"
+git reset --soft "${MERGE_BASE}"
+git reset HEAD .
+
+stage_group_files "source"
+create_group_commit "source"
+
+stage_group_files "patterns"
+create_group_commit "patterns"
+
+git add -A
+create_group_commit "other"
+
+NEW_COMMIT_COUNT="$(git rev-list --count "${MERGE_BASE}..HEAD")"
+if [ "${NEW_COMMIT_COUNT}" -eq 0 ]; then
+  echo "ERROR: No replacement commits created after soft reset. Restoring backup." >&2
+  git reset --hard "${BACKUP_BRANCH}"
+  exit 1
+fi
+
+echo "Step 10.5 guard passed: ${COMMIT_COUNT} commits with explicit verdict=Pass metadata. Rebase rollup is active."
+git push --force-with-lease "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+REBASE_PUSHED=true
+
+REBASE_CURRENT_SHA="$(git rev-parse HEAD)"
+REBASE_TRIGGER_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+REBASE_TRIGGER_BODY="${CLOUD_BOT_RETRIGGER_CMD}
+
+<!-- csa-retrigger:post-rebase:${REBASE_CURRENT_SHA}:${REBASE_TRIGGER_TS} -->"
+gh pr comment "${PR_NUM}" --repo "${REPO}" --body "${REBASE_TRIGGER_BODY}"
+echo "Triggered post-rebase review via '${CLOUD_BOT_RETRIGGER_CMD}' for HEAD ${REBASE_CURRENT_SHA}."
+
+GATE_PROMPT=$(cat <<EOF
+Bounded post-rebase gate task only. Do NOT invoke pr-bot skill or any full PR workflow. Operate on PR #${PR_NUM} in repo ${REPO} (branch ${WORKFLOW_BRANCH}). Complete the post-rebase review gate end-to-end. For each cloud bot trigger, wait ${CLOUD_BOT_WAIT_SECONDS} seconds quietly, then poll up to ${CLOUD_BOT_POLL_MAX_SECONDS} seconds for a response. If response contains P0/P1/P2 findings, iteratively fix/commit/push/re-trigger and re-check with the same wait policy (max 3 rounds). If bot times out, abort and report to user; return exactly one marker line REBASE_GATE=PASS when clean, otherwise REBASE_GATE=FAIL and exit non-zero.
+EOF
+)
+
+set +e
+GATE_SID="$(csa run --sa-mode true --tier tier-1 --timeout "${POST_REBASE_TIMEOUT}" --idle-timeout "${POST_REBASE_TIMEOUT}" "${GATE_PROMPT}")"
+DAEMON_RC=$?
+set -e
+if [ "${DAEMON_RC}" -ne 0 ] || [ -z "${GATE_SID}" ]; then
+  REBASE_REVIEW_HAS_ISSUES=true
+  FALLBACK_REVIEW_HAS_ISSUES=true
+  emit_var "REBASE_REVIEW_HAS_ISSUES" "${REBASE_REVIEW_HAS_ISSUES}"
+  emit_var "FALLBACK_REVIEW_HAS_ISSUES" "${FALLBACK_REVIEW_HAS_ISSUES}"
+  echo "ERROR: Failed to launch daemon for post-rebase gate (rc=${DAEMON_RC})." >&2
+  exit 1
+fi
+
+set +e
+GATE_RESULT="$(bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "${GATE_SID}")"
+GATE_RC=$?
+set -e
+if [ "${GATE_RC}" -ne 0 ]; then
+  REBASE_REVIEW_HAS_ISSUES=true
+  FALLBACK_REVIEW_HAS_ISSUES=true
+  emit_var "REBASE_REVIEW_HAS_ISSUES" "${REBASE_REVIEW_HAS_ISSUES}"
+  emit_var "FALLBACK_REVIEW_HAS_ISSUES" "${FALLBACK_REVIEW_HAS_ISSUES}"
+  echo "ERROR: Post-rebase delegated gate failed (rc=${GATE_RC})." >&2
+  exit 1
+fi
+
+GATE_MARKER="$(
+  printf '%s\n' "${GATE_RESULT}" \
+    | grep -E '^[[:space:]]*REBASE_GATE=(PASS|FAIL)[[:space:]]*$' \
+    | tail -n 1 \
+    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+    || true
+)"
+if [ "${GATE_MARKER}" != "REBASE_GATE=PASS" ]; then
+  REBASE_REVIEW_HAS_ISSUES=true
+  FALLBACK_REVIEW_HAS_ISSUES=true
+  emit_var "REBASE_REVIEW_HAS_ISSUES" "${REBASE_REVIEW_HAS_ISSUES}"
+  emit_var "FALLBACK_REVIEW_HAS_ISSUES" "${FALLBACK_REVIEW_HAS_ISSUES}"
+  echo "ERROR: Post-rebase review gate failed." >&2
+  exit 1
+fi
+
+BOT_SETTLE_SECS="${BOT_SETTLE_SECS:-20}"
+sleep "${BOT_SETTLE_SECS}"
+set +e
+LATE_ACTIONABLE_COUNT="$(
+  gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/comments" \
+    | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at > "'"${REBASE_TRIGGER_TS}"'") | select((.body | test("P0|P1|P2"))) ] | length' \
+    2>/dev/null
+)"
+LATE_ACTIONABLE_RC=$?
+set -e
+if [ "${LATE_ACTIONABLE_RC}" -ne 0 ]; then
+  REBASE_REVIEW_HAS_ISSUES=true
+  FALLBACK_REVIEW_HAS_ISSUES=true
+  emit_var "REBASE_REVIEW_HAS_ISSUES" "${REBASE_REVIEW_HAS_ISSUES}"
+  emit_var "FALLBACK_REVIEW_HAS_ISSUES" "${FALLBACK_REVIEW_HAS_ISSUES}"
+  echo "ERROR: Failed to query post-rebase actionable bot comments (rc=${LATE_ACTIONABLE_RC})." >&2
+  exit 1
+fi
+
+case "${LATE_ACTIONABLE_COUNT:-}" in
+  ''|*[!0-9]*)
+    REBASE_REVIEW_HAS_ISSUES=true
+    FALLBACK_REVIEW_HAS_ISSUES=true
+    emit_var "REBASE_REVIEW_HAS_ISSUES" "${REBASE_REVIEW_HAS_ISSUES}"
+    emit_var "FALLBACK_REVIEW_HAS_ISSUES" "${FALLBACK_REVIEW_HAS_ISSUES}"
+    echo "ERROR: Invalid post-rebase actionable comment count from GitHub API: '${LATE_ACTIONABLE_COUNT}'." >&2
+    exit 1
+    ;;
+esac
+
+if [ "${LATE_ACTIONABLE_COUNT}" -gt 0 ]; then
+  REBASE_REVIEW_HAS_ISSUES=true
+  FALLBACK_REVIEW_HAS_ISSUES=true
+  emit_var "REBASE_REVIEW_HAS_ISSUES" "${REBASE_REVIEW_HAS_ISSUES}"
+  emit_var "FALLBACK_REVIEW_HAS_ISSUES" "${FALLBACK_REVIEW_HAS_ISSUES}"
+  echo "ERROR: Detected ${LATE_ACTIONABLE_COUNT} actionable bot comment(s) after post-rebase trigger window." >&2
+  exit 1
+fi
+
+REBASE_REVIEW_HAS_ISSUES=false
+FALLBACK_REVIEW_HAS_ISSUES=false
+emit_var "REBASE_CLEAN_HISTORY_APPLIED" "true"
+emit_var "REBASE_REVIEW_HAS_ISSUES" "${REBASE_REVIEW_HAS_ISSUES}"
+emit_var "FALLBACK_REVIEW_HAS_ISSUES" "${FALLBACK_REVIEW_HAS_ISSUES}"

--- a/patterns/pr-bot/tests/rebase-rollup-reproducer.md
+++ b/patterns/pr-bot/tests/rebase-rollup-reproducer.md
@@ -1,0 +1,77 @@
+# Rebase Rollup Reproducer
+
+Manual reproducer for Step 10.5 (`patterns/pr-bot/scripts/rebase-with-rollup.sh`).
+
+## Goal
+
+Simulate a branch with 5 commits, all carrying explicit pass metadata, then run
+the Step 10.5 helper and verify that the rebased logical commits contain the
+rollup trailer.
+
+## Setup
+
+1. Start from a disposable branch created off `main`.
+2. Make 5 small commits touching at least two logical groups:
+   - one or more files under `src/` or `crates/`
+   - one or more files under `patterns/`
+   - one file outside those groups (for example a `.md` doc)
+3. Ensure each commit body includes explicit pass metadata. Minimal accepted
+   example:
+
+```text
+Test commit summary
+
+### AI Reviewer Metadata
+- **Design Intent**: Reproducer only.
+- **Key Decisions**: Reproducer only.
+- **Reviewer Guidance**:
+  - **Timing/Race Scenarios**: none
+  - **Boundary Cases**: none
+  - **Regression Tests Added**: none
+
+Review: codex session 01TESTSESSION0000000000000000 (status=success, summary=PASS)
+tool=codex
+verdict=Pass
+round=1
+```
+
+## Run
+
+Export the variables pr-bot Step 10.5 expects, then invoke the helper:
+
+```bash
+export DEFAULT_BRANCH=main
+export PR_NUM=999999
+export REPO=owner/repo
+export REMOTE_NAME=origin
+export WORKFLOW_BRANCH="$(git branch --show-current)"
+export CLOUD_BOT_NAME=gemini-code-assist
+export CLOUD_BOT_LOGIN=gemini-code-assist[bot]
+export CLOUD_BOT_RETRIGGER_CMD='/gemini review'
+export CLOUD_BOT_WAIT_SECONDS=60
+export CLOUD_BOT_POLL_MAX_SECONDS=240
+export POST_REBASE_TIMEOUT=1800
+
+bash patterns/pr-bot/scripts/rebase-with-rollup.sh
+```
+
+If you do not want to hit GitHub, stop after inspecting the rewritten local
+commits and before the helper reaches the `gh pr comment` / delegated gate
+portion.
+
+## Verify
+
+1. `git log --format='%h %s%n%b' -n 3` shows rebased logical commits.
+2. Each rebased commit still contains the normal `### AI Reviewer Metadata`
+   block.
+3. Each rebased commit also contains:
+
+```text
+## AI Reviewer Metadata Rollup
+
+This commit consolidates review history from:
+- <sha> verdict=Pass tool=codex round=<n> (<subject>)
+```
+
+4. `git branch --list "backup-${PR_NUM}-pre-rebase"` shows the backup branch.
+5. The force-push command uses `--force-with-lease`, never plain `--force`.

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -303,6 +303,9 @@ name = "REBASE_CURRENT_SHA"
 name = "REBASE_REVIEW_HAS_ISSUES"
 
 [[workflow.variables]]
+name = "REBASE_CLEAN_HISTORY_APPLIED"
+
+[[workflow.variables]]
 name = "REBASE_TRIGGER_BODY"
 
 [[workflow.variables]]
@@ -2118,171 +2121,43 @@ condition = "(${CLOUD_BOT}) && !(${BOT_UNAVAILABLE}) && !(${BOT_HAS_ISSUES}) && 
 
 [[workflow.steps]]
 id = 19
-title = "Step 10.5: Rebase for Clean History (DISABLED)"
+title = "Step 10.5: Rebase for Clean History"
 tool = "bash"
 prompt = '''
 > **Layer**: 0 (Orchestrator) -- git history cleanup before merge.
-> **Status**: Disabled. With `--merge` (not `--squash`), rebase destroys the
-> per-commit audit trail instead of cleaning it up.
-> Squash merges are forbidden for audit reasons.
-
-
 Reorganize accumulated fix commits into logical groups (source, patterns, other)
-before merging. Skip if <= 3 commits.
+before merging, but only when the branch meets the audit guard:
+- branch has 3+ commits since `${DEFAULT_BRANCH}`
+- every original commit carries explicit review metadata with `verdict=Pass`
+  (legacy `Review: ... summary=PASS|CLEAN` is also accepted)
 
-After rebase: backup branch, soft reset to merge-base, dynamic file grouping,
-force-push with lease, trigger final `@${CLOUD_BOT_NAME} review`, then delegate the long
-wait/fix/review loop to a single CSA-managed step.
+When the guard passes, Step 10.5:
+- creates/refreshes `backup-${PR_NUM}-pre-rebase`
+- soft-resets to the merge-base
+- rebuilds logical commits
+- preserves the current commit's `### AI Reviewer Metadata` block
+- appends an additive `## AI Reviewer Metadata Rollup` block naming the
+  original SHAs + verdict/tool/round metadata
+- force-pushes with `--force-with-lease`
+- triggers one final `@${CLOUD_BOT_NAME}` review on the rebased HEAD
+- blocks merge until the delegated post-rebase review gate returns
+  `REBASE_GATE=PASS`
 
-**Post-rebase review gate** (BLOCKING):
-- CSA delegated step handles both paths:
-  - Bot responds with P0/P1/P2 badges → CSA runs bounded fix/review retries (max 3 rounds), using the same configurable wait policy for each trigger (`cloud_bot_wait_seconds` quiet wait + `cloud_bot_poll_max_seconds` polling).
-  - Bot times out → CSA runs fallback `csa review --range "${DEFAULT_BRANCH}...HEAD"` and bounded fix/review retries (max 3 rounds).
-- CSA daemon + session wait (configured by `cloud_bot_wait_seconds` + `cloud_bot_poll_max_seconds`, defaults: `kv_cache.frequent_poll_seconds = 60` and `kv_cache.long_poll_seconds = 240`) enforces the hard timeout.
-- delegated execution failures are hard failures (no `|| true` silent downgrade).
-- On delegated gate failure (timeout, non-zero, or non-PASS marker), set `REBASE_REVIEW_HAS_ISSUES=true` (and `FALLBACK_REVIEW_HAS_ISSUES=true` when appropriate), then block merge.
-- On success, both `REBASE_REVIEW_HAS_ISSUES` and `FALLBACK_REVIEW_HAS_ISSUES` must be false.
-
-This step is disabled unconditionally. Keep the implementation text only as
-historical context; the workflow condition is `false` so the rebase path never
-executes.
+When the guard does not pass, the step logs the skip reason and the workflow
+falls back to the existing clean-branch path (Step 11 / Step 12).
 
 ```bash
 set -euo pipefail
 if [ -n "${CSA_WORKFLOW_DIR:-}" ]; then
-  CSA_HELPER_DIR="${CSA_WORKFLOW_DIR}/scripts/csa"
+  REBASE_SCRIPT="${CSA_WORKFLOW_DIR}/scripts/rebase-with-rollup.sh"
 else
-  CSA_HELPER_DIR="patterns/pr-bot/scripts/csa"
+  REBASE_SCRIPT="patterns/pr-bot/scripts/rebase-with-rollup.sh"
 fi
 
-COMMIT_COUNT=$(git rev-list --count "${DEFAULT_BRANCH}..HEAD")
-if [ "${COMMIT_COUNT}" -gt 3 ]; then
-  git branch -f "backup-${PR_NUM}-pre-rebase" HEAD
-
-  MERGE_BASE=$(git merge-base "${DEFAULT_BRANCH}" HEAD)
-  git reset --soft $MERGE_BASE
-
-  git reset HEAD .
-  git diff --name-only -z HEAD | { grep -zE '^(src/|crates/|lib/|bin/)' || true; } | xargs -0 --no-run-if-empty git add --
-  if ! git diff --cached --quiet; then
-    git commit -m "feat(scope): primary implementation changes"
-  fi
-
-  git diff --name-only -z HEAD | { grep -zE '^(patterns/|\.claude/)' || true; } | xargs -0 --no-run-if-empty git add --
-  if ! git diff --cached --quiet; then
-    git commit -m "fix(scope): pattern and skill updates"
-  fi
-
-  git add -A
-  if ! git diff --cached --quiet; then
-    git commit -m "chore(scope): config and documentation updates"
-  fi
-
-  NEW_COMMIT_COUNT=$(git rev-list --count ${MERGE_BASE}..HEAD)
-  if [ "${NEW_COMMIT_COUNT}" -eq 0 ]; then
-    echo "ERROR: No replacement commits after soft reset. Restoring backup."
-    git reset --hard "backup-${PR_NUM}-pre-rebase"
-    exit 1
-  fi
-
-  git push --force-with-lease
-  REBASE_CURRENT_SHA="$(git rev-parse HEAD)"
-  REBASE_TRIGGER_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  # ALWAYS trigger explicitly — force-push doesn't auto-review (#506)
-  REBASE_TRIGGER_BODY="${CLOUD_BOT_RETRIGGER_CMD}
-
-<!-- csa-retrigger:post-rebase:${REBASE_CURRENT_SHA}:${REBASE_TRIGGER_TS} -->"
-  gh pr comment "${PR_NUM}" --repo "${REPO}" --body "${REBASE_TRIGGER_BODY}"
-  echo "Triggered post-rebase review via '${CLOUD_BOT_RETRIGGER_CMD}' for HEAD ${REBASE_CURRENT_SHA}."
-
-  # POST_REBASE_TIMEOUT is pre-computed in Step 4a.
-  set +e
-  GATE_SID="$(csa run --sa-mode true --tier tier-1 --timeout ${POST_REBASE_TIMEOUT} --idle-timeout ${POST_REBASE_TIMEOUT} "Bounded post-rebase gate task only. Do NOT invoke pr-bot skill or any full PR workflow. Operate on PR #${PR_NUM} in repo ${REPO} (branch ${WORKFLOW_BRANCH}). Complete the post-rebase review gate end-to-end. For each cloud bot trigger, wait ${CLOUD_BOT_WAIT_SECONDS} seconds quietly, then poll up to ${CLOUD_BOT_POLL_MAX_SECONDS} seconds for a response. If response contains P0/P1/P2 findings, iteratively fix/commit/push/re-trigger and re-check with the same wait policy (max 3 rounds). If bot times out, abort and report to user; return exactly one marker line REBASE_GATE=PASS when clean, otherwise REBASE_GATE=FAIL and exit non-zero.")"
-  DAEMON_RC=$?
-  set -e
-  if [ "${DAEMON_RC}" -ne 0 ] || [ -z "${GATE_SID}" ]; then
-    REBASE_REVIEW_HAS_ISSUES=true
-    FALLBACK_REVIEW_HAS_ISSUES=true
-    echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-    echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-    echo "ERROR: Failed to launch daemon for post-rebase gate (rc=${DAEMON_RC})." >&2
-    exit 1
-  fi
-  set +e
-  GATE_RESULT="$(bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "${GATE_SID}")"
-  GATE_RC=$?
-  set -e
-  if [ "${GATE_RC}" -ne 0 ]; then
-    REBASE_REVIEW_HAS_ISSUES=true
-    FALLBACK_REVIEW_HAS_ISSUES=true
-    echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-    echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-    echo "ERROR: Post-rebase delegated gate failed (rc=${GATE_RC})." >&2
-    exit 1
-  fi
-
-  GATE_MARKER="$(
-    printf '%s\n' "${GATE_RESULT}" \
-      | grep -E '^[[:space:]]*REBASE_GATE=(PASS|FAIL)[[:space:]]*$' \
-      | tail -n 1 \
-      | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
-      || true
-  )"
-  if [ "${GATE_MARKER}" != "REBASE_GATE=PASS" ]; then
-    REBASE_REVIEW_HAS_ISSUES=true
-    FALLBACK_REVIEW_HAS_ISSUES=true
-    echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-    echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-    echo "ERROR: Post-rebase review gate failed."
-    exit 1
-  fi
-
-  BOT_SETTLE_SECS="${BOT_SETTLE_SECS:-20}"
-  sleep "${BOT_SETTLE_SECS}"
-  set +e
-  LATE_ACTIONABLE_COUNT="$(
-    gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/comments" \
-      | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at > "'"${REBASE_TRIGGER_TS}"'") | select((.body | test("P0|P1|P2"))) ] | length' \
-      2>/dev/null
-  )"
-  LATE_ACTIONABLE_RC=$?
-  set -e
-  if [ "${LATE_ACTIONABLE_RC}" -ne 0 ]; then
-    REBASE_REVIEW_HAS_ISSUES=true
-    FALLBACK_REVIEW_HAS_ISSUES=true
-    echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-    echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-    echo "ERROR: Failed to query post-rebase actionable bot comments (rc=${LATE_ACTIONABLE_RC})." >&2
-    exit 1
-  fi
-  case "${LATE_ACTIONABLE_COUNT:-}" in
-    ''|*[!0-9]*)
-      REBASE_REVIEW_HAS_ISSUES=true
-      FALLBACK_REVIEW_HAS_ISSUES=true
-      echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-      echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-      echo "ERROR: Invalid post-rebase actionable comment count from GitHub API: '${LATE_ACTIONABLE_COUNT}'." >&2
-      exit 1
-      ;;
-  esac
-  if [ "${LATE_ACTIONABLE_COUNT}" -gt 0 ]; then
-    REBASE_REVIEW_HAS_ISSUES=true
-    FALLBACK_REVIEW_HAS_ISSUES=true
-    echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-    echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-    echo "ERROR: Detected ${LATE_ACTIONABLE_COUNT} actionable bot comment(s) after post-rebase trigger window." >&2
-    exit 1
-  fi
-
-  REBASE_REVIEW_HAS_ISSUES=false
-  FALLBACK_REVIEW_HAS_ISSUES=false
-  echo "CSA_VAR:REBASE_REVIEW_HAS_ISSUES=$REBASE_REVIEW_HAS_ISSUES"
-  echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
-  git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
-fi
+bash "${REBASE_SCRIPT}"
 ```'''
 on_fail = "abort"
-condition = "false"
+condition = "(${CLOUD_BOT}) && !(${BOT_UNAVAILABLE}) && !(${BOT_HAS_ISSUES}) && !(${ROUND_LIMIT_REACHED}) && (${FIXES_ACCUMULATED})"
 
 [[workflow.steps]]
 id = 20
@@ -2396,7 +2271,7 @@ git push -u "${REMOTE_NAME}" "${CLEAN_BRANCH}"
 gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${CLEAN_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}"
 ```'''
 on_fail = "abort"
-condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED})"
+condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED}) && !(${REBASE_CLEAN_HISTORY_APPLIED})"
 
 [[workflow.steps]]
 id = 22
@@ -2444,17 +2319,17 @@ git log --oneline -1  # verify local matches remote
 echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
 ```'''
 on_fail = "abort"
-condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED})"
+condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED}) && !(${REBASE_CLEAN_HISTORY_APPLIED})"
 
 [[workflow.steps]]
 id = 23
-title = "Step 12b: Final Merge (Direct)"
+title = "Step 12b: Final Merge (Direct or Post-Rebase)"
 tool = "bash"
 prompt = '''
 > **Layer**: 0 (Orchestrator) -- direct merge, no code analysis needed.
 
 
-First-pass clean review: merge the existing PR directly.
+First-pass clean review or Step 10.5 post-rebase success: merge the existing PR directly.
 
 ```bash
 # --- Hard gate: unconditional pre-merge check ---
@@ -2492,4 +2367,4 @@ git log --oneline -1  # verify local matches remote
 echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
 ```'''
 on_fail = "abort"
-condition = "(!(${BOT_UNAVAILABLE})) && (!(${FIXES_ACCUMULATED}))"
+condition = "(!(${BOT_UNAVAILABLE})) && ((!(${FIXES_ACCUMULATED})) || (${REBASE_CLEAN_HISTORY_APPLIED}))"


### PR DESCRIPTION
## Summary

- Re-enables pr-bot Step 10.5 (rebase-for-clean-history → force-push → bot re-review), which had been disabled because rebase destroys per-commit audit trail under `--merge` (no-squash rule 039).
- Preserves audit via **AI Reviewer Metadata Rollup** trailer: each rebased logical commit carries a rollup block naming every original SHA + verdict + tool + round.
- **Guard**: fires only when branch has 3+ commits AND every commit has `verdict=Pass` metadata. Any Fail in the chain skips rebase (preserve record).
- Force-push uses `--force-with-lease`; branch preserved post-operation per rule 038.
- PATTERN.md + workflow.toml + references/rebase-clean-history.md synced per rule 027.
- Manual-reproduction doc added at `patterns/pr-bot/tests/rebase-rollup-reproducer.md`.

## Why

PR #655 (case study): 9 rounds of narrow fixes, round 9 introduced a blocking reconcile-lock HIGH that per-round review missed. Post-rebase review on compressed state would have surfaced it.

## Test plan

- [x] `weave compile patterns/pr-bot/workflow.toml` exit 0
- [x] `just pre-commit` exit 0
- [x] Version bumped
- [x] Reproducer doc present

Closes #662. Refs PR #655.