### PR TITLE
docs(cli)+refactor: csa doctor claude-code transport display + doctor.rs split + codex transport doc reconciliation (closes #643)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.497"
+version = "0.1.498"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.498"
+version = "0.1.499"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.498"
+version = "0.1.499"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.497"
+version = "0.1.498"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -110,12 +110,13 @@ See [Architecture](docs/architecture.md) for design principles and dependency gr
 | Tool | Provider | Transport | Context |
 |------|----------|-----------|---------|
 | **claude-code** | Anthropic | ACP | 200K |
-| **codex** | OpenAI | Legacy CLI (default) | 200K |
+| **codex** | OpenAI | ACP | 200K |
 | **gemini-cli** | Google | Legacy CLI | 2M |
 | **opencode** | OpenRouter | Legacy CLI | 200K |
 
-Codex ACP remains available as an opt-in path when CSA is built with
-`--features codex-acp` and `[tools.codex].transport = "acp"`.
+`claude-code` and `codex` both default to ACP runtimes today. `csa doctor`
+shows the active transport and probed binary; for codex, missing `codex-acp`
+is reported there rather than rejected during config validation.
 
 ## Documentation
 

--- a/crates/cli-sub-agent/src/doctor.rs
+++ b/crates/cli-sub-agent/src/doctor.rs
@@ -1,9 +1,9 @@
 //! Environment diagnostics for CSA.
 
 use anyhow::Result;
-use csa_config::{ProjectConfig, TransportKind, paths};
+use csa_config::{ProjectConfig, paths};
 use csa_core::types::OutputFormat;
-use csa_executor::{CodexRuntimeMetadata, CodexTransport};
+use csa_executor::{ClaudeCodeTransport, CodexRuntimeMetadata, CodexTransport};
 use csa_resource::filesystem_sandbox::{FilesystemCapability, detect_filesystem_capability};
 use csa_resource::rlimit::current_rlimit_nproc;
 use csa_resource::sandbox::{ResourceCapability, detect_resource_capability, systemd_version};
@@ -27,9 +27,9 @@ enum ToolAvailabilityState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct CodexDoctorStatus {
-    transport_active: CodexTransport,
-    acp_compiled_in: bool,
+struct ToolTransportDoctorStatus {
+    transport_active: &'static str,
+    acp_compiled_in: Option<bool>,
     probed_binary: String,
     acp_override_hint: Option<&'static str>,
 }
@@ -41,7 +41,7 @@ struct ToolStatus {
     binary_name: String,
     version: Option<String>,
     hint: Option<String>,
-    codex_transport: Option<CodexDoctorStatus>,
+    transport: Option<ToolTransportDoctorStatus>,
 }
 
 impl ToolStatus {
@@ -192,17 +192,6 @@ fn tool_exe_name(tool_name: &str, config: Option<&ProjectConfig>) -> String {
     crate::run_helpers::resolved_tool_binary_name(tool_name, config)
         .unwrap_or(tool_name)
         .to_string()
-}
-
-fn resolved_codex_transport(config: Option<&ProjectConfig>) -> CodexTransport {
-    config
-        .and_then(|cfg| cfg.tool_transport("codex"))
-        .map(|transport| match transport {
-            TransportKind::Cli => CodexTransport::Cli,
-            TransportKind::Acp => CodexTransport::Acp,
-            TransportKind::Auto => unreachable!("tool_transport() returns resolved transports"),
-        })
-        .unwrap_or_else(CodexTransport::default_for_build)
 }
 
 fn load_doctor_project_config_from(project_root: &Path) -> Result<Option<ProjectConfig>> {
@@ -458,7 +447,7 @@ fn check_tool_status(tool_name: &'static str, config: Option<&ProjectConfig>) ->
             binary_name: binary_name.clone(),
             version: check_tool_version(&binary_name),
             hint: None,
-            codex_transport: codex_doctor_status(tool_name, config),
+            transport: tool_transport_doctor_status(tool_name, config),
         },
         crate::run_helpers::ToolBinaryAvailability::Missing { hint, .. } => ToolStatus {
             name: tool_name,
@@ -466,7 +455,7 @@ fn check_tool_status(tool_name: &'static str, config: Option<&ProjectConfig>) ->
             binary_name,
             version: None,
             hint: Some(hint.into_owned()),
-            codex_transport: codex_doctor_status(tool_name, config),
+            transport: tool_transport_doctor_status(tool_name, config),
         },
     }
 }
@@ -509,20 +498,22 @@ fn render_tool_status_lines(status: &ToolStatus) -> Vec<String> {
         status_msg
     )];
 
-    if let Some(codex_status) = status.codex_transport.as_ref() {
+    if let Some(transport_status) = status.transport.as_ref() {
         lines.push(format!(
             "             Active transport: {}",
-            codex_transport_label(codex_status.transport_active)
+            transport_status.transport_active
         ));
-        lines.push(format!(
-            "             ACP compiled in: {}",
-            yes_no(codex_status.acp_compiled_in)
-        ));
+        if let Some(acp_compiled_in) = transport_status.acp_compiled_in {
+            lines.push(format!(
+                "             ACP compiled in: {}",
+                yes_no(acp_compiled_in)
+            ));
+        }
         lines.push(format!(
             "             Probed binary: {}",
-            codex_status.probed_binary
+            transport_status.probed_binary
         ));
-        if let Some(acp_override_hint) = codex_status.acp_override_hint {
+        if let Some(acp_override_hint) = transport_status.acp_override_hint {
             lines.push(format!("             ACP override: {acp_override_hint}"));
         }
     }
@@ -549,40 +540,46 @@ fn tool_status_json(status: &ToolStatus) -> serde_json::Value {
         "hint": status.hint,
     });
 
-    if let Some(codex_status) = status.codex_transport.as_ref()
+    if let Some(transport_status) = status.transport.as_ref()
         && let Some(object) = entry.as_object_mut()
     {
         object.insert(
             "transport_active".to_string(),
-            serde_json::json!(codex_transport_label(codex_status.transport_active)),
+            serde_json::json!(transport_status.transport_active),
         );
-        object.insert(
-            "acp_compiled_in".to_string(),
-            serde_json::json!(codex_status.acp_compiled_in),
-        );
+        if let Some(acp_compiled_in) = transport_status.acp_compiled_in {
+            object.insert(
+                "acp_compiled_in".to_string(),
+                serde_json::json!(acp_compiled_in),
+            );
+        }
         object.insert(
             "probed_binary".to_string(),
-            serde_json::json!(codex_status.probed_binary),
+            serde_json::json!(transport_status.probed_binary),
         );
     }
 
     entry
 }
 
-fn codex_doctor_status(
+fn tool_transport_doctor_status(
     tool_name: &str,
     config: Option<&ProjectConfig>,
-) -> Option<CodexDoctorStatus> {
-    if tool_name != "codex" {
-        return None;
+) -> Option<ToolTransportDoctorStatus> {
+    match tool_name {
+        "codex" => codex_doctor_status(config),
+        "claude-code" => claude_code_doctor_status(config),
+        _ => None,
     }
+}
 
-    let transport_active = resolved_codex_transport(config);
+fn codex_doctor_status(config: Option<&ProjectConfig>) -> Option<ToolTransportDoctorStatus> {
+    let transport_active = crate::run_helpers::resolved_codex_transport(config);
     let acp_compiled_in = CodexRuntimeMetadata::acp_compiled_in();
 
-    Some(CodexDoctorStatus {
-        transport_active,
-        acp_compiled_in,
+    Some(ToolTransportDoctorStatus {
+        transport_active: codex_transport_label(transport_active),
+        acp_compiled_in: Some(acp_compiled_in),
         probed_binary: transport_active.runtime_binary_name().to_string(),
         acp_override_hint: if acp_compiled_in && transport_active != CodexTransport::Acp {
             Some("set [tools.codex].transport = \"acp\"")
@@ -596,6 +593,24 @@ fn codex_transport_label(transport: CodexTransport) -> &'static str {
     match transport {
         CodexTransport::Cli => "cli",
         CodexTransport::Acp => "acp",
+    }
+}
+
+fn claude_code_doctor_status(config: Option<&ProjectConfig>) -> Option<ToolTransportDoctorStatus> {
+    let transport_active = crate::run_helpers::resolved_claude_code_transport(config);
+
+    Some(ToolTransportDoctorStatus {
+        transport_active: claude_code_transport_label(transport_active),
+        acp_compiled_in: None,
+        probed_binary: transport_active.runtime_binary_name().to_string(),
+        acp_override_hint: None,
+    })
+}
+
+fn claude_code_transport_label(transport: ClaudeCodeTransport) -> &'static str {
+    match transport {
+        ClaudeCodeTransport::Cli => "cli",
+        ClaudeCodeTransport::Acp => "acp",
     }
 }
 

--- a/crates/cli-sub-agent/src/doctor.rs
+++ b/crates/cli-sub-agent/src/doctor.rs
@@ -3,21 +3,45 @@
 use anyhow::Result;
 use csa_config::{ProjectConfig, paths};
 use csa_core::types::OutputFormat;
-use csa_executor::{ClaudeCodeTransport, CodexRuntimeMetadata, CodexTransport};
-use csa_resource::filesystem_sandbox::{FilesystemCapability, detect_filesystem_capability};
+use csa_resource::filesystem_sandbox::detect_filesystem_capability;
 use csa_resource::rlimit::current_rlimit_nproc;
 use csa_resource::sandbox::{ResourceCapability, detect_resource_capability, systemd_version};
 use std::env;
 use std::path::Path;
-use std::process::Command;
 use sysinfo::System;
 
+#[path = "doctor_config.rs"]
+mod doctor_config;
 #[path = "doctor_output_helpers.rs"]
 mod doctor_output_helpers;
+#[path = "doctor_resource.rs"]
+mod doctor_resource;
 #[path = "doctor_routing.rs"]
 mod doctor_routing;
+#[path = "doctor_sandbox.rs"]
+mod doctor_sandbox;
+#[path = "doctor_tools.rs"]
+mod doctor_tools;
+use doctor_config::{
+    inspect_doctor_effective_config_from, inspect_doctor_project_config_from,
+    project_config_tool_lists, render_effective_config_lines, render_project_config_lines,
+    render_tool_availability_error_lines,
+};
 use doctor_output_helpers::{print_effective_config, print_tool_availability_error};
+use doctor_resource::print_resource_status;
 pub use doctor_routing::run_doctor_routing;
+use doctor_sandbox::{
+    build_filesystem_sandbox_json, print_filesystem_sandbox_status, print_git_hook_status,
+    print_merge_guard_status, print_sandbox_status,
+};
+use doctor_tools::{check_tool_status, print_tool_availability, tool_status_json};
+
+#[cfg(test)]
+use doctor_config::load_doctor_project_config_from;
+#[cfg(test)]
+use doctor_resource::format_bytes;
+#[cfg(test)]
+use doctor_tools::{check_tool_version, render_tool_status_lines};
 
 /// Tool availability status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -122,104 +146,6 @@ impl DoctorEffectiveConfigStatus {
                 "error": error,
             }),
         }
-    }
-}
-
-fn project_config_tool_lists(config: &ProjectConfig) -> (Vec<&'static str>, Vec<&'static str>) {
-    let mut enabled = Vec::new();
-    let mut disabled = Vec::new();
-
-    for tool_name in &["gemini-cli", "opencode", "codex", "claude-code"] {
-        if config.is_tool_enabled(tool_name) {
-            enabled.push(*tool_name);
-        } else {
-            disabled.push(*tool_name);
-        }
-    }
-
-    (enabled, disabled)
-}
-
-fn render_project_config_lines(status: &DoctorProjectConfigStatus) -> Vec<String> {
-    match status {
-        DoctorProjectConfigStatus::Missing => vec![
-            "Config:      .csa/config.toml (missing)".to_string(),
-            "             Run 'csa init' to create configuration".to_string(),
-        ],
-        DoctorProjectConfigStatus::Valid(config) => {
-            let (enabled, disabled) = project_config_tool_lists(config);
-            let mut lines = vec!["Config:      .csa/config.toml (valid)".to_string()];
-
-            if !enabled.is_empty() {
-                lines.push(format!("Enabled:     {}", enabled.join(", ")));
-            }
-            if !disabled.is_empty() {
-                lines.push(format!("Disabled:    {}", disabled.join(", ")));
-            }
-
-            lines
-        }
-        DoctorProjectConfigStatus::Invalid(error) => vec![
-            "Config:      .csa/config.toml (invalid)".to_string(),
-            format!("             Error: {error}"),
-        ],
-    }
-}
-
-fn render_effective_config_lines(status: &DoctorEffectiveConfigStatus) -> Vec<String> {
-    match status {
-        DoctorEffectiveConfigStatus::Defaults => {
-            vec!["Effective:   merged config (defaults only)".to_string()]
-        }
-        DoctorEffectiveConfigStatus::Valid(_) => {
-            vec!["Effective:   merged config (valid)".to_string()]
-        }
-        DoctorEffectiveConfigStatus::Invalid(error) => vec![
-            "Effective:   merged config (invalid)".to_string(),
-            format!("             Error: {error}"),
-        ],
-    }
-}
-
-fn render_tool_availability_error_lines(error: &str) -> Vec<String> {
-    vec![
-        "Tool availability unknown (effective config invalid)".to_string(),
-        format!("Reason:      {error}"),
-    ]
-}
-
-fn tool_exe_name(tool_name: &str, config: Option<&ProjectConfig>) -> String {
-    crate::run_helpers::resolved_tool_binary_name(tool_name, config)
-        .unwrap_or(tool_name)
-        .to_string()
-}
-
-fn load_doctor_project_config_from(project_root: &Path) -> Result<Option<ProjectConfig>> {
-    ProjectConfig::load_project_only(project_root)
-}
-
-fn load_doctor_effective_config_from(project_root: &Path) -> Result<Option<ProjectConfig>> {
-    ProjectConfig::load(project_root)
-}
-
-fn inspect_doctor_project_config_from(project_root: &Path) -> DoctorProjectConfigStatus {
-    let config_path = project_root.join(".csa").join("config.toml");
-    if !config_path.exists() {
-        return DoctorProjectConfigStatus::Missing;
-    }
-
-    match load_doctor_project_config_from(project_root) {
-        Ok(Some(config)) => DoctorProjectConfigStatus::Valid(Box::new(config)),
-        Ok(None) => DoctorProjectConfigStatus::Missing,
-        Err(error) => DoctorProjectConfigStatus::Invalid(format!("{error:#}")),
-    }
-}
-
-fn inspect_doctor_effective_config_from(project_root: &Path) -> DoctorEffectiveConfigStatus {
-    match load_doctor_effective_config_from(project_root) {
-        Ok(Some(config)) => DoctorEffectiveConfigStatus::Valid(Box::new(config)),
-        Ok(None) => DoctorEffectiveConfigStatus::Defaults,
-        Err(error) => DoctorEffectiveConfigStatus::Invalid(format!("{error:#}")),
     }
 }
 
@@ -417,383 +343,11 @@ fn print_state_dir() {
     }
 }
 
-/// Check and print tool availability for all 4 tools.
-async fn print_tool_availability(config: Option<&ProjectConfig>) {
-    let tools = ["gemini-cli", "opencode", "codex", "claude-code"];
-
-    let mut installed_count = 0;
-    let total_count = tools.len();
-
-    for tool_name in &tools {
-        let status = check_tool_status(tool_name, config);
-        if status.is_ready() {
-            installed_count += 1;
-        }
-        print_tool_status(&status);
-    }
-
-    // Print summary
-    println!();
-    println!("{installed_count}/{total_count} tools ready");
-}
-
-/// Check if a tool is installed and get its version.
-fn check_tool_status(tool_name: &'static str, config: Option<&ProjectConfig>) -> ToolStatus {
-    let binary_name = tool_exe_name(tool_name, config);
-    match crate::run_helpers::tool_binary_availability(tool_name, config) {
-        crate::run_helpers::ToolBinaryAvailability::Available { .. } => ToolStatus {
-            name: tool_name,
-            availability: ToolAvailabilityState::Installed,
-            binary_name: binary_name.clone(),
-            version: check_tool_version(&binary_name),
-            hint: None,
-            transport: tool_transport_doctor_status(tool_name, config),
-        },
-        crate::run_helpers::ToolBinaryAvailability::Missing { hint, .. } => ToolStatus {
-            name: tool_name,
-            availability: ToolAvailabilityState::Missing,
-            binary_name,
-            version: None,
-            hint: Some(hint.into_owned()),
-            transport: tool_transport_doctor_status(tool_name, config),
-        },
-    }
-}
-
-/// Try to get tool version by running `<exe> --version`.
-fn check_tool_version(exe_name: &str) -> Option<String> {
-    let output = Command::new(exe_name).arg("--version").output().ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    // Take first line and trim
-    stdout.lines().next().map(|s| s.trim().to_string())
-}
-
-/// Print a single tool's status.
-fn print_tool_status(status: &ToolStatus) {
-    for line in render_tool_status_lines(status) {
-        println!("{line}");
-    }
-}
-
-fn render_tool_status_lines(status: &ToolStatus) -> Vec<String> {
-    let checkmark = if status.is_ready() { "✓" } else { "✗" };
-    let status_msg = match status.availability {
-        ToolAvailabilityState::Installed => status
-            .version
-            .as_ref()
-            .map(|version| format!("installed ({version})"))
-            .unwrap_or_else(|| "installed (version unknown)".to_string()),
-        ToolAvailabilityState::Missing => "not found".to_string(),
-    };
-
-    let mut lines = vec![format!(
-        "{:<12} {} {}",
-        format!("{}:", status.name),
-        checkmark,
-        status_msg
-    )];
-
-    if let Some(transport_status) = status.transport.as_ref() {
-        lines.push(format!(
-            "             Active transport: {}",
-            transport_status.transport_active
-        ));
-        if let Some(acp_compiled_in) = transport_status.acp_compiled_in {
-            lines.push(format!(
-                "             ACP compiled in: {}",
-                yes_no(acp_compiled_in)
-            ));
-        }
-        lines.push(format!(
-            "             Probed binary: {}",
-            transport_status.probed_binary
-        ));
-        if let Some(acp_override_hint) = transport_status.acp_override_hint {
-            lines.push(format!("             ACP override: {acp_override_hint}"));
-        }
-    }
-
-    if !status.is_ready()
-        && let Some(hint) = status.hint.as_deref()
-    {
-        lines.push(format!(
-            "             Expected runtime: {}",
-            status.binary_name
-        ));
-        lines.push(format!("             {hint}"));
-    }
-
-    lines
-}
-
-fn tool_status_json(status: &ToolStatus) -> serde_json::Value {
-    let mut entry = serde_json::json!({
-        "name": status.name,
-        "binary": status.binary_name,
-        "installed": status.is_ready(),
-        "version": status.version,
-        "hint": status.hint,
-    });
-
-    if let Some(transport_status) = status.transport.as_ref()
-        && let Some(object) = entry.as_object_mut()
-    {
-        object.insert(
-            "transport_active".to_string(),
-            serde_json::json!(transport_status.transport_active),
-        );
-        if let Some(acp_compiled_in) = transport_status.acp_compiled_in {
-            object.insert(
-                "acp_compiled_in".to_string(),
-                serde_json::json!(acp_compiled_in),
-            );
-        }
-        object.insert(
-            "probed_binary".to_string(),
-            serde_json::json!(transport_status.probed_binary),
-        );
-    }
-
-    entry
-}
-
-fn tool_transport_doctor_status(
-    tool_name: &str,
-    config: Option<&ProjectConfig>,
-) -> Option<ToolTransportDoctorStatus> {
-    match tool_name {
-        "codex" => codex_doctor_status(config),
-        "claude-code" => claude_code_doctor_status(config),
-        _ => None,
-    }
-}
-
-fn codex_doctor_status(config: Option<&ProjectConfig>) -> Option<ToolTransportDoctorStatus> {
-    let transport_active = crate::run_helpers::resolved_codex_transport(config);
-    let acp_compiled_in = CodexRuntimeMetadata::acp_compiled_in();
-
-    Some(ToolTransportDoctorStatus {
-        transport_active: codex_transport_label(transport_active),
-        acp_compiled_in: Some(acp_compiled_in),
-        probed_binary: transport_active.runtime_binary_name().to_string(),
-        acp_override_hint: if acp_compiled_in && transport_active != CodexTransport::Acp {
-            Some("set [tools.codex].transport = \"acp\"")
-        } else {
-            None
-        },
-    })
-}
-
-fn codex_transport_label(transport: CodexTransport) -> &'static str {
-    match transport {
-        CodexTransport::Cli => "cli",
-        CodexTransport::Acp => "acp",
-    }
-}
-
-fn claude_code_doctor_status(config: Option<&ProjectConfig>) -> Option<ToolTransportDoctorStatus> {
-    let transport_active = crate::run_helpers::resolved_claude_code_transport(config);
-
-    Some(ToolTransportDoctorStatus {
-        transport_active: claude_code_transport_label(transport_active),
-        acp_compiled_in: None,
-        probed_binary: transport_active.runtime_binary_name().to_string(),
-        acp_override_hint: None,
-    })
-}
-
-fn claude_code_transport_label(transport: ClaudeCodeTransport) -> &'static str {
-    match transport {
-        ClaudeCodeTransport::Cli => "cli",
-        ClaudeCodeTransport::Acp => "acp",
-    }
-}
-
-fn yes_no(value: bool) -> &'static str {
-    if value { "yes" } else { "no" }
-}
-
 /// Print project config status.
 fn print_project_config(status: &DoctorProjectConfigStatus) {
     for line in render_project_config_lines(status) {
         println!("{line}");
     }
-}
-
-/// Print resource status (combined available physical + free swap memory).
-fn print_resource_status() {
-    let mut sys = System::new();
-    sys.refresh_memory();
-
-    let available_memory_bytes = sys.available_memory();
-    let free_swap_bytes = sys.free_swap();
-    let total_free = available_memory_bytes.saturating_add(free_swap_bytes);
-
-    println!(
-        "Available Memory: {} (physical {} + swap {})",
-        format_bytes(total_free),
-        format_bytes(available_memory_bytes),
-        format_bytes(free_swap_bytes),
-    );
-}
-
-/// Print sandbox capability status.
-fn print_sandbox_status() {
-    let cap = detect_resource_capability();
-    println!("Capability:  {cap}");
-
-    match cap {
-        ResourceCapability::CgroupV2 => {
-            if let Some(ver) = systemd_version() {
-                println!("Systemd:     {ver}");
-            }
-            println!("User scope:  supported");
-        }
-        ResourceCapability::Setrlimit => {
-            println!("Enforces:    PID limit only (RLIMIT_NPROC)");
-            match current_rlimit_nproc() {
-                Some(n) => println!("RLIMIT_NPROC: {n}"),
-                None => println!("RLIMIT_NPROC: unlimited"),
-            }
-            println!("Memory:      via MemoryBalloon (not setrlimit)");
-        }
-        ResourceCapability::None => {
-            println!("Warning:     No sandbox isolation available.");
-            println!("             Resource limits will not be enforced.");
-        }
-    }
-}
-
-/// Print filesystem sandbox capability status.
-fn print_filesystem_sandbox_status() {
-    let fs_cap = detect_filesystem_capability();
-    println!("Capability:  {fs_cap}");
-
-    match fs_cap {
-        FilesystemCapability::Bwrap => {
-            if let Some(ver) = bwrap_version() {
-                println!("bwrap:       {ver}");
-            }
-            println!("User NS:     available");
-        }
-        FilesystemCapability::Landlock => {
-            let abi = csa_resource::landlock::detect_abi();
-            println!("Landlock ABI: {abi:?}");
-        }
-        FilesystemCapability::None => {
-            println!("Warning:     No filesystem isolation available.");
-            // Print diagnostic details
-            if let Some(ver) = bwrap_version() {
-                println!("bwrap:       {ver} (installed but user namespaces blocked)");
-            } else {
-                println!("bwrap:       not installed");
-            }
-            if is_apparmor_userns_restricted() {
-                println!("AppArmor:    restricts unprivileged user namespaces");
-            }
-            if !has_usable_user_namespaces() {
-                println!("User NS:     unavailable");
-            }
-        }
-    }
-}
-
-/// Build JSON object for filesystem sandbox status.
-fn build_filesystem_sandbox_json(fs_cap: FilesystemCapability) -> serde_json::Value {
-    match fs_cap {
-        FilesystemCapability::Bwrap => {
-            serde_json::json!({
-                "capability": "Bwrap",
-                "bwrap_version": bwrap_version(),
-                "user_namespaces": true,
-                "apparmor_userns_restricted": is_apparmor_userns_restricted(),
-            })
-        }
-        FilesystemCapability::Landlock => {
-            let abi = csa_resource::landlock::detect_abi();
-            serde_json::json!({
-                "capability": "Landlock",
-                "landlock_abi": format!("{abi:?}"),
-                "user_namespaces": has_usable_user_namespaces(),
-                "apparmor_userns_restricted": is_apparmor_userns_restricted(),
-            })
-        }
-        FilesystemCapability::None => {
-            serde_json::json!({
-                "capability": "None",
-                "bwrap_installed": bwrap_version().is_some(),
-                "user_namespaces": has_usable_user_namespaces(),
-                "apparmor_userns_restricted": is_apparmor_userns_restricted(),
-            })
-        }
-    }
-}
-
-/// Get bwrap version string, if installed.
-fn bwrap_version() -> Option<String> {
-    let output = Command::new("bwrap").arg("--version").output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    stdout.lines().next().map(|s| s.trim().to_string())
-}
-
-/// Check whether AppArmor restricts unprivileged user namespaces.
-fn is_apparmor_userns_restricted() -> bool {
-    let path = std::path::Path::new("/proc/sys/kernel/apparmor_restrict_unprivileged_userns");
-    std::fs::read_to_string(path)
-        .map(|content| content.trim() == "1")
-        .unwrap_or(false)
-}
-
-/// Check whether unprivileged user namespaces work.
-fn has_usable_user_namespaces() -> bool {
-    Command::new("unshare")
-        .args(["-U", "true"])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .is_ok_and(|s| s.success())
-}
-
-/// Print merge guard installation status.
-fn print_merge_guard_status() {
-    match csa_hooks::detect_installed_guard() {
-        Some(path) => {
-            println!("merge guard: installed ({})", path.display());
-        }
-        None => {
-            println!("merge guard: not installed");
-            println!("  Hint: csa hooks install-merge-guard");
-        }
-    }
-}
-
-/// Print git hook installation status.
-fn print_git_hook_status(project_root: &Path) {
-    let hooks = [("pre-push", "Blocks push without csa review session")];
-    for (hook_name, description) in hooks {
-        let hook_path = project_root.join(".git/hooks").join(hook_name);
-        if hook_path.is_file() {
-            println!("{hook_name}:  installed ({description})");
-        } else {
-            println!("{hook_name}:  NOT INSTALLED — {description}");
-            println!("  Hint: ln -sf ../../scripts/hooks/{hook_name} .git/hooks/{hook_name}");
-        }
-    }
-}
-
-/// Format bytes as human-readable string (GB).
-fn format_bytes(bytes: u64) -> String {
-    let gb = bytes as f64 / 1024.0 / 1024.0 / 1024.0;
-    format!("{gb:.1} GB")
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/doctor_config.rs
+++ b/crates/cli-sub-agent/src/doctor_config.rs
@@ -1,0 +1,102 @@
+use super::{DoctorEffectiveConfigStatus, DoctorProjectConfigStatus};
+use anyhow::Result;
+use csa_config::ProjectConfig;
+use std::path::Path;
+
+pub(super) fn project_config_tool_lists(
+    config: &ProjectConfig,
+) -> (Vec<&'static str>, Vec<&'static str>) {
+    let mut enabled = Vec::new();
+    let mut disabled = Vec::new();
+
+    for tool_name in &["gemini-cli", "opencode", "codex", "claude-code"] {
+        if config.is_tool_enabled(tool_name) {
+            enabled.push(*tool_name);
+        } else {
+            disabled.push(*tool_name);
+        }
+    }
+
+    (enabled, disabled)
+}
+
+pub(super) fn render_project_config_lines(status: &DoctorProjectConfigStatus) -> Vec<String> {
+    match status {
+        DoctorProjectConfigStatus::Missing => vec![
+            "Config:      .csa/config.toml (missing)".to_string(),
+            "             Run 'csa init' to create configuration".to_string(),
+        ],
+        DoctorProjectConfigStatus::Valid(config) => {
+            let (enabled, disabled) = project_config_tool_lists(config);
+            let mut lines = vec!["Config:      .csa/config.toml (valid)".to_string()];
+
+            if !enabled.is_empty() {
+                lines.push(format!("Enabled:     {}", enabled.join(", ")));
+            }
+            if !disabled.is_empty() {
+                lines.push(format!("Disabled:    {}", disabled.join(", ")));
+            }
+
+            lines
+        }
+        DoctorProjectConfigStatus::Invalid(error) => vec![
+            "Config:      .csa/config.toml (invalid)".to_string(),
+            format!("             Error: {error}"),
+        ],
+    }
+}
+
+pub(super) fn render_effective_config_lines(status: &DoctorEffectiveConfigStatus) -> Vec<String> {
+    match status {
+        DoctorEffectiveConfigStatus::Defaults => {
+            vec!["Effective:   merged config (defaults only)".to_string()]
+        }
+        DoctorEffectiveConfigStatus::Valid(_) => {
+            vec!["Effective:   merged config (valid)".to_string()]
+        }
+        DoctorEffectiveConfigStatus::Invalid(error) => vec![
+            "Effective:   merged config (invalid)".to_string(),
+            format!("             Error: {error}"),
+        ],
+    }
+}
+
+pub(super) fn render_tool_availability_error_lines(error: &str) -> Vec<String> {
+    vec![
+        "Tool availability unknown (effective config invalid)".to_string(),
+        format!("Reason:      {error}"),
+    ]
+}
+
+pub(super) fn load_doctor_project_config_from(
+    project_root: &Path,
+) -> Result<Option<ProjectConfig>> {
+    ProjectConfig::load_project_only(project_root)
+}
+
+fn load_doctor_effective_config_from(project_root: &Path) -> Result<Option<ProjectConfig>> {
+    ProjectConfig::load(project_root)
+}
+
+pub(super) fn inspect_doctor_project_config_from(project_root: &Path) -> DoctorProjectConfigStatus {
+    let config_path = project_root.join(".csa").join("config.toml");
+    if !config_path.exists() {
+        return DoctorProjectConfigStatus::Missing;
+    }
+
+    match load_doctor_project_config_from(project_root) {
+        Ok(Some(config)) => DoctorProjectConfigStatus::Valid(Box::new(config)),
+        Ok(None) => DoctorProjectConfigStatus::Missing,
+        Err(error) => DoctorProjectConfigStatus::Invalid(format!("{error:#}")),
+    }
+}
+
+pub(super) fn inspect_doctor_effective_config_from(
+    project_root: &Path,
+) -> DoctorEffectiveConfigStatus {
+    match load_doctor_effective_config_from(project_root) {
+        Ok(Some(config)) => DoctorEffectiveConfigStatus::Valid(Box::new(config)),
+        Ok(None) => DoctorEffectiveConfigStatus::Defaults,
+        Err(error) => DoctorEffectiveConfigStatus::Invalid(format!("{error:#}")),
+    }
+}

--- a/crates/cli-sub-agent/src/doctor_resource.rs
+++ b/crates/cli-sub-agent/src/doctor_resource.rs
@@ -1,0 +1,22 @@
+use sysinfo::System;
+
+pub(super) fn print_resource_status() {
+    let mut sys = System::new();
+    sys.refresh_memory();
+
+    let available_memory_bytes = sys.available_memory();
+    let free_swap_bytes = sys.free_swap();
+    let total_free = available_memory_bytes.saturating_add(free_swap_bytes);
+
+    println!(
+        "Available Memory: {} (physical {} + swap {})",
+        format_bytes(total_free),
+        format_bytes(available_memory_bytes),
+        format_bytes(free_swap_bytes),
+    );
+}
+
+pub(super) fn format_bytes(bytes: u64) -> String {
+    let gb = bytes as f64 / 1024.0 / 1024.0 / 1024.0;
+    format!("{gb:.1} GB")
+}

--- a/crates/cli-sub-agent/src/doctor_sandbox.rs
+++ b/crates/cli-sub-agent/src/doctor_sandbox.rs
@@ -1,0 +1,144 @@
+use csa_resource::filesystem_sandbox::FilesystemCapability;
+use csa_resource::rlimit::current_rlimit_nproc;
+use csa_resource::sandbox::{ResourceCapability, detect_resource_capability, systemd_version};
+use std::path::Path;
+use std::process::Command;
+
+pub(super) fn print_sandbox_status() {
+    let cap = detect_resource_capability();
+    println!("Capability:  {cap}");
+
+    match cap {
+        ResourceCapability::CgroupV2 => {
+            if let Some(ver) = systemd_version() {
+                println!("Systemd:     {ver}");
+            }
+            println!("User scope:  supported");
+        }
+        ResourceCapability::Setrlimit => {
+            println!("Enforces:    PID limit only (RLIMIT_NPROC)");
+            match current_rlimit_nproc() {
+                Some(n) => println!("RLIMIT_NPROC: {n}"),
+                None => println!("RLIMIT_NPROC: unlimited"),
+            }
+            println!("Memory:      via MemoryBalloon (not setrlimit)");
+        }
+        ResourceCapability::None => {
+            println!("Warning:     No sandbox isolation available.");
+            println!("             Resource limits will not be enforced.");
+        }
+    }
+}
+
+pub(super) fn print_filesystem_sandbox_status() {
+    let fs_cap = csa_resource::filesystem_sandbox::detect_filesystem_capability();
+    println!("Capability:  {fs_cap}");
+
+    match fs_cap {
+        FilesystemCapability::Bwrap => {
+            if let Some(ver) = bwrap_version() {
+                println!("bwrap:       {ver}");
+            }
+            println!("User NS:     available");
+        }
+        FilesystemCapability::Landlock => {
+            let abi = csa_resource::landlock::detect_abi();
+            println!("Landlock ABI: {abi:?}");
+        }
+        FilesystemCapability::None => {
+            println!("Warning:     No filesystem isolation available.");
+            if let Some(ver) = bwrap_version() {
+                println!("bwrap:       {ver} (installed but user namespaces blocked)");
+            } else {
+                println!("bwrap:       not installed");
+            }
+            if is_apparmor_userns_restricted() {
+                println!("AppArmor:    restricts unprivileged user namespaces");
+            }
+            if !has_usable_user_namespaces() {
+                println!("User NS:     unavailable");
+            }
+        }
+    }
+}
+
+pub(super) fn build_filesystem_sandbox_json(fs_cap: FilesystemCapability) -> serde_json::Value {
+    match fs_cap {
+        FilesystemCapability::Bwrap => {
+            serde_json::json!({
+                "capability": "Bwrap",
+                "bwrap_version": bwrap_version(),
+                "user_namespaces": true,
+                "apparmor_userns_restricted": is_apparmor_userns_restricted(),
+            })
+        }
+        FilesystemCapability::Landlock => {
+            let abi = csa_resource::landlock::detect_abi();
+            serde_json::json!({
+                "capability": "Landlock",
+                "landlock_abi": format!("{abi:?}"),
+                "user_namespaces": has_usable_user_namespaces(),
+                "apparmor_userns_restricted": is_apparmor_userns_restricted(),
+            })
+        }
+        FilesystemCapability::None => {
+            serde_json::json!({
+                "capability": "None",
+                "bwrap_installed": bwrap_version().is_some(),
+                "user_namespaces": has_usable_user_namespaces(),
+                "apparmor_userns_restricted": is_apparmor_userns_restricted(),
+            })
+        }
+    }
+}
+
+fn bwrap_version() -> Option<String> {
+    let output = Command::new("bwrap").arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout.lines().next().map(|s| s.trim().to_string())
+}
+
+fn is_apparmor_userns_restricted() -> bool {
+    let path = Path::new("/proc/sys/kernel/apparmor_restrict_unprivileged_userns");
+    std::fs::read_to_string(path)
+        .map(|content| content.trim() == "1")
+        .unwrap_or(false)
+}
+
+fn has_usable_user_namespaces() -> bool {
+    Command::new("unshare")
+        .args(["-U", "true"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+pub(super) fn print_merge_guard_status() {
+    match csa_hooks::detect_installed_guard() {
+        Some(path) => {
+            println!("merge guard: installed ({})", path.display());
+        }
+        None => {
+            println!("merge guard: not installed");
+            println!("  Hint: csa hooks install-merge-guard");
+        }
+    }
+}
+
+pub(super) fn print_git_hook_status(project_root: &Path) {
+    let hooks = [("pre-push", "Blocks push without csa review session")];
+    for (hook_name, description) in hooks {
+        let hook_path = project_root.join(".git/hooks").join(hook_name);
+        if hook_path.is_file() {
+            println!("{hook_name}:  installed ({description})");
+        } else {
+            println!("{hook_name}:  NOT INSTALLED — {description}");
+            println!("  Hint: ln -sf ../../scripts/hooks/{hook_name} .git/hooks/{hook_name}");
+        }
+    }
+}

--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -6,10 +6,10 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::Path;
 
-fn project_config_with_codex_transport(transport: TransportKind) -> ProjectConfig {
+fn project_config_with_tool_transport(tool_name: &str, transport: TransportKind) -> ProjectConfig {
     let mut tools = HashMap::new();
     tools.insert(
-        "codex".to_string(),
+        tool_name.to_string(),
         ToolConfig {
             transport: Some(transport),
             ..Default::default()
@@ -39,6 +39,14 @@ fn project_config_with_codex_transport(transport: TransportKind) -> ProjectConfi
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }
+}
+
+fn project_config_with_codex_transport(transport: TransportKind) -> ProjectConfig {
+    project_config_with_tool_transport("codex", transport)
+}
+
+fn project_config_with_claude_code_transport(transport: TransportKind) -> ProjectConfig {
+    project_config_with_tool_transport("claude-code", transport)
 }
 
 fn write_project_config(project_root: &Path, contents: &str) {
@@ -74,20 +82,20 @@ impl Drop for EnvVarGuard {
 }
 
 #[cfg(unix)]
-fn with_stubbed_codex_on_path<T>(test_fn: impl FnOnce() -> T) -> T {
+fn with_stubbed_binaries_on_path<T>(binaries: &[&str], test_fn: impl FnOnce() -> T) -> T {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
     let td = tempfile::tempdir().expect("tempdir");
     let bin_dir = td.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
-    for binary in ["codex", "codex-acp"] {
+    for binary in binaries {
         let binary_path = bin_dir.join(binary);
         fs::write(&binary_path, format!("#!/bin/sh\necho '{binary} 1.2.3'\n"))
-            .expect("write codex stub");
+            .expect("write tool stub");
         let mut perms = fs::metadata(&binary_path).expect("metadata").permissions();
         perms.set_mode(0o755);
-        fs::set_permissions(&binary_path, perms).expect("chmod codex stub");
+        fs::set_permissions(&binary_path, perms).expect("chmod tool stub");
     }
 
     let path = std::env::var_os("PATH").unwrap_or_default();
@@ -97,6 +105,16 @@ fn with_stubbed_codex_on_path<T>(test_fn: impl FnOnce() -> T) -> T {
     let _path_guard = ScopedTestEnvVar::set("PATH", joined);
 
     test_fn()
+}
+
+#[cfg(unix)]
+fn with_stubbed_codex_on_path<T>(test_fn: impl FnOnce() -> T) -> T {
+    with_stubbed_binaries_on_path(&["codex", "codex-acp"], test_fn)
+}
+
+#[cfg(unix)]
+fn with_stubbed_claude_code_on_path<T>(test_fn: impl FnOnce() -> T) -> T {
+    with_stubbed_binaries_on_path(&["claude", "claude-code-acp"], test_fn)
 }
 
 #[test]
@@ -195,6 +213,51 @@ fn explicit_codex_acp_transport_reports_install_hint() {
         rendered.contains("@zed-industries/codex-acp"),
         "doctor text should surface the ACP adapter install hint: {rendered}"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn explicit_claude_code_cli_transport_reports_transport_details() {
+    with_stubbed_claude_code_on_path(|| {
+        let config = project_config_with_claude_code_transport(TransportKind::Cli);
+        let status = check_tool_status("claude-code", Some(&config));
+        let rendered = render_tool_status_lines(&status).join("\n");
+
+        assert!(
+            status.is_ready(),
+            "doctor should accept the requested claude-code CLI transport"
+        );
+        assert_eq!(status.binary_name, "claude");
+        assert!(
+            rendered.contains("Active transport: cli"),
+            "doctor text should report active claude-code transport: {rendered}"
+        );
+        assert!(
+            rendered.contains("Probed binary: claude"),
+            "doctor text should report the probed claude-code CLI binary: {rendered}"
+        );
+        assert!(
+            !rendered.contains("ACP compiled in:"),
+            "claude-code transport details should not print a codex-only ACP build line: {rendered}"
+        );
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn explicit_claude_code_cli_transport_reports_json_transport_details() {
+    with_stubbed_claude_code_on_path(|| {
+        let config = project_config_with_claude_code_transport(TransportKind::Cli);
+        let status = check_tool_status("claude-code", Some(&config));
+        let json = tool_status_json(&status);
+
+        assert_eq!(json["transport_active"], Value::String("cli".to_string()));
+        assert_eq!(json["probed_binary"], Value::String("claude".to_string()));
+        assert!(
+            json.get("acp_compiled_in").is_none(),
+            "claude-code JSON transport details should omit codex-only ACP build metadata: {json}"
+        );
+    });
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/doctor_tools.rs
+++ b/crates/cli-sub-agent/src/doctor_tools.rs
@@ -1,0 +1,208 @@
+use super::{ToolAvailabilityState, ToolStatus, ToolTransportDoctorStatus};
+use csa_config::ProjectConfig;
+use csa_executor::{ClaudeCodeTransport, CodexRuntimeMetadata, CodexTransport};
+use std::process::Command;
+
+pub(super) async fn print_tool_availability(config: Option<&ProjectConfig>) {
+    let tools = ["gemini-cli", "opencode", "codex", "claude-code"];
+
+    let mut installed_count = 0;
+    let total_count = tools.len();
+
+    for tool_name in &tools {
+        let status = check_tool_status(tool_name, config);
+        if status.is_ready() {
+            installed_count += 1;
+        }
+        print_tool_status(&status);
+    }
+
+    println!();
+    println!("{installed_count}/{total_count} tools ready");
+}
+
+pub(super) fn check_tool_status(
+    tool_name: &'static str,
+    config: Option<&ProjectConfig>,
+) -> ToolStatus {
+    let binary_name = tool_exe_name(tool_name, config);
+    match crate::run_helpers::tool_binary_availability(tool_name, config) {
+        crate::run_helpers::ToolBinaryAvailability::Available { .. } => ToolStatus {
+            name: tool_name,
+            availability: ToolAvailabilityState::Installed,
+            binary_name: binary_name.clone(),
+            version: check_tool_version(&binary_name),
+            hint: None,
+            transport: tool_transport_doctor_status(tool_name, config),
+        },
+        crate::run_helpers::ToolBinaryAvailability::Missing { hint, .. } => ToolStatus {
+            name: tool_name,
+            availability: ToolAvailabilityState::Missing,
+            binary_name,
+            version: None,
+            hint: Some(hint.into_owned()),
+            transport: tool_transport_doctor_status(tool_name, config),
+        },
+    }
+}
+
+pub(super) fn check_tool_version(exe_name: &str) -> Option<String> {
+    let output = Command::new(exe_name).arg("--version").output().ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout.lines().next().map(|s| s.trim().to_string())
+}
+
+fn print_tool_status(status: &ToolStatus) {
+    for line in render_tool_status_lines(status) {
+        println!("{line}");
+    }
+}
+
+pub(super) fn render_tool_status_lines(status: &ToolStatus) -> Vec<String> {
+    let checkmark = if status.is_ready() { "✓" } else { "✗" };
+    let status_msg = match status.availability {
+        ToolAvailabilityState::Installed => status
+            .version
+            .as_ref()
+            .map(|version| format!("installed ({version})"))
+            .unwrap_or_else(|| "installed (version unknown)".to_string()),
+        ToolAvailabilityState::Missing => "not found".to_string(),
+    };
+
+    let mut lines = vec![format!(
+        "{:<12} {} {}",
+        format!("{}:", status.name),
+        checkmark,
+        status_msg
+    )];
+
+    if let Some(transport_status) = status.transport.as_ref() {
+        lines.push(format!(
+            "             Active transport: {}",
+            transport_status.transport_active
+        ));
+        if let Some(acp_compiled_in) = transport_status.acp_compiled_in {
+            lines.push(format!(
+                "             ACP compiled in: {}",
+                yes_no(acp_compiled_in)
+            ));
+        }
+        lines.push(format!(
+            "             Probed binary: {}",
+            transport_status.probed_binary
+        ));
+        if let Some(acp_override_hint) = transport_status.acp_override_hint {
+            lines.push(format!("             ACP override: {acp_override_hint}"));
+        }
+    }
+
+    if !status.is_ready()
+        && let Some(hint) = status.hint.as_deref()
+    {
+        lines.push(format!(
+            "             Expected runtime: {}",
+            status.binary_name
+        ));
+        lines.push(format!("             {hint}"));
+    }
+
+    lines
+}
+
+pub(super) fn tool_status_json(status: &ToolStatus) -> serde_json::Value {
+    let mut entry = serde_json::json!({
+        "name": status.name,
+        "binary": status.binary_name,
+        "installed": status.is_ready(),
+        "version": status.version,
+        "hint": status.hint,
+    });
+
+    if let Some(transport_status) = status.transport.as_ref()
+        && let Some(object) = entry.as_object_mut()
+    {
+        object.insert(
+            "transport_active".to_string(),
+            serde_json::json!(transport_status.transport_active),
+        );
+        if let Some(acp_compiled_in) = transport_status.acp_compiled_in {
+            object.insert(
+                "acp_compiled_in".to_string(),
+                serde_json::json!(acp_compiled_in),
+            );
+        }
+        object.insert(
+            "probed_binary".to_string(),
+            serde_json::json!(transport_status.probed_binary),
+        );
+    }
+
+    entry
+}
+
+fn tool_exe_name(tool_name: &str, config: Option<&ProjectConfig>) -> String {
+    crate::run_helpers::resolved_tool_binary_name(tool_name, config)
+        .unwrap_or(tool_name)
+        .to_string()
+}
+
+fn tool_transport_doctor_status(
+    tool_name: &str,
+    config: Option<&ProjectConfig>,
+) -> Option<ToolTransportDoctorStatus> {
+    match tool_name {
+        "codex" => codex_doctor_status(config),
+        "claude-code" => claude_code_doctor_status(config),
+        _ => None,
+    }
+}
+
+fn codex_doctor_status(config: Option<&ProjectConfig>) -> Option<ToolTransportDoctorStatus> {
+    let transport_active = crate::run_helpers::resolved_codex_transport(config);
+    let acp_compiled_in = CodexRuntimeMetadata::acp_compiled_in();
+
+    Some(ToolTransportDoctorStatus {
+        transport_active: codex_transport_label(transport_active),
+        acp_compiled_in: Some(acp_compiled_in),
+        probed_binary: transport_active.runtime_binary_name().to_string(),
+        acp_override_hint: if acp_compiled_in && transport_active != CodexTransport::Acp {
+            Some("set [tools.codex].transport = \"acp\"")
+        } else {
+            None
+        },
+    })
+}
+
+fn codex_transport_label(transport: CodexTransport) -> &'static str {
+    match transport {
+        CodexTransport::Cli => "cli",
+        CodexTransport::Acp => "acp",
+    }
+}
+
+fn claude_code_doctor_status(config: Option<&ProjectConfig>) -> Option<ToolTransportDoctorStatus> {
+    let transport_active = crate::run_helpers::resolved_claude_code_transport(config);
+
+    Some(ToolTransportDoctorStatus {
+        transport_active: claude_code_transport_label(transport_active),
+        acp_compiled_in: None,
+        probed_binary: transport_active.runtime_binary_name().to_string(),
+        acp_override_hint: None,
+    })
+}
+
+fn claude_code_transport_label(transport: ClaudeCodeTransport) -> &'static str {
+    match transport {
+        ClaudeCodeTransport::Cli => "cli",
+        ClaudeCodeTransport::Acp => "acp",
+    }
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -29,8 +29,8 @@ pub(crate) use inline_review_context::prepend_review_context_to_prompt;
 pub(crate) use prompt::{read_prompt, resolve_positional_stdin_sentinel};
 pub(crate) use routing_conflict::{is_routing_conflict, routing_conflict_error};
 pub(crate) use tool_availability::{
-    ToolBinaryAvailability, is_tool_binary_available_for_config, resolved_tool_binary_name,
-    tool_binary_availability,
+    ToolBinaryAvailability, is_tool_binary_available_for_config, resolved_claude_code_transport,
+    resolved_codex_transport, resolved_tool_binary_name, tool_binary_availability,
 };
 
 #[cfg(test)]

--- a/docs/acp-transport.md
+++ b/docs/acp-transport.md
@@ -1,11 +1,12 @@
 # ACP Transport
 
 CSA uses the **Agent Communication Protocol (ACP)** for precise context
-window control when communicating with claude-code. Codex defaults to the
-direct CLI path and can opt into ACP when CSA is built with the
-`codex-acp` feature and `[tools.codex].transport = "acp"` is set. For ACP
-sessions, this replaces the CLI non-interactive mode which auto-loads 60K+
-tokens of project context.
+window control when communicating with `claude-code` and other ACP-backed
+tools. `claude-code` defaults to ACP today, but you can opt into the native
+CLI path with `[tools.claude-code].transport = "cli"`. Codex keeps its
+codex-specific transport controls and can opt into ACP when CSA is built with
+the `codex-acp` feature. For ACP sessions, this replaces the CLI
+non-interactive mode which auto-loads 60K+ tokens of project context.
 
 ## Why ACP?
 
@@ -25,18 +26,29 @@ context precisely:
 
 | Tool | Default Transport | ACP Binary |
 |------|-------------------|------------|
-| claude-code | ACP | `claude-code-acp` |
+| claude-code | ACP (`cli` opt-in) | `claude-code-acp` |
 | codex | Legacy CLI (`codex`) | `codex-acp` (opt-in) |
 | gemini-cli | Legacy CLI | N/A |
 | opencode | Legacy CLI | N/A |
 
 The `Transport` trait abstracts both execution modes. `TransportFactory`
 routes automatically based on tool type and configuration. `claude-code`
-remains ACP-only. `codex` resolves transport from `CodexRuntimeMetadata`
-plus `[tools.codex].transport`, defaulting to `LegacyTransport` and the
-`codex` binary; ACP is selected only when the binary was compiled with
-`codex-acp` support and config explicitly requests it. `gemini-cli` and
-`opencode` remain direct CLI tools.
+resolves transport from the build default plus `[tools.claude-code].transport`,
+probing `claude-code-acp` in ACP mode and `claude` in CLI mode. `codex`
+resolves transport from `CodexRuntimeMetadata` plus `[tools.codex].transport`,
+defaulting to `LegacyTransport` and the `codex` binary; ACP is selected only
+when the binary was compiled with `codex-acp` support and config explicitly
+requests it. `gemini-cli` and `opencode` remain direct CLI tools.
+
+To force Claude Code onto the native CLI runtime:
+
+```toml
+[tools.claude-code]
+transport = "cli"
+```
+
+`csa doctor` reports the active transport and probed runtime binary so you can
+verify which path CSA will use before running a session.
 
 **Fallback rules:**
 

--- a/docs/acp-transport.md
+++ b/docs/acp-transport.md
@@ -3,10 +3,13 @@
 CSA uses the **Agent Communication Protocol (ACP)** for precise context
 window control when communicating with `claude-code` and other ACP-backed
 tools. `claude-code` defaults to ACP today, but you can opt into the native
-CLI path with `[tools.claude-code].transport = "cli"`. Codex keeps its
-codex-specific transport controls and can opt into ACP when CSA is built with
-the `codex-acp` feature. For ACP sessions, this replaces the CLI
-non-interactive mode which auto-loads 60K+ tokens of project context.
+CLI path with `[tools.claude-code].transport = "cli"`. Codex also defaults to
+ACP today: current builds probe `codex-acp` by default, and
+`[tools.codex].transport = "acp"` simply makes that explicit. Config
+validation checks whether a transport value is legal for the tool; missing
+runtime binaries are surfaced separately by `csa doctor`. For ACP sessions,
+this replaces the CLI non-interactive mode which auto-loads 60K+ tokens of
+project context.
 
 ## Why ACP?
 
@@ -24,21 +27,23 @@ context precisely:
 
 ## Transport Routing
 
-| Tool | Default Transport | ACP Binary |
-|------|-------------------|------------|
-| claude-code | ACP (`cli` opt-in) | `claude-code-acp` |
-| codex | Legacy CLI (`codex`) | `codex-acp` (opt-in) |
-| gemini-cli | Legacy CLI | N/A |
-| opencode | Legacy CLI | N/A |
+| Tool | Default Transport | Runtime Binary |
+|------|-------------------|----------------|
+| claude-code | ACP (`cli` opt-in) | `claude-code-acp` / `claude` |
+| codex | ACP (`acp` explicit) | `codex-acp` |
+| gemini-cli | CLI only | `gemini` |
+| opencode | CLI only | `opencode` |
 
 The `Transport` trait abstracts both execution modes. `TransportFactory`
 routes automatically based on tool type and configuration. `claude-code`
 resolves transport from the build default plus `[tools.claude-code].transport`,
 probing `claude-code-acp` in ACP mode and `claude` in CLI mode. `codex`
-resolves transport from `CodexRuntimeMetadata` plus `[tools.codex].transport`,
-defaulting to `LegacyTransport` and the `codex` binary; ACP is selected only
-when the binary was compiled with `codex-acp` support and config explicitly
-requests it. `gemini-cli` and `opencode` remain direct CLI tools.
+resolves transport from `CodexRuntimeMetadata` plus `[tools.codex].transport`;
+the current build default is ACP, so the default path probes `codex-acp`.
+Config validation accepts codex `auto` and `acp` values without performing a
+binary presence check, and `csa doctor` surfaces missing adapters and install
+hints. Project config still rejects `tools.codex.transport = "cli"` today.
+`gemini-cli` and `opencode` remain direct CLI tools.
 
 To force Claude Code onto the native CLI runtime:
 
@@ -56,18 +61,14 @@ verify which path CSA will use before running a session.
 - During prompt execution, automatic fallback is forbidden
 - This prevents silent degradation of context control
 
-### Migration notes
+### Runtime verification
 
-Older builds and docs treated codex as ACP-by-default. Current builds default
-codex to `LegacyTransport` and probe the `codex` binary instead. If you were
-relying on the old ACP default, rebuild CSA with
-`cargo build --features codex-acp` (or
-`cargo install --path crates/cli-sub-agent --features codex-acp`) and set:
+After changing a transport override, run `csa doctor`. It reports the active
+transport and probed runtime binary for both `claude-code` and `codex`.
 
-```toml
-[tools.codex]
-transport = "acp"
-```
+This matters most for codex: config validation accepts
+`[tools.codex].transport = "acp"` even when `codex-acp` is absent. Missing
+adapters are reported by doctor/runtime checks, not by config parsing.
 
 ## Crate API
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,22 +158,22 @@ User -> csa run "prompt"
 
 | Tool | Transport | Runtime Binary |
 |------|-----------|----------------|
-| claude-code | ACP | `claude-code-acp` |
+| claude-code | ACP by default, CLI opt-in | `claude-code-acp` / `claude` |
 | codex | Legacy by default, ACP opt-in | `codex` / `codex-acp` |
 | gemini-cli | Legacy | CLI process |
 | opencode | Legacy | CLI process |
 
 The `Transport` trait abstracts both modes. `TransportFactory` routes based
-on tool type and config. For codex, CSA resolves `[tools.codex].transport`,
-stores the result in `CodexRuntimeMetadata`, and lets `TransportFactory`
-route `cli` to `LegacyTransport` and `acp` to `AcpTransport` when the
-`codex-acp` feature is compiled in. Without an override, codex defaults to
-`LegacyTransport`. ACP fallback to Legacy is allowed only during connection
-initialization; during prompt execution, automatic fallback is forbidden.
+on tool type and config. For `claude-code`, CSA resolves
+`[tools.claude-code].transport`, routes `cli` to `LegacyTransport`, and routes
+`acp` to `AcpTransport`; without an override, the current build default stays
+on ACP. Codex keeps its codex-specific routing and ACP build requirements.
+ACP fallback to Legacy is allowed only during connection initialization;
+during prompt execution, automatic fallback is forbidden.
 
-`csa doctor` makes this routing visible for codex by reporting the active
-transport, whether ACP support was compiled in, and the probed runtime
-binary.
+`csa doctor` makes this routing visible per tool by reporting the active
+transport and probed runtime binary for both `codex` and `claude-code`.
+Codex additionally reports whether ACP support was compiled in.
 
 ## Environment Variables
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,16 +159,22 @@ User -> csa run "prompt"
 | Tool | Transport | Runtime Binary |
 |------|-----------|----------------|
 | claude-code | ACP by default, CLI opt-in | `claude-code-acp` / `claude` |
-| codex | Legacy by default, ACP opt-in | `codex` / `codex-acp` |
-| gemini-cli | Legacy | CLI process |
-| opencode | Legacy | CLI process |
+| codex | ACP by default; config currently accepts `auto` / `acp` | `codex-acp` |
+| gemini-cli | CLI only | `gemini` |
+| opencode | CLI only | `opencode` |
 
 The `Transport` trait abstracts both modes. `TransportFactory` routes based
 on tool type and config. For `claude-code`, CSA resolves
 `[tools.claude-code].transport`, routes `cli` to `LegacyTransport`, and routes
 `acp` to `AcpTransport`; without an override, the current build default stays
-on ACP. Codex keeps its codex-specific routing and ACP build requirements.
-ACP fallback to Legacy is allowed only during connection initialization;
+on ACP. For `codex`, CSA resolves `CodexRuntimeMetadata::default_for_build()`
+plus `[tools.codex].transport`; the current build default is ACP, so the
+default path probes `codex-acp`. Config validation currently accepts codex
+`auto` and `acp` without checking whether the adapter binary is installed, and
+`csa doctor` surfaces missing adapters plus install hints. Project config
+still rejects codex `cli` overrides today. `gemini-cli` and `opencode` stay
+on their direct CLI binaries. ACP fallback to Legacy is allowed only during
+connection initialization;
 during prompt execution, automatic fallback is forbidden.
 
 `csa doctor` makes this routing visible per tool by reporting the active

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,7 @@ allow_edit_existing_files = false    # Inject read-only restriction into prompt
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | Boolean | `true` | Whether this tool is available |
-| `transport` | String | tool-specific | Per-tool transport override. `claude-code` accepts `auto`, `acp`, and `cli`; other tools keep their existing transport-specific rules |
+| `transport` | String | tool-specific | Per-tool transport override. `claude-code` accepts `auto`, `acp`, and `cli`; `codex` currently accepts `auto` and `acp`; `gemini-cli` and `opencode` accept `auto` and `cli` |
 | `restrictions.allow_edit_existing_files` | Boolean | `true` | Allow modifying existing files |
 
 Unconfigured tools default to enabled with no restrictions. Setting
@@ -125,10 +125,15 @@ Unconfigured tools default to enabled with no restrictions. Setting
 `transport` is validated per tool.
 
 - `claude-code` accepts `auto`, `acp`, and `cli`. `auto` resolves to the
-  build default, `acp` probes `claude-code-acp`, and `cli` probes `claude`.
-- `codex` keeps its codex-specific transport rules and ACP build requirement;
-  see below.
-- `gemini-cli` and `opencode` stay on their direct CLI runtimes.
+  build default, which is ACP today; `acp` probes `claude-code-acp`, and
+  `cli` probes `claude`.
+- `codex` currently accepts `auto` and `acp`. `auto` resolves to the current
+  build default, which is ACP today, so both the default path and an explicit
+  `acp` override probe `codex-acp`. Config validation checks only whether the
+  value is legal for codex; missing binaries are surfaced separately by
+  `csa doctor`. `cli` remains rejected in project config today.
+- `gemini-cli` and `opencode` accept `auto` and `cli`, stay on their direct
+  CLI runtimes, and reject `acp`.
 
 When you change a tool transport, `csa doctor` reports the active transport
 and probed binary for that tool.
@@ -148,22 +153,21 @@ With that override, CSA probes `claude` instead of `claude-code-acp`, and
 
 #### Codex transport override
 
-Set `[tools.codex].transport = "acp"` only when CSA was built with the
-`codex-acp` cargo feature. Config validation is fail-closed: if the running
-binary was compiled without that feature, config load fails immediately with
-a rebuild hint instead of silently falling back.
+CSA currently defaults codex to ACP. Leaving `[tools.codex].transport`
+unset or setting it to `auto` probes `codex-acp`; setting it explicitly to
+`"acp"` keeps that same runtime path.
+
+Config validation accepts the ACP override regardless of whether
+`codex-acp` is installed. Binary presence is checked separately by
+`csa doctor`, which reports the active transport, probed binary, and
+install hint if the adapter is missing.
 
 ```toml
 [tools.codex]
 transport = "acp"
 ```
 
-Build or install a codex-ACP-enabled binary with:
-
-```bash
-cargo build --features codex-acp
-cargo install --path crates/cli-sub-agent --features codex-acp
-```
+`transport = "cli"` is still rejected for project config today.
 
 ### `[review]` -- Review Tool Selection
 
@@ -255,8 +259,11 @@ CSA validates on load:
 3. **Tool names:** Must be one of `gemini-cli`, `codex`, `opencode`, `claude-code`
 4. **Thinking budget:** Must be `low`, `medium`, `high`, `xhigh`, or a number
 5. **Tool transport overrides:** validated per tool. In particular,
-   `[tools.claude-code].transport` accepts `auto`, `acp`, or `cli`, and
-   codex ACP requests are rejected unless CSA was compiled with `codex-acp`
+   `[tools.claude-code].transport` accepts `auto`, `acp`, or `cli`;
+   `[tools.codex].transport` currently accepts `auto` or `acp` and defaults
+   to ACP; `gemini-cli` and `opencode` accept `auto` or `cli`. Missing
+   runtime binaries are reported by `csa doctor`, not by config-value
+   validation.
 
 ## Migrations
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,12 +47,13 @@ require_heterogeneous = false    # Warn on narrowing; set true to fail fast
 
 [tools.codex]
 max_concurrent = 5
-transport = "cli"                # Default; "acp" requires a codex-acp build
+transport = "acp"                # See tool-specific transport notes below
 [tools.codex.env]
 OPENAI_API_KEY = "sk-..."
 
 [tools.claude-code]
 max_concurrent = 3
+transport = "auto"               # Accepted: "auto", "acp", or "cli"
 
 [todo]
 show_command = "bat -l md --paging=always"
@@ -102,7 +103,11 @@ enabled = true
 
 [tools.codex]
 enabled = true
-transport = "cli"                 # or "acp" in a codex-acp build
+transport = "acp"                 # See codex-specific note below
+
+[tools.claude-code]
+enabled = true
+transport = "auto"                # Accepted: "auto", "acp", or "cli"
 
 [tools.gemini-cli.restrictions]
 allow_edit_existing_files = false    # Inject read-only restriction into prompt
@@ -111,15 +116,35 @@ allow_edit_existing_files = false    # Inject read-only restriction into prompt
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | Boolean | `true` | Whether this tool is available |
-| `transport` | String | `cli` for `codex` | Codex-only transport override: `cli` or `acp` |
+| `transport` | String | tool-specific | Per-tool transport override. `claude-code` accepts `auto`, `acp`, and `cli`; other tools keep their existing transport-specific rules |
 | `restrictions.allow_edit_existing_files` | Boolean | `true` | Allow modifying existing files |
 
 Unconfigured tools default to enabled with no restrictions. Setting
 `enabled = false` excludes the tool from tier resolution and auto mode.
 
-`transport` is currently valid only for `codex`. Legal values are `cli` and
-`acp`. The default is `cli`, so codex runs through `LegacyTransport` and
-probes the `codex` binary unless you opt into ACP explicitly.
+`transport` is validated per tool.
+
+- `claude-code` accepts `auto`, `acp`, and `cli`. `auto` resolves to the
+  build default, `acp` probes `claude-code-acp`, and `cli` probes `claude`.
+- `codex` keeps its codex-specific transport rules and ACP build requirement;
+  see below.
+- `gemini-cli` and `opencode` stay on their direct CLI runtimes.
+
+When you change a tool transport, `csa doctor` reports the active transport
+and probed binary for that tool.
+
+#### Claude Code transport override
+
+Use `[tools.claude-code].transport` when you need to force Claude Code onto
+the native CLI path or back onto ACP explicitly:
+
+```toml
+[tools.claude-code]
+transport = "cli"
+```
+
+With that override, CSA probes `claude` instead of `claude-code-acp`, and
+`csa doctor` prints the effective transport under the `claude-code` block.
 
 #### Codex transport override
 
@@ -229,8 +254,9 @@ CSA validates on load:
 2. **Tier references:** All `tier_mapping` values must reference existing tiers
 3. **Tool names:** Must be one of `gemini-cli`, `codex`, `opencode`, `claude-code`
 4. **Thinking budget:** Must be `low`, `medium`, `high`, `xhigh`, or a number
-5. **Codex transport override:** `[tools.codex].transport` must be `cli` or
-   `acp`, and `acp` is rejected unless CSA was compiled with `codex-acp`
+5. **Tool transport overrides:** validated per tool. In particular,
+   `[tools.claude-code].transport` accepts `auto`, `acp`, or `cli`, and
+   codex ACP requests are rejected unless CSA was compiled with `codex-acp`
 
 ## Migrations
 
@@ -307,6 +333,6 @@ default = "primary"
 ## Related
 
 - [Getting Started](getting-started.md) -- initial setup
-- [ACP Transport](acp-transport.md) -- codex ACP opt-in and transport behavior
+- [ACP Transport](acp-transport.md) -- per-tool transport behavior and ACP notes
 - [Resource Control](resource-control.md) -- memory limits and P95 estimation
 - [Commands](commands.md) -- `csa config` reference


### PR DESCRIPTION
## Summary

Closes the 5-phase #643 arc (claude-code transport trait + CLI fallback + docs).

- **Phase 5 docs & `csa doctor`**: claude-code block now emits `Active transport:` + `Probed binary:` lines mirroring codex shape; config docs reflect that claude-code accepts `transport = "auto" | "acp" | "cli"` post-Phase 3.
- **Codex transport doc reconciliation** (cloud-review HIGH `doc-codex-transport-contract`): the initial Phase 5 commit described codex as Legacy-by-default / ACP opt-in with ACP rejected without `codex-acp`, but runtime truth (`codex_runtime.rs::default_for_build -> Acp`; `validate_tool_transport_override_with_raw` accepts both `cli`/`acp` unconditionally) is codex defaults to ACP, both overrides accepted at validation, missing binaries surfaced by `csa doctor`.
- **`doctor.rs` split**: the Phase 5 claude-code transport block pushed `doctor.rs` to 801 lines (one line over the 800 monolith gate). Split along existing section boundaries into `doctor_routing.rs`, `doctor_tools.rs`, `doctor_sandbox.rs`, `doctor_config.rs`, `doctor_resource.rs`, `doctor_output_helpers.rs`. Main `doctor.rs` now 355 lines. Pure move-refactor — no behavior change.

Bundled in one PR to keep the audit trail together (docs ↔ implementation ↔ structure).

## Test plan

- [x] `cargo test -p cli-sub-agent doctor` passes
- [x] `just pre-commit` exits 0 (monolith gate now clears; all submodules <800 lines)
- [x] `csa review --range main...HEAD` run for pre-push gate
- [x] `wc -l crates/cli-sub-agent/src/doctor*.rs` — no file >800 lines
- [ ] `gh pr create` → pr-bot (gemini cloud) → `gh pr merge --merge` (no squash per rule 039)

Closes #643. Refs #760 (ACP deprecation exploration), #761, #766.