### PR TITLE
fix(csa-executor): propagate mise trust from host filesystem DB for sandboxed children (#1056)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.536"
+version = "0.1.537"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.535"
+version = "0.1.536"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.536"
+version = "0.1.537"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.535"
+version = "0.1.536"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -133,16 +133,13 @@ pub(crate) fn prepare_gemini_acp_runtime(
         let project_dir = project_dir
             .map(Path::to_path_buf)
             .or_else(|| std::env::current_dir().ok());
-        if let Some(project_dir) = project_dir {
-            let mise_toml_path = project_dir.join("mise.toml");
-            if let Some(trusted_config_path) =
-                probe_host_mise_trust_db(&project_dir, &mise_toml_path)
-            {
-                env.insert(
-                    "MISE_TRUSTED_CONFIG_PATHS".to_string(),
-                    trusted_config_path.to_string_lossy().into_owned(),
-                );
-            }
+        if let Some(project_dir) = project_dir
+            && let Some(trusted_config_path) = probe_host_mise_trust_db(&project_dir)
+        {
+            env.insert(
+                "MISE_TRUSTED_CONFIG_PATHS".to_string(),
+                trusted_config_path.to_string_lossy().into_owned(),
+            );
         }
     }
 

--- a/crates/csa-executor/src/transport_gemini_acp_runtime.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime.rs
@@ -10,6 +10,12 @@ use csa_resource::isolation_plan::canonicalize_through_existing_ancestors;
 use serde_json::{Map, Value};
 use tracing::{debug, warn};
 
+#[path = "transport_gemini_mise_trust.rs"]
+mod transport_gemini_mise_trust;
+#[cfg(test)]
+use transport_gemini_mise_trust::GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH;
+use transport_gemini_mise_trust::probe_host_mise_trust_db;
+
 const GEMINI_RUNTIME_ROOT_DIR: &str = "cli-sub-agent-gemini";
 const GEMINI_SESSION_RUNTIME_RELATIVE_PATH: &str = "runtime/gemini-home";
 const CSA_FS_SANDBOXED_ENV: &str = "CSA_FS_SANDBOXED";
@@ -120,12 +126,24 @@ pub(crate) fn prepare_gemini_acp_runtime(
     // Preserve explicit trust state from the inherited environment only.
     // Do not synthesize trust from project-local mise.toml, because that would
     // elevate repo-controlled input into trusted execution state. See #972.
-    if std::env::var("MISE_TRUSTED_CONFIG_PATHS").is_ok() {
+    if let Ok(trusted_config_paths) = std::env::var("MISE_TRUSTED_CONFIG_PATHS") {
         env.entry("MISE_TRUSTED_CONFIG_PATHS".to_string())
-            .or_insert_with(|| {
-                std::env::var("MISE_TRUSTED_CONFIG_PATHS")
-                    .expect("MISE_TRUSTED_CONFIG_PATHS existence checked above")
-            });
+            .or_insert(trusted_config_paths);
+    } else if !env.contains_key("MISE_TRUSTED_CONFIG_PATHS") {
+        let project_dir = project_dir
+            .map(Path::to_path_buf)
+            .or_else(|| std::env::current_dir().ok());
+        if let Some(project_dir) = project_dir {
+            let mise_toml_path = project_dir.join("mise.toml");
+            if let Some(trusted_config_path) =
+                probe_host_mise_trust_db(&project_dir, &mise_toml_path)
+            {
+                env.insert(
+                    "MISE_TRUSTED_CONFIG_PATHS".to_string(),
+                    trusted_config_path.to_string_lossy().into_owned(),
+                );
+            }
+        }
     }
 
     let inherited_path = env

--- a/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_acp_runtime_tests_tail.rs
@@ -730,6 +730,8 @@ fn prepare_gemini_acp_runtime_propagates_mise_trusted_config_paths_from_env() {
     );
 }
 
+include!("transport_gemini_mise_trust_tests_tail.rs");
+
 #[test]
 fn prepare_gemini_acp_runtime_sets_shared_npm_cache_from_source_home() {
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -412,6 +412,7 @@ pub(super) fn gemini_sandbox_runtime_env_overrides(
         "npm_config_cache",
         "MISE_CACHE_DIR",
         "MISE_STATE_DIR",
+        "MISE_TRUSTED_CONFIG_PATHS",
         "MISE_SHIM",
         "MISE_SHIMS_DIR",
     ] {

--- a/crates/csa-executor/src/transport_gemini_mise_trust.rs
+++ b/crates/csa-executor/src/transport_gemini_mise_trust.rs
@@ -3,17 +3,15 @@ use std::path::{Path, PathBuf};
 
 pub(super) const GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH: &str = "mise/trusted-configs";
 
-/// Check if the mise config at `mise_toml_path` is trusted on the host by
-/// scanning the host mise filesystem trust DB.
+/// Check if the project root is trusted on the host by scanning the host mise
+/// filesystem trust DB.
 ///
-/// Returns `Some(mise_toml_path)` when the host trust DB contains a direct
+/// Returns the matched trust DB target path when the host trust DB contains a
 /// symlink entry that points at `project_root` or one of its ancestors.
-pub(super) fn probe_host_mise_trust_db(
-    project_root: &Path,
-    mise_toml_path: &Path,
-) -> Option<PathBuf> {
+/// Propagating the trusted target preserves directory-scoped trust for any mise
+/// config filename under that path.
+pub(super) fn probe_host_mise_trust_db(project_root: &Path) -> Option<PathBuf> {
     let canonical_project_root = project_root.canonicalize().ok()?;
-    let canonical_mise_toml_path = mise_toml_path.canonicalize().ok()?;
     let trust_db_dir = host_mise_trust_db_dir()?;
     let entries = fs::read_dir(trust_db_dir).ok()?;
 
@@ -24,7 +22,7 @@ pub(super) fn probe_host_mise_trust_db(
         };
         let resolved_target = resolve_trust_db_symlink_target(&entry_path, &link_target);
         if canonical_project_root.starts_with(&resolved_target) {
-            return Some(canonical_mise_toml_path);
+            return Some(resolved_target);
         }
     }
 

--- a/crates/csa-executor/src/transport_gemini_mise_trust.rs
+++ b/crates/csa-executor/src/transport_gemini_mise_trust.rs
@@ -1,0 +1,56 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(super) const GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH: &str = "mise/trusted-configs";
+
+/// Check if the mise config at `mise_toml_path` is trusted on the host by
+/// scanning the host mise filesystem trust DB.
+///
+/// Returns `Some(mise_toml_path)` when the host trust DB contains a direct
+/// symlink entry that points at `project_root` or one of its ancestors.
+pub(super) fn probe_host_mise_trust_db(
+    project_root: &Path,
+    mise_toml_path: &Path,
+) -> Option<PathBuf> {
+    let canonical_project_root = project_root.canonicalize().ok()?;
+    let canonical_mise_toml_path = mise_toml_path.canonicalize().ok()?;
+    let trust_db_dir = host_mise_trust_db_dir()?;
+    let entries = fs::read_dir(trust_db_dir).ok()?;
+
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        let Ok(link_target) = fs::read_link(&entry_path) else {
+            continue;
+        };
+        let resolved_target = resolve_trust_db_symlink_target(&entry_path, &link_target);
+        if canonical_project_root.starts_with(&resolved_target) {
+            return Some(canonical_mise_toml_path);
+        }
+    }
+
+    None
+}
+
+fn host_mise_trust_db_dir() -> Option<PathBuf> {
+    let xdg_state_home = std::env::var_os("XDG_STATE_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+                .map(|home| home.join(".local").join("state"))
+        })?;
+    Some(xdg_state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH))
+}
+
+fn resolve_trust_db_symlink_target(entry_path: &Path, link_target: &Path) -> PathBuf {
+    if link_target.is_absolute() {
+        return link_target.to_path_buf();
+    }
+
+    entry_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(link_target)
+}

--- a/crates/csa-executor/src/transport_gemini_mise_trust_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_mise_trust_tests_tail.rs
@@ -35,21 +35,31 @@ impl Drop for ScopedEnvVar {
     }
 }
 
-fn create_project_with_mise(base: &Path, name: &str) -> (PathBuf, PathBuf) {
+fn create_project_with_mise_config(
+    base: &Path,
+    name: &str,
+    config_relative_path: &Path,
+) -> (PathBuf, PathBuf) {
     let project_root = base.join(name);
     fs::create_dir_all(&project_root).expect("create project root");
-    let mise_toml_path = project_root.join("mise.toml");
-    fs::write(&mise_toml_path, "[tools]\nnode = \"20\"\n").expect("write mise.toml");
-    (project_root, mise_toml_path)
+    let mise_config_path = project_root.join(config_relative_path);
+    let config_parent = mise_config_path.parent().unwrap_or(project_root.as_path());
+    fs::create_dir_all(config_parent).expect("create mise config parent");
+    fs::write(&mise_config_path, "[tools]\nnode = \"20\"\n").expect("write mise config");
+    (project_root, mise_config_path)
+}
+
+fn create_project_with_mise(base: &Path, name: &str) -> (PathBuf, PathBuf) {
+    create_project_with_mise_config(base, name, Path::new("mise.toml"))
 }
 
 #[test]
-fn probe_host_mise_trust_db_returns_project_mise_toml_when_project_root_is_trusted() {
+fn probe_host_mise_trust_db_returns_matched_trust_target_when_project_root_is_trusted() {
     let _env_guard = GEMINI_RUNTIME_ENV_LOCK.lock().expect("env lock");
     let temp = tempfile::tempdir().expect("tempdir");
     let state_home = temp.path().join("state-home");
     let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
-    let (project_root, mise_toml_path) = create_project_with_mise(temp.path(), "project");
+    let (project_root, _mise_toml_path) = create_project_with_mise(temp.path(), "project");
     fs::create_dir_all(&trust_db_dir).expect("create trust db dir");
     std::os::unix::fs::symlink(&project_root, trust_db_dir.join("trusted-project"))
         .expect("create trusted project symlink");
@@ -58,8 +68,8 @@ fn probe_host_mise_trust_db_returns_project_mise_toml_when_project_root_is_trust
     let _trusted_paths = ScopedEnvVar::unset("MISE_TRUSTED_CONFIG_PATHS");
 
     assert_eq!(
-        probe_host_mise_trust_db(&project_root, &mise_toml_path),
-        Some(canonicalize_if_exists(&mise_toml_path))
+        probe_host_mise_trust_db(&project_root),
+        Some(project_root.clone())
     );
 }
 
@@ -69,7 +79,7 @@ fn probe_host_mise_trust_db_rejects_non_matching_symlink_targets() {
     let temp = tempfile::tempdir().expect("tempdir");
     let state_home = temp.path().join("state-home");
     let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
-    let (project_root, mise_toml_path) = create_project_with_mise(temp.path(), "project");
+    let (project_root, _mise_toml_path) = create_project_with_mise(temp.path(), "project");
     let other_root = temp.path().join("other-project");
     fs::create_dir_all(&other_root).expect("create other project root");
     fs::create_dir_all(&trust_db_dir).expect("create trust db dir");
@@ -79,7 +89,7 @@ fn probe_host_mise_trust_db_rejects_non_matching_symlink_targets() {
     let _xdg_state_home = ScopedEnvVar::set("XDG_STATE_HOME", &state_home.to_string_lossy());
     let _trusted_paths = ScopedEnvVar::unset("MISE_TRUSTED_CONFIG_PATHS");
 
-    assert_eq!(probe_host_mise_trust_db(&project_root, &mise_toml_path), None);
+    assert_eq!(probe_host_mise_trust_db(&project_root), None);
 }
 
 #[test]
@@ -88,13 +98,13 @@ fn probe_host_mise_trust_db_skips_missing_non_symlink_and_broken_entries() {
     let temp = tempfile::tempdir().expect("tempdir");
     let state_home = temp.path().join("state-home");
     let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
-    let (project_root, mise_toml_path) = create_project_with_mise(temp.path(), "project");
+    let (project_root, _mise_toml_path) = create_project_with_mise(temp.path(), "project");
 
     let _xdg_state_home = ScopedEnvVar::set("XDG_STATE_HOME", &state_home.to_string_lossy());
     let _trusted_paths = ScopedEnvVar::unset("MISE_TRUSTED_CONFIG_PATHS");
 
     assert_eq!(
-        probe_host_mise_trust_db(&project_root, &mise_toml_path),
+        probe_host_mise_trust_db(&project_root),
         None,
         "missing trust DB dir should be treated as untrusted"
     );
@@ -108,9 +118,57 @@ fn probe_host_mise_trust_db_skips_missing_non_symlink_and_broken_entries() {
     .expect("create broken symlink");
 
     assert_eq!(
-        probe_host_mise_trust_db(&project_root, &mise_toml_path),
+        probe_host_mise_trust_db(&project_root),
         None,
         "invalid trust DB entries should be ignored"
+    );
+}
+
+#[test]
+fn probe_host_mise_trust_db_accepts_trusted_project_with_dot_mise_toml() {
+    let _env_guard = GEMINI_RUNTIME_ENV_LOCK.lock().expect("env lock");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state_home = temp.path().join("state-home");
+    let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
+    let (project_root, _mise_config_path) =
+        create_project_with_mise_config(temp.path(), "project-dot-mise", Path::new(".mise.toml"));
+    fs::create_dir_all(&trust_db_dir).expect("create trust db dir");
+    std::os::unix::fs::symlink(&project_root, trust_db_dir.join("trusted-project-dot-mise"))
+        .expect("create trusted project symlink");
+
+    let _xdg_state_home = ScopedEnvVar::set("XDG_STATE_HOME", &state_home.to_string_lossy());
+    let _trusted_paths = ScopedEnvVar::unset("MISE_TRUSTED_CONFIG_PATHS");
+
+    assert_eq!(
+        probe_host_mise_trust_db(&project_root),
+        Some(project_root.clone())
+    );
+}
+
+#[test]
+fn probe_host_mise_trust_db_accepts_trusted_project_with_dot_mise_config_toml() {
+    let _env_guard = GEMINI_RUNTIME_ENV_LOCK.lock().expect("env lock");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state_home = temp.path().join("state-home");
+    let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
+    let (project_root, _mise_config_path) = create_project_with_mise_config(
+        temp.path(),
+        "project-dot-mise-dir",
+        Path::new(".mise/config.toml"),
+    );
+    fs::create_dir_all(&trust_db_dir).expect("create trust db dir");
+    std::os::unix::fs::symlink(
+        &project_root,
+        trust_db_dir.join("trusted-project-dot-mise-dir"),
+    )
+    .expect("create trusted project symlink");
+
+    let _xdg_state_home = ScopedEnvVar::set("XDG_STATE_HOME", &state_home.to_string_lossy());
+    let _trusted_paths = ScopedEnvVar::unset("MISE_TRUSTED_CONFIG_PATHS");
+
+    assert_eq!(
+        probe_host_mise_trust_db(&project_root),
+        Some(project_root.clone())
     );
 }
 
@@ -120,7 +178,7 @@ fn prepare_gemini_acp_runtime_synthesizes_mise_trusted_config_paths_from_host_db
     let temp = tempfile::tempdir().expect("tempdir");
     let state_home = temp.path().join("state-home");
     let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
-    let (project_root, mise_toml_path) = create_project_with_mise(temp.path(), "project");
+    let (project_root, _mise_toml_path) = create_project_with_mise(temp.path(), "project");
     let source_home = temp.path().join("source-home");
     let session_id = "01TESTGEMINIMISETRUSTDB000000001";
     fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
@@ -148,7 +206,7 @@ fn prepare_gemini_acp_runtime_synthesizes_mise_trusted_config_paths_from_host_db
 
     assert_eq!(
         env.get("MISE_TRUSTED_CONFIG_PATHS"),
-        Some(&canonicalize_if_exists(&mise_toml_path).to_string_lossy().into_owned()),
+        Some(&project_root.to_string_lossy().into_owned()),
         "runtime should synthesize trust only from the host mise DB when the user already trusted this project"
     );
 }

--- a/crates/csa-executor/src/transport_gemini_mise_trust_tests_tail.rs
+++ b/crates/csa-executor/src/transport_gemini_mise_trust_tests_tail.rs
@@ -1,0 +1,196 @@
+use std::sync::{LazyLock, Mutex};
+
+static GEMINI_RUNTIME_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+struct ScopedEnvVar {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by GEMINI_RUNTIME_ENV_LOCK.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by GEMINI_RUNTIME_ENV_LOCK.
+        unsafe { std::env::remove_var(key) };
+        Self { key, original }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by GEMINI_RUNTIME_ENV_LOCK.
+        unsafe {
+            match self.original.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn create_project_with_mise(base: &Path, name: &str) -> (PathBuf, PathBuf) {
+    let project_root = base.join(name);
+    fs::create_dir_all(&project_root).expect("create project root");
+    let mise_toml_path = project_root.join("mise.toml");
+    fs::write(&mise_toml_path, "[tools]\nnode = \"20\"\n").expect("write mise.toml");
+    (project_root, mise_toml_path)
+}
+
+#[test]
+fn probe_host_mise_trust_db_returns_project_mise_toml_when_project_root_is_trusted() {
+    let _env_guard = GEMINI_RUNTIME_ENV_LOCK.lock().expect("env lock");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state_home = temp.path().join("state-home");
+    let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
+    let (project_root, mise_toml_path) = create_project_with_mise(temp.path(), "project");
+    fs::create_dir_all(&trust_db_dir).expect("create trust db dir");
+    std::os::unix::fs::symlink(&project_root, trust_db_dir.join("trusted-project"))
+        .expect("create trusted project symlink");
+
+    let _xdg_state_home = ScopedEnvVar::set("XDG_STATE_HOME", &state_home.to_string_lossy());
+    let _trusted_paths = ScopedEnvVar::unset("MISE_TRUSTED_CONFIG_PATHS");
+
+    assert_eq!(
+        probe_host_mise_trust_db(&project_root, &mise_toml_path),
+        Some(canonicalize_if_exists(&mise_toml_path))
+    );
+}
+
+#[test]
+fn probe_host_mise_trust_db_rejects_non_matching_symlink_targets() {
+    let _env_guard = GEMINI_RUNTIME_ENV_LOCK.lock().expect("env lock");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state_home = temp.path().join("state-home");
+    let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
+    let (project_root, mise_toml_path) = create_project_with_mise(temp.path(), "project");
+    let other_root = temp.path().join("other-project");
+    fs::create_dir_all(&other_root).expect("create other project root");
+    fs::create_dir_all(&trust_db_dir).expect("create trust db dir");
+    std::os::unix::fs::symlink(&other_root, trust_db_dir.join("trusted-other-project"))
+        .expect("create mismatched trusted project symlink");
+
+    let _xdg_state_home = ScopedEnvVar::set("XDG_STATE_HOME", &state_home.to_string_lossy());
+    let _trusted_paths = ScopedEnvVar::unset("MISE_TRUSTED_CONFIG_PATHS");
+
+    assert_eq!(probe_host_mise_trust_db(&project_root, &mise_toml_path), None);
+}
+
+#[test]
+fn probe_host_mise_trust_db_skips_missing_non_symlink_and_broken_entries() {
+    let _env_guard = GEMINI_RUNTIME_ENV_LOCK.lock().expect("env lock");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state_home = temp.path().join("state-home");
+    let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
+    let (project_root, mise_toml_path) = create_project_with_mise(temp.path(), "project");
+
+    let _xdg_state_home = ScopedEnvVar::set("XDG_STATE_HOME", &state_home.to_string_lossy());
+    let _trusted_paths = ScopedEnvVar::unset("MISE_TRUSTED_CONFIG_PATHS");
+
+    assert_eq!(
+        probe_host_mise_trust_db(&project_root, &mise_toml_path),
+        None,
+        "missing trust DB dir should be treated as untrusted"
+    );
+
+    fs::create_dir_all(&trust_db_dir).expect("create trust db dir");
+    fs::write(trust_db_dir.join("plain-file"), "not a symlink").expect("write plain file");
+    std::os::unix::fs::symlink(
+        temp.path().join("missing-project-root"),
+        trust_db_dir.join("broken-link"),
+    )
+    .expect("create broken symlink");
+
+    assert_eq!(
+        probe_host_mise_trust_db(&project_root, &mise_toml_path),
+        None,
+        "invalid trust DB entries should be ignored"
+    );
+}
+
+#[test]
+fn prepare_gemini_acp_runtime_synthesizes_mise_trusted_config_paths_from_host_db() {
+    let _env_guard = GEMINI_RUNTIME_ENV_LOCK.lock().expect("env lock");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state_home = temp.path().join("state-home");
+    let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
+    let (project_root, mise_toml_path) = create_project_with_mise(temp.path(), "project");
+    let source_home = temp.path().join("source-home");
+    let session_id = "01TESTGEMINIMISETRUSTDB000000001";
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+    fs::create_dir_all(&trust_db_dir).expect("create trust db dir");
+    std::os::unix::fs::symlink(&project_root, trust_db_dir.join("trusted-project"))
+        .expect("create trusted project symlink");
+
+    let _xdg_state_home = ScopedEnvVar::set("XDG_STATE_HOME", &state_home.to_string_lossy());
+    let _trusted_paths = ScopedEnvVar::unset("MISE_TRUSTED_CONFIG_PATHS");
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+
+    prepare_gemini_acp_runtime(
+        &mut env,
+        Some(project_root.as_path()),
+        None,
+        session_id,
+        &["--acp".to_string()],
+    )
+    .expect("prepare runtime");
+
+    assert_eq!(
+        env.get("MISE_TRUSTED_CONFIG_PATHS"),
+        Some(&canonicalize_if_exists(&mise_toml_path).to_string_lossy().into_owned()),
+        "runtime should synthesize trust only from the host mise DB when the user already trusted this project"
+    );
+}
+
+#[test]
+fn prepare_gemini_acp_runtime_prefers_process_mise_trusted_config_paths_over_host_db() {
+    let _env_guard = GEMINI_RUNTIME_ENV_LOCK.lock().expect("env lock");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state_home = temp.path().join("state-home");
+    let trust_db_dir = state_home.join(GEMINI_HOST_MISE_TRUST_DB_RELATIVE_PATH);
+    let (project_root, _mise_toml_path) = create_project_with_mise(temp.path(), "project");
+    let source_home = temp.path().join("source-home");
+    let session_id = "01TESTGEMINIMISETRUSTPROC0000001";
+    fs::create_dir_all(source_home.join(".gemini")).expect("create source gemini dir");
+    fs::create_dir_all(&trust_db_dir).expect("create trust db dir");
+    std::os::unix::fs::symlink(&project_root, trust_db_dir.join("trusted-project"))
+        .expect("create trusted project symlink");
+
+    let _xdg_state_home = ScopedEnvVar::set("XDG_STATE_HOME", &state_home.to_string_lossy());
+    let _trusted_paths = ScopedEnvVar::set(
+        "MISE_TRUSTED_CONFIG_PATHS",
+        "/tmp/process-env-trusted.mise.toml",
+    );
+
+    let mut env = HashMap::new();
+    env.insert(
+        "HOME".to_string(),
+        source_home.to_string_lossy().into_owned(),
+    );
+
+    prepare_gemini_acp_runtime(
+        &mut env,
+        Some(project_root.as_path()),
+        None,
+        session_id,
+        &["--acp".to_string()],
+    )
+    .expect("prepare runtime");
+
+    assert_eq!(
+        env.get("MISE_TRUSTED_CONFIG_PATHS"),
+        Some(&"/tmp/process-env-trusted.mise.toml".to_string()),
+        "an explicit process env trust setting must win over the host trust DB fallback"
+    );
+}

--- a/crates/csa-executor/src/transport_tests_gemini_fallback.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_fallback.rs
@@ -586,10 +586,9 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
     let runtime_config_home = runtime_home.join(".config").to_string_lossy().into_owned();
     let runtime_state_home = runtime_home.join(".local/state").to_string_lossy().into_owned();
     let runtime_mise_cache = runtime_home.join(".cache/mise").to_string_lossy().into_owned();
-    let runtime_mise_state = runtime_home
-        .join(".local/state/mise")
-        .to_string_lossy()
-        .into_owned();
+    let runtime_mise_state = runtime_home.join(".local/state/mise").to_string_lossy().into_owned();
+    let runtime_mise_trusted_config_paths =
+        runtime_home.join("mise.toml").to_string_lossy().into_owned();
     let xdg_cache_home_string = xdg_cache_home.to_string_lossy().into_owned();
     let shared_npm_cache_string = shared_npm_cache.to_string_lossy().into_owned();
     assert!(
@@ -610,6 +609,7 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
     env.insert("npm_config_cache".to_string(), shared_npm_cache_string.clone());
     env.insert("MISE_CACHE_DIR".to_string(), runtime_mise_cache.clone());
     env.insert("MISE_STATE_DIR".to_string(), runtime_mise_state.clone());
+    env.insert("MISE_TRUSTED_CONFIG_PATHS".to_string(), runtime_mise_trusted_config_paths.clone());
     env.insert("MISE_SHIM".to_string(), String::new());
     env.insert("MISE_SHIMS_DIR".to_string(), String::new());
     env.insert(
@@ -665,10 +665,8 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
         isolation_plan.env_overrides.get("HOME"),
         Some(&runtime_home_string)
     );
-    // TMPDIR is set by IsolationPlanBuilder::with_tool_defaults(), not by
-    // gemini sandbox overrides (which must NOT override it — see #704 review).
-    // The isolation plan fixture doesn't call with_tool_defaults(), so TMPDIR
-    // won't be present here. Verify gemini overrides did NOT inject a host TMPDIR.
+    // TMPDIR is owned by IsolationPlanBuilder::with_tool_defaults(), so Gemini overrides
+    // must not inject a host TMPDIR into this fixture (#704 review).
     assert!(
         !isolation_plan.env_overrides.contains_key("TMPDIR")
             || isolation_plan.env_overrides.get("TMPDIR") == Some(&"/tmp".to_string()),
@@ -701,6 +699,11 @@ fn test_apply_gemini_sandbox_runtime_env_overrides_pins_runtime_paths_and_clears
         isolation_plan.env_overrides.get("MISE_STATE_DIR"),
         Some(&runtime_mise_state),
         "sandbox should pin mise state inside the Gemini runtime home"
+    );
+    assert_eq!(
+        isolation_plan.env_overrides.get("MISE_TRUSTED_CONFIG_PATHS"),
+        Some(&runtime_mise_trusted_config_paths),
+        "sandbox must forward the resolved mise trust env so nested gemini-cli runs keep host-approved trust state"
     );
     assert_eq!(
         isolation_plan.env_overrides.get("MISE_SHIM"),


### PR DESCRIPTION
## Summary

Fixes **#1056** — `pr-bot` Step 3 (Local Pre-PR Review) fails fast with a \`mise ERROR Config files ... are not trusted\` error because the bwrap-sandboxed gemini-cli child cannot find the host mise filesystem trust DB.

## Root cause

\`crates/csa-executor/src/transport_gemini_acp_runtime.rs\` (from the #972 fix) only propagated \`MISE_TRUSTED_CONFIG_PATHS\` when the parent process already had that env var set. In practice users trust projects via \`mise trust <path>\`, which writes to \`~/.local/state/mise/trusted-configs/\` — NOT the env var. So for every normal workflow, the #972 propagation was a no-op, and inside the bwrap sandbox, mise couldn't find the trust DB because \$HOME was remapped.

## Fix

When the parent env is unset, scan the host mise trust DB for a symlink that resolves to the current project root. If found, propagate \`MISE_TRUSTED_CONFIG_PATHS\` pointing at the **matched trust-db target directory** (not a fabricated mise.toml path).

This preserves the #972 safety invariant: we only propagate trust the USER has already explicitly granted on the host (via \`mise trust\`).

### Why return the trusted directory, not a specific toml path

Pre-push review round 1 flagged a P1: round-1's helper returned \`project_root/mise.toml\`, which narrowed trust to a single filename and broke projects using \`.mise.toml\` / \`mise.local.toml\` / \`.mise/config.toml\` / \`mise/config.toml\`. Round-2 returns the matched trust-db symlink target — \`MISE_TRUSTED_CONFIG_PATHS\` accepts directories, and a directory entry covers all mise config filenames under it.

### Changed files

- \`crates/csa-executor/src/transport_gemini_mise_trust.rs\` — new helper \`probe_host_mise_trust_db(project_root: &Path) -> Option<PathBuf>\`
- \`crates/csa-executor/src/transport_gemini_mise_trust_tests_tail.rs\` — 7 test cases (positive root, alternate filenames \`.mise.toml\` / \`.mise/config.toml\`, DB missing, non-matching target, broken symlink, parent env takes precedence)
- \`crates/csa-executor/src/transport_gemini_acp_runtime.rs\` — wired the helper as a fallback after #972's parent-env-wins branch
- \`crates/csa-executor/src/transport_gemini_helpers.rs\` — added \`MISE_TRUSTED_CONFIG_PATHS\` to the sandbox env override allowlist (so the env var actually propagates through bwrap)
- \`crates/csa-executor/src/transport_tests_gemini_fallback.rs\` — regression test asserting the sandbox preserves \`MISE_TRUSTED_CONFIG_PATHS\`

## Impact

Unblocks pr-bot Step 3 (Local Pre-PR Review) which has required manual merge workaround since the regression landed. Every PR since #1053 has been manually merged — this restores automated merge.

## Test plan

- [x] \`cargo test -p csa-executor\` — 417 passed, 0 failed
- [x] \`just pre-commit\` — exit 0
- [x] Manual end-to-end: ran \`./target/release/csa review --branch main\` under session \`01KPXBBTXDAGFVE9W43MVHMHTZ\` post-fix; stderr had 0 hits on \`not trusted|Config files|mise ERROR\`, only 429/RESOURCE_EXHAUSTED (quota, unrelated)
- [x] Pre-push review (session \`01KPXE1EFWFZVZ5R7ZYCFX8KW2\`) — PASS, findings=[]
- [ ] pr-bot cloud review (this PR — should now run Step 3 successfully)

Closes #1056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)