### PR TITLE
fix(scripts): convert line 131 echo to here-string for #1059 (drop #1057 regression)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.534"
+version = "0.1.535"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.534"
+version = "0.1.535"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/scripts/extract-rules-from-pr.sh
+++ b/scripts/extract-rules-from-pr.sh
@@ -128,7 +128,7 @@ while IFS= read -r finding; do
   # Remove badge image markdown from first line
   BODY_NO_BADGE="$(sed '1s/^!\['"${SEVERITY}"'\]([^)]*)[[:space:]]*//' <<< "${BODY}")"
   # First non-empty line after badge removal = dedupe key
-  FIRST_LINE="$(echo "${BODY_NO_BADGE}" | sed '/^[[:space:]]*$/d' | head -1)"
+  FIRST_LINE="$(sed '/^[[:space:]]*$/d' <<< "${BODY_NO_BADGE}" | head -1)"
 
   # --- Dedupe check ---
   DUPLICATE_CANDIDATE=""


### PR DESCRIPTION
## Summary

Post-#1043 gemini cloud review flagged two MEDIUMs adjacent to PR #1058's printf/here-string polish:

- **#1059** — `scripts/extract-rules-from-pr.sh` line 131 had a remaining `echo \"\${BODY_NO_BADGE}\" | sed ... | head -1` call-site after #1043 converted the other four. Converted to `sed ... <<< \"\${BODY_NO_BADGE}\" | head -1` to match the established pattern.
- **#1057** — **RETRACTED**: gemini bot flagged an explicit `shared_gemini_npm_cache_raw_path.as_deref()` arg to `apply_gemini_sandbox_runtime_contract` as \"redundant\". Local review (session \`01KPX7VE825BQYX2F3JTRFA46Q\`) correctly identified this as a HIGH regression — the arg is load-bearing for the raw-path-for-diagnostics vs canonical-path-for-child env split. Under bwrap, \`/tmp\` is replaced with a tmpfs before writable binds, so forwarding the raw path to a sandboxed child (instead of the canonical path) would make a symlink-backed \`XDG_CACHE_HOME=/tmp/...\` cache root unreachable inside the sandbox. Round 1's bundled commit was reverted; only the #1059 shell fix remains.

#1057 will be closed as wontfix with a pointer to this PR.

### Why echo→here-string matters (MEDIUM)

\`echo\` behavior is shell-dependent:
- Strings starting with \`-e\`, \`-n\`, \`-E\` may be interpreted as flags in some shells.
- Escape sequences (\`\\\\n\`, \`\\\\t\`, \`\\\\\\\\\`) may be interpreted in \`sh\`/\`dash\`/\`bash-with-xpg_echo\`.
- \`BODY_NO_BADGE\` is arbitrary markdown from PR comment bodies.

Realistic exploitation surface is ~zero (gemini/codex produce well-formed markdown), but this is a Layer-0 rule-extraction utility that may eventually process less-trusted sources.

Closes #1059.
Relates to #1057 (retracted).

## Test plan

- [x] \`bash scripts/tests/extract-rules-from-pr-tests.sh\` — 32 passed, 0 failed
- [x] Ad hoc reproduction with a finding body whose first meaningful line starts with \`-n\`: output preserved correctly
- [x] \`just pre-commit\` exit 0
- [ ] pr-bot cloud review (**blocked by #1056 mise-trust infrastructure bug** — merge manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)