### PR TITLE
fix(csa-review): verdict from severity_counts + synthetic-empty cross-check (#1045)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.513"
+version = "0.1.514"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.512"
+version = "0.1.513"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.510"
+version = "0.1.511"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.511"
+version = "0.1.512"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.511"
+version = "0.1.512"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.512"
+version = "0.1.513"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.513"
+version = "0.1.514"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.510"
+version = "0.1.511"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -9,10 +9,21 @@ use crate::review_cmd::output::extract_review_text;
 
 const FINDINGS_TOML_FENCE_LABEL: &str = "findings.toml";
 
+/// Sidecar marker file written alongside `output/findings.toml` when the TOML
+/// was synthesized (extraction failed or block missing). Downstream verdict
+/// derivation checks for this marker to distinguish synthetic-empty from
+/// true-empty (#1045 round 3).
+pub(super) const FINDINGS_TOML_SYNTHETIC_MARKER: &str = ".findings.toml.synthetic";
+
 /// Persist `output/findings.toml` extracted from the reviewer message.
 ///
 /// Best-effort: missing/invalid fenced TOML produces a synthetic empty file and
 /// logs a warning, but never fails the review command.
+///
+/// When extraction fails, a sidecar marker file
+/// `output/.findings.toml.synthetic` is written so downstream readers can
+/// distinguish "reviewer said clean" from "extraction failed, we synthesized
+/// empty" (#1045 round 3).
 pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSessionMeta) {
     match csa_session::get_session_dir(project_root, &meta.session_id) {
         Ok(session_dir) => {
@@ -27,6 +38,8 @@ pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSes
                     (FindingsFile::default(), Some("derivation failure"))
                 }
             };
+
+            let is_synthetic = warning_reason.is_some();
 
             if let Some(reason) = warning_reason {
                 warn!(
@@ -44,6 +57,23 @@ pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSes
                 );
             } else {
                 debug!(session_id = %meta.session_id, "Wrote output/findings.toml");
+            }
+
+            // Write or remove sidecar marker depending on whether the TOML is synthetic.
+            let marker_path = session_dir
+                .join("output")
+                .join(FINDINGS_TOML_SYNTHETIC_MARKER);
+            if is_synthetic {
+                if let Err(error) = fs::write(&marker_path, b"") {
+                    warn!(
+                        session_id = %meta.session_id,
+                        error = %error,
+                        "Failed to write synthetic-empty marker"
+                    );
+                }
+            } else {
+                // Real extraction succeeded — remove any stale marker from a prior round.
+                let _ = fs::remove_file(&marker_path);
             }
         }
         Err(error) => {

--- a/crates/cli-sub-agent/src/review_cmd_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix.rs
@@ -244,6 +244,19 @@ fn persist_fix_final_artifacts(
                         "Failed to write output/findings.toml after CLEAN convergence"
                     );
                 }
+                // Clear stale review-findings.json so the cross-check in
+                // derive_review_verdict_artifact does not override the
+                // cleanly-converged empty findings.toml (#1045 round 4).
+                let stale_json = session_dir.join("review-findings.json");
+                if stale_json.exists()
+                    && let Err(error) = std::fs::remove_file(&stale_json)
+                {
+                    warn!(
+                        session_id = %review_meta.session_id,
+                        error = %error,
+                        "Failed to remove stale review-findings.json after CLEAN convergence"
+                    );
+                }
             }
             Err(error) => {
                 warn!(
@@ -408,6 +421,191 @@ mod tests {
                 .expect("parse verdict");
         assert_eq!(artifact.decision, ReviewDecision::Pass);
         assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&0));
+    }
+
+    /// Round 4 repro (#1045): stale review-findings.json with a HIGH finding
+    /// left over from the pre-fix review round. Fix loop converges clean →
+    /// both findings.toml and review-findings.json must be cleared, and the
+    /// final verdict must report decision=pass / severity_counts.high=0.
+    #[test]
+    fn persist_fix_final_artifacts_clears_stale_review_findings_json_on_clean() {
+        let project_root = temp_project_root("persist-fix-stale-json");
+        let _state_home = ScopedTestEnvVar::set("XDG_STATE_HOME", project_root.join("state"));
+        let session_id = unique_session_id("01FIXSTALEJSON");
+        let session_dir = create_session_dir(&project_root, &session_id);
+
+        // Seed stale review-findings.json with a HIGH finding (from pre-fix round).
+        let stale_json = serde_json::json!({
+            "findings": [{
+                "severity": "high",
+                "fid": "stale-high",
+                "file": "src/lib.rs",
+                "line": 42,
+                "rule_id": "rule.stale",
+                "summary": "Stale high finding from pre-fix review",
+                "engine": "reviewer"
+            }],
+            "severity_summary": { "critical": 0, "high": 1, "medium": 0, "low": 0 },
+            "overall_risk": "high"
+        });
+        fs::write(
+            session_dir.join("review-findings.json"),
+            serde_json::to_vec_pretty(&stale_json).expect("serialize stale json"),
+        )
+        .expect("write stale review-findings.json");
+
+        // No stale findings.toml — persist_fix_final_artifacts will create a clean one.
+        persist_fix_final_artifacts(&project_root, &make_clean_review_meta(&session_id), true);
+
+        // findings.toml must be empty.
+        let findings_path = session_dir.join("output").join("findings.toml");
+        let parsed: FindingsFile =
+            toml::from_str(&fs::read_to_string(&findings_path).expect("read findings.toml"))
+                .expect("parse findings.toml");
+        assert_eq!(parsed, FindingsFile::default());
+
+        // review-findings.json must be removed.
+        assert!(
+            !session_dir.join("review-findings.json").exists(),
+            "review-findings.json should be removed after clean convergence"
+        );
+
+        // Verdict must report pass.
+        let verdict_path = session_dir.join("output").join("review-verdict.json");
+        let artifact: csa_session::ReviewVerdictArtifact =
+            serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+                .expect("parse verdict");
+        assert_eq!(artifact.decision, ReviewDecision::Pass);
+        assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&0));
+    }
+
+    /// Mixed staleness (#1045 round 4): stale findings.toml with a MEDIUM finding
+    /// + stale review-findings.json with a HIGH finding. Converge clean → both
+    /// must be cleared, verdict must be pass.
+    #[test]
+    fn persist_fix_final_artifacts_clears_both_stale_artifacts_on_clean() {
+        let project_root = temp_project_root("persist-fix-both-stale");
+        let _state_home = ScopedTestEnvVar::set("XDG_STATE_HOME", project_root.join("state"));
+        let session_id = unique_session_id("01FIXBOTHSTALE");
+        let session_dir = create_session_dir(&project_root, &session_id);
+
+        // Stale findings.toml with a MEDIUM finding.
+        write_findings_toml(
+            &session_dir,
+            &FindingsFile {
+                findings: vec![sample_stale_finding()],
+            },
+        )
+        .expect("write stale findings.toml");
+
+        // Stale review-findings.json with a HIGH finding.
+        let stale_json = serde_json::json!({
+            "findings": [{
+                "severity": "high",
+                "fid": "stale-high-json",
+                "file": "src/main.rs",
+                "line": 10,
+                "rule_id": "rule.stale-json",
+                "summary": "Stale high from JSON",
+                "engine": "reviewer"
+            }],
+            "severity_summary": { "critical": 0, "high": 1, "medium": 0, "low": 0 },
+            "overall_risk": "high"
+        });
+        fs::write(
+            session_dir.join("review-findings.json"),
+            serde_json::to_vec_pretty(&stale_json).expect("serialize stale json"),
+        )
+        .expect("write stale review-findings.json");
+
+        persist_fix_final_artifacts(&project_root, &make_clean_review_meta(&session_id), true);
+
+        // findings.toml must be empty.
+        let findings_path = session_dir.join("output").join("findings.toml");
+        let parsed: FindingsFile =
+            toml::from_str(&fs::read_to_string(&findings_path).expect("read findings.toml"))
+                .expect("parse findings.toml");
+        assert_eq!(parsed, FindingsFile::default());
+
+        // review-findings.json must be removed.
+        assert!(
+            !session_dir.join("review-findings.json").exists(),
+            "review-findings.json should be removed after clean convergence"
+        );
+
+        // Verdict must report pass with zero blocking counts.
+        let verdict_path = session_dir.join("output").join("review-verdict.json");
+        let artifact: csa_session::ReviewVerdictArtifact =
+            serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+                .expect("parse verdict");
+        assert_eq!(artifact.decision, ReviewDecision::Pass);
+        assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&0));
+        assert_eq!(artifact.severity_counts.get(&Severity::Medium), Some(&0));
+    }
+
+    /// Non-converged fix (exhausted rounds): stale artifacts must be PRESERVED
+    /// — this is the existing contract per decision #820 Option A.
+    #[test]
+    fn fix_loop_exhausted_preserves_stale_review_findings_json() {
+        let project_root = temp_project_root("persist-fix-exhausted-json");
+        let _state_home = ScopedTestEnvVar::set("XDG_STATE_HOME", project_root.join("state"));
+        let session_id = unique_session_id("01FIXEXHAUSTEDJSON");
+        let session_dir = create_session_dir(&project_root, &session_id);
+
+        // Stale review-findings.json with a HIGH finding.
+        let stale_json = serde_json::json!({
+            "findings": [{
+                "severity": "high",
+                "fid": "stale-high-exhausted",
+                "file": "src/lib.rs",
+                "line": 99,
+                "rule_id": "rule.stale-exhausted",
+                "summary": "Stale high finding persisted on exhaustion",
+                "engine": "reviewer"
+            }],
+            "severity_summary": { "critical": 0, "high": 1, "medium": 0, "low": 0 },
+            "overall_risk": "high"
+        });
+        fs::write(
+            session_dir.join("review-findings.json"),
+            serde_json::to_vec_pretty(&stale_json).expect("serialize stale json"),
+        )
+        .expect("write stale review-findings.json");
+
+        // Stale findings.toml too.
+        write_findings_toml(
+            &session_dir,
+            &FindingsFile {
+                findings: vec![sample_stale_finding()],
+            },
+        )
+        .expect("write stale findings.toml");
+
+        let mut exhausted_meta = make_clean_review_meta(&session_id);
+        exhausted_meta.decision = ReviewDecision::Fail.as_str().to_string();
+        exhausted_meta.verdict = "HAS_ISSUES".to_string();
+        exhausted_meta.exit_code = 1;
+        exhausted_meta.fix_rounds = 3;
+
+        persist_fix_final_artifacts(&project_root, &exhausted_meta, false);
+
+        // review-findings.json must still exist (not cleaned on non-convergence).
+        assert!(
+            session_dir.join("review-findings.json").exists(),
+            "review-findings.json should be preserved when fix loop is exhausted"
+        );
+
+        // findings.toml must still have the stale content.
+        let findings_path = session_dir.join("output").join("findings.toml");
+        let parsed: FindingsFile =
+            toml::from_str(&fs::read_to_string(&findings_path).expect("read findings.toml"))
+                .expect("parse findings.toml");
+        assert_eq!(
+            parsed,
+            FindingsFile {
+                findings: vec![sample_stale_finding()],
+            }
+        );
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -279,6 +279,47 @@ pub(crate) fn persist_review_verdict_for_tests(
     persist_review_verdict(project_root, meta, findings, prior_round_refs);
 }
 
+/// Build a [`ReviewVerdictArtifact`] from meta fields + computed decision/counts.
+fn verdict_from_meta(
+    meta: &ReviewSessionMeta,
+    decision: ReviewDecision,
+    severity_counts: std::collections::BTreeMap<Severity, u32>,
+) -> ReviewVerdictArtifact {
+    build_review_verdict_artifact(
+        meta.session_id.clone(),
+        decision,
+        legacy_verdict_for_decision(decision, &meta.verdict),
+        severity_counts,
+        meta.routed_to.clone(),
+        meta.primary_failure.clone(),
+        meta.failure_reason.clone(),
+        Vec::new(),
+    )
+}
+
+/// Cross-check review-findings.json when findings.toml shows zero counts.
+/// Returns `Some(artifact)` if JSON has blocking findings; `None` otherwise.
+fn cross_check_json_for_blocking(
+    session_dir: &Path,
+    meta: &ReviewSessionMeta,
+) -> Result<Option<ReviewVerdictArtifact>, anyhow::Error> {
+    let Some(json_artifact) = load_review_artifact_from_output(session_dir)? else {
+        return Ok(None);
+    };
+    let json_counts = severity_counts_for_artifact(&json_artifact, zero_severity_counts);
+    if !has_blocking_severity(&json_counts) {
+        return Ok(None);
+    }
+    let decision = derive_decision_from_severity_counts(
+        &json_counts,
+        json_artifact.findings.is_empty(),
+        json_artifact.overall_risk.as_deref(),
+        ReviewDecision::from_str(&meta.decision).ok(),
+        || review_contains_prose_clean_conclusion(session_dir),
+    )?;
+    Ok(Some(verdict_from_meta(meta, decision, json_counts)))
+}
+
 fn derive_review_verdict_artifact(
     session_dir: &Path,
     meta: &ReviewSessionMeta,
@@ -288,53 +329,45 @@ fn derive_review_verdict_artifact(
         let severity_counts =
             severity_counts_for_findings_toml(&findings_file, zero_severity_counts);
 
-        // Cross-check: when findings.toml is empty (possibly synthetic-empty from
-        // failed TOML extraction), consult review-findings.json before trusting
-        // the zero-count signal. A synthetic-empty findings.toml must not mask
-        // blocking findings that the reviewer actually produced (#1045 round 2).
-        if findings_file.findings.is_empty()
-            && severity_counts_are_zero(&severity_counts)
-            && let Some(json_artifact) = load_review_artifact_from_output(session_dir)?
-        {
-            let json_counts = severity_counts_for_artifact(&json_artifact, zero_severity_counts);
-            if has_blocking_severity(&json_counts) {
-                let decision = derive_decision_from_severity_counts(
-                    &json_counts,
-                    json_artifact.findings.is_empty(),
-                    json_artifact.overall_risk.as_deref(),
-                    ReviewDecision::from_str(&meta.decision).ok(),
-                    || review_contains_prose_clean_conclusion(session_dir),
-                )?;
-                return Ok(build_review_verdict_artifact(
-                    meta.session_id.clone(),
-                    decision,
-                    legacy_verdict_for_decision(decision, &meta.verdict),
-                    json_counts,
-                    meta.routed_to.clone(),
-                    meta.primary_failure.clone(),
-                    meta.failure_reason.clone(),
-                    Vec::new(),
-                ));
-            }
-        }
+        // Detect synthetic-empty findings.toml: the sidecar marker is written by
+        // persist_review_findings_toml when TOML extraction failed (#1045 round 3).
+        let synthetic_marker = session_dir
+            .join("output")
+            .join(super::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER);
+        let is_synthetic = synthetic_marker.exists();
 
-        let decision = derive_decision_from_severity_counts(
-            &severity_counts,
-            findings_file.findings.is_empty(),
-            None,
-            ReviewDecision::from_str(&meta.decision).ok(),
-            || review_contains_prose_clean_conclusion(session_dir),
-        )?;
-        return Ok(build_review_verdict_artifact(
-            meta.session_id.clone(),
-            decision,
-            legacy_verdict_for_decision(decision, &meta.verdict),
-            severity_counts,
-            meta.routed_to.clone(),
-            meta.primary_failure.clone(),
-            meta.failure_reason.clone(),
-            Vec::new(),
-        ));
+        // Synthetic-empty + zero counts → fall through to full.md chain (#1045 r3).
+        if is_synthetic
+            && findings_file.findings.is_empty()
+            && severity_counts_are_zero(&severity_counts)
+        {
+            if let Some(artifact) = cross_check_json_for_blocking(session_dir, meta)? {
+                return Ok(artifact);
+            }
+            // Synthetic-empty + no blocking JSON → fall through to full.md chain.
+            debug!(
+                session_id = %meta.session_id,
+                "Synthetic-empty findings.toml detected; falling through to full.md fallback chain"
+            );
+        } else {
+            // Non-synthetic (trusted) or non-empty findings.toml: cross-check
+            // review-findings.json for the empty case (round 2 logic), then return.
+            if findings_file.findings.is_empty()
+                && severity_counts_are_zero(&severity_counts)
+                && let Some(artifact) = cross_check_json_for_blocking(session_dir, meta)?
+            {
+                return Ok(artifact);
+            }
+
+            let decision = derive_decision_from_severity_counts(
+                &severity_counts,
+                findings_file.findings.is_empty(),
+                None,
+                ReviewDecision::from_str(&meta.decision).ok(),
+                || review_contains_prose_clean_conclusion(session_dir),
+            )?;
+            return Ok(verdict_from_meta(meta, decision, severity_counts));
+        }
     }
 
     if let Some(artifact) = load_review_artifact_from_output(session_dir)? {
@@ -346,16 +379,7 @@ fn derive_review_verdict_artifact(
             ReviewDecision::from_str(&meta.decision).ok(),
             || review_contains_prose_clean_conclusion(session_dir),
         )?;
-        return Ok(build_review_verdict_artifact(
-            meta.session_id.clone(),
-            decision,
-            legacy_verdict_for_decision(decision, &meta.verdict),
-            severity_counts,
-            meta.routed_to.clone(),
-            meta.primary_failure.clone(),
-            meta.failure_reason.clone(),
-            Vec::new(),
-        ));
+        return Ok(verdict_from_meta(meta, decision, severity_counts));
     }
 
     if let Some(artifact) = infer_review_verdict_from_full_output(session_dir, meta)? {
@@ -404,16 +428,7 @@ fn infer_review_verdict_from_full_output(
     let counts = severity_counts_from_text(&review_text);
     let overall_risk = parse_overall_risk_from_text(&review_text);
     let decision = derive_decision_from_text(&review_text, &counts, overall_risk.as_deref());
-    Ok(Some(build_review_verdict_artifact(
-        meta.session_id.clone(),
-        decision,
-        legacy_verdict_for_decision(decision, &meta.verdict),
-        counts,
-        meta.routed_to.clone(),
-        meta.primary_failure.clone(),
-        meta.failure_reason.clone(),
-        Vec::new(),
-    )))
+    Ok(Some(verdict_from_meta(meta, decision, counts)))
 }
 
 fn full_output_is_effectively_empty(session_dir: &Path) -> Result<bool, anyhow::Error> {

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -285,18 +285,13 @@ fn derive_review_verdict_artifact(
     if let Some(findings_file) = load_findings_toml_from_output(session_dir)? {
         let severity_counts =
             severity_counts_for_findings_toml(&findings_file, zero_severity_counts);
-        let decision = if findings_file.findings.is_empty()
-            && severity_counts_are_zero(&severity_counts)
-            && review_contains_prose_clean_conclusion(session_dir)?
-        {
-            ReviewDecision::Pass
-        } else {
-            derive_decision_from_findings(
-                findings_file.findings.is_empty(),
-                None,
-                ReviewDecision::from_str(&meta.decision).ok(),
-            )
-        };
+        let decision = derive_decision_from_severity_counts(
+            &severity_counts,
+            findings_file.findings.is_empty(),
+            None,
+            ReviewDecision::from_str(&meta.decision).ok(),
+            || review_contains_prose_clean_conclusion(session_dir),
+        )?;
         return Ok(build_review_verdict_artifact(
             meta.session_id.clone(),
             decision,
@@ -311,19 +306,13 @@ fn derive_review_verdict_artifact(
 
     if let Some(artifact) = load_review_artifact_from_output(session_dir)? {
         let severity_counts = severity_counts_for_artifact(&artifact, zero_severity_counts);
-        let decision = if artifact.findings.is_empty()
-            && severity_counts_are_zero(&severity_counts)
-            && !artifact.overall_risk_is_severe()
-            && review_contains_prose_clean_conclusion(session_dir)?
-        {
-            ReviewDecision::Pass
-        } else {
-            derive_decision_from_findings(
-                artifact.findings.is_empty(),
-                artifact.overall_risk.as_deref(),
-                ReviewDecision::from_str(&meta.decision).ok(),
-            )
-        };
+        let decision = derive_decision_from_severity_counts(
+            &severity_counts,
+            artifact.findings.is_empty(),
+            artifact.overall_risk.as_deref(),
+            ReviewDecision::from_str(&meta.decision).ok(),
+            || review_contains_prose_clean_conclusion(session_dir),
+        )?;
         return Ok(build_review_verdict_artifact(
             meta.session_id.clone(),
             decision,
@@ -512,35 +501,75 @@ fn parse_overall_risk_from_text(text: &str) -> Option<String> {
         .map(|level| level.as_str().to_ascii_lowercase())
 }
 
-fn derive_decision_from_findings(
+/// Whether the severity counts contain any blocking findings (critical, high, or medium).
+fn has_blocking_severity(counts: &std::collections::BTreeMap<Severity, u32>) -> bool {
+    counts
+        .iter()
+        .any(|(severity, count)| *count > 0 && *severity > Severity::Low)
+}
+
+/// Derive the review decision from structured severity counts.
+///
+/// Core invariant (#1045): the decision is derived from `severity_counts`, not from
+/// summary-text keywords or stale `meta.decision` values.
+///
+/// - critical > 0 or high > 0 or medium > 0 → `Fail` / `HAS_ISSUES`
+/// - low > 0 only → `Pass` / `CLEAN` (LOWs don't block merge)
+/// - all zero + findings empty → `Pass` / `CLEAN`
+fn derive_decision_from_severity_counts(
+    severity_counts: &std::collections::BTreeMap<Severity, u32>,
     findings_empty: bool,
     overall_risk: Option<&str>,
     meta_decision: Option<ReviewDecision>,
-) -> ReviewDecision {
-    if findings_empty {
-        match meta_decision {
-            Some(
-                meta_decision @ (ReviewDecision::Skip
-                | ReviewDecision::Uncertain
-                | ReviewDecision::Unavailable
-                | ReviewDecision::Fail),
-            ) => {
-                return meta_decision;
-            }
-            Some(ReviewDecision::Pass)
-                if overall_risk.is_none_or(|risk| risk.eq_ignore_ascii_case("low")) =>
-            {
-                return ReviewDecision::Pass;
-            }
-            Some(ReviewDecision::Pass) => return ReviewDecision::Fail,
-            None if overall_risk.is_none_or(|risk| risk.eq_ignore_ascii_case("low")) => {
-                return ReviewDecision::Uncertain;
-            }
-            None => return ReviewDecision::Fail,
-        }
+    prose_clean_check: impl FnOnce() -> Result<bool, anyhow::Error>,
+) -> Result<ReviewDecision, anyhow::Error> {
+    // Blocking findings (critical/high/medium) always fail.
+    if has_blocking_severity(severity_counts) {
+        return Ok(ReviewDecision::Fail);
     }
 
-    ReviewDecision::Fail
+    // Non-blocking findings (low only) → pass.
+    // Zero severity counts but non-empty findings list → fail-closed (parsing anomaly).
+    if !findings_empty && !severity_counts_are_zero(severity_counts) {
+        // Only low-severity findings present — non-blocking.
+        return Ok(ReviewDecision::Pass);
+    }
+    if !findings_empty && severity_counts_are_zero(severity_counts) {
+        // Findings exist but severity counts are zero (unrecognized severities).
+        // Fail-closed.
+        return Ok(ReviewDecision::Fail);
+    }
+
+    // From here: findings list is empty AND severity_counts are all zero.
+
+    // Honour overall_risk as a fail-closed signal when it's severe.
+    if overall_risk.is_some_and(|risk| {
+        risk.eq_ignore_ascii_case("high") || risk.eq_ignore_ascii_case("critical")
+    }) {
+        return Ok(ReviewDecision::Fail);
+    }
+
+    // Preserve non-fail meta decisions (skip, uncertain, unavailable) as-is:
+    // these represent infrastructure/scope signals, not finding-based verdicts.
+    if let Some(
+        meta @ (ReviewDecision::Skip | ReviewDecision::Uncertain | ReviewDecision::Unavailable),
+    ) = meta_decision
+    {
+        return Ok(meta);
+    }
+
+    // At this point: zero severity counts, empty findings, non-severe overall_risk,
+    // and meta_decision is either Pass, Fail, or None. Prose clean check is a tiebreaker
+    // only when meta_decision is None (no verdict token was parsed from output).
+    if meta_decision == Some(ReviewDecision::Pass) || prose_clean_check()? {
+        return Ok(ReviewDecision::Pass);
+    }
+
+    // No findings, no prose clean marker, meta_decision is Fail or None.
+    // Zero findings + meta_decision=fail is the exact bug scenario (#1045):
+    // the caller parsed "fail" from summary prose, but there are no actual findings.
+    // The invariant says: zero severity_counts → pass.
+    Ok(ReviewDecision::Pass)
 }
 
 fn derive_decision_from_text(

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -29,7 +29,9 @@ use artifacts::{
     load_findings_toml_from_output, load_review_artifact_from_output, severity_counts_for_artifact,
     severity_counts_for_findings_toml,
 };
-use clean_detection::{contains_clean_phrase, review_contains_prose_clean_conclusion};
+use clean_detection::{
+    contains_clean_phrase, review_contains_prose_clean_conclusion, strip_prompt_guards,
+};
 pub(crate) use diagnostics::detect_tool_diagnostic;
 pub(super) use summary_artifact::{
     ensure_review_summary_artifact, is_edit_restriction_summary, truncate_review_result_summary,
@@ -285,6 +287,37 @@ fn derive_review_verdict_artifact(
     if let Some(findings_file) = load_findings_toml_from_output(session_dir)? {
         let severity_counts =
             severity_counts_for_findings_toml(&findings_file, zero_severity_counts);
+
+        // Cross-check: when findings.toml is empty (possibly synthetic-empty from
+        // failed TOML extraction), consult review-findings.json before trusting
+        // the zero-count signal. A synthetic-empty findings.toml must not mask
+        // blocking findings that the reviewer actually produced (#1045 round 2).
+        if findings_file.findings.is_empty()
+            && severity_counts_are_zero(&severity_counts)
+            && let Some(json_artifact) = load_review_artifact_from_output(session_dir)?
+        {
+            let json_counts = severity_counts_for_artifact(&json_artifact, zero_severity_counts);
+            if has_blocking_severity(&json_counts) {
+                let decision = derive_decision_from_severity_counts(
+                    &json_counts,
+                    json_artifact.findings.is_empty(),
+                    json_artifact.overall_risk.as_deref(),
+                    ReviewDecision::from_str(&meta.decision).ok(),
+                    || review_contains_prose_clean_conclusion(session_dir),
+                )?;
+                return Ok(build_review_verdict_artifact(
+                    meta.session_id.clone(),
+                    decision,
+                    legacy_verdict_for_decision(decision, &meta.verdict),
+                    json_counts,
+                    meta.routed_to.clone(),
+                    meta.primary_failure.clone(),
+                    meta.failure_reason.clone(),
+                    Vec::new(),
+                ));
+            }
+        }
+
         let decision = derive_decision_from_severity_counts(
             &severity_counts,
             findings_file.findings.is_empty(),
@@ -726,46 +759,7 @@ pub(super) fn print_reviewer_outcomes(outcomes: &[ReviewerOutcome]) {
     }
 }
 
-/// Check whether review output contains substantive content beyond prompt guards.
-///
-/// Returns `true` when the raw output is empty or contains only CSA prompt
-/// injection markers / hook output and whitespace — indicating the review tool
-/// produced no actual findings.
-pub(super) fn is_review_output_empty(raw_output: &str) -> bool {
-    strip_prompt_guards(raw_output).trim().is_empty()
-}
-
-/// Remove non-review content: prompt injection blocks, hook markers, and section wrappers.
-fn strip_prompt_guards(text: &str) -> String {
-    let mut result = String::new();
-    let mut in_guard = false;
-    for line in text.lines() {
-        if line.contains("<csa-caller-prompt-injection") {
-            in_guard = true;
-            continue;
-        }
-        if line.contains("</csa-caller-prompt-injection>") {
-            in_guard = false;
-            continue;
-        }
-        if in_guard {
-            continue;
-        }
-        if line.trim_start().starts_with("[csa-hook]") {
-            continue;
-        }
-        if line.trim_start().starts_with("[csa-heartbeat]") {
-            continue;
-        }
-        // Strip CSA section markers (empty wrappers are not substantive content)
-        if line.trim_start().starts_with("<!-- CSA:SECTION:") {
-            continue;
-        }
-        result.push_str(line);
-        result.push('\n');
-    }
-    result
-}
+pub(in crate::review_cmd) use clean_detection::is_review_output_empty;
 
 fn contains_verdict_token(haystack: &str, token: &str) -> bool {
     haystack

--- a/crates/cli-sub-agent/src/review_cmd_output_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_artifacts.rs
@@ -15,14 +15,6 @@ pub(super) struct PersistedReviewArtifact {
     pub(super) overall_risk: Option<String>,
 }
 
-impl PersistedReviewArtifact {
-    pub(super) fn overall_risk_is_severe(&self) -> bool {
-        self.overall_risk.as_deref().is_some_and(|risk| {
-            risk.eq_ignore_ascii_case("high") || risk.eq_ignore_ascii_case("critical")
-        })
-    }
-}
-
 pub(super) fn load_review_artifact_from_output(
     session_dir: &Path,
 ) -> Result<Option<PersistedReviewArtifact>, anyhow::Error> {

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -60,6 +60,47 @@ pub(super) fn contains_clean_phrase(output: &str) -> bool {
         || contains_positive_no_issue_clause(&lower)
 }
 
+/// Check whether review output contains substantive content beyond prompt guards.
+///
+/// Returns `true` when the raw output is empty or contains only CSA prompt
+/// injection markers / hook output and whitespace — indicating the review tool
+/// produced no actual findings.
+pub(in crate::review_cmd) fn is_review_output_empty(raw_output: &str) -> bool {
+    strip_prompt_guards(raw_output).trim().is_empty()
+}
+
+/// Remove non-review content: prompt injection blocks, hook markers, and section wrappers.
+pub(super) fn strip_prompt_guards(text: &str) -> String {
+    let mut result = String::new();
+    let mut in_guard = false;
+    for line in text.lines() {
+        if line.contains("<csa-caller-prompt-injection") {
+            in_guard = true;
+            continue;
+        }
+        if line.contains("</csa-caller-prompt-injection>") {
+            in_guard = false;
+            continue;
+        }
+        if in_guard {
+            continue;
+        }
+        if line.trim_start().starts_with("[csa-hook]") {
+            continue;
+        }
+        if line.trim_start().starts_with("[csa-heartbeat]") {
+            continue;
+        }
+        // Strip CSA section markers (empty wrappers are not substantive content)
+        if line.trim_start().starts_with("<!-- CSA:SECTION:") {
+            continue;
+        }
+        result.push_str(line);
+        result.push('\n');
+    }
+    result
+}
+
 fn contains_positive_no_issue_clause(lower: &str) -> bool {
     const NOUNS: &[&str] = &[
         "issue", "issues", "finding", "findings", "concern", "concerns",

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
@@ -71,7 +71,9 @@ fn persist_review_verdict_empty_findings_with_chinese_prose_clean_summary_emits_
 }
 
 #[test]
-fn persist_review_verdict_empty_findings_without_prose_clean_marker_stays_fail_closed() {
+fn persist_review_verdict_empty_findings_without_prose_clean_marker_emits_pass() {
+    // #1045: zero findings + zero severity_counts MUST yield Pass regardless
+    // of whether the summary contains a prose-clean phrase.
     let session_id = "01TESTNOPROSECLEAN000000000";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("persist-review-verdict-no-prose-clean", session_id);
@@ -98,8 +100,8 @@ fn persist_review_verdict_empty_findings_without_prose_clean_marker_stays_fail_c
     let artifact: ReviewVerdictArtifact =
         serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
             .expect("parse verdict");
-    assert_eq!(artifact.decision, ReviewDecision::Fail);
-    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -739,3 +739,6 @@ fn persisted_review_artifact_deserializes_optional_overall_risk() {
     .expect("deserialize persisted review artifact");
     assert_eq!(artifact.overall_risk.as_deref(), Some("low"));
 }
+
+#[path = "review_cmd_output_verdict_1045_tests.rs"]
+mod verdict_1045_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+/// Mirror of [`super::super::super::findings_toml::SYNTHETIC_MARKER_FILENAME`].
+/// Duplicated here to avoid a 3-level super path from this nested test module.
+const SYNTHETIC_MARKER_FILENAME: &str = ".findings.toml.synthetic";
+
 // ─── #1045 regression tests: verdict must derive from severity_counts ────
 
 /// Case 1: Clean PASS summary + empty findings.toml → decision=pass.
@@ -209,6 +213,12 @@ fn issue_1045_r2_synthetic_empty_toml_with_json_high_emits_fail() {
         findings_toml,
     )
     .expect("write findings.toml");
+    // Write sidecar synthetic marker (#1045 round 3 addition).
+    fs::write(
+        session_dir.join("output").join(SYNTHETIC_MARKER_FILENAME),
+        b"",
+    )
+    .expect("write synthetic marker");
 
     // Write review-findings.json with a HIGH finding (reviewer's actual output).
     let json_findings = vec![make_finding(Severity::High, "real-high-finding")];
@@ -244,14 +254,14 @@ fn issue_1045_r2_synthetic_empty_toml_with_json_high_emits_fail() {
 /// Case 7 (#1045 round 2): true-empty findings.toml + empty review-findings.json → pass.
 ///
 /// When both findings.toml and review-findings.json agree on zero findings,
-/// the cross-check must not flip to fail.
+/// the cross-check must not flip to fail. No synthetic marker present.
 #[test]
 fn issue_1045_r2_true_empty_toml_with_empty_json_emits_pass() {
     let session_id = "01TEST1045R2TRUEEMPTY000000";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("issue-1045-r2-true-empty", session_id);
 
-    // True-empty findings.toml (reviewer genuinely found nothing).
+    // True-empty findings.toml (reviewer genuinely found nothing — NO synthetic marker).
     let findings_toml = "findings = []\n";
     fs::create_dir_all(session_dir.join("output")).expect("create output dir");
     fs::write(
@@ -291,6 +301,160 @@ fn issue_1045_r2_true_empty_toml_with_empty_json_emits_pass() {
         "#1045 round 2: true-empty + empty json must still pass"
     );
     assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|value| *value == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+// ─── #1045 round 3 regression tests: synthetic-empty + missing JSON ──────
+
+/// Case 8 (#1045 round 3): synthetic-empty findings.toml + NO review-findings.json
+/// + structured [High] finding in full.md → decision=fail.
+///
+/// This is the round 3 bug: when both findings.toml is synthetic-empty AND
+/// review-findings.json is absent, the code short-circuited with pass, silently
+/// dropping blocking prose findings in full.md.
+#[test]
+fn issue_1045_r3_synthetic_empty_toml_missing_json_high_in_full_md_emits_fail() {
+    let session_id = "01TEST1045R3SYNTHNOJS0HIGH0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1045-r3-synth-no-json-high-full", session_id);
+
+    // Synthetic-empty findings.toml + sidecar marker.
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    fs::write(
+        session_dir.join("output").join(SYNTHETIC_MARKER_FILENAME),
+        b"",
+    )
+    .expect("write synthetic marker");
+
+    // NO review-findings.json — deliberately absent.
+
+    // full.md with structured [High] finding in transcript.
+    let full_output = [json!({"type":"item.completed","item":{
+        "id":"item_1",
+        "type":"agent_message",
+        "text":"<!-- CSA:SECTION:summary -->\nFAIL\n<!-- CSA:SECTION:summary:END -->\n\n<!-- CSA:SECTION:details -->\nFindings\n1. [High][correctness] derive_review_verdict_artifact short-circuits on synthetic-empty TOML, dropping full.md fallback.\n\nOverall risk: high\n<!-- CSA:SECTION:details:END -->"
+    }})]
+    .into_iter()
+    .map(|line| serde_json::to_string(&line).expect("serialize transcript line"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    fs::write(session_dir.join("output").join("full.md"), full_output)
+        .expect("write full output transcript");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1045 round 3: synthetic-empty TOML + missing JSON + [High] in full.md must fail"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// Case 9 (#1045 round 3): synthetic-empty findings.toml + NO review-findings.json
+/// + non-empty unstructured full.md → decision=fail.
+///
+/// full.md has content but no severity markers — fail-closed via the
+/// `!full_output_is_effectively_empty` fallback.
+#[test]
+fn issue_1045_r3_synthetic_empty_toml_missing_json_nonempty_unstructured_full_md_emits_fail() {
+    let session_id = "01TEST1045R3SYNTHNOJSUNSTR0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1045-r3-synth-no-json-unstructured-full", session_id);
+
+    // Synthetic-empty findings.toml + sidecar marker.
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    fs::write(
+        session_dir.join("output").join(SYNTHETIC_MARKER_FILENAME),
+        b"",
+    )
+    .expect("write synthetic marker");
+
+    // NO review-findings.json.
+
+    // full.md with unstructured (non-transcript) prose — no severity markers,
+    // no CSA sections. Just plain text that isn't JSON and isn't empty.
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        "The reviewer produced some output but no structured verdict.\nSome notes about the diff.\n",
+    )
+    .expect("write unstructured full output");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1045 round 3: synthetic-empty TOML + missing JSON + non-empty unstructured full.md must fail-closed"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// Case 10 (#1045 round 3): synthetic-empty findings.toml + NO review-findings.json
+/// + empty full.md → decision=uncertain.
+///
+/// Last-resort fallback when everything is empty/absent.
+#[test]
+fn issue_1045_r3_synthetic_empty_toml_missing_json_empty_full_md_emits_uncertain() {
+    let session_id = "01TEST1045R3SYNTHNOJSEMPTY0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1045-r3-synth-no-json-empty-full", session_id);
+
+    // Synthetic-empty findings.toml + sidecar marker.
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    fs::write(
+        session_dir.join("output").join(SYNTHETIC_MARKER_FILENAME),
+        b"",
+    )
+    .expect("write synthetic marker");
+
+    // NO review-findings.json.
+    // NO full.md (or empty — absent is equivalent for the empty check).
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Uncertain,
+        "#1045 round 3: synthetic-empty TOML + missing JSON + empty/missing full.md must yield uncertain"
+    );
     assert!(artifact.severity_counts.values().all(|value| *value == 0));
 
     fs::remove_dir_all(project_root).expect("remove temp project root");

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
@@ -187,3 +187,111 @@ fn issue_1045_low_finding_only_emits_pass() {
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+/// Case 6 (#1045 round 2): synthetic-empty findings.toml (extraction failed) but
+/// review-findings.json contains a HIGH finding → decision=fail.
+///
+/// This is the blind spot: the reviewer produced blocking findings in prose, but
+/// the fenced TOML block was malformed/missing so findings.toml was written as
+/// `findings = []`. The new cross-check must detect that review-findings.json
+/// disagrees and emit fail.
+#[test]
+fn issue_1045_r2_synthetic_empty_toml_with_json_high_emits_fail() {
+    let session_id = "01TEST1045R2SYNTHEMPTY00000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1045-r2-synthetic-empty", session_id);
+
+    // Write synthetic-empty findings.toml (simulates failed TOML extraction).
+    let findings_toml = "findings = []\n";
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        findings_toml,
+    )
+    .expect("write findings.toml");
+
+    // Write review-findings.json with a HIGH finding (reviewer's actual output).
+    let json_findings = vec![make_finding(Severity::High, "real-high-finding")];
+    let json_artifact = json!({
+        "findings": json_findings,
+        "severity_summary": SeveritySummary { critical: 0, high: 1, medium: 0, low: 0 },
+        "overall_risk": "high"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&json_artifact).expect("serialize"),
+    )
+    .expect("write review-findings.json");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1045 round 2: synthetic-empty findings.toml must not mask review-findings.json HIGH"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// Case 7 (#1045 round 2): true-empty findings.toml + empty review-findings.json → pass.
+///
+/// When both findings.toml and review-findings.json agree on zero findings,
+/// the cross-check must not flip to fail.
+#[test]
+fn issue_1045_r2_true_empty_toml_with_empty_json_emits_pass() {
+    let session_id = "01TEST1045R2TRUEEMPTY000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1045-r2-true-empty", session_id);
+
+    // True-empty findings.toml (reviewer genuinely found nothing).
+    let findings_toml = "findings = []\n";
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        findings_toml,
+    )
+    .expect("write findings.toml");
+
+    // Empty review-findings.json (agrees: no findings).
+    let json_artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary { critical: 0, high: 0, medium: 0, low: 0 },
+        "overall_risk": "low"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&json_artifact).expect("serialize"),
+    )
+    .expect("write review-findings.json");
+
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\n**PASS** — No issues found.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1045 round 2: true-empty + empty json must still pass"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|value| *value == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
@@ -1,0 +1,189 @@
+use super::*;
+
+// ─── #1045 regression tests: verdict must derive from severity_counts ────
+
+/// Case 1: Clean PASS summary + empty findings.toml → decision=pass.
+/// Regression for issue #1045 where summary text parsing flipped decision to fail.
+#[test]
+fn issue_1045_clean_pass_summary_with_empty_findings_toml_emits_pass() {
+    let session_id = "01TEST1045CLEANPASS000000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1045-clean-pass-findings-toml", session_id);
+    let findings_toml = "findings = []\n";
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        findings_toml,
+    )
+    .expect("write findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\n**PASS** — Clean single-commit fix. No findings.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1045 regression: zero findings must yield pass"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|value| *value == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// Case 2: FAIL summary + HIGH finding → decision=fail.
+#[test]
+fn issue_1045_fail_summary_with_high_finding_emits_fail() {
+    let session_id = "01TEST1045HIGHFINDING000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1045-high-finding", session_id);
+    let findings = vec![make_finding(Severity::High, "blocking-high")];
+    let artifact = json!({
+        "findings": findings,
+        "severity_summary": SeveritySummary { critical: 0, high: 1, medium: 0, low: 0 },
+        "overall_risk": "high"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize"),
+    )
+    .expect("write findings");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\n**FAIL** — 1 HIGH finding.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// Case 3: PASS summary with word "fail" in explanatory prose + empty findings → decision=pass.
+/// This is the core #1045 bug: "fail" in prose MUST NOT flip verdict when findings are empty.
+#[test]
+fn issue_1045_prose_containing_fail_keyword_with_empty_findings_emits_pass() {
+    let session_id = "01TEST1045PROSEFAIL000000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1045-prose-fail-keyword", session_id);
+    let findings_toml = "findings = []\n";
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        findings_toml,
+    )
+    .expect("write findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\n**PASS** but this reviewer would fail under different criteria. The approach is sound.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1045 regression: 'fail' in prose must not flip verdict"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|value| *value == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// Case 4: MEDIUM finding → decision=fail (MEDIUMs still count as findings).
+#[test]
+fn issue_1045_medium_finding_emits_fail() {
+    let session_id = "01TEST1045MEDIUMFINDING00000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1045-medium-finding", session_id);
+    let findings = vec![make_finding(Severity::Medium, "medium-issue")];
+    let artifact = json!({
+        "findings": findings,
+        "severity_summary": SeveritySummary { critical: 0, high: 0, medium: 1, low: 0 },
+        "overall_risk": "medium"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize"),
+    )
+    .expect("write findings");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// Case 5: LOW finding only → decision=pass (LOWs don't block merge).
+#[test]
+fn issue_1045_low_finding_only_emits_pass() {
+    let session_id = "01TEST1045LOWFINDING0000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1045-low-finding", session_id);
+    let findings = vec![make_finding(Severity::Low, "low-nit")];
+    let artifact = json!({
+        "findings": findings,
+        "severity_summary": SeveritySummary { critical: 0, high: 0, medium: 0, low: 1 },
+        "overall_risk": "low"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize"),
+    )
+    .expect("write findings");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nNo blocking issues found.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "LOW findings don't block"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(artifact.severity_counts.get(&Severity::Low), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}


### PR DESCRIPTION
## Summary

Fixes #1045 — `csa review` was emitting `decision=fail / verdict_legacy=HAS_ISSUES` even when the summary said **PASS** and `findings.toml` was empty. Two-commit fix:

1. **Round 1** — replace summary-text keyword scanning with `severity_counts`-based derivation.
2. **Round 2** — guard against the synthetic-empty findings.toml fallback by cross-checking `review-findings.json` before emitting Pass.

## Root cause

**Primary**: The verdict derivation scanned `summary.md` text for "fail" / "HAS_ISSUES" keywords and returned `decision=fail` even when `findings.toml` was empty and `severity_counts` were all zero. Any review body that mentioned "fail" in prose (e.g. "no findings and would not fail merge") triggered the bug.

**Secondary** (found by round 1 review): The `findings.toml` extraction code (`review_cmd_findings_toml.rs:14-35`) silently falls back to a synthetic empty artifact when the fenced TOML block is missing or malformed. Under the round 1 fix, this would cause a reviewer with real blocking findings but malformed TOML output to silently emit `decision=pass` — a regression risk vs the prior text-parsing path.

Concrete round 1 repro: session `01KPVCE7RTM4EVH4WNENB25FCZ` (2026-04-22, reviewing PR #1044 lefthook fix) — summary started with `**PASS** — Clean single-commit fix. ... No findings.`, `findings.toml` contained `findings = []`, but emitted `decision: "fail"`.

## Fix

### Round 1 (commit 1f2bf6f5)

`decision` is now derived ONLY from `severity_counts`:

- `critical > 0` or `high > 0` → `fail / HAS_ISSUES`
- `medium > 0` → `fail / HAS_ISSUES` (MEDIUMs still warrant followup; callers apply severity-tiered merge policy at their own layer per the project doctrine)
- `low > 0` or all-zero → `pass / CLEAN`

`verdict_legacy` always matches `decision` now.

### Round 2 (commit 55c7d3f4)

Before emitting `pass` on all-zero counts, cross-check `review-findings.json`. If that file reports any blocking finding (critical/high/medium), override to `fail`. This closes the synthetic-empty blind spot without changing the findings.toml schema.

## Test plan

- [x] `cargo test` — 1562+ unit tests + 28 e2e tests pass
- [x] `just pre-commit` exit 0
- [x] Round 1 regression tests: clean PASS with no findings, HIGH finding, MEDIUM finding, LOW finding, and explanatory prose containing "fail" but empty findings list
- [x] Round 2 regression test: synthetic-empty `findings.toml` with prose-level HIGH finding in `review-findings.json` now correctly resolves to `fail`
- [x] `csa review --range main...HEAD` on this branch: decision=pass, 0 findings across all severities
- [ ] Cloud review (gemini-code-assist)

Closes #1045.