### PR TITLE
refactor(cli): shared PRIMARY_TOOL_NAMES constant + doctor JSON acp_override_hint (#1033)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.500"
+version = "0.1.501"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.500"
+version = "0.1.501"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/doctor.rs
+++ b/crates/cli-sub-agent/src/doctor.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use csa_config::{ProjectConfig, paths};
-use csa_core::types::OutputFormat;
+use csa_core::types::{OutputFormat, PRIMARY_TOOL_NAMES};
 use csa_resource::filesystem_sandbox::detect_filesystem_capability;
 use csa_resource::rlimit::current_rlimit_nproc;
 use csa_resource::sandbox::{ResourceCapability, detect_resource_capability, systemd_version};
@@ -239,8 +239,9 @@ fn build_doctor_json(project_root: &Path) -> serde_json::Value {
         .unwrap_or_default();
 
     let tool_statuses: Vec<serde_json::Value> = match effective_config_status.runtime_config() {
-        Some(config) => ["gemini-cli", "opencode", "codex", "claude-code"]
+        Some(config) => PRIMARY_TOOL_NAMES
             .iter()
+            .copied()
             .map(|tool_name| {
                 let status = check_tool_status(tool_name, Some(config));
                 tool_status_json(&status)
@@ -250,8 +251,9 @@ fn build_doctor_json(project_root: &Path) -> serde_json::Value {
             if effective_config_status.tool_availability_error().is_some() {
                 Vec::new()
             } else {
-                ["gemini-cli", "opencode", "codex", "claude-code"]
+                PRIMARY_TOOL_NAMES
                     .iter()
+                    .copied()
                     .map(|tool_name| {
                         let status = check_tool_status(tool_name, None);
                         tool_status_json(&status)

--- a/crates/cli-sub-agent/src/doctor_config.rs
+++ b/crates/cli-sub-agent/src/doctor_config.rs
@@ -1,6 +1,7 @@
 use super::{DoctorEffectiveConfigStatus, DoctorProjectConfigStatus};
 use anyhow::Result;
 use csa_config::ProjectConfig;
+use csa_core::types::PRIMARY_TOOL_NAMES;
 use std::path::Path;
 
 pub(super) fn project_config_tool_lists(
@@ -9,11 +10,11 @@ pub(super) fn project_config_tool_lists(
     let mut enabled = Vec::new();
     let mut disabled = Vec::new();
 
-    for tool_name in &["gemini-cli", "opencode", "codex", "claude-code"] {
+    for &tool_name in PRIMARY_TOOL_NAMES {
         if config.is_tool_enabled(tool_name) {
-            enabled.push(*tool_name);
+            enabled.push(tool_name);
         } else {
-            disabled.push(*tool_name);
+            disabled.push(tool_name);
         }
     }
 

--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -191,6 +191,10 @@ fn default_build_doctor_json_output_reports_codex_transport_details() {
             json["probed_binary"],
             Value::String("codex-acp".to_string())
         );
+        assert!(
+            json.get("acp_override_hint").is_none(),
+            "doctor JSON should omit ACP override hints when codex already uses ACP: {json}"
+        );
     });
 }
 
@@ -213,6 +217,34 @@ fn explicit_codex_acp_transport_reports_install_hint() {
         rendered.contains("@zed-industries/codex-acp"),
         "doctor text should surface the ACP adapter install hint: {rendered}"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn codex_cli_transport_json_matches_text_override_hint_visibility() {
+    with_stubbed_codex_on_path(|| {
+        let config = project_config_with_codex_transport(TransportKind::Cli);
+        let status = check_tool_status("codex", Some(&config));
+        let rendered = render_tool_status_lines(&status).join("\n");
+        let json = tool_status_json(&status);
+        let expected_hint = Value::String("set [tools.codex].transport = \"acp\"".to_string());
+
+        assert_eq!(json["transport_active"], Value::String("cli".to_string()));
+        assert_eq!(json["probed_binary"], Value::String("codex".to_string()));
+
+        if rendered.contains("ACP override: set [tools.codex].transport = \"acp\"") {
+            assert_eq!(
+                json.get("acp_override_hint"),
+                Some(&expected_hint),
+                "doctor JSON should include the same ACP override hint shown in text output: {json}"
+            );
+        } else {
+            assert!(
+                json.get("acp_override_hint").is_none(),
+                "doctor JSON should omit ACP override hints when text output has none: {json}"
+            );
+        }
+    });
 }
 
 #[cfg(unix)]
@@ -256,6 +288,10 @@ fn explicit_claude_code_cli_transport_reports_json_transport_details() {
         assert!(
             json.get("acp_compiled_in").is_none(),
             "claude-code JSON transport details should omit codex-only ACP build metadata: {json}"
+        );
+        assert!(
+            json.get("acp_override_hint").is_none(),
+            "claude-code JSON transport details should omit codex-only ACP override hints: {json}"
         );
     });
 }

--- a/crates/cli-sub-agent/src/doctor_tools.rs
+++ b/crates/cli-sub-agent/src/doctor_tools.rs
@@ -1,15 +1,16 @@
 use super::{ToolAvailabilityState, ToolStatus, ToolTransportDoctorStatus};
 use csa_config::ProjectConfig;
+use csa_core::types::PRIMARY_TOOL_NAMES;
 use csa_executor::{ClaudeCodeTransport, CodexRuntimeMetadata, CodexTransport};
 use std::process::Command;
 
 pub(super) async fn print_tool_availability(config: Option<&ProjectConfig>) {
-    let tools = ["gemini-cli", "opencode", "codex", "claude-code"];
+    let tools = PRIMARY_TOOL_NAMES;
 
     let mut installed_count = 0;
     let total_count = tools.len();
 
-    for tool_name in &tools {
+    for tool_name in tools.iter().copied() {
         let status = check_tool_status(tool_name, config);
         if status.is_ready() {
             installed_count += 1;
@@ -134,6 +135,12 @@ pub(super) fn tool_status_json(status: &ToolStatus) -> serde_json::Value {
             object.insert(
                 "acp_compiled_in".to_string(),
                 serde_json::json!(acp_compiled_in),
+            );
+        }
+        if let Some(acp_override_hint) = transport_status.acp_override_hint {
+            object.insert(
+                "acp_override_hint".to_string(),
+                serde_json::json!(acp_override_hint),
             );
         }
         object.insert(

--- a/crates/csa-core/src/types.rs
+++ b/crates/csa-core/src/types.rs
@@ -13,6 +13,9 @@ pub enum ToolName {
     OpenaiCompat,
 }
 
+/// Primary CLI-backed tools surfaced by doctor and default tool listings.
+pub const PRIMARY_TOOL_NAMES: &[&str] = &["gemini-cli", "opencode", "codex", "claude-code"];
+
 impl ToolName {
     /// Returns the CLI-facing name for this tool
     pub fn as_str(&self) -> &'static str {


### PR DESCRIPTION
## Summary

Three MEDIUM findings from gemini-code-assist on PR #1032 (#643 Phase 5 close-out), bundled per severity-tiered doctrine.

1. **`doctor_tools.rs:143`**: text output emitted `acp_override_hint` but JSON branch omitted it. Added conditional JSON emission (matches `acp_compiled_in` pattern, `skip_serializing_if = Option::is_none`).
2. **Hardcoded tool list**: `["gemini-cli", "opencode", "codex", "claude-code"]` was duplicated across `doctor.rs`, `doctor_config.rs`, `doctor_tools.rs`. Extracted to a shared `PRIMARY_TOOL_NAMES` constant; doctor submodules now import from the single source.

No behavior change. Adding a new tool now requires editing exactly one list location.

## Test plan

- [x] `cargo test -p cli-sub-agent doctor` passes
- [x] `just pre-commit` exits 0
- [x] `csa review --range main...HEAD` run for pre-push gate
- [ ] gemini cloud review

Closes #1033. Refs PR #1032, #643 Phase 5.