### PR TITLE
fix(dev2merge): make Step 7 gate authoritative over mktd exit (#1067)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.543"
+version = "0.1.544"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.543"
+version = "0.1.544"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -191,7 +191,7 @@ printf '%s\n' "${MKTD_OUTPUT}"
 print_mktd_failure_context() {
   echo "mktd exit code: ${MKTD_EXIT}" >&2
   echo "mktd failure context (step/exit lines):" >&2
-  MKTD_FAILURE_CONTEXT="$(printf '%s\n' "${MKTD_OUTPUT}" | rg -i '(^error:|failed|failure|exit status|Step [0-9]+|step [0-9]+|Phase [0-9]|User Approval)' | tail -40 || true)"
+  MKTD_FAILURE_CONTEXT="$(printf '%s\n' "${MKTD_OUTPUT}" | grep -Ei '(error|Step [0-9]+|timeout|fail)' | tail -40 || true)"
   if [ -n "${MKTD_FAILURE_CONTEXT}" ]; then
     printf '%s\n' "${MKTD_FAILURE_CONTEXT}" >&2
   else

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -178,20 +178,50 @@ else
   MKTD_INTENSITY="full"
   echo "Planning intensity: full (${PLAN_CODE_FILES} code files, ${PLAN_INSERTIONS} insertions)"
 fi
-csa plan run --sa-mode true patterns/mktd/workflow.toml \
+set +e
+MKTD_OUTPUT="$(csa plan run --sa-mode true patterns/mktd/workflow.toml \
   "${MKTD_TOOL_ARGS[@]}" \
   --var CWD="$(pwd)" \
   --var FEATURE="Plan dev2merge for branch ${CURRENT_BRANCH}. Scope: ${FEATURE_INPUT}." \
   --var USER_LANGUAGE="${USER_LANGUAGE_OVERRIDE}" \
-  --var INTENSITY="${MKTD_INTENSITY}"
+  --var INTENSITY="${MKTD_INTENSITY}" 2>&1)"
+MKTD_EXIT=$?
+set -e
+printf '%s\n' "${MKTD_OUTPUT}"
+print_mktd_failure_context() {
+  echo "mktd exit code: ${MKTD_EXIT}" >&2
+  echo "mktd failure context (step/exit lines):" >&2
+  MKTD_FAILURE_CONTEXT="$(printf '%s\n' "${MKTD_OUTPUT}" | rg -i '(^error:|failed|failure|exit status|Step [0-9]+|step [0-9]+|Phase [0-9]|User Approval)' | tail -40 || true)"
+  if [ -n "${MKTD_FAILURE_CONTEXT}" ]; then
+    printf '%s\n' "${MKTD_FAILURE_CONTEXT}" >&2
+  else
+    printf '%s\n' "${MKTD_OUTPUT}" | tail -80 >&2
+  fi
+}
+fail_step7_gate() {
+  echo "ERROR: ${1}" >&2
+  if [ "${MKTD_EXIT}" -ne 0 ]; then
+    print_mktd_failure_context
+  else
+    echo "mktd exit code: 0" >&2
+  fi
+  exit 1
+}
 LATEST_TS="$(csa todo list --format json | jq -r --arg br "${CURRENT_BRANCH}" '[.[] | select(.branch == $br)] | sort_by(.timestamp) | last | .timestamp // empty')"
 if [ -z "${LATEST_TS}" ]; then
-  echo "ERROR: mktd did not produce a TODO for branch ${CURRENT_BRANCH}." >&2
-  exit 1
+  fail_step7_gate "mktd did not produce a TODO for branch ${CURRENT_BRANCH}."
 fi
 TODO_PATH="$(csa todo show -t "${LATEST_TS}" --path)"
-grep -qF -- '- [ ] ' "${TODO_PATH}" || { echo "ERROR: TODO missing checkbox tasks." >&2; exit 1; }
-grep -q 'DONE WHEN' "${TODO_PATH}" || { echo "ERROR: TODO missing DONE WHEN clauses." >&2; exit 1; }
+if ! grep -qF -- '- [ ] ' "${TODO_PATH}"; then
+  fail_step7_gate "TODO missing checkbox tasks."
+fi
+if ! grep -q 'DONE WHEN' "${TODO_PATH}"; then
+  fail_step7_gate "TODO missing DONE WHEN clauses."
+fi
+if [ "${MKTD_EXIT}" -ne 0 ]; then
+  echo "WARNING: mktd exited ${MKTD_EXIT}, but TODO gates passed; treating Step 7 as successful." >&2
+  print_mktd_failure_context
+fi
 echo "CSA_VAR:MKTD_TODO_TIMESTAMP=${LATEST_TS}"
 echo "CSA_VAR:MKTD_TODO_PATH=${TODO_PATH}"
 ```

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -298,7 +298,7 @@ printf '%s\n' "${MKTD_OUTPUT}"
 print_mktd_failure_context() {
   echo "mktd exit code: ${MKTD_EXIT}" >&2
   echo "mktd failure context (step/exit lines):" >&2
-  MKTD_FAILURE_CONTEXT="$(printf '%s\n' "${MKTD_OUTPUT}" | rg -i '(^error:|failed|failure|exit status|Step [0-9]+|step [0-9]+|Phase [0-9]|User Approval)' | tail -40 || true)"
+  MKTD_FAILURE_CONTEXT="$(printf '%s\n' "${MKTD_OUTPUT}" | grep -Ei '(error|Step [0-9]+|timeout|fail)' | tail -40 || true)"
   if [ -n "${MKTD_FAILURE_CONTEXT}" ]; then
     printf '%s\n' "${MKTD_FAILURE_CONTEXT}" >&2
   else

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -285,20 +285,50 @@ else
   MKTD_INTENSITY="full"
   echo "Planning intensity: full (${PLAN_CODE_FILES} code files, ${PLAN_INSERTIONS} insertions)"
 fi
-csa plan run --sa-mode true patterns/mktd/workflow.toml \
+set +e
+MKTD_OUTPUT="$(csa plan run --sa-mode true patterns/mktd/workflow.toml \
   "${MKTD_TOOL_ARGS[@]}" \
   --var CWD="$(pwd)" \
   --var FEATURE="Plan dev2merge for branch ${CURRENT_BRANCH}. Scope: ${FEATURE_INPUT}." \
   --var USER_LANGUAGE="${USER_LANGUAGE_OVERRIDE}" \
-  --var INTENSITY="${MKTD_INTENSITY}"
+  --var INTENSITY="${MKTD_INTENSITY}" 2>&1)"
+MKTD_EXIT=$?
+set -e
+printf '%s\n' "${MKTD_OUTPUT}"
+print_mktd_failure_context() {
+  echo "mktd exit code: ${MKTD_EXIT}" >&2
+  echo "mktd failure context (step/exit lines):" >&2
+  MKTD_FAILURE_CONTEXT="$(printf '%s\n' "${MKTD_OUTPUT}" | rg -i '(^error:|failed|failure|exit status|Step [0-9]+|step [0-9]+|Phase [0-9]|User Approval)' | tail -40 || true)"
+  if [ -n "${MKTD_FAILURE_CONTEXT}" ]; then
+    printf '%s\n' "${MKTD_FAILURE_CONTEXT}" >&2
+  else
+    printf '%s\n' "${MKTD_OUTPUT}" | tail -80 >&2
+  fi
+}
+fail_step7_gate() {
+  echo "ERROR: ${1}" >&2
+  if [ "${MKTD_EXIT}" -ne 0 ]; then
+    print_mktd_failure_context
+  else
+    echo "mktd exit code: 0" >&2
+  fi
+  exit 1
+}
 LATEST_TS="$(csa todo list --format json | jq -r --arg br "${CURRENT_BRANCH}" '[.[] | select(.branch == $br)] | sort_by(.timestamp) | last | .timestamp // empty')"
 if [ -z "${LATEST_TS}" ]; then
-  echo "ERROR: mktd did not produce a TODO for branch ${CURRENT_BRANCH}." >&2
-  exit 1
+  fail_step7_gate "mktd did not produce a TODO for branch ${CURRENT_BRANCH}."
 fi
 TODO_PATH="$(csa todo show -t "${LATEST_TS}" --path)"
-grep -qF -- '- [ ] ' "${TODO_PATH}" || { echo "ERROR: TODO missing checkbox tasks." >&2; exit 1; }
-grep -q 'DONE WHEN' "${TODO_PATH}" || { echo "ERROR: TODO missing DONE WHEN clauses." >&2; exit 1; }
+if ! grep -qF -- '- [ ] ' "${TODO_PATH}"; then
+  fail_step7_gate "TODO missing checkbox tasks."
+fi
+if ! grep -q 'DONE WHEN' "${TODO_PATH}"; then
+  fail_step7_gate "TODO missing DONE WHEN clauses."
+fi
+if [ "${MKTD_EXIT}" -ne 0 ]; then
+  echo "WARNING: mktd exited ${MKTD_EXIT}, but TODO gates passed; treating Step 7 as successful." >&2
+  print_mktd_failure_context
+fi
 echo "CSA_VAR:MKTD_TODO_TIMESTAMP=${LATEST_TS}"
 echo "CSA_VAR:MKTD_TODO_PATH=${TODO_PATH}"
 ```'''


### PR DESCRIPTION
Closes #1067.

## Problem
`patterns/dev2merge/workflow.toml` Step 7 ("Plan with mktd") wraps `csa plan run patterns/mktd/workflow.toml` under `set -euo pipefail`. When mktd's own workflow returns non-zero in an epilogue step (despite all 6 sub-sessions exiting 0 and the TODO plan being persisted validly), Step 7 aborts BEFORE reaching its own grep gates. The gates — which test the persisted plan for `- [ ] ` and `DONE WHEN` markers — are the real pass/fail signal and PASS manually even when Step 7 reports FAIL.

## Fix
Option A (primary): make Step 7 grep gates authoritative — if the persisted TODO plan has both `- [ ] ` and `DONE WHEN` markers, Step 7 is a success regardless of mktd's workflow exit code. The gate is the source of truth: if the plan is valid and persisted, the user has what dev2merge needs.

Option B (diagnostic): capture mktd exit code + stderr into step output when gates fail, so failure messages identify WHICH mktd step failed instead of just "Step 7 failed".

Rule 027 sync: `patterns/dev2merge/PATTERN.md` updated in lockstep with `workflow.toml`.

## Verification
- Local csa review tier-4-critical: session 01KPZ8GVVV5KRED4XSVVWGV1HF.
- `just pre-commit` exit 0 on final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)