### PR TITLE
refactor(cli,executor): dedup transport resolution + user-facing error text (#1031)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.499"
+version = "0.1.500"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.499"
+version = "0.1.500"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -8,8 +8,6 @@ use std::path::Path;
 use std::process::Command;
 
 use csa_config::ProjectConfig;
-#[cfg(not(test))]
-use csa_config::TransportKind;
 use csa_config::global::GlobalConfig;
 use csa_core::consensus::{
     AgentResponse, ConsensusResult, ConsensusStrategy, resolve_majority, resolve_unanimous,
@@ -50,16 +48,7 @@ fn reviewer_tool_binary_available(tool_name: &str, config: Option<&ProjectConfig
     }
 
     if tool_name == "codex" {
-        let transport = config
-            .and_then(|cfg| cfg.tool_transport("codex"))
-            .map(|transport| match transport {
-                TransportKind::Cli => CodexTransport::Cli,
-                TransportKind::Acp => CodexTransport::Acp,
-                TransportKind::Auto => {
-                    unreachable!("tool_transport() returns resolved transports")
-                }
-            })
-            .unwrap_or_else(CodexTransport::default_for_build);
+        let transport = crate::run_helpers::resolved_codex_transport(config);
         if matches!(transport, CodexTransport::Acp) && !CodexRuntimeMetadata::acp_compiled_in() {
             return false;
         }

--- a/crates/csa-executor/src/transport_factory.rs
+++ b/crates/csa-executor/src/transport_factory.rs
@@ -132,37 +132,37 @@ impl TransportFactory {
             (Executor::ClaudeCode { .. }, TransportMode::Acp) => Ok(()),
             (Executor::ClaudeCode { .. }, TransportMode::Legacy) => Ok(()),
             (Executor::ClaudeCode { .. }, TransportMode::OpenaiCompat) => {
-                err("claude-code only supports Legacy or ACP transport")
+                err("claude-code only supports cli or acp transport")
             }
 
             // Codex: Legacy and ACP are both supported
             (Executor::Codex { .. }, TransportMode::Legacy) => Ok(()),
             (Executor::Codex { .. }, TransportMode::Acp) => Ok(()),
             (Executor::Codex { .. }, TransportMode::OpenaiCompat) => {
-                err("codex only supports Legacy or ACP transport")
+                err("codex only supports cli or acp transport")
             }
 
             // GeminiCli: Legacy and ACP (native --acp mode)
             (Executor::GeminiCli { .. }, TransportMode::Legacy) => Ok(()),
             (Executor::GeminiCli { .. }, TransportMode::Acp) => Ok(()),
             (Executor::GeminiCli { .. }, TransportMode::OpenaiCompat) => {
-                err("gemini-cli only supports Legacy or ACP transport")
+                err("gemini-cli only supports cli or acp transport")
             }
 
             // Opencode: Legacy only
             (Executor::Opencode { .. }, TransportMode::Legacy) => Ok(()),
-            (Executor::Opencode { .. }, TransportMode::Acp) => err("opencode has no ACP transport"),
+            (Executor::Opencode { .. }, TransportMode::Acp) => err("opencode has no acp transport"),
             (Executor::Opencode { .. }, TransportMode::OpenaiCompat) => {
-                err("opencode only supports Legacy transport")
+                err("opencode only supports cli transport")
             }
 
             // OpenaiCompat: OpenaiCompat mode only
             (Executor::OpenaiCompat { .. }, TransportMode::OpenaiCompat) => Ok(()),
             (Executor::OpenaiCompat { .. }, TransportMode::Legacy) => {
-                err("openai-compat has no CLI binary")
+                err("openai-compat has no cli binary")
             }
             (Executor::OpenaiCompat { .. }, TransportMode::Acp) => {
-                err("openai-compat does not support ACP transport")
+                err("openai-compat does not support acp transport")
             }
         }
     }

--- a/crates/csa-executor/src/transport_tests_capabilities.rs
+++ b/crates/csa-executor/src/transport_tests_capabilities.rs
@@ -199,7 +199,7 @@ fn test_matrix_claude_code_openai_compat_rejected() {
     assert_unsupported(
         &make_claude_code(),
         super::TransportMode::OpenaiCompat,
-        "only supports Legacy or ACP",
+        "only supports cli or acp",
     );
 }
 
@@ -220,7 +220,7 @@ fn test_matrix_codex_openai_compat_rejected() {
     assert_unsupported(
         &make_codex(),
         super::TransportMode::OpenaiCompat,
-        "only supports Legacy or ACP",
+        "only supports cli or acp",
     );
 }
 
@@ -241,7 +241,7 @@ fn test_matrix_gemini_cli_openai_compat_rejected() {
     assert_unsupported(
         &make_gemini_cli(),
         super::TransportMode::OpenaiCompat,
-        "only supports Legacy or ACP",
+        "only supports cli or acp",
     );
 }
 
@@ -257,7 +257,7 @@ fn test_matrix_opencode_acp_rejected() {
     assert_unsupported(
         &make_opencode(),
         super::TransportMode::Acp,
-        "no ACP transport",
+        "no acp transport",
     );
 }
 
@@ -266,7 +266,7 @@ fn test_matrix_opencode_openai_compat_rejected() {
     assert_unsupported(
         &make_opencode(),
         super::TransportMode::OpenaiCompat,
-        "only supports Legacy",
+        "only supports cli",
     );
 }
 
@@ -282,7 +282,7 @@ fn test_matrix_openai_compat_legacy_rejected() {
     assert_unsupported(
         &make_openai_compat(),
         super::TransportMode::Legacy,
-        "no CLI binary",
+        "no cli binary",
     );
 }
 
@@ -291,7 +291,7 @@ fn test_matrix_openai_compat_acp_rejected() {
     assert_unsupported(
         &make_openai_compat(),
         super::TransportMode::Acp,
-        "does not support ACP",
+        "does not support acp",
     );
 }
 


### PR DESCRIPTION
## Summary

Two MEDIUM findings from gemini-code-assist on PR #1029 (#643 Phase 3), bundled per severity-tiered doctrine.

1. **`review_consensus.rs`**: inlined codex transport resolution duplicated `run_helpers::resolved_codex_transport`. Replaced with the helper call (and parallel claude-code block if present).
2. **`transport_factory.rs`**: error messages used internal enum names (`Legacy`/`Acp`). Changed to user-facing schema terms (`cli`/`acp`) that match `[tools.<name>].transport` config values.

No behavior change.

## Test plan

- [x] `cargo test -p cli-sub-agent review_consensus` passes
- [x] `cargo test -p csa-executor transport` passes
- [x] `just pre-commit` exits 0
- [x] `csa review --range main...HEAD` run for pre-push gate

Closes #1031. Refs PR #1029, #643 Phase 3.