### PR TITLE
feat(csa-config): --hint-difficulty + prompt frontmatter for auto tier routing (#1066)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.551"
+version = "0.1.552"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.551"
+version = "0.1.552"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -89,11 +89,12 @@ pub enum Commands {
         /// Combine with --force-ignore-tier-setting to bypass tiers entirely.
         #[arg(long)]
         tool: Option<ToolArg>,
-
         /// Intent-based auto-routing through `[tier_mapping]` or a tier selector while keeping tool choice automatic.
         #[arg(long, value_name = "INTENT", conflicts_with = "tier")]
         auto_route: Option<String>,
-
+        /// Difficulty label looked up in `[tier_mapping]` when no explicit tier/model-spec is set.
+        #[arg(long, value_name = "LABEL")]
+        hint_difficulty: Option<String>,
         /// Run a named skill as a sub-agent (resolves SKILL.md + .skill.toml)
         #[arg(long)]
         skill: Option<String>,
@@ -131,7 +132,6 @@ pub enum Commands {
         /// Incompatible with --session, --last, --ephemeral.
         #[arg(long, conflicts_with_all = ["session", "last", "ephemeral"])]
         fork_call: bool,
-
         /// Session to return results to after fork-call completion.
         /// Values: "last" (most recent session), "auto" (auto-detect parent), or a session ID.
         #[arg(
@@ -144,11 +144,9 @@ pub enum Commands {
         /// Parent session ULID (defaults to CSA_SESSION_ID env var)
         #[arg(long, hide = true)]
         parent: Option<String>,
-
         /// Ephemeral session (no session persistence, auto-cleanup; tool runs in project dir)
         #[arg(long, conflicts_with = "session")]
         ephemeral: bool,
-
         /// Working directory (defaults to CWD)
         #[arg(long)]
         cd: Option<String>,

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -93,7 +93,7 @@ pub enum Commands {
         #[arg(long, value_name = "INTENT", conflicts_with = "tier")]
         auto_route: Option<String>,
         /// Difficulty label looked up in `[tier_mapping]` when no explicit tier/model-spec is set.
-        #[arg(long, value_name = "LABEL")]
+        #[arg(long, value_name = "LABEL", conflicts_with_all = ["tier", "auto_route"])]
         hint_difficulty: Option<String>,
         /// Run a named skill as a sub-agent (resolves SKILL.md + .skill.toml)
         #[arg(long)]

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -59,6 +59,10 @@ pub struct ReviewArgs {
     #[arg(long)]
     pub model_spec: Option<String>,
 
+    /// Difficulty label looked up in `[tier_mapping]` when no explicit tier/model-spec is set.
+    #[arg(long, value_name = "LABEL")]
+    pub hint_difficulty: Option<String>,
+
     /// Thinking budget (accepted for CLI compatibility but not used by review;
     /// thinking level is controlled via tier configuration)
     #[arg(long)]
@@ -347,6 +351,10 @@ pub struct DebateArgs {
     /// Use this for a single fixed model choice; use `--tier` for tier-managed routing and failover.
     #[arg(long)]
     pub model_spec: Option<String>,
+
+    /// Difficulty label looked up in `[tier_mapping]` when no explicit tier/model-spec is set.
+    #[arg(long, value_name = "LABEL")]
+    pub hint_difficulty: Option<String>,
 
     /// Thinking budget (low, medium, high, xhigh, max)
     #[arg(long)]

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -60,7 +60,7 @@ pub struct ReviewArgs {
     pub model_spec: Option<String>,
 
     /// Difficulty label looked up in `[tier_mapping]` when no explicit tier/model-spec is set.
-    #[arg(long, value_name = "LABEL")]
+    #[arg(long, value_name = "LABEL", conflicts_with = "tier")]
     pub hint_difficulty: Option<String>,
 
     /// Thinking budget (accepted for CLI compatibility but not used by review;
@@ -353,7 +353,7 @@ pub struct DebateArgs {
     pub model_spec: Option<String>,
 
     /// Difficulty label looked up in `[tier_mapping]` when no explicit tier/model-spec is set.
-    #[arg(long, value_name = "LABEL")]
+    #[arg(long, value_name = "LABEL", conflicts_with = "tier")]
     pub hint_difficulty: Option<String>,
 
     /// Thinking budget (low, medium, high, xhigh, max)

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -167,6 +167,9 @@ pub(crate) async fn handle_debate(
     let effective_question =
         crate::run_helpers::resolve_positional_stdin_sentinel(args.question)?.or(args.topic);
     let mut question = resolve_prompt_with_file(effective_question, args.prompt_file.as_deref())?;
+    let parsed_question = crate::difficulty_routing::strip_difficulty_frontmatter(question)?;
+    let frontmatter_difficulty = parsed_question.difficulty;
+    question = parsed_question.prompt;
     if let Some(ctx) = &args.context {
         question = format!("<debate-context>\n{ctx}\n</debate-context>\n\n{question}");
     }
@@ -208,6 +211,30 @@ pub(crate) async fn handle_debate(
             .and_then(|spec| spec.split('/').next())
             .and_then(|tool_name| crate::run_helpers::parse_tool_name(tool_name).ok())
     });
+    let effective_tier =
+        match crate::difficulty_routing::resolve_effective_tier_with_difficulty_hint(
+            config.as_ref(),
+            args.tier.as_deref(),
+            args.model_spec.as_deref(),
+            args.hint_difficulty.as_deref(),
+            frontmatter_difficulty.as_deref(),
+        ) {
+            Ok(tier) => tier,
+            Err(err) => {
+                return Err(crate::session_guard::persist_pre_exec_error_result(
+                    crate::session_guard::PreExecErrorCtx {
+                        project_root: &project_root,
+                        session_id: args.session.as_deref(),
+                        description: Some(debate_description.as_str()),
+                        parent: None,
+                        tool_name: explicit_tool.map(|tool| tool.as_str()),
+                        task_type: Some("debate"),
+                        tier_name: args.tier.as_deref(),
+                        error: err,
+                    },
+                ));
+            }
+        };
     let resolved_selection = match resolve_debate_selection(
         args.tool,
         args.model_spec.as_deref(),
@@ -216,7 +243,7 @@ pub(crate) async fn handle_debate(
         parent_tool.as_deref(),
         &project_root,
         args.force_override_user_config,
-        args.tier.as_deref(),
+        effective_tier.as_deref(),
         args.force_ignore_tier_setting,
     ) {
         Ok(resolved) => resolved,
@@ -229,7 +256,7 @@ pub(crate) async fn handle_debate(
                     parent: None,
                     tool_name: explicit_tool.map(|tool| tool.as_str()),
                     task_type: Some("debate"),
-                    tier_name: args.tier.as_deref(),
+                    tier_name: effective_tier.as_deref(),
                     error: err,
                 },
             ));
@@ -246,7 +273,7 @@ pub(crate) async fn handle_debate(
         resolve_debate_tier_name(
             config.as_ref(),
             &global_config,
-            args.tier.as_deref(),
+            effective_tier.as_deref(),
             args.force_override_user_config,
             args.force_ignore_tier_setting,
         )?

--- a/crates/cli-sub-agent/src/debate_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_resolve.rs
@@ -75,6 +75,7 @@ pub(crate) fn resolve_debate_selection(
         anyhow::bail!(
             "Direct --tool is restricted when tiers are configured. \
              Use --tier <name> to specify which tier's model/thinking config to use, \
+             --hint-difficulty <label> to route through [tier_mapping], \
              or add --force-ignore-tier-setting to override. \
              Available tiers: [{}]{alias_hint}",
             available.join(", ")

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -713,6 +713,20 @@ fn debate_cli_parses_thinking_flag() {
 }
 
 #[test]
+fn debate_cli_parses_hint_difficulty_flag() {
+    let args = parse_debate_args(&[
+        "csa",
+        "debate",
+        "--tool",
+        "claude-code",
+        "--hint-difficulty",
+        "architecture_design",
+        "question",
+    ]);
+    assert_eq!(args.hint_difficulty.as_deref(), Some("architecture_design"));
+}
+
+#[test]
 fn debate_cli_parses_no_stream_stdout_flag() {
     let args = parse_debate_args(&["csa", "debate", "--no-stream-stdout", "question"]);
     assert!(!args.stream_stdout);

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -727,6 +727,25 @@ fn debate_cli_parses_hint_difficulty_flag() {
 }
 
 #[test]
+fn debate_cli_hint_difficulty_conflicts_with_tier() {
+    use clap::Parser;
+
+    let err = match crate::cli::Cli::try_parse_from([
+        "csa",
+        "debate",
+        "--hint-difficulty",
+        "architecture_design",
+        "--tier",
+        "tier-2-standard",
+        "question",
+    ]) {
+        Ok(_) => panic!("hint-difficulty and tier should conflict"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
 fn debate_cli_parses_no_stream_stdout_flag() {
     let args = parse_debate_args(&["csa", "debate", "--no-stream-stdout", "question"]);
     assert!(!args.stream_stdout);

--- a/crates/cli-sub-agent/src/difficulty_routing.rs
+++ b/crates/cli-sub-agent/src/difficulty_routing.rs
@@ -1,0 +1,299 @@
+use anyhow::Result;
+use csa_config::ProjectConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedPromptDifficulty {
+    pub(crate) difficulty: Option<String>,
+    pub(crate) prompt: String,
+}
+
+pub(crate) fn strip_difficulty_frontmatter(prompt: String) -> Result<ParsedPromptDifficulty> {
+    let Some(body_start) = frontmatter_body_start(&prompt) else {
+        return Ok(ParsedPromptDifficulty {
+            difficulty: None,
+            prompt,
+        });
+    };
+
+    let mut line_start = body_start;
+    for line in prompt[body_start..].split_inclusive('\n') {
+        let line_end = line_start + line.len();
+        if line.trim_end_matches(['\r', '\n']) == "---" {
+            let frontmatter = &prompt[body_start..line_start];
+            let difficulty = parse_frontmatter_difficulty(frontmatter)?;
+            return Ok(ParsedPromptDifficulty {
+                difficulty,
+                prompt: prompt[line_end..].to_string(),
+            });
+        }
+        line_start = line_end;
+    }
+
+    if prompt[body_start..].trim_end_matches('\r') == "---" {
+        return Ok(ParsedPromptDifficulty {
+            difficulty: None,
+            prompt: String::new(),
+        });
+    }
+
+    anyhow::bail!("Malformed YAML frontmatter: opening '---' has no closing '---' delimiter")
+}
+
+fn frontmatter_body_start(prompt: &str) -> Option<usize> {
+    if prompt.starts_with("---\n") {
+        Some(4)
+    } else if prompt.starts_with("---\r\n") {
+        Some(5)
+    } else {
+        None
+    }
+}
+
+fn parse_frontmatter_difficulty(frontmatter: &str) -> Result<Option<String>> {
+    let mut difficulty = None;
+    for (index, raw_line) in frontmatter.lines().enumerate() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            anyhow::bail!(
+                "Malformed YAML frontmatter: expected `key: value` on line {}",
+                index + 2
+            );
+        };
+        if key.trim() != "difficulty" {
+            continue;
+        }
+        let label = unquote_yaml_scalar(value.trim());
+        if label.trim().is_empty() {
+            anyhow::bail!("Malformed YAML frontmatter: difficulty value cannot be empty");
+        }
+        difficulty = Some(label.to_string());
+    }
+    Ok(difficulty)
+}
+
+fn unquote_yaml_scalar(value: &str) -> &str {
+    if value.len() >= 2 {
+        let bytes = value.as_bytes();
+        let quoted = (bytes[0] == b'"' && bytes[value.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[value.len() - 1] == b'\'');
+        if quoted {
+            return &value[1..value.len() - 1];
+        }
+    }
+    value
+}
+
+pub(crate) fn resolve_effective_tier_with_difficulty_hint(
+    config: Option<&ProjectConfig>,
+    explicit_tier: Option<&str>,
+    model_spec: Option<&str>,
+    cli_hint: Option<&str>,
+    frontmatter_hint: Option<&str>,
+) -> Result<Option<String>> {
+    if let Some(tier) = explicit_tier {
+        return Ok(Some(tier.to_string()));
+    }
+    if model_spec.is_some() {
+        return Ok(None);
+    }
+    let Some(label) = cli_hint.or(frontmatter_hint) else {
+        return Ok(None);
+    };
+    resolve_tier_mapping_label(config, label).map(Some)
+}
+
+pub(crate) fn resolve_tier_mapping_label(
+    config: Option<&ProjectConfig>,
+    label: &str,
+) -> Result<String> {
+    let normalized = label.trim();
+    if normalized.is_empty() {
+        anyhow::bail!(
+            "Difficulty hint label cannot be empty. Available difficulty labels: [{}]",
+            available_difficulty_labels(config)
+        );
+    }
+
+    let Some(cfg) = config else {
+        anyhow::bail!(
+            "Difficulty hint '{}' requires [tier_mapping], but no project config is loaded.",
+            normalized
+        );
+    };
+
+    let Some(tier_name) = cfg.tier_mapping.get(normalized) else {
+        anyhow::bail!(
+            "Difficulty hint '{}' not found in [tier_mapping]. Available difficulty labels: [{}]",
+            normalized,
+            available_difficulty_labels(Some(cfg))
+        );
+    };
+
+    if !cfg.tiers.contains_key(tier_name) {
+        let mut available_tiers: Vec<&str> = cfg.tiers.keys().map(String::as_str).collect();
+        available_tiers.sort_unstable();
+        anyhow::bail!(
+            "tier_mapping.{} references unknown tier '{}'. Available tiers: [{}]",
+            normalized,
+            tier_name,
+            available_tiers.join(", ")
+        );
+    }
+
+    Ok(tier_name.clone())
+}
+
+fn available_difficulty_labels(config: Option<&ProjectConfig>) -> String {
+    let Some(cfg) = config else {
+        return "none".to_string();
+    };
+    if cfg.tier_mapping.is_empty() {
+        return "none".to_string();
+    }
+    let mut labels: Vec<&str> = cfg.tier_mapping.keys().map(String::as_str).collect();
+    labels.sort_unstable();
+    labels.join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use csa_config::{ProjectMeta, ResourcesConfig, TierConfig, TierStrategy, ToolConfig};
+    use std::collections::HashMap;
+
+    fn test_config() -> ProjectConfig {
+        let mut tiers = HashMap::new();
+        tiers.insert(
+            "tier-1-quick".to_string(),
+            TierConfig {
+                description: "Quick".to_string(),
+                models: vec!["claude-code/anthropic/default/low".to_string()],
+                strategy: TierStrategy::default(),
+                token_budget: None,
+                max_turns: None,
+            },
+        );
+        tiers.insert(
+            "tier-2-standard".to_string(),
+            TierConfig {
+                description: "Standard".to_string(),
+                models: vec!["claude-code/anthropic/default/high".to_string()],
+                strategy: TierStrategy::default(),
+                token_budget: None,
+                max_turns: None,
+            },
+        );
+
+        ProjectConfig {
+            schema_version: csa_config::config::CURRENT_SCHEMA_VERSION,
+            project: ProjectMeta {
+                name: "test".to_string(),
+                created_at: chrono::Utc::now(),
+                max_recursion_depth: 5,
+            },
+            resources: ResourcesConfig::default(),
+            acp: Default::default(),
+            tools: HashMap::<String, ToolConfig>::new(),
+            review: None,
+            debate: None,
+            tiers,
+            tier_mapping: HashMap::from([
+                ("bug_fix".to_string(), "tier-2-standard".to_string()),
+                ("quick_question".to_string(), "tier-1-quick".to_string()),
+            ]),
+            aliases: HashMap::new(),
+            tool_aliases: HashMap::new(),
+            preferences: None,
+            session: Default::default(),
+            memory: Default::default(),
+            hooks: Default::default(),
+            run: Default::default(),
+            execution: Default::default(),
+            session_wait: None,
+            preflight: Default::default(),
+            vcs: Default::default(),
+            filesystem_sandbox: Default::default(),
+        }
+    }
+
+    #[test]
+    fn frontmatter_parse_valid_difficulty_and_strips_block() {
+        let parsed = strip_difficulty_frontmatter(
+            "---\ndifficulty: quick_question\n---\nanswer this".to_string(),
+        )
+        .expect("valid frontmatter");
+
+        assert_eq!(parsed.difficulty.as_deref(), Some("quick_question"));
+        assert_eq!(parsed.prompt, "answer this");
+    }
+
+    #[test]
+    fn frontmatter_parse_missing_difficulty_strips_block() {
+        let parsed = strip_difficulty_frontmatter("---\nowner: docs\n---\nbody".to_string())
+            .expect("frontmatter without difficulty is valid");
+
+        assert_eq!(parsed.difficulty, None);
+        assert_eq!(parsed.prompt, "body");
+    }
+
+    #[test]
+    fn frontmatter_parse_malformed_errors() {
+        let err =
+            strip_difficulty_frontmatter("---\ndifficulty quick_question\n---\nbody".to_string())
+                .expect_err("malformed key/value must error");
+
+        assert!(
+            err.to_string().contains("expected `key: value`"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn no_frontmatter_passes_prompt_through() {
+        let parsed = strip_difficulty_frontmatter("plain prompt".to_string())
+            .expect("plain prompt should pass through");
+
+        assert_eq!(parsed.difficulty, None);
+        assert_eq!(parsed.prompt, "plain prompt");
+    }
+
+    #[test]
+    fn tier_mapping_lookup_hits() {
+        let config = test_config();
+        let tier = resolve_tier_mapping_label(Some(&config), "quick_question")
+            .expect("quick_question should resolve");
+
+        assert_eq!(tier, "tier-1-quick");
+    }
+
+    #[test]
+    fn tier_mapping_lookup_miss_lists_available_labels() {
+        let config = test_config();
+        let err = resolve_tier_mapping_label(Some(&config), "security_audit")
+            .expect_err("missing label must error");
+        let msg = err.to_string();
+
+        assert!(msg.contains("Difficulty hint 'security_audit' not found in [tier_mapping]"));
+        assert!(msg.contains("bug_fix"));
+        assert!(msg.contains("quick_question"));
+    }
+
+    #[test]
+    fn cli_hint_wins_over_frontmatter_hint() {
+        let config = test_config();
+        let tier = resolve_effective_tier_with_difficulty_hint(
+            Some(&config),
+            None,
+            None,
+            Some("bug_fix"),
+            Some("quick_question"),
+        )
+        .expect("CLI hint should resolve")
+        .expect("tier selected");
+
+        assert_eq!(tier, "tier-2-standard");
+    }
+}

--- a/crates/cli-sub-agent/src/difficulty_routing.rs
+++ b/crates/cli-sub-agent/src/difficulty_routing.rs
@@ -18,7 +18,7 @@ pub(crate) fn strip_difficulty_frontmatter(prompt: String) -> Result<ParsedPromp
     let mut line_start = body_start;
     for line in prompt[body_start..].split_inclusive('\n') {
         let line_end = line_start + line.len();
-        if line.trim_end_matches(['\r', '\n']) == "---" {
+        if line.trim_end() == "---" {
             let frontmatter = &prompt[body_start..line_start];
             let difficulty = parse_frontmatter_difficulty(frontmatter)?;
             return Ok(ParsedPromptDifficulty {
@@ -29,21 +29,13 @@ pub(crate) fn strip_difficulty_frontmatter(prompt: String) -> Result<ParsedPromp
         line_start = line_end;
     }
 
-    if prompt[body_start..].trim_end_matches('\r') == "---" {
-        return Ok(ParsedPromptDifficulty {
-            difficulty: None,
-            prompt: String::new(),
-        });
-    }
-
     anyhow::bail!("Malformed YAML frontmatter: opening '---' has no closing '---' delimiter")
 }
 
 fn frontmatter_body_start(prompt: &str) -> Option<usize> {
-    if prompt.starts_with("---\n") {
-        Some(4)
-    } else if prompt.starts_with("---\r\n") {
-        Some(5)
+    let first_line = prompt.split_inclusive('\n').next().unwrap_or(prompt);
+    if first_line.trim_end() == "---" {
+        Some(first_line.len())
     } else {
         None
     }
@@ -51,16 +43,13 @@ fn frontmatter_body_start(prompt: &str) -> Option<usize> {
 
 fn parse_frontmatter_difficulty(frontmatter: &str) -> Result<Option<String>> {
     let mut difficulty = None;
-    for (index, raw_line) in frontmatter.lines().enumerate() {
+    for raw_line in frontmatter.lines() {
         let line = raw_line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
         let Some((key, value)) = line.split_once(':') else {
-            anyhow::bail!(
-                "Malformed YAML frontmatter: expected `key: value` on line {}",
-                index + 2
-            );
+            continue;
         };
         if key.trim() != "difficulty" {
             continue;
@@ -240,13 +229,45 @@ mod tests {
     }
 
     #[test]
-    fn frontmatter_parse_malformed_errors() {
-        let err =
-            strip_difficulty_frontmatter("---\ndifficulty quick_question\n---\nbody".to_string())
-                .expect_err("malformed key/value must error");
+    fn frontmatter_parse_ignores_yaml_sequence_lines() {
+        let parsed = strip_difficulty_frontmatter(
+            "---\ntags:\n- foo\n- bar\ndifficulty: quick_question\n---\nbody".to_string(),
+        )
+        .expect("sequence frontmatter should be accepted");
+
+        assert_eq!(parsed.difficulty.as_deref(), Some("quick_question"));
+        assert_eq!(parsed.prompt, "body");
+    }
+
+    #[test]
+    fn frontmatter_parse_ignores_unknown_lines() {
+        let parsed = strip_difficulty_frontmatter(
+            "---\nowner: docs\nfreeform owner line\ndifficulty: bug_fix\n---\nbody".to_string(),
+        )
+        .expect("unknown frontmatter lines should be accepted");
+
+        assert_eq!(parsed.difficulty.as_deref(), Some("bug_fix"));
+        assert_eq!(parsed.prompt, "body");
+    }
+
+    #[test]
+    fn frontmatter_parse_allows_delimiter_trailing_space_and_crlf() {
+        let parsed = strip_difficulty_frontmatter(
+            "---  \r\ndifficulty: quick_question\r\n--- \t\r\nbody".to_string(),
+        )
+        .expect("frontmatter delimiters may have trailing whitespace");
+
+        assert_eq!(parsed.difficulty.as_deref(), Some("quick_question"));
+        assert_eq!(parsed.prompt, "body");
+    }
+
+    #[test]
+    fn frontmatter_parse_empty_difficulty_errors() {
+        let err = strip_difficulty_frontmatter("---\ndifficulty:\n---\nbody".to_string())
+            .expect_err("empty difficulty must error");
 
         assert!(
-            err.to_string().contains("expected `key: value`"),
+            err.to_string().contains("difficulty value cannot be empty"),
             "unexpected error: {err:#}"
         );
     }

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -14,6 +14,7 @@ mod debate_cmd;
 mod debate_cmd_output;
 mod debate_cmd_resolve;
 mod debate_errors;
+mod difficulty_routing;
 mod doctor;
 mod edit_restriction_guard;
 mod error_hints;
@@ -333,6 +334,7 @@ async fn run() -> Result<()> {
         Commands::Run {
             tool,
             auto_route,
+            hint_difficulty,
             skill,
             sa_mode: _,
             prompt,
@@ -389,10 +391,7 @@ async fn run() -> Result<()> {
                 ),
             )?;
 
-            // Daemon child path: continue with normal run logic.
-            // --stream-stdout forces streaming intent; --no-stream-stdout forces buffering.
-            // The ACP transport may still suppress stderr mirroring in daemon mode because
-            // output.log is the canonical progressive output channel there.
+            // Daemon child path: continue with normal run logic and resolve stream mode.
             let stream_mode = if no_stream_stdout {
                 csa_process::StreamMode::BufferOnly
             } else if stream_stdout || matches!(output_format, OutputFormat::Text) {
@@ -404,6 +403,7 @@ async fn run() -> Result<()> {
             let result = run_cmd::handle_run(
                 tool,
                 auto_route,
+                hint_difficulty,
                 skill,
                 prompt,
                 prompt_flag,

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -69,9 +69,10 @@ use resolve::build_review_instruction;
 pub(crate) use resolve::resolve_review_tool;
 use resolve::{
     ReviewProjectPromptOptions, build_review_instruction_for_project, derive_scope,
-    resolve_review_model, resolve_review_selection, resolve_review_stream_mode,
-    resolve_review_thinking, resolve_review_tier_name, review_scope_allows_auto_discovery,
-    verify_review_skill_available, write_multi_reviewer_consolidated_artifact,
+    resolve_review_effective_tier, resolve_review_model, resolve_review_selection,
+    resolve_review_stream_mode, resolve_review_thinking, resolve_review_tier_name,
+    review_scope_allows_auto_discovery, verify_review_skill_available,
+    write_multi_reviewer_consolidated_artifact,
 };
 use result_handling::{build_reviewer_outcome, resolve_single_review_result};
 #[rustfmt::skip]
@@ -260,9 +261,9 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         prompt.push_str(summary);
     }
 
-    // 5. Determine tool (with tier-based resolution)
     let detected_parent_tool = crate::run_helpers::detect_parent_tool();
     let parent_tool = crate::run_helpers::resolve_tool(detected_parent_tool, &global_config);
+    let effective_tier = resolve_review_effective_tier(&args, config.as_ref())?;
     let resolved_selection = match resolve_review_selection(
         args.tool,
         args.model_spec.as_deref(),
@@ -271,7 +272,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         parent_tool.as_deref(),
         &project_root,
         args.force_override_user_config,
-        args.tier.as_deref(),
+        effective_tier.as_deref(),
         args.force_ignore_tier_setting,
     ) {
         Ok(resolved) => resolved,
@@ -284,7 +285,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
                     parent: None,
                     tool_name: explicit_review_tool(&args).map(|tool| tool.as_str()),
                     task_type: Some("review"),
-                    tier_name: args.tier.as_deref(),
+                    tier_name: effective_tier.as_deref(),
                     error: err,
                 },
             ));
@@ -300,7 +301,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         resolve_review_tier_name(
             config.as_ref(),
             &global_config,
-            args.tier.as_deref(),
+            effective_tier.as_deref(),
             args.force_override_user_config,
             args.force_ignore_tier_setting,
         )?

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -138,6 +138,7 @@ pub(crate) fn resolve_review_selection(
         anyhow::bail!(
             "Direct --tool is restricted when tiers are configured. \
              Use --tier <name> to specify which tier's model/thinking config to use, \
+             --hint-difficulty <label> to route through [tier_mapping], \
              or add --force-ignore-tier-setting to override. \
              Available tiers: [{}]{alias_hint}",
             available.join(", ")
@@ -358,6 +359,19 @@ pub(crate) fn resolve_review_tier_name(
         .and_then(|r| r.tier.as_deref())
         .or(global_config.review.tier.as_deref())
         .map(|s| s.to_string()))
+}
+
+pub(crate) fn resolve_review_effective_tier(
+    args: &ReviewArgs,
+    project_config: Option<&ProjectConfig>,
+) -> Result<Option<String>> {
+    crate::difficulty_routing::resolve_effective_tier_with_difficulty_hint(
+        project_config,
+        args.tier.as_deref(),
+        args.model_spec.as_deref(),
+        args.hint_difficulty.as_deref(),
+        None,
+    )
 }
 
 pub(crate) fn resolve_review_model(

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -100,6 +100,20 @@ fn parse_or_validate_review_error(argv: &[&str]) -> clap::Error {
     }
 }
 
+#[test]
+fn review_cli_parses_hint_difficulty_flag() {
+    let args = parse_review_args(&[
+        "csa",
+        "review",
+        "--tool",
+        "claude-code",
+        "--hint-difficulty",
+        "code_review",
+        "--diff",
+    ]);
+    assert_eq!(args.hint_difficulty.as_deref(), Some("code_review"));
+}
+
 fn sample_spec_document(plan_ulid: &str, criterion_id: &str) -> SpecDocument {
     SpecDocument {
         schema_version: 1,
@@ -399,6 +413,7 @@ fn default_review_args() -> ReviewArgs {
         session: None,
         model: None,
         model_spec: None,
+        hint_difficulty: None,
         thinking: None,
         no_failover: false,
         diff: false,

--- a/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
@@ -7,6 +7,25 @@ fn assume_tier_tools_available() -> ScopedTestEnvVar {
     ScopedTestEnvVar::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1")
 }
 
+#[test]
+fn review_cli_hint_difficulty_conflicts_with_tier() {
+    use clap::Parser;
+
+    let err = match Cli::try_parse_from([
+        "csa",
+        "review",
+        "--hint-difficulty",
+        "code_review",
+        "--tier",
+        "tier-2-standard",
+        "--diff",
+    ]) {
+        Ok(_) => panic!("hint-difficulty and tier should conflict"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
 fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
     let mut tool_map = HashMap::new();
     for tool in csa_config::global::all_known_tools() {

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -28,7 +28,8 @@ use crate::run_cmd_tool_selection::{
 #[path = "run_cmd_execute_routing.rs"]
 mod routing;
 use routing::{
-    RunModelSelectionFlags, resolve_primary_writer_spec_for_run, resolve_run_tier_context,
+    RunModelSelectionFlags, resolve_primary_writer_spec_for_run, resolve_run_effective_tier,
+    resolve_run_tier_context,
 };
 
 use super::attempt::{RunLoopCompletion, RunLoopRequest, execute_run_loop};
@@ -229,6 +230,7 @@ where
 pub(crate) async fn handle_run(
     tool: Option<csa_core::types::ToolArg>,
     auto_route: Option<String>,
+    hint_difficulty: Option<String>,
     skill: Option<String>,
     prompt: Option<String>,
     prompt_flag: Option<String>,
@@ -348,20 +350,6 @@ pub(crate) async fn handle_run(
     else {
         return Ok(1);
     };
-    let model_selection_flags = RunModelSelectionFlags {
-        tool: tool.is_some(),
-        auto_route: auto_route.is_some(),
-        skill: skill.is_some(),
-        model_spec: model_spec.is_some(),
-        model: model.is_some(),
-        thinking: thinking.is_some(),
-        tier: tier.is_some(),
-    };
-    let primary_writer_spec =
-        resolve_primary_writer_spec_for_run(model_selection_flags, config.as_ref(), &global_config);
-    let model_spec = model_spec.or(primary_writer_spec);
-    let effective_tier = tier.or(auto_route.clone());
-
     // Track whether user explicitly provided --tool on the CLI (before skill
     // resolution may override it).  This drives tier enforcement: explicit
     // --tool (including --tool auto) is blocked when tiers are configured.
@@ -388,6 +376,7 @@ pub(crate) async fn handle_run(
     )?;
     let resolved_skill = skill_res.resolved_skill;
     let gate_prompt_text = skill_res.prompt_text.clone();
+    let frontmatter_difficulty = skill_res.frontmatter_difficulty.clone();
     let task_needs_edit = crate::run_helpers::resolve_task_edit_requirement(
         resolved_skill.as_ref(),
         &skill_res.prompt_text,
@@ -401,6 +390,20 @@ pub(crate) async fn handle_run(
     let thinking = skill_res.thinking;
     let model = skill_res.model;
     let skill_session_tag = skill.as_deref().map(skill_session_description);
+
+    let model_selection_flags = RunModelSelectionFlags {
+        tool: user_explicit_tool,
+        auto_route: auto_route.is_some(),
+        skill: skill.is_some(),
+        model_spec: model_spec.is_some(),
+        model: model.is_some(),
+        thinking: thinking.is_some(),
+        tier: tier.is_some(),
+        hint_difficulty: hint_difficulty.is_some() || frontmatter_difficulty.is_some(),
+    };
+    let primary_writer_spec =
+        resolve_primary_writer_spec_for_run(model_selection_flags, config.as_ref(), &global_config);
+    let model_spec = model_spec.or(primary_writer_spec);
 
     let mut merged_aliases = global_config.tool_aliases.clone();
     if let Some(c) = config.as_ref() {
@@ -421,6 +424,15 @@ pub(crate) async fn handle_run(
         parent.as_deref()
     };
 
+    let effective_tier = resolve_run_effective_tier(
+        config.as_ref(),
+        tier.as_deref(),
+        auto_route.as_deref(),
+        model_spec.as_deref(),
+        hint_difficulty.as_deref(),
+        frontmatter_difficulty.as_deref(),
+    )?;
+
     // Enforce tier routing: when tiers are configured, explicit --tool (any
     // value, including "auto") is blocked unless --tier is also specified or
     // --force-ignore-tier-setting is active.
@@ -436,6 +448,7 @@ pub(crate) async fn handle_run(
         let err = anyhow::anyhow!(
             "Direct --tool is blocked when tiers are configured.\n\
              Use --tier <name> or --auto-route <intent> to select tier-based routing, or \
+             --hint-difficulty <label> to route through [tier_mapping], or \
              --force-ignore-tier-setting to bypass.\n\
              Available tiers: {}",
             tier_list.join(", ")

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -88,6 +88,7 @@ async fn handle_run_persists_result_for_model_spec_tier_conflict() {
         None,
         None,
         None,
+        None,
         Some("inspect the repository".to_string()),
         None,
         None,
@@ -167,6 +168,7 @@ async fn handle_run_does_not_persist_result_for_non_conflict_pre_exec_error() {
     write_project_config(project_dir.path(), &config);
 
     let err = handle_run(
+        None,
         None,
         None,
         None,

--- a/crates/cli-sub-agent/src/run_cmd_execute_routing.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_routing.rs
@@ -41,6 +41,7 @@ pub(super) struct RunModelSelectionFlags {
     pub(super) model: bool,
     pub(super) thinking: bool,
     pub(super) tier: bool,
+    pub(super) hint_difficulty: bool,
 }
 
 impl RunModelSelectionFlags {
@@ -52,6 +53,7 @@ impl RunModelSelectionFlags {
             || self.model
             || self.thinking
             || self.tier
+            || self.hint_difficulty
     }
 }
 
@@ -64,4 +66,21 @@ pub(super) fn resolve_primary_writer_spec_for_run(
         .then(|| csa_config::global::effective_primary_writer_spec(config, global_config))
         .flatten()
         .map(ToOwned::to_owned)
+}
+
+pub(super) fn resolve_run_effective_tier(
+    config: Option<&ProjectConfig>,
+    tier: Option<&str>,
+    auto_route: Option<&str>,
+    model_spec: Option<&str>,
+    hint_difficulty: Option<&str>,
+    frontmatter_difficulty: Option<&str>,
+) -> anyhow::Result<Option<String>> {
+    crate::difficulty_routing::resolve_effective_tier_with_difficulty_hint(
+        config,
+        tier.or(auto_route),
+        model_spec,
+        hint_difficulty,
+        frontmatter_difficulty,
+    )
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
@@ -529,6 +529,10 @@ fn primary_writer_spec_is_suppressed_by_any_model_selecting_flag() {
             tier: true,
             ..Default::default()
         },
+        RunModelSelectionFlags {
+            hint_difficulty: true,
+            ..Default::default()
+        },
     ];
 
     for flags in cases {

--- a/crates/cli-sub-agent/src/run_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests.rs
@@ -56,6 +56,26 @@ fn try_parse_cli(args: &[&str]) -> Result<Cli, clap::Error> {
     Cli::try_parse_from(args)
 }
 
+#[test]
+fn run_cli_hint_difficulty_parses() {
+    let cli = try_parse_cli(&[
+        "csa",
+        "run",
+        "--tool",
+        "claude",
+        "--hint-difficulty",
+        "quick_question",
+        "prompt",
+    ])
+    .unwrap();
+    match cli.command {
+        crate::cli::Commands::Run {
+            hint_difficulty, ..
+        } => assert_eq!(hint_difficulty.as_deref(), Some("quick_question")),
+        _ => panic!("expected Run command"),
+    }
+}
+
 include!("run_cmd_tests_core.rs");
 include!("run_cmd_tests_policy.rs");
 

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -83,6 +83,7 @@ async fn handle_run_persists_result_for_direct_tool_tier_rejection() {
         Some(ToolArg::Specific(ToolName::Codex)),
         None,
         None,
+        None,
         Some("inspect the repository".to_string()),
         None,
         None,

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -5,6 +5,37 @@ use std::collections::HashMap;
 use std::path::Path;
 use tempfile::tempdir;
 
+#[test]
+fn test_cli_hint_difficulty_conflicts_with_tier() {
+    let result = try_parse_cli(&[
+        "csa",
+        "run",
+        "--hint-difficulty",
+        "quick_question",
+        "--tier",
+        "tier-1-quick",
+        "prompt",
+    ]);
+    assert!(result.is_err(), "hint-difficulty and tier should conflict");
+}
+
+#[test]
+fn test_cli_hint_difficulty_conflicts_with_auto_route() {
+    let result = try_parse_cli(&[
+        "csa",
+        "run",
+        "--hint-difficulty",
+        "quick_question",
+        "--auto-route",
+        "code",
+        "prompt",
+    ]);
+    assert!(
+        result.is_err(),
+        "hint-difficulty and auto-route should conflict"
+    );
+}
+
 fn run_config_with_tier(
     tier_name: &str,
     models: Vec<&str>,

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
@@ -456,6 +456,7 @@ fn resolve_heterogeneous_strict(
 /// Resolved skill, prompt text, and overridden CLI params.
 pub(crate) struct SkillResolution {
     pub(crate) prompt_text: String,
+    pub(crate) frontmatter_difficulty: Option<String>,
     pub(crate) resolved_skill: Option<ResolvedSkill>,
     pub(crate) tool: Option<csa_core::types::ToolArg>,
     pub(crate) model: Option<String>,
@@ -478,7 +479,7 @@ pub(crate) fn resolve_skill_and_prompt(
         None
     };
 
-    let prompt_text = if let Some(ref sk) = resolved_skill {
+    let (prompt_text, frontmatter_difficulty) = if let Some(ref sk) = resolved_skill {
         // Skills execute inside `csa run` as the leaf executor. Inject an
         // explicit mode marker so skill docs can branch deterministically and
         // avoid orchestrator-style recursive `csa run` loops.
@@ -508,13 +509,17 @@ pub(crate) fn resolve_skill_and_prompt(
             }
         }
 
+        let mut difficulty = None;
         if let Some(user_prompt) = prompt {
-            parts.push(format!("---\n\n{user_prompt}"));
+            let parsed = crate::difficulty_routing::strip_difficulty_frontmatter(user_prompt)?;
+            difficulty = parsed.difficulty;
+            parts.push(format!("---\n\n{}", parsed.prompt));
         }
 
-        parts.join("\n\n")
+        (parts.join("\n\n"), difficulty)
     } else {
-        read_prompt(prompt)?
+        let parsed = crate::difficulty_routing::strip_difficulty_frontmatter(read_prompt(prompt)?)?;
+        (parsed.prompt, parsed.difficulty)
     };
 
     // Apply skill agent config overrides for tool/model when CLI didn't specify.
@@ -547,6 +552,7 @@ pub(crate) fn resolve_skill_and_prompt(
 
     Ok(SkillResolution {
         prompt_text,
+        frontmatter_difficulty,
         resolved_skill,
         tool,
         model,
@@ -765,3 +771,7 @@ mod tests {
 #[cfg(test)]
 #[path = "run_cmd_tool_selection_model_spec_tests.rs"]
 mod model_spec_tests;
+
+#[cfg(test)]
+#[path = "run_cmd_tool_selection_hint_tests.rs"]
+mod hint_tests;

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection_hint_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection_hint_tests.rs
@@ -1,0 +1,138 @@
+use super::*;
+use crate::test_env_lock::ScopedTestEnvVar;
+use clap::Parser;
+use csa_config::{
+    GlobalConfig, ProjectConfig, ProjectMeta, ResourcesConfig, TierConfig, TierStrategy, ToolConfig,
+};
+use csa_core::types::ToolName;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+fn config_with_enabled_tiers(
+    enabled_tools: &[&str],
+    tiers: &[(&str, Vec<&str>)],
+    tier_mapping: &[(&str, &str)],
+) -> ProjectConfig {
+    let mut tools = HashMap::new();
+    for tool in csa_config::global::all_known_tools() {
+        let name = tool.as_str();
+        tools.insert(
+            name.to_string(),
+            ToolConfig {
+                enabled: enabled_tools.contains(&name),
+                ..Default::default()
+            },
+        );
+    }
+
+    ProjectConfig {
+        schema_version: csa_config::config::CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: chrono::Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools,
+        review: None,
+        debate: None,
+        tiers: tiers
+            .iter()
+            .map(|(name, models)| {
+                (
+                    (*name).to_string(),
+                    TierConfig {
+                        description: "Test tier".to_string(),
+                        models: models.iter().map(|model| (*model).to_string()).collect(),
+                        strategy: TierStrategy::default(),
+                        token_budget: None,
+                        max_turns: None,
+                    },
+                )
+            })
+            .collect(),
+        tier_mapping: tier_mapping
+            .iter()
+            .map(|(label, tier_name)| ((*label).to_string(), (*tier_name).to_string()))
+            .collect(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    }
+}
+
+#[test]
+fn csa_run_tool_hint_difficulty_resolves_quick_tier() {
+    let _tool_availability =
+        ScopedTestEnvVar::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let tmp = TempDir::new().expect("tempdir");
+    let cli = crate::cli::Cli::try_parse_from([
+        "csa",
+        "run",
+        "--tool",
+        "claude",
+        "--hint-difficulty",
+        "quick_question",
+        "answer briefly",
+    ])
+    .expect("run CLI should parse hint difficulty");
+    let (tool_arg, hint_difficulty) = match cli.command {
+        crate::cli::Commands::Run {
+            tool,
+            hint_difficulty,
+            ..
+        } => (tool, hint_difficulty),
+        _ => panic!("expected run command"),
+    };
+    let config = config_with_enabled_tiers(
+        &["claude-code"],
+        &[(
+            "tier-1-quick",
+            vec!["claude-code/anthropic/claude-haiku/low"],
+        )],
+        &[("quick_question", "tier-1-quick")],
+    );
+    let effective_tier = crate::difficulty_routing::resolve_effective_tier_with_difficulty_hint(
+        Some(&config),
+        None,
+        None,
+        hint_difficulty.as_deref(),
+        None,
+    )
+    .expect("hint should map through tier_mapping");
+    let strategy = tool_arg.expect("tool should parse").into_strategy();
+    let resolution = resolve_tool_by_strategy(
+        &strategy,
+        None,
+        None,
+        Some(&config),
+        &GlobalConfig::default(),
+        tmp.path(),
+        false,
+        false,
+        false,
+        effective_tier.as_deref(),
+        false,
+    )
+    .expect("hint-selected tier should route requested tool");
+
+    assert_eq!(resolution.tool, ToolName::ClaudeCode);
+    assert_eq!(
+        resolution.model_spec.as_deref(),
+        Some("claude-code/anthropic/claude-haiku/low")
+    );
+    assert_eq!(
+        resolution.resolved_tier_name.as_deref(),
+        Some("tier-1-quick")
+    );
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,6 +16,7 @@ csa run --sa-mode false [OPTIONS] [PROMPT]
 | `--sa-mode <BOOL>` | Root callers must pass `true` or `false`; internal recursive calls default to `false` |
 | `--tool <TOOL>` | Tool selection: `auto` (default), `any-available`, or specific name |
 | `--auto-route <INTENT>` | Resolve routing intent through `[tier_mapping]` or a tier selector while keeping tool choice automatic |
+| `--hint-difficulty <LABEL>` | Resolve a difficulty label through `[tier_mapping]` when no explicit `--tier`/`--model-spec` is set |
 | `--skill <NAME>` | Run a named skill as a sub-agent |
 | `--session <ID>` | Resume existing session (ULID or prefix) |
 | `--last` | Resume the most recent session |
@@ -40,6 +41,7 @@ If `PROMPT` is omitted, reads from stdin.
 ```bash
 csa run --sa-mode false "fix the login bug"
 csa run --sa-mode false --tool codex --thinking high "refactor error handling"
+csa run --sa-mode false --tool claude --hint-difficulty quick_question "answer briefly"
 csa run --sa-mode false --auto-route analysis "trace the auth flow"
 csa run --sa-mode false --model-spec "codex/openai/gpt-5.3-codex/xhigh" "complex task"
 csa run --sa-mode false --last "continue where I left off"
@@ -63,6 +65,7 @@ csa review --sa-mode false [OPTIONS]
 | `--files <PATHSPEC>` | Review specific files |
 | `--branch <BRANCH>` | Compare against branch (default: main) |
 | `--tool <TOOL>` | Override tool selection |
+| `--hint-difficulty <LABEL>` | Resolve a difficulty label through `[tier_mapping]` when no explicit `--tier`/`--model-spec` is set |
 | `--model <MODEL>` | Override model |
 | `--fix` | Review-and-fix mode (apply fixes directly) |
 | `--security-mode <MODE>` | `auto`, `on`, or `off` |
@@ -78,6 +81,7 @@ csa review --sa-mode false [OPTIONS]
 
 ```bash
 csa review --sa-mode false --diff
+csa review --sa-mode false --tool claude-code --hint-difficulty code_review --diff
 csa review --sa-mode false --range main...HEAD
 csa review --sa-mode false --diff --reviewers 3 --consensus majority
 csa review --sa-mode false --diff --fix --security-mode on
@@ -95,6 +99,7 @@ csa debate --sa-mode false [OPTIONS] [QUESTION]
 |------|-------------|
 | `--sa-mode <BOOL>` | Root callers must pass `true` or `false`; internal recursive calls default to `false` |
 | `--tool <TOOL>` | Override tool selection |
+| `--hint-difficulty <LABEL>` | Resolve a difficulty label through `[tier_mapping]` when no explicit `--tier`/`--model-spec` is set |
 | `--session <ID>` | Resume existing debate session |
 | `--model <MODEL>` | Override model |
 | `--thinking <LEVEL>` | Thinking budget |
@@ -106,6 +111,7 @@ csa debate --sa-mode false [OPTIONS] [QUESTION]
 
 ```bash
 csa debate --sa-mode false "Should we use anyhow or thiserror?"
+csa debate --sa-mode false --tool claude-code --hint-difficulty architecture_design "Pick the storage boundary"
 csa debate --sa-mode false --session 01JK "reconsider with performance data"
 csa debate --sa-mode false --rounds 5 "Redis vs Memcached for session storage"
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,12 +219,29 @@ tool is enabled.
 ```toml
 [tier_mapping]
 default = "tier-2-standard"
-quick = "tier-1-quick"
-analysis = "tier-2-standard"
-code-review = "tier-2-standard"
-complex-reasoning = "tier-3-complex"
-security = "tier-3-complex"
+quick_question = "tier-1-quick"
+documentation = "tier-1-quick"
+bug_fix = "tier-2-standard"
+feature_implementation = "tier-2-standard"
+code_review = "tier-2-standard"
+architecture_design = "tier-3-complex"
+security_audit = "tier-3-complex"
 ```
+
+`csa run`, `csa review`, and `csa debate` can select these mappings with
+`--hint-difficulty <LABEL>` when no explicit `--tier` or `--model-spec` is set.
+For `csa run` and `csa debate`, the prompt may also start with YAML frontmatter:
+
+```text
+---
+difficulty: quick_question
+---
+Explain the failing command.
+```
+
+The frontmatter block is stripped before forwarding the prompt to the selected
+tool. CLI `--hint-difficulty` wins over prompt frontmatter; explicit `--tier` or
+`--model-spec` wins over both.
 
 ### `[aliases]` -- Model Aliases
 


### PR DESCRIPTION
Closes #1066. Adds --hint-difficulty <label> flag to csa run/review/debate and YAML frontmatter (difficulty: <label>) in prompts. When only --tool is set (no --tier/--model-spec/--model/--thinking), the label maps via [tier_mapping] to a tier and resolves tool/model/thinking from that tier. Precedence: --model-spec/--tier > --hint-difficulty > frontmatter difficulty > existing fallback. Zero LLM tokens spent on classification per issue's hard constraint.