### PR TITLE
docs(cli): document sandbox /tmp non-persistence in employee preamble (#1036)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.501"
+version = "0.1.502"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.502"
+version = "0.1.503"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.502"
+version = "0.1.503"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.501"
+version = "0.1.502"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
@@ -95,6 +95,11 @@ fn finalize_prompt_text_prepends_atomic_commit_preamble() {
         "preamble must not instruct manual git add; got: {preamble_body}"
     );
     assert!(
+        preamble_body.contains("session output directory IS persisted")
+            && preamble_body.contains("$CSA_SESSION_DIR/output/<name>.md"),
+        "preamble must document persisted artifact location; got: {preamble_body}"
+    );
+    assert!(
         result.find("<atomic-commit-discipline>").unwrap() < result.find("user task").unwrap(),
         "preamble must come BEFORE the user prompt"
     );
@@ -127,6 +132,11 @@ fn finalize_prompt_text_uses_subprocess_atomic_commit_preamble_when_csa_depth_po
     assert!(
         !preamble_body.contains("/commit"),
         "subprocess preamble must not reference /commit; got: {preamble_body}"
+    );
+    assert!(
+        preamble_body.contains("session output directory IS persisted")
+            && preamble_body.contains("$CSA_SESSION_DIR/output/<name>.md"),
+        "subprocess preamble must document persisted artifact location; got: {preamble_body}"
     );
 }
 

--- a/crates/cli-sub-agent/src/run_helpers_atomic_commit.rs
+++ b/crates/cli-sub-agent/src/run_helpers_atomic_commit.rs
@@ -14,6 +14,12 @@ For EACH logical change:
   3. Verify the working tree is clean (post-skill) before starting
      the next logical change.
 
+Filesystem persistence: when the bwrap filesystem sandbox is active,
+writes to host paths like `/tmp/`, `/var/tmp/`, and `$TMPDIR` are NOT
+persisted outside this session. For deliverables the caller must read
+after session end, write to `$CSA_SESSION_DIR/output/<name>.md` — the
+session output directory IS persisted.
+
 If a single logical change must touch multiple unrelated files,
 explain the grouping to `/commit` (it surfaces in the commit body).
 </atomic-commit-discipline>"#;
@@ -37,6 +43,12 @@ NOTE: In interactive Claude Code sessions the commit skill handles
 staging, pre-commit gates, two-layer review, and message generation.
 That skill is NOT available in this CSA subprocess context, so direct
 `git add` + `git commit -m` is the sanctioned path here.
+
+Filesystem persistence: when the bwrap filesystem sandbox is active,
+writes to host paths like `/tmp/`, `/var/tmp/`, and `$TMPDIR` are NOT
+persisted outside this session. For deliverables the caller must read
+after session end, write to `$CSA_SESSION_DIR/output/<name>.md` — the
+session output directory IS persisted.
 
 If a single logical change must touch multiple unrelated files,
 mention the grouping in the commit body.

--- a/crates/cli-sub-agent/src/run_helpers_atomic_commit.rs
+++ b/crates/cli-sub-agent/src/run_helpers_atomic_commit.rs
@@ -16,9 +16,9 @@ For EACH logical change:
 
 Filesystem persistence: when the bwrap filesystem sandbox is active,
 writes to host paths like `/tmp/`, `/var/tmp/`, and `$TMPDIR` are NOT
-persisted outside this session. For deliverables the caller must read
-after session end, write to `$CSA_SESSION_DIR/output/<name>.md` — the
-session output directory IS persisted.
+persisted outside this session. Write deliverables the caller must read after session end
+to `$CSA_SESSION_DIR/output/<name>.md` — the session output directory IS persisted
+and is the canonical location for cross-session artifacts.
 
 If a single logical change must touch multiple unrelated files,
 explain the grouping to `/commit` (it surfaces in the commit body).
@@ -46,9 +46,9 @@ That skill is NOT available in this CSA subprocess context, so direct
 
 Filesystem persistence: when the bwrap filesystem sandbox is active,
 writes to host paths like `/tmp/`, `/var/tmp/`, and `$TMPDIR` are NOT
-persisted outside this session. For deliverables the caller must read
-after session end, write to `$CSA_SESSION_DIR/output/<name>.md` — the
-session output directory IS persisted.
+persisted outside this session. Write deliverables the caller must read after session end
+to `$CSA_SESSION_DIR/output/<name>.md` — the session output directory IS persisted
+and is the canonical location for cross-session artifacts.
 
 If a single logical change must touch multiple unrelated files,
 mention the grouping in the commit body.
@@ -88,6 +88,49 @@ pub(crate) fn prepend_atomic_commit_discipline_to_prompt(prompt: String) -> Stri
 mod tests {
     use super::is_csa_subprocess;
     use crate::test_env_lock::{ScopedEnvVarRestore, ScopedTestEnvVar};
+    use csa_core::env::CSA_SESSION_DIR_ENV_KEY;
+    use csa_executor::Executor;
+    use csa_session::state::{
+        ContextStatus, Genealogy, MetaSessionState, SessionPhase, TaskContext,
+    };
+    use std::collections::HashMap;
+    use std::ffi::OsStr;
+
+    fn make_test_session() -> MetaSessionState {
+        let now = chrono::Utc::now();
+        MetaSessionState {
+            meta_session_id: "01HTEST000000000000000000".to_string(),
+            description: Some("test session".to_string()),
+            project_path: "/tmp/test-project".to_string(),
+            branch: None,
+            created_at: now,
+            last_accessed: now,
+            csa_version: None,
+            genealogy: Genealogy {
+                parent_session_id: None,
+                depth: 0,
+                ..Default::default()
+            },
+            tools: HashMap::new(),
+            context_status: ContextStatus::default(),
+            total_token_usage: None,
+            phase: SessionPhase::Active,
+            task_context: TaskContext::default(),
+            turn_count: 0,
+            token_budget: None,
+            sandbox_info: None,
+            termination_reason: None,
+            is_seed_candidate: false,
+            git_head_at_creation: None,
+            pre_session_porcelain: None,
+            last_return_packet: None,
+            change_id: None,
+            spec_id: None,
+            fork_call_timestamps: Vec::new(),
+            vcs_identity: None,
+            identity_version: 1,
+        }
+    }
 
     #[test]
     fn run_helpers_atomic_commit_daemon_session_id_alone_marks_csa_subprocess() {
@@ -97,5 +140,54 @@ mod tests {
         let _session_guard = ScopedEnvVarRestore::unset("CSA_SESSION_ID");
 
         assert!(is_csa_subprocess());
+    }
+
+    #[test]
+    fn run_helpers_atomic_commit_preamble_uses_exported_canonical_session_output_path() {
+        let exec = Executor::GeminiCli {
+            model_override: None,
+            thinking_budget: None,
+        };
+        let session = make_test_session();
+        let (cmd, _stdin_data) = exec.build_command("hello", None, &session, None);
+
+        let envs: Vec<_> = cmd.as_std().get_envs().collect();
+        let env_map: HashMap<&OsStr, Option<&OsStr>> = envs.into_iter().collect();
+        let session_dir = env_map
+            .get(OsStr::new(CSA_SESSION_DIR_ENV_KEY))
+            .expect("CSA_SESSION_DIR should be present")
+            .expect("CSA_SESSION_DIR should have a value")
+            .to_string_lossy();
+
+        for preamble in [
+            super::ATOMIC_COMMIT_DISCIPLINE_PREAMBLE,
+            super::ATOMIC_COMMIT_DISCIPLINE_SUBPROCESS_PREAMBLE,
+        ] {
+            assert!(
+                preamble.contains("Write deliverables the caller must read after session end"),
+                "preamble should use the complete deliverable-persistence sentence"
+            );
+            assert!(
+                preamble.contains("$CSA_SESSION_DIR/output/<name>.md"),
+                "preamble should point to the canonical session output artifact path"
+            );
+            assert!(
+                preamble.contains("session output directory IS persisted"),
+                "preamble should retain the persisted-output anchor phrase"
+            );
+            assert!(
+                preamble.contains("canonical location for cross-session artifacts"),
+                "preamble should clarify that the persisted output path is canonical"
+            );
+        }
+
+        assert!(
+            session_dir.contains("/sessions/"),
+            "CSA_SESSION_DIR should contain the session path segment, got: {session_dir}"
+        );
+        assert!(
+            session_dir.contains("01HTEST000000000000000000"),
+            "CSA_SESSION_DIR should include the session ID, got: {session_dir}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

bwrap filesystem sandbox isolates host `/tmp` writes — they succeed inside the sandbox rootfs but evaporate at session end. Sessions that follow prompts like "write report to `/tmp/foo.md`" self-report success, but Layer 0 never sees the file. Concrete cost: #661 RECON session's full report was lost this way, forcing reconstruction from session-log summary.

Added a preamble line naming `$CSA_SESSION_DIR/output/<name>.md` as the canonical persisted location for deliverables. Option B from the issue's three options (document + inject) — no behavior change; future sessions self-correct when they read the preamble.

Rule 037 (no-write-fallback-dirs) and rule 041 (ask-on-sandbox-or-path-fallback) are adjacent but orthogonal: 037 forbids repo-internal fallbacks; 041 forbids autonomous alternate-path picks on sandbox denial. This fix is "make the correct path obvious" — it neither forbids nor provides a fallback.

## Test plan

- [x] `cargo test -p cli-sub-agent preamble` passes (new assertion anchors on the persistence-hint string)
- [x] `just pre-commit` exits 0
- [x] `csa review --range main...HEAD` run for pre-push gate
- [ ] gemini cloud review

Closes #1036.