### PR TITLE
fix(csa-executor): shared npm cache bwrap sandbox lockstep (#1047 followup)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.523"
+version = "0.1.524"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.527"
+version = "0.1.528"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.528"
+version = "0.1.529"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.530"
+version = "0.1.531"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.529"
+version = "0.1.530"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.524"
+version = "0.1.525"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.526"
+version = "0.1.527"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.525"
+version = "0.1.526"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.528"
+version = "0.1.529"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.524"
+version = "0.1.525"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.525"
+version = "0.1.526"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.526"
+version = "0.1.527"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.523"
+version = "0.1.524"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.530"
+version = "0.1.531"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.527"
+version = "0.1.528"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.529"
+version = "0.1.530"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -470,6 +470,10 @@ async fn handle_debate_marks_unavailable_when_all_tier_models_fail() {
     unsafe {
         std::env::remove_var("CSA_SESSION_ID");
     }
+    let cache_home = project_dir.path().join("xdg-cache");
+    std::fs::create_dir_all(&cache_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", project_dir.path());
+    let _cache_guard = EnvVarGuard::set("XDG_CACHE_HOME", &cache_home);
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
 

--- a/crates/cli-sub-agent/src/test_session_sandbox.rs
+++ b/crates/cli-sub-agent/src/test_session_sandbox.rs
@@ -1,5 +1,5 @@
-/// Redirect session I/O into a tempdir so tests work in sandboxed CI environments
-/// (avoids "Read-only file system" on the real XDG_STATE_HOME).
+/// Redirect session state/cache I/O into a tempdir so tests work in sandboxed
+/// CI environments (avoids read-only host XDG paths leaking into test runs).
 ///
 /// Also clears `CSA_DAEMON_*` env vars to prevent daemon session ID leaking
 /// into fresh test sessions.
@@ -34,16 +34,22 @@ impl ScopedSessionSandbox {
 
     fn from_guard(tmp: &tempfile::TempDir, lock: OwnedMutexGuard<()>) -> Self {
         let keys: &[&'static str] = &[
+            "HOME",
             "XDG_STATE_HOME",
+            "XDG_CACHE_HOME",
             "CSA_DAEMON_SESSION_ID",
             "CSA_DAEMON_SESSION_DIR",
             "CSA_DAEMON_PROJECT_ROOT",
         ];
         let originals: Vec<_> = keys.iter().map(|k| (*k, std::env::var_os(k))).collect();
+        let home_path = tmp.path();
         let state_path = tmp.path().join("state");
+        let cache_path = tmp.path().join("cache");
         // SAFETY: test-scoped env mutation protected by TEST_ENV_LOCK.
         unsafe {
+            std::env::set_var("HOME", home_path);
             std::env::set_var("XDG_STATE_HOME", state_path.to_str().unwrap());
+            std::env::set_var("XDG_CACHE_HOME", cache_path.to_str().unwrap());
             std::env::remove_var("CSA_DAEMON_SESSION_ID");
             std::env::remove_var("CSA_DAEMON_SESSION_DIR");
             std::env::remove_var("CSA_DAEMON_PROJECT_ROOT");

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -448,37 +448,43 @@ impl AcpTransport {
         if self.tool_name == "codex" {
             sanitize_args_for_codex(&mut acp_args);
         }
-        let mut gemini_sandbox_env_overrides =
+        let gemini_sandbox_env_overrides =
             (self.tool_name == "gemini-cli").then(|| gemini_sandbox_runtime_env_overrides(&env));
 
-        let sandbox_plan = options.sandbox.map(|s| {
-            let mut isolation_plan = s.isolation_plan.clone();
-            if self.tool_name == "gemini-cli" {
-                ensure_gemini_runtime_home_writable_path(
-                    &mut isolation_plan,
-                    gemini_runtime_home.as_deref(),
-                );
-                if let Some(shared_npm_cache) = shared_gemini_npm_cache.as_deref()
-                    && !ensure_gemini_runtime_home_writable_path(
+        let sandbox_plan = options
+            .sandbox
+            .map(|s| -> Result<_> {
+                let mut isolation_plan = s.isolation_plan.clone();
+                if self.tool_name == "gemini-cli" {
+                    ensure_gemini_runtime_home_writable_path(
                         &mut isolation_plan,
-                        Some(shared_npm_cache),
-                    )
-                {
-                    env.remove("npm_config_cache");
-                    if let Some(env_overrides) = gemini_sandbox_env_overrides.as_mut() {
-                        env_overrides.remove("npm_config_cache");
-                    }
-                    tracing::warn!(
-                        path = %shared_npm_cache.display(),
-                        "shared npm cache dir not writable under sandbox; falling back to default per-session npm cache"
+                        gemini_runtime_home.as_deref(),
                     );
+                    if let Some(shared_npm_cache) = shared_gemini_npm_cache.as_deref()
+                        && !ensure_gemini_runtime_home_writable_path(
+                            &mut isolation_plan,
+                            Some(shared_npm_cache),
+                        )
+                    {
+                        return Err(anyhow!(
+                            "gemini-cli sandbox plan failed: denied path {} for intent \
+                             'bwrap writable bind for shared npm cache (#1047 Phase 1 optimization)'. \
+                             Set XDG_CACHE_HOME to a writable location, or add this path \
+                             (or a writable parent) to [filesystem_sandbox].writable_paths or \
+                             [tools.gemini-cli].filesystem_sandbox.writable_paths.",
+                            shared_npm_cache.display(),
+                        ));
+                    }
+                    if let Some(ref env_overrides) = gemini_sandbox_env_overrides {
+                        apply_gemini_sandbox_runtime_env_overrides(
+                            &mut isolation_plan,
+                            env_overrides,
+                        );
+                    }
                 }
-                if let Some(ref env_overrides) = gemini_sandbox_env_overrides {
-                    apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, env_overrides);
-                }
-            }
-            isolation_plan
-        });
+                Ok(isolation_plan)
+            })
+            .transpose()?;
         let gemini_env_allowlist_applied = gemini_sandbox_env_overrides
             .as_ref()
             .map(|overrides| {

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -39,8 +39,9 @@ use transport_gemini_helpers::{
     classify_gemini_legacy_initial_stall, classify_gemini_oauth_prompt_result, classify_join_error,
     ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure,
     gemini_acp_initial_response_timeout_seconds, gemini_phase_desc,
-    gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure, is_gemini_mcp_issue_result,
-    is_gemini_oauth_prompt_result,
+    gemini_sandbox_runtime_env_overrides, gemini_shared_npm_cache_bind_error,
+    is_gemini_acp_init_failure, is_gemini_mcp_issue_result, is_gemini_oauth_prompt_result,
+    resolve_gemini_shared_npm_cache_source, validate_gemini_shared_npm_cache_writable_path,
 };
 pub use transport_gemini_helpers::{
     contains_gemini_oauth_prompt, normalize_gemini_prompt_text, strip_ansi_escape_sequences,
@@ -152,6 +153,12 @@ struct ExecuteInAttempt<'a> {
     resolved_initial_response_timeout: ResolvedTimeout,
 }
 
+#[derive(Clone, Copy)]
+struct LegacyAttemptEnv<'a> {
+    extra_env: Option<&'a HashMap<String, String>>,
+    gemini_shared_npm_cache_source: Option<transport_gemini_helpers::GeminiSharedNpmCacheSource>,
+}
+
 impl LegacyTransport {
     pub fn new(executor: Executor) -> Self {
         Self { executor }
@@ -252,22 +259,25 @@ impl LegacyTransport {
         prompt: &str,
         tool_state: Option<&ToolState>,
         session: &MetaSessionState,
-        extra_env: Option<&HashMap<String, String>>,
+        attempt_env: LegacyAttemptEnv<'_>,
         options: TransportOptions<'_>,
     ) -> Result<TransportResult> {
-        let (cmd, stdin_data) = executor.build_command(prompt, tool_state, session, extra_env);
+        let (cmd, stdin_data) =
+            executor.build_command(prompt, tool_state, session, attempt_env.extra_env);
 
         let gemini_sandbox_plan = options
             .sandbox
             .filter(|_| executor.tool_name() == "gemini-cli")
             .map(|s| -> Result<_> {
                 let mut isolation_plan = s.isolation_plan.clone();
-                if let Some(env) = extra_env {
+                if let Some(env) = attempt_env.extra_env {
                     let runtime_home = gemini_runtime_home_from_env(env);
                     apply_gemini_sandbox_runtime_contract(
                         &mut isolation_plan,
+                        Path::new(&session.project_path),
                         runtime_home.as_deref(),
                         env,
+                        attempt_env.gemini_shared_npm_cache_source,
                     )?;
                 }
                 Ok(isolation_plan)
@@ -310,7 +320,7 @@ impl LegacyTransport {
                     "sandbox spawn failed in best-effort mode, falling back to unsandboxed: {e:#}"
                 );
                 let fallback_cmd = executor
-                    .build_command(prompt, tool_state, session, extra_env)
+                    .build_command(prompt, tool_state, session, attempt_env.extra_env)
                     .0;
                 let child =
                     spawn_tool_with_options(fallback_cmd, stdin_data, spawn_options).await?;
@@ -441,16 +451,20 @@ impl AcpTransport {
             csa_session::manager::get_session_dir(&working_dir, &session.meta_session_id).ok();
 
         let mut gemini_runtime_home = None;
-        let shared_gemini_npm_cache = if self.tool_name == "gemini-cli" {
-            let source_home = env
-                .get("HOME")
-                .cloned()
-                .or_else(|| std::env::var("HOME").ok())
-                .map(PathBuf::from);
-            shared_npm_cache_dir(&env, source_home.as_deref())
-        } else {
-            None
-        };
+        let (shared_gemini_npm_cache, shared_gemini_npm_cache_source) =
+            if self.tool_name == "gemini-cli" {
+                let source_home = env
+                    .get("HOME")
+                    .cloned()
+                    .or_else(|| std::env::var("HOME").ok())
+                    .map(PathBuf::from);
+                (
+                    shared_npm_cache_dir(&env, source_home.as_deref()),
+                    resolve_gemini_shared_npm_cache_source(&env, source_home.as_deref()),
+                )
+            } else {
+                (None, None)
+            };
         if self.tool_name == "gemini-cli" {
             let launch = prepare_gemini_acp_runtime(
                 &mut env,
@@ -478,20 +492,22 @@ impl AcpTransport {
                         &mut isolation_plan,
                         gemini_runtime_home.as_deref(),
                     );
-                    if let Some(shared_npm_cache) = shared_gemini_npm_cache.as_deref()
-                        && !ensure_gemini_runtime_home_writable_path(
+                    if let Some(shared_npm_cache) = shared_gemini_npm_cache.as_deref() {
+                        validate_gemini_shared_npm_cache_writable_path(
+                            shared_npm_cache,
+                            working_dir.as_path(),
+                            shared_gemini_npm_cache_source,
+                        )?;
+                        if !ensure_gemini_runtime_home_writable_path(
                             &mut isolation_plan,
                             Some(shared_npm_cache),
-                        )
-                    {
-                        return Err(anyhow!(
-                            "gemini-cli sandbox plan failed: denied path {} for intent \
-                             'bwrap writable bind for shared npm cache (#1047 Phase 1 optimization)'. \
-                             Set XDG_CACHE_HOME to a writable location, or add this path \
-                             (or a writable parent) to [filesystem_sandbox].writable_paths or \
-                             [tools.gemini-cli].filesystem_sandbox.writable_paths.",
-                            shared_npm_cache.display(),
-                        ));
+                        ) {
+                            return Err(gemini_shared_npm_cache_bind_error(
+                                shared_npm_cache,
+                                shared_gemini_npm_cache_source,
+                                None,
+                            ));
+                        }
                     }
                     if let Some(ref env_overrides) = gemini_sandbox_env_overrides {
                         apply_gemini_sandbox_runtime_env_overrides(

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -156,6 +156,7 @@ struct ExecuteInAttempt<'a> {
 #[derive(Clone, Copy)]
 struct LegacyAttemptEnv<'a> {
     extra_env: Option<&'a HashMap<String, String>>,
+    gemini_shared_npm_cache_raw_path: Option<&'a Path>,
     gemini_shared_npm_cache_source: Option<transport_gemini_helpers::GeminiSharedNpmCacheSource>,
 }
 
@@ -277,6 +278,7 @@ impl LegacyTransport {
                         Path::new(&session.project_path),
                         runtime_home.as_deref(),
                         env,
+                        attempt_env.gemini_shared_npm_cache_raw_path,
                         attempt_env.gemini_shared_npm_cache_source,
                     )?;
                 }
@@ -451,7 +453,7 @@ impl AcpTransport {
             csa_session::manager::get_session_dir(&working_dir, &session.meta_session_id).ok();
 
         let mut gemini_runtime_home = None;
-        let (shared_gemini_npm_cache, shared_gemini_npm_cache_source) =
+        let (shared_gemini_npm_cache_raw_path, shared_gemini_npm_cache_source) =
             if self.tool_name == "gemini-cli" {
                 let source_home = env
                     .get("HOME")
@@ -480,6 +482,11 @@ impl AcpTransport {
         if self.tool_name == "codex" {
             sanitize_args_for_codex(&mut acp_args);
         }
+        let shared_gemini_npm_cache = if self.tool_name == "gemini-cli" {
+            env.get("npm_config_cache").map(PathBuf::from)
+        } else {
+            None
+        };
         let gemini_sandbox_env_overrides =
             (self.tool_name == "gemini-cli").then(|| gemini_sandbox_runtime_env_overrides(&env));
 
@@ -493,17 +500,22 @@ impl AcpTransport {
                         gemini_runtime_home.as_deref(),
                     );
                     if let Some(shared_npm_cache) = shared_gemini_npm_cache.as_deref() {
-                        validate_gemini_shared_npm_cache_writable_path(
-                            shared_npm_cache,
-                            working_dir.as_path(),
-                            shared_gemini_npm_cache_source,
-                        )?;
+                        let requested_shared_npm_cache = shared_gemini_npm_cache_raw_path
+                            .as_deref()
+                            .unwrap_or(shared_npm_cache);
+                        let resolved_shared_npm_cache =
+                            validate_gemini_shared_npm_cache_writable_path(
+                                requested_shared_npm_cache,
+                                working_dir.as_path(),
+                                shared_gemini_npm_cache_source,
+                            )?;
                         if !ensure_gemini_runtime_home_writable_path(
                             &mut isolation_plan,
-                            Some(shared_npm_cache),
+                            Some(resolved_shared_npm_cache.as_path()),
                         ) {
                             return Err(gemini_shared_npm_cache_bind_error(
-                                shared_npm_cache,
+                                requested_shared_npm_cache,
+                                Some(resolved_shared_npm_cache.as_path()),
                                 shared_gemini_npm_cache_source,
                                 None,
                             ));

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -34,9 +34,9 @@ use transport_gemini_helpers::{
     GeminiAcpInitFailureClassification, GeminiRetryPhase, annotate_gemini_retry_error,
     append_gemini_retry_report, apply_gemini_acp_initial_stall_summary,
     apply_gemini_legacy_initial_stall_summary, apply_gemini_mcp_warning_summary,
-    apply_gemini_sandbox_runtime_env_overrides, classify_gemini_acp_init_failure,
-    classify_gemini_acp_initial_stall, classify_gemini_legacy_initial_stall,
-    classify_gemini_oauth_prompt_result, classify_join_error,
+    apply_gemini_sandbox_runtime_contract, apply_gemini_sandbox_runtime_env_overrides,
+    classify_gemini_acp_init_failure, classify_gemini_acp_initial_stall,
+    classify_gemini_legacy_initial_stall, classify_gemini_oauth_prompt_result, classify_join_error,
     ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure,
     gemini_acp_initial_response_timeout_seconds, gemini_phase_desc,
     gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure, is_gemini_mcp_issue_result,
@@ -257,7 +257,25 @@ impl LegacyTransport {
     ) -> Result<TransportResult> {
         let (cmd, stdin_data) = executor.build_command(prompt, tool_state, session, extra_env);
 
-        let isolation_plan = options.sandbox.map(|s| &s.isolation_plan);
+        let gemini_sandbox_plan = options
+            .sandbox
+            .filter(|_| executor.tool_name() == "gemini-cli")
+            .map(|s| -> Result<_> {
+                let mut isolation_plan = s.isolation_plan.clone();
+                if let Some(env) = extra_env {
+                    let runtime_home = gemini_runtime_home_from_env(env);
+                    apply_gemini_sandbox_runtime_contract(
+                        &mut isolation_plan,
+                        runtime_home.as_deref(),
+                        env,
+                    )?;
+                }
+                Ok(isolation_plan)
+            })
+            .transpose()?;
+        let isolation_plan = gemini_sandbox_plan
+            .as_ref()
+            .or_else(|| options.sandbox.map(|s| &s.isolation_plan));
         let best_effort = options.sandbox.is_some_and(|s| s.best_effort);
         let (tool_name, session_id) = options
             .sandbox

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::executor::Executor;
@@ -49,6 +49,7 @@ pub use transport_gemini_helpers::{
 mod transport_gemini_acp_runtime;
 use transport_gemini_acp_runtime::{
     gemini_runtime_home_from_env, prepare_gemini_acp_runtime, prepare_gemini_runtime_env,
+    shared_npm_cache_dir,
 };
 #[path = "transport_gemini_mcp_diagnostic.rs"]
 mod transport_gemini_mcp_diagnostic;
@@ -422,6 +423,16 @@ impl AcpTransport {
             csa_session::manager::get_session_dir(&working_dir, &session.meta_session_id).ok();
 
         let mut gemini_runtime_home = None;
+        let shared_gemini_npm_cache = if self.tool_name == "gemini-cli" {
+            let source_home = env
+                .get("HOME")
+                .cloned()
+                .or_else(|| std::env::var("HOME").ok())
+                .map(PathBuf::from);
+            shared_npm_cache_dir(&env, source_home.as_deref())
+        } else {
+            None
+        };
         if self.tool_name == "gemini-cli" {
             let launch = prepare_gemini_acp_runtime(
                 &mut env,
@@ -455,6 +466,10 @@ impl AcpTransport {
                 ensure_gemini_runtime_home_writable_path(
                     &mut isolation_plan,
                     gemini_runtime_home.as_deref(),
+                );
+                ensure_gemini_runtime_home_writable_path(
+                    &mut isolation_plan,
+                    shared_gemini_npm_cache.as_deref(),
                 );
                 apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, env_overrides);
             }

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -448,8 +448,37 @@ impl AcpTransport {
         if self.tool_name == "codex" {
             sanitize_args_for_codex(&mut acp_args);
         }
-        let gemini_sandbox_env_overrides =
+        let mut gemini_sandbox_env_overrides =
             (self.tool_name == "gemini-cli").then(|| gemini_sandbox_runtime_env_overrides(&env));
+
+        let sandbox_plan = options.sandbox.map(|s| {
+            let mut isolation_plan = s.isolation_plan.clone();
+            if self.tool_name == "gemini-cli" {
+                ensure_gemini_runtime_home_writable_path(
+                    &mut isolation_plan,
+                    gemini_runtime_home.as_deref(),
+                );
+                if let Some(shared_npm_cache) = shared_gemini_npm_cache.as_deref()
+                    && !ensure_gemini_runtime_home_writable_path(
+                        &mut isolation_plan,
+                        Some(shared_npm_cache),
+                    )
+                {
+                    env.remove("npm_config_cache");
+                    if let Some(env_overrides) = gemini_sandbox_env_overrides.as_mut() {
+                        env_overrides.remove("npm_config_cache");
+                    }
+                    tracing::warn!(
+                        path = %shared_npm_cache.display(),
+                        "shared npm cache dir not writable under sandbox; falling back to default per-session npm cache"
+                    );
+                }
+                if let Some(ref env_overrides) = gemini_sandbox_env_overrides {
+                    apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, env_overrides);
+                }
+            }
+            isolation_plan
+        });
         let gemini_env_allowlist_applied = gemini_sandbox_env_overrides
             .as_ref()
             .map(|overrides| {
@@ -459,22 +488,6 @@ impl AcpTransport {
             })
             .unwrap_or_else(|| "none".to_string());
         let gemini_classification_env = (self.tool_name == "gemini-cli").then(|| env.clone());
-
-        let sandbox_plan = options.sandbox.map(|s| {
-            let mut isolation_plan = s.isolation_plan.clone();
-            if let Some(ref env_overrides) = gemini_sandbox_env_overrides {
-                ensure_gemini_runtime_home_writable_path(
-                    &mut isolation_plan,
-                    gemini_runtime_home.as_deref(),
-                );
-                ensure_gemini_runtime_home_writable_path(
-                    &mut isolation_plan,
-                    shared_gemini_npm_cache.as_deref(),
-                );
-                apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, env_overrides);
-            }
-            isolation_plan
-        });
         let sandbox_tool_name = options.sandbox.map(|s| s.tool_name.clone());
         let sandbox_session_id = options.sandbox.map(|s| s.session_id.clone());
         let sandbox_best_effort = options.sandbox.is_some_and(|s| s.best_effort);

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -55,7 +55,7 @@ pub(crate) fn prepare_gemini_acp_runtime(
     // Capture original XDG_CACHE_HOME before env is overwritten with per-session paths.
     // Used to derive the shared npm cache so gemini-cli sessions reuse a single npm
     // _cacache instead of duplicating ~186 MiB per session. See #1047.
-    let shared_npm_cache = resolve_shared_npm_cache_dir(env, source_home.as_deref());
+    let shared_npm_cache = shared_npm_cache_dir(env, source_home.as_deref());
     let runtime_session_dir = session_dir
         .map(Path::to_path_buf)
         .or_else(|| runtime_session_dir_from_env(env));
@@ -263,7 +263,7 @@ fn runtime_root_from_env(env: &HashMap<String, String>) -> PathBuf {
 ///
 /// Returns `None` when neither `XDG_CACHE_HOME` nor `HOME` is available (extremely
 /// rare; per rule 041, we fail open rather than autonomously picking `/tmp`).
-fn resolve_shared_npm_cache_dir(
+pub(crate) fn shared_npm_cache_dir(
     env: &HashMap<String, String>,
     source_home: Option<&Path>,
 ) -> Option<PathBuf> {

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result};
 use csa_resource::isolation_plan::DEFAULT_SANDBOX_TMPDIR;
+use csa_resource::isolation_plan::canonicalize_through_existing_ancestors;
 use serde_json::{Map, Value};
 use tracing::{debug, warn};
 
@@ -55,7 +56,16 @@ pub(crate) fn prepare_gemini_acp_runtime(
     // Capture original XDG_CACHE_HOME before env is overwritten with per-session paths.
     // Used to derive the shared npm cache so gemini-cli sessions reuse a single npm
     // _cacache instead of duplicating ~186 MiB per session. See #1047.
-    let shared_npm_cache = shared_npm_cache_dir(env, source_home.as_deref());
+    let shared_npm_cache = shared_npm_cache_dir(env, source_home.as_deref())
+        .map(|path| {
+            canonicalize_through_existing_ancestors(&path).with_context(|| {
+                format!(
+                    "failed to resolve shared npm cache path {} through existing ancestors",
+                    path.display()
+                )
+            })
+        })
+        .transpose()?;
     let runtime_session_dir = session_dir
         .map(Path::to_path_buf)
         .or_else(|| runtime_session_dir_from_env(env));

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -247,9 +247,9 @@ pub(super) fn annotate_gemini_retry_error(
 pub(super) fn ensure_gemini_runtime_home_writable_path(
     isolation_plan: &mut IsolationPlan,
     runtime_home: Option<&Path>,
-) {
+) -> bool {
     let Some(runtime_home) = runtime_home else {
-        return;
+        return false;
     };
 
     let runtime_home_is_visible = isolation_plan.writable_paths.iter().any(|existing| {
@@ -257,10 +257,10 @@ pub(super) fn ensure_gemini_runtime_home_writable_path(
             || (existing != Path::new("/tmp") && runtime_home.starts_with(existing))
     });
     if runtime_home_is_visible {
-        return;
+        return true;
     }
 
-    isolation_plan.add_writable_dir_or_creatable_parent(runtime_home);
+    isolation_plan.add_writable_dir_or_creatable_parent(runtime_home)
 }
 
 pub(super) fn gemini_sandbox_runtime_env_overrides(

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -307,6 +307,7 @@ pub(super) fn ensure_gemini_runtime_home_writable_path(
 
 pub(super) fn gemini_shared_npm_cache_bind_error(
     shared_npm_cache: &Path,
+    resolved_shared_npm_cache: Option<&Path>,
     source: Option<GeminiSharedNpmCacheSource>,
     cause: Option<&str>,
 ) -> anyhow::Error {
@@ -318,18 +319,33 @@ pub(super) fn gemini_shared_npm_cache_bind_error(
         "Set XDG_CACHE_HOME, or HOME/.cache fallback, to a writable location inside [filesystem_sandbox].writable_paths",
         GeminiSharedNpmCacheSource::remediation,
     );
+    let resolved_suffix = resolved_shared_npm_cache
+        .filter(|resolved| *resolved != shared_npm_cache)
+        .map(|resolved| format!(" (resolved to {})", resolved.display()))
+        .unwrap_or_default();
+    let canonical_target_hint = resolved_shared_npm_cache
+        .filter(|resolved| *resolved != shared_npm_cache)
+        .map(|resolved| {
+            format!(
+                " If this cache root resolves through a symlink, point it at a non-symlinked location or add the canonical target {} (or a writable parent) to [filesystem_sandbox].writable_paths or [tools.gemini-cli].filesystem_sandbox.writable_paths.",
+                resolved.display()
+            )
+        })
+        .unwrap_or_default();
     let cause_suffix = cause
         .map(|text| format!(" Validation error: {text}"))
         .unwrap_or_default();
 
     anyhow!(
-        "gemini-cli sandbox plan failed: denied path {} derived from {} for intent \
+        "gemini-cli sandbox plan failed: denied path {}{} derived from {} for intent \
          'bwrap writable bind for shared npm cache (#1047 Phase 1 optimization)'. \
          {} or add this path (or a writable parent) to [filesystem_sandbox].writable_paths or \
-         [tools.gemini-cli].filesystem_sandbox.writable_paths.{}",
+         [tools.gemini-cli].filesystem_sandbox.writable_paths.{}{}",
         shared_npm_cache.display(),
+        resolved_suffix,
         source_description,
         remediation,
+        canonical_target_hint,
         cause_suffix,
     )
 }
@@ -338,15 +354,45 @@ pub(super) fn validate_gemini_shared_npm_cache_writable_path(
     shared_npm_cache: &Path,
     project_root: &Path,
     source: Option<GeminiSharedNpmCacheSource>,
-) -> Result<()> {
+) -> Result<PathBuf> {
+    let resolved_shared_npm_cache =
+        csa_resource::isolation_plan::canonicalize_through_existing_ancestors(shared_npm_cache)
+            .map_err(|error| {
+                let error_text = format!(
+                    "failed to resolve the shared npm cache path {} through existing ancestors: {error:#}",
+                    shared_npm_cache.display()
+                );
+                gemini_shared_npm_cache_bind_error(
+                    shared_npm_cache,
+                    None,
+                    source,
+                    Some(error_text.as_str()),
+                )
+            })?;
+
     csa_resource::isolation_plan::validate_writable_paths(
-        &[PathBuf::from(shared_npm_cache)],
+        std::slice::from_ref(&resolved_shared_npm_cache),
         project_root,
     )
     .map_err(|error| {
-        let error_text = error.to_string();
-        gemini_shared_npm_cache_bind_error(shared_npm_cache, source, Some(error_text.as_str()))
-    })
+        let error_text = if resolved_shared_npm_cache == shared_npm_cache {
+            error.to_string()
+        } else {
+            format!(
+                "original path {} resolves to {}; {error}",
+                shared_npm_cache.display(),
+                resolved_shared_npm_cache.display()
+            )
+        };
+        gemini_shared_npm_cache_bind_error(
+            shared_npm_cache,
+            Some(resolved_shared_npm_cache.as_path()),
+            source,
+            Some(error_text.as_str()),
+        )
+    })?;
+
+    Ok(resolved_shared_npm_cache)
 }
 
 pub(super) fn gemini_sandbox_runtime_env_overrides(
@@ -415,18 +461,24 @@ pub(super) fn apply_gemini_sandbox_runtime_contract(
     project_root: &Path,
     runtime_home: Option<&Path>,
     env: &HashMap<String, String>,
+    shared_npm_cache_raw_path: Option<&Path>,
     shared_npm_cache_source: Option<GeminiSharedNpmCacheSource>,
 ) -> Result<()> {
     ensure_gemini_runtime_home_writable_path(isolation_plan, runtime_home);
     if let Some(shared_npm_cache) = env.get("npm_config_cache").map(Path::new) {
-        validate_gemini_shared_npm_cache_writable_path(
-            shared_npm_cache,
+        let requested_shared_npm_cache = shared_npm_cache_raw_path.unwrap_or(shared_npm_cache);
+        let resolved_shared_npm_cache = validate_gemini_shared_npm_cache_writable_path(
+            requested_shared_npm_cache,
             project_root,
             shared_npm_cache_source,
         )?;
-        if !ensure_gemini_runtime_home_writable_path(isolation_plan, Some(shared_npm_cache)) {
+        if !ensure_gemini_runtime_home_writable_path(
+            isolation_plan,
+            Some(resolved_shared_npm_cache.as_path()),
+        ) {
             return Err(gemini_shared_npm_cache_bind_error(
-                shared_npm_cache,
+                requested_shared_npm_cache,
+                Some(resolved_shared_npm_cache.as_path()),
                 shared_npm_cache_source,
                 None,
             ));

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -260,9 +260,7 @@ pub(super) fn ensure_gemini_runtime_home_writable_path(
         return;
     }
 
-    isolation_plan
-        .writable_paths
-        .push(runtime_home.to_path_buf());
+    isolation_plan.add_writable_dir_or_creatable_parent(runtime_home);
 }
 
 pub(super) fn gemini_sandbox_runtime_env_overrides(

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 
@@ -50,6 +50,48 @@ pub(super) struct GeminiAcpInitialStallClassification {
 pub(super) struct GeminiLegacyInitialStallClassification {
     pub(super) code: &'static str,
     pub(super) timeout_seconds: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GeminiSharedNpmCacheSource {
+    XdgCacheHome,
+    HomeCacheFallback,
+}
+
+impl GeminiSharedNpmCacheSource {
+    fn description(self) -> &'static str {
+        match self {
+            Self::XdgCacheHome => "XDG_CACHE_HOME",
+            Self::HomeCacheFallback => "HOME/.cache fallback",
+        }
+    }
+
+    fn remediation(self) -> &'static str {
+        match self {
+            Self::XdgCacheHome => {
+                "Set XDG_CACHE_HOME to a writable location inside [filesystem_sandbox].writable_paths"
+            }
+            Self::HomeCacheFallback => {
+                "Set HOME so HOME/.cache resolves to a writable location inside [filesystem_sandbox].writable_paths"
+            }
+        }
+    }
+}
+
+pub(super) fn resolve_gemini_shared_npm_cache_source(
+    env: &HashMap<String, String>,
+    source_home: Option<&Path>,
+) -> Option<GeminiSharedNpmCacheSource> {
+    if env
+        .get("XDG_CACHE_HOME")
+        .is_some_and(|value| !value.is_empty())
+    {
+        Some(GeminiSharedNpmCacheSource::XdgCacheHome)
+    } else if source_home.is_some() {
+        Some(GeminiSharedNpmCacheSource::HomeCacheFallback)
+    } else {
+        None
+    }
 }
 
 pub(super) fn gemini_acp_initial_response_timeout_seconds(
@@ -263,6 +305,50 @@ pub(super) fn ensure_gemini_runtime_home_writable_path(
     isolation_plan.add_writable_dir_or_creatable_parent(runtime_home)
 }
 
+pub(super) fn gemini_shared_npm_cache_bind_error(
+    shared_npm_cache: &Path,
+    source: Option<GeminiSharedNpmCacheSource>,
+    cause: Option<&str>,
+) -> anyhow::Error {
+    let source_description = source.map_or(
+        "XDG_CACHE_HOME or HOME/.cache fallback",
+        GeminiSharedNpmCacheSource::description,
+    );
+    let remediation = source.map_or(
+        "Set XDG_CACHE_HOME, or HOME/.cache fallback, to a writable location inside [filesystem_sandbox].writable_paths",
+        GeminiSharedNpmCacheSource::remediation,
+    );
+    let cause_suffix = cause
+        .map(|text| format!(" Validation error: {text}"))
+        .unwrap_or_default();
+
+    anyhow!(
+        "gemini-cli sandbox plan failed: denied path {} derived from {} for intent \
+         'bwrap writable bind for shared npm cache (#1047 Phase 1 optimization)'. \
+         {} or add this path (or a writable parent) to [filesystem_sandbox].writable_paths or \
+         [tools.gemini-cli].filesystem_sandbox.writable_paths.{}",
+        shared_npm_cache.display(),
+        source_description,
+        remediation,
+        cause_suffix,
+    )
+}
+
+pub(super) fn validate_gemini_shared_npm_cache_writable_path(
+    shared_npm_cache: &Path,
+    project_root: &Path,
+    source: Option<GeminiSharedNpmCacheSource>,
+) -> Result<()> {
+    csa_resource::isolation_plan::validate_writable_paths(
+        &[PathBuf::from(shared_npm_cache)],
+        project_root,
+    )
+    .map_err(|error| {
+        let error_text = error.to_string();
+        gemini_shared_npm_cache_bind_error(shared_npm_cache, source, Some(error_text.as_str()))
+    })
+}
+
 pub(super) fn gemini_sandbox_runtime_env_overrides(
     env: &HashMap<String, String>,
 ) -> HashMap<String, String> {
@@ -326,21 +412,25 @@ pub(super) fn apply_gemini_sandbox_runtime_env_overrides(
 
 pub(super) fn apply_gemini_sandbox_runtime_contract(
     isolation_plan: &mut IsolationPlan,
+    project_root: &Path,
     runtime_home: Option<&Path>,
     env: &HashMap<String, String>,
+    shared_npm_cache_source: Option<GeminiSharedNpmCacheSource>,
 ) -> Result<()> {
     ensure_gemini_runtime_home_writable_path(isolation_plan, runtime_home);
-    if let Some(shared_npm_cache) = env.get("npm_config_cache").map(Path::new)
-        && !ensure_gemini_runtime_home_writable_path(isolation_plan, Some(shared_npm_cache))
-    {
-        return Err(anyhow!(
-            "gemini-cli sandbox plan failed: denied path {} for intent \
-             'bwrap writable bind for shared npm cache (#1047 Phase 1 optimization)'. \
-             Set XDG_CACHE_HOME to a writable location, or add this path \
-             (or a writable parent) to [filesystem_sandbox].writable_paths or \
-             [tools.gemini-cli].filesystem_sandbox.writable_paths.",
-            shared_npm_cache.display(),
-        ));
+    if let Some(shared_npm_cache) = env.get("npm_config_cache").map(Path::new) {
+        validate_gemini_shared_npm_cache_writable_path(
+            shared_npm_cache,
+            project_root,
+            shared_npm_cache_source,
+        )?;
+        if !ensure_gemini_runtime_home_writable_path(isolation_plan, Some(shared_npm_cache)) {
+            return Err(gemini_shared_npm_cache_bind_error(
+                shared_npm_cache,
+                shared_npm_cache_source,
+                None,
+            ));
+        }
     }
     let env_overrides = gemini_sandbox_runtime_env_overrides(env);
     apply_gemini_sandbox_runtime_env_overrides(isolation_plan, &env_overrides);

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -279,6 +279,7 @@ pub(super) fn gemini_sandbox_runtime_env_overrides(
         "XDG_CONFIG_HOME",
         "XDG_CACHE_HOME",
         "XDG_STATE_HOME",
+        "npm_config_cache",
         "MISE_CACHE_DIR",
         "MISE_STATE_DIR",
         "MISE_SHIM",

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use anyhow::anyhow;
+use anyhow::{Result, anyhow};
 
 use csa_process::ExecutionResult;
 use csa_resource::isolation_plan::IsolationPlan;
@@ -322,6 +322,29 @@ pub(super) fn apply_gemini_sandbox_runtime_env_overrides(
             .iter()
             .map(|(key, value)| (key.clone(), value.clone())),
     );
+}
+
+pub(super) fn apply_gemini_sandbox_runtime_contract(
+    isolation_plan: &mut IsolationPlan,
+    runtime_home: Option<&Path>,
+    env: &HashMap<String, String>,
+) -> Result<()> {
+    ensure_gemini_runtime_home_writable_path(isolation_plan, runtime_home);
+    if let Some(shared_npm_cache) = env.get("npm_config_cache").map(Path::new)
+        && !ensure_gemini_runtime_home_writable_path(isolation_plan, Some(shared_npm_cache))
+    {
+        return Err(anyhow!(
+            "gemini-cli sandbox plan failed: denied path {} for intent \
+             'bwrap writable bind for shared npm cache (#1047 Phase 1 optimization)'. \
+             Set XDG_CACHE_HOME to a writable location, or add this path \
+             (or a writable parent) to [filesystem_sandbox].writable_paths or \
+             [tools.gemini-cli].filesystem_sandbox.writable_paths.",
+            shared_npm_cache.display(),
+        ));
+    }
+    let env_overrides = gemini_sandbox_runtime_env_overrides(env);
+    apply_gemini_sandbox_runtime_env_overrides(isolation_plan, &env_overrides);
+    Ok(())
 }
 
 pub(crate) fn is_gemini_oauth_prompt_result(execution: &ExecutionResult) -> bool {

--- a/crates/csa-executor/src/transport_legacy_impl.rs
+++ b/crates/csa-executor/src/transport_legacy_impl.rs
@@ -39,19 +39,23 @@ impl Transport for LegacyTransport {
             let mut prepared_attempt_env = api_key_env
                 .as_ref()
                 .map_or_else(|| extra_env.cloned().unwrap_or_default(), Clone::clone);
-            let gemini_shared_npm_cache_source = if executor.tool_name() == "gemini-cli" {
-                let source_home = prepared_attempt_env
-                    .get("HOME")
-                    .cloned()
-                    .or_else(|| std::env::var("HOME").ok())
-                    .map(PathBuf::from);
-                resolve_gemini_shared_npm_cache_source(
-                    &prepared_attempt_env,
-                    source_home.as_deref(),
-                )
-            } else {
-                None
-            };
+            let (gemini_shared_npm_cache_raw_path, gemini_shared_npm_cache_source) =
+                if executor.tool_name() == "gemini-cli" {
+                    let source_home = prepared_attempt_env
+                        .get("HOME")
+                        .cloned()
+                        .or_else(|| std::env::var("HOME").ok())
+                        .map(PathBuf::from);
+                    (
+                        shared_npm_cache_dir(&prepared_attempt_env, source_home.as_deref()),
+                        resolve_gemini_shared_npm_cache_source(
+                            &prepared_attempt_env,
+                            source_home.as_deref(),
+                        ),
+                    )
+                } else {
+                    (None, None)
+                };
             let mut gemini_runtime_home = None;
             let mut mcp_diagnostic = None;
             let allow_degraded_mcp = if executor.tool_name() == "gemini-cli" {
@@ -86,6 +90,8 @@ impl Transport for LegacyTransport {
                         session,
                         LegacyAttemptEnv {
                             extra_env: Some(&prepared_attempt_env),
+                            gemini_shared_npm_cache_raw_path: gemini_shared_npm_cache_raw_path
+                                .as_deref(),
                             gemini_shared_npm_cache_source,
                         },
                         options.clone(),
@@ -198,6 +204,8 @@ impl Transport for LegacyTransport {
                                 session,
                                 LegacyAttemptEnv {
                                     extra_env: Some(&prepared_attempt_env),
+                                    gemini_shared_npm_cache_raw_path: gemini_shared_npm_cache_raw_path
+                                        .as_deref(),
                                     gemini_shared_npm_cache_source,
                                 },
                                 retry_options,

--- a/crates/csa-executor/src/transport_legacy_impl.rs
+++ b/crates/csa-executor/src/transport_legacy_impl.rs
@@ -39,6 +39,19 @@ impl Transport for LegacyTransport {
             let mut prepared_attempt_env = api_key_env
                 .as_ref()
                 .map_or_else(|| extra_env.cloned().unwrap_or_default(), Clone::clone);
+            let gemini_shared_npm_cache_source = if executor.tool_name() == "gemini-cli" {
+                let source_home = prepared_attempt_env
+                    .get("HOME")
+                    .cloned()
+                    .or_else(|| std::env::var("HOME").ok())
+                    .map(PathBuf::from);
+                resolve_gemini_shared_npm_cache_source(
+                    &prepared_attempt_env,
+                    source_home.as_deref(),
+                )
+            } else {
+                None
+            };
             let mut gemini_runtime_home = None;
             let mut mcp_diagnostic = None;
             let allow_degraded_mcp = if executor.tool_name() == "gemini-cli" {
@@ -71,7 +84,10 @@ impl Transport for LegacyTransport {
                         prompt,
                         tool_state,
                         session,
-                        Some(&prepared_attempt_env),
+                        LegacyAttemptEnv {
+                            extra_env: Some(&prepared_attempt_env),
+                            gemini_shared_npm_cache_source,
+                        },
                         options.clone(),
                     )
                     .await?;
@@ -180,7 +196,10 @@ impl Transport for LegacyTransport {
                                 prompt,
                                 tool_state,
                                 session,
-                                Some(&prepared_attempt_env),
+                                LegacyAttemptEnv {
+                                    extra_env: Some(&prepared_attempt_env),
+                                    gemini_shared_npm_cache_source,
+                                },
                                 retry_options,
                             )
                             .await?;

--- a/crates/csa-executor/src/transport_tests_gemini_fallback.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_fallback.rs
@@ -621,9 +621,34 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
         memory_monitor_interval_seconds: None,
     };
 
+    let shared_npm_cache = PathBuf::from(
+        env.get("npm_config_cache")
+            .expect("sandbox env fixture must include npm_config_cache"),
+    );
+    ensure_gemini_runtime_home_writable_path(
+        &mut isolation_plan,
+        Some(std::path::Path::new(runtime_home)),
+    );
+    ensure_gemini_runtime_home_writable_path(&mut isolation_plan, Some(shared_npm_cache.as_path()));
     let env_overrides = gemini_sandbox_runtime_env_overrides(&env);
     apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, &env_overrides);
 
+    assert!(
+        isolation_plan
+            .writable_paths
+            .contains(&PathBuf::from(runtime_home)),
+        "sandbox should add the per-session Gemini runtime home as a writable bind"
+    );
+    assert_eq!(
+        shared_npm_cache,
+        PathBuf::from("/shared/cache/cli-sub-agent/npm")
+    );
+    assert!(
+        isolation_plan
+            .writable_paths
+            .contains(&PathBuf::from("/shared/cache/cli-sub-agent/npm")),
+        "sandbox should add the shared npm cache as a writable bind under bwrap (#1047)"
+    );
     assert_eq!(
         isolation_plan.env_overrides.get("HOME"),
         Some(&runtime_home.to_string())

--- a/crates/csa-executor/src/transport_tests_gemini_fallback.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_fallback.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use tempfile::tempdir;
+
 #[test]
 fn test_gemini_should_use_api_key_by_phase() {
     // Phase 1: OAuth auth
@@ -566,39 +568,39 @@ fn test_ensure_gemini_runtime_home_writable_path_is_noop_without_runtime_home() 
 
 #[test]
 fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears_api_key() {
-    let runtime_home = "/tmp/cli-sub-agent-gemini/01TEST/runtime-home";
+    let temp = tempdir().expect("tempdir");
+    let runtime_home = temp.path().join("runtime-home");
+    let xdg_cache_home = temp.path().join("xdg-cache-home");
+    std::fs::create_dir_all(&xdg_cache_home).expect("create xdg cache home");
+    let shared_npm_cache = xdg_cache_home.join("cli-sub-agent/npm");
+    let runtime_home_string = runtime_home.to_string_lossy().into_owned();
+    let runtime_config_home = runtime_home.join(".config").to_string_lossy().into_owned();
+    let runtime_state_home = runtime_home.join(".local/state").to_string_lossy().into_owned();
+    let runtime_mise_cache = runtime_home.join(".cache/mise").to_string_lossy().into_owned();
+    let runtime_mise_state = runtime_home
+        .join(".local/state/mise")
+        .to_string_lossy()
+        .into_owned();
+    let xdg_cache_home_string = xdg_cache_home.to_string_lossy().into_owned();
+    let shared_npm_cache_string = shared_npm_cache.to_string_lossy().into_owned();
+    assert!(
+        !shared_npm_cache.exists(),
+        "regression setup requires a cold-start shared npm cache path"
+    );
     let mut env = HashMap::new();
-    env.insert("HOME".to_string(), runtime_home.to_string());
+    env.insert("HOME".to_string(), runtime_home_string.clone());
     env.insert("TMPDIR".to_string(), "/tmp".to_string());
     env.insert(
         "PATH".to_string(),
         "/runtime/node/bin:/runtime/yarn/bin:/usr/local/bin".to_string(),
     );
-    env.insert("GEMINI_CLI_HOME".to_string(), runtime_home.to_string());
-    env.insert(
-        "XDG_CONFIG_HOME".to_string(),
-        format!("{runtime_home}/.config"),
-    );
-    env.insert(
-        "XDG_CACHE_HOME".to_string(),
-        format!("{runtime_home}/.cache"),
-    );
-    env.insert(
-        "XDG_STATE_HOME".to_string(),
-        format!("{runtime_home}/.local/state"),
-    );
-    env.insert(
-        "npm_config_cache".to_string(),
-        "/shared/cache/cli-sub-agent/npm".to_string(),
-    );
-    env.insert(
-        "MISE_CACHE_DIR".to_string(),
-        format!("{runtime_home}/.cache/mise"),
-    );
-    env.insert(
-        "MISE_STATE_DIR".to_string(),
-        format!("{runtime_home}/.local/state/mise"),
-    );
+    env.insert("GEMINI_CLI_HOME".to_string(), runtime_home_string.clone());
+    env.insert("XDG_CONFIG_HOME".to_string(), runtime_config_home);
+    env.insert("XDG_CACHE_HOME".to_string(), xdg_cache_home_string);
+    env.insert("XDG_STATE_HOME".to_string(), runtime_state_home.clone());
+    env.insert("npm_config_cache".to_string(), shared_npm_cache_string.clone());
+    env.insert("MISE_CACHE_DIR".to_string(), runtime_mise_cache.clone());
+    env.insert("MISE_STATE_DIR".to_string(), runtime_mise_state.clone());
     env.insert("MISE_SHIM".to_string(), String::new());
     env.insert("MISE_SHIMS_DIR".to_string(), String::new());
     env.insert(
@@ -627,7 +629,7 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
     );
     ensure_gemini_runtime_home_writable_path(
         &mut isolation_plan,
-        Some(std::path::Path::new(runtime_home)),
+        Some(runtime_home.as_path()),
     );
     ensure_gemini_runtime_home_writable_path(&mut isolation_plan, Some(shared_npm_cache.as_path()));
     let env_overrides = gemini_sandbox_runtime_env_overrides(&env);
@@ -636,22 +638,20 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
     assert!(
         isolation_plan
             .writable_paths
-            .contains(&PathBuf::from(runtime_home)),
+            .contains(&runtime_home),
         "sandbox should add the per-session Gemini runtime home as a writable bind"
     );
-    assert_eq!(
-        shared_npm_cache,
-        PathBuf::from("/shared/cache/cli-sub-agent/npm")
+    assert!(
+        isolation_plan.writable_paths.contains(&shared_npm_cache),
+        "sandbox should add the shared npm cache as a writable bind under bwrap (#1047)"
     );
     assert!(
-        isolation_plan
-            .writable_paths
-            .contains(&PathBuf::from("/shared/cache/cli-sub-agent/npm")),
-        "sandbox should add the shared npm cache as a writable bind under bwrap (#1047)"
+        shared_npm_cache.is_dir(),
+        "sandbox-plan assembly must pre-create the shared npm cache dir before bwrap binds it (#1047)"
     );
     assert_eq!(
         isolation_plan.env_overrides.get("HOME"),
-        Some(&runtime_home.to_string())
+        Some(&runtime_home_string)
     );
     // TMPDIR is set by IsolationPlanBuilder::with_tool_defaults(), not by
     // gemini sandbox overrides (which must NOT override it — see #704 review).
@@ -664,7 +664,7 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
     );
     assert_eq!(
         isolation_plan.env_overrides.get("GEMINI_CLI_HOME"),
-        Some(&runtime_home.to_string())
+        Some(&runtime_home_string)
     );
     assert_eq!(
         isolation_plan.env_overrides.get("PATH"),
@@ -673,21 +673,21 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
     );
     assert_eq!(
         isolation_plan.env_overrides.get("XDG_STATE_HOME"),
-        Some(&format!("{runtime_home}/.local/state"))
+        Some(&runtime_state_home)
     );
     assert_eq!(
         isolation_plan.env_overrides.get("npm_config_cache"),
-        Some(&"/shared/cache/cli-sub-agent/npm".to_string()),
+        Some(&shared_npm_cache_string),
         "sandbox should preserve the shared npm cache override under bwrap (#1047)"
     );
     assert_eq!(
         isolation_plan.env_overrides.get("MISE_CACHE_DIR"),
-        Some(&format!("{runtime_home}/.cache/mise")),
+        Some(&runtime_mise_cache),
         "sandbox should pin mise cache inside the Gemini runtime home"
     );
     assert_eq!(
         isolation_plan.env_overrides.get("MISE_STATE_DIR"),
-        Some(&format!("{runtime_home}/.local/state/mise")),
+        Some(&runtime_mise_state),
         "sandbox should pin mise state inside the Gemini runtime home"
     );
     assert_eq!(

--- a/crates/csa-executor/src/transport_tests_gemini_fallback.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_fallback.rs
@@ -499,7 +499,10 @@ fn test_ensure_gemini_runtime_home_writable_path_adds_runtime_home_under_tmp() {
         memory_monitor_interval_seconds: None,
     };
 
-    ensure_gemini_runtime_home_writable_path(&mut isolation_plan, Some(&runtime_home));
+    assert!(ensure_gemini_runtime_home_writable_path(
+        &mut isolation_plan,
+        Some(&runtime_home)
+    ));
 
     assert!(
         isolation_plan.writable_paths.contains(&runtime_home),
@@ -527,7 +530,10 @@ fn test_ensure_gemini_runtime_home_writable_path_skips_when_parent_is_bound() {
         memory_monitor_interval_seconds: None,
     };
 
-    ensure_gemini_runtime_home_writable_path(&mut isolation_plan, Some(&runtime_home));
+    assert!(ensure_gemini_runtime_home_writable_path(
+        &mut isolation_plan,
+        Some(&runtime_home)
+    ));
 
     assert_eq!(
         isolation_plan
@@ -558,7 +564,10 @@ fn test_ensure_gemini_runtime_home_writable_path_is_noop_without_runtime_home() 
         memory_monitor_interval_seconds: None,
     };
 
-    ensure_gemini_runtime_home_writable_path(&mut isolation_plan, None);
+    assert!(!ensure_gemini_runtime_home_writable_path(
+        &mut isolation_plan,
+        None
+    ));
 
     assert_eq!(
         isolation_plan.writable_paths,
@@ -627,11 +636,14 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
         env.get("npm_config_cache")
             .expect("sandbox env fixture must include npm_config_cache"),
     );
-    ensure_gemini_runtime_home_writable_path(
+    assert!(ensure_gemini_runtime_home_writable_path(
         &mut isolation_plan,
         Some(runtime_home.as_path()),
-    );
-    ensure_gemini_runtime_home_writable_path(&mut isolation_plan, Some(shared_npm_cache.as_path()));
+    ));
+    assert!(ensure_gemini_runtime_home_writable_path(
+        &mut isolation_plan,
+        Some(shared_npm_cache.as_path())
+    ));
     let env_overrides = gemini_sandbox_runtime_env_overrides(&env);
     apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, &env_overrides);
 

--- a/crates/csa-executor/src/transport_tests_gemini_fallback.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_fallback.rs
@@ -588,6 +588,10 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
         format!("{runtime_home}/.local/state"),
     );
     env.insert(
+        "npm_config_cache".to_string(),
+        "/shared/cache/cli-sub-agent/npm".to_string(),
+    );
+    env.insert(
         "MISE_CACHE_DIR".to_string(),
         format!("{runtime_home}/.cache/mise"),
     );
@@ -645,6 +649,11 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
     assert_eq!(
         isolation_plan.env_overrides.get("XDG_STATE_HOME"),
         Some(&format!("{runtime_home}/.local/state"))
+    );
+    assert_eq!(
+        isolation_plan.env_overrides.get("npm_config_cache"),
+        Some(&"/shared/cache/cli-sub-agent/npm".to_string()),
+        "sandbox should preserve the shared npm cache override under bwrap (#1047)"
     );
     assert_eq!(
         isolation_plan.env_overrides.get("MISE_CACHE_DIR"),

--- a/crates/csa-executor/src/transport_tests_gemini_sandbox_lockstep.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_sandbox_lockstep.rs
@@ -97,3 +97,106 @@ async fn test_execute_fails_fast_when_shared_npm_cache_bind_cannot_be_added() {
         "sandbox plan failure should abort before the fake gemini process runs"
     );
 }
+
+#[tokio::test]
+async fn test_legacy_execute_fails_fast_when_shared_npm_cache_bind_cannot_be_added() {
+    let (temp, mut env, model_log_path) = setup_fake_gemini_environment(99);
+    let source_home = temp.path().join("source-home");
+    std::fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert("XDG_CACHE_HOME".to_string(), "/proc/nonexistent".to_string());
+
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+    let session = build_test_meta_session(temp.path().to_str().expect("utf8 temp path"));
+    let sandbox = SandboxTransportConfig {
+        isolation_plan: IsolationPlan {
+            resource: csa_resource::sandbox::ResourceCapability::None,
+            filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+            writable_paths: Vec::new(),
+            readable_paths: Vec::new(),
+            env_overrides: HashMap::new(),
+            degraded_reasons: Vec::new(),
+            memory_max_mb: None,
+            memory_swap_max_mb: None,
+            pids_max: None,
+            readonly_project_root: false,
+            project_root: None,
+            soft_limit_percent: None,
+            memory_monitor_interval_seconds: None,
+        },
+        tool_name: "gemini-cli".to_string(),
+        best_effort: false,
+        session_id: "01HTESTGEMINILEGACYNPMLOCKSTEP01".to_string(),
+    };
+    let options = TransportOptions {
+        stream_mode: StreamMode::BufferOnly,
+        idle_timeout_seconds: 30,
+        acp_crash_max_attempts: 2,
+        initial_response_timeout: super::ResolvedTimeout(None),
+        liveness_dead_seconds: 30,
+        stdin_write_timeout_seconds: 30,
+        acp_init_timeout_seconds: 30,
+        termination_grace_period_seconds: 1,
+        output_spool: None,
+        output_spool_max_bytes: csa_process::DEFAULT_SPOOL_MAX_BYTES,
+        output_spool_keep_rotated: csa_process::DEFAULT_SPOOL_KEEP_ROTATED,
+        setting_sources: None,
+        sandbox: Some(&sandbox),
+    };
+
+    let error = transport
+        .execute(
+            "legacy shared npm cache bind failure should fail fast",
+            None,
+            &session,
+            Some(&env),
+            options,
+        )
+        .await
+        .expect_err("legacy sandbox plan assembly should fail fast");
+
+    let error_text = format!("{error:#}");
+    let denied_path = "/proc/nonexistent/cli-sub-agent/npm";
+    assert!(
+        error_text.contains(denied_path),
+        "error should name denied path, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("filesystem_sandbox") || error_text.contains("writable_paths"),
+        "error should point at sandbox writable_paths config, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("XDG_CACHE_HOME"),
+        "error should mention XDG_CACHE_HOME remediation, got: {error_text}"
+    );
+
+    assert!(
+        !env.contains_key("npm_config_cache"),
+        "caller env must not leak a partially-coupled npm_config_cache override"
+    );
+    assert!(
+        !sandbox.isolation_plan.env_overrides.contains_key("npm_config_cache"),
+        "base sandbox config must remain untouched when plan assembly aborts"
+    );
+    assert!(
+        !sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&PathBuf::from(denied_path)),
+        "base sandbox config must not accumulate failed writable binds"
+    );
+    assert!(
+        !model_log_path.exists(),
+        "gemini should not launch after sandbox plan failure"
+    );
+    assert!(
+        !model_log_path.with_file_name("attempts.txt").exists(),
+        "sandbox plan failure should abort before the fake gemini process runs"
+    );
+}

--- a/crates/csa-executor/src/transport_tests_gemini_sandbox_lockstep.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_sandbox_lockstep.rs
@@ -1,81 +1,99 @@
-#[test]
-fn test_apply_gemini_sandbox_runtime_env_overrides_retracts_unbound_shared_npm_cache() {
-    let temp = tempdir().expect("tempdir");
-    let session_dir = temp.path().join("session");
+#[tokio::test]
+async fn test_execute_fails_fast_when_shared_npm_cache_bind_cannot_be_added() {
+    let (temp, mut env, model_log_path) = setup_fake_gemini_environment(99);
     let source_home = temp.path().join("source-home");
     std::fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
-
-    let mut env = HashMap::new();
     env.insert(
         "HOME".to_string(),
         source_home.to_string_lossy().into_owned(),
     );
     env.insert("XDG_CACHE_HOME".to_string(), "/proc/nonexistent".to_string());
 
-    prepare_gemini_acp_runtime(
-        &mut env,
-        None,
-        Some(session_dir.as_path()),
-        "01TESTGEMININPMLOCKSTEP0000001",
-        &["--acp".to_string()],
-    )
-    .expect("prepare runtime");
-
-    let runtime_home =
-        gemini_runtime_home_from_env(&env).expect("runtime home should be configured");
-    let shared_npm_cache = PathBuf::from(
-        env.get("npm_config_cache")
-            .expect("prepare runtime should set npm_config_cache before sandbox coupling"),
-    );
-    assert_eq!(
-        shared_npm_cache,
-        PathBuf::from("/proc/nonexistent").join("cli-sub-agent/npm")
-    );
-
-    let mut isolation_plan = IsolationPlan {
-        resource: csa_resource::sandbox::ResourceCapability::None,
-        filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
-        writable_paths: Vec::new(),
-        readable_paths: Vec::new(),
-        env_overrides: HashMap::new(),
-        degraded_reasons: Vec::new(),
-        memory_max_mb: None,
-        memory_swap_max_mb: None,
-        pids_max: None,
-        readonly_project_root: false,
-        project_root: None,
-        soft_limit_percent: None,
-        memory_monitor_interval_seconds: None,
+    let transport = AcpTransport::new("gemini-cli", None);
+    let session = build_test_meta_session(temp.path().to_str().expect("utf8 temp path"));
+    let sandbox = SandboxTransportConfig {
+        isolation_plan: IsolationPlan {
+            resource: csa_resource::sandbox::ResourceCapability::None,
+            filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+            writable_paths: Vec::new(),
+            readable_paths: Vec::new(),
+            env_overrides: HashMap::new(),
+            degraded_reasons: Vec::new(),
+            memory_max_mb: None,
+            memory_swap_max_mb: None,
+            pids_max: None,
+            readonly_project_root: false,
+            project_root: None,
+            soft_limit_percent: None,
+            memory_monitor_interval_seconds: None,
+        },
+        tool_name: "gemini-cli".to_string(),
+        best_effort: false,
+        session_id: "01HTESTGEMININPMLOCKSTEP0000001".to_string(),
+    };
+    let options = TransportOptions {
+        stream_mode: StreamMode::BufferOnly,
+        idle_timeout_seconds: 30,
+        acp_crash_max_attempts: 2,
+        initial_response_timeout: super::ResolvedTimeout(None),
+        liveness_dead_seconds: 30,
+        stdin_write_timeout_seconds: 30,
+        acp_init_timeout_seconds: 30,
+        termination_grace_period_seconds: 1,
+        output_spool: None,
+        output_spool_max_bytes: csa_process::DEFAULT_SPOOL_MAX_BYTES,
+        output_spool_keep_rotated: csa_process::DEFAULT_SPOOL_KEEP_ROTATED,
+        setting_sources: None,
+        sandbox: Some(&sandbox),
     };
 
-    assert!(ensure_gemini_runtime_home_writable_path(
-        &mut isolation_plan,
-        Some(runtime_home.as_path())
-    ));
-    let shared_npm_cache_bound = ensure_gemini_runtime_home_writable_path(
-        &mut isolation_plan,
-        Some(shared_npm_cache.as_path()),
+    let error = transport
+        .execute(
+            "shared npm cache bind failure should fail fast",
+            None,
+            &session,
+            Some(&env),
+            options,
+        )
+        .await
+        .expect_err("sandbox plan assembly should fail fast");
+
+    let error_text = format!("{error:#}");
+    let denied_path = "/proc/nonexistent/cli-sub-agent/npm";
+    assert!(
+        error_text.contains(denied_path),
+        "error should name denied path, got: {error_text}"
     );
-    if !shared_npm_cache_bound {
-        env.remove("npm_config_cache");
-    }
-    let env_overrides = gemini_sandbox_runtime_env_overrides(&env);
-    apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, &env_overrides);
+    assert!(
+        error_text.contains("filesystem_sandbox") || error_text.contains("writable_paths"),
+        "error should point at sandbox writable_paths config, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("XDG_CACHE_HOME"),
+        "error should mention XDG_CACHE_HOME remediation, got: {error_text}"
+    );
 
     assert!(
-        !shared_npm_cache_bound,
-        "sensitive /proc path must not be accepted as a writable bind source"
-    );
-    assert!(
-        !isolation_plan.writable_paths.contains(&shared_npm_cache),
-        "sandbox must skip the shared npm cache bind when the host path cannot be prepared"
-    );
-    assert!(
         !env.contains_key("npm_config_cache"),
-        "spawn env must retract npm_config_cache when the writable bind cannot be added"
+        "caller env must not leak a partially-coupled npm_config_cache override"
     );
     assert!(
-        !isolation_plan.env_overrides.contains_key("npm_config_cache"),
-        "sandbox env overrides must stay in lockstep with writable binds (#1047)"
+        !sandbox.isolation_plan.env_overrides.contains_key("npm_config_cache"),
+        "base sandbox config must remain untouched when plan assembly aborts"
+    );
+    assert!(
+        !sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&PathBuf::from(denied_path)),
+        "base sandbox config must not accumulate failed writable binds"
+    );
+    assert!(
+        !model_log_path.exists(),
+        "gemini should not launch after sandbox plan failure"
+    );
+    assert!(
+        !model_log_path.with_file_name("attempts.txt").exists(),
+        "sandbox plan failure should abort before the fake gemini process runs"
     );
 }

--- a/crates/csa-executor/src/transport_tests_gemini_sandbox_lockstep.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_sandbox_lockstep.rs
@@ -1,0 +1,81 @@
+#[test]
+fn test_apply_gemini_sandbox_runtime_env_overrides_retracts_unbound_shared_npm_cache() {
+    let temp = tempdir().expect("tempdir");
+    let session_dir = temp.path().join("session");
+    let source_home = temp.path().join("source-home");
+    std::fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert("XDG_CACHE_HOME".to_string(), "/proc/nonexistent".to_string());
+
+    prepare_gemini_acp_runtime(
+        &mut env,
+        None,
+        Some(session_dir.as_path()),
+        "01TESTGEMININPMLOCKSTEP0000001",
+        &["--acp".to_string()],
+    )
+    .expect("prepare runtime");
+
+    let runtime_home =
+        gemini_runtime_home_from_env(&env).expect("runtime home should be configured");
+    let shared_npm_cache = PathBuf::from(
+        env.get("npm_config_cache")
+            .expect("prepare runtime should set npm_config_cache before sandbox coupling"),
+    );
+    assert_eq!(
+        shared_npm_cache,
+        PathBuf::from("/proc/nonexistent").join("cli-sub-agent/npm")
+    );
+
+    let mut isolation_plan = IsolationPlan {
+        resource: csa_resource::sandbox::ResourceCapability::None,
+        filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+        writable_paths: Vec::new(),
+        readable_paths: Vec::new(),
+        env_overrides: HashMap::new(),
+        degraded_reasons: Vec::new(),
+        memory_max_mb: None,
+        memory_swap_max_mb: None,
+        pids_max: None,
+        readonly_project_root: false,
+        project_root: None,
+        soft_limit_percent: None,
+        memory_monitor_interval_seconds: None,
+    };
+
+    assert!(ensure_gemini_runtime_home_writable_path(
+        &mut isolation_plan,
+        Some(runtime_home.as_path())
+    ));
+    let shared_npm_cache_bound = ensure_gemini_runtime_home_writable_path(
+        &mut isolation_plan,
+        Some(shared_npm_cache.as_path()),
+    );
+    if !shared_npm_cache_bound {
+        env.remove("npm_config_cache");
+    }
+    let env_overrides = gemini_sandbox_runtime_env_overrides(&env);
+    apply_gemini_sandbox_runtime_env_overrides(&mut isolation_plan, &env_overrides);
+
+    assert!(
+        !shared_npm_cache_bound,
+        "sensitive /proc path must not be accepted as a writable bind source"
+    );
+    assert!(
+        !isolation_plan.writable_paths.contains(&shared_npm_cache),
+        "sandbox must skip the shared npm cache bind when the host path cannot be prepared"
+    );
+    assert!(
+        !env.contains_key("npm_config_cache"),
+        "spawn env must retract npm_config_cache when the writable bind cannot be added"
+    );
+    assert!(
+        !isolation_plan.env_overrides.contains_key("npm_config_cache"),
+        "sandbox env overrides must stay in lockstep with writable binds (#1047)"
+    );
+}

--- a/crates/csa-executor/src/transport_tests_gemini_sandbox_lockstep.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_sandbox_lockstep.rs
@@ -1,3 +1,36 @@
+#[cfg(unix)]
+static GEMINI_SHARED_NPM_CACHE_ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
+#[cfg(unix)]
+struct GeminiSharedNpmCacheScopedEnvVar {
+    key: &'static str,
+    original: Option<String>,
+}
+
+#[cfg(unix)]
+impl GeminiSharedNpmCacheScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by GEMINI_SHARED_NPM_CACHE_ENV_LOCK.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for GeminiSharedNpmCacheScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by GEMINI_SHARED_NPM_CACHE_ENV_LOCK.
+        unsafe {
+            match self.original.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 #[tokio::test]
 async fn test_execute_fails_fast_when_shared_npm_cache_bind_cannot_be_added() {
     let (temp, mut env, model_log_path) = setup_fake_gemini_environment(99);
@@ -407,6 +440,270 @@ async fn test_legacy_execute_fails_fast_when_shared_npm_cache_path_violates_writ
             .writable_paths
             .contains(&PathBuf::from(denied_path)),
         "base sandbox config must not accumulate failed writable binds"
+    );
+    assert!(
+        !model_log_path.exists(),
+        "gemini should not launch after sandbox plan failure"
+    );
+    assert!(
+        !model_log_path.with_file_name("attempts.txt").exists(),
+        "sandbox plan failure should abort before the fake gemini process runs"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn test_execute_fails_fast_when_symlinked_shared_npm_cache_resolves_outside_allowlist() {
+    let (temp, mut env, model_log_path) = setup_fake_gemini_environment(99);
+    let source_home = temp.path().join("source-home");
+    std::fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+    let _env_lock = GEMINI_SHARED_NPM_CACHE_ENV_LOCK.lock().expect("env lock");
+    let _home_guard = GeminiSharedNpmCacheScopedEnvVar::set(
+        "HOME",
+        source_home.to_str().expect("utf8 source home path"),
+    );
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    let outside_allowlist_root = tempfile::tempdir_in(
+        std::env::current_dir().expect("current dir for outside-allowlist tempdir"),
+    )
+    .expect("create outside-allowlist tempdir");
+    let symlink_cache_root = temp.path().join("symlink-cache");
+    std::os::unix::fs::symlink(outside_allowlist_root.path(), &symlink_cache_root)
+        .expect("symlink cache root");
+    env.insert(
+        "XDG_CACHE_HOME".to_string(),
+        symlink_cache_root.to_string_lossy().into_owned(),
+    );
+
+    let transport = AcpTransport::new("gemini-cli", None);
+    let session = build_test_meta_session(temp.path().to_str().expect("utf8 temp path"));
+    let sandbox = SandboxTransportConfig {
+        isolation_plan: IsolationPlan {
+            resource: csa_resource::sandbox::ResourceCapability::None,
+            filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+            writable_paths: Vec::new(),
+            readable_paths: Vec::new(),
+            env_overrides: HashMap::new(),
+            degraded_reasons: Vec::new(),
+            memory_max_mb: None,
+            memory_swap_max_mb: None,
+            pids_max: None,
+            readonly_project_root: false,
+            project_root: None,
+            soft_limit_percent: None,
+            memory_monitor_interval_seconds: None,
+        },
+        tool_name: "gemini-cli".to_string(),
+        best_effort: false,
+        session_id: "01HTESTGEMINISYMLINKACPNPM0001".to_string(),
+    };
+    let options = TransportOptions {
+        stream_mode: StreamMode::BufferOnly,
+        idle_timeout_seconds: 30,
+        acp_crash_max_attempts: 2,
+        initial_response_timeout: super::ResolvedTimeout(None),
+        liveness_dead_seconds: 30,
+        stdin_write_timeout_seconds: 30,
+        acp_init_timeout_seconds: 30,
+        termination_grace_period_seconds: 1,
+        output_spool: None,
+        output_spool_max_bytes: csa_process::DEFAULT_SPOOL_MAX_BYTES,
+        output_spool_keep_rotated: csa_process::DEFAULT_SPOOL_KEEP_ROTATED,
+        setting_sources: None,
+        sandbox: Some(&sandbox),
+    };
+
+    let error = transport
+        .execute(
+            "symlinked shared npm cache should fail fast",
+            None,
+            &session,
+            Some(&env),
+            options,
+        )
+        .await
+        .expect_err("sandbox plan assembly should reject a symlinked outside-allowlist npm cache");
+
+    let error_text = format!("{error:#}");
+    let requested_path = symlink_cache_root.join("cli-sub-agent/npm");
+    let canonical_path = outside_allowlist_root.path().join("cli-sub-agent/npm");
+    assert!(
+        error_text.contains(requested_path.to_string_lossy().as_ref()),
+        "error should name the original XDG_CACHE_HOME-derived path, got: {error_text}"
+    );
+    assert!(
+        error_text.contains(canonical_path.to_string_lossy().as_ref()),
+        "error should name the canonical target path, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("[filesystem_sandbox].writable_paths"),
+        "error should point at writable_paths allowlist config, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("non-symlinked location"),
+        "error should explain the non-symlinked remediation, got: {error_text}"
+    );
+
+    assert!(
+        !env.contains_key("npm_config_cache"),
+        "caller env must not leak a partially-coupled npm_config_cache override"
+    );
+    assert!(
+        !sandbox.isolation_plan.env_overrides.contains_key("npm_config_cache"),
+        "base sandbox config must remain untouched when plan assembly aborts"
+    );
+    assert!(
+        !sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&canonical_path),
+        "base sandbox config must not accumulate failed writable binds"
+    );
+    assert!(
+        !requested_path.exists(),
+        "symlinked denied path must not be created during failed plan assembly"
+    );
+    assert!(
+        !canonical_path.exists(),
+        "canonical target must not be created during failed plan assembly"
+    );
+    assert!(
+        !model_log_path.exists(),
+        "gemini should not launch after sandbox plan failure"
+    );
+    assert!(
+        !model_log_path.with_file_name("attempts.txt").exists(),
+        "sandbox plan failure should abort before the fake gemini process runs"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn test_legacy_execute_fails_fast_when_symlinked_shared_npm_cache_resolves_outside_allowlist()
+{
+    let (temp, mut env, model_log_path) = setup_fake_gemini_environment(99);
+    let source_home = temp.path().join("source-home");
+    std::fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+    let _env_lock = GEMINI_SHARED_NPM_CACHE_ENV_LOCK.lock().expect("env lock");
+    let _home_guard = GeminiSharedNpmCacheScopedEnvVar::set(
+        "HOME",
+        source_home.to_str().expect("utf8 source home path"),
+    );
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    let outside_allowlist_root = tempfile::tempdir_in(
+        std::env::current_dir().expect("current dir for outside-allowlist tempdir"),
+    )
+    .expect("create outside-allowlist tempdir");
+    let symlink_cache_root = temp.path().join("symlink-cache");
+    std::os::unix::fs::symlink(outside_allowlist_root.path(), &symlink_cache_root)
+        .expect("symlink cache root");
+    env.insert(
+        "XDG_CACHE_HOME".to_string(),
+        symlink_cache_root.to_string_lossy().into_owned(),
+    );
+
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+    let session = build_test_meta_session(temp.path().to_str().expect("utf8 temp path"));
+    let sandbox = SandboxTransportConfig {
+        isolation_plan: IsolationPlan {
+            resource: csa_resource::sandbox::ResourceCapability::None,
+            filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+            writable_paths: Vec::new(),
+            readable_paths: Vec::new(),
+            env_overrides: HashMap::new(),
+            degraded_reasons: Vec::new(),
+            memory_max_mb: None,
+            memory_swap_max_mb: None,
+            pids_max: None,
+            readonly_project_root: false,
+            project_root: None,
+            soft_limit_percent: None,
+            memory_monitor_interval_seconds: None,
+        },
+        tool_name: "gemini-cli".to_string(),
+        best_effort: false,
+        session_id: "01HTESTGEMINISYMLINKLEGACYNPM01".to_string(),
+    };
+    let options = TransportOptions {
+        stream_mode: StreamMode::BufferOnly,
+        idle_timeout_seconds: 30,
+        acp_crash_max_attempts: 2,
+        initial_response_timeout: super::ResolvedTimeout(None),
+        liveness_dead_seconds: 30,
+        stdin_write_timeout_seconds: 30,
+        acp_init_timeout_seconds: 30,
+        termination_grace_period_seconds: 1,
+        output_spool: None,
+        output_spool_max_bytes: csa_process::DEFAULT_SPOOL_MAX_BYTES,
+        output_spool_keep_rotated: csa_process::DEFAULT_SPOOL_KEEP_ROTATED,
+        setting_sources: None,
+        sandbox: Some(&sandbox),
+    };
+
+    let error = transport
+        .execute(
+            "legacy symlinked shared npm cache should fail fast",
+            None,
+            &session,
+            Some(&env),
+            options,
+        )
+        .await
+        .expect_err(
+            "legacy sandbox plan assembly should reject a symlinked outside-allowlist npm cache",
+        );
+
+    let error_text = format!("{error:#}");
+    let requested_path = symlink_cache_root.join("cli-sub-agent/npm");
+    let canonical_path = outside_allowlist_root.path().join("cli-sub-agent/npm");
+    assert!(
+        error_text.contains(requested_path.to_string_lossy().as_ref()),
+        "error should name the original XDG_CACHE_HOME-derived path, got: {error_text}"
+    );
+    assert!(
+        error_text.contains(canonical_path.to_string_lossy().as_ref()),
+        "error should name the canonical target path, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("[filesystem_sandbox].writable_paths"),
+        "error should point at writable_paths allowlist config, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("non-symlinked location"),
+        "error should explain the non-symlinked remediation, got: {error_text}"
+    );
+
+    assert!(
+        !env.contains_key("npm_config_cache"),
+        "caller env must not leak a partially-coupled npm_config_cache override"
+    );
+    assert!(
+        !sandbox.isolation_plan.env_overrides.contains_key("npm_config_cache"),
+        "base sandbox config must remain untouched when plan assembly aborts"
+    );
+    assert!(
+        !sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&canonical_path),
+        "base sandbox config must not accumulate failed writable binds"
+    );
+    assert!(
+        !requested_path.exists(),
+        "symlinked denied path must not be created during failed plan assembly"
+    );
+    assert!(
+        !canonical_path.exists(),
+        "canonical target must not be created during failed plan assembly"
     );
     assert!(
         !model_log_path.exists(),

--- a/crates/csa-executor/src/transport_tests_gemini_sandbox_lockstep.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_sandbox_lockstep.rs
@@ -200,3 +200,220 @@ async fn test_legacy_execute_fails_fast_when_shared_npm_cache_bind_cannot_be_add
         "sandbox plan failure should abort before the fake gemini process runs"
     );
 }
+
+#[tokio::test]
+async fn test_execute_fails_fast_when_shared_npm_cache_path_violates_writable_allowlist() {
+    let (temp, mut env, model_log_path) = setup_fake_gemini_environment(99);
+    let source_home = temp.path().join("source-home");
+    std::fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "XDG_CACHE_HOME".to_string(),
+        "/var/tmp/csa-outside-allowlist-1047".to_string(),
+    );
+
+    let transport = AcpTransport::new("gemini-cli", None);
+    let session = build_test_meta_session(temp.path().to_str().expect("utf8 temp path"));
+    let sandbox = SandboxTransportConfig {
+        isolation_plan: IsolationPlan {
+            resource: csa_resource::sandbox::ResourceCapability::None,
+            filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+            writable_paths: Vec::new(),
+            readable_paths: Vec::new(),
+            env_overrides: HashMap::new(),
+            degraded_reasons: Vec::new(),
+            memory_max_mb: None,
+            memory_swap_max_mb: None,
+            pids_max: None,
+            readonly_project_root: false,
+            project_root: None,
+            soft_limit_percent: None,
+            memory_monitor_interval_seconds: None,
+        },
+        tool_name: "gemini-cli".to_string(),
+        best_effort: false,
+        session_id: "01HTESTGEMINIALLOWLISTACPNPM0001".to_string(),
+    };
+    let options = TransportOptions {
+        stream_mode: StreamMode::BufferOnly,
+        idle_timeout_seconds: 30,
+        acp_crash_max_attempts: 2,
+        initial_response_timeout: super::ResolvedTimeout(None),
+        liveness_dead_seconds: 30,
+        stdin_write_timeout_seconds: 30,
+        acp_init_timeout_seconds: 30,
+        termination_grace_period_seconds: 1,
+        output_spool: None,
+        output_spool_max_bytes: csa_process::DEFAULT_SPOOL_MAX_BYTES,
+        output_spool_keep_rotated: csa_process::DEFAULT_SPOOL_KEEP_ROTATED,
+        setting_sources: None,
+        sandbox: Some(&sandbox),
+    };
+
+    let error = transport
+        .execute(
+            "shared npm cache allowlist violation should fail fast",
+            None,
+            &session,
+            Some(&env),
+            options,
+        )
+        .await
+        .expect_err("sandbox plan assembly should reject outside-allowlist npm cache");
+
+    let error_text = format!("{error:#}");
+    let denied_path = "/var/tmp/csa-outside-allowlist-1047/cli-sub-agent/npm";
+    assert!(
+        error_text.contains(denied_path),
+        "error should name denied path, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("XDG_CACHE_HOME"),
+        "error should mention XDG_CACHE_HOME remediation, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("[filesystem_sandbox].writable_paths"),
+        "error should point at writable_paths allowlist config, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("outside allowed roots"),
+        "error should preserve validator policy detail, got: {error_text}"
+    );
+
+    assert!(
+        !env.contains_key("npm_config_cache"),
+        "caller env must not leak a partially-coupled npm_config_cache override"
+    );
+    assert!(
+        !sandbox.isolation_plan.env_overrides.contains_key("npm_config_cache"),
+        "base sandbox config must remain untouched when plan assembly aborts"
+    );
+    assert!(
+        !sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&PathBuf::from(denied_path)),
+        "base sandbox config must not accumulate failed writable binds"
+    );
+    assert!(
+        !model_log_path.exists(),
+        "gemini should not launch after sandbox plan failure"
+    );
+    assert!(
+        !model_log_path.with_file_name("attempts.txt").exists(),
+        "sandbox plan failure should abort before the fake gemini process runs"
+    );
+}
+
+#[tokio::test]
+async fn test_legacy_execute_fails_fast_when_shared_npm_cache_path_violates_writable_allowlist() {
+    let (temp, mut env, model_log_path) = setup_fake_gemini_environment(99);
+    let source_home = temp.path().join("source-home");
+    std::fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+    env.insert(
+        "XDG_CACHE_HOME".to_string(),
+        "/var/tmp/csa-outside-allowlist-1047".to_string(),
+    );
+
+    let transport = LegacyTransport::new(Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    });
+    let session = build_test_meta_session(temp.path().to_str().expect("utf8 temp path"));
+    let sandbox = SandboxTransportConfig {
+        isolation_plan: IsolationPlan {
+            resource: csa_resource::sandbox::ResourceCapability::None,
+            filesystem: csa_resource::filesystem_sandbox::FilesystemCapability::Bwrap,
+            writable_paths: Vec::new(),
+            readable_paths: Vec::new(),
+            env_overrides: HashMap::new(),
+            degraded_reasons: Vec::new(),
+            memory_max_mb: None,
+            memory_swap_max_mb: None,
+            pids_max: None,
+            readonly_project_root: false,
+            project_root: None,
+            soft_limit_percent: None,
+            memory_monitor_interval_seconds: None,
+        },
+        tool_name: "gemini-cli".to_string(),
+        best_effort: false,
+        session_id: "01HTESTGEMINIALLOWLISTLEGACY0001".to_string(),
+    };
+    let options = TransportOptions {
+        stream_mode: StreamMode::BufferOnly,
+        idle_timeout_seconds: 30,
+        acp_crash_max_attempts: 2,
+        initial_response_timeout: super::ResolvedTimeout(None),
+        liveness_dead_seconds: 30,
+        stdin_write_timeout_seconds: 30,
+        acp_init_timeout_seconds: 30,
+        termination_grace_period_seconds: 1,
+        output_spool: None,
+        output_spool_max_bytes: csa_process::DEFAULT_SPOOL_MAX_BYTES,
+        output_spool_keep_rotated: csa_process::DEFAULT_SPOOL_KEEP_ROTATED,
+        setting_sources: None,
+        sandbox: Some(&sandbox),
+    };
+
+    let error = transport
+        .execute(
+            "legacy shared npm cache allowlist violation should fail fast",
+            None,
+            &session,
+            Some(&env),
+            options,
+        )
+        .await
+        .expect_err("legacy sandbox plan assembly should reject outside-allowlist npm cache");
+
+    let error_text = format!("{error:#}");
+    let denied_path = "/var/tmp/csa-outside-allowlist-1047/cli-sub-agent/npm";
+    assert!(
+        error_text.contains(denied_path),
+        "error should name denied path, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("XDG_CACHE_HOME"),
+        "error should mention XDG_CACHE_HOME remediation, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("[filesystem_sandbox].writable_paths"),
+        "error should point at writable_paths allowlist config, got: {error_text}"
+    );
+    assert!(
+        error_text.contains("outside allowed roots"),
+        "error should preserve validator policy detail, got: {error_text}"
+    );
+
+    assert!(
+        !env.contains_key("npm_config_cache"),
+        "caller env must not leak a partially-coupled npm_config_cache override"
+    );
+    assert!(
+        !sandbox.isolation_plan.env_overrides.contains_key("npm_config_cache"),
+        "base sandbox config must remain untouched when plan assembly aborts"
+    );
+    assert!(
+        !sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&PathBuf::from(denied_path)),
+        "base sandbox config must not accumulate failed writable binds"
+    );
+    assert!(
+        !model_log_path.exists(),
+        "gemini should not launch after sandbox plan failure"
+    );
+    assert!(
+        !model_log_path.with_file_name("attempts.txt").exists(),
+        "sandbox plan failure should abort before the fake gemini process runs"
+    );
+}

--- a/crates/csa-executor/src/transport_tests_mod.rs
+++ b/crates/csa-executor/src/transport_tests_mod.rs
@@ -6,6 +6,7 @@ use csa_resource::isolation_plan::IsolationPlan;
 include!("transport_tests_tail.rs");
 include!("transport_tests_ephemeral.rs");
 include!("transport_tests_gemini_fallback.rs");
+include!("transport_tests_gemini_sandbox_lockstep.rs");
 include!("transport_tests_gemini_init_classification.rs");
 include!("transport_tests_gemini_acp_mcp_retry.rs");
 include!("transport_tests_gemini_oauth_prompt.rs");

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -64,6 +64,14 @@ pub struct IsolationPlan {
     pub memory_monitor_interval_seconds: Option<u64>,
 }
 
+impl IsolationPlan {
+    /// Add a writable directory, pre-creating it when its parent exists so
+    /// bwrap bind sources are present on cold start.
+    pub fn add_writable_dir_or_creatable_parent(&mut self, dir: &Path) {
+        add_dir_or_creatable_parent(&mut self.writable_paths, dir);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // IsolationPlanBuilder
 // ---------------------------------------------------------------------------
@@ -525,8 +533,8 @@ fn canonicalize_or_fallback(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
-/// Add `dir` to `paths` if it exists, otherwise pre-create it when its
-/// parent exists (bwrap `--bind` requires the source path to exist).
+/// Add `dir` to `paths` if it exists, otherwise pre-create it when a
+/// non-root ancestor exists (bwrap `--bind` requires the source path to exist).
 ///
 /// Rejects paths under sensitive system directories (`/etc`, `/var/lib`,
 /// `/boot`, `/sbin`, etc.) to prevent env vars like `CARGO_HOME` from
@@ -542,10 +550,16 @@ fn add_dir_or_creatable_parent(paths: &mut Vec<PathBuf>, dir: &Path) {
 
     if dir.exists() {
         paths.push(dir.to_path_buf());
-    } else if dir.parent().is_some_and(|p| p.exists()) {
+    } else if dir
+        .ancestors()
+        .skip(1)
+        .find(|ancestor| ancestor.exists())
+        .is_some_and(|ancestor| ancestor != Path::new("/"))
+    {
         // Pre-create the directory so bwrap --bind can mount it.
-        // On cold starts (fresh CARGO_HOME/RUSTUP_HOME) the dir won't
-        // exist yet; bwrap requires the source path to be present.
+        // On cold starts (fresh CARGO_HOME/RUSTUP_HOME/shared npm cache) the
+        // dir or one of its intermediate parents won't exist yet; bwrap
+        // requires the source path to be present.
         match std::fs::create_dir_all(dir) {
             Ok(()) => paths.push(dir.to_path_buf()),
             Err(e) => tracing::warn!(

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -4,6 +4,8 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
+
 use crate::filesystem_sandbox::FilesystemCapability;
 use crate::sandbox::ResourceCapability;
 
@@ -441,6 +443,70 @@ pub fn validate_readable_paths(paths: &[PathBuf], project_root: &Path) -> anyhow
             canonicalize_for_allowlist: true,
         },
     )
+}
+
+/// Canonicalize `path` by resolving its deepest existing ancestor, then
+/// re-attaching any missing tail components.
+///
+/// This preserves symlink resolution for already-existing prefixes without
+/// requiring the full path to exist yet, which is important for writable
+/// directories that may be pre-created later via `create_dir_all()`.
+pub fn canonicalize_through_existing_ancestors(path: &Path) -> anyhow::Result<PathBuf> {
+    let mut candidate = path.to_path_buf();
+    let mut missing_suffix = Vec::new();
+
+    loop {
+        if candidate.as_os_str().is_empty() {
+            let mut resolved = std::env::current_dir().with_context(|| {
+                format!(
+                    "failed to resolve current directory while canonicalizing {}",
+                    path.display()
+                )
+            })?;
+            for component in missing_suffix.iter().rev() {
+                resolved.push(component);
+            }
+            return Ok(resolved);
+        }
+
+        match candidate.canonicalize() {
+            Ok(mut resolved) => {
+                for component in missing_suffix.iter().rev() {
+                    resolved.push(component);
+                }
+                return Ok(resolved);
+            }
+            Err(error) => match candidate.try_exists() {
+                Ok(true) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "failed to canonicalize existing path {} while resolving {}",
+                            candidate.display(),
+                            path.display()
+                        )
+                    });
+                }
+                Ok(false) => {
+                    let component = candidate.file_name().with_context(|| {
+                        format!(
+                            "path {} has no existing ancestor to canonicalize through",
+                            path.display()
+                        )
+                    })?;
+                    missing_suffix.push(component.to_os_string());
+                    candidate.pop();
+                }
+                Err(exists_error) => {
+                    return Err(exists_error).with_context(|| {
+                        format!(
+                            "failed to probe path existence while resolving {}",
+                            path.display()
+                        )
+                    });
+                }
+            },
+        }
+    }
 }
 
 struct PathValidationOptions<'a> {

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -67,8 +67,8 @@ pub struct IsolationPlan {
 impl IsolationPlan {
     /// Add a writable directory, pre-creating it when its parent exists so
     /// bwrap bind sources are present on cold start.
-    pub fn add_writable_dir_or_creatable_parent(&mut self, dir: &Path) {
-        add_dir_or_creatable_parent(&mut self.writable_paths, dir);
+    pub fn add_writable_dir_or_creatable_parent(&mut self, dir: &Path) -> bool {
+        add_dir_or_creatable_parent(&mut self.writable_paths, dir)
     }
 }
 
@@ -539,17 +539,18 @@ fn canonicalize_or_fallback(path: &Path) -> PathBuf {
 /// Rejects paths under sensitive system directories (`/etc`, `/var/lib`,
 /// `/boot`, `/sbin`, etc.) to prevent env vars like `CARGO_HOME` from
 /// escaping the sandbox boundary.
-fn add_dir_or_creatable_parent(paths: &mut Vec<PathBuf>, dir: &Path) {
+fn add_dir_or_creatable_parent(paths: &mut Vec<PathBuf>, dir: &Path) -> bool {
     if is_sensitive_system_path(dir) {
         tracing::warn!(
             path = %dir.display(),
             "rejecting writable path under sensitive system directory"
         );
-        return;
+        return false;
     }
 
     if dir.exists() {
         paths.push(dir.to_path_buf());
+        true
     } else if dir
         .ancestors()
         .skip(1)
@@ -561,13 +562,21 @@ fn add_dir_or_creatable_parent(paths: &mut Vec<PathBuf>, dir: &Path) {
         // dir or one of its intermediate parents won't exist yet; bwrap
         // requires the source path to be present.
         match std::fs::create_dir_all(dir) {
-            Ok(()) => paths.push(dir.to_path_buf()),
-            Err(e) => tracing::warn!(
-                path = %dir.display(),
-                error = %e,
-                "failed to pre-create directory for sandbox writable mount, skipping"
-            ),
+            Ok(()) => {
+                paths.push(dir.to_path_buf());
+                true
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %dir.display(),
+                    error = %e,
+                    "failed to pre-create directory for sandbox writable mount, skipping"
+                );
+                false
+            }
         }
+    } else {
+        false
     }
 }
 

--- a/crates/csa-resource/src/isolation_plan_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_tests.rs
@@ -621,19 +621,16 @@ fn test_add_dir_or_creatable_parent_precreates_missing_dir() {
 }
 
 #[test]
-fn test_add_dir_or_creatable_parent_skips_when_parent_missing() {
+fn test_add_dir_or_creatable_parent_precreates_nested_dir_when_non_root_ancestor_exists() {
     let tmp = tempfile::tempdir().unwrap();
-    // Both parent and child are missing
     let deep = tmp.path().join("no_parent").join("no_child");
+    assert!(!deep.exists(), "precondition: nested dir must not exist");
 
     let mut paths = Vec::new();
     add_dir_or_creatable_parent(&mut paths, &deep);
 
-    assert!(!deep.exists());
-    assert!(
-        paths.is_empty(),
-        "should not add path when parent is missing"
-    );
+    assert!(deep.exists(), "nested dir should be pre-created");
+    assert_eq!(paths, vec![deep]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Seven-round followup on #1047 Phase 1 (PR #1050) to ensure the shared `npm_config_cache` optimization works under bwrap sandbox for both gemini-cli ACP and legacy CLI spawn paths — and does so within the configured writable-paths allowlist.

Each round named a distinct concrete bug in a different file/line — iterative quality work, not design ping-pong:

- **R1** (`8f6e1b91`): add `npm_config_cache` to the gemini-cli bwrap env allowlist. Without this, bwrap stripped the var and Phase 1's optimization was inert.
- **R2** (`308f21dc`): add `shared_gemini_npm_cache()` to the sandbox-plan extra-writable binds. Under bwrap the path itself is read-only unless explicitly bound, so npm hit EROFS on `_cacache` population.
- **R3** (`b52fefb8`): switch the direct `push()` to `add_dir_or_creatable_parent()` so the cache dir is created before bwrap binds it. R2 crashed bwrap on cold-start when the dir didn't exist yet.
- **R4** (`423f63f5`): couple the env override with the writable bind. R2/R3 left them independent — if the bind silently failed, the env override still pointed at the unusable path.
- **R5** (`8b77831f`): replace R4's silent env-retract with fail-fast. Local review flagged the retract as a Rule 041 violation (forbidden per-session-state-dir fallback). Fail-fast surfaces the policy decision rather than degrading silently.
- **R6** (`aee47033`): port the R1–R5 fix to the legacy CLI spawn path. `gemini-cli`'s default `transport = "auto"` resolves to CLI, not ACP — rounds 1–5 covered only ACP users.
- **R7** (`919ee5b2`): re-run the writable-paths allowlist validator on the env-derived path before appending it. A user setting `XDG_CACHE_HOME` outside their configured allowlist could bypass the sandbox boundary — the env-derived path was being inserted without going through the same policy check that configured paths use. Fixed in both ACP and legacy CLI codepaths.

Refs #1047.

## Test plan

- [x] `cargo test -p csa-executor` — gemini-fallback + sandbox-lockstep regression tests pass across all 7 rounds
- [x] `just pre-commit` — exit 0 for each round's commit
- [x] `csa review --range main...HEAD --tier tier-4-critical` — final review (session 01KPWT38XYMZDYEFHSDNCBS2Z7) returns verdict: PASS, no findings
- [ ] pr-bot cloud review

🤖 Generated with [Claude Code](https://claude.com/claude-code)