### PR TITLE
fix(hooks): lefthook no_tty stops quality-gates spinner hang (#1040)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.509"
+version = "0.1.510"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.509"
+version = "0.1.510"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,6 +2,12 @@
 # Install: lefthook install
 # Docs: https://github.com/evilmartians/lefthook
 
+# Suppress interactive spinner in non-TTY contexts (CSA daemon sessions,
+# CI, piped invocations). Without this, lefthook renders ⠙/⠹ spinner
+# frames with \r that accumulate as literal bytes in output.log, ballooning
+# it to ~30 MB and causing "quality-gates" hang symptoms (#1040).
+no_tty: true
+
 pre-commit:
   commands:
     branch-protection:


### PR DESCRIPTION
## Summary

Fixes #1040 — `csa run --daemon` child sessions invoking `/commit` skill hang in `quality-gates` spinner for ~10 minutes after a successful commit, then the daemon exits with `status=failure` even though the commit landed correctly.

**Root cause**: `lefthook` (the pre-commit hook runner) renders an interactive spinner (`⠙ waiting: quality-gates\r\^[[K…`) when invoked without `no_tty: true`. Under `csa run --daemon` (no TTY attached), the spinner frames are captured into `output.log` indefinitely — ~2 MB of ANSI control codes, no actual hang, but the output-based completion detection never sees a clean "quality-gates passed" signal.

**Fix**: Add `no_tty: true` to the repo's `lefthook.yml`. lefthook then switches to line-based progress output that respects non-TTY callers. Spinner noise stops. Daemon sees clean hook completion.

## Test plan

- [x] `cargo test` — 4013 + 3985 pass
- [x] `just pre-commit` interactive — still works, human-friendly output preserved by lefthook
- [x] Non-TTY repro: `script -q /dev/null -c 'just pre-commit 2>&1 | head -50'` completes cleanly without spinner spam
- [ ] Cloud review (gemini-code-assist)

## Additional observation (deferred, not fixed in this PR)

The commit pattern runs quality gates twice: explicitly in Steps 3-5 (fmt, clippy, test) and again implicitly via the lefthook pre-commit hook when `git commit` runs in Step 20. ~100s of duplicated CI work per commit. Candidate followup — not in scope for this PR since the spinner-hang fix is independent and higher priority.

Closes #1040.