### PR TITLE
fix(csa-hooks): detect primary remote dynamically in _post_merge_sync (#1076)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.547"
+version = "0.1.548"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.547"
+version = "0.1.548"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-hooks/src/merge_guard/mod.rs
+++ b/crates/csa-hooks/src/merge_guard/mod.rs
@@ -96,13 +96,22 @@ fi
 # Best-effort local sync of the default branch after a successful merge.
 # Non-fatal: sync failure does NOT change the wrapper's exit code.
 _post_merge_sync() {
+  local PRIMARY_REMOTE
+  PRIMARY_REMOTE="$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null | sed 's!/.*!!' || true)"
+  if [ -z "${PRIMARY_REMOTE}" ]; then
+    PRIMARY_REMOTE="$(git remote 2>/dev/null | head -n1 || true)"
+  fi
+  if [ -z "${PRIMARY_REMOTE}" ]; then
+    return 0
+  fi
+
   local DEFAULT_BRANCH
   DEFAULT_BRANCH="$("${REAL_GH}" repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)"
   if [ -z "${DEFAULT_BRANCH}" ]; then
-    DEFAULT_BRANCH="$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's!^origin/!!' || true)"
+    DEFAULT_BRANCH="$(git rev-parse --abbrev-ref "${PRIMARY_REMOTE}/HEAD" 2>/dev/null | sed "s!^${PRIMARY_REMOTE}/!!" || true)"
   fi
   if [ -z "${DEFAULT_BRANCH}" ]; then
-    printf 'NOTE: post-merge sync skipped — could not determine default branch (gh repo view failed, origin/HEAD not set)\n' >&2
+    printf 'NOTE: post-merge sync skipped — could not determine default branch (gh repo view failed, %s/HEAD not set)\n' "${PRIMARY_REMOTE}" >&2
     return 0
   fi
 
@@ -111,12 +120,12 @@ _post_merge_sync() {
 
   if [ "${CURRENT_BRANCH}" = "${DEFAULT_BRANCH}" ]; then
     {
-      git fetch origin "${DEFAULT_BRANCH}" &&
-      git merge "origin/${DEFAULT_BRANCH}" --ff-only
+      git fetch "${PRIMARY_REMOTE}" "${DEFAULT_BRANCH}" &&
+      git merge "${PRIMARY_REMOTE}/${DEFAULT_BRANCH}" --ff-only
     } >&2 || printf 'NOTE: in-place fast-forward failed, continuing\n' >&2
   else
     {
-      git fetch origin "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}"
+      git fetch "${PRIMARY_REMOTE}" "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}"
     } >&2 || printf 'NOTE: refspec update failed, continuing\n' >&2
   fi
 }

--- a/crates/csa-hooks/src/merge_guard/mod.rs
+++ b/crates/csa-hooks/src/merge_guard/mod.rs
@@ -97,7 +97,7 @@ fi
 # Non-fatal: sync failure does NOT change the wrapper's exit code.
 _post_merge_sync() {
   local PRIMARY_REMOTE
-  PRIMARY_REMOTE="$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null | sed 's!/.*!!' || true)"
+  PRIMARY_REMOTE="$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null | grep / | sed 's!/.*!!' || true)"
   if [ -z "${PRIMARY_REMOTE}" ]; then
     PRIMARY_REMOTE="$(git remote 2>/dev/null | head -n1 || true)"
   fi
@@ -108,7 +108,8 @@ _post_merge_sync() {
   local DEFAULT_BRANCH
   DEFAULT_BRANCH="$("${REAL_GH}" repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)"
   if [ -z "${DEFAULT_BRANCH}" ]; then
-    DEFAULT_BRANCH="$(git rev-parse --abbrev-ref "${PRIMARY_REMOTE}/HEAD" 2>/dev/null | sed "s!^${PRIMARY_REMOTE}/!!" || true)"
+    DEFAULT_BRANCH="$(git rev-parse --abbrev-ref "${PRIMARY_REMOTE}/HEAD" 2>/dev/null || true)"
+    DEFAULT_BRANCH="${DEFAULT_BRANCH#${PRIMARY_REMOTE}/}"
   fi
   if [ -z "${DEFAULT_BRANCH}" ]; then
     printf 'NOTE: post-merge sync skipped — could not determine default branch (gh repo view failed, %s/HEAD not set)\n' "${PRIMARY_REMOTE}" >&2

--- a/crates/csa-hooks/src/merge_guard/tests_post_merge_sync.rs
+++ b/crates/csa-hooks/src/merge_guard/tests_post_merge_sync.rs
@@ -6,6 +6,14 @@ use super::*;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+struct GitMockConfig<'a> {
+    upstream_ref: Option<&'a str>,
+    remotes: &'a [&'a str],
+    remote_head: Option<&'a str>,
+    current_branch: Option<&'a str>,
+    merge_exit: i32,
+}
+
 /// Setup for post-merge sync tests. Returns (guard_dir, fake_gh, mock_bin_dir, git_log_file).
 fn setup_post_merge_env(
     tmp: &Path,
@@ -24,6 +32,26 @@ fn setup_post_merge_env_with_git(
     current_branch: Option<&str>,
     git_merge_exit: i32,
 ) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    setup_post_merge_env_with_git_remote(
+        tmp,
+        gh_exit,
+        branch,
+        GitMockConfig {
+            upstream_ref: None,
+            remotes: &["origin"],
+            remote_head: origin_head,
+            current_branch,
+            merge_exit: git_merge_exit,
+        },
+    )
+}
+
+fn setup_post_merge_env_with_git_remote(
+    tmp: &Path,
+    gh_exit: i32,
+    branch: Option<&str>,
+    git: GitMockConfig<'_>,
+) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
     let guard_dir = tmp.join("guard");
     fs::create_dir_all(&guard_dir).unwrap();
     let wrapper_path = guard_dir.join("gh");
@@ -35,11 +63,20 @@ fn setup_post_merge_env_with_git(
         Some(b) => format!("printf '{}\\n'", b),
         None => "exit 1".to_string(),
     };
-    let origin_head_out = match origin_head {
+    let upstream_ref_out = match git.upstream_ref {
         Some(b) => format!("printf '{}\\n'", b),
         None => "exit 1".to_string(),
     };
-    let current_branch_out = match current_branch {
+    let remotes_out = if git.remotes.is_empty() {
+        "exit 1".to_string()
+    } else {
+        format!("printf '{}\\n'", git.remotes.join("\\n"))
+    };
+    let remote_head_out = match git.remote_head {
+        Some(b) => format!("printf '{}\\n'", b),
+        None => "exit 1".to_string(),
+    };
+    let current_branch_out = match git.current_branch {
         Some(b) => format!("printf '{}\\n'", b),
         None => "exit 1".to_string(),
     };
@@ -69,18 +106,22 @@ echo REAL_GH_CALLED
         format!(
             r#"#!/bin/bash
 echo "$@" >> "{log}"
+if [ "$1" = "remote" ] && [ "$#" -eq 1 ]; then {remotes_out}; exit $?; fi
 if [ "$1" = "rev-parse" ] && [ "$2" = "--abbrev-ref" ]; then
   case "$3" in
-    origin/HEAD) {origin_head_out}; exit $?;;
+    '@{{upstream}}') {upstream_ref_out}; exit $?;;
+    */HEAD) {remote_head_out}; exit $?;;
     HEAD) {current_branch_out}; exit $?;;
   esac
 fi
 for a in "$@"; do [ "$a" = "--ff-only" ] && exit {me}; done; exit 0
 "#,
             log = git_log.to_str().unwrap(),
-            origin_head_out = origin_head_out,
+            remotes_out = remotes_out,
+            upstream_ref_out = upstream_ref_out,
+            remote_head_out = remote_head_out,
             current_branch_out = current_branch_out,
-            me = git_merge_exit
+            me = git.merge_exit
         ),
     )
     .unwrap();
@@ -141,21 +182,29 @@ fn assert_log_lacks_prefix(lines: &[String], prefix: &str) {
 }
 
 fn assert_in_place_sync_log(git_log: &Path, branch: &str) {
+    assert_in_place_sync_log_with_remote(git_log, "origin", branch);
+}
+
+fn assert_in_place_sync_log_with_remote(git_log: &Path, remote: &str, branch: &str) {
     let lines = git_log_lines(git_log);
-    assert_log_has_line(&lines, &format!("fetch origin {branch}"));
-    assert_log_has_line(&lines, &format!("merge origin/{branch} --ff-only"));
+    assert_log_has_line(&lines, &format!("fetch {remote} {branch}"));
+    assert_log_has_line(&lines, &format!("merge {remote}/{branch} --ff-only"));
     assert_log_lacks_prefix(&lines, "checkout ");
     assert!(
         !lines
             .iter()
-            .any(|line| line == &format!("fetch origin {branch}:{branch}")),
+            .any(|line| line == &format!("fetch {remote} {branch}:{branch}")),
         "must not use refspec on default branch: {lines:?}"
     );
 }
 
 fn assert_refspec_sync_log(git_log: &Path, branch: &str) {
+    assert_refspec_sync_log_with_remote(git_log, "origin", branch);
+}
+
+fn assert_refspec_sync_log_with_remote(git_log: &Path, remote: &str, branch: &str) {
     let lines = git_log_lines(git_log);
-    assert_log_has_line(&lines, &format!("fetch origin {branch}:{branch}"));
+    assert_log_has_line(&lines, &format!("fetch {remote} {branch}:{branch}"));
     assert_log_lacks_prefix(&lines, "checkout ");
     assert_log_lacks_prefix(&lines, "merge ");
 }
@@ -218,6 +267,30 @@ fn post_merge_sync_uses_git_head_fallback_when_gh_view_fails() {
     let (code, _, _) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
     assert_eq!(code, 0);
     assert_in_place_sync_log(&gl, "develop");
+}
+
+#[test]
+fn post_merge_sync_uses_upstream_remote_for_head_fetch_and_merge() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (gd, gh, mb, gl) = setup_post_merge_env_with_git_remote(
+        tmp.path(),
+        0,
+        None,
+        GitMockConfig {
+            upstream_ref: Some("upstream/develop"),
+            remotes: &["origin"],
+            remote_head: Some("upstream/develop"),
+            current_branch: Some("develop"),
+            merge_exit: 0,
+        },
+    );
+    create_test_marker(tmp.path());
+    let (code, _, _) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
+    assert_eq!(code, 0);
+    assert_in_place_sync_log_with_remote(&gl, "upstream", "develop");
+    let lines = git_log_lines(&gl);
+    assert_log_lacks_prefix(&lines, "fetch origin ");
+    assert_log_lacks_prefix(&lines, "merge origin/");
 }
 
 #[test]

--- a/crates/csa-hooks/src/merge_guard/tests_post_merge_sync.rs
+++ b/crates/csa-hooks/src/merge_guard/tests_post_merge_sync.rs
@@ -294,6 +294,30 @@ fn post_merge_sync_uses_upstream_remote_for_head_fetch_and_merge() {
 }
 
 #[test]
+fn post_merge_sync_ignores_local_branch_upstream_for_primary_remote() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (gd, gh, mb, gl) = setup_post_merge_env_with_git_remote(
+        tmp.path(),
+        0,
+        None,
+        GitMockConfig {
+            upstream_ref: Some("main"),
+            remotes: &["origin"],
+            remote_head: Some("origin/main"),
+            current_branch: Some("feature"),
+            merge_exit: 0,
+        },
+    );
+    create_test_marker(tmp.path());
+    let (code, _, _) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
+    assert_eq!(code, 0);
+    assert_refspec_sync_log_with_remote(&gl, "origin", "main");
+    let lines = git_log_lines(&gl);
+    assert_log_lacks_prefix(&lines, "fetch main ");
+    assert_log_lacks_prefix(&lines, "merge main/");
+}
+
+#[test]
 fn post_merge_sync_skips_when_all_default_detection_fails() {
     let tmp = tempfile::tempdir().unwrap();
     let (gd, gh, mb, gl) =


### PR DESCRIPTION
Closes #1076.

## Summary
`_post_merge_sync` in the gh wrapper previously hardcoded `origin` for default-branch detection, fetch, and the refspec/merge steps. For users whose primary remote is `upstream`, `github`, or any other name, the post-merge sync silently skipped or targeted the wrong remote.

## Fix
Detect primary remote dynamically at function entry:
1. `git rev-parse --abbrev-ref @{upstream} | sed s!/.*!!` — prefer the remote the current branch tracks
2. fallback `git remote | head -n1`
3. if none, return 0 (nothing to sync)

Substitute the resolved `${PRIMARY_REMOTE}` for every hardcoded `origin` reference inside the function.

## Test plan
- [x] `cargo test -p csa-hooks`
- [x] New test: non-origin primary remote exercises fetch/merge against `${PRIMARY_REMOTE}` not `origin`
- [x] Existing post_merge_sync_* tests (default origin) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)