### PR TITLE
fix(csa-executor): dedupe ThinkingBudget keyword list + Max codex stall-retry parity (#1065)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.540"
+version = "0.1.541"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.540"
+version = "0.1.541"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -58,14 +58,11 @@ impl ThinkingBudget {
     pub fn try_split_from_model(model: &str) -> (&str, Option<Self>) {
         if let Some(pos) = model.rfind('/') {
             let suffix = &model[pos + 1..];
-            // Only match named keywords, not numeric — numbers in model names are common
-            // (e.g., "gpt-5.4" or version suffixes) and would cause false positives.
-            match suffix.to_lowercase().as_str() {
-                "default" | "low" | "medium" | "med" | "high" | "xhigh" | "extra-high" | "max" => {
-                    // Safe to unwrap: we matched a known keyword above.
-                    let budget = Self::parse(suffix).expect("matched keyword must parse");
-                    (&model[..pos], Some(budget))
-                }
+            // Delegate keyword validation to parse() so the valid-keyword set is defined
+            // in exactly one place. Only match named keywords, not Custom(n) — numbers in
+            // model names are common (e.g., "gpt-5.4") and would cause false positives.
+            match Self::parse(suffix) {
+                Ok(budget) if !matches!(budget, Self::Custom(_)) => (&model[..pos], Some(budget)),
                 _ => (model, None),
             }
         } else {
@@ -106,6 +103,16 @@ impl ThinkingBudget {
             Self::Xhigh => 65536,
             Self::Max => 131072,
             Self::Custom(n) => *n,
+        }
+    }
+
+    /// One-shot downgrade target when a codex run at this budget stalls on the
+    /// initial response. `None` means no retry — the budget is already low
+    /// enough that stalling suggests a real failure, not an over-thinking stall.
+    pub fn codex_stall_retry_downgrade(&self) -> Option<ThinkingBudget> {
+        match self {
+            Self::Xhigh | Self::Max => Some(ThinkingBudget::High),
+            _ => None,
         }
     }
 
@@ -346,6 +353,42 @@ mod tests {
         let (model, budget) = ThinkingBudget::try_split_from_model("some-model/max");
         assert_eq!(model, "some-model");
         assert!(matches!(budget, Some(ThinkingBudget::Max)));
+    }
+
+    #[test]
+    fn try_split_from_model_handles_max() {
+        let (model, budget) = ThinkingBudget::try_split_from_model("gpt-5.4/max");
+        assert_eq!(model, "gpt-5.4");
+        assert!(matches!(budget, Some(ThinkingBudget::Max)));
+    }
+
+    #[test]
+    fn codex_stall_retry_downgrade_covers_max() {
+        assert!(matches!(
+            ThinkingBudget::Max.codex_stall_retry_downgrade(),
+            Some(ThinkingBudget::High)
+        ));
+        assert!(matches!(
+            ThinkingBudget::Xhigh.codex_stall_retry_downgrade(),
+            Some(ThinkingBudget::High)
+        ));
+        assert!(ThinkingBudget::High.codex_stall_retry_downgrade().is_none());
+        assert!(
+            ThinkingBudget::Medium
+                .codex_stall_retry_downgrade()
+                .is_none()
+        );
+        assert!(ThinkingBudget::Low.codex_stall_retry_downgrade().is_none());
+        assert!(
+            ThinkingBudget::DefaultBudget
+                .codex_stall_retry_downgrade()
+                .is_none()
+        );
+        assert!(
+            ThinkingBudget::Custom(50000)
+                .codex_stall_retry_downgrade()
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/csa-executor/src/transport_codex_exec_stall.rs
+++ b/crates/csa-executor/src/transport_codex_exec_stall.rs
@@ -88,7 +88,7 @@ pub fn classify_codex_exec_initial_stall(
     Some(CodexExecInitialStallClassification {
         effort: budget.codex_effort(),
         timeout_seconds: timeout_seconds.unwrap_or(DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS),
-        retry_effort: matches!(budget, ThinkingBudget::Xhigh).then_some(ThinkingBudget::High),
+        retry_effort: budget.codex_stall_retry_downgrade(),
     })
 }
 


### PR DESCRIPTION
## Summary

Two MEDIUM follow-ups from PR #1064 review (which introduced `ThinkingBudget::Max` for #1062):

- **Dedupe keyword list** — `try_split_from_model` now delegates to `ThinkingBudget::parse()` with a `Custom(_)` guard, instead of maintaining a duplicate hardcoded alias list. Adding a new alias in the future touches exactly one place.
- **Codex stall-retry covers Max** — new `ThinkingBudget::codex_stall_retry_downgrade()` method extends the stall-retry downgrade (`Xhigh → High`) to also cover `Max → High`. Both map to codex effort `"xhigh"`, so same stall profile.

Closes #1065.

## Test plan

- [ ] `cargo test -p csa-executor` — includes 2 new regression tests (`try_split_from_model_handles_max`, `codex_stall_retry_downgrade_covers_max`)
- [ ] `just pre-commit` clean
- [ ] No behavior change in `codex_effort()` mapping — `Max → "xhigh"` stays
