### PR TITLE
fix(csa): waitable session ids + diagnostic synthetic failures (#1072)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.544"
+version = "0.1.545"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.544"
+version = "0.1.545"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -381,6 +381,12 @@ async fn run() -> Result<()> {
                 daemon_child,
                 &session_id,
                 cd.as_deref(),
+                run_cmd_daemon::DaemonSpawnOptions::for_run(
+                    skill.as_deref(),
+                    prompt.as_deref(),
+                    prompt_flag.as_deref(),
+                    prompt_file.as_deref(),
+                ),
             )?;
 
             // Daemon child path: continue with normal run logic.
@@ -503,6 +509,7 @@ async fn run() -> Result<()> {
                 args.daemon_child,
                 &args.session_id,
                 args.cd.as_deref(),
+                run_cmd_daemon::DaemonSpawnOptions::default(),
             )?;
             let result = review_cmd::handle_review(args, current_depth).await;
             let exit_code = report_daemon_error_or_exit_code(result, &mut daemon_guard);
@@ -521,6 +528,7 @@ async fn run() -> Result<()> {
                 args.daemon_child,
                 &args.session_id,
                 args.cd.as_deref(),
+                run_cmd_daemon::DaemonSpawnOptions::default(),
             )?;
             let result = debate_cmd::handle_debate(args, current_depth, output_format).await;
             let exit_code = report_daemon_error_or_exit_code(result, &mut daemon_guard);

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -1,9 +1,45 @@
 //! Daemon spawn logic for execution commands (daemon mode is the default).
 //! Shared by `csa run`, `csa review`, and `csa debate`.
 
+use std::io::IsTerminal;
 use std::io::Write;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct DaemonSpawnOptions {
+    run_stdin_prompt: RunStdinPrompt,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum RunStdinPrompt {
+    #[default]
+    None,
+    Omitted,
+    PositionalSentinel,
+}
+
+impl DaemonSpawnOptions {
+    pub(crate) fn for_run(
+        skill: Option<&str>,
+        prompt: Option<&str>,
+        prompt_flag: Option<&str>,
+        prompt_file: Option<&Path>,
+    ) -> Self {
+        let run_stdin_prompt = if prompt_file.is_some() || prompt_flag.is_some() {
+            RunStdinPrompt::None
+        } else if prompt == Some("-") {
+            RunStdinPrompt::PositionalSentinel
+        } else if prompt.is_none() && skill.is_none() {
+            RunStdinPrompt::Omitted
+        } else {
+            RunStdinPrompt::None
+        };
+
+        Self { run_stdin_prompt }
+    }
+}
 
 /// Guard returned by [`check_daemon_flags`] when running as daemon child.
 ///
@@ -40,12 +76,13 @@ pub(crate) fn check_daemon_flags(
     daemon_child: bool,
     session_id: &Option<String>,
     cd: Option<&str>,
+    spawn_options: DaemonSpawnOptions,
 ) -> Result<DaemonChildGuard> {
     if !no_daemon && !daemon_child {
         if session_id.is_some() {
             anyhow::bail!("--session-id is an internal flag and must not be used directly");
         }
-        spawn_and_exit(subcommand, cd)?;
+        spawn_and_exit(subcommand, cd, spawn_options)?;
     }
     let mut stderr_rotation = None;
     if let Some(sid) = session_id {
@@ -116,24 +153,30 @@ fn resolve_stderr_spool_config(project_root: &std::path::Path) -> (u64, bool, st
 /// captured in the session directory.
 ///
 /// This function **never returns on success** — it calls `process::exit(0)`.
-pub(crate) fn spawn_and_exit(subcommand: &str, cd: Option<&str>) -> Result<()> {
+pub(crate) fn spawn_and_exit(
+    subcommand: &str,
+    cd: Option<&str>,
+    spawn_options: DaemonSpawnOptions,
+) -> Result<()> {
     let sid = csa_session::new_session_id();
     let project_root = crate::pipeline::determine_project_root(cd)?;
     let session_root = csa_session::get_session_root(&project_root)?;
     let session_dir = session_root.join("sessions").join(&sid);
+    let stdin_prompt = read_stdin_prompt_if_needed(spawn_options)?;
+    persist_daemon_placeholder_session(&project_root, &session_dir, &sid, subcommand)?;
+    let stdin_prompt_file = write_stdin_prompt_if_needed(&session_dir, stdin_prompt)?;
 
     // Collect args to forward: everything after the subcommand verb.
     // spawn_daemon() injects '<subcommand> --daemon-child --session-id <ID>' itself.
     // We find the subcommand by position (not substring) to handle global flags
     // that may appear before the subcommand (e.g. `csa --format json review ...`).
     let all_args: Vec<String> = std::env::args().collect();
-    let run_pos = all_args.iter().position(|a| a == subcommand).unwrap_or(1);
-    let forwarded_args: Vec<String> = all_args
-        .iter()
-        .skip(run_pos + 1)
-        .filter(|a| *a != "--daemon") // daemon is now default; strip no-op flag
-        .cloned()
-        .collect();
+    let forwarded_args = build_forwarded_args(
+        &all_args,
+        subcommand,
+        spawn_options,
+        stdin_prompt_file.as_deref(),
+    );
 
     let csa_binary = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("csa"));
     let mut daemon_env = std::collections::HashMap::new();
@@ -182,4 +225,267 @@ pub(crate) fn spawn_and_exit(subcommand: &str, cd: Option<&str>) -> Result<()> {
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
     std::process::exit(0);
+}
+
+fn persist_daemon_placeholder_session(
+    project_root: &Path,
+    session_dir: &Path,
+    session_id: &str,
+    subcommand: &str,
+) -> Result<()> {
+    let _daemon_env = ScopedDaemonSessionEnv::set(project_root, session_dir, session_id);
+    let state = csa_session::create_session(
+        project_root,
+        Some(&format!("initializing daemon {subcommand}")),
+        None,
+        None,
+    )?;
+    anyhow::ensure!(
+        state.meta_session_id == session_id,
+        "daemon placeholder session id mismatch: requested {session_id}, persisted {}",
+        state.meta_session_id
+    );
+    Ok(())
+}
+
+struct ScopedDaemonSessionEnv {
+    original_id: Option<std::ffi::OsString>,
+    original_dir: Option<std::ffi::OsString>,
+    original_root: Option<std::ffi::OsString>,
+}
+
+impl ScopedDaemonSessionEnv {
+    fn set(project_root: &Path, session_dir: &Path, session_id: &str) -> Self {
+        let guard = Self {
+            original_id: std::env::var_os("CSA_DAEMON_SESSION_ID"),
+            original_dir: std::env::var_os("CSA_DAEMON_SESSION_DIR"),
+            original_root: std::env::var_os("CSA_DAEMON_PROJECT_ROOT"),
+        };
+        // SAFETY: daemon parent is single-threaded here, before spawning the child process.
+        unsafe {
+            std::env::set_var("CSA_DAEMON_SESSION_ID", session_id);
+            std::env::set_var("CSA_DAEMON_SESSION_DIR", session_dir);
+            std::env::set_var("CSA_DAEMON_PROJECT_ROOT", project_root);
+        }
+        guard
+    }
+}
+
+impl Drop for ScopedDaemonSessionEnv {
+    fn drop(&mut self) {
+        // SAFETY: restores process env in the same single-threaded daemon parent scope.
+        unsafe {
+            restore_env("CSA_DAEMON_SESSION_ID", self.original_id.take());
+            restore_env("CSA_DAEMON_SESSION_DIR", self.original_dir.take());
+            restore_env("CSA_DAEMON_PROJECT_ROOT", self.original_root.take());
+        }
+    }
+}
+
+unsafe fn restore_env(key: &str, original: Option<std::ffi::OsString>) {
+    match original {
+        Some(value) => {
+            // SAFETY: caller guarantees env mutation is scoped and single-threaded.
+            unsafe { std::env::set_var(key, value) };
+        }
+        None => {
+            // SAFETY: caller guarantees env mutation is scoped and single-threaded.
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+}
+
+fn read_stdin_prompt_if_needed(spawn_options: DaemonSpawnOptions) -> Result<Option<String>> {
+    if spawn_options.run_stdin_prompt == RunStdinPrompt::None {
+        return Ok(None);
+    }
+
+    let mut stdin = std::io::stdin();
+    if stdin.is_terminal() {
+        anyhow::bail!(
+            "No prompt provided and stdin is a terminal.\n\n\
+             Usage:\n  \
+             csa run --sa-mode <true|false> --tool <tool> \"your prompt here\"\n  \
+             echo \"prompt\" | csa run --sa-mode <true|false> --tool <tool>"
+        );
+    }
+
+    let mut prompt = String::new();
+    std::io::Read::read_to_string(&mut stdin, &mut prompt)
+        .context("failed to read daemon run prompt from stdin")?;
+    if prompt.trim().is_empty() {
+        anyhow::bail!("Empty prompt from stdin. Provide a non-empty prompt.");
+    }
+    Ok(Some(prompt))
+}
+
+fn write_stdin_prompt_if_needed(
+    session_dir: &Path,
+    prompt: Option<String>,
+) -> Result<Option<PathBuf>> {
+    let Some(prompt) = prompt else {
+        return Ok(None);
+    };
+    let input_dir = session_dir.join("input");
+    std::fs::create_dir_all(&input_dir).with_context(|| {
+        format!(
+            "failed to create daemon prompt input dir {}",
+            input_dir.display()
+        )
+    })?;
+    let prompt_path = input_dir.join("stdin-prompt.txt");
+    std::fs::write(&prompt_path, prompt).with_context(|| {
+        format!(
+            "failed to write daemon stdin prompt file {}",
+            prompt_path.display()
+        )
+    })?;
+    Ok(Some(prompt_path))
+}
+
+fn build_forwarded_args(
+    all_args: &[String],
+    subcommand: &str,
+    spawn_options: DaemonSpawnOptions,
+    stdin_prompt_file: Option<&Path>,
+) -> Vec<String> {
+    let run_pos = all_args.iter().position(|a| a == subcommand).unwrap_or(1);
+    let mut forwarded_args: Vec<String> = all_args
+        .iter()
+        .skip(run_pos + 1)
+        .filter(|a| *a != "--daemon")
+        .cloned()
+        .collect();
+
+    if spawn_options.run_stdin_prompt == RunStdinPrompt::PositionalSentinel
+        && let Some(pos) = forwarded_args.iter().rposition(|arg| arg == "-")
+    {
+        forwarded_args.remove(pos);
+        if forwarded_args.last().is_some_and(|arg| arg == "--") {
+            forwarded_args.pop();
+        }
+    }
+
+    if let Some(prompt_file) = stdin_prompt_file {
+        forwarded_args.push("--prompt-file".to_string());
+        forwarded_args.push(prompt_file.display().to_string());
+    }
+
+    forwarded_args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_daemon_options_detect_omitted_stdin_prompt_without_skill() {
+        let options = DaemonSpawnOptions::for_run(None, None, None, None);
+        assert_eq!(options.run_stdin_prompt, RunStdinPrompt::Omitted);
+    }
+
+    #[test]
+    fn run_daemon_options_do_not_capture_stdin_for_skill_only_run() {
+        let options = DaemonSpawnOptions::for_run(Some("demo"), None, None, None);
+        assert_eq!(options.run_stdin_prompt, RunStdinPrompt::None);
+    }
+
+    #[test]
+    fn run_daemon_options_detect_positional_stdin_sentinel() {
+        let options = DaemonSpawnOptions::for_run(None, Some("-"), None, None);
+        assert_eq!(options.run_stdin_prompt, RunStdinPrompt::PositionalSentinel);
+    }
+
+    #[test]
+    fn forwarded_args_append_prompt_file_for_omitted_stdin_prompt() {
+        let all_args = vec![
+            "csa".to_string(),
+            "run".to_string(),
+            "--sa-mode".to_string(),
+            "true".to_string(),
+        ];
+        let prompt_file = Path::new("/state/session/input/stdin-prompt.txt");
+
+        let forwarded = build_forwarded_args(
+            &all_args,
+            "run",
+            DaemonSpawnOptions {
+                run_stdin_prompt: RunStdinPrompt::Omitted,
+            },
+            Some(prompt_file),
+        );
+
+        assert_eq!(
+            forwarded,
+            vec![
+                "--sa-mode",
+                "true",
+                "--prompt-file",
+                "/state/session/input/stdin-prompt.txt"
+            ]
+        );
+    }
+
+    #[test]
+    fn forwarded_args_replace_positional_stdin_sentinel_with_prompt_file() {
+        let all_args = vec![
+            "csa".to_string(),
+            "run".to_string(),
+            "--sa-mode".to_string(),
+            "true".to_string(),
+            "-".to_string(),
+        ];
+        let prompt_file = Path::new("/state/session/input/stdin-prompt.txt");
+
+        let forwarded = build_forwarded_args(
+            &all_args,
+            "run",
+            DaemonSpawnOptions {
+                run_stdin_prompt: RunStdinPrompt::PositionalSentinel,
+            },
+            Some(prompt_file),
+        );
+
+        assert_eq!(
+            forwarded,
+            vec![
+                "--sa-mode",
+                "true",
+                "--prompt-file",
+                "/state/session/input/stdin-prompt.txt"
+            ]
+        );
+    }
+
+    #[test]
+    fn forwarded_args_remove_trailing_double_dash_with_stdin_sentinel() {
+        let all_args = vec![
+            "csa".to_string(),
+            "run".to_string(),
+            "--sa-mode".to_string(),
+            "true".to_string(),
+            "--".to_string(),
+            "-".to_string(),
+        ];
+        let prompt_file = Path::new("/state/session/input/stdin-prompt.txt");
+
+        let forwarded = build_forwarded_args(
+            &all_args,
+            "run",
+            DaemonSpawnOptions {
+                run_stdin_prompt: RunStdinPrompt::PositionalSentinel,
+            },
+            Some(prompt_file),
+        );
+
+        assert_eq!(
+            forwarded,
+            vec![
+                "--sa-mode",
+                "true",
+                "--prompt-file",
+                "/state/session/input/stdin-prompt.txt"
+            ]
+        );
+    }
 }

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -1,11 +1,12 @@
 //! Daemon spawn logic for execution commands (daemon mode is the default).
 //! Shared by `csa run`, `csa review`, and `csa debate`.
 
-use std::io::IsTerminal;
-use std::io::Write;
+use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+
+const STDIN_PROMPT_MAX_BYTES: u64 = 10 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct DaemonSpawnOptions {
@@ -233,12 +234,14 @@ fn persist_daemon_placeholder_session(
     session_id: &str,
     subcommand: &str,
 ) -> Result<()> {
-    let _daemon_env = ScopedDaemonSessionEnv::set(project_root, session_dir, session_id);
-    let state = csa_session::create_session(
+    let state = csa_session::create_session_with_daemon_env(
         project_root,
         Some(&format!("initializing daemon {subcommand}")),
         None,
         None,
+        Some(session_id),
+        Some(session_dir),
+        Some(project_root),
     )?;
     anyhow::ensure!(
         state.meta_session_id == session_id,
@@ -246,53 +249,6 @@ fn persist_daemon_placeholder_session(
         state.meta_session_id
     );
     Ok(())
-}
-
-struct ScopedDaemonSessionEnv {
-    original_id: Option<std::ffi::OsString>,
-    original_dir: Option<std::ffi::OsString>,
-    original_root: Option<std::ffi::OsString>,
-}
-
-impl ScopedDaemonSessionEnv {
-    fn set(project_root: &Path, session_dir: &Path, session_id: &str) -> Self {
-        let guard = Self {
-            original_id: std::env::var_os("CSA_DAEMON_SESSION_ID"),
-            original_dir: std::env::var_os("CSA_DAEMON_SESSION_DIR"),
-            original_root: std::env::var_os("CSA_DAEMON_PROJECT_ROOT"),
-        };
-        // SAFETY: daemon parent is single-threaded here, before spawning the child process.
-        unsafe {
-            std::env::set_var("CSA_DAEMON_SESSION_ID", session_id);
-            std::env::set_var("CSA_DAEMON_SESSION_DIR", session_dir);
-            std::env::set_var("CSA_DAEMON_PROJECT_ROOT", project_root);
-        }
-        guard
-    }
-}
-
-impl Drop for ScopedDaemonSessionEnv {
-    fn drop(&mut self) {
-        // SAFETY: restores process env in the same single-threaded daemon parent scope.
-        unsafe {
-            restore_env("CSA_DAEMON_SESSION_ID", self.original_id.take());
-            restore_env("CSA_DAEMON_SESSION_DIR", self.original_dir.take());
-            restore_env("CSA_DAEMON_PROJECT_ROOT", self.original_root.take());
-        }
-    }
-}
-
-unsafe fn restore_env(key: &str, original: Option<std::ffi::OsString>) {
-    match original {
-        Some(value) => {
-            // SAFETY: caller guarantees env mutation is scoped and single-threaded.
-            unsafe { std::env::set_var(key, value) };
-        }
-        None => {
-            // SAFETY: caller guarantees env mutation is scoped and single-threaded.
-            unsafe { std::env::remove_var(key) };
-        }
-    }
 }
 
 fn read_stdin_prompt_if_needed(spawn_options: DaemonSpawnOptions) -> Result<Option<String>> {
@@ -310,13 +266,25 @@ fn read_stdin_prompt_if_needed(spawn_options: DaemonSpawnOptions) -> Result<Opti
         );
     }
 
-    let mut prompt = String::new();
-    std::io::Read::read_to_string(&mut stdin, &mut prompt)
+    let prompt = read_bounded_stdin_prompt(&mut stdin, STDIN_PROMPT_MAX_BYTES)
         .context("failed to read daemon run prompt from stdin")?;
     if prompt.trim().is_empty() {
         anyhow::bail!("Empty prompt from stdin. Provide a non-empty prompt.");
     }
     Ok(Some(prompt))
+}
+
+fn read_bounded_stdin_prompt(reader: impl Read, max_bytes: u64) -> Result<String> {
+    let mut prompt = String::new();
+    let mut limited_reader = reader.take(max_bytes.saturating_add(1));
+    limited_reader.read_to_string(&mut prompt)?;
+    if prompt.len() as u64 > max_bytes {
+        anyhow::bail!(
+            "Prompt from stdin exceeds the {} byte daemon limit. Use --prompt-file for larger input.",
+            max_bytes
+        );
+    }
+    Ok(prompt)
 }
 
 fn write_stdin_prompt_if_needed(
@@ -486,6 +454,27 @@ mod tests {
                 "--prompt-file",
                 "/state/session/input/stdin-prompt.txt"
             ]
+        );
+    }
+
+    #[test]
+    fn bounded_stdin_prompt_accepts_prompt_at_limit() {
+        let prompt = "x".repeat(16);
+        let read = read_bounded_stdin_prompt(std::io::Cursor::new(prompt.as_bytes()), 16)
+            .expect("prompt at limit should be accepted");
+
+        assert_eq!(read, prompt);
+    }
+
+    #[test]
+    fn bounded_stdin_prompt_rejects_prompt_over_limit() {
+        let prompt = "x".repeat(17);
+        let err = read_bounded_stdin_prompt(std::io::Cursor::new(prompt.as_bytes()), 16)
+            .expect_err("prompt over limit should fail");
+
+        assert!(
+            err.to_string().contains("exceeds the 16 byte daemon limit"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -12,10 +12,13 @@ use tracing::{debug, info, warn};
 use crate::plan_cmd::shell_escape_for_command;
 #[path = "session_cmds_reconcile_cleanup.rs"]
 mod reconcile_cleanup;
+#[path = "session_cmds_reconcile_diagnostics.rs"]
+mod reconcile_diagnostics;
 #[path = "session_cmds_reconcile_git.rs"]
 mod reconcile_git;
 #[path = "session_cmds_reconcile_liveness.rs"]
 mod reconcile_liveness;
+use reconcile_diagnostics::synthetic_failure_diagnostics;
 use reconcile_git::{git_output, git_success, resolve_fallback_base_branch};
 use reconcile_liveness::reconcile_liveness_decision;
 
@@ -347,9 +350,11 @@ where
     #[rustfmt::skip]
     let artifacts = crate::pipeline_post_exec::collect_fallback_result_artifacts(project_root, session_id);
     let output_log_mtime = format_optional_file_mtime(&session_dir.join("output.log"));
+    let diagnostics = synthetic_failure_diagnostics(session_dir, &session, liveness.reason);
     let summary_prefix = format!(
-        "synthetic failure by {trigger}: process dead, result.toml missing (reconciliation_reason=true_missing_result, output_log_mtime={})",
-        output_log_mtime.as_deref().unwrap_or("missing")
+        "synthetic failure by {trigger}: process dead, result.toml missing (reconciliation_reason=true_missing_result, output_log_mtime={}){}",
+        output_log_mtime.as_deref().unwrap_or("missing"),
+        diagnostics
     );
     let fallback = SessionResult {
         status: "failure".to_string(),
@@ -768,6 +773,10 @@ fn format_optional_file_mtime(path: &Path) -> Option<String> {
 #[cfg(test)]
 #[path = "session_cmds_reconcile_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "session_cmds_reconcile_diagnostics_tests.rs"]
+mod diagnostics_tests;
 
 #[cfg(test)]
 #[path = "session_cmds_reconcile_tests_tail.rs"]

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics.rs
@@ -1,0 +1,183 @@
+use csa_session::MetaSessionState;
+use std::fs;
+use std::io::{ErrorKind, Read, Seek, SeekFrom};
+use std::path::Path;
+
+const DIAGNOSTIC_TAIL_BYTES: u64 = 8192;
+const DIAGNOSTIC_VALUE_MAX_CHARS: usize = 500;
+
+pub(super) fn synthetic_failure_diagnostics(
+    session_dir: &Path,
+    session: &MetaSessionState,
+    liveness_reason: &str,
+) -> String {
+    let mut lines = vec![
+        "Diagnostics:".to_string(),
+        format!("session_phase={:?}", session.phase),
+        format!(
+            "termination_reason={}",
+            option_or_missing(session.termination_reason.as_deref())
+        ),
+        format!("last_accessed={}", session.last_accessed.to_rfc3339()),
+        format!("liveness_reason={liveness_reason}"),
+    ];
+
+    push_file_diagnostic(
+        &mut lines,
+        "daemon_completion",
+        &session_dir.join("daemon-completion.toml"),
+    );
+    push_file_diagnostic(&mut lines, "daemon_pid", &session_dir.join("daemon.pid"));
+    push_file_diagnostic(&mut lines, "output_log", &session_dir.join("output.log"));
+    push_file_diagnostic(&mut lines, "stderr_log", &session_dir.join("stderr.log"));
+    push_file_diagnostic(
+        &mut lines,
+        "acp_events",
+        &session_dir.join("output").join("acp-events.jsonl"),
+    );
+    push_file_diagnostic(
+        &mut lines,
+        "liveness_snapshot",
+        &session_dir.join(".liveness.snapshot"),
+    );
+
+    if let Some(packet) = read_daemon_completion_summary(session_dir) {
+        lines.push(format!("daemon_completion_packet={packet}"));
+    }
+    if let Some(pid_record) = read_small_file_compact(&session_dir.join("daemon.pid")) {
+        lines.push(format!("daemon_pid_record={pid_record}"));
+    }
+    if let Some(heartbeat) = last_line_matching(&session_dir.join("output.log"), |line| {
+        line.trim_start().starts_with("[csa-heartbeat]")
+    }) {
+        lines.push(format!("last_heartbeat={heartbeat}"));
+    }
+    if let Some(stderr_tail) = read_tail_compact(&session_dir.join("stderr.log")) {
+        lines.push(format!("stderr_tail={stderr_tail}"));
+        if let Some(hint) = classify_diagnostic_hint(&stderr_tail) {
+            lines.push(format!("diagnostic_hint={hint}"));
+        }
+    }
+    if let Some(acp_last_event) =
+        last_nonempty_line(&session_dir.join("output").join("acp-events.jsonl"))
+    {
+        lines.push(format!("acp_last_event={acp_last_event}"));
+    }
+
+    format!("\n\n{}", lines.join("\n"))
+}
+
+fn push_file_diagnostic(lines: &mut Vec<String>, label: &str, path: &Path) {
+    match fs::metadata(path) {
+        Ok(metadata) => {
+            let mtime = format_optional_file_mtime(path).unwrap_or_else(|| "unknown".to_string());
+            lines.push(format!(
+                "{label}=present size_bytes={} mtime={mtime}",
+                metadata.len()
+            ));
+        }
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            lines.push(format!("{label}=missing"));
+        }
+        Err(err) => {
+            lines.push(format!(
+                "{label}=unreadable error={}",
+                compact_diagnostic_value(&err.to_string())
+            ));
+        }
+    }
+}
+
+fn read_daemon_completion_summary(session_dir: &Path) -> Option<String> {
+    let contents = read_small_file_compact(&session_dir.join("daemon-completion.toml"))?;
+    Some(contents.replace(" = ", "="))
+}
+
+fn read_small_file_compact(path: &Path) -> Option<String> {
+    let metadata = fs::metadata(path).ok()?;
+    if metadata.len() > DIAGNOSTIC_TAIL_BYTES {
+        return read_tail_compact(path);
+    }
+    let contents = fs::read_to_string(path).ok()?;
+    Some(compact_diagnostic_value(&contents))
+}
+
+fn read_tail_compact(path: &Path) -> Option<String> {
+    Some(compact_diagnostic_value(&read_tail_lossy(path)?))
+}
+
+fn read_tail_lossy(path: &Path) -> Option<String> {
+    let mut file = fs::File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    let start = len.saturating_sub(DIAGNOSTIC_TAIL_BYTES);
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).ok()?;
+    Some(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn last_line_matching(path: &Path, predicate: impl Fn(&str) -> bool) -> Option<String> {
+    let tail = read_tail_lossy(path)?;
+    tail.lines()
+        .rev()
+        .find(|line| predicate(line))
+        .map(compact_diagnostic_value)
+}
+
+fn last_nonempty_line(path: &Path) -> Option<String> {
+    let tail = read_tail_lossy(path)?;
+    tail.lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .map(compact_diagnostic_value)
+}
+
+fn classify_diagnostic_hint(stderr_tail: &str) -> Option<&'static str> {
+    let lowered = stderr_tail.to_ascii_lowercase();
+    if lowered.contains("empty prompt from stdin") {
+        return Some("empty_stdin_before_session_execution");
+    }
+    if lowered.contains("out of memory")
+        || lowered.contains("oom")
+        || lowered.contains("sigkill")
+        || lowered.contains("exit code 137")
+    {
+        return Some("possible_oom_or_sigkill");
+    }
+    if lowered.contains("permission denied")
+        || lowered.contains("operation not permitted")
+        || lowered.contains("eacces")
+        || lowered.contains("sandbox")
+    {
+        return Some("possible_sandbox_or_permission_denial");
+    }
+    if lowered.contains("server shut down unexpectedly") || lowered.contains("transport") {
+        return Some("possible_transport_crash");
+    }
+    None
+}
+
+fn compact_diagnostic_value(value: &str) -> String {
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    truncate_chars(&compact, DIAGNOSTIC_VALUE_MAX_CHARS)
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut iter = value.chars();
+    let truncated = iter.by_ref().take(max_chars).collect::<String>();
+    if iter.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}
+
+fn option_or_missing(value: Option<&str>) -> &str {
+    value.unwrap_or("missing")
+}
+
+fn format_optional_file_mtime(path: &Path) -> Option<String> {
+    let modified = fs::metadata(path).ok()?.modified().ok()?;
+    let modified = chrono::DateTime::<chrono::Utc>::from(modified);
+    Some(modified.to_rfc3339())
+}

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics.rs
@@ -138,7 +138,9 @@ fn classify_diagnostic_hint(stderr_tail: &str) -> Option<&'static str> {
         return Some("empty_stdin_before_session_execution");
     }
     if lowered.contains("out of memory")
-        || lowered.contains("oom")
+        || lowered
+            .split_whitespace()
+            .any(|word| word.trim_matches(|c: char| !c.is_alphanumeric()) == "oom")
         || lowered.contains("sigkill")
         || lowered.contains("exit code 137")
     {
@@ -192,4 +194,22 @@ fn format_optional_file_mtime(path: &Path) -> Option<String> {
     let modified = fs::metadata(path).ok()?.modified().ok()?;
     let modified = chrono::DateTime::<chrono::Utc>::from(modified);
     Some(modified.to_rfc3339())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostic_hint_matches_oom_as_punctuated_word() {
+        assert_eq!(
+            classify_diagnostic_hint("kernel killed process: OOM."),
+            Some("possible_oom_or_sigkill")
+        );
+    }
+
+    #[test]
+    fn diagnostic_hint_ignores_oom_substrings() {
+        assert_eq!(classify_diagnostic_hint("room broom zoom"), None);
+    }
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics.rs
@@ -158,18 +158,30 @@ fn classify_diagnostic_hint(stderr_tail: &str) -> Option<&'static str> {
 }
 
 fn compact_diagnostic_value(value: &str) -> String {
-    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
-    truncate_chars(&compact, DIAGNOSTIC_VALUE_MAX_CHARS)
-}
+    let mut compact = String::new();
+    let mut chars = 0;
 
-fn truncate_chars(value: &str, max_chars: usize) -> String {
-    let mut iter = value.chars();
-    let truncated = iter.by_ref().take(max_chars).collect::<String>();
-    if iter.next().is_some() {
-        format!("{truncated}...")
-    } else {
-        truncated
+    for word in value.split_whitespace() {
+        if !compact.is_empty() {
+            if chars == DIAGNOSTIC_VALUE_MAX_CHARS {
+                compact.push_str("...");
+                return compact;
+            }
+            compact.push(' ');
+            chars += 1;
+        }
+
+        for ch in word.chars() {
+            if chars == DIAGNOSTIC_VALUE_MAX_CHARS {
+                compact.push_str("...");
+                return compact;
+            }
+            compact.push(ch);
+            chars += 1;
+        }
     }
+
+    compact
 }
 
 fn option_or_missing(value: Option<&str>) -> &str {

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
@@ -1,0 +1,149 @@
+use super::*;
+use crate::test_env_lock::TEST_ENV_LOCK;
+use csa_session::{create_session, get_session_dir, load_result};
+use std::fs;
+use tokio::sync::OwnedMutexGuard;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+struct SessionTestEnv {
+    _env_lock: OwnedMutexGuard<()>,
+    _home_guard: EnvVarGuard,
+    _state_guard: EnvVarGuard,
+}
+
+impl SessionTestEnv {
+    fn new(td: &tempfile::TempDir) -> Self {
+        let env_lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
+        let state_home = td.path().join("xdg-state");
+        fs::create_dir_all(&state_home).expect("create state home");
+        let home_guard = EnvVarGuard::set("HOME", td.path());
+        let state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+        Self {
+            _env_lock: env_lock,
+            _home_guard: home_guard,
+            _state_guard: state_guard,
+        }
+    }
+}
+
+#[cfg(unix)]
+fn set_file_mtime_seconds_ago(path: &std::path::Path, seconds_ago: u64) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let target = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(seconds_ago))
+        .expect("target time before unix epoch")
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before unix epoch");
+    let tv_sec = libc::time_t::try_from(target.as_secs()).expect("mtime seconds fit in time_t");
+    let tv_nsec = target.subsec_nanos() as libc::c_long;
+    let times = [
+        libc::timespec { tv_sec, tv_nsec },
+        libc::timespec { tv_sec, tv_nsec },
+    ];
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("path contains NUL");
+    // SAFETY: `utimensat` receives a valid C path pointer and valid timespec array.
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    assert_eq!(rc, 0, "utimensat failed for {}", path.display());
+}
+
+#[cfg(unix)]
+fn backdate_tree(path: &std::path::Path, seconds_ago: u64) {
+    if path.is_dir() {
+        for entry in fs::read_dir(path).expect("read_dir") {
+            let entry = entry.expect("dir entry");
+            backdate_tree(&entry.path(), seconds_ago);
+        }
+    }
+    set_file_mtime_seconds_ago(path, seconds_ago);
+}
+
+#[cfg(unix)]
+#[test]
+fn synthesized_failure_summary_includes_post_mortem_diagnostics() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(project, Some("diagnostic-synthesis"), None, None).unwrap();
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 137\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+    fs::write(session_dir.join("daemon.pid"), "424242 1\n").unwrap();
+    fs::write(
+        session_dir.join("stderr.log"),
+        "ACP transport failed: server shut down unexpectedly\nout of memory\n",
+    )
+    .unwrap();
+    fs::write(
+        session_dir.join("output.log"),
+        "[csa-heartbeat] ACP prompt still running: elapsed=44s idle=15s\n",
+    )
+    .unwrap();
+    fs::create_dir_all(session_dir.join("output")).unwrap();
+    fs::write(
+        session_dir.join("output").join("acp-events.jsonl"),
+        "{\"event\":\"last\"}\n",
+    )
+    .unwrap();
+    backdate_tree(&session_dir, 120);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session wait")
+            .unwrap();
+
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("synthetic result");
+    assert!(result.summary.contains("Diagnostics:"));
+    assert!(
+        result
+            .summary
+            .contains("daemon_completion_packet=exit_code=137")
+    );
+    assert!(result.summary.contains("last_heartbeat=[csa-heartbeat]"));
+    assert!(
+        result
+            .summary
+            .contains("diagnostic_hint=possible_oom_or_sigkill")
+    );
+    assert!(
+        result
+            .summary
+            .contains("acp_last_event={\"event\":\"last\"}")
+    );
+}

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -81,15 +81,16 @@ pub use vcs_backends::{GitBackend, JjBackend, create_vcs_backend};
 pub use manager::{
     CONTRACT_RESULT_ARTIFACT_PATH, LEGACY_USER_RESULT_ARTIFACT_PATH, RESULT_TOML_PATH_CONTRACT_ENV,
     RepoWriteAudit, SaveOptions, clear_manager_sidecar, complete_session, compute_repo_write_audit,
-    contract_result_path, create_session, create_session_fresh, decode_session_created_at,
-    delete_session, delete_session_from_root, detect_git_head, find_sessions, get_session_dir,
-    get_session_dir_global, get_session_root, legacy_user_result_path,
-    list_all_project_session_roots, list_all_sessions, list_all_sessions_all_projects,
-    list_artifacts, list_sessions, list_sessions_from_root, list_sessions_from_root_readonly,
-    load_metadata, load_result, load_result_view, load_session, load_session_global_exact,
-    redact_result_sidecar_value, render_redacted_result_sidecar, resolve_fork_source,
-    resolve_resume_session, save_result, save_result_with_options, save_session, save_session_in,
-    update_last_accessed, validate_tool_access, write_audit_warning_artifact,
+    contract_result_path, create_session, create_session_fresh, create_session_with_daemon_env,
+    decode_session_created_at, delete_session, delete_session_from_root, detect_git_head,
+    find_sessions, get_session_dir, get_session_dir_global, get_session_root,
+    legacy_user_result_path, list_all_project_session_roots, list_all_sessions,
+    list_all_sessions_all_projects, list_artifacts, list_sessions, list_sessions_from_root,
+    list_sessions_from_root_readonly, load_metadata, load_result, load_result_view, load_session,
+    load_session_global_exact, redact_result_sidecar_value, render_redacted_result_sidecar,
+    resolve_fork_source, resolve_resume_session, save_result, save_result_with_options,
+    save_session, save_session_in, update_last_accessed, validate_tool_access,
+    write_audit_warning_artifact,
 };
 
 pub use manager::ResumeSessionResolution;

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -21,8 +21,8 @@ mod manager_paths;
 mod manager_result;
 
 pub use manager_audit::{RepoWriteAudit, compute_repo_write_audit, write_audit_warning_artifact};
-pub use manager_daemon::ResumeSessionResolution;
-use manager_daemon::{SessionIdStrategy, preassigned_daemon_session_id};
+pub use manager_daemon::{ResumeSessionResolution, create_session_with_daemon_env};
+use manager_daemon::{SessionIdStrategy, preassigned_daemon_session_id_from_env};
 pub use manager_legacy::decode_session_created_at;
 #[cfg(test)]
 use manager_paths::project_storage_key_from_path;
@@ -63,7 +63,7 @@ pub fn create_session(
         description,
         parent_id,
         tool,
-        SessionIdStrategy::DaemonAware,
+        SessionIdStrategy::DaemonAware(preassigned_daemon_session_id_from_env()),
     )
 }
 
@@ -101,7 +101,7 @@ pub(crate) fn create_session_in(
         description,
         parent_id,
         tool,
-        SessionIdStrategy::DaemonAware,
+        SessionIdStrategy::DaemonAware(preassigned_daemon_session_id_from_env()),
     )
 }
 
@@ -118,7 +118,7 @@ fn create_session_in_with_strategy(
     // child sessions must opt out of that binding so they do not collapse onto
     // the caller's own daemon session.
     let session_id = match session_id_strategy {
-        SessionIdStrategy::DaemonAware => match preassigned_daemon_session_id() {
+        SessionIdStrategy::DaemonAware(preassigned_session_id) => match preassigned_session_id {
             Some(id) => {
                 validate_session_id(&id)?;
                 id

--- a/crates/csa-session/src/manager_daemon.rs
+++ b/crates/csa-session/src/manager_daemon.rs
@@ -1,16 +1,61 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+use std::path::Path;
+
+use crate::state::MetaSessionState;
+use anyhow::Result;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SessionIdStrategy {
-    DaemonAware,
+    DaemonAware(Option<String>),
     Fresh,
 }
 
-pub(crate) fn preassigned_daemon_session_id() -> Option<String> {
+pub(crate) fn preassigned_daemon_session_id_from_env() -> Option<String> {
     let session_id = std::env::var(super::DAEMON_SESSION_ID_ENV)
         .ok()
         .filter(|value| !value.is_empty())?;
-    let has_daemon_context = std::env::var_os(super::DAEMON_SESSION_DIR_ENV).is_some()
-        || std::env::var_os(super::DAEMON_PROJECT_ROOT_ENV).is_some();
-    has_daemon_context.then_some(session_id)
+    let session_dir = std::env::var_os(super::DAEMON_SESSION_DIR_ENV);
+    let project_root = std::env::var_os(super::DAEMON_PROJECT_ROOT_ENV);
+    preassigned_daemon_session_id_from_values(
+        Some(session_id.as_str()),
+        session_dir.as_deref().map(Path::new),
+        project_root.as_deref().map(Path::new),
+    )
+}
+
+pub(crate) fn preassigned_daemon_session_id_from_values(
+    session_id: Option<&str>,
+    session_dir: Option<&Path>,
+    project_root: Option<&Path>,
+) -> Option<String> {
+    let session_id = session_id.filter(|value| !value.is_empty())?;
+    let has_daemon_context = session_dir.is_some() || project_root.is_some();
+    has_daemon_context.then(|| session_id.to_string())
+}
+
+/// Create a session using explicit daemon env values rather than mutating the
+/// process environment.
+pub fn create_session_with_daemon_env(
+    project_path: &Path,
+    description: Option<&str>,
+    parent_id: Option<&str>,
+    tool: Option<&str>,
+    daemon_session_id: Option<&str>,
+    daemon_session_dir: Option<&Path>,
+    daemon_project_root: Option<&Path>,
+) -> Result<MetaSessionState> {
+    let base_dir = super::get_session_root(project_path)?;
+    super::create_session_in_with_strategy(
+        &base_dir,
+        project_path,
+        description,
+        parent_id,
+        tool,
+        SessionIdStrategy::DaemonAware(preassigned_daemon_session_id_from_values(
+            daemon_session_id,
+            daemon_session_dir,
+            daemon_project_root,
+        )),
+    )
 }
 
 /// Resolved identifiers for resuming a tool session.

--- a/crates/csa-session/src/manager_tests.rs
+++ b/crates/csa-session/src/manager_tests.rs
@@ -180,6 +180,32 @@ fn test_create_session_ignores_bare_inherited_daemon_session_id() {
 }
 
 #[test]
+fn test_create_session_with_daemon_env_uses_preassigned_id() {
+    let td = tempdir().unwrap();
+    let _xdg = ScopedXdgOverride::new(&td);
+    let project = td.path();
+    let session_id = "01K00000000000000000000001";
+    let session_dir = get_session_root(project)
+        .unwrap()
+        .join("sessions")
+        .join(session_id);
+
+    let state = create_session_with_daemon_env(
+        project,
+        Some("daemon placeholder"),
+        None,
+        None,
+        Some(session_id),
+        Some(&session_dir),
+        Some(project),
+    )
+    .unwrap();
+
+    assert_eq!(state.meta_session_id, session_id);
+    assert!(session_dir.join(STATE_FILE_NAME).exists());
+}
+
+#[test]
 fn test_list_sessions_with_tool_filter() {
     let td = tempdir().unwrap();
     let _xdg = ScopedXdgOverride::new(&td);


### PR DESCRIPTION
Closes #1072.

## Problem
Two related bugs hit while dogfooding on #1071:
1. **Bug-A (unwaitable session id)**: `csa run` returned a session id that `csa session wait` could not find; `csa session list` instead showed a DIFFERENT active session for the same task.
2. **Bug-B (silent synthetic failure)**: when a daemon died and `result.toml` was missing, the synthetic terminal result only said "process dead, result.toml missing" — no way to distinguish crash / OOM / sandbox denial / lifecycle reconciliation bug.

## Fix
- **`fix(run): make daemon session ids waitable`** — ensure `csa run` only emits the ULID of the actually-persisted-and-running session.
- **`fix(session): add diagnostics to synthetic failures`** — when synthesizing a failure result, gather available post-mortem signals (daemon completion marker, stderr tail, ACP last-event, heartbeat mtime) and append as a diagnostics block.

## Residual risks
Post-mortem is limited to files persisted in the session dir. No reliable access to kernel-level signals (dmesg/journalctl OOM, cgroup termination reason) without elevated privileges — those remain out of reach when the process is killed before flushing its own state.

## Verification
- Local csa review tier-4-critical: session 01KPZDTDFE4MVM75TJA7AC622D.
- `just pre-commit` exit 0 on the session's final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)