### PR TITLE
refactor(cli): simplify make_test_session via ..Default::default() (#1038)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.505"
+version = "0.1.506"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.506"
+version = "0.1.507"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.506"
+version = "0.1.507"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.505"
+version = "0.1.506"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_helpers_atomic_commit.rs
+++ b/crates/cli-sub-agent/src/run_helpers_atomic_commit.rs
@@ -90,9 +90,7 @@ mod tests {
     use crate::test_env_lock::{ScopedEnvVarRestore, ScopedTestEnvVar};
     use csa_core::env::CSA_SESSION_DIR_ENV_KEY;
     use csa_executor::Executor;
-    use csa_session::state::{
-        ContextStatus, Genealogy, MetaSessionState, SessionPhase, TaskContext,
-    };
+    use csa_session::state::MetaSessionState;
     use std::collections::HashMap;
     use std::ffi::OsStr;
 
@@ -100,35 +98,10 @@ mod tests {
         let now = chrono::Utc::now();
         MetaSessionState {
             meta_session_id: "01HTEST000000000000000000".to_string(),
-            description: Some("test session".to_string()),
             project_path: "/tmp/test-project".to_string(),
-            branch: None,
             created_at: now,
             last_accessed: now,
-            csa_version: None,
-            genealogy: Genealogy {
-                parent_session_id: None,
-                depth: 0,
-                ..Default::default()
-            },
-            tools: HashMap::new(),
-            context_status: ContextStatus::default(),
-            total_token_usage: None,
-            phase: SessionPhase::Active,
-            task_context: TaskContext::default(),
-            turn_count: 0,
-            token_budget: None,
-            sandbox_info: None,
-            termination_reason: None,
-            is_seed_candidate: false,
-            git_head_at_creation: None,
-            pre_session_porcelain: None,
-            last_return_packet: None,
-            change_id: None,
-            spec_id: None,
-            fork_call_timestamps: Vec::new(),
-            vcs_identity: None,
-            identity_version: 1,
+            ..MetaSessionState::default()
         }
     }
 

--- a/crates/csa-session/src/state.rs
+++ b/crates/csa-session/src/state.rs
@@ -130,6 +130,40 @@ pub struct MetaSessionState {
     pub fork_call_timestamps: Vec<Instant>,
 }
 
+impl Default for MetaSessionState {
+    fn default() -> Self {
+        let now = Utc::now();
+        Self {
+            meta_session_id: String::new(),
+            description: None,
+            project_path: String::new(),
+            branch: None,
+            created_at: now,
+            last_accessed: now,
+            csa_version: None,
+            genealogy: Genealogy::default(),
+            tools: HashMap::new(),
+            context_status: ContextStatus::default(),
+            total_token_usage: None,
+            phase: SessionPhase::default(),
+            task_context: TaskContext::default(),
+            turn_count: 0,
+            token_budget: None,
+            sandbox_info: None,
+            termination_reason: None,
+            is_seed_candidate: false,
+            git_head_at_creation: None,
+            pre_session_porcelain: None,
+            last_return_packet: None,
+            change_id: None,
+            spec_id: None,
+            vcs_identity: None,
+            identity_version: default_identity_version(),
+            fork_call_timestamps: Vec::new(),
+        }
+    }
+}
+
 /// Structured metadata about a review execution.
 ///
 /// Written to `{session_dir}/review_meta.json` after `csa review` completes,

--- a/crates/csa-session/src/state.rs
+++ b/crates/csa-session/src/state.rs
@@ -132,14 +132,13 @@ pub struct MetaSessionState {
 
 impl Default for MetaSessionState {
     fn default() -> Self {
-        let now = Utc::now();
         Self {
             meta_session_id: String::new(),
             description: None,
             project_path: String::new(),
             branch: None,
-            created_at: now,
-            last_accessed: now,
+            created_at: DateTime::<Utc>::default(),
+            last_accessed: DateTime::<Utc>::default(),
             csa_version: None,
             genealogy: Genealogy::default(),
             tools: HashMap::new(),


### PR DESCRIPTION
## Summary

PR #1037 round 2 review (gemini-code-assist MEDIUM) flagged the new `make_test_session` helper in `run_helpers_atomic_commit.rs` as verbose — many fields were explicitly set to their default values.

Added a manual `Default` impl for `MetaSessionState` in `csa-session::state` so the helper can use struct-update syntax without regressing `identity_version` semantics (`identity_version` defaults to `1`, matching the existing migration-version convention). Rewrote the helper to keep only the fields that genuinely differ from defaults.

Workspace patch version bumped to 0.1.506 because `MetaSessionState` gained a production `Default` impl.

## Test plan

- [x] `cargo test -p cli-sub-agent run_helpers_atomic_commit` passes (2 passed)
- [x] `csa review --range main...HEAD` verdict is Pass (session `01KPV4558Q1789JVZWYMZEWQQ4`, 0 findings across all severities)
- [ ] gemini cloud review

Closes #1038.
