### PR TITLE
fix(csa-hooks): smarter default-branch fallback + refspec when not on default (#1071)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.539"
+version = "0.1.540"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.539"
+version = "0.1.540"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-hooks/src/merge_guard/mod.rs
+++ b/crates/csa-hooks/src/merge_guard/mod.rs
@@ -96,12 +96,29 @@ fi
 # Best-effort local sync of the default branch after a successful merge.
 # Non-fatal: sync failure does NOT change the wrapper's exit code.
 _post_merge_sync() {
-  DEFAULT_BRANCH="$("${REAL_GH}" repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo main)"
-  {
-    git fetch origin "${DEFAULT_BRANCH}" &&
-    git checkout "${DEFAULT_BRANCH}" &&
-    git merge "origin/${DEFAULT_BRANCH}" --ff-only
-  } >&2 || echo "NOTE: post-merge local sync failed (non-fatal). Run manually: git fetch origin && git checkout ${DEFAULT_BRANCH} && git merge origin/${DEFAULT_BRANCH} --ff-only" >&2
+  local DEFAULT_BRANCH
+  DEFAULT_BRANCH="$("${REAL_GH}" repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)"
+  if [ -z "${DEFAULT_BRANCH}" ]; then
+    DEFAULT_BRANCH="$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's!^origin/!!' || true)"
+  fi
+  if [ -z "${DEFAULT_BRANCH}" ]; then
+    printf 'NOTE: post-merge sync skipped — could not determine default branch (gh repo view failed, origin/HEAD not set)\n' >&2
+    return 0
+  fi
+
+  local CURRENT_BRANCH
+  CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+
+  if [ "${CURRENT_BRANCH}" = "${DEFAULT_BRANCH}" ]; then
+    {
+      git fetch origin "${DEFAULT_BRANCH}" &&
+      git merge "origin/${DEFAULT_BRANCH}" --ff-only
+    } >&2 || printf 'NOTE: in-place fast-forward failed, continuing\n' >&2
+  else
+    {
+      git fetch origin "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}"
+    } >&2 || printf 'NOTE: refspec update failed, continuing\n' >&2
+  fi
 }
 
 # Complete --help passthrough now that we have REAL_GH.

--- a/crates/csa-hooks/src/merge_guard/tests_post_merge_sync.rs
+++ b/crates/csa-hooks/src/merge_guard/tests_post_merge_sync.rs
@@ -13,6 +13,17 @@ fn setup_post_merge_env(
     branch: Option<&str>,
     git_merge_exit: i32,
 ) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    setup_post_merge_env_with_git(tmp, gh_exit, branch, None, branch, git_merge_exit)
+}
+
+fn setup_post_merge_env_with_git(
+    tmp: &Path,
+    gh_exit: i32,
+    branch: Option<&str>,
+    origin_head: Option<&str>,
+    current_branch: Option<&str>,
+    git_merge_exit: i32,
+) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
     let guard_dir = tmp.join("guard");
     fs::create_dir_all(&guard_dir).unwrap();
     let wrapper_path = guard_dir.join("gh");
@@ -21,6 +32,14 @@ fn setup_post_merge_env(
     fs::set_permissions(&wrapper_path, fs::Permissions::from_mode(0o755)).unwrap();
 
     let branch_out = match branch {
+        Some(b) => format!("printf '{}\\n'", b),
+        None => "exit 1".to_string(),
+    };
+    let origin_head_out = match origin_head {
+        Some(b) => format!("printf '{}\\n'", b),
+        None => "exit 1".to_string(),
+    };
+    let current_branch_out = match current_branch {
         Some(b) => format!("printf '{}\\n'", b),
         None => "exit 1".to_string(),
     };
@@ -50,9 +69,17 @@ echo REAL_GH_CALLED
         format!(
             r#"#!/bin/bash
 echo "$@" >> "{log}"
+if [ "$1" = "rev-parse" ] && [ "$2" = "--abbrev-ref" ]; then
+  case "$3" in
+    origin/HEAD) {origin_head_out}; exit $?;;
+    HEAD) {current_branch_out}; exit $?;;
+  esac
+fi
 for a in "$@"; do [ "$a" = "--ff-only" ] && exit {me}; done; exit 0
 "#,
             log = git_log.to_str().unwrap(),
+            origin_head_out = origin_head_out,
+            current_branch_out = current_branch_out,
             me = git_merge_exit
         ),
     )
@@ -94,20 +121,43 @@ fn create_test_marker(tmp: &Path) {
     fs::write(d.join("42-abc123.done"), "").unwrap();
 }
 
-fn assert_sync_log(git_log: &Path, branch: &str) {
+fn git_log_lines(git_log: &Path) -> Vec<String> {
     let log = fs::read_to_string(git_log).unwrap_or_default();
+    log.lines().map(String::from).collect()
+}
+
+fn assert_log_has_line(lines: &[String], expected: &str) {
     assert!(
-        log.contains(&format!("fetch origin {branch}")),
-        "missing fetch: {log}"
+        lines.iter().any(|line| line == expected),
+        "missing `{expected}` in {lines:?}"
     );
+}
+
+fn assert_log_lacks_prefix(lines: &[String], prefix: &str) {
     assert!(
-        log.contains(&format!("checkout {branch}")),
-        "missing checkout: {log}"
+        !lines.iter().any(|line| line.starts_with(prefix)),
+        "unexpected `{prefix}` call in {lines:?}"
     );
+}
+
+fn assert_in_place_sync_log(git_log: &Path, branch: &str) {
+    let lines = git_log_lines(git_log);
+    assert_log_has_line(&lines, &format!("fetch origin {branch}"));
+    assert_log_has_line(&lines, &format!("merge origin/{branch} --ff-only"));
+    assert_log_lacks_prefix(&lines, "checkout ");
     assert!(
-        log.contains(&format!("merge origin/{branch} --ff-only")),
-        "missing merge: {log}"
+        !lines
+            .iter()
+            .any(|line| line == &format!("fetch origin {branch}:{branch}")),
+        "must not use refspec on default branch: {lines:?}"
     );
+}
+
+fn assert_refspec_sync_log(git_log: &Path, branch: &str) {
+    let lines = git_log_lines(git_log);
+    assert_log_has_line(&lines, &format!("fetch origin {branch}:{branch}"));
+    assert_log_lacks_prefix(&lines, "checkout ");
+    assert_log_lacks_prefix(&lines, "merge ");
 }
 
 #[test]
@@ -117,7 +167,7 @@ fn post_merge_sync_runs_on_success() {
     create_test_marker(tmp.path());
     let (code, _, _) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
     assert_eq!(code, 0);
-    assert_sync_log(&gl, "main");
+    assert_in_place_sync_log(&gl, "main");
 }
 
 #[test]
@@ -150,17 +200,64 @@ fn post_merge_sync_uses_default_branch_from_gh() {
     create_test_marker(tmp.path());
     let (code, _, _) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
     assert_eq!(code, 0);
-    assert_sync_log(&gl, "develop");
+    assert_in_place_sync_log(&gl, "develop");
 }
 
 #[test]
-fn post_merge_sync_falls_back_to_main_when_gh_view_fails() {
+fn post_merge_sync_uses_git_head_fallback_when_gh_view_fails() {
     let tmp = tempfile::tempdir().unwrap();
-    let (gd, gh, mb, gl) = setup_post_merge_env(tmp.path(), 0, None, 0);
+    let (gd, gh, mb, gl) = setup_post_merge_env_with_git(
+        tmp.path(),
+        0,
+        None,
+        Some("origin/develop"),
+        Some("develop"),
+        0,
+    );
     create_test_marker(tmp.path());
     let (code, _, _) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
     assert_eq!(code, 0);
-    assert_sync_log(&gl, "main");
+    assert_in_place_sync_log(&gl, "develop");
+}
+
+#[test]
+fn post_merge_sync_skips_when_all_default_detection_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (gd, gh, mb, gl) =
+        setup_post_merge_env_with_git(tmp.path(), 0, None, None, Some("main"), 0);
+    create_test_marker(tmp.path());
+    let (code, _, stderr) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
+    assert_eq!(code, 0);
+    assert!(
+        stderr.contains("could not determine default branch"),
+        "should explain skipped sync: {stderr}"
+    );
+    let lines = git_log_lines(&gl);
+    assert_log_lacks_prefix(&lines, "fetch ");
+    assert_log_lacks_prefix(&lines, "checkout ");
+    assert_log_lacks_prefix(&lines, "merge ");
+}
+
+#[test]
+fn post_merge_sync_uses_refspec_when_not_on_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (gd, gh, mb, gl) =
+        setup_post_merge_env_with_git(tmp.path(), 0, Some("main"), None, Some("feat/xyz"), 0);
+    create_test_marker(tmp.path());
+    let (code, _, _) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
+    assert_eq!(code, 0);
+    assert_refspec_sync_log(&gl, "main");
+}
+
+#[test]
+fn post_merge_sync_fastforwards_in_place_when_on_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (gd, gh, mb, gl) =
+        setup_post_merge_env_with_git(tmp.path(), 0, Some("main"), None, Some("main"), 0);
+    create_test_marker(tmp.path());
+    let (code, _, _) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
+    assert_eq!(code, 0);
+    assert_in_place_sync_log(&gl, "main");
 }
 
 #[test]
@@ -170,7 +267,7 @@ fn force_skip_pr_bot_still_triggers_post_merge_sync() {
     let (code, _, _) =
         run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42", "--force-skip-pr-bot"]);
     assert_eq!(code, 0);
-    assert_sync_log(&gl, "main");
+    assert_in_place_sync_log(&gl, "main");
 }
 
 #[test]
@@ -181,7 +278,7 @@ fn post_merge_sync_stdout_stays_clean_during_success() {
     let (code, stdout, _stderr) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
     assert_eq!(code, 0);
     // Sync ran (git was called).
-    assert_sync_log(&gl, "main");
+    assert_in_place_sync_log(&gl, "main");
     // The wrapper's stdout must NOT contain any git fetch/checkout/merge output.
     // All sync output should be on stderr only.
     assert!(


### PR DESCRIPTION
## Summary

Two MEDIUM follow-ups from PR #1070 review:

- **3-tier default-branch detection** — replace hardcoded `main` fallback with `gh repo view` → `git rev-parse origin/HEAD` → skip. Non-main repos (develop/master) no longer get silently wrong-targeted.
- **Refspec-when-not-on-default** — when the user is on a feature branch at merge time, update local default via `git fetch origin <default>:<default>` instead of `checkout`. Feature branch stays intact.

Both changes preserve the stderr-only output contract (commit `83ae50f7`) and the best-effort exit-0 guarantee (sync never fails the merge).

Closes #1071.

## Test plan

- [ ] `cargo test -p csa-hooks` — includes 4 new/updated post-merge-sync tests
- [ ] `just pre-commit` clean
- [ ] Manual dogfood: run `gh pr merge <this-PR> --merge` from a feature branch → local main updated via refspec, feature branch unchanged
