### PR TITLE
fix(patterns): pr-bot Step 1 to bash echo (#1030)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.504"
+version = "0.1.505"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.503"
+version = "0.1.504"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.504"
+version = "0.1.505"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.503"
+version = "0.1.504"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
@@ -183,7 +183,7 @@ fn pr_bot_workflow_marks_non_ai_steps_explicitly() {
         .iter()
         .find(|step| step.title == "Assumed Fork Convention")
         .expect("missing fork convention advisory step");
-    assert_eq!(fork_convention.tool.as_deref(), Some("bash"));
+    assert_eq!(fork_convention.tool.as_deref(), Some("note"));
 
     let clean_note = plan
         .steps

--- a/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
@@ -178,6 +178,13 @@ fn pr_bot_workflow_marks_non_ai_steps_explicitly() {
         .expect("missing bot setup abort step");
     assert_eq!(setup_abort.tool.as_deref(), Some("await-user"));
 
+    let fork_convention = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Assumed Fork Convention")
+        .expect("missing fork convention advisory step");
+    assert_eq!(fork_convention.tool.as_deref(), Some("bash"));
+
     let clean_note = plan
         .steps
         .iter()

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -44,6 +44,8 @@ Each step below is annotated with its execution layer.
 
 ## Assumed Fork Convention
 
+Tool: bash
+
 pr-bot assumes the GitHub-common fork convention:
 
 - `origin` = your personal fork (push target and PR source)

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -42,9 +42,11 @@ This pattern follows a 3-layer dispatcher architecture:
 
 Each step below is annotated with its execution layer.
 
-## Assumed Fork Convention
+## Workflow Step 1: Assumed Fork Convention
 
-Tool: bash
+Tool: note
+
+> **Layer**: 0 (Orchestrator) -- advisory text only.
 
 pr-bot assumes the GitHub-common fork convention:
 

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -476,9 +476,8 @@ name = "tmp_file"
 [[workflow.steps]]
 id = 1
 title = "Assumed Fork Convention"
-tool = "bash"
+tool = "note"
 prompt = """
-cat <<'EOF'
 pr-bot assumes the GitHub-common fork convention:
 
 - `origin` = your personal fork (push target and PR source)
@@ -506,7 +505,6 @@ When multiple remotes exist, `origin` does not reference the authenticated
 GitHub login, and no explicit push remote is configured, pr-bot fails closed
 with an actionable error instead of guessing and risking a push to the
 canonical repository.
-EOF
 """
 on_fail = "abort"
 

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -476,7 +476,9 @@ name = "tmp_file"
 [[workflow.steps]]
 id = 1
 title = "Assumed Fork Convention"
+tool = "bash"
 prompt = """
+cat <<'EOF'
 pr-bot assumes the GitHub-common fork convention:
 
 - `origin` = your personal fork (push target and PR source)
@@ -503,7 +505,9 @@ git config remote.pushDefault <fork-remote-name>
 When multiple remotes exist, `origin` does not reference the authenticated
 GitHub login, and no explicit push remote is configured, pr-bot fails closed
 with an actionable error instead of guessing and risking a push to the
-canonical repository."""
+canonical repository.
+EOF
+"""
 on_fail = "abort"
 
 [[workflow.steps]]


### PR DESCRIPTION
## Summary

pr-bot Step 1 "Assumed Fork Convention" is a purely advisory text-only step warning about fork-vs-upstream conventions, but had no `tool` field in `workflow.toml`. It defaulted to the configured CSA tier, which resolved to gemini-cli during the 2026-04-22 overnight sprint. When local gemini-cli OAuth lapsed to 401, the entire pr-bot pipeline failed at Step 1 — burning ~25s + a full CSA session (session `01KPTKY8NJYA777R3TE4C84FCD`) to render static text.

Converted Step 1 to `tool = "bash"` with a heredoc echo of the advisory text. Zero CSA cost, zero dependency on gemini-cli availability. Option A from the issue (recommended).

PATTERN.md synced per rule 027. Regression test added in `plan_cmd_tests_tail.rs` asserting Step 1's tool is explicitly bash.

## Test plan

- [x] `cargo test -p cli-sub-agent plan_cmd` passes
- [x] `just pre-commit` exits 0
- [x] `csa review --range main...HEAD` verdict is Pass (session `01KPV1R0CGZF501FRKY82AMCHA`)
- [ ] gemini cloud review

Closes #1030.
