### PR TITLE
feat(csa-config): state_dir size cap + scan + prompt-warn (#1047 phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.517"
+version = "0.1.518"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.516"
+version = "0.1.517"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.518"
+version = "0.1.519"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.522"
+version = "0.1.523"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.519"
+version = "0.1.520"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.520"
+version = "0.1.521"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.521"
+version = "0.1.522"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.521"
+version = "0.1.522"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.518"
+version = "0.1.519"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.516"
+version = "0.1.517"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.519"
+version = "0.1.520"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.520"
+version = "0.1.521"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.522"
+version = "0.1.523"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.517"
+version = "0.1.518"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -604,7 +604,7 @@ fn prefers_effective_lookup(key: &str) -> Result<bool> {
 }
 
 fn global_key_prefers_raw_lookup(key: &str) -> bool {
-    key.starts_with("kv_cache.")
+    key.starts_with("kv_cache.") || key.starts_with("state_dir.")
 }
 
 fn known_effective_top_level_sections() -> Result<BTreeSet<String>> {

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -368,7 +368,7 @@ struct LookupResolution {
 }
 
 fn is_global_only_key(key: &str) -> bool {
-    key.starts_with("kv_cache.")
+    key.starts_with("kv_cache.") || key.starts_with("state_dir.")
 }
 
 #[derive(Debug, Clone)]

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -298,24 +298,24 @@ pub(crate) fn handle_gc(
 
     Ok(())
 }
-
-/// Global GC: scan all project session roots under `~/.local/state/cli-sub-agent/`.
-///
-/// Discovers project roots by recursively finding directories that contain
-/// a `sessions/` subdirectory, then applies the same cleanup criteria as
-/// per-project GC plus cross-project slot cleanup.
+/// Global GC: scan all project session roots under all existing CSA state dirs.
+/// Applies the same cleanup criteria as per-project GC plus cross-project slot cleanup.
 pub(crate) fn handle_gc_global(
     dry_run: bool,
     max_age_days: Option<u64>,
     format: OutputFormat,
 ) -> Result<()> {
-    let state_base = GlobalConfig::state_base_dir()?;
-    if !state_base.exists() {
+    let state_bases = csa_config::paths::state_dir_all_roots();
+    if state_bases.is_empty() {
+        let state_base = GlobalConfig::state_base_dir()?;
         eprintln!("No CSA state directory found at {}", state_base.display());
         return Ok(());
     }
 
-    let project_roots = discover_project_roots(&state_base);
+    let mut project_roots = Vec::new();
+    for state_base in &state_bases {
+        project_roots.extend(discover_project_roots(state_base));
+    }
 
     let now = chrono::Utc::now();
     let mut total_stale_locks = 0u64;
@@ -652,25 +652,29 @@ pub(crate) fn handle_gc_global(
 }
 
 fn invalidate_state_dir_size_cache() {
-    let Ok(state_dir) = GlobalConfig::state_base_dir() else {
+    let state_roots = csa_config::paths::state_dir_all_roots();
+    if state_roots.is_empty() {
         return;
-    };
-    let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
-    // GC is the remediation path advertised by state-dir preflight; clear the
-    // cached aggregate so the next spawn always rescans current disk usage.
-    match fs::remove_file(&cache_path) {
-        Ok(()) => info!(path = %cache_path.display(), "Invalidated state directory size cache"),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) => warn!(
-            path = %cache_path.display(),
-            error = %err,
-            "Failed to invalidate state directory size cache"
-        ),
+    }
+
+    // GC is the remediation path advertised by state-dir preflight; clear the cached aggregate.
+    for state_dir in state_roots {
+        let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
+        match fs::remove_file(&cache_path) {
+            Ok(()) => {
+                info!(path = %cache_path.display(), "Invalidated state directory size cache")
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => warn!(
+                path = %cache_path.display(),
+                error = %err,
+                "Failed to invalidate state directory size cache"
+            ),
+        }
     }
 }
 
 /// Discover project roots (dirs with `sessions/` containing ULID dirs with `state.toml`).
-/// Skips symlinks, validates canonical paths, and skips `slots/`/`todos/` at top level.
 fn discover_project_roots(state_base: &std::path::Path) -> Vec<std::path::PathBuf> {
     let canonical_base = match state_base.canonicalize() {
         Ok(p) => p,
@@ -682,7 +686,6 @@ fn discover_project_roots(state_base: &std::path::Path) -> Vec<std::path::PathBu
 }
 
 /// Top-level CSA internal directories (not project paths) under the state base.
-/// Note: "tmp" is NOT skipped because `/tmp/...` project paths map to `<state>/csa/tmp/...`.
 const TOP_LEVEL_SKIP: &[&str] = &["slots", "todos"];
 
 fn discover_roots_recursive(
@@ -696,8 +699,7 @@ fn discover_roots_recursive(
         Err(_) => return,
     };
     for entry in entries.flatten() {
-        // Skip symlinks to prevent traversal outside state tree.
-        // Use file_type() which does NOT follow symlinks (unlike metadata()).
+        // Skip symlinks to prevent traversal outside state tree; file_type() does not follow them.
         let ft = match entry.file_type() {
             Ok(ft) => ft,
             Err(_) => continue,

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -292,7 +292,9 @@ pub(crate) fn handle_gc(
         }
     }
 
-    invalidate_state_dir_size_cache();
+    if !dry_run {
+        invalidate_state_dir_size_cache();
+    }
 
     Ok(())
 }
@@ -642,7 +644,9 @@ pub(crate) fn handle_gc_global(
         }
     }
 
-    invalidate_state_dir_size_cache();
+    if !dry_run {
+        invalidate_state_dir_size_cache();
+    }
 
     Ok(())
 }

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -14,6 +14,7 @@ use transcript::{cleanup_project_transcripts, load_gc_config_for_sessions};
 
 /// Default age threshold (in days) for retiring stale Active sessions.
 const RETIRE_AFTER_DAYS: i64 = 7;
+const STATE_DIR_SIZE_CACHE_FILENAME: &str = ".size-cache.toml";
 
 pub(crate) fn handle_gc(
     dry_run: bool,
@@ -290,6 +291,8 @@ pub(crate) fn handle_gc(
             eprintln!("{prefix}  Orphan cgroup scopes cleaned: {orphan_scopes_cleaned}");
         }
     }
+
+    invalidate_state_dir_size_cache();
 
     Ok(())
 }
@@ -639,7 +642,27 @@ pub(crate) fn handle_gc_global(
         }
     }
 
+    invalidate_state_dir_size_cache();
+
     Ok(())
+}
+
+fn invalidate_state_dir_size_cache() {
+    let Ok(state_dir) = GlobalConfig::state_base_dir() else {
+        return;
+    };
+    let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
+    // GC is the remediation path advertised by state-dir preflight; clear the
+    // cached aggregate so the next spawn always rescans current disk usage.
+    match fs::remove_file(&cache_path) {
+        Ok(()) => info!(path = %cache_path.display(), "Invalidated state directory size cache"),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => warn!(
+            path = %cache_path.display(),
+            error = %err,
+            "Failed to invalidate state directory size cache"
+        ),
+    }
 }
 
 /// Discover project roots (dirs with `sessions/` containing ULID dirs with `state.toml`).

--- a/crates/cli-sub-agent/src/gc_tests.rs
+++ b/crates/cli-sub-agent/src/gc_tests.rs
@@ -242,58 +242,74 @@ fn test_discover_finds_rotation_only_roots() {
 fn test_gc_global_invalidates_state_dir_size_cache() {
     let tmp = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
-    let state_dir = csa_config::GlobalConfig::state_base_dir().expect("state base dir");
-    fs::create_dir_all(&state_dir).unwrap();
+    let canonical = csa_config::paths::state_dir_write().expect("canonical state dir");
+    let legacy = csa_config::paths::legacy_state_dir().expect("legacy state dir");
 
-    let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
-    fs::write(
-        &cache_path,
-        r#"
+    for state_dir in [&canonical, &legacy] {
+        fs::create_dir_all(state_dir).unwrap();
+        let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
+        fs::write(
+            &cache_path,
+            r#"
 size_bytes = 999999999
 scanned_at = 1
 "#,
-    )
-    .unwrap();
-    assert!(
-        cache_path.exists(),
-        "test precondition: cache file must exist"
-    );
+        )
+        .unwrap();
+        assert!(
+            cache_path.exists(),
+            "test precondition: cache file must exist at {}",
+            cache_path.display()
+        );
+    }
 
     handle_gc_global(false, None, OutputFormat::Text).expect("global gc should succeed");
 
-    assert!(
-        !cache_path.exists(),
-        "gc must invalidate the cached state-dir size reading"
-    );
+    for state_dir in [&canonical, &legacy] {
+        let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
+        assert!(
+            !cache_path.exists(),
+            "gc must invalidate the cached state-dir size reading at {}",
+            cache_path.display()
+        );
+    }
 }
 
 #[test]
 fn test_gc_global_dry_run_preserves_state_dir_size_cache() {
     let tmp = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
-    let state_dir = csa_config::GlobalConfig::state_base_dir().expect("state base dir");
-    fs::create_dir_all(&state_dir).unwrap();
+    let canonical = csa_config::paths::state_dir_write().expect("canonical state dir");
+    let legacy = csa_config::paths::legacy_state_dir().expect("legacy state dir");
 
-    let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
-    fs::write(
-        &cache_path,
-        r#"
+    for state_dir in [&canonical, &legacy] {
+        fs::create_dir_all(state_dir).unwrap();
+        let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
+        fs::write(
+            &cache_path,
+            r#"
 size_bytes = 999999999
 scanned_at = 1
 "#,
-    )
-    .unwrap();
-    assert!(
-        cache_path.exists(),
-        "test precondition: cache file must exist"
-    );
+        )
+        .unwrap();
+        assert!(
+            cache_path.exists(),
+            "test precondition: cache file must exist at {}",
+            cache_path.display()
+        );
+    }
 
     handle_gc_global(true, None, OutputFormat::Text).expect("global dry-run gc should succeed");
 
-    assert!(
-        cache_path.exists(),
-        "dry-run gc must not invalidate the cached state-dir size reading"
-    );
+    for state_dir in [&canonical, &legacy] {
+        let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
+        assert!(
+            cache_path.exists(),
+            "dry-run gc must not invalidate the cached state-dir size reading at {}",
+            cache_path.display()
+        );
+    }
 }
 
 // --- Retirement logic tests ---

--- a/crates/cli-sub-agent/src/gc_tests.rs
+++ b/crates/cli-sub-agent/src/gc_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_core::types::OutputFormat;
 use std::os::unix::fs as unix_fs;
 use tempfile::tempdir;
 
@@ -233,6 +235,35 @@ fn test_discover_finds_rotation_only_roots() {
         roots.len(),
         1,
         "Root with empty sessions/ + rotation.toml should be discovered"
+    );
+}
+
+#[test]
+fn test_gc_global_invalidates_state_dir_size_cache() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let state_dir = csa_config::GlobalConfig::state_base_dir().expect("state base dir");
+    fs::create_dir_all(&state_dir).unwrap();
+
+    let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
+    fs::write(
+        &cache_path,
+        r#"
+size_bytes = 999999999
+scanned_at = 1
+"#,
+    )
+    .unwrap();
+    assert!(
+        cache_path.exists(),
+        "test precondition: cache file must exist"
+    );
+
+    handle_gc_global(true, None, OutputFormat::Text).expect("global gc should succeed");
+
+    assert!(
+        !cache_path.exists(),
+        "gc must invalidate the cached state-dir size reading"
     );
 }
 

--- a/crates/cli-sub-agent/src/gc_tests.rs
+++ b/crates/cli-sub-agent/src/gc_tests.rs
@@ -259,11 +259,40 @@ scanned_at = 1
         "test precondition: cache file must exist"
     );
 
-    handle_gc_global(true, None, OutputFormat::Text).expect("global gc should succeed");
+    handle_gc_global(false, None, OutputFormat::Text).expect("global gc should succeed");
 
     assert!(
         !cache_path.exists(),
         "gc must invalidate the cached state-dir size reading"
+    );
+}
+
+#[test]
+fn test_gc_global_dry_run_preserves_state_dir_size_cache() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let state_dir = csa_config::GlobalConfig::state_base_dir().expect("state base dir");
+    fs::create_dir_all(&state_dir).unwrap();
+
+    let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
+    fs::write(
+        &cache_path,
+        r#"
+size_bytes = 999999999
+scanned_at = 1
+"#,
+    )
+    .unwrap();
+    assert!(
+        cache_path.exists(),
+        "test precondition: cache file must exist"
+    );
+
+    handle_gc_global(true, None, OutputFormat::Text).expect("global dry-run gc should succeed");
+
+    assert!(
+        cache_path.exists(),
+        "dry-run gc must not invalidate the cached state-dir size reading"
     );
 }
 

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -37,6 +37,7 @@ mod pipeline_transcript;
 mod plan_cmd;
 mod plan_condition;
 mod plan_display;
+mod preflight_state_dir;
 mod preflight_symlink;
 mod process_tree;
 mod review_cmd;

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -371,8 +371,9 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     debug!(tool = %executor.tool_name(), can_edit, can_write_new, "Restriction flags resolved");
     let raw_prompt = prompt.to_string();
     let mut effective_prompt = raw_prompt.clone();
+    crate::preflight_state_dir::enforce_state_dir_cap(global_config)?;
     if (session_arg.is_none() || fresh_spawn_preflight_override)
-        && let Some(w) = crate::preflight_state_dir::run_state_dir_preflight(global_config)?
+        && let Some(w) = crate::preflight_state_dir::run_state_dir_preflight(global_config)
     {
         effective_prompt = format!("{w}{effective_prompt}");
     }
@@ -504,7 +505,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         ("CHANGED_CRATES_FLAGS".to_string(), String::new()),
     ]);
     run_pipeline_hook(HookEvent::PreRun, &hooks_config, &pre_run_vars)?;
-
     // New-file guard captured AFTER PreRun hooks (baseline includes hook-created files).
     let new_file_guard = if !can_write_new {
         crate::edit_restriction_guard::maybe_capture_new_file_guard(project_root)?

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -275,20 +275,23 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     } else {
         None
     };
+    let mut persist_pre_exec_failure = |err: anyhow::Error| {
+        write_pre_exec_error_result(
+            project_root,
+            &session.meta_session_id,
+            executor.tool_name(),
+            &err,
+        );
+        if let Some(ref mut cg) = cleanup_guard {
+            cg.defuse();
+        }
+        err
+    };
     let (_log_writer, _log_guard) = match csa_executor::create_session_log_writer(&session_dir) {
         Ok(pair) => pair,
         Err(e) => {
             let err = anyhow::anyhow!(e).context("Failed to create session log writer");
-            write_pre_exec_error_result(
-                project_root,
-                &session.meta_session_id,
-                executor.tool_name(),
-                &err,
-            );
-            if let Some(ref mut cg) = cleanup_guard {
-                cg.defuse();
-            }
-            return Err(err);
+            return Err(persist_pre_exec_failure(err));
         }
     };
     let lock_reason = truncate_prompt(prompt, 80);
@@ -299,16 +302,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
                 "Failed to acquire lock for session {}",
                 session.meta_session_id
             ));
-            write_pre_exec_error_result(
-                project_root,
-                &session.meta_session_id,
-                executor.tool_name(),
-                &err,
-            );
-            if let Some(ref mut cg) = cleanup_guard {
-                cg.defuse();
-            }
-            return Err(err);
+            return Err(persist_pre_exec_failure(err));
         }
     };
     let mut resource_guard = config.map(|cfg| {
@@ -319,16 +313,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     if let Some(ref mut guard) = resource_guard
         && let Err(e) = guard.check_availability(executor.tool_name())
     {
-        write_pre_exec_error_result(
-            project_root,
-            &session.meta_session_id,
-            executor.tool_name(),
-            &e,
-        );
-        if let Some(ref mut cg) = cleanup_guard {
-            cg.defuse();
-        }
-        return Err(e);
+        return Err(persist_pre_exec_failure(e));
     }
     if let (Some(guard), Some(cfg)) = (&mut resource_guard, config) {
         guard.check_health(
@@ -371,7 +356,9 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     debug!(tool = %executor.tool_name(), can_edit, can_write_new, "Restriction flags resolved");
     let raw_prompt = prompt.to_string();
     let mut effective_prompt = raw_prompt.clone();
-    crate::preflight_state_dir::enforce_state_dir_cap(global_config)?;
+    if let Err(err) = crate::preflight_state_dir::enforce_state_dir_cap(global_config) {
+        return Err(persist_pre_exec_failure(err));
+    }
     if (session_arg.is_none() || fresh_spawn_preflight_override)
         && let Some(w) = crate::preflight_state_dir::run_state_dir_preflight(global_config)
     {

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -371,6 +371,11 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     debug!(tool = %executor.tool_name(), can_edit, can_write_new, "Restriction flags resolved");
     let raw_prompt = prompt.to_string();
     let mut effective_prompt = raw_prompt.clone();
+    if (session_arg.is_none() || fresh_spawn_preflight_override)
+        && let Some(w) = crate::preflight_state_dir::run_state_dir_preflight(global_config)?
+    {
+        effective_prompt = format!("{w}{effective_prompt}");
+    }
     let is_first_turn = session
         .tools
         .get(executor.tool_name())
@@ -457,7 +462,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             ..Default::default()
         }
     });
-
     let mut merged_env = crate::pipeline_env::build_merged_env(
         extra_env,
         config,
@@ -539,7 +543,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         info!("Injecting structured output instructions into prompt");
         effective_prompt.push_str(instructions);
     }
-
     // Resolve sandbox configuration from project config and enforcement mode.
     let liveness_dead_seconds = resolve_liveness_dead_seconds(config);
     let mut execute_options = match crate::pipeline_sandbox::resolve_sandbox_options(
@@ -582,7 +585,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         execute_options.with_output_spool_rotation(spool_max_bytes, spool_keep_rotated);
     execute_options.output_spool = Some(session_dir.join("output.log"));
     apply_transport_failover_overrides(&mut execute_options, merged_env_ref);
-
     crate::pipeline_sandbox::record_sandbox_telemetry(&execute_options, &mut session);
     crate::pipeline_sandbox::maybe_inflate_balloon(tool.as_str());
     if let Err(err) = session_exec_metadata::persist_session_runtime_binary(&session_dir, executor)
@@ -593,7 +595,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             "Failed to persist session runtime binary metadata"
         );
     }
-
     let pre_exec_snapshot = session_exec_audit::capture_pre_execution_snapshot(project_root);
     let transport_result = crate::pipeline_execute::execute_transport_with_signal(
         executor,

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -254,6 +254,7 @@ async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
         csa_session::create_session(project_root, Some("resume target"), None, Some("opencode"))
             .expect("create resume session");
     let stale_summary = "stale prior result";
+    let stale_manager_summary = "stale sidecar manager summary";
     csa_session::save_result(
         project_root,
         &session.meta_session_id,
@@ -267,7 +268,15 @@ async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
             events_count: 0,
             artifacts: Vec::new(),
             peak_memory_mb: None,
-            manager_fields: Default::default(),
+            manager_fields: csa_session::SessionManagerFields {
+                report: Some(
+                    toml::toml! {
+                        summary = stale_manager_summary
+                    }
+                    .into(),
+                ),
+                ..Default::default()
+            },
         },
     )
     .expect("seed stale result");
@@ -316,5 +325,22 @@ async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
     assert_ne!(
         loaded.summary, stale_summary,
         "resume path must overwrite stale result.toml"
+    );
+    assert!(
+        loaded.manager_fields.as_sidecar().is_none(),
+        "cap-error overwrite must not rehydrate stale manager sidecar fields"
+    );
+    assert!(
+        loaded
+            .artifacts
+            .iter()
+            .all(|artifact| artifact.path != csa_session::CONTRACT_RESULT_ARTIFACT_PATH),
+        "cap-error overwrite must not keep advertising the stale manager sidecar"
+    );
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    assert!(
+        !csa_session::contract_result_path(&session_dir).exists(),
+        "cap-error overwrite must clear the stale manager sidecar file"
     );
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -1,6 +1,67 @@
+use super::*;
 use crate::session_guard::{SessionCleanupGuard, write_pre_exec_error_result};
 use crate::test_session_sandbox::ScopedSessionSandbox;
+use chrono::Utc;
+use csa_config::GlobalConfig;
+use csa_core::types::OutputFormat;
+use csa_executor::Executor;
 use std::fs;
+use std::path::Path;
+
+const STATE_DIR_CAP_TEST_BYTES: u64 = 2 * 1024 * 1024;
+
+fn state_dir_error_global_config() -> GlobalConfig {
+    toml::from_str(
+        r#"
+        [state_dir]
+        max_size_mb = 1
+        scan_interval_seconds = 0
+        on_exceed = "error"
+        "#,
+    )
+    .expect("parse global config")
+}
+
+fn seed_state_dir_over_cap() {
+    let state_dir = csa_config::paths::state_dir().expect("state dir");
+    fs::create_dir_all(&state_dir).expect("create state dir");
+    let filler = std::fs::File::create(state_dir.join("oversized.bin")).expect("create filler");
+    filler
+        .set_len(STATE_DIR_CAP_TEST_BYTES)
+        .expect("extend filler file");
+}
+
+fn assert_state_dir_cap_failure_result(project_root: &Path, session_id: &str) {
+    let session_dir = csa_session::get_session_dir(project_root, session_id).expect("session dir");
+    assert!(
+        session_dir.exists(),
+        "session directory must survive pre-exec state-dir cap failure"
+    );
+
+    let result_path = session_dir.join("result.toml");
+    assert!(result_path.exists(), "result.toml must be written");
+
+    let raw_result = fs::read_to_string(&result_path).expect("read result.toml");
+    assert!(
+        raw_result.contains("/ 1 MB cap exceeded"),
+        "result.toml must record the configured cap: {raw_result}"
+    );
+    assert!(
+        raw_result.contains("on_exceed = \"error\""),
+        "result.toml must record on_exceed=error: {raw_result}"
+    );
+
+    let loaded = csa_session::load_result(project_root, session_id)
+        .expect("load_result must not error")
+        .expect("result.toml must exist");
+    assert_eq!(loaded.status, "failure");
+    assert!(loaded.summary.starts_with("pre-exec:"));
+    assert!(
+        loaded.summary.contains("cap exceeded"),
+        "summary must mention cap failure, got: {}",
+        loaded.summary
+    );
+}
 
 /// Verify that `SessionCleanupGuard` removes the directory on drop when not defused.
 #[test]
@@ -110,4 +171,150 @@ fn pre_exec_error_writes_failure_result() {
     );
     assert_eq!(loaded.tool, "codex");
     assert!(loaded.artifacts.is_empty());
+}
+
+#[tokio::test]
+async fn state_dir_cap_failure_persists_result_for_fresh_spawn() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut sandbox = ScopedSessionSandbox::new(&tmp).await;
+    sandbox.track_env("CSA_SESSION_ID");
+    // SAFETY: test-scoped env mutation while ScopedSessionSandbox holds TEST_ENV_LOCK.
+    unsafe { std::env::remove_var("CSA_SESSION_ID") };
+    let project_root = tmp.path();
+    let global = state_dir_error_global_config();
+    let executor = Executor::Opencode {
+        model_override: None,
+        agent: None,
+        thinking_budget: None,
+    };
+
+    seed_state_dir_over_cap();
+
+    let err = match execute_with_session_and_meta(
+        &executor,
+        &ToolName::Opencode,
+        "trip the state-dir cap",
+        OutputFormat::Json,
+        None,
+        false,
+        Some("fresh-state-dir-cap".to_string()),
+        None,
+        project_root,
+        None,
+        None,
+        Some("run"),
+        None,
+        None,
+        csa_process::StreamMode::BufferOnly,
+        DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        None,
+        None,
+        Some(&global),
+        false,
+        false,
+        &[],
+        &[],
+    )
+    .await
+    {
+        Ok(_) => panic!("state-dir cap must reject fresh spawn"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.to_string().contains("cap exceeded"),
+        "fresh-spawn error should mention the state-dir cap: {err:#}"
+    );
+
+    let sessions = csa_session::list_sessions(project_root, None).expect("list sessions");
+    assert_eq!(
+        sessions.len(),
+        1,
+        "fresh-spawn pre-exec failure must preserve the new session"
+    );
+    assert_state_dir_cap_failure_result(project_root, &sessions[0].meta_session_id);
+}
+
+#[tokio::test]
+async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let global = state_dir_error_global_config();
+    let executor = Executor::Opencode {
+        model_override: None,
+        agent: None,
+        thinking_budget: None,
+    };
+
+    seed_state_dir_over_cap();
+
+    let session =
+        csa_session::create_session(project_root, Some("resume target"), None, Some("opencode"))
+            .expect("create resume session");
+    let stale_summary = "stale prior result";
+    csa_session::save_result(
+        project_root,
+        &session.meta_session_id,
+        &csa_session::SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: stale_summary.to_string(),
+            tool: "opencode".to_string(),
+            started_at: Utc::now(),
+            completed_at: Utc::now(),
+            events_count: 0,
+            artifacts: Vec::new(),
+            peak_memory_mb: None,
+            manager_fields: Default::default(),
+        },
+    )
+    .expect("seed stale result");
+
+    let err = match execute_with_session_and_meta(
+        &executor,
+        &ToolName::Opencode,
+        "trip the state-dir cap on resume",
+        OutputFormat::Json,
+        Some(session.meta_session_id.clone()),
+        false,
+        Some("resume-state-dir-cap".to_string()),
+        None,
+        project_root,
+        None,
+        None,
+        Some("run"),
+        None,
+        None,
+        csa_process::StreamMode::BufferOnly,
+        DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        None,
+        None,
+        Some(&global),
+        false,
+        false,
+        &[],
+        &[],
+    )
+    .await
+    {
+        Ok(_) => panic!("state-dir cap must reject resume"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.to_string().contains("cap exceeded"),
+        "resume error should mention the state-dir cap: {err:#}"
+    );
+
+    assert_state_dir_cap_failure_result(project_root, &session.meta_session_id);
+    let loaded = csa_session::load_result(project_root, &session.meta_session_id)
+        .expect("load_result must not error")
+        .expect("result.toml must exist");
+    assert_ne!(
+        loaded.summary, stale_summary,
+        "resume path must overwrite stale result.toml"
+    );
 }

--- a/crates/cli-sub-agent/src/preflight_state_dir.rs
+++ b/crates/cli-sub-agent/src/preflight_state_dir.rs
@@ -27,19 +27,34 @@ pub(crate) enum StateDirCheckResult {
     Error(anyhow::Error),
 }
 
-/// Run state-dir preflight from global config. Returns `Ok(Some(preamble))` for
-/// warning injection, `Ok(None)` when within cap or unconfigured, `Err` on block.
-pub(crate) fn run_state_dir_preflight(
+/// Enforce the state-dir hard cap. MUST run on **every** execution (fresh or resumed).
+/// Returns `Err` when `on_exceed = "error"` and size exceeds cap. Returns `Ok(())` otherwise.
+pub(crate) fn enforce_state_dir_cap(
     global_config: Option<&csa_config::GlobalConfig>,
-) -> anyhow::Result<Option<String>> {
+) -> anyhow::Result<()> {
     let config = match global_config {
         Some(gc) if gc.state_dir.max_size_mb > 0 => &gc.state_dir,
-        _ => return Ok(None),
+        _ => return Ok(()),
     };
     match check_state_dir_size(config) {
-        StateDirCheckResult::Ok => Ok(None),
-        StateDirCheckResult::Warn(preamble) => Ok(Some(preamble)),
         StateDirCheckResult::Error(err) => Err(err),
+        _ => Ok(()),
+    }
+}
+
+/// Run state-dir preflight preamble injection. Returns `Ok(Some(preamble))` for
+/// warning injection on fresh-spawn, `Ok(None)` when within cap or unconfigured.
+/// Does NOT enforce the hard block — call `enforce_state_dir_cap()` separately.
+pub(crate) fn run_state_dir_preflight(
+    global_config: Option<&csa_config::GlobalConfig>,
+) -> Option<String> {
+    let config = match global_config {
+        Some(gc) if gc.state_dir.max_size_mb > 0 => &gc.state_dir,
+        _ => return None,
+    };
+    match check_state_dir_size(config) {
+        StateDirCheckResult::Warn(preamble) => Some(preamble),
+        _ => None,
     }
 }
 
@@ -170,20 +185,28 @@ fn walk_dir_size(dir: &Path, total: &mut u64) -> Result<()> {
 
     for entry in entries {
         let entry = entry?;
-        let metadata = match entry.metadata() {
-            Ok(m) => m,
+        // Use file_type() which does NOT follow symlinks (unlike metadata()).
+        // This prevents traversal outside the state tree and infinite recursion
+        // on symlink cycles. Matches the safe pattern in gc.rs:672.
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
             Err(e) => {
                 debug!(path = %entry.path().display(), error = %e, "Skipping entry during size walk");
                 continue;
             }
         };
 
-        if metadata.is_file() {
-            *total = total.saturating_add(metadata.len());
-        } else if metadata.is_dir() {
+        if ft.is_symlink() {
+            continue; // Skip symlinks: avoids external overcount + loop recursion
+        } else if ft.is_file() {
+            // symlink_metadata() is equivalent to metadata() for non-symlinks,
+            // but we've already excluded symlinks above so either call is safe.
+            if let Ok(m) = entry.metadata() {
+                *total = total.saturating_add(m.len());
+            }
+        } else if ft.is_dir() {
             walk_dir_size(&entry.path(), total)?;
         }
-        // Skip symlinks to avoid double-counting
     }
     Ok(())
 }
@@ -329,5 +352,128 @@ mod tests {
         assert_eq!(config.scan_interval_seconds, 3600);
         assert_eq!(config.on_exceed, StateDirOnExceed::Warn);
         assert!(config.is_default());
+    }
+
+    /// HIGH-1 regression: symlinks must not be followed during size walk.
+    /// A symlink pointing to a large external file must NOT inflate the total.
+    #[cfg(unix)]
+    #[test]
+    fn symlink_to_external_file_not_counted() {
+        let state = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+
+        // Real file inside state dir: 10 bytes
+        std::fs::write(state.path().join("real.txt"), "0123456789").unwrap();
+
+        // Large external file: 1000 bytes
+        std::fs::write(external.path().join("big.bin"), vec![0u8; 1000]).unwrap();
+
+        // Symlink inside state dir → external file
+        std::os::unix::fs::symlink(
+            external.path().join("big.bin"),
+            state.path().join("link_to_big"),
+        )
+        .unwrap();
+
+        let size = compute_state_dir_size(state.path()).unwrap();
+        // Should only count the 10-byte real file, NOT the 1000-byte symlink target
+        assert_eq!(size, 10);
+    }
+
+    /// HIGH-1 regression: a symlink cycle (dir → ancestor) must not infinite-recurse.
+    #[cfg(unix)]
+    #[test]
+    fn symlink_cycle_does_not_infinite_recurse() {
+        let state = tempfile::tempdir().unwrap();
+        std::fs::write(state.path().join("data.txt"), "abc").unwrap();
+
+        // Create symlink pointing back to the state dir root (cycle)
+        std::os::unix::fs::symlink(state.path(), state.path().join("cycle_link")).unwrap();
+
+        // Must return without hanging; the cycle link is skipped.
+        let size = compute_state_dir_size(state.path()).unwrap();
+        assert_eq!(size, 3); // Only "abc"
+    }
+
+    /// HIGH-2 regression: enforce_state_dir_cap must block on_exceed="error" even
+    /// when called from a resume path (no fresh_spawn_preflight_override).
+    ///
+    /// Since check_state_dir_size reads paths::state_dir() internally, we test:
+    /// 1. The public enforce_state_dir_cap API exercises the config → check path.
+    /// 2. The core enum logic: size > cap + on_exceed=error => Error variant.
+    #[test]
+    fn enforce_cap_blocks_on_error_mode() {
+        use csa_config::GlobalConfig;
+
+        let gc: GlobalConfig = toml::from_str(
+            r#"
+            [state_dir]
+            max_size_mb = 1
+            scan_interval_seconds = 0
+            on_exceed = "error"
+            "#,
+        )
+        .unwrap();
+
+        // Exercise the public API path (uses real state_dir()).
+        // Result depends on actual state dir size — we can't control it here,
+        // but this proves enforce_state_dir_cap routes through check_state_dir_size.
+        let _result = enforce_state_dir_cap(Some(&gc));
+
+        // Core enum-routing test: verify that when size > cap AND on_exceed=error,
+        // check_state_dir_size returns the Error variant (not Warn/Ok).
+        let config = StateDirConfig {
+            max_size_mb: 1,
+            scan_interval_seconds: 0,
+            on_exceed: StateDirOnExceed::Error,
+        };
+        // check_state_dir_size reads paths::state_dir(); if real dir > 1 MB → Error,
+        // if ≤ 1 MB or missing → Ok. Both are valid; the key invariant is it never
+        // returns Warn for on_exceed=error.
+        let result = check_state_dir_size(&config);
+        assert!(
+            !matches!(result, StateDirCheckResult::Warn(_)),
+            "on_exceed=error must never produce Warn variant"
+        );
+    }
+
+    /// HIGH-2 regression: run_state_dir_preflight returns preamble (not error) for warn mode.
+    #[test]
+    fn warn_mode_returns_preamble_not_error() {
+        let config = StateDirConfig {
+            max_size_mb: 1,
+            scan_interval_seconds: 0,
+            on_exceed: StateDirOnExceed::Warn,
+        };
+        // For warn mode, check_state_dir_size returns Warn (if over) or Ok (if under).
+        // Either way it must NOT return Error.
+        let result = check_state_dir_size(&config);
+        assert!(
+            !matches!(result, StateDirCheckResult::Error(_)),
+            "Warn mode must never produce Error variant"
+        );
+    }
+
+    /// HIGH-2 regression: enforce_state_dir_cap with warn mode returns Ok (not Err).
+    #[test]
+    fn enforce_cap_allows_warn_mode() {
+        use csa_config::GlobalConfig;
+
+        let gc: GlobalConfig = toml::from_str(
+            r#"
+            [state_dir]
+            max_size_mb = 1
+            scan_interval_seconds = 0
+            on_exceed = "warn"
+            "#,
+        )
+        .unwrap();
+
+        // enforce_state_dir_cap should Ok even if state dir is over cap in warn mode
+        let result = enforce_state_dir_cap(Some(&gc));
+        assert!(
+            result.is_ok(),
+            "Warn mode must not return Err from enforce_state_dir_cap"
+        );
     }
 }

--- a/crates/cli-sub-agent/src/preflight_state_dir.rs
+++ b/crates/cli-sub-agent/src/preflight_state_dir.rs
@@ -176,11 +176,11 @@ fn get_or_compute_size(state_dir: &Path, scan_interval_seconds: u64) -> Result<u
 /// Walk the state directory tree and sum all file sizes.
 pub(crate) fn compute_state_dir_size(state_dir: &Path) -> Result<u64> {
     let mut total: u64 = 0;
-    walk_dir_size(state_dir, &mut total)?;
+    walk_dir_size(state_dir, state_dir, &mut total)?;
     Ok(total)
 }
 
-fn walk_dir_size(dir: &Path, total: &mut u64) -> Result<()> {
+fn walk_dir_size(root: &Path, dir: &Path, total: &mut u64) -> Result<()> {
     let entries = match std::fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -206,13 +206,21 @@ fn walk_dir_size(dir: &Path, total: &mut u64) -> Result<()> {
         if ft.is_symlink() {
             continue; // Skip symlinks: avoids external overcount + loop recursion
         } else if ft.is_file() {
+            if dir == root
+                && entry
+                    .path()
+                    .file_name()
+                    .is_some_and(|name| name == std::ffi::OsStr::new(SIZE_CACHE_FILENAME))
+            {
+                continue;
+            }
             // symlink_metadata() is equivalent to metadata() for non-symlinks,
             // but we've already excluded symlinks above so either call is safe.
             if let Ok(m) = entry.metadata() {
                 *total = total.saturating_add(m.len());
             }
         } else if ft.is_dir() {
-            walk_dir_size(&entry.path(), total)?;
+            walk_dir_size(root, &entry.path(), total)?;
         }
     }
     Ok(())
@@ -302,6 +310,25 @@ mod tests {
         // Should have rescanned — real size is 512 (data file)
         // The cache file itself also exists now but we don't count it as 999.
         assert_ne!(size, 999);
+    }
+
+    #[test]
+    fn repeated_rescans_ignore_root_size_cache_file() {
+        const ONE_MIB: u64 = 1024 * 1024;
+
+        let d = tempfile::tempdir().unwrap();
+        let file = std::fs::File::create(d.path().join("exact.bin")).unwrap();
+        file.set_len(ONE_MIB).unwrap();
+
+        let first = get_or_compute_size(d.path(), 0).unwrap();
+        assert_eq!(first, ONE_MIB);
+        assert!(
+            d.path().join(SIZE_CACHE_FILENAME).exists(),
+            "first scan should write the cache file"
+        );
+
+        let second = get_or_compute_size(d.path(), 0).unwrap();
+        assert_eq!(second, ONE_MIB);
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/preflight_state_dir.rs
+++ b/crates/cli-sub-agent/src/preflight_state_dir.rs
@@ -89,8 +89,9 @@ fn check_state_dir_size(config: &StateDirConfig) -> StateDirCheckResult {
 
     let size_mb = size_bytes / (1024 * 1024);
     let cap_mb = config.max_size_mb;
+    let cap_bytes = cap_mb.saturating_mul(1024 * 1024);
 
-    if size_mb <= cap_mb {
+    if size_bytes <= cap_bytes {
         debug!(size_mb, cap_mb, "State directory within cap");
         return StateDirCheckResult::Ok;
     }
@@ -236,6 +237,7 @@ fn now_unix_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
     use csa_config::{StateDirConfig, StateDirOnExceed};
 
     #[test]
@@ -352,6 +354,49 @@ mod tests {
         assert_eq!(config.scan_interval_seconds, 3600);
         assert_eq!(config.on_exceed, StateDirOnExceed::Warn);
         assert!(config.is_default());
+    }
+
+    #[test]
+    fn cap_boundary_uses_raw_bytes_instead_of_floored_mib() {
+        const ONE_MIB: u64 = 1024 * 1024;
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let config = StateDirConfig {
+            max_size_mb: 1,
+            scan_interval_seconds: 0,
+            on_exceed: StateDirOnExceed::Error,
+        };
+
+        {
+            let temp = tempfile::tempdir().unwrap();
+            let state_home = temp.path().join("xdg-state");
+            let _home_guard = ScopedEnvVarRestore::set("HOME", temp.path());
+            let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+            let state_dir = csa_config::paths::state_dir().unwrap();
+            std::fs::create_dir_all(&state_dir).unwrap();
+            let file = std::fs::File::create(state_dir.join("exact.bin")).unwrap();
+            file.set_len(ONE_MIB).unwrap();
+
+            assert!(matches!(
+                check_state_dir_size(&config),
+                StateDirCheckResult::Ok
+            ));
+        }
+
+        {
+            let temp = tempfile::tempdir().unwrap();
+            let state_home = temp.path().join("xdg-state");
+            let _home_guard = ScopedEnvVarRestore::set("HOME", temp.path());
+            let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+            let state_dir = csa_config::paths::state_dir().unwrap();
+            std::fs::create_dir_all(&state_dir).unwrap();
+            let file = std::fs::File::create(state_dir.join("over.bin")).unwrap();
+            file.set_len(ONE_MIB + 1).unwrap();
+
+            assert!(matches!(
+                check_state_dir_size(&config),
+                StateDirCheckResult::Error(_)
+            ));
+        }
     }
 
     /// HIGH-1 regression: symlinks must not be followed during size walk.

--- a/crates/cli-sub-agent/src/preflight_state_dir.rs
+++ b/crates/cli-sub-agent/src/preflight_state_dir.rs
@@ -67,25 +67,28 @@ fn check_state_dir_size(config: &StateDirConfig) -> StateDirCheckResult {
         return StateDirCheckResult::Ok;
     }
 
-    let state_dir = match csa_config::paths::state_dir() {
-        Some(d) => d,
-        None => {
-            debug!("State directory not resolvable; skipping size check");
-            return StateDirCheckResult::Ok;
-        }
-    };
-
-    if !state_dir.exists() {
+    let state_roots = csa_config::paths::state_dir_all_roots();
+    if state_roots.is_empty() {
+        debug!("No existing state directory roots found; skipping size check");
         return StateDirCheckResult::Ok;
     }
 
-    let size_bytes = match get_or_compute_size(&state_dir, config.scan_interval_seconds) {
-        Ok(size) => size,
-        Err(e) => {
-            warn!(error = %e, "Failed to compute state directory size; skipping check");
-            return StateDirCheckResult::Ok;
+    let mut size_bytes = 0u64;
+    for state_root in &state_roots {
+        match get_or_compute_size(state_root, config.scan_interval_seconds) {
+            Ok(size) => {
+                size_bytes = size_bytes.saturating_add(size);
+            }
+            Err(e) => {
+                warn!(
+                    path = %state_root.display(),
+                    error = %e,
+                    "Failed to compute state directory size; skipping check"
+                );
+                return StateDirCheckResult::Ok;
+            }
         }
-    };
+    }
 
     let size_mb = size_bytes / (1024 * 1024);
     let cap_mb = config.max_size_mb;
@@ -430,6 +433,59 @@ mod tests {
                 StateDirCheckResult::Error(_)
             ));
         }
+    }
+
+    fn run_dual_root_cap_check(canonical_bytes: u64, legacy_bytes: u64) -> StateDirCheckResult {
+        let temp = tempfile::tempdir().unwrap();
+        let state_home = temp.path().join("xdg-state");
+        let _home_guard = ScopedEnvVarRestore::set("HOME", temp.path());
+        let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+
+        let canonical = csa_config::paths::state_dir_write().expect("canonical state dir");
+        let legacy = csa_config::paths::legacy_state_dir().expect("legacy state dir");
+        std::fs::create_dir_all(&canonical).unwrap();
+        std::fs::create_dir_all(&legacy).unwrap();
+
+        if canonical_bytes > 0 {
+            let file = std::fs::File::create(canonical.join("canonical.bin")).unwrap();
+            file.set_len(canonical_bytes).unwrap();
+        }
+        if legacy_bytes > 0 {
+            let file = std::fs::File::create(legacy.join("legacy.bin")).unwrap();
+            file.set_len(legacy_bytes).unwrap();
+        }
+
+        check_state_dir_size(&StateDirConfig {
+            max_size_mb: 1,
+            scan_interval_seconds: 0,
+            on_exceed: StateDirOnExceed::Error,
+        })
+    }
+
+    fn assert_cap_error_size(result: StateDirCheckResult, actual_mb: u64) {
+        match result {
+            StateDirCheckResult::Error(err) => {
+                let message = err.to_string();
+                assert!(
+                    message.contains(&format!("{actual_mb} MB / 1 MB cap exceeded")),
+                    "unexpected error message: {message}"
+                );
+            }
+            StateDirCheckResult::Warn(message) => {
+                panic!("expected error result, got warning: {message}")
+            }
+            StateDirCheckResult::Ok => panic!("expected error result, got ok"),
+        }
+    }
+
+    #[test]
+    fn check_state_dir_size_sums_existing_canonical_and_legacy_roots() {
+        const ONE_MIB: u64 = 1024 * 1024;
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+
+        assert_cap_error_size(run_dual_root_cap_check(0, 2 * ONE_MIB), 2);
+        assert_cap_error_size(run_dual_root_cap_check(2 * ONE_MIB, 0), 2);
+        assert_cap_error_size(run_dual_root_cap_check(ONE_MIB, ONE_MIB), 2);
     }
 
     /// HIGH-1 regression: symlinks must not be followed during size walk.

--- a/crates/cli-sub-agent/src/preflight_state_dir.rs
+++ b/crates/cli-sub-agent/src/preflight_state_dir.rs
@@ -1,0 +1,333 @@
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Result, anyhow};
+use csa_config::StateDirConfig;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+/// Cached size measurement for the state directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SizeCache {
+    /// Total size in bytes.
+    size_bytes: u64,
+    /// Unix timestamp (seconds) of last scan.
+    scanned_at: u64,
+}
+
+const SIZE_CACHE_FILENAME: &str = ".size-cache.toml";
+
+/// Result of the state directory preflight check.
+pub(crate) enum StateDirCheckResult {
+    /// No cap configured or size is within limits.
+    Ok,
+    /// Size exceeds cap — returns warning preamble to inject.
+    Warn(String),
+    /// Size exceeds cap and `on_exceed = error`.
+    Error(anyhow::Error),
+}
+
+/// Run state-dir preflight from global config. Returns `Ok(Some(preamble))` for
+/// warning injection, `Ok(None)` when within cap or unconfigured, `Err` on block.
+pub(crate) fn run_state_dir_preflight(
+    global_config: Option<&csa_config::GlobalConfig>,
+) -> anyhow::Result<Option<String>> {
+    let config = match global_config {
+        Some(gc) if gc.state_dir.max_size_mb > 0 => &gc.state_dir,
+        _ => return Ok(None),
+    };
+    match check_state_dir_size(config) {
+        StateDirCheckResult::Ok => Ok(None),
+        StateDirCheckResult::Warn(preamble) => Ok(Some(preamble)),
+        StateDirCheckResult::Error(err) => Err(err),
+    }
+}
+
+/// Run the state directory size check against the configured cap.
+///
+/// Returns a `StateDirCheckResult` indicating whether the session should
+/// proceed (with optional warning injection) or be blocked.
+fn check_state_dir_size(config: &StateDirConfig) -> StateDirCheckResult {
+    if config.max_size_mb == 0 {
+        return StateDirCheckResult::Ok;
+    }
+
+    let state_dir = match csa_config::paths::state_dir() {
+        Some(d) => d,
+        None => {
+            debug!("State directory not resolvable; skipping size check");
+            return StateDirCheckResult::Ok;
+        }
+    };
+
+    if !state_dir.exists() {
+        return StateDirCheckResult::Ok;
+    }
+
+    let size_bytes = match get_or_compute_size(&state_dir, config.scan_interval_seconds) {
+        Ok(size) => size,
+        Err(e) => {
+            warn!(error = %e, "Failed to compute state directory size; skipping check");
+            return StateDirCheckResult::Ok;
+        }
+    };
+
+    let size_mb = size_bytes / (1024 * 1024);
+    let cap_mb = config.max_size_mb;
+
+    if size_mb <= cap_mb {
+        debug!(size_mb, cap_mb, "State directory within cap");
+        return StateDirCheckResult::Ok;
+    }
+
+    info!(size_mb, cap_mb, on_exceed = ?config.on_exceed, "State directory exceeds cap");
+
+    match config.on_exceed {
+        csa_config::StateDirOnExceed::Error => StateDirCheckResult::Error(anyhow!(
+            "State directory is {} MB / {} MB cap exceeded.\n\
+                 To reclaim space: `csa gc --max-age-days 5 --global`\n\
+                 Or raise `state_dir.max_size_mb` in ~/.config/cli-sub-agent/config.toml.",
+            size_mb,
+            cap_mb,
+        )),
+        csa_config::StateDirOnExceed::AutoGc => {
+            // Phase 3 will wire actual gc invocation. For now, fall back to warn.
+            StateDirCheckResult::Warn(build_warning_preamble(
+                size_mb, cap_mb, true, // auto_gc_note
+            ))
+        }
+        csa_config::StateDirOnExceed::Warn => {
+            StateDirCheckResult::Warn(build_warning_preamble(size_mb, cap_mb, false))
+        }
+    }
+}
+
+fn build_warning_preamble(actual_mb: u64, cap_mb: u64, auto_gc_pending: bool) -> String {
+    let auto_gc_note = if auto_gc_pending {
+        "\nNote: `on_exceed = \"auto-gc\"` is configured but not yet implemented (Phase 3).\n\
+         Falling back to warning mode.\n"
+    } else {
+        ""
+    };
+    format!(
+        "\n<state-dir-warning>\n\
+         CSA state directory is {actual_mb} MB / {cap_mb} MB cap exceeded.\n\
+         To reclaim space: `csa gc --max-age-days 5 --global` (removes sessions\n\
+         older than 5 days) or raise `state_dir.max_size_mb` in\n\
+         ~/.config/cli-sub-agent/config.toml.\n\
+         Common large consumers: runtime/gemini-home/.npm (~186 MB each) -- if\n\
+         you're on csa >= 0.1.514, Phase 1 of #1047 should have mitigated this.\
+         {auto_gc_note}\n\
+         </state-dir-warning>\n"
+    )
+}
+
+/// Get the cached size or recompute if stale.
+fn get_or_compute_size(state_dir: &Path, scan_interval_seconds: u64) -> Result<u64> {
+    let cache_path = state_dir.join(SIZE_CACHE_FILENAME);
+
+    // Try to read cached value
+    if let Some(cached) = read_size_cache(&cache_path) {
+        let now = now_unix_secs();
+        if scan_interval_seconds > 0
+            && now.saturating_sub(cached.scanned_at) < scan_interval_seconds
+        {
+            debug!(
+                cached_size_bytes = cached.size_bytes,
+                age_secs = now.saturating_sub(cached.scanned_at),
+                "Using cached state directory size"
+            );
+            return Ok(cached.size_bytes);
+        }
+    }
+
+    let size_bytes = compute_state_dir_size(state_dir)?;
+
+    // Best-effort cache write
+    if let Err(e) = write_size_cache(&cache_path, size_bytes) {
+        debug!(error = %e, "Failed to write size cache (non-fatal)");
+    }
+
+    Ok(size_bytes)
+}
+
+/// Walk the state directory tree and sum all file sizes.
+pub(crate) fn compute_state_dir_size(state_dir: &Path) -> Result<u64> {
+    let mut total: u64 = 0;
+    walk_dir_size(state_dir, &mut total)?;
+    Ok(total)
+}
+
+fn walk_dir_size(dir: &Path, total: &mut u64) -> Result<()> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            debug!(path = %dir.display(), "Permission denied during size walk; skipping");
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let metadata = match entry.metadata() {
+            Ok(m) => m,
+            Err(e) => {
+                debug!(path = %entry.path().display(), error = %e, "Skipping entry during size walk");
+                continue;
+            }
+        };
+
+        if metadata.is_file() {
+            *total = total.saturating_add(metadata.len());
+        } else if metadata.is_dir() {
+            walk_dir_size(&entry.path(), total)?;
+        }
+        // Skip symlinks to avoid double-counting
+    }
+    Ok(())
+}
+
+fn read_size_cache(path: &Path) -> Option<SizeCache> {
+    let content = std::fs::read_to_string(path).ok()?;
+    toml::from_str(&content).ok()
+}
+
+fn write_size_cache(path: &Path, size_bytes: u64) -> Result<()> {
+    let cache = SizeCache {
+        size_bytes,
+        scanned_at: now_unix_secs(),
+    };
+    let content = toml::to_string_pretty(&cache)?;
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use csa_config::{StateDirConfig, StateDirOnExceed};
+
+    #[test]
+    fn compute_size_of_temp_dir() {
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(d.path().join("a.txt"), "hello").unwrap();
+        std::fs::write(d.path().join("b.txt"), "world!").unwrap();
+        std::fs::create_dir(d.path().join("sub")).unwrap();
+        std::fs::write(d.path().join("sub/c.txt"), "!!").unwrap();
+        let size = compute_state_dir_size(d.path()).unwrap();
+        assert_eq!(size, 5 + 6 + 2); // "hello" + "world!" + "!!"
+    }
+
+    #[test]
+    fn cache_roundtrip() {
+        let d = tempfile::tempdir().unwrap();
+        let cache_path = d.path().join(SIZE_CACHE_FILENAME);
+        write_size_cache(&cache_path, 12345).unwrap();
+        let cached = read_size_cache(&cache_path).unwrap();
+        assert_eq!(cached.size_bytes, 12345);
+        assert!(cached.scanned_at > 0);
+    }
+
+    #[test]
+    fn cache_reused_within_interval() {
+        let d = tempfile::tempdir().unwrap();
+        // Create a file so the dir is non-empty
+        std::fs::write(d.path().join("data"), vec![0u8; 1024]).unwrap();
+
+        // Write a cache that claims size=999 (stale value, but within interval)
+        let cache_path = d.path().join(SIZE_CACHE_FILENAME);
+        let cache = SizeCache {
+            size_bytes: 999,
+            scanned_at: now_unix_secs(),
+        };
+        std::fs::write(&cache_path, toml::to_string_pretty(&cache).unwrap()).unwrap();
+
+        let size = get_or_compute_size(d.path(), 3600).unwrap();
+        assert_eq!(size, 999); // Should use cached, not recompute
+    }
+
+    #[test]
+    fn cache_stale_triggers_rescan() {
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(d.path().join("data"), vec![0u8; 512]).unwrap();
+
+        // Write a cache with timestamp far in the past
+        let cache_path = d.path().join(SIZE_CACHE_FILENAME);
+        let cache = SizeCache {
+            size_bytes: 999,
+            scanned_at: 1000, // ancient timestamp
+        };
+        std::fs::write(&cache_path, toml::to_string_pretty(&cache).unwrap()).unwrap();
+
+        let size = get_or_compute_size(d.path(), 3600).unwrap();
+        // Should have rescanned — real size is 512 (data file)
+        // The cache file itself also exists now but we don't count it as 999.
+        assert_ne!(size, 999);
+    }
+
+    #[test]
+    fn zero_cap_always_ok() {
+        let config = StateDirConfig {
+            max_size_mb: 0,
+            ..Default::default()
+        };
+        assert!(matches!(
+            check_state_dir_size(&config),
+            StateDirCheckResult::Ok
+        ));
+    }
+
+    #[test]
+    fn on_exceed_warn_produces_preamble() {
+        let preamble = build_warning_preamble(500, 100, false);
+        assert!(preamble.contains("500 MB"));
+        assert!(preamble.contains("100 MB"));
+        assert!(preamble.contains("csa gc"));
+        assert!(!preamble.contains("auto-gc"));
+    }
+
+    #[test]
+    fn on_exceed_auto_gc_shows_note() {
+        let preamble = build_warning_preamble(500, 100, true);
+        assert!(preamble.contains("auto-gc"));
+        assert!(preamble.contains("not yet implemented"));
+    }
+
+    #[test]
+    fn config_roundtrip_all_on_exceed_variants() {
+        for (input, expected) in [
+            (r#"on_exceed = "warn""#, StateDirOnExceed::Warn),
+            (r#"on_exceed = "error""#, StateDirOnExceed::Error),
+            (r#"on_exceed = "auto-gc""#, StateDirOnExceed::AutoGc),
+        ] {
+            let toml_str = format!("max_size_mb = 1024\nscan_interval_seconds = 3600\n{input}");
+            let parsed: StateDirConfig = toml::from_str(&toml_str).unwrap();
+            assert_eq!(parsed.on_exceed, expected, "for input: {input}");
+
+            // Roundtrip
+            let serialized = toml::to_string(&parsed).unwrap();
+            let reparsed: StateDirConfig = toml::from_str(&serialized).unwrap();
+            assert_eq!(
+                reparsed.on_exceed, expected,
+                "roundtrip failed for: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn config_defaults() {
+        let config: StateDirConfig = toml::from_str("").unwrap();
+        assert_eq!(config.max_size_mb, 0);
+        assert_eq!(config.scan_interval_seconds, 3600);
+        assert_eq!(config.on_exceed, StateDirOnExceed::Warn);
+        assert!(config.is_default());
+    }
+}

--- a/crates/cli-sub-agent/src/preflight_state_dir.rs
+++ b/crates/cli-sub-agent/src/preflight_state_dir.rs
@@ -100,11 +100,8 @@ fn check_state_dir_size(config: &StateDirConfig) -> StateDirCheckResult {
 
     match config.on_exceed {
         csa_config::StateDirOnExceed::Error => StateDirCheckResult::Error(anyhow!(
-            "State directory is {} MB / {} MB cap exceeded.\n\
-                 To reclaim space: `csa gc --max-age-days 5 --global`\n\
-                 Or raise `state_dir.max_size_mb` in ~/.config/cli-sub-agent/config.toml.",
-            size_mb,
-            cap_mb,
+            "{}",
+            build_error_message(size_mb, cap_mb, size_bytes, cap_bytes)
         )),
         csa_config::StateDirOnExceed::AutoGc => {
             // Phase 3 will wire actual gc invocation. For now, fall back to warn.
@@ -116,6 +113,15 @@ fn check_state_dir_size(config: &StateDirConfig) -> StateDirCheckResult {
             StateDirCheckResult::Warn(build_warning_preamble(size_mb, cap_mb, false))
         }
     }
+}
+
+fn build_error_message(actual_mb: u64, cap_mb: u64, actual_bytes: u64, cap_bytes: u64) -> String {
+    format!(
+        "CSA state directory is {actual_mb} MB / {cap_mb} MB cap exceeded \
+         ({actual_bytes} bytes / {cap_bytes} bytes) with `on_exceed = \"error\"`.\n\
+         To reclaim space: `csa gc --max-age-days 5 --global`\n\
+         Or raise `state_dir.max_size_mb` in ~/.config/cli-sub-agent/config.toml."
+    )
 }
 
 fn build_warning_preamble(actual_mb: u64, cap_mb: u64, auto_gc_pending: bool) -> String {

--- a/crates/cli-sub-agent/src/session_guard.rs
+++ b/crates/cli-sub-agent/src/session_guard.rs
@@ -4,7 +4,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 
-use csa_session::{SessionResult, create_session, save_result, save_session};
+use csa_session::{
+    SaveOptions, SessionResult, create_session, save_result_with_options, save_session,
+};
 
 /// RAII guard that cleans up a newly created session directory on failure.
 ///
@@ -91,7 +93,14 @@ pub(crate) fn write_pre_exec_error_result(
         peak_memory_mb: None,
         manager_fields: Default::default(),
     };
-    if let Err(e) = save_result(project_root, session_id, &result) {
+    if let Err(e) = save_result_with_options(
+        project_root,
+        session_id,
+        &result,
+        SaveOptions {
+            clear_stale_manager_sidecar: true,
+        },
+    ) {
         warn!("Failed to save pre-execution error result: {}", e);
     }
     // Best-effort cooldown marker

--- a/crates/cli-sub-agent/tests/config_get_state_dir_e2e.rs
+++ b/crates/cli-sub-agent/tests/config_get_state_dir_e2e.rs
@@ -1,0 +1,64 @@
+use std::path::Path;
+use std::process::Command;
+
+fn csa_cmd(tmp: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+fn global_config_path(tmp: &Path) -> std::path::PathBuf {
+    if cfg!(target_os = "macos") {
+        tmp.join("Library/Application Support/cli-sub-agent/config.toml")
+    } else {
+        tmp.join(".config/cli-sub-agent/config.toml")
+    }
+}
+
+#[test]
+fn config_get_state_dir_keys_require_explicit_global_values() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let global_config_path = global_config_path(tmp.path());
+    let global_dir = global_config_path.parent().expect("global config dir");
+    std::fs::create_dir_all(global_dir).expect("create global config dir");
+    std::fs::write(
+        &global_config_path,
+        r#"
+[state_dir]
+max_size_mb = 1024
+"#,
+    )
+    .expect("write global config");
+
+    let max_size_output = csa_cmd(tmp.path())
+        .args(["config", "get", "state_dir.max_size_mb"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa config get state_dir.max_size_mb");
+    assert!(max_size_output.status.success(), "config get should exit 0");
+    assert_eq!(
+        String::from_utf8_lossy(&max_size_output.stdout).trim(),
+        "1024"
+    );
+
+    for key in ["state_dir.on_exceed", "state_dir.scan_interval_seconds"] {
+        let output = csa_cmd(tmp.path())
+            .args(["config", "get", key])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap_or_else(|_| panic!("failed to run csa config get {key}"));
+
+        assert!(
+            !output.status.success(),
+            "config get for {key} should fail when the key is not explicitly set"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(&format!("Key not found: {key}")),
+            "stderr should report missing explicit key for {key}, got: {stderr}"
+        );
+    }
+}

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -59,6 +59,9 @@ pub struct GlobalConfig {
     /// Pre-flight repository integrity checks before session spawn.
     #[serde(default)]
     pub preflight: PreflightConfig,
+    /// State directory size cap and monitoring configuration.
+    #[serde(default, skip_serializing_if = "StateDirConfig::is_default")]
+    pub state_dir: StateDirConfig,
     /// ACP transport overrides; project-level `[acp]` takes precedence.
     #[serde(default, skip_serializing_if = "crate::AcpConfig::is_default")]
     pub acp: crate::AcpConfig,
@@ -125,6 +128,58 @@ impl AiConfigSymlinkCheckConfig {
     pub fn is_default(&self) -> bool {
         !self.enabled && self.paths.is_none() && self.treat_broken_symlink_as_error
     }
+}
+
+/// State directory size monitoring and cap enforcement.
+///
+/// When `max_size_mb > 0`, CSA scans the state directory on preflight and
+/// takes action when the size exceeds the cap (warn, error, or auto-gc).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateDirConfig {
+    /// Maximum size in MB. `0` (default) = unlimited.
+    #[serde(default)]
+    pub max_size_mb: u64,
+    /// How often to recompute the size (seconds). `0` = every invocation.
+    #[serde(default = "default_scan_interval_seconds")]
+    pub scan_interval_seconds: u64,
+    /// What to do when size exceeds `max_size_mb`.
+    #[serde(default)]
+    pub on_exceed: StateDirOnExceed,
+}
+
+const fn default_scan_interval_seconds() -> u64 {
+    3600
+}
+
+impl Default for StateDirConfig {
+    fn default() -> Self {
+        Self {
+            max_size_mb: 0,
+            scan_interval_seconds: default_scan_interval_seconds(),
+            on_exceed: StateDirOnExceed::default(),
+        }
+    }
+}
+
+impl StateDirConfig {
+    pub fn is_default(&self) -> bool {
+        self.max_size_mb == 0
+            && self.scan_interval_seconds == default_scan_interval_seconds()
+            && self.on_exceed == StateDirOnExceed::Warn
+    }
+}
+
+/// Action taken when the state directory exceeds `max_size_mb`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StateDirOnExceed {
+    /// Inject a warning preamble into the spawned session (non-blocking).
+    #[default]
+    Warn,
+    /// Refuse to spawn the session with a clear error.
+    Error,
+    /// Run `csa gc` before spawning (Phase 3 — currently falls back to warn).
+    AutoGc,
 }
 
 /// User preferences for tool selection and routing.
@@ -599,3 +654,7 @@ mod tests_priority;
 #[cfg(test)]
 #[path = "global_tests_review_batch.rs"]
 mod tests_review_batch;
+
+#[cfg(test)]
+#[path = "global_tests_state_dir.rs"]
+mod tests_state_dir;

--- a/crates/csa-config/src/global_tests_state_dir.rs
+++ b/crates/csa-config/src/global_tests_state_dir.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+#[test]
+fn test_state_dir_defaults_parse_when_section_omitted() {
+    let config: GlobalConfig = toml::from_str("").unwrap();
+    assert_eq!(config.state_dir.max_size_mb, 0);
+    assert_eq!(config.state_dir.scan_interval_seconds, 3600);
+    assert_eq!(config.state_dir.on_exceed, StateDirOnExceed::Warn);
+    assert!(config.state_dir.is_default());
+}
+
+#[test]
+fn test_state_dir_parses_all_on_exceed_variants() {
+    let config: GlobalConfig = toml::from_str(
+        r#"
+[state_dir]
+max_size_mb = 10240
+scan_interval_seconds = 1800
+on_exceed = "error"
+"#,
+    )
+    .unwrap();
+    assert_eq!(config.state_dir.max_size_mb, 10240);
+    assert_eq!(config.state_dir.scan_interval_seconds, 1800);
+    assert_eq!(config.state_dir.on_exceed, StateDirOnExceed::Error);
+    assert!(!config.state_dir.is_default());
+}
+
+#[test]
+fn test_state_dir_auto_gc_variant() {
+    let config: GlobalConfig = toml::from_str(
+        r#"
+[state_dir]
+max_size_mb = 5120
+on_exceed = "auto-gc"
+"#,
+    )
+    .unwrap();
+    assert_eq!(config.state_dir.on_exceed, StateDirOnExceed::AutoGc);
+}
+
+#[test]
+fn test_state_dir_skip_serializing_when_default() {
+    let config = GlobalConfig::default();
+    let toml_str = toml::to_string(&config).unwrap();
+    assert!(
+        !toml_str.contains("[state_dir]"),
+        "Default state_dir should not appear in TOML: {toml_str}"
+    );
+}
+
+#[test]
+fn test_state_dir_serialized_when_non_default() {
+    let mut config = GlobalConfig::default();
+    config.state_dir.max_size_mb = 10240;
+    let toml_str = toml::to_string(&config).unwrap();
+    assert!(
+        toml_str.contains("max_size_mb = 10240"),
+        "Non-default state_dir should appear in TOML: {toml_str}"
+    );
+}

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -40,7 +40,8 @@ pub use global::{
     AiConfigSymlinkCheckConfig, DEFAULT_KV_CACHE_FREQUENT_POLL_SECS,
     DEFAULT_KV_CACHE_LONG_POLL_SECS, ExecutionEnvOptions, GateMode, GateStep, GlobalConfig,
     GlobalMcpConfig, KvCacheConfig, KvCacheValueSource, LEGACY_SESSION_WAIT_FALLBACK_SECS,
-    PreflightConfig, ResolvedKvCacheValue, ReviewConfig, SessionWaitConfig, ToolSelection,
+    PreflightConfig, ResolvedKvCacheValue, ReviewConfig, SessionWaitConfig, StateDirConfig,
+    StateDirOnExceed, ToolSelection,
 };
 pub use init::{detect_installed_tools, init_project};
 pub use mcp::{McpFilter, McpRegistry, McpServerConfig, McpTransport};

--- a/crates/csa-config/src/paths.rs
+++ b/crates/csa-config/src/paths.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Canonical XDG app name used for all new path writes.
 pub const APP_NAME: &str = "cli-sub-agent";
@@ -101,6 +101,44 @@ pub fn legacy_config_dir() -> Option<PathBuf> {
 
 pub fn legacy_state_dir() -> Option<PathBuf> {
     project_state_dir(LEGACY_APP_NAME)
+}
+
+fn paths_equivalent(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
+fn push_existing_unique_path(paths: &mut Vec<PathBuf>, candidate: Option<PathBuf>) {
+    let Some(candidate) = candidate else {
+        return;
+    };
+    if !candidate.exists() {
+        return;
+    }
+    if paths
+        .iter()
+        .any(|existing| paths_equivalent(existing, &candidate))
+    {
+        return;
+    }
+    paths.push(candidate);
+}
+
+/// Existing CSA state roots, in read priority order.
+///
+/// Includes the canonical root first and then any legacy roots that still
+/// exist, while de-duplicating symlink-equivalent paths.
+pub fn state_dir_all_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    push_existing_unique_path(&mut roots, state_dir_write());
+    push_existing_unique_path(&mut roots, legacy_state_dir());
+    roots
 }
 
 pub fn legacy_runtime_dir() -> PathBuf {

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -88,8 +88,8 @@ pub use manager::{
     list_artifacts, list_sessions, list_sessions_from_root, list_sessions_from_root_readonly,
     load_metadata, load_result, load_result_view, load_session, load_session_global_exact,
     redact_result_sidecar_value, render_redacted_result_sidecar, resolve_fork_source,
-    resolve_resume_session, save_result, save_session, save_session_in, update_last_accessed,
-    validate_tool_access, write_audit_warning_artifact,
+    resolve_resume_session, save_result, save_result_with_options, save_session, save_session_in,
+    update_last_accessed, validate_tool_access, write_audit_warning_artifact,
 };
 
 pub use manager::ResumeSessionResolution;

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -35,6 +35,7 @@ pub use manager_result::{
     SaveOptions, SessionResultView, clear_manager_sidecar, contract_result_path,
     legacy_user_result_path, list_artifacts, load_result, load_result_view,
     redact_result_sidecar_value, render_redacted_result_sidecar, save_result,
+    save_result_with_options,
 };
 #[cfg(test)]
 pub(crate) use manager_result::{

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -51,8 +51,18 @@ pub fn redact_result_sidecar_value(sidecar: &toml::Value) -> Result<toml::Value>
 
 /// Write a session result to disk
 pub fn save_result(project_path: &Path, session_id: &str, result: &SessionResult) -> Result<()> {
+    save_result_with_options(project_path, session_id, result, SaveOptions::default())
+}
+
+/// Write a session result to disk with explicit sidecar preservation semantics.
+pub fn save_result_with_options(
+    project_path: &Path,
+    session_id: &str,
+    result: &SessionResult,
+    options: SaveOptions,
+) -> Result<()> {
     let base_dir = super::resolve_write_base_dir(project_path, session_id)?;
-    save_result_in(&base_dir, session_id, result, SaveOptions::default())
+    save_result_in(&base_dir, session_id, result, options)
 }
 
 pub(crate) fn save_result_in(


### PR DESCRIPTION
## Summary

Addresses #1047 Phase 2 — safety net for `~/.local/state/cli-sub-agent/` bloat. Adds a configurable size cap, periodic scan, and prompt-injection warning when the cap is exceeded.

Phase 1 (PR #1050) fixed the root cause by sharing the gemini-cli npm cache. Phase 2 ensures users on tight-disk hosts get an in-session heads-up if growth recurs.

## Config schema

```toml
[state_dir]
# 0 or unset = unlimited (default = unlimited)
max_size_mb = 10240
# How often to recompute the size (seconds). 0 = every invocation.
scan_interval_seconds = 3600
# What to do when size > max_size_mb:
#   "warn"    = inject a warning into the spawned session's preamble (default)
#   "error"   = refuse to spawn with a clear error
#   "auto-gc" = run `csa gc --max-age-days 30 --global` before spawning
on_exceed = "warn"
```

## Behavior

On `csa run` / `csa review` / `csa debate` preflight:

1. If `max_size_mb == 0` → skip (default unlimited, no cost).
2. Else compute state-dir size; cache in `~/.local/state/cli-sub-agent/.size-cache.toml` for `scan_interval_seconds`.
3. If size > cap:
   - `warn` → prepend a warning block (size, cap, GC hint, config pointer) to the session preamble. Visible in the first response. Does NOT block.
   - `error` → fail fast with a user-friendly message.
   - `auto-gc` → falls back to `warn` with an "auto-gc not yet implemented, warning instead" note. Phase 3 will wire the actual gc invocation.

## Deferred to Phase 3

- `on_exceed = "auto-gc"` real implementation (needs `csa gc --reap-runtime`).
- `csa gc --reap-runtime` to delete completed-session `runtime/` payloads while preserving audit artifacts.

## Test plan

- [x] `cargo test` — all pass
- [x] Round-trip tests for all three `on_exceed` values
- [x] Size scan + cache freshness tests
- [x] Preflight logic tests (cap=0 skip, cap>size no-warn, cap<size warn/error/auto-gc-fallback)
- [x] `csa config get state_dir.max_size_mb` / `csa config show` E2E
- [x] `just pre-commit` exit 0
- [ ] Cloud review (gemini-code-assist)

Refs #1047 phase 2.