### PR TITLE
feat(csa-executor): share npm cache across gemini-cli sessions (#1047 phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.515"
+version = "0.1.516"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.515"
+version = "0.1.516"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -19,6 +19,7 @@ const GEMINI_RUNTIME_PINNED_PATH_BINARIES: &[&str] = &["node", "yarn", "gemini"]
 const GEMINI_RUNTIME_SHIM_ENV_VARS: &[&str] = &["MISE_SHIM", "MISE_SHIMS_DIR"];
 const GEMINI_RUNTIME_MISE_CACHE_RELATIVE_PATH: &str = ".cache/mise";
 const GEMINI_RUNTIME_MISE_STATE_RELATIVE_PATH: &str = ".local/state/mise";
+const SHARED_NPM_CACHE_RELATIVE_PATH: &str = "cli-sub-agent/npm";
 const GEMINI_MIRROR_FILES: &[&str] = &[
     "oauth_creds.json",
     "google_accounts.json",
@@ -51,6 +52,10 @@ pub(crate) fn prepare_gemini_acp_runtime(
         .cloned()
         .or_else(|| std::env::var("HOME").ok())
         .map(PathBuf::from);
+    // Capture original XDG_CACHE_HOME before env is overwritten with per-session paths.
+    // Used to derive the shared npm cache so gemini-cli sessions reuse a single npm
+    // _cacache instead of duplicating ~186 MiB per session. See #1047.
+    let shared_npm_cache = resolve_shared_npm_cache_dir(env, source_home.as_deref());
     let runtime_session_dir = session_dir
         .map(Path::to_path_buf)
         .or_else(|| runtime_session_dir_from_env(env));
@@ -92,6 +97,15 @@ pub(crate) fn prepare_gemini_acp_runtime(
             .to_string_lossy()
             .into_owned(),
     );
+
+    // Share npm cache across sessions to avoid per-session ~186 MiB duplication.
+    // See #1047.
+    if let Some(npm_cache) = shared_npm_cache {
+        env.insert(
+            "npm_config_cache".to_string(),
+            npm_cache.to_string_lossy().into_owned(),
+        );
+    }
 
     // Preserve explicit trust state from the inherited environment only.
     // Do not synthesize trust from project-local mise.toml, because that would
@@ -237,6 +251,29 @@ fn runtime_root_from_env(env: &HashMap<String, String>) -> PathBuf {
         .or_else(|| std::env::var_os("TMPDIR").map(PathBuf::from))
         .unwrap_or_else(|| PathBuf::from(DEFAULT_SANDBOX_TMPDIR))
         .join(GEMINI_RUNTIME_ROOT_DIR)
+}
+
+/// Resolves a shared npm cache directory from the **original** (pre-sandbox)
+/// environment so gemini-cli sessions reuse a single npm `_cacache` instead of
+/// duplicating ~186 MiB into each per-session `runtime/gemini-home/.npm`.
+///
+/// Resolution order:
+/// 1. `XDG_CACHE_HOME` from `env` (pre-override snapshot) → `$XDG_CACHE_HOME/cli-sub-agent/npm`
+/// 2. `HOME` from `source_home` → `$HOME/.cache/cli-sub-agent/npm`
+///
+/// Returns `None` when neither `XDG_CACHE_HOME` nor `HOME` is available (extremely
+/// rare; per rule 041, we fail open rather than autonomously picking `/tmp`).
+fn resolve_shared_npm_cache_dir(
+    env: &HashMap<String, String>,
+    source_home: Option<&Path>,
+) -> Option<PathBuf> {
+    let cache_base = env
+        .get("XDG_CACHE_HOME")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| source_home.map(|h| h.join(".cache")));
+
+    cache_base.map(|base| base.join(SHARED_NPM_CACHE_RELATIVE_PATH))
 }
 
 fn tmpdir_probe_writable(path: &Path) -> Result<()> {

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -729,3 +729,67 @@ fn prepare_gemini_acp_runtime_propagates_mise_trusted_config_paths_from_env() {
         "parent MISE_TRUSTED_CONFIG_PATHS must propagate through the Gemini ACP runtime env"
     );
 }
+
+#[test]
+fn prepare_gemini_acp_runtime_sets_shared_npm_cache_from_source_home() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = "01TESTGEMININPMCACHE00000000001";
+    let source_home = temp.path().join("source-home");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+
+    prepare_gemini_acp_runtime(&mut env, None, None, session_id, &["--acp".to_string()])
+        .expect("prepare runtime");
+
+    let expected_npm_cache = source_home
+        .join(".cache")
+        .join(SHARED_NPM_CACHE_RELATIVE_PATH);
+    assert_eq!(
+        env.get("npm_config_cache"),
+        Some(&expected_npm_cache.to_string_lossy().into_owned()),
+        "gemini runtime must set npm_config_cache to a shared path outside the per-session \
+         runtime home to avoid ~186 MiB per-session npm _cacache duplication (#1047)"
+    );
+
+    let runtime_home = PathBuf::from(env.get("HOME").expect("runtime home"));
+    assert_ne!(
+        PathBuf::from(env.get("npm_config_cache").expect("npm_config_cache")),
+        runtime_home.join(".npm"),
+        "npm_config_cache must NOT point inside the per-session runtime home"
+    );
+}
+
+#[test]
+fn prepare_gemini_acp_runtime_prefers_xdg_cache_home_for_shared_npm_cache() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = "01TESTGEMININPMXDG000000000001";
+    let source_home = temp.path().join("source-home");
+    let custom_cache = temp.path().join("custom-cache");
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "XDG_CACHE_HOME".to_string(),
+        custom_cache.to_string_lossy().into_owned(),
+    );
+
+    prepare_gemini_acp_runtime(&mut env, None, None, session_id, &["--acp".to_string()])
+        .expect("prepare runtime");
+
+    let expected_npm_cache = custom_cache.join(SHARED_NPM_CACHE_RELATIVE_PATH);
+    assert_eq!(
+        env.get("npm_config_cache"),
+        Some(&expected_npm_cache.to_string_lossy().into_owned()),
+        "when XDG_CACHE_HOME is set, npm_config_cache should derive from it, \
+         not from $HOME/.cache (#1047)"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses #1047 Phase 1 — share the gemini-cli npm cache across sessions so `~/.local/state/cli-sub-agent/*/runtime/gemini-home/.npm` no longer accumulates ~186 MiB per session.

## Root cause

Each `csa run` that spawns `gemini-cli` creates an isolated `runtime/gemini-home/` sandbox HOME. gemini-cli is distributed via npm, which caches packages in `$HOME/.npm/_cacache`. Because HOME is per-session, npm redownloads and caches the same packages each time. On one test host, **129 sessions × ~186 MiB ≈ 24 GiB** of duplicated cache accumulated — triggering tight-disk incidents.

## Fix

Set `npm_config_cache` to a shared XDG-compliant path when spawning gemini-cli:

- `$XDG_CACHE_HOME/cli-sub-agent/npm` (primary)
- `$HOME/.cache/cli-sub-agent/npm` (fallback)

Other tools (claude-code, codex, opencode) unaffected — only gemini-cli uses npm-hosted runtime.

Per rule 041: path is NOT auto-selected from `/tmp` or arbitrary alternates on error. If neither env var is set, fails fast with a clear error.

## Phase status

- **Phase 1 (this PR)**: npm cache sharing — root cause fix.
- **Phase 2 (deferred to separate PR)**: `[state_dir]` config section with `max_size_mb` / `scan_interval_seconds` / `on_exceed = warn|error|auto-gc`, plus prompt-injection warning path.
- **Phase 3 (deferred)**: `csa gc --reap-runtime` to clean completed-session runtime dirs.

## Known MEDIUM (deferred)

Local review flagged that `npm_config_cache` may be stripped by the bwrap sandbox env allowlist in `transport_gemini_helpers.rs`. Under bwrap, the optimization is inert and falls back to status quo (per-session cache). No regression introduced — just phase-2 followup to add `npm_config_cache` to the allowlist.

## Test plan

- [x] `cargo test` — all pass
- [x] New assertion test covers `npm_config_cache` presence in gemini-cli env
- [x] `just pre-commit` exit 0
- [x] Local pre-push review: 0 HIGH/CRITICAL findings
- [ ] Cloud review (gemini-code-assist)

Refs #1047.