### PR TITLE
feat(csa-gc): --reap-runtime flag + wire Phase 2 on_exceed=auto-gc (#1047 p3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.531"
+version = "0.1.532"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.531"
+version = "0.1.532"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -19,7 +19,6 @@ pub use cli_review::*;
 #[path = "cli_tokuin.rs"]
 mod cli_tokuin;
 pub use cli_tokuin::*;
-
 #[path = "cli_xurl.rs"]
 mod cli_xurl;
 pub use cli_xurl::*;
@@ -287,20 +286,8 @@ pub enum Commands {
         template: bool,
     },
 
-    /// Garbage collect expired locks and empty sessions
-    Gc {
-        /// Show what would be removed without actually removing
-        #[arg(long)]
-        dry_run: bool,
-
-        /// Remove sessions not accessed within N days
-        #[arg(long)]
-        max_age_days: Option<u64>,
-
-        /// Scan all projects under ~/.local/state/cli-sub-agent/ (not just current project)
-        #[arg(long)]
-        global: bool,
-    },
+    /// Garbage collect stale session artifacts
+    Gc(crate::gc::GcArgs),
 
     /// Show/manage configuration
     Config {
@@ -443,11 +430,7 @@ pub enum Commands {
 
 #[derive(Subcommand)]
 pub enum HooksCommands {
-    /// Install the merge guard `gh` wrapper to PATH
-    ///
-    /// Writes a `gh` wrapper script that intercepts `gh pr merge` and
-    /// enforces the pr-bot workflow.  The wrapper must appear before the
-    /// real `gh` in PATH.
+    /// Install a `gh` wrapper that intercepts `gh pr merge` before the real binary in PATH
     InstallMergeGuard {
         /// Custom install directory (default: ~/.local/bin/csa-gh-guard)
         #[arg(long, value_name = "DIR")]
@@ -465,19 +448,15 @@ pub struct ClaudeSubAgentArgs {
     /// Tool to use (overrides config-based selection)
     #[arg(long)]
     pub tool: Option<ToolArg>,
-
     /// Resume existing session
     #[arg(short, long)]
     pub session: Option<String>,
-
     /// Override model
     #[arg(short, long)]
     pub model: Option<String>,
-
     /// Model spec override
     #[arg(long)]
     pub model_spec: Option<String>,
-
     /// Working directory
     #[arg(long)]
     pub cd: Option<String>,

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::fs;
+use std::path::Path;
 use tracing::{info, warn};
 
 use csa_config::{GcConfig, GlobalConfig};
@@ -9,16 +10,40 @@ use csa_session::{
     PhaseEvent, delete_session, get_session_dir, get_session_root, list_sessions, save_session_in,
 };
 
+mod auto_gc;
+#[path = "gc_args.rs"]
+mod gc_args;
+mod reaper;
 mod transcript;
+
+#[cfg(test)]
+use auto_gc::discover_project_roots;
+pub(crate) use auto_gc::{handle_gc_global, invalidate_state_dir_size_cache};
+pub use gc_args::GcArgs;
+pub(crate) use reaper::AUTO_GC_REAP_RUNTIME_MAX_AGE_DAYS;
+use reaper::{
+    print_runtime_reap_summary, reap_runtime_payloads_in_root, require_runtime_reap_max_age,
+};
 use transcript::{cleanup_project_transcripts, load_gc_config_for_sessions};
 
 /// Default age threshold (in days) for retiring stale Active sessions.
 const RETIRE_AFTER_DAYS: i64 = 7;
 const STATE_DIR_SIZE_CACHE_FILENAME: &str = ".size-cache.toml";
+const RUNTIME_DIR_NAME: &str = "runtime";
+
+pub(crate) type RuntimeReapStats = reaper::RuntimeReapStats;
+
+pub(crate) fn reap_runtime_payloads_global(
+    dry_run: bool,
+    max_age_days: u64,
+) -> Result<RuntimeReapStats> {
+    reaper::reap_runtime_payloads_global(dry_run, max_age_days)
+}
 
 pub(crate) fn handle_gc(
     dry_run: bool,
     max_age_days: Option<u64>,
+    reap_runtime: bool,
     format: OutputFormat,
 ) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(None)?;
@@ -26,6 +51,23 @@ pub(crate) fn handle_gc(
     let sessions = list_sessions(&project_root, None)?;
     let gc_config = GcConfig::load_for_project(&project_root)?;
     let now = chrono::Utc::now();
+    let runtime_reap_max_age_days = if reap_runtime {
+        Some(require_runtime_reap_max_age(max_age_days)?)
+    } else {
+        None
+    };
+    let current_session_id = std::env::var("CSA_SESSION_ID").ok();
+    let runtime_reap_stats = runtime_reap_max_age_days
+        .map(|days| {
+            reap_runtime_payloads_in_root(
+                &session_root,
+                &sessions,
+                dry_run,
+                days,
+                current_session_id.as_deref(),
+            )
+        })
+        .transpose()?;
 
     let mut stale_locks_removed = 0;
     let mut empty_sessions_removed = 0;
@@ -131,7 +173,8 @@ pub(crate) fn handle_gc(
             }
         }
 
-        if let Some(days) = max_age_days
+        if !reap_runtime
+            && let Some(days) = max_age_days
             && age.num_days() > days as i64
         {
             if dry_run {
@@ -262,8 +305,11 @@ pub(crate) fn handle_gc(
                 "stale_slots_cleaned": stale_slots_cleaned,
                 "orphan_scopes_cleaned": orphan_scopes_cleaned,
             });
-            if max_age_days.is_some() {
+            if !reap_runtime && max_age_days.is_some() {
                 summary["expired_sessions_removed"] = serde_json::json!(expired_sessions_removed);
+            }
+            if let Some(runtime_reap_stats) = runtime_reap_stats.as_ref() {
+                summary["runtime_reap"] = serde_json::to_value(runtime_reap_stats)?;
             }
             println!("{}", serde_json::to_string_pretty(&summary)?);
         }
@@ -279,8 +325,11 @@ pub(crate) fn handle_gc(
             if sessions_retired > 0 {
                 eprintln!("{prefix}  Sessions retired: {sessions_retired}");
             }
-            if max_age_days.is_some() {
+            if !reap_runtime && max_age_days.is_some() {
                 eprintln!("{prefix}  Expired sessions removed: {expired_sessions_removed}");
+            }
+            if let Some(runtime_reap_stats) = runtime_reap_stats.as_ref() {
+                print_runtime_reap_summary(prefix, runtime_reap_stats);
             }
             eprintln!("{prefix}  Orphan directories removed: {orphan_dirs_removed}");
             eprintln!(
@@ -297,452 +346,6 @@ pub(crate) fn handle_gc(
     }
 
     Ok(())
-}
-/// Global GC: scan all project session roots under all existing CSA state dirs.
-/// Applies the same cleanup criteria as per-project GC plus cross-project slot cleanup.
-pub(crate) fn handle_gc_global(
-    dry_run: bool,
-    max_age_days: Option<u64>,
-    format: OutputFormat,
-) -> Result<()> {
-    let state_bases = csa_config::paths::state_dir_all_roots();
-    if state_bases.is_empty() {
-        let state_base = GlobalConfig::state_base_dir()?;
-        eprintln!("No CSA state directory found at {}", state_base.display());
-        return Ok(());
-    }
-
-    let mut project_roots = Vec::new();
-    for state_base in &state_bases {
-        project_roots.extend(discover_project_roots(state_base));
-    }
-
-    let now = chrono::Utc::now();
-    let mut total_stale_locks = 0u64;
-    let mut total_empty_sessions = 0u64;
-    let mut total_orphan_dirs = 0u64;
-    let mut total_expired_sessions = 0u64;
-    let mut total_sessions_retired = 0u64;
-    let mut total_transcripts_removed = 0u64;
-    let mut total_transcript_bytes_reclaimed = 0u64;
-    let mut projects_failed = 0u64;
-
-    if dry_run {
-        eprintln!("[dry-run] Global GC — no changes will be made.");
-    }
-
-    for session_root in &project_roots {
-        // Use readonly variant in dry-run to avoid corrupt-state recovery writes
-        let sessions = match if dry_run {
-            csa_session::list_sessions_from_root_readonly(session_root)
-        } else {
-            csa_session::list_sessions_from_root(session_root)
-        } {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!(
-                    path = %session_root.display(),
-                    error = %e,
-                    "Failed to list sessions for project root (skipping)"
-                );
-                projects_failed += 1;
-                continue;
-            }
-        };
-
-        let mut project_removed = 0usize; // track per-project removals for rotation preview
-        for session in &sessions {
-            let session_dir = session_root.join("sessions").join(&session.meta_session_id);
-            let locks_dir = session_dir.join("locks");
-
-            if locks_dir.exists()
-                && let Ok(entries) = fs::read_dir(&locks_dir)
-            {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if path.extension().is_some_and(|ext| ext == "lock")
-                        && let Ok(content) = fs::read_to_string(&path)
-                        && let Some(pid) = extract_pid_from_lock(&content)
-                        && !is_process_alive(pid)
-                    {
-                        if dry_run {
-                            eprintln!(
-                                "[dry-run] Would remove stale lock (PID {}): {}",
-                                pid,
-                                path.display()
-                            );
-                            total_stale_locks += 1;
-                        } else if fs::remove_file(&path).is_ok() {
-                            info!("Removed stale lock (PID {}): {}", pid, path.display());
-                            total_stale_locks += 1;
-                        }
-                    }
-                }
-            }
-
-            if session.tools.is_empty() {
-                if dry_run {
-                    eprintln!(
-                        "[dry-run] Would remove empty session: {} (in {})",
-                        session.meta_session_id,
-                        session_root.display()
-                    );
-                    total_empty_sessions += 1;
-                    project_removed += 1;
-                } else if csa_session::delete_session_from_root(
-                    session_root,
-                    &session.meta_session_id,
-                )
-                .is_ok()
-                {
-                    total_empty_sessions += 1;
-                    project_removed += 1;
-                }
-                continue;
-            }
-
-            // Retire stale Active/Available sessions (>7 days since last access)
-            let age = now.signed_duration_since(session.last_accessed);
-            if age.num_days() > RETIRE_AFTER_DAYS
-                && session.phase.transition(&PhaseEvent::Retired).is_ok()
-            {
-                if dry_run {
-                    eprintln!(
-                        "[dry-run] Would retire stale session: {} (phase={}, {} days old, in {})",
-                        session.meta_session_id,
-                        session.phase,
-                        age.num_days(),
-                        session_root.display()
-                    );
-                    total_sessions_retired += 1;
-                } else {
-                    let mut updated = session.clone();
-                    match updated.phase.transition(&PhaseEvent::Retired) {
-                        Ok(new_phase) => {
-                            updated.phase = new_phase;
-                            match save_session_in(session_root, &updated) {
-                                Ok(_) => {
-                                    info!(
-                                        session = %session.meta_session_id,
-                                        age_days = age.num_days(),
-                                        root = %session_root.display(),
-                                        "Retired stale session"
-                                    );
-                                    total_sessions_retired += 1;
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        session = %session.meta_session_id,
-                                        error = %e,
-                                        root = %session_root.display(),
-                                        "Failed to persist retirement"
-                                    );
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            warn!(
-                                session = %session.meta_session_id,
-                                error = %e,
-                                "Skipping retirement"
-                            );
-                        }
-                    }
-                }
-            }
-
-            if let Some(days) = max_age_days
-                && age.num_days() > days as i64
-            {
-                if dry_run {
-                    eprintln!(
-                        "[dry-run] Would remove expired session: {} ({} days old, in {})",
-                        session.meta_session_id,
-                        age.num_days(),
-                        session_root.display()
-                    );
-                    total_expired_sessions += 1;
-                    project_removed += 1;
-                } else if csa_session::delete_session_from_root(
-                    session_root,
-                    &session.meta_session_id,
-                )
-                .is_ok()
-                {
-                    info!(
-                        "Removed expired session: {} (in {})",
-                        session.meta_session_id,
-                        session_root.display()
-                    );
-                    total_expired_sessions += 1;
-                    project_removed += 1;
-                }
-            }
-        }
-
-        let sessions_dir = session_root.join("sessions");
-        let sessions_is_real_dir = sessions_dir.is_dir()
-            && !fs::symlink_metadata(&sessions_dir)
-                .map(|m| m.file_type().is_symlink())
-                .unwrap_or(true);
-        if sessions_is_real_dir && let Ok(entries) = fs::read_dir(&sessions_dir) {
-            for entry in entries.flatten() {
-                if entry.file_type().is_ok_and(|ft| ft.is_dir()) && is_orphan_session_dir(&entry) {
-                    let session_dir = entry.path();
-                    if dry_run {
-                        eprintln!(
-                            "[dry-run] Would remove orphan directory: {}",
-                            session_dir.display()
-                        );
-                        total_orphan_dirs += 1;
-                    } else if fs::remove_dir_all(&session_dir).is_ok() {
-                        info!("Removed orphan directory: {}", session_dir.display());
-                        total_orphan_dirs += 1;
-                    }
-                }
-            }
-        }
-
-        let rotation_path = session_root.join("rotation.toml");
-        if rotation_path.exists() {
-            let no_sessions_remain = if dry_run {
-                project_removed >= sessions.len()
-            } else {
-                csa_session::list_sessions_from_root(session_root)
-                    .map(|s| s.is_empty())
-                    .unwrap_or(false) // treat error as "sessions might still exist"
-            };
-            if no_sessions_remain {
-                if dry_run {
-                    eprintln!("[dry-run] Would remove rotation state: {rotation_path:?}");
-                } else if fs::remove_file(&rotation_path).is_ok() {
-                    info!(
-                        "Removed rotation state (no sessions remain): {:?}",
-                        rotation_path
-                    );
-                }
-            }
-        }
-
-        let project_gc_config = load_gc_config_for_sessions(session_root, &sessions);
-        let transcript_stats =
-            cleanup_project_transcripts(session_root, project_gc_config, dry_run);
-        total_transcripts_removed =
-            total_transcripts_removed.saturating_add(transcript_stats.files_removed);
-        total_transcript_bytes_reclaimed =
-            total_transcript_bytes_reclaimed.saturating_add(transcript_stats.bytes_reclaimed);
-    }
-
-    let mut orphan_scopes_cleaned = 0u64;
-    if dry_run {
-        eprintln!("[dry-run] Would scan for orphan csa-*.scope units with 0 active PIDs");
-    } else {
-        match cleanup_orphan_scopes() {
-            Ok(cleaned) => {
-                orphan_scopes_cleaned = cleaned.len() as u64;
-                for scope in cleaned {
-                    info!(
-                        scope = %scope.unit_name,
-                        active_pids = scope.active_pids,
-                        "Stopped orphan cgroup scope (stale unit with no live processes)"
-                    );
-                }
-            }
-            Err(err) => {
-                warn!(error = %err, "Failed to enumerate orphan cgroup scopes; skipping");
-            }
-        }
-    }
-
-    let mut stale_slots_cleaned = 0u64;
-    if let Ok(slots_dir) = GlobalConfig::slots_dir()
-        && slots_dir.exists()
-        && let Ok(entries) = fs::read_dir(&slots_dir)
-    {
-        for entry in entries.flatten() {
-            if entry.file_type().is_ok_and(|ft| ft.is_dir()) {
-                let tool_dir = entry.path();
-                if let Ok(slot_entries) = fs::read_dir(&tool_dir) {
-                    for slot_entry in slot_entries.flatten() {
-                        let path = slot_entry.path();
-                        if path.extension().is_some_and(|ext| ext == "lock")
-                            && let Ok(content) = fs::read_to_string(&path)
-                            && let Some(pid) = extract_pid_from_lock(&content)
-                            && !is_process_alive(pid)
-                        {
-                            if dry_run {
-                                eprintln!(
-                                    "[dry-run] Would clean stale slot: {:?} (dead PID {})",
-                                    path.file_name(),
-                                    pid
-                                );
-                                stale_slots_cleaned += 1;
-                            } else if fs::remove_file(&path).is_ok() {
-                                info!(
-                                    "Cleaned stale slot: {:?} (dead PID {})",
-                                    path.file_name(),
-                                    pid
-                                );
-                                stale_slots_cleaned += 1;
-                            }
-                        }
-                    }
-                }
-                if !dry_run {
-                    let _ = fs::remove_dir(&tool_dir);
-                }
-            }
-        }
-    }
-
-    match format {
-        OutputFormat::Json => {
-            let mut summary = serde_json::json!({
-                "dry_run": dry_run,
-                "global": true,
-                "projects_scanned": project_roots.len(),
-                "projects_failed": projects_failed,
-                "stale_locks_removed": total_stale_locks,
-                "empty_sessions_removed": total_empty_sessions,
-                "orphan_dirs_removed": total_orphan_dirs,
-                "sessions_retired": total_sessions_retired,
-                "transcripts_removed": total_transcripts_removed,
-                "transcript_bytes_reclaimed": total_transcript_bytes_reclaimed,
-                "stale_slots_cleaned": stale_slots_cleaned,
-                "orphan_scopes_cleaned": orphan_scopes_cleaned,
-            });
-            if max_age_days.is_some() {
-                summary["expired_sessions_removed"] = serde_json::json!(total_expired_sessions);
-            }
-            println!("{}", serde_json::to_string_pretty(&summary)?);
-        }
-        OutputFormat::Text => {
-            let prefix = if dry_run { "[dry-run] " } else { "" };
-            eprintln!(
-                "{}Global garbage collection {}:",
-                prefix,
-                if dry_run { "preview" } else { "complete" }
-            );
-            eprintln!("{}  Projects scanned: {}", prefix, project_roots.len());
-            if projects_failed > 0 {
-                eprintln!("{prefix}  Projects failed: {projects_failed}");
-            }
-            eprintln!("{prefix}  Stale locks removed: {total_stale_locks}");
-            eprintln!("{prefix}  Empty sessions removed: {total_empty_sessions}");
-            if total_sessions_retired > 0 {
-                eprintln!("{prefix}  Sessions retired: {total_sessions_retired}");
-            }
-            if max_age_days.is_some() {
-                eprintln!("{prefix}  Expired sessions removed: {total_expired_sessions}");
-            }
-            eprintln!("{prefix}  Orphan directories removed: {total_orphan_dirs}");
-            eprintln!(
-                "{prefix}  Transcript files removed: {total_transcripts_removed} ({total_transcript_bytes_reclaimed} bytes)"
-            );
-            eprintln!("{prefix}  Stale slots cleaned: {stale_slots_cleaned}");
-            eprintln!("{prefix}  Orphan cgroup scopes cleaned: {orphan_scopes_cleaned}");
-        }
-    }
-
-    if !dry_run {
-        invalidate_state_dir_size_cache();
-    }
-
-    Ok(())
-}
-
-fn invalidate_state_dir_size_cache() {
-    let state_roots = csa_config::paths::state_dir_all_roots();
-    if state_roots.is_empty() {
-        return;
-    }
-
-    // GC is the remediation path advertised by state-dir preflight; clear the cached aggregate.
-    for state_dir in state_roots {
-        let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
-        match fs::remove_file(&cache_path) {
-            Ok(()) => {
-                info!(path = %cache_path.display(), "Invalidated state directory size cache")
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(err) => warn!(
-                path = %cache_path.display(),
-                error = %err,
-                "Failed to invalidate state directory size cache"
-            ),
-        }
-    }
-}
-
-/// Discover project roots (dirs with `sessions/` containing ULID dirs with `state.toml`).
-fn discover_project_roots(state_base: &std::path::Path) -> Vec<std::path::PathBuf> {
-    let canonical_base = match state_base.canonicalize() {
-        Ok(p) => p,
-        Err(_) => return Vec::new(),
-    };
-    let mut roots = Vec::new();
-    discover_roots_recursive(&canonical_base, &canonical_base, true, &mut roots);
-    roots
-}
-
-/// Top-level CSA internal directories (not project paths) under the state base.
-const TOP_LEVEL_SKIP: &[&str] = &["slots", "todos"];
-
-fn discover_roots_recursive(
-    dir: &std::path::Path,
-    canonical_base: &std::path::Path,
-    is_top_level: bool,
-    roots: &mut Vec<std::path::PathBuf>,
-) {
-    let entries = match fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-    for entry in entries.flatten() {
-        // Skip symlinks to prevent traversal outside state tree; file_type() does not follow them.
-        let ft = match entry.file_type() {
-            Ok(ft) => ft,
-            Err(_) => continue,
-        };
-        if ft.is_symlink() || !ft.is_dir() {
-            continue;
-        }
-        let path = entry.path();
-        // Canonical path check: ensure we stay within state base
-        let canonical = match path.canonicalize() {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-        if !canonical.starts_with(canonical_base) {
-            continue;
-        }
-        // Only skip known directories at the top level of the state base
-        if is_top_level {
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            if TOP_LEVEL_SKIP.contains(&name_str.as_ref()) {
-                continue;
-            }
-        }
-        let sessions_path = path.join("sessions");
-        // Accept sessions/ only if real dir (not symlink) with ULID entries or rotation state.
-        let has_sessions = sessions_path.is_dir()
-            && !fs::symlink_metadata(&sessions_path)
-                .map(|m| m.file_type().is_symlink())
-                .unwrap_or(true)
-            && (has_confirmed_sessions(&sessions_path) || path.join("rotation.toml").exists());
-        if has_sessions {
-            roots.push(path.clone());
-        }
-        // Skip confirmed session containers (ULID subdirs with state.toml).
-        // Path-segment "sessions" dirs with ULID-like children but no state.toml are traversed.
-        let name = entry.file_name();
-        if name.to_string_lossy() == "sessions" && has_confirmed_sessions(&path) {
-            continue;
-        }
-        // Recurse to find nested sub-project roots (parent and child can coexist).
-        discover_roots_recursive(&path, canonical_base, false, roots);
-    }
 }
 
 /// Extract PID from lock file JSON content (expects `{"pid": N}`).
@@ -776,7 +379,7 @@ fn is_orphan_session_dir(entry: &fs::DirEntry) -> bool {
 /// Check if a directory has ULID subdirs with `state.toml` (confirmed session container).
 /// Used for recursion skip: only skip traversal into confirmed session containers.
 /// Path-segment "sessions/" dirs whose ULID children lack `state.toml` are traversed.
-fn has_confirmed_sessions(dir: &std::path::Path) -> bool {
+fn has_confirmed_sessions(dir: &Path) -> bool {
     fs::read_dir(dir).is_ok_and(|rd| {
         rd.flatten().any(|e| {
             e.file_type().is_ok_and(|ft| ft.is_dir())

--- a/crates/cli-sub-agent/src/gc/auto_gc.rs
+++ b/crates/cli-sub-agent/src/gc/auto_gc.rs
@@ -1,0 +1,482 @@
+use anyhow::Result;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
+
+use csa_config::GlobalConfig;
+use csa_core::types::OutputFormat;
+use csa_resource::cleanup_orphan_scopes;
+use csa_session::{
+    PhaseEvent, list_sessions_from_root, list_sessions_from_root_readonly, save_session_in,
+};
+
+use super::load_gc_config_for_sessions;
+use super::reaper::{
+    print_runtime_reap_summary, reap_runtime_payloads_global, require_runtime_reap_max_age,
+};
+use super::{
+    RETIRE_AFTER_DAYS, STATE_DIR_SIZE_CACHE_FILENAME, extract_pid_from_lock,
+    has_confirmed_sessions, is_orphan_session_dir, is_process_alive,
+};
+
+pub(crate) fn handle_gc_global(
+    dry_run: bool,
+    max_age_days: Option<u64>,
+    reap_runtime: bool,
+    format: OutputFormat,
+) -> Result<()> {
+    let state_bases = csa_config::paths::state_dir_all_roots();
+    if state_bases.is_empty() {
+        let state_base = GlobalConfig::state_base_dir()?;
+        eprintln!("No CSA state directory found at {}", state_base.display());
+        return Ok(());
+    }
+
+    let mut project_roots = Vec::new();
+    for state_base in &state_bases {
+        project_roots.extend(discover_project_roots(state_base));
+    }
+
+    let runtime_reap_max_age_days = if reap_runtime {
+        Some(require_runtime_reap_max_age(max_age_days)?)
+    } else {
+        None
+    };
+    let runtime_reap_stats = runtime_reap_max_age_days
+        .map(|days| reap_runtime_payloads_global(dry_run, days))
+        .transpose()?;
+
+    let now = chrono::Utc::now();
+    let mut total_stale_locks = 0u64;
+    let mut total_empty_sessions = 0u64;
+    let mut total_orphan_dirs = 0u64;
+    let mut total_expired_sessions = 0u64;
+    let mut total_sessions_retired = 0u64;
+    let mut total_transcripts_removed = 0u64;
+    let mut total_transcript_bytes_reclaimed = 0u64;
+    let mut projects_failed = 0u64;
+
+    if dry_run {
+        eprintln!("[dry-run] Global GC — no changes will be made.");
+    }
+
+    for session_root in &project_roots {
+        // Use readonly variant in dry-run to avoid corrupt-state recovery writes
+        let sessions = match if dry_run {
+            list_sessions_from_root_readonly(session_root)
+        } else {
+            list_sessions_from_root(session_root)
+        } {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    path = %session_root.display(),
+                    error = %e,
+                    "Failed to list sessions for project root (skipping)"
+                );
+                projects_failed += 1;
+                continue;
+            }
+        };
+
+        let mut project_removed = 0usize;
+        for session in &sessions {
+            let session_dir = session_root.join("sessions").join(&session.meta_session_id);
+            let locks_dir = session_dir.join("locks");
+
+            if locks_dir.exists()
+                && let Ok(entries) = fs::read_dir(&locks_dir)
+            {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().is_some_and(|ext| ext == "lock")
+                        && let Ok(content) = fs::read_to_string(&path)
+                        && let Some(pid) = extract_pid_from_lock(&content)
+                        && !is_process_alive(pid)
+                    {
+                        if dry_run {
+                            eprintln!(
+                                "[dry-run] Would remove stale lock (PID {}): {}",
+                                pid,
+                                path.display()
+                            );
+                            total_stale_locks += 1;
+                        } else if fs::remove_file(&path).is_ok() {
+                            info!("Removed stale lock (PID {}): {}", pid, path.display());
+                            total_stale_locks += 1;
+                        }
+                    }
+                }
+            }
+
+            if session.tools.is_empty() {
+                if dry_run {
+                    eprintln!(
+                        "[dry-run] Would remove empty session: {} (in {})",
+                        session.meta_session_id,
+                        session_root.display()
+                    );
+                    total_empty_sessions += 1;
+                    project_removed += 1;
+                } else if csa_session::delete_session_from_root(
+                    session_root,
+                    &session.meta_session_id,
+                )
+                .is_ok()
+                {
+                    total_empty_sessions += 1;
+                    project_removed += 1;
+                }
+                continue;
+            }
+
+            // Retire stale Active/Available sessions (>7 days since last access)
+            let age = now.signed_duration_since(session.last_accessed);
+            if age.num_days() > RETIRE_AFTER_DAYS
+                && session.phase.transition(&PhaseEvent::Retired).is_ok()
+            {
+                if dry_run {
+                    eprintln!(
+                        "[dry-run] Would retire stale session: {} (phase={}, {} days old, in {})",
+                        session.meta_session_id,
+                        session.phase,
+                        age.num_days(),
+                        session_root.display()
+                    );
+                    total_sessions_retired += 1;
+                } else {
+                    let mut updated = session.clone();
+                    match updated.phase.transition(&PhaseEvent::Retired) {
+                        Ok(new_phase) => {
+                            updated.phase = new_phase;
+                            match save_session_in(session_root, &updated) {
+                                Ok(_) => {
+                                    info!(
+                                        session = %session.meta_session_id,
+                                        age_days = age.num_days(),
+                                        root = %session_root.display(),
+                                        "Retired stale session"
+                                    );
+                                    total_sessions_retired += 1;
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        session = %session.meta_session_id,
+                                        error = %e,
+                                        root = %session_root.display(),
+                                        "Failed to persist retirement"
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                session = %session.meta_session_id,
+                                error = %e,
+                                "Skipping retirement"
+                            );
+                        }
+                    }
+                }
+            }
+
+            if !reap_runtime
+                && let Some(days) = max_age_days
+                && age.num_days() > days as i64
+            {
+                if dry_run {
+                    eprintln!(
+                        "[dry-run] Would remove expired session: {} ({} days old, in {})",
+                        session.meta_session_id,
+                        age.num_days(),
+                        session_root.display()
+                    );
+                    total_expired_sessions += 1;
+                    project_removed += 1;
+                } else if csa_session::delete_session_from_root(
+                    session_root,
+                    &session.meta_session_id,
+                )
+                .is_ok()
+                {
+                    info!(
+                        "Removed expired session: {} (in {})",
+                        session.meta_session_id,
+                        session_root.display()
+                    );
+                    total_expired_sessions += 1;
+                    project_removed += 1;
+                }
+            }
+        }
+
+        let sessions_dir = session_root.join("sessions");
+        let sessions_is_real_dir = sessions_dir.is_dir()
+            && !fs::symlink_metadata(&sessions_dir)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(true);
+        if sessions_is_real_dir && let Ok(entries) = fs::read_dir(&sessions_dir) {
+            for entry in entries.flatten() {
+                if entry.file_type().is_ok_and(|ft| ft.is_dir()) && is_orphan_session_dir(&entry) {
+                    let session_dir = entry.path();
+                    if dry_run {
+                        eprintln!(
+                            "[dry-run] Would remove orphan directory: {}",
+                            session_dir.display()
+                        );
+                        total_orphan_dirs += 1;
+                    } else if fs::remove_dir_all(&session_dir).is_ok() {
+                        info!("Removed orphan directory: {}", session_dir.display());
+                        total_orphan_dirs += 1;
+                    }
+                }
+            }
+        }
+
+        let rotation_path = session_root.join("rotation.toml");
+        if rotation_path.exists() {
+            let no_sessions_remain = if dry_run {
+                project_removed >= sessions.len()
+            } else {
+                csa_session::list_sessions_from_root(session_root)
+                    .map(|s| s.is_empty())
+                    .unwrap_or(false)
+            };
+            if no_sessions_remain {
+                if dry_run {
+                    eprintln!("[dry-run] Would remove rotation state: {rotation_path:?}");
+                } else if fs::remove_file(&rotation_path).is_ok() {
+                    info!(
+                        "Removed rotation state (no sessions remain): {:?}",
+                        rotation_path
+                    );
+                }
+            }
+        }
+
+        let project_gc_config = load_gc_config_for_sessions(session_root, &sessions);
+        let transcript_stats =
+            super::cleanup_project_transcripts(session_root, project_gc_config, dry_run);
+        total_transcripts_removed =
+            total_transcripts_removed.saturating_add(transcript_stats.files_removed);
+        total_transcript_bytes_reclaimed =
+            total_transcript_bytes_reclaimed.saturating_add(transcript_stats.bytes_reclaimed);
+    }
+
+    let mut orphan_scopes_cleaned = 0u64;
+    if dry_run {
+        eprintln!("[dry-run] Would scan for orphan csa-*.scope units with 0 active PIDs");
+    } else {
+        match cleanup_orphan_scopes() {
+            Ok(cleaned) => {
+                orphan_scopes_cleaned = cleaned.len() as u64;
+                for scope in cleaned {
+                    info!(
+                        scope = %scope.unit_name,
+                        active_pids = scope.active_pids,
+                        "Stopped orphan cgroup scope (stale unit with no live processes)"
+                    );
+                }
+            }
+            Err(err) => {
+                warn!(error = %err, "Failed to enumerate orphan cgroup scopes; skipping");
+            }
+        }
+    }
+
+    let mut stale_slots_cleaned = 0u64;
+    if let Ok(slots_dir) = GlobalConfig::slots_dir()
+        && slots_dir.exists()
+        && let Ok(entries) = fs::read_dir(&slots_dir)
+    {
+        for entry in entries.flatten() {
+            if entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+                let tool_dir = entry.path();
+                if let Ok(slot_entries) = fs::read_dir(&tool_dir) {
+                    for slot_entry in slot_entries.flatten() {
+                        let path = slot_entry.path();
+                        if path.extension().is_some_and(|ext| ext == "lock")
+                            && let Ok(content) = fs::read_to_string(&path)
+                            && let Some(pid) = extract_pid_from_lock(&content)
+                            && !is_process_alive(pid)
+                        {
+                            if dry_run {
+                                eprintln!(
+                                    "[dry-run] Would clean stale slot: {:?} (dead PID {})",
+                                    path.file_name(),
+                                    pid
+                                );
+                                stale_slots_cleaned += 1;
+                            } else if fs::remove_file(&path).is_ok() {
+                                info!(
+                                    "Cleaned stale slot: {:?} (dead PID {})",
+                                    path.file_name(),
+                                    pid
+                                );
+                                stale_slots_cleaned += 1;
+                            }
+                        }
+                    }
+                }
+                if !dry_run {
+                    let _ = fs::remove_dir(&tool_dir);
+                }
+            }
+        }
+    }
+
+    match format {
+        OutputFormat::Json => {
+            let mut summary = serde_json::json!({
+                "dry_run": dry_run,
+                "global": true,
+                "projects_scanned": project_roots.len(),
+                "projects_failed": projects_failed,
+                "stale_locks_removed": total_stale_locks,
+                "empty_sessions_removed": total_empty_sessions,
+                "orphan_dirs_removed": total_orphan_dirs,
+                "sessions_retired": total_sessions_retired,
+                "transcripts_removed": total_transcripts_removed,
+                "transcript_bytes_reclaimed": total_transcript_bytes_reclaimed,
+                "stale_slots_cleaned": stale_slots_cleaned,
+                "orphan_scopes_cleaned": orphan_scopes_cleaned,
+            });
+            if !reap_runtime && max_age_days.is_some() {
+                summary["expired_sessions_removed"] = serde_json::json!(total_expired_sessions);
+            }
+            if let Some(runtime_reap_stats) = runtime_reap_stats.as_ref() {
+                summary["runtime_reap"] = serde_json::to_value(runtime_reap_stats)?;
+            }
+            println!("{}", serde_json::to_string_pretty(&summary)?);
+        }
+        OutputFormat::Text => {
+            let prefix = if dry_run { "[dry-run] " } else { "" };
+            eprintln!(
+                "{}Global garbage collection {}:",
+                prefix,
+                if dry_run { "preview" } else { "complete" }
+            );
+            eprintln!("{}  Projects scanned: {}", prefix, project_roots.len());
+            if projects_failed > 0 {
+                eprintln!("{prefix}  Projects failed: {projects_failed}");
+            }
+            eprintln!("{prefix}  Stale locks removed: {total_stale_locks}");
+            eprintln!("{prefix}  Empty sessions removed: {total_empty_sessions}");
+            if total_sessions_retired > 0 {
+                eprintln!("{prefix}  Sessions retired: {total_sessions_retired}");
+            }
+            if !reap_runtime && max_age_days.is_some() {
+                eprintln!("{prefix}  Expired sessions removed: {total_expired_sessions}");
+            }
+            if let Some(runtime_reap_stats) = runtime_reap_stats.as_ref() {
+                print_runtime_reap_summary(prefix, runtime_reap_stats);
+            }
+            eprintln!("{prefix}  Orphan directories removed: {total_orphan_dirs}");
+            eprintln!(
+                "{prefix}  Transcript files removed: {total_transcripts_removed} ({total_transcript_bytes_reclaimed} bytes)"
+            );
+            eprintln!("{prefix}  Stale slots cleaned: {stale_slots_cleaned}");
+            eprintln!("{prefix}  Orphan cgroup scopes cleaned: {orphan_scopes_cleaned}");
+        }
+    }
+
+    if !dry_run {
+        invalidate_state_dir_size_cache();
+    }
+
+    Ok(())
+}
+
+pub(crate) fn invalidate_state_dir_size_cache() {
+    let state_roots = csa_config::paths::state_dir_all_roots();
+    if state_roots.is_empty() {
+        return;
+    }
+
+    // GC is the remediation path advertised by state-dir preflight; clear the cached aggregate.
+    for state_dir in state_roots {
+        let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
+        match fs::remove_file(&cache_path) {
+            Ok(()) => {
+                info!(path = %cache_path.display(), "Invalidated state directory size cache")
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => warn!(
+                path = %cache_path.display(),
+                error = %err,
+                "Failed to invalidate state directory size cache"
+            ),
+        }
+    }
+}
+
+/// Discover project roots (dirs with `sessions/` containing ULID dirs with `state.toml`).
+pub(super) fn discover_project_roots(state_base: &Path) -> Vec<PathBuf> {
+    let canonical_base = match state_base.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    let mut roots = Vec::new();
+    discover_roots_recursive(&canonical_base, &canonical_base, true, &mut roots);
+    roots
+}
+
+/// Top-level CSA internal directories (not project paths) under the state base.
+const TOP_LEVEL_SKIP: &[&str] = &["slots", "todos"];
+
+fn discover_roots_recursive(
+    dir: &Path,
+    canonical_base: &Path,
+    is_top_level: bool,
+    roots: &mut Vec<PathBuf>,
+) {
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        // Skip symlinks to prevent traversal outside state tree; file_type() does not follow them.
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if ft.is_symlink() || !ft.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        // Canonical path check: ensure we stay within state base
+        let canonical = match path.canonicalize() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if !canonical.starts_with(canonical_base) {
+            continue;
+        }
+        // Only skip known directories at the top level of the state base
+        if is_top_level {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if TOP_LEVEL_SKIP.contains(&name_str.as_ref()) {
+                continue;
+            }
+        }
+        let sessions_path = path.join("sessions");
+        // Accept sessions/ only if real dir (not symlink) with ULID entries or rotation state.
+        let has_sessions = sessions_path.is_dir()
+            && !fs::symlink_metadata(&sessions_path)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(true)
+            && (has_confirmed_sessions(&sessions_path) || path.join("rotation.toml").exists());
+        if has_sessions {
+            roots.push(path.clone());
+        }
+        // Skip confirmed session containers (ULID subdirs with state.toml).
+        // Path-segment "sessions" dirs with ULID-like children but no state.toml are traversed.
+        let name = entry.file_name();
+        if name.to_string_lossy() == "sessions" && has_confirmed_sessions(&path) {
+            continue;
+        }
+        // Recurse to find nested sub-project roots (parent and child can coexist).
+        discover_roots_recursive(&path, canonical_base, false, roots);
+    }
+}

--- a/crates/cli-sub-agent/src/gc/reaper.rs
+++ b/crates/cli-sub-agent/src/gc/reaper.rs
@@ -1,0 +1,244 @@
+use anyhow::{Result, anyhow};
+use serde::Serialize;
+use std::fs::{self, OpenOptions};
+use std::os::fd::AsRawFd;
+use std::path::Path;
+use tracing::{info, warn};
+
+use csa_session::{
+    MetaSessionState, SessionPhase, list_sessions_from_root, list_sessions_from_root_readonly,
+};
+
+use super::RUNTIME_DIR_NAME;
+use super::auto_gc::discover_project_roots;
+
+pub(crate) const AUTO_GC_REAP_RUNTIME_MAX_AGE_DAYS: u64 = 30;
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub(crate) struct RuntimeReapStats {
+    pub(crate) sessions_reaped: u64,
+    pub(crate) bytes_reclaimed: u64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) entries: Vec<RuntimeReapEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct RuntimeReapEntry {
+    pub(crate) session_id: String,
+    pub(crate) runtime_path: String,
+    pub(crate) bytes_reclaimed: u64,
+}
+
+pub(super) fn require_runtime_reap_max_age(max_age_days: Option<u64>) -> Result<u64> {
+    max_age_days.ok_or_else(|| anyhow!("`csa gc --reap-runtime` requires `--max-age-days <N>`"))
+}
+
+pub(crate) fn reap_runtime_payloads_global(
+    dry_run: bool,
+    max_age_days: u64,
+) -> Result<RuntimeReapStats> {
+    let state_bases = csa_config::paths::state_dir_all_roots();
+    if state_bases.is_empty() {
+        return Ok(RuntimeReapStats::default());
+    }
+
+    let current_session_id = std::env::var("CSA_SESSION_ID").ok();
+    let mut total = RuntimeReapStats::default();
+    let mut project_roots = Vec::new();
+    for state_base in &state_bases {
+        project_roots.extend(discover_project_roots(state_base));
+    }
+
+    for session_root in &project_roots {
+        let sessions = match if dry_run {
+            list_sessions_from_root_readonly(session_root)
+        } else {
+            list_sessions_from_root(session_root)
+        } {
+            Ok(sessions) => sessions,
+            Err(err) => {
+                warn!(
+                    path = %session_root.display(),
+                    error = %err,
+                    "Failed to enumerate sessions for runtime reap; skipping project"
+                );
+                continue;
+            }
+        };
+        let project_stats = match reap_runtime_payloads_in_root(
+            session_root,
+            &sessions,
+            dry_run,
+            max_age_days,
+            current_session_id.as_deref(),
+        ) {
+            Ok(stats) => stats,
+            Err(err) => {
+                warn!(
+                    path = %session_root.display(),
+                    error = %err,
+                    "Failed to reap runtime payloads for project; skipping project"
+                );
+                continue;
+            }
+        };
+        merge_runtime_reap_stats(&mut total, project_stats);
+    }
+
+    Ok(total)
+}
+
+pub(super) fn reap_runtime_payloads_in_root(
+    session_root: &Path,
+    sessions: &[MetaSessionState],
+    dry_run: bool,
+    max_age_days: u64,
+    current_session_id: Option<&str>,
+) -> Result<RuntimeReapStats> {
+    let now = chrono::Utc::now();
+    let mut stats = RuntimeReapStats::default();
+
+    for session in sessions {
+        if current_session_id.is_some_and(|current| current == session.meta_session_id) {
+            continue;
+        }
+        if !matches!(session.phase, SessionPhase::Retired) {
+            continue;
+        }
+
+        let age = now.signed_duration_since(session.last_accessed);
+        if age.num_days() < max_age_days as i64 {
+            continue;
+        }
+
+        let session_dir = session_root.join("sessions").join(&session.meta_session_id);
+        if session_has_live_lock(&session_dir)? {
+            info!(
+                session = %session.meta_session_id,
+                "Skipping runtime reap for locked session"
+            );
+            continue;
+        }
+
+        let runtime_dir = session_dir.join(RUNTIME_DIR_NAME);
+        let metadata = match fs::symlink_metadata(&runtime_dir) {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                warn!(
+                    session = %session.meta_session_id,
+                    path = %runtime_dir.display(),
+                    error = %err,
+                    "Failed to inspect runtime directory; skipping"
+                );
+                continue;
+            }
+        };
+
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            warn!(
+                session = %session.meta_session_id,
+                path = %runtime_dir.display(),
+                "Skipping non-directory runtime path"
+            );
+            continue;
+        }
+
+        let bytes_reclaimed = match crate::preflight_state_dir::compute_state_dir_size(&runtime_dir)
+        {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                warn!(
+                    session = %session.meta_session_id,
+                    path = %runtime_dir.display(),
+                    error = %err,
+                    "Failed to size runtime directory; skipping"
+                );
+                continue;
+            }
+        };
+
+        if !dry_run {
+            fs::remove_dir_all(&runtime_dir)?;
+        }
+
+        stats.sessions_reaped = stats.sessions_reaped.saturating_add(1);
+        stats.bytes_reclaimed = stats.bytes_reclaimed.saturating_add(bytes_reclaimed);
+        stats.entries.push(RuntimeReapEntry {
+            session_id: session.meta_session_id.clone(),
+            runtime_path: runtime_dir.display().to_string(),
+            bytes_reclaimed,
+        });
+    }
+
+    Ok(stats)
+}
+
+fn merge_runtime_reap_stats(total: &mut RuntimeReapStats, stats: RuntimeReapStats) {
+    total.sessions_reaped = total.sessions_reaped.saturating_add(stats.sessions_reaped);
+    total.bytes_reclaimed = total.bytes_reclaimed.saturating_add(stats.bytes_reclaimed);
+    total.entries.extend(stats.entries);
+}
+
+fn session_has_live_lock(session_dir: &Path) -> Result<bool> {
+    let locks_dir = session_dir.join("locks");
+    if !locks_dir.is_dir() {
+        return Ok(false);
+    }
+
+    for entry in fs::read_dir(&locks_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_none_or(|ext| ext != "lock") {
+            continue;
+        }
+        if probe_lock_is_held(&path)? {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn probe_lock_is_held(lock_path: &Path) -> Result<bool> {
+    let file = OpenOptions::new()
+        .read(true)
+        .open(lock_path)
+        .map_err(|err| anyhow!("failed to open lock file {}: {err}", lock_path.display()))?;
+    // SAFETY: `file.as_raw_fd()` is a valid descriptor for the opened lock file.
+    // `LOCK_EX | LOCK_NB` performs the same non-blocking advisory-lock probe used
+    // elsewhere in CSA session locking.
+    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if ret == 0 {
+        // SAFETY: the fd above is still valid and currently holds the advisory lock;
+        // unlocking before returning releases our probe lock immediately.
+        unsafe {
+            libc::flock(file.as_raw_fd(), libc::LOCK_UN);
+        }
+        return Ok(false);
+    }
+
+    let err = std::io::Error::last_os_error();
+    match err.raw_os_error() {
+        Some(code) if code == libc::EWOULDBLOCK || code == libc::EAGAIN => Ok(true),
+        _ => Err(err.into()),
+    }
+}
+
+pub(super) fn print_runtime_reap_summary(prefix: &str, stats: &RuntimeReapStats) {
+    eprintln!(
+        "{}  Runtime payloads reaped: {} ({})",
+        prefix,
+        stats.sessions_reaped,
+        crate::session_cmds::format_file_size(stats.bytes_reclaimed)
+    );
+    for entry in &stats.entries {
+        eprintln!(
+            "{}    {}: {} ({})",
+            prefix,
+            entry.session_id,
+            crate::session_cmds::format_file_size(entry.bytes_reclaimed),
+            entry.runtime_path
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/gc_args.rs
+++ b/crates/cli-sub-agent/src/gc_args.rs
@@ -1,0 +1,20 @@
+#[derive(Debug, clap::Args, Clone)]
+pub struct GcArgs {
+    /// Show what would be removed without actually removing
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Age threshold in days. Deletes whole sessions by default; with
+    /// `--reap-runtime`, only removes the session's `runtime/` subtree.
+    #[arg(long)]
+    pub max_age_days: Option<u64>,
+
+    /// Reap completed sessions' `runtime/` payload instead of deleting the
+    /// entire session directory.
+    #[arg(long, requires = "max_age_days")]
+    pub reap_runtime: bool,
+
+    /// Scan all projects under ~/.local/state/cli-sub-agent/ (not just current project)
+    #[arg(long)]
+    pub global: bool,
+}

--- a/crates/cli-sub-agent/src/gc_tests.rs
+++ b/crates/cli-sub-agent/src/gc_tests.rs
@@ -1,6 +1,11 @@
 use super::*;
+use crate::session_cmds_result::{StructuredOutputOpts, handle_session_result};
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_core::types::OutputFormat;
+use csa_session::{
+    SessionArtifact, SessionPhase, SessionResult, create_session, get_session_root, list_sessions,
+    save_result, save_session,
+};
 use std::os::unix::fs as unix_fs;
 use tempfile::tempdir;
 
@@ -263,7 +268,7 @@ scanned_at = 1
         );
     }
 
-    handle_gc_global(false, None, OutputFormat::Text).expect("global gc should succeed");
+    handle_gc_global(false, None, false, OutputFormat::Text).expect("global gc should succeed");
 
     for state_dir in [&canonical, &legacy] {
         let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
@@ -300,7 +305,8 @@ scanned_at = 1
         );
     }
 
-    handle_gc_global(true, None, OutputFormat::Text).expect("global dry-run gc should succeed");
+    handle_gc_global(true, None, false, OutputFormat::Text)
+        .expect("global dry-run gc should succeed");
 
     for state_dir in [&canonical, &legacy] {
         let cache_path = state_dir.join(STATE_DIR_SIZE_CACHE_FILENAME);
@@ -310,6 +316,264 @@ scanned_at = 1
             cache_path.display()
         );
     }
+}
+
+fn legacy_session_root_for(project_root: &std::path::Path) -> std::path::PathBuf {
+    let normalized =
+        std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let storage_key = normalized
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .replace('/', std::path::MAIN_SEPARATOR_STR);
+    csa_config::paths::legacy_state_dir()
+        .expect("legacy state dir")
+        .join(storage_key)
+}
+
+fn seed_runtime_session(
+    project_root: &std::path::Path,
+    phase: SessionPhase,
+    last_accessed: chrono::DateTime<chrono::Utc>,
+    runtime_bytes: u64,
+    store_in_legacy: bool,
+) -> (String, std::path::PathBuf, std::path::PathBuf) {
+    std::fs::create_dir_all(project_root).unwrap();
+
+    let mut session =
+        create_session(project_root, Some("gc runtime test"), None, Some("codex")).unwrap();
+    session.phase = phase;
+    session.last_accessed = last_accessed;
+    save_session(&session).unwrap();
+
+    let canonical_root = get_session_root(project_root).unwrap();
+    let mut session_dir = canonical_root
+        .join("sessions")
+        .join(&session.meta_session_id);
+    if store_in_legacy {
+        let legacy_root = legacy_session_root_for(project_root);
+        std::fs::create_dir_all(legacy_root.join("sessions")).unwrap();
+        let legacy_dir = legacy_root.join("sessions").join(&session.meta_session_id);
+        std::fs::rename(&session_dir, &legacy_dir).unwrap();
+        session_dir = legacy_dir;
+    }
+
+    let runtime_dir = session_dir
+        .join("runtime")
+        .join("gemini-home")
+        .join(".npm")
+        .join("_cacache");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    let cache_blob = runtime_dir.join("blob.bin");
+    let file = std::fs::File::create(&cache_blob).unwrap();
+    file.set_len(runtime_bytes).unwrap();
+
+    let now = chrono::Utc::now();
+    save_result(
+        project_root,
+        &session.meta_session_id,
+        &SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "completed".to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: vec![SessionArtifact::new("output/summary.md")],
+            peak_memory_mb: None,
+            manager_fields: Default::default(),
+        },
+    )
+    .unwrap();
+    std::fs::write(session_dir.join("stderr.log"), "stderr").unwrap();
+    std::fs::write(session_dir.join("output/summary.md"), "summary").unwrap();
+
+    (
+        session.meta_session_id,
+        session_dir.clone(),
+        session_dir.join("runtime"),
+    )
+}
+
+#[test]
+fn test_reap_runtime_basic_preserves_audit_files_and_session_result() {
+    const TWO_MIB: u64 = 2 * 1024 * 1024;
+
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path().join("project");
+    let (session_id, session_dir, runtime_dir) = seed_runtime_session(
+        &project_root,
+        SessionPhase::Retired,
+        chrono::Utc::now() - chrono::Duration::days(40),
+        TWO_MIB,
+        false,
+    );
+    let session_root = get_session_root(&project_root).unwrap();
+    let sessions = list_sessions(&project_root, None).unwrap();
+
+    let stats = reap_runtime_payloads_in_root(&session_root, &sessions, false, 30, None).unwrap();
+
+    assert_eq!(stats.sessions_reaped, 1);
+    assert_eq!(stats.bytes_reclaimed, TWO_MIB);
+    assert!(!runtime_dir.exists(), "runtime/ should be removed");
+    assert!(session_dir.join("state.toml").exists());
+    assert!(session_dir.join("metadata.toml").exists());
+    assert!(session_dir.join("result.toml").exists());
+    assert!(session_dir.join("stderr.log").exists());
+    assert!(session_dir.join("output").exists());
+    handle_session_result(
+        session_id,
+        false,
+        Some(project_root.to_string_lossy().to_string()),
+        StructuredOutputOpts::default(),
+    )
+    .expect("csa session result should still work after runtime reap");
+}
+
+#[test]
+fn test_reap_runtime_skips_active_session() {
+    const TWO_MIB: u64 = 2 * 1024 * 1024;
+
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path().join("project");
+    let (_, _, runtime_dir) = seed_runtime_session(
+        &project_root,
+        SessionPhase::Active,
+        chrono::Utc::now() - chrono::Duration::days(40),
+        TWO_MIB,
+        false,
+    );
+    let session_root = get_session_root(&project_root).unwrap();
+    let sessions = list_sessions(&project_root, None).unwrap();
+
+    let stats = reap_runtime_payloads_in_root(&session_root, &sessions, false, 30, None).unwrap();
+
+    assert_eq!(stats.sessions_reaped, 0);
+    assert!(
+        runtime_dir.exists(),
+        "active session runtime/ must be preserved"
+    );
+}
+
+#[test]
+fn test_reap_runtime_skips_current_session() {
+    const TWO_MIB: u64 = 2 * 1024 * 1024;
+
+    let tmp = tempdir().unwrap();
+    let mut sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    sandbox.track_env("CSA_SESSION_ID");
+    let project_root = tmp.path().join("project");
+    let (session_id, _, runtime_dir) = seed_runtime_session(
+        &project_root,
+        SessionPhase::Retired,
+        chrono::Utc::now() - chrono::Duration::days(40),
+        TWO_MIB,
+        false,
+    );
+    let session_root = get_session_root(&project_root).unwrap();
+    let sessions = list_sessions(&project_root, None).unwrap();
+    // SAFETY: test-scoped env mutation while ScopedSessionSandbox holds TEST_ENV_LOCK.
+    unsafe {
+        std::env::set_var("CSA_SESSION_ID", &session_id);
+    }
+
+    let stats = reap_runtime_payloads_in_root(
+        &session_root,
+        &sessions,
+        false,
+        30,
+        std::env::var("CSA_SESSION_ID").ok().as_deref(),
+    )
+    .unwrap();
+
+    assert_eq!(stats.sessions_reaped, 0);
+    assert!(
+        runtime_dir.exists(),
+        "current session runtime/ must be preserved"
+    );
+}
+
+#[test]
+fn test_reap_runtime_respects_max_age_days() {
+    const TWO_MIB: u64 = 2 * 1024 * 1024;
+
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path().join("project");
+    let (_, _, runtime_dir) = seed_runtime_session(
+        &project_root,
+        SessionPhase::Retired,
+        chrono::Utc::now() - chrono::Duration::days(5),
+        TWO_MIB,
+        false,
+    );
+    let session_root = get_session_root(&project_root).unwrap();
+    let sessions = list_sessions(&project_root, None).unwrap();
+
+    let stats = reap_runtime_payloads_in_root(&session_root, &sessions, false, 30, None).unwrap();
+
+    assert_eq!(stats.sessions_reaped, 0);
+    assert!(
+        runtime_dir.exists(),
+        "recent retired session should be skipped"
+    );
+}
+
+#[test]
+fn test_reap_runtime_dry_run_reports_bytes_without_deleting() {
+    const TWO_MIB: u64 = 2 * 1024 * 1024;
+
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path().join("project");
+    let (_, _, runtime_dir) = seed_runtime_session(
+        &project_root,
+        SessionPhase::Retired,
+        chrono::Utc::now() - chrono::Duration::days(40),
+        TWO_MIB,
+        false,
+    );
+    let session_root = get_session_root(&project_root).unwrap();
+    let sessions = list_sessions(&project_root, None).unwrap();
+
+    let stats = reap_runtime_payloads_in_root(&session_root, &sessions, true, 30, None).unwrap();
+
+    assert_eq!(stats.sessions_reaped, 1);
+    assert_eq!(stats.bytes_reclaimed, TWO_MIB);
+    assert!(runtime_dir.exists(), "dry-run must not delete runtime/");
+}
+
+#[test]
+fn test_reap_runtime_global_covers_canonical_and_legacy_roots() {
+    const TWO_MIB: u64 = 2 * 1024 * 1024;
+
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let canonical_project = tmp.path().join("canonical-project");
+    let legacy_project = tmp.path().join("legacy-project");
+    let (_, _, canonical_runtime) = seed_runtime_session(
+        &canonical_project,
+        SessionPhase::Retired,
+        chrono::Utc::now() - chrono::Duration::days(40),
+        TWO_MIB,
+        false,
+    );
+    let (_, _, legacy_runtime) = seed_runtime_session(
+        &legacy_project,
+        SessionPhase::Retired,
+        chrono::Utc::now() - chrono::Duration::days(40),
+        TWO_MIB,
+        true,
+    );
+
+    let stats = reap_runtime_payloads_global(false, 30).unwrap();
+
+    assert_eq!(stats.sessions_reaped, 2);
+    assert_eq!(stats.bytes_reclaimed, 2 * TWO_MIB);
+    assert!(!canonical_runtime.exists());
+    assert!(!legacy_runtime.exists());
 }
 
 // --- Retirement logic tests ---

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -461,15 +461,16 @@ async fn run() -> Result<()> {
         } => {
             config_cmds::handle_init(non_interactive, full, template)?;
         }
-        Commands::Gc {
+        Commands::Gc(gc::GcArgs {
             dry_run,
             max_age_days,
+            reap_runtime,
             global,
-        } => {
+        }) => {
             if global {
-                gc::handle_gc_global(dry_run, max_age_days, output_format)?;
+                gc::handle_gc_global(dry_run, max_age_days, reap_runtime, output_format)?;
             } else {
-                gc::handle_gc(dry_run, max_age_days, output_format)?;
+                gc::handle_gc(dry_run, max_age_days, reap_runtime, output_format)?;
             }
         }
         Commands::Config { cmd } => match cmd {

--- a/crates/cli-sub-agent/src/mcp_server.rs
+++ b/crates/cli-sub-agent/src/mcp_server.rs
@@ -131,8 +131,9 @@ fn get_tools() -> Vec<McpToolDef> {
         },
         McpToolDef {
             name: "csa_gc".to_string(),
-            description: "Run garbage collection to clean stale locks and empty sessions"
-                .to_string(),
+            description:
+                "Run garbage collection to clean stale locks, old sessions, or runtime payloads"
+                    .to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -142,7 +143,11 @@ fn get_tools() -> Vec<McpToolDef> {
                     },
                     "max_age_days": {
                         "type": "number",
-                        "description": "Remove sessions not accessed within N days"
+                        "description": "Age threshold in days for deleting whole sessions or reaping runtime/"
+                    },
+                    "reap_runtime": {
+                        "type": "boolean",
+                        "description": "Reap completed sessions' runtime/ payload instead of deleting the full session"
                     }
                 }
             }),
@@ -416,9 +421,18 @@ async fn handle_gc_tool(args: Value) -> Result<Value> {
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     let max_age_days = args.get("max_age_days").and_then(|v| v.as_u64());
+    let reap_runtime = args
+        .get("reap_runtime")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     // Call gc logic (MCP server always uses Text format, response is wrapped in JSON-RPC)
-    crate::gc::handle_gc(dry_run, max_age_days, crate::OutputFormat::Text)?;
+    crate::gc::handle_gc(
+        dry_run,
+        max_age_days,
+        reap_runtime,
+        crate::OutputFormat::Text,
+    )?;
 
     let msg = if dry_run {
         "Garbage collection dry-run completed (see logs for details)"

--- a/crates/cli-sub-agent/src/preflight_state_dir.rs
+++ b/crates/cli-sub-agent/src/preflight_state_dir.rs
@@ -17,6 +17,14 @@ struct SizeCache {
 
 const SIZE_CACHE_FILENAME: &str = ".size-cache.toml";
 
+#[derive(Debug, Clone, Copy)]
+struct StateDirUsage {
+    size_bytes: u64,
+    size_mb: u64,
+    cap_bytes: u64,
+    cap_mb: u64,
+}
+
 /// Result of the state directory preflight check.
 pub(crate) enum StateDirCheckResult {
     /// No cap configured or size is within limits.
@@ -67,10 +75,93 @@ fn check_state_dir_size(config: &StateDirConfig) -> StateDirCheckResult {
         return StateDirCheckResult::Ok;
     }
 
+    let Some(usage) = compute_state_dir_usage(config) else {
+        return StateDirCheckResult::Ok;
+    };
+
+    match config.on_exceed {
+        csa_config::StateDirOnExceed::Error => StateDirCheckResult::Error(anyhow!(
+            "{}",
+            build_error_message(
+                usage.size_mb,
+                usage.cap_mb,
+                usage.size_bytes,
+                usage.cap_bytes
+            )
+        )),
+        csa_config::StateDirOnExceed::AutoGc => {
+            match crate::gc::reap_runtime_payloads_global(
+                false,
+                crate::gc::AUTO_GC_REAP_RUNTIME_MAX_AGE_DAYS,
+            ) {
+                Ok(stats) => {
+                    crate::gc::invalidate_state_dir_size_cache();
+                    info!(
+                        sessions_reaped = stats.sessions_reaped,
+                        bytes_reclaimed = stats.bytes_reclaimed,
+                        max_age_days = crate::gc::AUTO_GC_REAP_RUNTIME_MAX_AGE_DAYS,
+                        "State-dir auto-gc reaped runtime payloads"
+                    );
+                    let Some(post_gc_usage) = compute_state_dir_usage(config) else {
+                        return StateDirCheckResult::Ok;
+                    };
+                    if post_gc_usage.size_bytes <= post_gc_usage.cap_bytes {
+                        StateDirCheckResult::Ok
+                    } else {
+                        StateDirCheckResult::Warn(build_warning_preamble(
+                            post_gc_usage.size_mb,
+                            post_gc_usage.cap_mb,
+                            Some(&format!(
+                                "Auto-gc reaped runtime/ for {} session(s), reclaiming {} bytes, but the cap is still exceeded.",
+                                stats.sessions_reaped, stats.bytes_reclaimed
+                            )),
+                        ))
+                    }
+                }
+                Err(err) => StateDirCheckResult::Warn(build_warning_preamble(
+                    usage.size_mb,
+                    usage.cap_mb,
+                    Some(&format!("Auto-gc failed: {err}")),
+                )),
+            }
+        }
+        csa_config::StateDirOnExceed::Warn => {
+            StateDirCheckResult::Warn(build_warning_preamble(usage.size_mb, usage.cap_mb, None))
+        }
+    }
+}
+
+fn build_error_message(actual_mb: u64, cap_mb: u64, actual_bytes: u64, cap_bytes: u64) -> String {
+    format!(
+        "CSA state directory is {actual_mb} MB / {cap_mb} MB cap exceeded \
+         ({actual_bytes} bytes / {cap_bytes} bytes) with `on_exceed = \"error\"`.\n\
+         To reclaim space: `csa gc --reap-runtime --max-age-days 30 --global`\n\
+         Or raise `state_dir.max_size_mb` in ~/.config/cli-sub-agent/config.toml."
+    )
+}
+
+fn build_warning_preamble(actual_mb: u64, cap_mb: u64, note: Option<&str>) -> String {
+    let note_block = note
+        .map(|note| format!("\nNote: {note}\n"))
+        .unwrap_or_default();
+    format!(
+        "\n<state-dir-warning>\n\
+         CSA state directory is {actual_mb} MB / {cap_mb} MB cap exceeded.\n\
+         To reclaim space: `csa gc --reap-runtime --max-age-days 30 --global`\n\
+         or raise `state_dir.max_size_mb` in\n\
+         ~/.config/cli-sub-agent/config.toml.\n\
+         Common large consumers: runtime/gemini-home/.npm (~186 MB each) -- if\n\
+         you're on csa >= 0.1.514, Phase 1 of #1047 should have mitigated this.\
+         {note_block}\n\
+         </state-dir-warning>\n"
+    )
+}
+
+fn compute_state_dir_usage(config: &StateDirConfig) -> Option<StateDirUsage> {
     let state_roots = csa_config::paths::state_dir_all_roots();
     if state_roots.is_empty() {
         debug!("No existing state directory roots found; skipping size check");
-        return StateDirCheckResult::Ok;
+        return None;
     }
 
     let mut size_bytes = 0u64;
@@ -85,66 +176,26 @@ fn check_state_dir_size(config: &StateDirConfig) -> StateDirCheckResult {
                     error = %e,
                     "Failed to compute state directory size; skipping check"
                 );
-                return StateDirCheckResult::Ok;
+                return None;
             }
         }
     }
 
-    let size_mb = size_bytes / (1024 * 1024);
     let cap_mb = config.max_size_mb;
     let cap_bytes = cap_mb.saturating_mul(1024 * 1024);
-
+    let size_mb = size_bytes / (1024 * 1024);
     if size_bytes <= cap_bytes {
         debug!(size_mb, cap_mb, "State directory within cap");
-        return StateDirCheckResult::Ok;
+        return None;
     }
 
     info!(size_mb, cap_mb, on_exceed = ?config.on_exceed, "State directory exceeds cap");
-
-    match config.on_exceed {
-        csa_config::StateDirOnExceed::Error => StateDirCheckResult::Error(anyhow!(
-            "{}",
-            build_error_message(size_mb, cap_mb, size_bytes, cap_bytes)
-        )),
-        csa_config::StateDirOnExceed::AutoGc => {
-            // Phase 3 will wire actual gc invocation. For now, fall back to warn.
-            StateDirCheckResult::Warn(build_warning_preamble(
-                size_mb, cap_mb, true, // auto_gc_note
-            ))
-        }
-        csa_config::StateDirOnExceed::Warn => {
-            StateDirCheckResult::Warn(build_warning_preamble(size_mb, cap_mb, false))
-        }
-    }
-}
-
-fn build_error_message(actual_mb: u64, cap_mb: u64, actual_bytes: u64, cap_bytes: u64) -> String {
-    format!(
-        "CSA state directory is {actual_mb} MB / {cap_mb} MB cap exceeded \
-         ({actual_bytes} bytes / {cap_bytes} bytes) with `on_exceed = \"error\"`.\n\
-         To reclaim space: `csa gc --max-age-days 5 --global`\n\
-         Or raise `state_dir.max_size_mb` in ~/.config/cli-sub-agent/config.toml."
-    )
-}
-
-fn build_warning_preamble(actual_mb: u64, cap_mb: u64, auto_gc_pending: bool) -> String {
-    let auto_gc_note = if auto_gc_pending {
-        "\nNote: `on_exceed = \"auto-gc\"` is configured but not yet implemented (Phase 3).\n\
-         Falling back to warning mode.\n"
-    } else {
-        ""
-    };
-    format!(
-        "\n<state-dir-warning>\n\
-         CSA state directory is {actual_mb} MB / {cap_mb} MB cap exceeded.\n\
-         To reclaim space: `csa gc --max-age-days 5 --global` (removes sessions\n\
-         older than 5 days) or raise `state_dir.max_size_mb` in\n\
-         ~/.config/cli-sub-agent/config.toml.\n\
-         Common large consumers: runtime/gemini-home/.npm (~186 MB each) -- if\n\
-         you're on csa >= 0.1.514, Phase 1 of #1047 should have mitigated this.\
-         {auto_gc_note}\n\
-         </state-dir-warning>\n"
-    )
+    Some(StateDirUsage {
+        size_bytes,
+        size_mb,
+        cap_bytes,
+        cap_mb,
+    })
 }
 
 /// Get the cached size or recompute if stale.
@@ -255,7 +306,11 @@ fn now_unix_secs() -> u64 {
 mod tests {
     use super::*;
     use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+    use crate::test_session_sandbox::ScopedSessionSandbox;
     use csa_config::{StateDirConfig, StateDirOnExceed};
+    use csa_session::{
+        SessionArtifact, SessionPhase, SessionResult, create_session, save_result, save_session,
+    };
 
     #[test]
     fn compute_size_of_temp_dir() {
@@ -348,18 +403,17 @@ mod tests {
 
     #[test]
     fn on_exceed_warn_produces_preamble() {
-        let preamble = build_warning_preamble(500, 100, false);
+        let preamble = build_warning_preamble(500, 100, None);
         assert!(preamble.contains("500 MB"));
         assert!(preamble.contains("100 MB"));
         assert!(preamble.contains("csa gc"));
-        assert!(!preamble.contains("auto-gc"));
+        assert!(preamble.contains("reap-runtime"));
     }
 
     #[test]
-    fn on_exceed_auto_gc_shows_note() {
-        let preamble = build_warning_preamble(500, 100, true);
-        assert!(preamble.contains("auto-gc"));
-        assert!(preamble.contains("not yet implemented"));
+    fn warning_preamble_includes_optional_note() {
+        let preamble = build_warning_preamble(500, 100, Some("auto-gc ran"));
+        assert!(preamble.contains("Note: auto-gc ran"));
     }
 
     #[test]
@@ -608,6 +662,94 @@ mod tests {
         assert!(
             result.is_ok(),
             "Warn mode must not return Err from enforce_state_dir_cap"
+        );
+    }
+
+    fn seed_retired_session_with_runtime(
+        project_root: &std::path::Path,
+        last_accessed: chrono::DateTime<chrono::Utc>,
+        runtime_bytes: u64,
+    ) -> std::path::PathBuf {
+        std::fs::create_dir_all(project_root).unwrap();
+
+        let mut session = create_session(project_root, Some("auto-gc"), None, Some("codex"))
+            .expect("create session");
+        session.phase = SessionPhase::Retired;
+        session.last_accessed = last_accessed;
+        save_session(&session).expect("persist retired session");
+
+        let session_root = csa_session::get_session_root(project_root).expect("session root");
+        let session_dir = session_root.join("sessions").join(&session.meta_session_id);
+        let runtime_blob = session_dir
+            .join("runtime")
+            .join("gemini-home")
+            .join(".npm")
+            .join("_cacache")
+            .join("blob.bin");
+        std::fs::create_dir_all(runtime_blob.parent().unwrap()).unwrap();
+        let file = std::fs::File::create(&runtime_blob).unwrap();
+        file.set_len(runtime_bytes).unwrap();
+
+        let now = chrono::Utc::now();
+        save_result(
+            project_root,
+            &session.meta_session_id,
+            &SessionResult {
+                status: "success".to_string(),
+                exit_code: 0,
+                summary: "completed".to_string(),
+                tool: "codex".to_string(),
+                started_at: now,
+                completed_at: now,
+                events_count: 0,
+                artifacts: vec![SessionArtifact::new("output/summary.md")],
+                peak_memory_mb: None,
+                manager_fields: Default::default(),
+            },
+        )
+        .expect("save result");
+        std::fs::write(session_dir.join("stderr.log"), "stderr").unwrap();
+        std::fs::write(session_dir.join("output/summary.md"), "summary").unwrap();
+
+        session_dir.join("runtime")
+    }
+
+    #[test]
+    fn auto_gc_default_runtime_reap_age_is_30_days() {
+        assert_eq!(crate::gc::AUTO_GC_REAP_RUNTIME_MAX_AGE_DAYS, 30);
+    }
+
+    #[test]
+    fn auto_gc_reaps_runtime_and_next_check_is_ok() {
+        const TWO_MIB: u64 = 2 * 1024 * 1024;
+
+        let temp = tempfile::tempdir().unwrap();
+        let _sandbox = ScopedSessionSandbox::new_blocking(&temp);
+        let project_root = temp.path().join("project");
+        let runtime_dir = seed_retired_session_with_runtime(
+            &project_root,
+            chrono::Utc::now()
+                - chrono::Duration::days(crate::gc::AUTO_GC_REAP_RUNTIME_MAX_AGE_DAYS as i64 + 10),
+            TWO_MIB,
+        );
+
+        let config = StateDirConfig {
+            max_size_mb: 1,
+            scan_interval_seconds: 0,
+            on_exceed: StateDirOnExceed::AutoGc,
+        };
+
+        assert!(
+            matches!(check_state_dir_size(&config), StateDirCheckResult::Ok),
+            "auto-gc should reap old runtime payloads until the cap check passes"
+        );
+        assert!(
+            !runtime_dir.exists(),
+            "runtime/ should be removed by auto-gc when the session is old enough"
+        );
+        assert!(
+            matches!(check_state_dir_size(&config), StateDirCheckResult::Ok),
+            "subsequent checks should stay within the cap after auto-gc"
         );
     }
 }

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -3,6 +3,8 @@
 
 #[path = "../src/cli.rs"]
 mod cli_defs;
+#[path = "../src/gc_args.rs"]
+mod gc;
 
 use clap::Parser;
 use cli_defs::{AuditCommands, Cli, Commands, McpHubCommands, validate_command_args};

--- a/crates/cli-sub-agent/tests/review_mode_compat.rs
+++ b/crates/cli-sub-agent/tests/review_mode_compat.rs
@@ -1,5 +1,7 @@
 #[path = "../src/cli.rs"]
 mod cli_defs;
+#[path = "../src/gc_args.rs"]
+mod gc;
 
 #[allow(dead_code)]
 #[path = "../src/bug_class.rs"]


### PR DESCRIPTION
## Summary

Phase 3 of #1047 — the cleanup side of the state-dir bloat mitigation. Phase 1 (PR #1050) made new sessions reuse npm packages instead of re-downloading ~186 MiB each. Phase 2 (PR #1051) added a configurable size cap with periodic scan and `on_exceed` action. Phase 3 closes the loop.

### What it does

- **`csa gc --reap-runtime`**: for sessions with `state == "completed"`/`Retired` older than `--max-age-days`, delete the `runtime/` subtree while preserving the audit-load-bearing files (`state.toml`, `metadata.toml`, `result.toml`, `output/`, `stderr.log`). Only sandbox HOME dirs get reaped.
- **Safety guards**: never reaps Active sessions (lock-checked), never reaps the current session (by `CSA_SESSION_ID` match), supports `--dry-run` with bytes-freed summary, respects `--max-age-days` and `--global`.
- **Phase 2 auto-gc wiring**: `[state_dir].on_exceed = "auto-gc"` now invokes the reaper with a conservative default `--max-age-days=30`. The cap-check invalidates and recomputes the size cache after auto-gc runs.
- **Dual-root coverage**: handles both canonical (`~/.local/state/cli-sub-agent/`) and legacy (`~/.local/state/csa/`) state roots, mirroring Phase 2 round 7's fix.

### Structural changes

Monolith-gate-driven splits kept cli.rs ≤780 lines:
- `gc_args.rs` — clap `GcArgs` definition, previously inline in `cli.rs`.
- `gc/reaper.rs` — runtime-reaper logic + lock/age/current-session guards.
- `gc/auto_gc.rs` — Phase 2 `on_exceed = "auto-gc"` glue.
- `gc.rs` — module entry, public API, orchestration (was 799 lines on main, now 402).

### Tests

Seven regression tests cover:
1. Basic reap (Retired + old → runtime/ removed, audit files preserved).
2. Skip Active sessions.
3. Skip the current session by `$CSA_SESSION_ID`.
4. Respect `--max-age-days` (in-age Retired session untouched).
5. Dry-run prints bytes freed but does not delete.
6. Phase 2 auto-gc wiring end-to-end.
7. Dual-root coverage (canonical + legacy).

Refs #1047.

## Test plan

- [x] `cargo test -p cli-sub-agent` — 7 new regression tests pass
- [x] `just pre-commit` — exit 0
- [x] `csa review --range main...HEAD --tier tier-4-critical` — verdict: PASS, no findings
- [ ] pr-bot cloud review

🤖 Generated with [Claude Code](https://claude.com/claude-code)