### PR TITLE
refactor(csa-executor): dedupe gemini sandbox runtime contract at CLI path (#1053)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.532"
+version = "0.1.533"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.532"
+version = "0.1.533"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -28,20 +28,21 @@ pub use transport_meta::PeakMemoryContext;
 use transport_meta::{build_summary, run_acp_sandboxed};
 #[path = "transport_gemini_helpers.rs"]
 mod transport_gemini_helpers;
-#[cfg(test)]
-use transport_gemini_helpers::format_gemini_retry_report;
 use transport_gemini_helpers::{
     GeminiAcpInitFailureClassification, GeminiRetryPhase, annotate_gemini_retry_error,
     append_gemini_retry_report, apply_gemini_acp_initial_stall_summary,
     apply_gemini_legacy_initial_stall_summary, apply_gemini_mcp_warning_summary,
-    apply_gemini_sandbox_runtime_contract, apply_gemini_sandbox_runtime_env_overrides,
-    classify_gemini_acp_init_failure, classify_gemini_acp_initial_stall,
-    classify_gemini_legacy_initial_stall, classify_gemini_oauth_prompt_result, classify_join_error,
-    ensure_gemini_runtime_home_writable_path, format_gemini_acp_init_failure,
+    apply_gemini_sandbox_runtime_contract, classify_gemini_acp_init_failure,
+    classify_gemini_acp_initial_stall, classify_gemini_legacy_initial_stall,
+    classify_gemini_oauth_prompt_result, classify_join_error, format_gemini_acp_init_failure,
     gemini_acp_initial_response_timeout_seconds, gemini_phase_desc,
-    gemini_sandbox_runtime_env_overrides, gemini_shared_npm_cache_bind_error,
-    is_gemini_acp_init_failure, is_gemini_mcp_issue_result, is_gemini_oauth_prompt_result,
-    resolve_gemini_shared_npm_cache_source, validate_gemini_shared_npm_cache_writable_path,
+    gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure, is_gemini_mcp_issue_result,
+    is_gemini_oauth_prompt_result, resolve_gemini_shared_npm_cache_source,
+};
+#[cfg(test)]
+use transport_gemini_helpers::{
+    apply_gemini_sandbox_runtime_env_overrides, ensure_gemini_runtime_home_writable_path,
+    format_gemini_retry_report,
 };
 pub use transport_gemini_helpers::{
     contains_gemini_oauth_prompt, normalize_gemini_prompt_text, strip_ansi_escape_sequences,
@@ -482,11 +483,6 @@ impl AcpTransport {
         if self.tool_name == "codex" {
             sanitize_args_for_codex(&mut acp_args);
         }
-        let shared_gemini_npm_cache = if self.tool_name == "gemini-cli" {
-            env.get("npm_config_cache").map(PathBuf::from)
-        } else {
-            None
-        };
         let gemini_sandbox_env_overrides =
             (self.tool_name == "gemini-cli").then(|| gemini_sandbox_runtime_env_overrides(&env));
 
@@ -495,38 +491,14 @@ impl AcpTransport {
             .map(|s| -> Result<_> {
                 let mut isolation_plan = s.isolation_plan.clone();
                 if self.tool_name == "gemini-cli" {
-                    ensure_gemini_runtime_home_writable_path(
+                    apply_gemini_sandbox_runtime_contract(
                         &mut isolation_plan,
+                        working_dir.as_path(),
                         gemini_runtime_home.as_deref(),
-                    );
-                    if let Some(shared_npm_cache) = shared_gemini_npm_cache.as_deref() {
-                        let requested_shared_npm_cache = shared_gemini_npm_cache_raw_path
-                            .as_deref()
-                            .unwrap_or(shared_npm_cache);
-                        let resolved_shared_npm_cache =
-                            validate_gemini_shared_npm_cache_writable_path(
-                                requested_shared_npm_cache,
-                                working_dir.as_path(),
-                                shared_gemini_npm_cache_source,
-                            )?;
-                        if !ensure_gemini_runtime_home_writable_path(
-                            &mut isolation_plan,
-                            Some(resolved_shared_npm_cache.as_path()),
-                        ) {
-                            return Err(gemini_shared_npm_cache_bind_error(
-                                requested_shared_npm_cache,
-                                Some(resolved_shared_npm_cache.as_path()),
-                                shared_gemini_npm_cache_source,
-                                None,
-                            ));
-                        }
-                    }
-                    if let Some(ref env_overrides) = gemini_sandbox_env_overrides {
-                        apply_gemini_sandbox_runtime_env_overrides(
-                            &mut isolation_plan,
-                            env_overrides,
-                        );
-                    }
+                        &env,
+                        shared_gemini_npm_cache_raw_path.as_deref(),
+                        shared_gemini_npm_cache_source,
+                    )?;
                 }
                 Ok(isolation_plan)
             })


### PR DESCRIPTION
## Summary

MEDIUM refactor followup flagged by gemini cloud review on PR #1052 (#1047 bwrap rounds 1–8). The Gemini CLI transport path at `crates/csa-executor/src/transport.rs:498-512` inlined the full sandbox-runtime-contract admission sequence (ensure runtime home writable → validate shared npm cache → second ensure call), duplicating what `apply_gemini_sandbox_runtime_contract` at `transport_gemini_helpers.rs:459` already wraps. The ACP call-site at `transport.rs:276` goes through the helper correctly; the CLI call-site did not.

The duplication grew across #1047 bwrap rounds 6–8 when the CLI transport was brought to parity with the ACP path (env-derived path validation, symlink canonicalization). Now both call-sites expand the same contract inline vs going through the helper.

### What changed

Replaced the inline sequence at `transport.rs:498-512` with a single `apply_gemini_sandbox_runtime_contract(...)` call. Both ACP and CLI paths now funnel through the helper.

### Preserved contracts

All three security invariants from the #1047 bwrap rounds live inside the helper, so funneling through it INHERITS them:

- **Round 5** — fail-fast on bind failure (no silent retract, no per-session-state-dir fallback). Rule 041 compliance.
- **Round 7** — env-derived npm cache path validated against `validate_writable_paths()` allowlist.
- **Round 8** — canonicalize-through-existing-ancestors before validation to close symlink bypass.

No behavior change. Round 8 regression tests continue to pass.

Closes #1053.

## Test plan

- [x] `cargo test -p csa-executor` — all bwrap-related tests pass (round 8 symlink-bypass test by name)
- [x] `just pre-commit` — exit 0
- [x] `csa review --range main...HEAD --tier tier-4-critical` — verdict: PASS
- [ ] pr-bot cloud review

🤖 Generated with [Claude Code](https://claude.com/claude-code)