### PR TITLE
fix(csa-review): 3 MEDIUM edge cases in verdict derivation (#1048)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.514"
+version = "0.1.515"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.514"
+version = "0.1.515"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix.rs
@@ -257,6 +257,21 @@ fn persist_fix_final_artifacts(
                         "Failed to remove stale review-findings.json after CLEAN convergence"
                     );
                 }
+                // Clear the synthetic-empty sidecar marker so
+                // derive_review_verdict_artifact does not fall through to
+                // full.md after clean convergence (#1048 M3).
+                let synthetic_marker = session_dir
+                    .join("output")
+                    .join(super::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER);
+                if let Err(error) = std::fs::remove_file(&synthetic_marker)
+                    && error.kind() != std::io::ErrorKind::NotFound
+                {
+                    warn!(
+                        session_id = %review_meta.session_id,
+                        error = %error,
+                        "Failed to remove synthetic marker after CLEAN convergence"
+                    );
+                }
             }
             Err(error) => {
                 warn!(
@@ -606,6 +621,77 @@ mod tests {
                 findings: vec![sample_stale_finding()],
             }
         );
+    }
+
+    /// #1048 M3: --fix session that started from synthetic-empty initial
+    /// review, converges clean → synthetic marker must be removed alongside
+    /// findings.toml and review-findings.json.
+    ///
+    /// Bug: persist_fix_final_artifacts(converged_clean=true) cleared
+    /// findings.toml + review-findings.json but left the synthetic sidecar
+    /// marker in place, causing derive_review_verdict_artifact to fall
+    /// through to full.md on subsequent reads.
+    #[test]
+    fn persist_fix_final_artifacts_clears_synthetic_marker_on_clean_convergence() {
+        let project_root = temp_project_root("persist-fix-synthetic-marker-clean");
+        let _state_home = ScopedTestEnvVar::set("XDG_STATE_HOME", project_root.join("state"));
+        let session_id = unique_session_id("01FIXSYNTHETICMARKERCLEAN");
+        let session_dir = create_session_dir(&project_root, &session_id);
+
+        // Create the synthetic marker (simulates a fix session that started
+        // from a synthetic-empty initial review).
+        let marker_path = session_dir
+            .join("output")
+            .join(super::super::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER);
+        fs::write(&marker_path, b"").expect("write synthetic marker");
+
+        // Seed stale review-findings.json to verify it's also removed.
+        let stale_json = serde_json::json!({
+            "findings": [{
+                "severity": "medium",
+                "fid": "stale-medium-synth",
+                "file": "src/lib.rs",
+                "line": 10,
+                "rule_id": "rule.stale",
+                "summary": "Stale finding from pre-fix review",
+                "engine": "reviewer"
+            }],
+            "severity_summary": { "critical": 0, "high": 0, "medium": 1, "low": 0 },
+            "overall_risk": "medium"
+        });
+        fs::write(
+            session_dir.join("review-findings.json"),
+            serde_json::to_vec_pretty(&stale_json).expect("serialize stale json"),
+        )
+        .expect("write stale review-findings.json");
+
+        persist_fix_final_artifacts(&project_root, &make_clean_review_meta(&session_id), true);
+
+        // findings.toml must be empty.
+        let findings_path = session_dir.join("output").join("findings.toml");
+        let parsed: FindingsFile =
+            toml::from_str(&fs::read_to_string(&findings_path).expect("read findings.toml"))
+                .expect("parse findings.toml");
+        assert_eq!(parsed, FindingsFile::default());
+
+        // review-findings.json must be removed.
+        assert!(
+            !session_dir.join("review-findings.json").exists(),
+            "review-findings.json should be removed after clean convergence"
+        );
+
+        // Synthetic marker must be removed (#1048 M3).
+        assert!(
+            !marker_path.exists(),
+            "#1048 M3: synthetic marker must be removed after clean convergence"
+        );
+
+        // Verdict must report pass.
+        let verdict_path = session_dir.join("output").join("review-verdict.json");
+        let artifact: csa_session::ReviewVerdictArtifact =
+            serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+                .expect("parse verdict");
+        assert_eq!(artifact.decision, ReviewDecision::Pass);
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -10,9 +10,7 @@ use csa_executor::{
 };
 use csa_session::output_parser::parse_sections;
 use csa_session::state::{ReviewSessionMeta, write_review_meta};
-use csa_session::{
-    Finding, OutputSection, ReviewVerdictArtifact, Severity, SeveritySummary, write_review_verdict,
-};
+use csa_session::{Finding, OutputSection, ReviewVerdictArtifact, Severity, write_review_verdict};
 use regex::Regex;
 use serde::Deserialize;
 use tracing::{debug, warn};
@@ -26,7 +24,8 @@ mod diagnostics;
 #[path = "review_cmd_output_summary.rs"]
 mod summary_artifact;
 use artifacts::{
-    load_findings_toml_from_output, load_review_artifact_from_output, severity_counts_for_artifact,
+    has_blocking_severity, json_severity_counts_if_present, load_findings_toml_from_output,
+    load_review_artifact_from_output, severity_counts_are_zero, severity_counts_for_artifact,
     severity_counts_for_findings_toml,
 };
 use clean_detection::{
@@ -352,11 +351,24 @@ fn derive_review_verdict_artifact(
         } else {
             // Non-synthetic (trusted) or non-empty findings.toml: cross-check
             // review-findings.json for the empty case (round 2 logic), then return.
-            if findings_file.findings.is_empty()
-                && severity_counts_are_zero(&severity_counts)
-                && let Some(artifact) = cross_check_json_for_blocking(session_dir, meta)?
-            {
-                return Ok(artifact);
+            if findings_file.findings.is_empty() && severity_counts_are_zero(&severity_counts) {
+                if let Some(artifact) = cross_check_json_for_blocking(session_dir, meta)? {
+                    return Ok(artifact);
+                }
+                // No blocking JSON findings, but JSON may have low-only counts.
+                // Preserve them so downstream telemetry sees the low count (#1048 M1).
+                if let Some(json_counts) =
+                    json_severity_counts_if_present(session_dir, zero_severity_counts)?
+                {
+                    let decision = derive_decision_from_severity_counts(
+                        &json_counts,
+                        false, // JSON has findings (low-only)
+                        None,
+                        ReviewDecision::from_str(&meta.decision).ok(),
+                        || review_contains_prose_clean_conclusion(session_dir),
+                    )?;
+                    return Ok(verdict_from_meta(meta, decision, json_counts));
+                }
             }
 
             let decision = derive_decision_from_severity_counts(
@@ -495,25 +507,15 @@ fn looks_like_review_message(text: &str) -> bool {
         })
 }
 
-fn severity_counts_from_summary(
-    summary: &SeveritySummary,
-) -> std::collections::BTreeMap<Severity, u32> {
+fn zero_severity_counts() -> std::collections::BTreeMap<Severity, u32> {
     [
-        (Severity::Critical, summary.critical),
-        (Severity::High, summary.high),
-        (Severity::Medium, summary.medium),
-        (Severity::Low, summary.low),
+        (Severity::Critical, 0),
+        (Severity::High, 0),
+        (Severity::Medium, 0),
+        (Severity::Low, 0),
     ]
     .into_iter()
     .collect()
-}
-
-fn severity_counts_are_zero(counts: &std::collections::BTreeMap<Severity, u32>) -> bool {
-    counts.values().all(|count| *count == 0)
-}
-
-fn zero_severity_counts() -> std::collections::BTreeMap<Severity, u32> {
-    severity_counts_from_summary(&SeveritySummary::default())
 }
 
 fn severity_counts_from_text(text: &str) -> std::collections::BTreeMap<Severity, u32> {
@@ -547,13 +549,6 @@ fn parse_overall_risk_from_text(text: &str) -> Option<String> {
         .captures(text)
         .and_then(|captures| captures.get(1))
         .map(|level| level.as_str().to_ascii_lowercase())
-}
-
-/// Whether the severity counts contain any blocking findings (critical, high, or medium).
-fn has_blocking_severity(counts: &std::collections::BTreeMap<Severity, u32>) -> bool {
-    counts
-        .iter()
-        .any(|(severity, count)| *count > 0 && *severity > Severity::Low)
 }
 
 /// Derive the review decision from structured severity counts.
@@ -625,7 +620,9 @@ fn derive_decision_from_text(
     counts: &std::collections::BTreeMap<Severity, u32>,
     overall_risk: Option<&str>,
 ) -> ReviewDecision {
-    if counts.values().any(|count| *count > 0) {
+    // Only blocking severities (critical/high/medium) cause fail.
+    // Low-only findings are advisory and do not block (#1048 M2).
+    if has_blocking_severity(counts) {
         return ReviewDecision::Fail;
     }
     if contains_verdict_token(text, "FAIL") || contains_verdict_token(text, "HAS_ISSUES") {

--- a/crates/cli-sub-agent/src/review_cmd_output_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_artifacts.rs
@@ -68,6 +68,38 @@ pub(super) fn severity_counts_for_artifact(
     counts
 }
 
+/// Load severity counts from review-findings.json when present.
+///
+/// Returns `Some(counts)` if JSON exists and has any non-zero counts (even
+/// low-only). Returns `None` if JSON is absent, unparseable, or all-zero.
+///
+/// Used to preserve informational low-severity counts in the final verdict
+/// when findings.toml is empty but JSON recorded low findings (#1048 M1).
+pub(super) fn json_severity_counts_if_present(
+    session_dir: &Path,
+    zero_severity_counts: impl Fn() -> std::collections::BTreeMap<Severity, u32>,
+) -> Result<Option<std::collections::BTreeMap<Severity, u32>>, anyhow::Error> {
+    let Some(json_artifact) = load_review_artifact_from_output(session_dir)? else {
+        return Ok(None);
+    };
+    let json_counts = severity_counts_for_artifact(&json_artifact, zero_severity_counts);
+    if json_counts.values().all(|count| *count == 0) {
+        return Ok(None);
+    }
+    Ok(Some(json_counts))
+}
+
+/// Whether the severity counts contain any blocking findings (critical, high, or medium).
+pub(super) fn has_blocking_severity(counts: &std::collections::BTreeMap<Severity, u32>) -> bool {
+    counts
+        .iter()
+        .any(|(severity, count)| *count > 0 && *severity > Severity::Low)
+}
+
+pub(super) fn severity_counts_are_zero(counts: &std::collections::BTreeMap<Severity, u32>) -> bool {
+    counts.values().all(|count| *count == 0)
+}
+
 pub(super) fn severity_counts_for_findings_toml(
     artifact: &FindingsFile,
     zero_severity_counts: impl Fn() -> std::collections::BTreeMap<Severity, u32>,

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
@@ -459,3 +459,107 @@ fn issue_1045_r3_synthetic_empty_toml_missing_json_empty_full_md_emits_uncertain
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+// ─── #1048 MEDIUM regression tests ──────────────────────────────────────
+
+/// #1048 M1: empty findings.toml + review-findings.json with ONLY low
+/// findings → verdict must report severity_counts.low = 1 and decision = pass.
+///
+/// Bug: cross_check_json_for_blocking() returned None for low-only JSON,
+/// so the caller rebuilt from zero TOML counts, dropping the low count.
+#[test]
+fn issue_1048_m1_low_only_json_preserves_severity_counts_low() {
+    let session_id = "01TEST1048M1LOWONLYJSON0000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1048-m1-low-only-json", session_id);
+
+    // True-empty findings.toml (no synthetic marker).
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+
+    // review-findings.json with ONLY a low-severity finding.
+    let json_findings = vec![make_finding(Severity::Low, "advisory-low")];
+    let json_artifact = json!({
+        "findings": json_findings,
+        "severity_summary": SeveritySummary { critical: 0, high: 0, medium: 0, low: 1 },
+        "overall_risk": "low"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&json_artifact).expect("serialize"),
+    )
+    .expect("write review-findings.json");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1048 M1: low-only JSON must not block"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(
+        artifact.severity_counts.get(&Severity::Low),
+        Some(&1),
+        "#1048 M1: low count from JSON must be preserved in verdict"
+    );
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&0));
+    assert_eq!(artifact.severity_counts.get(&Severity::Medium), Some(&0));
+    assert_eq!(artifact.severity_counts.get(&Severity::Critical), Some(&0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1048 M2: full.md transcript with only [info]/[p4] advisory findings
+/// → decision = pass, not fail.
+///
+/// Bug: derive_decision_from_text() treated any non-zero count as blocking.
+#[test]
+fn issue_1048_m2_info_only_full_md_transcript_emits_pass() {
+    let session_id = "01TEST1048M2INFOONLYFULLMD0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1048-m2-info-only-full-md", session_id);
+
+    // No findings.toml, no review-findings.json — only full.md.
+    let full_output = [json!({"type":"item.completed","item":{
+        "id":"item_1",
+        "type":"agent_message",
+        "text":"<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n\n<!-- CSA:SECTION:details -->\nFindings\n1. [Info][style] Minor formatting inconsistency.\n2. [P4][nit] Extra whitespace.\n\nNo blocking issues found in this scope.\nOverall risk: low\n<!-- CSA:SECTION:details:END -->"
+    }})]
+    .into_iter()
+    .map(|line| serde_json::to_string(&line).expect("serialize transcript line"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    fs::write(session_dir.join("output").join("full.md"), full_output)
+        .expect("write full output transcript");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1048 M2: [info]/[p4]-only transcript must not block"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(
+        artifact.severity_counts.get(&Severity::Low),
+        Some(&2),
+        "#1048 M2: two advisory findings should map to low count"
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}


### PR DESCRIPTION
## Summary

Fixes #1048 — three MEDIUM edge cases in `csa review` verdict derivation surfaced during #1046 round 5 review, after the round 1-4 HIGH fixes converged.

## The three fixes

### M1 — low-only JSON dropped from final verdict

`cross_check_json_for_blocking()` returned `None` unless critical/high/medium > 0, so the empty-TOML branches dropped `severity_counts.low` from the final verdict when `review-findings.json` had only low-severity findings. Now returns JSON counts even when only Low is present (preserves the count for telemetry/dashboards; doesn't change blocking/non-blocking behavior).

### M2 — full.md fallback blocks on advisory-only transcripts

`derive_decision_from_text()` treated any non-zero count as blocking, so a reviewer emitting only `[info]`/`[low]`/`[p3]`/`[p4]` advisories false-failed. Now only critical/high/medium > 0 blocks — aligned with `derive_decision_from_severity_counts`.

### M3 — `--fix` clean convergence leaves synthetic sidecar marker

Round 4 (PR #1046 commit `63e81140`) cleared `findings.toml` + `review-findings.json` on clean convergence but left the synthetic sidecar marker from round 3. If a `--fix` session entered from a synthetic-empty initial review, the marker persisted and made `derive_review_verdict_artifact` fall through to `full.md` even after the fix round converged cleanly. Now deletes the marker alongside the other artifacts.

## Test plan

- [x] `cargo test` — all tests pass (including PR #1046 rounds 1-4 regression tests)
- [x] 3 new regression tests covering M1/M2/M3
- [x] `just pre-commit` exit 0
- [ ] Cloud review (gemini-code-assist)

Closes #1048.