### PR TITLE
feat(csa-config): preferences.primary_writer_spec default model-spec (#1073)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "chrono",
@@ -565,6 +565,7 @@ dependencies = [
  "tokio",
  "tokuin",
  "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "ulid",
@@ -721,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -741,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "chrono",
@@ -759,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -774,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "chrono",
@@ -788,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -815,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "chrono",
@@ -844,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "axum",
@@ -867,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "chrono",
@@ -904,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -920,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "chrono",
@@ -938,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4489,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.549"
+version = "0.1.550"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.549"
+version = "0.1.550"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/Cargo.toml
+++ b/crates/cli-sub-agent/Cargo.toml
@@ -36,6 +36,7 @@ tempfile.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
+toml_edit.workspace = true
 chrono.workspace = true
 ulid.workspace = true
 sysinfo.workspace = true

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -583,6 +583,28 @@ pub enum ConfigCommands {
         #[arg(long)]
         cd: Option<String>,
     },
+    /// Set a scalar config value by dotted key path.
+    ///
+    /// Defaults to the global config. Use --project to write `.csa/config.toml`.
+    Set {
+        /// Dotted key path (e.g., "preferences.primary_writer_spec")
+        key: String,
+
+        /// String value to write
+        value: String,
+
+        /// Write project config instead of global config
+        #[arg(long, conflicts_with = "global")]
+        project: bool,
+
+        /// Write global config (default)
+        #[arg(long, conflicts_with = "project")]
+        global: bool,
+
+        /// Working directory for --project (defaults to CWD)
+        #[arg(long)]
+        cd: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -14,6 +14,9 @@ use helpers::{format_missing_key_message, format_toml_value, resolve_key, sugges
 #[path = "config_cmds_display.rs"]
 mod display;
 use display::{inject_resolved_tool_transports_json, inject_resolved_tool_transports_toml};
+#[path = "config_cmds_set.rs"]
+mod set;
+pub(crate) use set::handle_config_set;
 
 pub(crate) fn handle_config_show(cd: Option<String>, format: OutputFormat) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;

--- a/crates/cli-sub-agent/src/config_cmds_set.rs
+++ b/crates/cli-sub-agent/src/config_cmds_set.rs
@@ -1,0 +1,194 @@
+use anyhow::Result;
+use csa_config::{GlobalConfig, ProjectConfig};
+
+pub(crate) fn handle_config_set(
+    key: String,
+    value: String,
+    project: bool,
+    _global: bool,
+    cd: Option<String>,
+) -> Result<()> {
+    validate_config_set_value(&key, &value)?;
+
+    let path = if project {
+        let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+        ProjectConfig::config_path(&project_root)
+    } else {
+        GlobalConfig::config_path()?
+    };
+
+    write_string_config_value(&path, &key, &value)
+}
+
+fn validate_config_set_value(key: &str, value: &str) -> Result<()> {
+    if key == "preferences.primary_writer_spec" {
+        csa_executor::ModelSpec::parse(value).map_err(|err| {
+            anyhow::anyhow!(
+                "Invalid preferences.primary_writer_spec: {err}\n\
+                 Expected format: tool/provider/model/thinking_budget"
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn write_string_config_value(path: &std::path::Path, key: &str, value: &str) -> Result<()> {
+    let mut doc = match std::fs::read_to_string(path) {
+        Ok(content) if !content.trim().is_empty() => content
+            .parse::<toml_edit::DocumentMut>()
+            .map_err(|err| anyhow::anyhow!("TOML parse error: {err}"))?,
+        Ok(_) => toml_edit::DocumentMut::new(),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => toml_edit::DocumentMut::new(),
+        Err(err) => return Err(err.into()),
+    };
+
+    set_document_string_value(&mut doc, key, value)?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, doc.to_string())?;
+    Ok(())
+}
+
+fn set_document_string_value(
+    doc: &mut toml_edit::DocumentMut,
+    key: &str,
+    value: &str,
+) -> Result<()> {
+    let parts = parse_dotted_key(key)?;
+    set_table_string_value(doc.as_table_mut(), &parts, value)
+}
+
+fn parse_dotted_key(key: &str) -> Result<Vec<&str>> {
+    let parts: Vec<&str> = key.split('.').collect();
+    if parts.is_empty() || parts.iter().any(|part| part.is_empty()) {
+        anyhow::bail!("Invalid config key path: {key}");
+    }
+    Ok(parts)
+}
+
+fn set_table_string_value(table: &mut toml_edit::Table, parts: &[&str], value: &str) -> Result<()> {
+    let Some((head, tail)) = parts.split_first() else {
+        anyhow::bail!("Invalid empty config key path");
+    };
+
+    if tail.is_empty() {
+        table[head] = toml_edit::value(value);
+        return Ok(());
+    }
+
+    if !table.contains_key(head) || table[head].is_none() {
+        table[head] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+
+    let Some(child) = table[head].as_table_mut() else {
+        anyhow::bail!("Cannot set {head}: existing value is not a table");
+    };
+
+    set_table_string_value(child, tail, value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config_cmds::{build_global_display_toml, resolve_effective_key};
+    use crate::test_env_lock::TEST_ENV_LOCK;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe {
+                match self.original.as_deref() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn set_document_string_value_creates_nested_preferences_key() {
+        let mut doc = toml_edit::DocumentMut::new();
+
+        set_document_string_value(
+            &mut doc,
+            "preferences.primary_writer_spec",
+            "codex/openai/gpt-5.4/high",
+        )
+        .unwrap();
+
+        assert_eq!(
+            doc["preferences"]["primary_writer_spec"].as_str(),
+            Some("codex/openai/gpt-5.4/high")
+        );
+    }
+
+    #[test]
+    fn handle_config_set_global_primary_writer_spec_round_trips() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let config_root = dir.path().join("xdg-config");
+        std::fs::create_dir_all(&config_root).unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", dir.path());
+        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+
+        handle_config_set(
+            "preferences.primary_writer_spec".to_string(),
+            "codex/openai/gpt-5.4/high".to_string(),
+            false,
+            false,
+            None,
+        )
+        .unwrap();
+
+        let value = resolve_effective_key(
+            Some(dir.path()),
+            "preferences.primary_writer_spec",
+            false,
+            false,
+        )
+        .unwrap()
+        .expect("primary_writer_spec should resolve");
+        assert_eq!(value.as_str(), Some("codex/openai/gpt-5.4/high"));
+
+        let rendered = toml::to_string_pretty(
+            &build_global_display_toml(&GlobalConfig::load().unwrap()).unwrap(),
+        )
+        .unwrap();
+        assert!(rendered.contains("primary_writer_spec = \"codex/openai/gpt-5.4/high\""));
+    }
+
+    #[test]
+    fn handle_config_set_rejects_invalid_primary_writer_spec() {
+        let err = handle_config_set(
+            "preferences.primary_writer_spec".to_string(),
+            "codex/openai/missing-thinking".to_string(),
+            false,
+            false,
+            None,
+        )
+        .expect_err("invalid model spec should fail before writing");
+
+        assert!(
+            err.to_string()
+                .contains("Invalid preferences.primary_writer_spec"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/config_cmds_set.rs
+++ b/crates/cli-sub-agent/src/config_cmds_set.rs
@@ -5,7 +5,6 @@ pub(crate) fn handle_config_set(
     key: String,
     value: String,
     project: bool,
-    _global: bool,
     cd: Option<String>,
 ) -> Result<()> {
     validate_config_set_value(&key, &value)?;
@@ -17,7 +16,7 @@ pub(crate) fn handle_config_set(
         GlobalConfig::config_path()?
     };
 
-    write_string_config_value(&path, &key, &value)
+    write_config_value(&path, &key, &value)
 }
 
 fn validate_config_set_value(key: &str, value: &str) -> Result<()> {
@@ -33,7 +32,7 @@ fn validate_config_set_value(key: &str, value: &str) -> Result<()> {
     Ok(())
 }
 
-fn write_string_config_value(path: &std::path::Path, key: &str, value: &str) -> Result<()> {
+fn write_config_value(path: &std::path::Path, key: &str, value: &str) -> Result<()> {
     let mut doc = match std::fs::read_to_string(path) {
         Ok(content) if !content.trim().is_empty() => content
             .parse::<toml_edit::DocumentMut>()
@@ -43,7 +42,7 @@ fn write_string_config_value(path: &std::path::Path, key: &str, value: &str) -> 
         Err(err) => return Err(err.into()),
     };
 
-    set_document_string_value(&mut doc, key, value)?;
+    set_document_config_value(&mut doc, key, value)?;
 
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -52,13 +51,13 @@ fn write_string_config_value(path: &std::path::Path, key: &str, value: &str) -> 
     Ok(())
 }
 
-fn set_document_string_value(
+fn set_document_config_value(
     doc: &mut toml_edit::DocumentMut,
     key: &str,
     value: &str,
 ) -> Result<()> {
     let parts = parse_dotted_key(key)?;
-    set_table_string_value(doc.as_table_mut(), &parts, value)
+    set_table_config_value(doc.as_table_mut(), &parts, key, value, "")
 }
 
 fn parse_dotted_key(key: &str) -> Result<Vec<&str>> {
@@ -69,13 +68,27 @@ fn parse_dotted_key(key: &str) -> Result<Vec<&str>> {
     Ok(parts)
 }
 
-fn set_table_string_value(table: &mut toml_edit::Table, parts: &[&str], value: &str) -> Result<()> {
+fn set_table_config_value(
+    table: &mut toml_edit::Table,
+    parts: &[&str],
+    target_key: &str,
+    value: &str,
+    parent_path: &str,
+) -> Result<()> {
     let Some((head, tail)) = parts.split_first() else {
         anyhow::bail!("Invalid empty config key path");
     };
+    let current_path = if parent_path.is_empty() {
+        (*head).to_string()
+    } else {
+        format!("{parent_path}.{head}")
+    };
 
     if tail.is_empty() {
-        table[head] = toml_edit::value(value);
+        let toml_value = value
+            .parse::<toml_edit::Value>()
+            .unwrap_or_else(|_| toml_edit::Value::from(value));
+        table[head] = toml_edit::Item::Value(toml_value);
         return Ok(());
     }
 
@@ -83,11 +96,25 @@ fn set_table_string_value(table: &mut toml_edit::Table, parts: &[&str], value: &
         table[head] = toml_edit::Item::Table(toml_edit::Table::new());
     }
 
-    let Some(child) = table[head].as_table_mut() else {
-        anyhow::bail!("Cannot set {head}: existing value is not a table");
+    let item = &mut table[head];
+    if item.as_inline_table().is_some() {
+        anyhow::bail!(
+            "Cannot set config key '{}': existing path '{}' is an inline table; \
+             inline tables are not currently supported. Convert it to a standard TOML table first.",
+            target_key,
+            current_path
+        );
+    }
+
+    let Some(child) = item.as_table_mut() else {
+        anyhow::bail!(
+            "Cannot set config key '{}': existing path '{}' is not a table",
+            target_key,
+            current_path
+        );
     };
 
-    set_table_string_value(child, tail, value)
+    set_table_config_value(child, tail, target_key, value, &current_path)
 }
 
 #[cfg(test)]
@@ -123,10 +150,10 @@ mod tests {
     }
 
     #[test]
-    fn set_document_string_value_creates_nested_preferences_key() {
+    fn set_document_config_value_creates_nested_preferences_string_key() {
         let mut doc = toml_edit::DocumentMut::new();
 
-        set_document_string_value(
+        set_document_config_value(
             &mut doc,
             "preferences.primary_writer_spec",
             "codex/openai/gpt-5.4/high",
@@ -136,6 +163,45 @@ mod tests {
         assert_eq!(
             doc["preferences"]["primary_writer_spec"].as_str(),
             Some("codex/openai/gpt-5.4/high")
+        );
+    }
+
+    #[test]
+    fn set_document_config_value_preserves_boolean_type() {
+        let mut doc = toml_edit::DocumentMut::new();
+
+        set_document_config_value(&mut doc, "tools.codex.enabled", "false").unwrap();
+
+        assert_eq!(doc["tools"]["codex"]["enabled"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn set_document_config_value_preserves_integer_type() {
+        let mut doc = toml_edit::DocumentMut::new();
+
+        set_document_config_value(&mut doc, "defaults.max_concurrent", "7").unwrap();
+
+        assert_eq!(doc["defaults"]["max_concurrent"].as_integer(), Some(7));
+    }
+
+    #[test]
+    fn set_document_config_value_rejects_inline_table_parent_with_context() {
+        let mut doc = "[tools]\ncodex = { enabled = true }\n"
+            .parse::<toml_edit::DocumentMut>()
+            .unwrap();
+
+        let err = set_document_config_value(&mut doc, "tools.codex.model", "gpt-5")
+            .expect_err("inline table parent should be rejected");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("Cannot set config key 'tools.codex.model'"),
+            "{message}"
+        );
+        assert!(message.contains("existing path 'tools.codex'"), "{message}");
+        assert!(
+            message.contains("inline tables are not currently supported"),
+            "{message}"
         );
     }
 
@@ -151,7 +217,6 @@ mod tests {
         handle_config_set(
             "preferences.primary_writer_spec".to_string(),
             "codex/openai/gpt-5.4/high".to_string(),
-            false,
             false,
             None,
         )
@@ -179,7 +244,6 @@ mod tests {
         let err = handle_config_set(
             "preferences.primary_writer_spec".to_string(),
             "codex/openai/missing-thinking".to_string(),
-            false,
             false,
             None,
         )

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -498,6 +498,15 @@ async fn run() -> Result<()> {
             } => {
                 config_cmds::handle_config_get(key, default, project, global, cd)?;
             }
+            ConfigCommands::Set {
+                key,
+                value,
+                project,
+                global,
+                cd,
+            } => {
+                config_cmds::handle_config_set(key, value, project, global, cd)?;
+            }
         },
         Commands::Memory { command } => {
             memory_cmd::handle_memory_command(command).await?;

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -502,10 +502,10 @@ async fn run() -> Result<()> {
                 key,
                 value,
                 project,
-                global,
                 cd,
+                ..
             } => {
-                config_cmds::handle_config_set(key, value, project, global, cd)?;
+                config_cmds::handle_config_set(key, value, project, cd)?;
             }
         },
         Commands::Memory { command } => {

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -25,44 +25,17 @@ use crate::run_cmd_tool_selection::{
     resolve_last_session_selection, resolve_return_target_session_id, resolve_skill_and_prompt,
     resolve_tool_by_strategy,
 };
+#[path = "run_cmd_execute_routing.rs"]
+mod routing;
+use routing::{
+    RunModelSelectionFlags, resolve_primary_writer_spec_for_run, resolve_run_tier_context,
+};
 
 use super::attempt::{RunLoopCompletion, RunLoopRequest, execute_run_loop};
 use super::resume::{
     detect_effective_repo, find_recent_interrupted_skill_session, resolve_run_timeout_seconds,
     skill_session_description,
 };
-
-fn resolve_run_tier_context(
-    config: Option<&ProjectConfig>,
-    tool_name: &str,
-    strategy_resolved_tier_name: Option<String>,
-    fallback_tier_name: Option<String>,
-    force_ignore_tier_setting: bool,
-    user_model_spec_explicit: bool,
-    user_explicit_tool: bool,
-) -> (bool, bool, Option<String>) {
-    if force_ignore_tier_setting || user_model_spec_explicit {
-        return (false, false, None);
-    }
-
-    let resolved_tier_name = strategy_resolved_tier_name.or_else(|| {
-        (!user_explicit_tool)
-            .then_some(fallback_tier_name)
-            .flatten()
-    });
-    let tier_auto_select = !user_explicit_tool && resolved_tier_name.is_some();
-    let failover_on_crash_enabled = tier_auto_select
-        || (user_explicit_tool
-            && resolved_tier_name.as_deref().is_some_and(|tier_name| {
-                config.is_some_and(|cfg| cfg.tier_contains_tool(tier_name, tool_name))
-            }));
-
-    (
-        tier_auto_select,
-        failover_on_crash_enabled,
-        resolved_tier_name,
-    )
-}
 
 fn finalize_prompt_text(
     project_root: &Path,
@@ -375,6 +348,18 @@ pub(crate) async fn handle_run(
     else {
         return Ok(1);
     };
+    let model_selection_flags = RunModelSelectionFlags {
+        tool: tool.is_some(),
+        auto_route: auto_route.is_some(),
+        skill: skill.is_some(),
+        model_spec: model_spec.is_some(),
+        model: model.is_some(),
+        thinking: thinking.is_some(),
+        tier: tier.is_some(),
+    };
+    let primary_writer_spec =
+        resolve_primary_writer_spec_for_run(model_selection_flags, config.as_ref(), &global_config);
+    let model_spec = model_spec.or(primary_writer_spec);
     let effective_tier = tier.or(auto_route.clone());
 
     // Track whether user explicitly provided --tool on the CLI (before skill

--- a/crates/cli-sub-agent/src/run_cmd_execute_routing.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_routing.rs
@@ -1,0 +1,67 @@
+use csa_config::ProjectConfig;
+
+pub(super) fn resolve_run_tier_context(
+    config: Option<&ProjectConfig>,
+    tool_name: &str,
+    strategy_resolved_tier_name: Option<String>,
+    fallback_tier_name: Option<String>,
+    force_ignore_tier_setting: bool,
+    user_model_spec_explicit: bool,
+    user_explicit_tool: bool,
+) -> (bool, bool, Option<String>) {
+    if force_ignore_tier_setting || user_model_spec_explicit {
+        return (false, false, None);
+    }
+
+    let resolved_tier_name = strategy_resolved_tier_name.or_else(|| {
+        (!user_explicit_tool)
+            .then_some(fallback_tier_name)
+            .flatten()
+    });
+    let tier_auto_select = !user_explicit_tool && resolved_tier_name.is_some();
+    let failover_on_crash_enabled = tier_auto_select
+        || (user_explicit_tool
+            && resolved_tier_name.as_deref().is_some_and(|tier_name| {
+                config.is_some_and(|cfg| cfg.tier_contains_tool(tier_name, tool_name))
+            }));
+
+    (
+        tier_auto_select,
+        failover_on_crash_enabled,
+        resolved_tier_name,
+    )
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct RunModelSelectionFlags {
+    pub(super) tool: bool,
+    pub(super) auto_route: bool,
+    pub(super) skill: bool,
+    pub(super) model_spec: bool,
+    pub(super) model: bool,
+    pub(super) thinking: bool,
+    pub(super) tier: bool,
+}
+
+impl RunModelSelectionFlags {
+    fn any_present(self) -> bool {
+        self.tool
+            || self.auto_route
+            || self.skill
+            || self.model_spec
+            || self.model
+            || self.thinking
+            || self.tier
+    }
+}
+
+pub(super) fn resolve_primary_writer_spec_for_run(
+    flags: RunModelSelectionFlags,
+    config: Option<&ProjectConfig>,
+    global_config: &csa_config::GlobalConfig,
+) -> Option<String> {
+    (!flags.any_present())
+        .then(|| csa_config::global::effective_primary_writer_spec(config, global_config))
+        .flatten()
+        .map(ToOwned::to_owned)
+}

--- a/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
@@ -1,8 +1,13 @@
-use super::{finalize_prompt_text, resolve_run_tier_context};
-use crate::run_cmd_tool_selection::resolve_skill_and_prompt;
+use super::{
+    RunModelSelectionFlags, finalize_prompt_text, resolve_primary_writer_spec_for_run,
+    resolve_run_tier_context,
+};
+use crate::run_cmd_tool_selection::{resolve_skill_and_prompt, resolve_tool_by_strategy};
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use chrono::Utc;
-use csa_config::{ProjectConfig, ProjectMeta, TierConfig, TierStrategy};
+use csa_config::global::PreferencesConfig;
+use csa_config::{GlobalConfig, ProjectConfig, ProjectMeta, TierConfig, TierStrategy};
+use csa_core::types::{ToolName, ToolSelectionStrategy};
 use std::collections::HashMap;
 use std::fs;
 use tempfile::TempDir;
@@ -50,6 +55,15 @@ fn make_test_config() -> ProjectConfig {
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }
+}
+
+fn make_config_with_primary_writer_spec(spec: &str) -> ProjectConfig {
+    let mut config = make_test_config();
+    config.preferences = Some(PreferencesConfig {
+        primary_writer_spec: Some(spec.to_string()),
+        ..Default::default()
+    });
+    config
 }
 
 fn atomic_commit_block<'a>(prompt: &'a str, user_task_marker: &str) -> &'a str {
@@ -429,4 +443,99 @@ fn resolve_run_tier_context_drops_tier_for_explicit_model_spec() {
     assert!(!tier_auto_select);
     assert!(!failover_on_crash_enabled);
     assert!(resolved_tier_name.is_none());
+}
+
+#[test]
+fn primary_writer_spec_seeds_run_without_model_selecting_flags_and_bypasses_tiers() {
+    let tmp = TempDir::new().expect("tempdir");
+    let config = make_config_with_primary_writer_spec("codex/openai/gpt-5.4/high");
+    let global_config = GlobalConfig::default();
+
+    let spec = resolve_primary_writer_spec_for_run(
+        RunModelSelectionFlags::default(),
+        Some(&config),
+        &global_config,
+    )
+    .expect("primary writer spec should apply");
+    let resolution = resolve_tool_by_strategy(
+        &ToolSelectionStrategy::AnyAvailable,
+        Some(&spec),
+        None,
+        Some(&config),
+        &global_config,
+        tmp.path(),
+        false,
+        false,
+        false,
+        None,
+        false,
+    )
+    .expect("primary writer spec should resolve as model-spec");
+
+    assert_eq!(resolution.tool, ToolName::Codex);
+    assert_eq!(resolution.model_spec.as_deref(), Some(spec.as_str()));
+    assert!(
+        resolution.resolved_tier_name.is_none(),
+        "synthetic model-spec must keep --model-spec tier bypass semantics"
+    );
+}
+
+#[test]
+fn primary_writer_spec_prefers_project_over_global() {
+    let config = make_config_with_primary_writer_spec("codex/openai/gpt-5.4/high");
+    let mut global_config = GlobalConfig::default();
+    global_config.preferences.primary_writer_spec =
+        Some("claude-code/anthropic/default/xhigh".to_string());
+
+    let spec = resolve_primary_writer_spec_for_run(
+        RunModelSelectionFlags::default(),
+        Some(&config),
+        &global_config,
+    );
+
+    assert_eq!(spec.as_deref(), Some("codex/openai/gpt-5.4/high"));
+}
+
+#[test]
+fn primary_writer_spec_is_suppressed_by_any_model_selecting_flag() {
+    let config = make_config_with_primary_writer_spec("codex/openai/gpt-5.4/high");
+    let global_config = GlobalConfig::default();
+    let cases = [
+        RunModelSelectionFlags {
+            tool: true,
+            ..Default::default()
+        },
+        RunModelSelectionFlags {
+            auto_route: true,
+            ..Default::default()
+        },
+        RunModelSelectionFlags {
+            skill: true,
+            ..Default::default()
+        },
+        RunModelSelectionFlags {
+            model_spec: true,
+            ..Default::default()
+        },
+        RunModelSelectionFlags {
+            model: true,
+            ..Default::default()
+        },
+        RunModelSelectionFlags {
+            thinking: true,
+            ..Default::default()
+        },
+        RunModelSelectionFlags {
+            tier: true,
+            ..Default::default()
+        },
+    ];
+
+    for flags in cases {
+        let spec = resolve_primary_writer_spec_for_run(flags, Some(&config), &global_config);
+        assert!(
+            spec.is_none(),
+            "flags should suppress primary writer: {flags:?}"
+        );
+    }
 }

--- a/crates/cli-sub-agent/tests/config_primary_writer_spec_e2e.rs
+++ b/crates/cli-sub-agent/tests/config_primary_writer_spec_e2e.rs
@@ -1,0 +1,51 @@
+use std::process::Command;
+
+fn csa_cmd(tmp: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+#[test]
+fn config_set_get_show_round_trips_primary_writer_spec() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let set_output = csa_cmd(tmp.path())
+        .args([
+            "config",
+            "set",
+            "preferences.primary_writer_spec",
+            "codex/openai/gpt-5.4/high",
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa config set");
+    assert!(
+        set_output.status.success(),
+        "config set should exit 0, stderr: {}",
+        String::from_utf8_lossy(&set_output.stderr)
+    );
+
+    let get_output = csa_cmd(tmp.path())
+        .args(["config", "get", "preferences.primary_writer_spec"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa config get");
+    assert!(get_output.status.success(), "config get should exit 0");
+    assert_eq!(
+        String::from_utf8_lossy(&get_output.stdout).trim(),
+        "codex/openai/gpt-5.4/high"
+    );
+
+    let show_output = csa_cmd(tmp.path())
+        .args(["config", "show"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa config show");
+    assert!(show_output.status.success(), "config show should exit 0");
+    let stdout = String::from_utf8_lossy(&show_output.stdout);
+    assert!(stdout.contains("primary_writer_spec = \"codex/openai/gpt-5.4/high\""));
+}

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -185,6 +185,12 @@ pub enum StateDirOnExceed {
 /// User preferences for tool selection and routing.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PreferencesConfig {
+    /// Default exact model selector for `csa run` when no model-selecting CLI
+    /// flag is present.
+    ///
+    /// Format matches `csa run --model-spec`: `tool/provider/model/thinking_budget`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_writer_spec: Option<String>,
     /// Tool priority order for auto-selection. First = most preferred.
     ///
     /// Affects: heterogeneous candidate ordering, reviewer allocation,
@@ -570,6 +576,19 @@ pub fn effective_tool_priority<'a>(
         .map(|p| p.tool_priority.as_slice())
         .filter(|p| !p.is_empty())
         .unwrap_or(&global_config.preferences.tool_priority)
+}
+
+/// Resolve the default exact writer model spec for `csa run`.
+///
+/// Project-level preferences override global preferences.
+pub fn effective_primary_writer_spec<'a>(
+    project_config: Option<&'a crate::ProjectConfig>,
+    global_config: &'a GlobalConfig,
+) -> Option<&'a str> {
+    project_config
+        .and_then(|p| p.preferences.as_ref())
+        .and_then(|p| p.primary_writer_spec.as_deref())
+        .or(global_config.preferences.primary_writer_spec.as_deref())
 }
 
 /// Sort tools using effective priority from project (if set) or global config.

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -34,8 +34,11 @@ max_concurrent = 3  # Default max parallel instances per tool
 
 # Tool priority for auto-selection (heterogeneous routing, review, debate).
 # First = most preferred. Tools not listed keep their default order.
+# Optional: primary_writer_spec seeds `csa run` when no model-selecting
+# flag is given. Format matches --model-spec: tool/provider/model/thinking_budget.
 # Example: prefer Claude Code for worker tasks, then Codex.
 # [preferences]
+# primary_writer_spec = "codex/openai/gpt-5.4/high"
 # tool_priority = ["claude-code", "codex", "gemini-cli", "opencode"]
 
 # Review workflow: which tool to use for code review.

--- a/crates/csa-config/src/global_tests_priority.rs
+++ b/crates/csa-config/src/global_tests_priority.rs
@@ -82,9 +82,14 @@ fn sort_by_priority_method_uses_preferences() {
 fn preferences_deserialize() {
     let toml_str = r#"
 [preferences]
+primary_writer_spec = "codex/openai/gpt-5.4/high"
 tool_priority = ["claude-code", "codex"]
 "#;
     let config: GlobalConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(
+        config.preferences.primary_writer_spec.as_deref(),
+        Some("codex/openai/gpt-5.4/high")
+    );
     assert_eq!(config.preferences.tool_priority.len(), 2);
     assert_eq!(config.preferences.tool_priority[0], "claude-code");
     assert_eq!(config.preferences.tool_priority[1], "codex");
@@ -93,6 +98,10 @@ tool_priority = ["claude-code", "codex"]
 #[test]
 fn preferences_default_empty() {
     let config = GlobalConfig::default();
+    assert!(
+        config.preferences.primary_writer_spec.is_none(),
+        "default primary_writer_spec should be unset"
+    );
     assert!(
         config.preferences.tool_priority.is_empty(),
         "default tool_priority should be empty"
@@ -109,6 +118,10 @@ fn default_template_contains_preferences_section() {
     assert!(
         template.contains("tool_priority"),
         "template should contain tool_priority key"
+    );
+    assert!(
+        template.contains("primary_writer_spec"),
+        "template should contain primary_writer_spec key"
     );
 }
 
@@ -159,6 +172,7 @@ fn effective_tool_priority_uses_project_override() {
     gc.preferences.tool_priority = vec!["codex".into(), "claude-code".into()];
     let pc = project_config_with_preferences(Some(PreferencesConfig {
         tool_priority: vec!["gemini-cli".into(), "opencode".into()],
+        ..Default::default()
     }));
     let result = effective_tool_priority(Some(&pc), &gc);
     assert_eq!(result, &["gemini-cli", "opencode"]);
@@ -170,6 +184,7 @@ fn effective_tool_priority_falls_back_when_project_empty() {
     gc.preferences.tool_priority = vec!["codex".into()];
     let pc = project_config_with_preferences(Some(PreferencesConfig {
         tool_priority: vec![],
+        ..Default::default()
     }));
     let result = effective_tool_priority(Some(&pc), &gc);
     assert_eq!(result, &["codex"]);
@@ -180,9 +195,60 @@ fn sort_tools_by_effective_priority_project_override() {
     let gc = GlobalConfig::default(); // empty global priority
     let pc = project_config_with_preferences(Some(PreferencesConfig {
         tool_priority: vec!["opencode".into(), "codex".into()],
+        ..Default::default()
     }));
     let tools = all_known_tools();
     let sorted = sort_tools_by_effective_priority(tools, Some(&pc), &gc);
     assert_eq!(sorted[0], ToolName::Opencode);
     assert_eq!(sorted[1], ToolName::Codex);
+}
+
+#[test]
+fn effective_primary_writer_spec_uses_global_when_no_project() {
+    let mut gc = GlobalConfig::default();
+    gc.preferences.primary_writer_spec = Some("codex/openai/gpt-5.4/high".into());
+
+    let result = effective_primary_writer_spec(None, &gc);
+
+    assert_eq!(result, Some("codex/openai/gpt-5.4/high"));
+}
+
+#[test]
+fn effective_primary_writer_spec_uses_project_override() {
+    let mut gc = GlobalConfig::default();
+    gc.preferences.primary_writer_spec = Some("codex/openai/gpt-5.4/high".into());
+    let pc = project_config_with_preferences(Some(PreferencesConfig {
+        primary_writer_spec: Some("claude-code/anthropic/default/xhigh".into()),
+        ..Default::default()
+    }));
+
+    let result = effective_primary_writer_spec(Some(&pc), &gc);
+
+    assert_eq!(result, Some("claude-code/anthropic/default/xhigh"));
+}
+
+#[test]
+fn effective_primary_writer_spec_falls_back_when_project_empty() {
+    let mut gc = GlobalConfig::default();
+    gc.preferences.primary_writer_spec = Some("codex/openai/gpt-5.4/high".into());
+    let pc = project_config_with_preferences(Some(PreferencesConfig {
+        primary_writer_spec: None,
+        ..Default::default()
+    }));
+
+    let result = effective_primary_writer_spec(Some(&pc), &gc);
+
+    assert_eq!(result, Some("codex/openai/gpt-5.4/high"));
+}
+
+#[test]
+fn primary_writer_spec_can_be_set_on_preferences() {
+    let mut config = GlobalConfig::default();
+
+    config.preferences.primary_writer_spec = Some("openai-compat/openai/gpt-5/high".into());
+
+    assert_eq!(
+        config.preferences.primary_writer_spec.as_deref(),
+        Some("openai-compat/openai/gpt-5/high")
+    );
 }

--- a/crates/csa-config/src/validate_tests_preferences.rs
+++ b/crates/csa-config/src/validate_tests_preferences.rs
@@ -23,6 +23,7 @@ fn test_validate_config_warns_but_passes_on_unknown_tool_priority() {
         tool_aliases: HashMap::new(),
         preferences: Some(crate::global::PreferencesConfig {
             tool_priority: vec!["codexx".into(), "codex".into()],
+            ..Default::default()
         }),
         session: Default::default(),
         memory: Default::default(),


### PR DESCRIPTION
Closes #1073. Adds scalar [preferences].primary_writer_spec config key (format: tool/provider/model/thinking, same as --model-spec). When csa run has no model-selecting flag, synthesizes --model-spec from this key. Precedence: CLI > project config > global config > tiers > tool defaults > tool_priority. Project config overrides global.