### PR TITLE
refactor(csa-executor): table-drive codex_stall_retry_downgrade non-downgrade test (#1078)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.550"
+version = "0.1.551"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.550"
+version = "0.1.551"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -372,23 +372,18 @@ mod tests {
             ThinkingBudget::Xhigh.codex_stall_retry_downgrade(),
             Some(ThinkingBudget::High)
         ));
-        assert!(ThinkingBudget::High.codex_stall_retry_downgrade().is_none());
-        assert!(
-            ThinkingBudget::Medium
-                .codex_stall_retry_downgrade()
-                .is_none()
-        );
-        assert!(ThinkingBudget::Low.codex_stall_retry_downgrade().is_none());
-        assert!(
-            ThinkingBudget::DefaultBudget
-                .codex_stall_retry_downgrade()
-                .is_none()
-        );
-        assert!(
-            ThinkingBudget::Custom(50000)
-                .codex_stall_retry_downgrade()
-                .is_none()
-        );
+        for budget in [
+            ThinkingBudget::High,
+            ThinkingBudget::Medium,
+            ThinkingBudget::Low,
+            ThinkingBudget::DefaultBudget,
+            ThinkingBudget::Custom(50000),
+        ] {
+            assert!(
+                budget.codex_stall_retry_downgrade().is_none(),
+                "expected no downgrade for {budget:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #1078. Converts 5 repeated assert! calls in codex_stall_retry_downgrade_covers_max to a table-driven for-loop over ThinkingBudget variants (High, Medium, Low, DefaultBudget, Custom(50_000)) with descriptive failure messages. Pure test refactor; behavior unchanged.