### PR TITLE
fix(csa): no-op exit gate rewrites synthetic success to failure (#1080)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.541"
+version = "0.1.542"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.541"
+version = "0.1.542"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -25,6 +25,10 @@ mod audit;
 
 const FALLBACK_OUTPUT_TAIL_LINES: usize = 8;
 const OUTPUT_LOG_TAIL_READ_BYTES: u64 = 8 * 1024;
+/// Sessions shorter than this threshold (in seconds) that exit 0 with zero
+/// tool calls in sa-mode are classified as no-op exits.  Hardcoded — not
+/// a config key — to keep the gate simple and predictable.
+const NO_OP_ELAPSED_THRESHOLD_SECS: i64 = 60;
 /// All inputs needed for post-execution processing.
 pub(crate) struct PostExecContext<'a> {
     pub executor: &'a Executor,
@@ -48,6 +52,10 @@ pub(crate) struct PostExecContext<'a> {
     pub changed_paths: Vec<String>,
     /// Fresh repo baseline captured immediately before the current execution.
     pub pre_exec_snapshot: Option<PreExecutionSnapshot>,
+    /// Whether the transport observed any tool calls during execution.
+    pub has_tool_calls: bool,
+    /// Whether this session is running in SA (sub-agent / autonomous) mode.
+    pub sa_mode: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -156,6 +164,33 @@ pub(crate) async fn process_execution_result(
         if let Some(tool_state) = session.tools.get_mut(ctx.executor.tool_name()) {
             tool_state.last_action_summary = classified_summary;
         }
+    }
+    // No-op exit gate: detect sa-mode sessions that reported success but
+    // produced zero useful work (single turn, no tool calls, very short
+    // elapsed time).  Rewrite status to failure so orchestrators retry.
+    let elapsed_secs = (execution_end_time - ctx.execution_start_time).num_seconds();
+    if ctx.sa_mode
+        && result.exit_code == 0
+        && session.turn_count <= 1
+        && !ctx.has_tool_calls
+        && elapsed_secs < NO_OP_ELAPSED_THRESHOLD_SECS
+    {
+        let original_summary = session_result.summary.clone();
+        let no_op_summary = format!(
+            "no-op exit detected: turn_count={}, elapsed={}s, no tool calls. Original: {}",
+            session.turn_count, elapsed_secs, original_summary,
+        );
+        warn!(
+            session = %session.meta_session_id,
+            turn_count = session.turn_count,
+            elapsed_secs,
+            "SA-mode no-op exit gate triggered — rewriting status to failure"
+        );
+        session_result.exit_code = 1;
+        session_result.status = SessionResult::status_from_exit_code(1);
+        session_result.summary = no_op_summary.clone();
+        result.summary = no_op_summary;
+        result.exit_code = 1;
     }
     audit::maybe_record_repo_write_audit(&ctx, session, &mut session_result);
     if let Err(e) = save_result(ctx.project_root, &session.meta_session_id, &session_result) {
@@ -593,207 +628,9 @@ fn persist_output_sections(session_dir: &Path) {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test_session_sandbox::ScopedSessionSandbox;
-    use csa_session::{create_session, get_session_dir, load_session};
+#[path = "pipeline_tests_post_exec.rs"]
+mod tests;
 
-    #[test]
-    fn ensure_terminal_result_on_post_exec_error_writes_missing_result() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
-        let project_root = tmp.path();
-        let mut session = create_session(project_root, Some("test"), None, Some("codex"))
-            .expect("create session");
-
-        assert!(
-            load_result(project_root, &session.meta_session_id)
-                .expect("load result")
-                .is_none(),
-            "precondition: result.toml must be missing"
-        );
-
-        let started_at = chrono::Utc::now() - chrono::Duration::seconds(1);
-        let err = anyhow::anyhow!("post-run hook failed");
-        ensure_terminal_result_on_post_exec_error(
-            project_root,
-            &mut session,
-            "codex",
-            started_at,
-            &err,
-        );
-
-        let persisted = load_result(project_root, &session.meta_session_id)
-            .expect("load fallback result")
-            .expect("fallback result should exist");
-        assert_eq!(persisted.status, "failure");
-        assert_eq!(persisted.exit_code, 1);
-        assert!(
-            persisted.summary.contains("post-exec:"),
-            "summary should indicate post-exec fallback"
-        );
-
-        let reloaded = load_session(project_root, &session.meta_session_id)
-            .expect("reload session after fallback");
-        assert_eq!(
-            reloaded.termination_reason.as_deref(),
-            Some("post_exec_error")
-        );
-    }
-
-    #[test]
-    fn ensure_terminal_result_on_post_exec_error_keeps_existing_result() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
-        let project_root = tmp.path();
-        let mut session = create_session(project_root, Some("test"), None, Some("codex"))
-            .expect("create session");
-        let now = chrono::Utc::now();
-        let existing = SessionResult {
-            status: "success".to_string(),
-            exit_code: 0,
-            summary: "already persisted".to_string(),
-            tool: "codex".to_string(),
-            started_at: now,
-            completed_at: now,
-            events_count: 1,
-            artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
-            peak_memory_mb: None,
-            manager_fields: Default::default(),
-        };
-        save_result(project_root, &session.meta_session_id, &existing)
-            .expect("write existing result");
-
-        let err = anyhow::anyhow!("late hook failure");
-        ensure_terminal_result_on_post_exec_error(project_root, &mut session, "codex", now, &err);
-
-        let persisted = load_result(project_root, &session.meta_session_id)
-            .expect("load existing result")
-            .expect("existing result should remain");
-        assert_eq!(persisted.status, "success");
-        assert_eq!(persisted.exit_code, 0);
-        assert_eq!(persisted.summary, "already persisted");
-    }
-
-    #[test]
-    fn ensure_terminal_result_for_session_on_post_exec_error_persists_output_tail_for_fork() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
-        let project_root = tmp.path();
-        let parent = create_session(project_root, Some("parent"), None, Some("codex"))
-            .expect("create parent session");
-        let child = create_session(
-            project_root,
-            Some("fork"),
-            Some(&parent.meta_session_id),
-            Some("codex"),
-        )
-        .expect("create forked child session");
-        let session_id = child.meta_session_id.clone();
-        let session_dir = get_session_dir(project_root, &session_id).expect("session dir");
-        fs::create_dir_all(session_dir.join("output")).expect("create output dir");
-        fs::write(
-            session_dir.join("output.log"),
-            "first line\nstill running\npartial summary line\n",
-        )
-        .expect("write output log");
-        fs::write(
-            session_dir.join("output").join("user-result.toml"),
-            "status = \"success\"\nsummary = \"sidecar\"\n",
-        )
-        .expect("write sidecar result");
-
-        let started_at = chrono::Utc::now() - chrono::Duration::seconds(1);
-        let err = anyhow::anyhow!("wall timeout interrupted fork before post-exec");
-        ensure_terminal_result_for_session_on_post_exec_error(
-            project_root,
-            &session_id,
-            "codex",
-            started_at,
-            &err,
-        );
-
-        let persisted = load_result(project_root, &session_id)
-            .expect("load fallback result")
-            .expect("fallback result should exist");
-        assert_eq!(persisted.status, "failure");
-        assert_eq!(persisted.exit_code, 1);
-        assert!(
-            persisted.summary.contains("partial summary line"),
-            "summary should include output.log tail"
-        );
-        assert!(
-            persisted
-                .artifacts
-                .iter()
-                .any(|artifact| artifact.path == "output/user-result.toml"),
-            "fallback should register user-result sidecar"
-        );
-
-        let reloaded = load_session(project_root, &session_id).expect("reload session");
-        assert_eq!(
-            reloaded.termination_reason.as_deref(),
-            Some("post_exec_error")
-        );
-    }
-
-    // Handoff artifact tests are in pipeline_handoff.rs
-
-    #[test]
-    fn codex_exec_initial_stall_summary_forces_failure_status_in_result_toml() {
-        let now = chrono::Utc::now();
-        let mut result = SessionResult {
-            status: SessionResult::status_from_exit_code(137),
-            exit_code: 137,
-            summary: "codex_exec_initial_stall: no stdout within 300s (effort=high, retry_attempted=true, original_effort=xhigh)".to_string(),
-            tool: "codex".to_string(),
-            started_at: now,
-            completed_at: now,
-            events_count: 0,
-            artifacts: Vec::new(),
-            peak_memory_mb: None,
-            manager_fields: Default::default(),
-        };
-
-        if is_codex_exec_initial_stall_summary(&result.tool, result.exit_code, &result.summary) {
-            result.status = SessionResult::status_from_exit_code(1);
-        }
-
-        let toml = toml::to_string_pretty(&result).expect("serialize result.toml");
-        assert_eq!(result.status, "failure");
-        assert!(toml.contains("status = \"failure\""));
-        assert!(toml.contains(CODEX_EXEC_INITIAL_STALL_REASON));
-    }
-
-    #[test]
-    fn codex_exec_initial_stall_detection_rejects_plain_substring_collisions() {
-        assert!(!is_codex_exec_initial_stall_summary(
-            "codex",
-            0,
-            "completed successfully after discussing codex_exec_initial_stall handling"
-        ));
-        assert!(!is_codex_exec_initial_stall_summary(
-            "claude-code",
-            137,
-            "codex_exec_initial_stall: no stdout within 300s (effort=high, retry_attempted=true)"
-        ));
-    }
-
-    #[test]
-    fn read_output_log_tail_reads_from_file_end_window() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let session_dir = tmp.path();
-        let contents = (0..1500)
-            .map(|idx| format!("line-{idx:04}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        fs::write(session_dir.join("output.log"), format!("{contents}\n")).expect("write output");
-
-        let tail = read_output_log_tail(session_dir, 3).expect("tail");
-        assert_eq!(tail, "line-1497\nline-1498\nline-1499");
-        assert!(
-            !tail.contains("line-0000"),
-            "tail reader should not depend on loading the full file"
-        );
-    }
-}
+#[cfg(test)]
+#[path = "pipeline_tests_no_op_gate.rs"]
+mod no_op_gate_tests;

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -173,6 +173,7 @@ pub(crate) async fn process_execution_result(
         && result.exit_code == 0
         && session.turn_count <= 1
         && !ctx.has_tool_calls
+        && ctx.changed_paths.is_empty()
         && elapsed_secs < NO_OP_ELAPSED_THRESHOLD_SECS
     {
         let original_summary = session_result.summary.clone();
@@ -189,8 +190,13 @@ pub(crate) async fn process_execution_result(
         session_result.exit_code = 1;
         session_result.status = SessionResult::status_from_exit_code(1);
         session_result.summary = no_op_summary.clone();
-        result.summary = no_op_summary;
+        result.summary = no_op_summary.clone();
         result.exit_code = 1;
+        // Sync tool_state so state.toml agrees with result.toml after rewrite.
+        if let Some(tool_state) = session.tools.get_mut(ctx.executor.tool_name()) {
+            tool_state.last_exit_code = 1;
+            tool_state.last_action_summary = no_op_summary;
+        }
     }
     audit::maybe_record_repo_write_audit(&ctx, session, &mut session_result);
     if let Err(e) = save_result(ctx.project_root, &session.meta_session_id, &session_result) {

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -170,6 +170,7 @@ pub(crate) async fn process_execution_result(
     // elapsed time).  Rewrite status to failure so orchestrators retry.
     let elapsed_secs = (execution_end_time - ctx.execution_start_time).num_seconds();
     if ctx.sa_mode
+        && ctx.task_type.is_none_or(|t| t == "run")
         && result.exit_code == 0
         && session.turn_count <= 1
         && !ctx.has_tool_calls

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -746,6 +746,12 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             execute_events_observed,
         );
     }
+    let has_tool_calls = transport_result.metadata.has_tool_calls
+        || transport_result.metadata.has_execute_tool_calls;
+    let sa_mode = std::env::var(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1"))
+        .unwrap_or(false);
     let post_ctx = crate::pipeline_post_exec::PostExecContext {
         executor,
         prompt,
@@ -765,6 +771,8 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         transcript_artifacts,
         changed_paths,
         pre_exec_snapshot,
+        has_tool_calls,
+        sa_mode,
     };
     if let Err(err) =
         crate::pipeline_post_exec::process_execution_result(post_ctx, &mut session, &mut result)

--- a/crates/cli-sub-agent/src/pipeline_tests_no_op_gate.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_no_op_gate.rs
@@ -418,3 +418,158 @@ async fn no_op_gate_does_not_trigger_when_turn_count_exceeds_one() {
         "gate must not fire for multi-turn sessions"
     );
 }
+
+#[tokio::test]
+async fn no_op_gate_does_not_trigger_for_non_run_task_type() {
+    for task_type in &["review", "debate", "plan"] {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+        let project_root = tmp.path();
+        let mut session =
+            create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+        let session_dir =
+            csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+        let executor = Executor::ClaudeCode {
+            model_override: None,
+            thinking_budget: None,
+            runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+        };
+        let hooks_config = csa_hooks::HooksConfig::default();
+        let start = chrono::Utc::now() - chrono::Duration::seconds(15);
+        let mut ctx = build_test_ctx(
+            &executor,
+            session_dir,
+            project_root,
+            start,
+            &hooks_config,
+            false,
+            true,
+        );
+        ctx.task_type = Some(task_type);
+        let mut result = build_test_result("Review completed successfully.");
+
+        process_execution_result(ctx, &mut session, &mut result)
+            .await
+            .expect("process_execution_result");
+
+        let persisted = load_result(project_root, &session.meta_session_id)
+            .expect("load")
+            .expect("result exists");
+        assert_eq!(
+            persisted.exit_code, 0,
+            "gate must not fire for task_type={task_type}"
+        );
+        assert_eq!(
+            persisted.status,
+            SessionResult::status_from_exit_code(0),
+            "status must remain success for task_type={task_type}"
+        );
+        assert!(
+            !persisted.summary.starts_with("no-op exit detected"),
+            "summary must NOT be prefixed for task_type={task_type}, got: {}",
+            persisted.summary
+        );
+    }
+}
+
+#[tokio::test]
+async fn no_op_gate_still_triggers_for_run_task_type() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(10);
+    let mut ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        true,
+    );
+    ctx.task_type = Some("run");
+    let mut result = build_test_result("I'll start by exploring.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 1, "gate must fire for task_type=run");
+    assert_eq!(
+        persisted.status,
+        SessionResult::status_from_exit_code(1),
+        "status must be failure for task_type=run"
+    );
+    assert!(
+        persisted.summary.starts_with("no-op exit detected"),
+        "summary must be prefixed for task_type=run, got: {}",
+        persisted.summary
+    );
+}
+
+#[tokio::test]
+async fn no_op_gate_triggers_when_task_type_is_none() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(10);
+    let mut ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        true,
+    );
+    ctx.task_type = None;
+    let mut result = build_test_result("I'll start by exploring.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(
+        persisted.exit_code, 1,
+        "gate must fire when task_type is None"
+    );
+    assert_eq!(
+        persisted.status,
+        SessionResult::status_from_exit_code(1),
+        "status must be failure when task_type is None"
+    );
+    assert!(
+        persisted.summary.starts_with("no-op exit detected"),
+        "summary must be prefixed when task_type is None, got: {}",
+        persisted.summary
+    );
+}

--- a/crates/cli-sub-agent/src/pipeline_tests_no_op_gate.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_no_op_gate.rs
@@ -268,6 +268,112 @@ async fn no_op_gate_preserves_original_summary_as_suffix() {
 }
 
 #[tokio::test]
+async fn no_op_gate_does_not_trigger_when_changed_paths_present() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(15);
+    let mut ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        true,
+    );
+    ctx.changed_paths = vec!["src/foo.rs".to_string()];
+    let mut result = build_test_result("Applied the fix.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(0));
+    assert!(
+        !persisted.summary.starts_with("no-op exit detected"),
+        "gate must not fire when changed_paths is non-empty, got: {}",
+        persisted.summary
+    );
+}
+
+#[tokio::test]
+async fn no_op_gate_syncs_tool_state_last_exit_code_and_summary() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    // Pre-seed the tool state entry so we can verify it gets overwritten.
+    session.tools.insert(
+        "claude-code".to_string(),
+        csa_session::ToolState {
+            provider_session_id: None,
+            last_action_summary: "original".to_string(),
+            last_exit_code: 0,
+            updated_at: chrono::Utc::now(),
+            tool_version: None,
+            token_usage: None,
+        },
+    );
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(10);
+    let ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        true,
+    );
+    let mut result = build_test_result("I'll start by exploring the codebase.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let tool_state = session
+        .tools
+        .get("claude-code")
+        .expect("tool state must exist after process_execution_result");
+    assert_eq!(
+        tool_state.last_exit_code, 1,
+        "tool_state.last_exit_code must be synced to 1 after gate fires"
+    );
+    assert!(
+        tool_state
+            .last_action_summary
+            .starts_with("no-op exit detected"),
+        "tool_state.last_action_summary must reflect gate rewrite, got: {}",
+        tool_state.last_action_summary
+    );
+}
+
+#[tokio::test]
 async fn no_op_gate_does_not_trigger_when_turn_count_exceeds_one() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let _sandbox = ScopedSessionSandbox::new(&tmp).await;

--- a/crates/cli-sub-agent/src/pipeline_tests_no_op_gate.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_no_op_gate.rs
@@ -1,0 +1,314 @@
+//! Tests for the SA-mode no-op exit gate in `process_execution_result`.
+
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_executor::{ClaudeCodeRuntimeMetadata, Executor};
+use csa_session::{create_session, load_result};
+
+/// Build a minimal `PostExecContext` suitable for no-op gate testing.
+fn build_test_ctx<'a>(
+    executor: &'a Executor,
+    session_dir: std::path::PathBuf,
+    project_root: &'a std::path::Path,
+    execution_start_time: chrono::DateTime<chrono::Utc>,
+    hooks_config: &'a csa_hooks::HooksConfig,
+    has_tool_calls: bool,
+    sa_mode: bool,
+) -> PostExecContext<'a> {
+    PostExecContext {
+        executor,
+        prompt: "test prompt",
+        effective_prompt: "test prompt",
+        task_type: Some("run"),
+        readonly_project_root: false,
+        project_root,
+        config: None,
+        global_config: None,
+        session_dir,
+        sessions_root: "test-root".to_string(),
+        execution_start_time,
+        hooks_config,
+        memory_project_key: None,
+        provider_session_id: None,
+        events_count: 4,
+        transcript_artifacts: vec![],
+        changed_paths: vec![],
+        pre_exec_snapshot: None,
+        has_tool_calls,
+        sa_mode,
+    }
+}
+
+fn build_test_result(summary: &str) -> csa_process::ExecutionResult {
+    csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: summary.to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+    }
+}
+
+#[tokio::test]
+async fn no_op_gate_triggers_when_sa_mode_and_zero_tools_and_short_elapsed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(15);
+    let ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        true,
+    );
+    let mut result = build_test_result("I'll start by exploring the codebase.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 1);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(1));
+    assert!(
+        persisted.summary.starts_with("no-op exit detected"),
+        "summary should start with diagnostic prefix, got: {}",
+        persisted.summary
+    );
+    assert_eq!(
+        result.exit_code, 1,
+        "ExecutionResult exit_code must also be rewritten"
+    );
+}
+
+#[tokio::test]
+async fn no_op_gate_does_not_trigger_without_sa_mode() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(15);
+    let ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        false,
+    );
+    let mut result = build_test_result("I'll start by exploring the codebase.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(0));
+    assert!(
+        !persisted.summary.starts_with("no-op exit detected"),
+        "summary must NOT be prefixed when sa_mode=false"
+    );
+}
+
+#[tokio::test]
+async fn no_op_gate_does_not_trigger_when_tool_calls_observed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(15);
+    let ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        true,
+        true,
+    );
+    let mut result = build_test_result("Ran tools and explored.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(0));
+}
+
+#[tokio::test]
+async fn no_op_gate_does_not_trigger_when_elapsed_exceeds_threshold() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    // 65 seconds elapsed — exceeds the 60s threshold
+    let start = chrono::Utc::now() - chrono::Duration::seconds(65);
+    let ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        true,
+    );
+    let mut result = build_test_result("Spent time thinking.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(0));
+}
+
+#[tokio::test]
+async fn no_op_gate_preserves_original_summary_as_suffix() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(10);
+    let original_summary = "I'll start by exploring the codebase structure.";
+    let ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        true,
+    );
+    let mut result = build_test_result(original_summary);
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert!(
+        persisted.summary.starts_with("no-op exit detected"),
+        "should start with diagnostic, got: {}",
+        persisted.summary
+    );
+    assert!(
+        persisted.summary.contains(original_summary),
+        "original summary must be preserved as suffix, got: {}",
+        persisted.summary
+    );
+}
+
+#[tokio::test]
+async fn no_op_gate_does_not_trigger_when_turn_count_exceeds_one() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    // Simulate a session that already had 5 turns before this execution.
+    // process_execution_result increments turn_count, so 5 → 6 which is > 1.
+    session.turn_count = 5;
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(15);
+    let ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        true,
+    );
+    let mut result = build_test_result("Quick response.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(0));
+    assert!(
+        !persisted.summary.starts_with("no-op exit detected"),
+        "gate must not fire for multi-turn sessions"
+    );
+}

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
@@ -1,0 +1,201 @@
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_session::{create_session, get_session_dir, load_session};
+
+#[test]
+fn ensure_terminal_result_on_post_exec_error_writes_missing_result() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("codex")).expect("create session");
+
+    assert!(
+        load_result(project_root, &session.meta_session_id)
+            .expect("load result")
+            .is_none(),
+        "precondition: result.toml must be missing"
+    );
+
+    let started_at = chrono::Utc::now() - chrono::Duration::seconds(1);
+    let err = anyhow::anyhow!("post-run hook failed");
+    ensure_terminal_result_on_post_exec_error(
+        project_root,
+        &mut session,
+        "codex",
+        started_at,
+        &err,
+    );
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load fallback result")
+        .expect("fallback result should exist");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 1);
+    assert!(
+        persisted.summary.contains("post-exec:"),
+        "summary should indicate post-exec fallback"
+    );
+
+    let reloaded = load_session(project_root, &session.meta_session_id)
+        .expect("reload session after fallback");
+    assert_eq!(
+        reloaded.termination_reason.as_deref(),
+        Some("post_exec_error")
+    );
+}
+
+#[test]
+fn ensure_terminal_result_on_post_exec_error_keeps_existing_result() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("codex")).expect("create session");
+    let now = chrono::Utc::now();
+    let existing = SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "already persisted".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
+        peak_memory_mb: None,
+        manager_fields: Default::default(),
+    };
+    save_result(project_root, &session.meta_session_id, &existing).expect("write existing result");
+
+    let err = anyhow::anyhow!("late hook failure");
+    ensure_terminal_result_on_post_exec_error(project_root, &mut session, "codex", now, &err);
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load existing result")
+        .expect("existing result should remain");
+    assert_eq!(persisted.status, "success");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.summary, "already persisted");
+}
+
+#[test]
+fn ensure_terminal_result_for_session_on_post_exec_error_persists_output_tail_for_fork() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path();
+    let parent = create_session(project_root, Some("parent"), None, Some("codex"))
+        .expect("create parent session");
+    let child = create_session(
+        project_root,
+        Some("fork"),
+        Some(&parent.meta_session_id),
+        Some("codex"),
+    )
+    .expect("create forked child session");
+    let session_id = child.meta_session_id.clone();
+    let session_dir = get_session_dir(project_root, &session_id).expect("session dir");
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output.log"),
+        "first line\nstill running\npartial summary line\n",
+    )
+    .expect("write output log");
+    fs::write(
+        session_dir.join("output").join("user-result.toml"),
+        "status = \"success\"\nsummary = \"sidecar\"\n",
+    )
+    .expect("write sidecar result");
+
+    let started_at = chrono::Utc::now() - chrono::Duration::seconds(1);
+    let err = anyhow::anyhow!("wall timeout interrupted fork before post-exec");
+    ensure_terminal_result_for_session_on_post_exec_error(
+        project_root,
+        &session_id,
+        "codex",
+        started_at,
+        &err,
+    );
+
+    let persisted = load_result(project_root, &session_id)
+        .expect("load fallback result")
+        .expect("fallback result should exist");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 1);
+    assert!(
+        persisted.summary.contains("partial summary line"),
+        "summary should include output.log tail"
+    );
+    assert!(
+        persisted
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "output/user-result.toml"),
+        "fallback should register user-result sidecar"
+    );
+
+    let reloaded = load_session(project_root, &session_id).expect("reload session");
+    assert_eq!(
+        reloaded.termination_reason.as_deref(),
+        Some("post_exec_error")
+    );
+}
+
+// Handoff artifact tests are in pipeline_handoff.rs
+
+#[test]
+fn codex_exec_initial_stall_summary_forces_failure_status_in_result_toml() {
+    let now = chrono::Utc::now();
+    let mut result = SessionResult {
+        status: SessionResult::status_from_exit_code(137),
+        exit_code: 137,
+        summary: "codex_exec_initial_stall: no stdout within 300s (effort=high, retry_attempted=true, original_effort=xhigh)".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        manager_fields: Default::default(),
+    };
+
+    if is_codex_exec_initial_stall_summary(&result.tool, result.exit_code, &result.summary) {
+        result.status = SessionResult::status_from_exit_code(1);
+    }
+
+    let toml = toml::to_string_pretty(&result).expect("serialize result.toml");
+    assert_eq!(result.status, "failure");
+    assert!(toml.contains("status = \"failure\""));
+    assert!(toml.contains(CODEX_EXEC_INITIAL_STALL_REASON));
+}
+
+#[test]
+fn codex_exec_initial_stall_detection_rejects_plain_substring_collisions() {
+    assert!(!is_codex_exec_initial_stall_summary(
+        "codex",
+        0,
+        "completed successfully after discussing codex_exec_initial_stall handling"
+    ));
+    assert!(!is_codex_exec_initial_stall_summary(
+        "claude-code",
+        137,
+        "codex_exec_initial_stall: no stdout within 300s (effort=high, retry_attempted=true)"
+    ));
+}
+
+#[test]
+fn read_output_log_tail_reads_from_file_end_window() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let session_dir = tmp.path();
+    let contents = (0..1500)
+        .map(|idx| format!("line-{idx:04}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(session_dir.join("output.log"), format!("{contents}\n")).expect("write output");
+
+    let tail = read_output_log_tail(session_dir, 3).expect("tail");
+    assert_eq!(tail, "line-1497\nline-1498\nline-1499");
+    assert!(
+        !tail.contains("line-0000"),
+        "tail reader should not depend on loading the full file"
+    );
+}

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec_audit.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec_audit.rs
@@ -198,6 +198,8 @@ fn pre_execution_audit_baseline_returns_none_for_legacy_sessions_without_snapsho
         transcript_artifacts: vec![],
         changed_paths: vec![],
         pre_exec_snapshot: None,
+        has_tool_calls: false,
+        sa_mode: false,
     };
 
     assert_eq!(pre_execution_audit_baseline(&ctx, &session), None);
@@ -262,6 +264,8 @@ fn pre_execution_audit_baseline_prefers_per_execution_snapshot() {
             head: "def456".to_string(),
             porcelain: Some(" M fresh.txt\0".to_string()),
         }),
+        has_tool_calls: false,
+        sa_mode: false,
     };
 
     assert_eq!(
@@ -353,6 +357,8 @@ fn audit_failure_does_not_fail_execution() {
         transcript_artifacts: vec![],
         changed_paths: vec![],
         pre_exec_snapshot: None,
+        has_tool_calls: false,
+        sa_mode: false,
     };
     let session = MetaSessionState {
         meta_session_id: "01TESTAUDITFAILURE000000000".to_string(),
@@ -469,6 +475,8 @@ fn reused_session_audit_uses_per_execution_baseline_not_session_creation() {
         transcript_artifacts: vec![],
         changed_paths: vec![],
         pre_exec_snapshot: Some(turn_two_snapshot),
+        has_tool_calls: false,
+        sa_mode: false,
     };
     let session = MetaSessionState {
         meta_session_id: "01TESTREUSEDSESSIONAUDIT000".to_string(),
@@ -564,6 +572,8 @@ fn first_execution_falls_back_to_session_creation_baseline_when_per_exec_capture
         transcript_artifacts: vec![],
         changed_paths: vec![],
         pre_exec_snapshot: None,
+        has_tool_calls: false,
+        sa_mode: false,
     };
     let session = MetaSessionState {
         meta_session_id: "01TESTAUDITFALLBACK000000000".to_string(),

--- a/crates/cli-sub-agent/src/test_session_sandbox.rs
+++ b/crates/cli-sub-agent/src/test_session_sandbox.rs
@@ -40,6 +40,9 @@ impl ScopedSessionSandbox {
             "CSA_DAEMON_SESSION_ID",
             "CSA_DAEMON_SESSION_DIR",
             "CSA_DAEMON_PROJECT_ROOT",
+            // Prevent sa-mode env leak from parent CSA session into test
+            // processes (triggers no-op exit gate on fast test executions).
+            "CSA_EMIT_CALLER_GUARD_INJECTION",
         ];
         let originals: Vec<_> = keys.iter().map(|k| (*k, std::env::var_os(k))).collect();
         let home_path = tmp.path();
@@ -53,6 +56,7 @@ impl ScopedSessionSandbox {
             std::env::remove_var("CSA_DAEMON_SESSION_ID");
             std::env::remove_var("CSA_DAEMON_SESSION_DIR");
             std::env::remove_var("CSA_DAEMON_PROJECT_ROOT");
+            std::env::remove_var("CSA_EMIT_CALLER_GUARD_INJECTION");
         }
         Self {
             originals,


### PR DESCRIPTION
## Summary

Fixes #1080 where \`csa run\` sessions that produce zero work (no tool calls, no file changes) were reported as \`exit_code=0 status=success\` after ~15s, polluting the orchestrator's main advance signal.

- Add post-exec no-op gate in \`pipeline_post_exec.rs\` that rewrites success→failure when a turn completes without observable work (no tool calls, no file changes).
- Gate is scoped to \`task_type == \"run\"\` (preserves csa review/debate/plan pipelines).
- Hardened for legacy transport (consults \`changed_paths\`) and keeps \`tool_state\` consistent after rewrite.
- New streaming metadata (\`has_tool_calls\`, \`has_execute_tool_calls\`) is runtime-only — not persisted to \`state.toml\`.
- 11 new unit tests in \`pipeline_tests_no_op_gate.rs\` covering ACP / legacy / task-type scoping / tool_state sync.

Review: \`csa review\` decision=pass, verdict=CLEAN, 3 iterations, reviewers unanimous (tier-4-critical).

## Commits

- \`0fe0c69e\` round 1: initial gate
- \`a56dc0a3\` round 2: harden against legacy transport + tool_state sync
- \`c208fc06\` round 3: scope to run task_type

## Test plan

- [x] \`cargo test\` — 1709/1709 pass
- [x] \`just pre-commit\` — exit 0
- [x] \`csa review --range main...HEAD --tier tier-4-critical\` — PASS (review session 01KPYZ02QEK86EA53AFR4VA573)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>