### PR TITLE
docs(cli): advertise max thinking-budget alias in --thinking help (#1081)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "chrono",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.548"
+version = "0.1.549"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.548"
+version = "0.1.549"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -160,7 +160,7 @@ pub enum Commands {
         #[arg(short, long)]
         model: Option<String>,
 
-        /// Thinking budget (low, medium, high, xhigh)
+        /// Thinking budget (low, medium, high, xhigh, max)
         #[arg(long)]
         thinking: Option<String>,
 

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -348,7 +348,7 @@ pub struct DebateArgs {
     #[arg(long)]
     pub model_spec: Option<String>,
 
-    /// Thinking budget (low, medium, high, xhigh)
+    /// Thinking budget (low, medium, high, xhigh, max)
     #[arg(long)]
     pub thinking: Option<String>,
 

--- a/crates/csa-config/src/config_tool.rs
+++ b/crates/csa-config/src/config_tool.rs
@@ -64,13 +64,13 @@ pub struct ToolConfig {
     pub default_model: Option<String>,
     /// Default thinking budget used when `--tool` is explicit but `--thinking` is omitted.
     ///
-    /// Accepts the same values as `--thinking`: low, medium, high, xhigh, or a number.
+    /// Accepts the same values as `--thinking`: low, medium, high, xhigh, max, or a number.
     /// Lower priority than `--thinking` and `thinking_lock`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_thinking: Option<String>,
     /// Lock thinking budget for this tool. When set, any CLI `--thinking` or
     /// `--model-spec` thinking override is silently replaced with this value.
-    /// Accepts the same values as `--thinking`: low, medium, high, xhigh, or a number.
+    /// Accepts the same values as `--thinking`: low, medium, high, xhigh, max, or a number.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking_lock: Option<String>,
     /// Per-tool initial-response timeout override (seconds).

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -621,7 +621,7 @@ pub struct GlobalToolConfig {
     pub memory_swap_max_mb: Option<u64>,
     /// Lock thinking budget for this tool. When set, any CLI `--thinking` or
     /// `--model-spec` thinking override is silently replaced with this value.
-    /// Accepts: low, medium, high, xhigh, or a numeric token count.
+    /// Accepts: low, medium, high, xhigh, max, or a numeric token count.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking_lock: Option<String>,
     /// API key for fallback authentication. Used when OAuth quota is exhausted


### PR DESCRIPTION
Closes #1081.

## Summary
The `max` thinking-budget alias was already accepted by the parser (#1062 / #1065), but the `--thinking` help text in `csa run` and `csa review` still advertised only "low, medium, high, xhigh". Users copy-pasting `max` from Claude CLI configuration received no indication it was supported.

## Fix
Update the doc comments on `--thinking` flags in `cli.rs:163` and `cli_review.rs:351` to list `max` alongside the other aliases.

## Test plan
- [x] `cargo build -p cli-sub-agent`
- [x] `just pre-commit`
- [x] `csa run --help | grep -- --thinking` advertises max

🤖 Generated with [Claude Code](https://claude.com/claude-code)