### PR TITLE
chore(patterns): add rule-extractor skill for auto-extracting rules from HIGH/CRITICAL findings (#661)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.555"
+version = "0.1.556"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.555"
+version = "0.1.556"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -1954,3 +1954,7 @@ echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false --
 ## ENDIF
 
 ## ENDIF
+
+## Post-Merge Extensions
+
+> Post-merge rule-extractor pattern is available at `patterns/rule-extractor/` — integration pending separate PR. Invoke via `csa plan run patterns/rule-extractor/workflow.toml` after successful merge when HIGH/CRITICAL findings exist.

--- a/patterns/rule-extractor/PATTERN.md
+++ b/patterns/rule-extractor/PATTERN.md
@@ -111,7 +111,9 @@ fi
 Tool: bash
 
 Check whether an existing rule already covers this bug class. Search
-project-local rules (`.agents/project-rules-ref/`).
+project-local rules (`.agents/project-rules-ref/`). Emits
+`CSA_VAR:SHOULD_DRAFT=yes` when Step 4 should run, and
+`CSA_VAR:DEDUPE_RESULT` with the semantic comparison outcome.
 
 ```bash
 set -euo pipefail
@@ -126,6 +128,8 @@ fi
 if [ -z "${PROJECT_MATCHES}" ]; then
   echo "EXISTING_RULE_MATCH=none"
   echo "CSA_VAR:EXISTING_RULE_MATCH=none"
+  echo "CSA_VAR:DEDUPE_RESULT=NO_MATCH"
+  echo "CSA_VAR:SHOULD_DRAFT=yes"
 else
   echo "Potential matches found:"
   echo "${PROJECT_MATCHES}"
@@ -141,12 +145,25 @@ else
      Output: DEDUPE_RESULT=EXACT_MATCH|PARTIAL_MATCH|NO_MATCH
      If PARTIAL_MATCH: UPDATE_SUGGESTION: <what to add>")
   csa session wait --session "$DEDUPE_SID"
+
+  # Read dedupe result and decide whether to draft
+  DEDUPE_OUTPUT=$(csa session result --session "$DEDUPE_SID" --section summary 2>/dev/null || true)
+  if echo "$DEDUPE_OUTPUT" | grep -q "DEDUPE_RESULT=EXACT_MATCH"; then
+    echo "CSA_VAR:DEDUPE_RESULT=EXACT_MATCH"
+    echo "CSA_VAR:SHOULD_DRAFT="
+  elif echo "$DEDUPE_OUTPUT" | grep -q "DEDUPE_RESULT=PARTIAL_MATCH"; then
+    echo "CSA_VAR:DEDUPE_RESULT=PARTIAL_MATCH"
+    echo "CSA_VAR:SHOULD_DRAFT=yes"
+  else
+    echo "CSA_VAR:DEDUPE_RESULT=NO_MATCH"
+    echo "CSA_VAR:SHOULD_DRAFT=yes"
+  fi
 fi
 ```
 
 ## Step 4: Generate Rule Draft
 
-Tool: csa
+Tool: bash (dispatches csa run, captures draft into DRAFT_FILE)
 Tier: tier-2-standard
 
 Generate a rule file following the structure of existing rules
@@ -172,6 +189,7 @@ finding-ids: [<list of finding IDs>]
 ```
 
 ```bash
+set -euo pipefail
 DRAFT_SID=$(csa run --sa-mode true --tier tier-2-standard \
   --description "draft-rule: ${BUG_CLASS_NAME}" \
   "Generate a coding rule file for the following bug class.
@@ -196,6 +214,23 @@ DRAFT_SID=$(csa run --sa-mode true --tier tier-2-standard \
 
    Output the complete rule file content between RULE_DRAFT_START and RULE_DRAFT_END markers.")
 csa session wait --session "$DRAFT_SID"
+
+# Extract rule content from session output between markers
+DRAFT_RAW=$(csa session result --session "$DRAFT_SID" --section details 2>/dev/null || \
+            csa session result --session "$DRAFT_SID" 2>/dev/null || true)
+DRAFT_CONTENT=$(echo "$DRAFT_RAW" | sed -n '/RULE_DRAFT_START/,/RULE_DRAFT_END/{/RULE_DRAFT_START/d;/RULE_DRAFT_END/d;p}')
+
+if [ -z "$DRAFT_CONTENT" ]; then
+  echo "ERROR: Could not extract rule draft from session $DRAFT_SID"
+  exit 1
+fi
+
+# Write draft to a temp file and emit its path
+DRAFT_FILE=".agents/project-rules-ref/.draft-${BUG_CLASS_SLUG}.md"
+mkdir -p "$(dirname "$DRAFT_FILE")"
+echo "$DRAFT_CONTENT" > "$DRAFT_FILE"
+echo "CSA_VAR:DRAFT_FILE=$DRAFT_FILE"
+echo "CSA_VAR:STEP4_SESSION_ID=$DRAFT_SID"
 ```
 
 ## Step 5: Propose via PR
@@ -203,10 +238,18 @@ csa session wait --session "$DRAFT_SID"
 Tool: bash
 
 Create a proposal PR with the rule draft. NEVER auto-commit rules to
-the main rules repository. Human review is mandatory.
+the main rules repository. Human review is mandatory. Reads draft
+content from `DRAFT_FILE` produced by Step 4.
 
 ```bash
 set -euo pipefail
+
+# Read draft content from Step 4 output file
+if [ ! -f "${DRAFT_FILE}" ]; then
+  echo "ERROR: DRAFT_FILE not found at ${DRAFT_FILE}"
+  exit 1
+fi
+
 # Determine target directory (project-local, fork-only per rule 030)
 RULE_DIR=".agents/project-rules-ref/${LANG}"
 mkdir -p "${RULE_DIR}"
@@ -226,8 +269,10 @@ SHORT_SHA=$(echo "${FIX_COMMIT_SHA}" | cut -c1-7)
 PROPOSAL_BRANCH="chore/rules-propose-${SHORT_SHA}"
 git checkout -b "${PROPOSAL_BRANCH}"
 
-# Write rule file (RULE_CONTENT extracted from Step 4 output between markers)
-echo "${RULE_CONTENT}" > "${RULE_DIR}/${RULE_FILE}"
+# Copy draft to final rule location
+cp "${DRAFT_FILE}" "${RULE_DIR}/${RULE_FILE}"
+# Clean up draft file
+rm -f "${DRAFT_FILE}"
 
 git add "${RULE_DIR}/${RULE_FILE}"
 git commit -m "chore(rules): propose ${LANG}/${RULE_FILE} from PR #${PR_NUM}
@@ -282,7 +327,11 @@ NNN|bug-class-slug|one-line summary of the rule
 - `${ANTI_PATTERN_EXAMPLES}`: Code examples of the anti-pattern.
 - `${CORRECT_PATTERN}`: Code examples of the correct pattern.
 - `${SEVERITY}`: Finding severity for frontmatter.
-- `${RULE_CONTENT}`: Generated rule file content.
+- `${RULE_CONTENT}`: Generated rule file content (deprecated — use DRAFT_FILE).
+- `${SHOULD_DRAFT}`: Set to "yes" by Step 3 when Step 4 should run (empty on EXACT_MATCH).
+- `${DEDUPE_RESULT}`: Deduplication outcome from Step 3 (EXACT_MATCH|PARTIAL_MATCH|NO_MATCH).
+- `${DRAFT_FILE}`: Path to draft rule file written by Step 4 (read by Step 5).
+- `${STEP4_SESSION_ID}`: Session ID of the Step 4 CSA run (for audit).
 
 ### Filter criteria (enforced before Step 2)
 

--- a/patterns/rule-extractor/PATTERN.md
+++ b/patterns/rule-extractor/PATTERN.md
@@ -34,23 +34,28 @@ Tool: bash
 Read the merged PR's review artifacts and extract HIGH/CRITICAL findings.
 
 ```bash
-# Collect review findings from the merged PR
-# FINDINGS_SOURCE can be: findings.toml from csa review session, or PR comments
+# Collect review findings from the merged PR and parse findings.toml.
+# Emits CSA_VAR:FINDING_DESCRIPTION, CSA_VAR:FINDING_SEVERITY, CSA_VAR:FINDING_FILE
+# for the first HIGH/CRITICAL finding. Pattern processes one finding per invocation;
+# invoke once per finding for multi-finding PRs.
 if [ -n "${REVIEW_SESSION_ID:-}" ]; then
-  csa session result --session "${REVIEW_SESSION_ID}" --section details
+  # Extract findings.toml from the review session output directory
+  SESSION_DIR=$(csa session result --session "${REVIEW_SESSION_ID}" --session-dir 2>/dev/null || true)
+  if [ -n "$SESSION_DIR" ] && [ -f "$SESSION_DIR/output/findings.toml" ]; then
+    FINDINGS_RAW=$(cat "$SESSION_DIR/output/findings.toml")
+  else
+    FINDINGS_RAW=$(csa session result --session "${REVIEW_SESSION_ID}" --section details 2>/dev/null || true)
+  fi
 else
   # Fall back to PR comment history for bot findings
   gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/comments" \
     | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL")) | {id: .id, body: .body, path: .path}'
 fi
+# Parse first HIGH/CRITICAL finding from TOML and emit CSA_VARs
 ```
 
-Output: structured list of HIGH/CRITICAL findings with:
-- Finding ID or comment ID
-- Severity (HIGH/CRITICAL/P1)
-- File path and line range
-- Description of the issue
-- Whether it was fixed (commit SHA) or dismissed (debate verdict)
+Output: CSA_VAR:FINDING_DESCRIPTION, CSA_VAR:FINDING_SEVERITY, CSA_VAR:FINDING_FILE
+for the first HIGH/CRITICAL finding. Empty values if no findings found.
 
 ## Step 2: Classify Bug Class vs Isolated Mistake
 
@@ -136,12 +141,23 @@ else
   echo "EXISTING_RULE_MATCH=potential"
   echo "CSA_VAR:EXISTING_RULE_MATCH=potential"
 
+  # Read actual content from matched rule files for semantic comparison
+  MATCHED_CONTENT=""
+  while IFS= read -r match_file; do
+    [ -z "$match_file" ] && continue
+    MATCHED_CONTENT="${MATCHED_CONTENT}
+--- ${match_file} ---
+$(cat "$match_file")
+"
+  done <<< "${PROJECT_MATCHES}"
+
   # Dispatch semantic deduplication for potential matches
   DEDUPE_SID=$(csa run --sa-mode true --tier tier-1-quick \
     --description "dedupe-check: ${BUG_CLASS_NAME}" \
-    "Compare this bug class against the existing rule.
+    "Compare this bug class against the existing rule(s).
      Bug class: ${BUG_CLASS_DESCRIPTION}
-     Existing rule content: (read from matched file)
+     Existing rule content:
+${MATCHED_CONTENT}
      Output: DEDUPE_RESULT=EXACT_MATCH|PARTIAL_MATCH|NO_MATCH
      If PARTIAL_MATCH: UPDATE_SUGGESTION: <what to add>")
   csa session wait --session "$DEDUPE_SID"
@@ -342,7 +358,7 @@ NNN|bug-class-slug|one-line summary of the rule
 
 ## Integration
 
-- **Invoked by**: pr-bot (post-merge, opt-in) via `csa plan run patterns/rule-extractor/workflow.toml`
+- **Invoked by**: pr-bot (post-merge, opt-in) via `csa plan run --sa-mode true patterns/rule-extractor/workflow.toml`
 - **Depends on**: pr-bot review artifacts (findings, debate verdicts, fix commits)
 - **Outputs to**: `.agents/project-rules-ref/<lang>/` (project-local, fork-only per rule 030)
 - **Constraint**: NEVER auto-commits. Always proposes via PR for human review.

--- a/patterns/rule-extractor/PATTERN.md
+++ b/patterns/rule-extractor/PATTERN.md
@@ -34,16 +34,20 @@ Tool: bash
 Read the merged PR's review artifacts and extract HIGH/CRITICAL findings.
 
 ```bash
+set -euo pipefail
 # Collect review findings from the merged PR and parse findings.toml.
 # Emits CSA_VAR:FINDING_DESCRIPTION, CSA_VAR:FINDING_SEVERITY, CSA_VAR:FINDING_FILE
 # for the first HIGH/CRITICAL finding. Pattern processes one finding per invocation;
 # invoke once per finding for multi-finding PRs.
+FINDINGS_RAW=""
+FINDING_EMITTED=""
 if [ -n "${REVIEW_SESSION_ID:-}" ]; then
   # Extract findings.toml from the review session output directory
   SESSION_DIR=$(csa session result --session "${REVIEW_SESSION_ID}" --session-dir 2>/dev/null || true)
   if [ -n "$SESSION_DIR" ] && [ -f "$SESSION_DIR/output/findings.toml" ]; then
     FINDINGS_RAW=$(cat "$SESSION_DIR/output/findings.toml")
   else
+    # Fallback: read from session details text
     FINDINGS_RAW=$(csa session result --session "${REVIEW_SESSION_ID}" --section details 2>/dev/null || true)
   fi
 else
@@ -70,22 +74,61 @@ else
       echo "CSA_VAR:FINDING_DESCRIPTION=$COMMENT_DESC"
       echo "CSA_VAR:FINDING_SEVERITY=$COMMENT_SEV"
       echo "CSA_VAR:FINDING_FILE=${COMMENT_PATH:-unknown}"
+      FINDING_EMITTED=1
+      echo "Extracted finding from PR comment: severity=$COMMENT_SEV file=$COMMENT_PATH"
     else
       echo "WARNING: No HIGH/CRITICAL findings in PR comments"
       echo "CSA_VAR:FINDING_DESCRIPTION="
       echo "CSA_VAR:FINDING_SEVERITY="
       echo "CSA_VAR:FINDING_FILE="
+      FINDING_EMITTED=1
     fi
   else
     echo "WARNING: Could not fetch PR comments"
     echo "CSA_VAR:FINDING_DESCRIPTION="
     echo "CSA_VAR:FINDING_SEVERITY="
     echo "CSA_VAR:FINDING_FILE="
+    FINDING_EMITTED=1
   fi
   # Skip the TOML parser below — CSA_VARs already emitted
   FINDINGS_RAW=""
 fi
-# Parse first HIGH/CRITICAL finding from TOML and emit CSA_VARs
+
+# Parse findings.toml for first HIGH/CRITICAL finding and emit CSA_VARs.
+# findings.toml uses [[findings]] sections with id, severity, description,
+# and file_ranges (array of {path, start, end}).
+if [ -n "$FINDINGS_RAW" ]; then
+  # Extract severity, description, and file path from first high/critical finding.
+  # The toml structure: severity = "high"|"critical", description = "...",
+  # file_ranges has path = "..." entries.
+  # Filter: only consider lines where severity is high or critical
+  FIRST_SEV=$(echo "$FINDINGS_RAW" | grep -iE '^severity\s*=\s*"(high|critical)"' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
+  # Find the description from the same [[findings]] block as the matched severity.
+  # Since findings.toml is flat-ish (severity then description then file_ranges),
+  # we take the description line following the first high/critical severity line.
+  FIRST_DESC=$(echo "$FINDINGS_RAW" | grep -iA 20 '^severity\s*=\s*".*\(high\|critical\)"' | grep -i '^description' | head -1 | sed 's/.*= *"\(.*\)".*/\1/')
+  FIRST_FILE=$(echo "$FINDINGS_RAW" | grep -iA 30 '^severity\s*=\s*".*\(high\|critical\)"' | grep -i '^path' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
+
+  if [ -n "$FIRST_DESC" ]; then
+    echo "CSA_VAR:FINDING_DESCRIPTION=$FIRST_DESC"
+    echo "CSA_VAR:FINDING_SEVERITY=${FIRST_SEV:-HIGH}"
+    echo "CSA_VAR:FINDING_FILE=${FIRST_FILE:-unknown}"
+    FINDING_EMITTED=1
+    echo "Extracted finding: severity=$FIRST_SEV file=$FIRST_FILE"
+    echo "Description: $FIRST_DESC"
+  else
+    echo "WARNING: No parseable findings in review session output"
+    echo "CSA_VAR:FINDING_DESCRIPTION="
+    echo "CSA_VAR:FINDING_SEVERITY="
+    echo "CSA_VAR:FINDING_FILE="
+    FINDING_EMITTED=1
+  fi
+elif [ -z "$FINDING_EMITTED" ]; then
+  echo "WARNING: No findings data available from session or PR comments"
+  echo "CSA_VAR:FINDING_DESCRIPTION="
+  echo "CSA_VAR:FINDING_SEVERITY="
+  echo "CSA_VAR:FINDING_FILE="
+fi
 ```
 
 Output: CSA_VAR:FINDING_DESCRIPTION, CSA_VAR:FINDING_SEVERITY, CSA_VAR:FINDING_FILE
@@ -150,13 +193,13 @@ fi
 Tool: bash
 
 Check whether an existing rule already covers this bug class. Search
-project-local rules (`.agents/project-rules-ref/`). Emits
+project-local rules (`docs/rules-proposed/`). Emits
 `CSA_VAR:SHOULD_DRAFT=yes` when Step 4 should run, and
 `CSA_VAR:DEDUPE_RESULT` with the semantic comparison outcome.
 
 ```bash
 set -euo pipefail
-PROJECT_RULES_DIR=".agents/project-rules-ref"
+PROJECT_RULES_DIR="docs/rules-proposed"
 
 # Keyword grep across project-local rules
 PROJECT_MATCHES=""
@@ -276,7 +319,7 @@ if [ -z "$DRAFT_CONTENT" ]; then
 fi
 
 # Write draft to a temp file and emit its path
-DRAFT_FILE=".agents/project-rules-ref/.draft-${BUG_CLASS_SLUG}.md"
+DRAFT_FILE="docs/rules-proposed/.draft-${BUG_CLASS_SLUG}.md"
 mkdir -p "$(dirname "$DRAFT_FILE")"
 echo "$DRAFT_CONTENT" > "$DRAFT_FILE"
 echo "CSA_VAR:DRAFT_FILE=$DRAFT_FILE"
@@ -301,7 +344,7 @@ if [ ! -f "${DRAFT_FILE}" ]; then
 fi
 
 # Determine target directory (project-local, fork-only per rule 030)
-RULE_DIR=".agents/project-rules-ref/${LANG}"
+RULE_DIR="docs/rules-proposed/${LANG}"
 mkdir -p "${RULE_DIR}"
 
 # Determine next rule number (safe for empty directory)
@@ -394,7 +437,7 @@ NNN|bug-class-slug|one-line summary of the rule
 
 - **Invoked by**: pr-bot (post-merge, opt-in) via `csa plan run --sa-mode true patterns/rule-extractor/workflow.toml`
 - **Depends on**: pr-bot review artifacts (findings, debate verdicts, fix commits)
-- **Outputs to**: `.agents/project-rules-ref/<lang>/` (project-local, fork-only per rule 030)
+- **Outputs to**: `docs/rules-proposed/<lang>/` (project-local, fork-only per rule 030)
 - **Constraint**: NEVER auto-commits. Always proposes via PR for human review.
 - **Constraint**: AGENTS.md rule 030 (fork-only) — PRs target user's fork.
 

--- a/patterns/rule-extractor/PATTERN.md
+++ b/patterns/rule-extractor/PATTERN.md
@@ -64,11 +64,11 @@ else
     if [ -n "$COMMENT_BODY" ]; then
       # Infer severity from the comment text
       COMMENT_SEV="HIGH"
-      if echo "$COMMENT_BODY" | grep -qi "CRITICAL\|P0"; then
+      if echo "$COMMENT_BODY" | grep -qiE "CRITICAL|P0"; then
         COMMENT_SEV="CRITICAL"
       fi
       # Use first line of comment body as description (strip markdown headers)
-      COMMENT_DESC=$(echo "$COMMENT_BODY" | grep -v '^#' | grep -v '^\s*$' | head -1 | sed 's/^[[:space:]]*//')
+      COMMENT_DESC=$(echo "$COMMENT_BODY" | grep -v '^#' | grep -v '^[[:space:]]*$' | head -1 | sed 's/^[[:space:]]*//')
       echo "CSA_VAR:FINDING_DESCRIPTION=$COMMENT_DESC"
       echo "CSA_VAR:FINDING_SEVERITY=$COMMENT_SEV"
       echo "CSA_VAR:FINDING_FILE=${COMMENT_PATH:-unknown}"
@@ -100,12 +100,12 @@ if [ -n "$FINDINGS_RAW" ]; then
   # The toml structure: severity = "high"|"critical", description = "...",
   # file_ranges has path = "..." entries.
   # Filter: only consider lines where severity is high or critical
-  FIRST_SEV=$(echo "$FINDINGS_RAW" | grep -iE '^severity\s*=\s*"(high|critical)"' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
+  FIRST_SEV=$(echo "$FINDINGS_RAW" | grep -iE '^severity[[:space:]]*=[[:space:]]*"(high|critical)"' | head -1 | sed -E 's/.*= *"([^"]*)".*/\1/')
   # Find the description from the same [[findings]] block as the matched severity.
   # Since findings.toml is flat-ish (severity then description then file_ranges),
   # we take the description line following the first high/critical severity line.
-  FIRST_DESC=$(echo "$FINDINGS_RAW" | grep -iA 20 '^severity\s*=\s*".*\(high\|critical\)"' | grep -i '^description' | head -1 | sed 's/.*= *"\(.*\)".*/\1/')
-  FIRST_FILE=$(echo "$FINDINGS_RAW" | grep -iA 30 '^severity\s*=\s*".*\(high\|critical\)"' | grep -i '^path' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
+  FIRST_DESC=$(echo "$FINDINGS_RAW" | grep -iEA 20 '^severity[[:space:]]*=[[:space:]]*".*(high|critical)"' | grep -i '^description' | head -1 | sed -E 's/.*= *"(.*)".*/\1/')
+  FIRST_FILE=$(echo "$FINDINGS_RAW" | grep -iEA 30 '^severity[[:space:]]*=[[:space:]]*".*(high|critical)"' | grep -i '^path' | head -1 | sed -E 's/.*= *"([^"]*)".*/\1/')
 
   if [ -n "$FIRST_DESC" ]; then
     echo "CSA_VAR:FINDING_DESCRIPTION=$FIRST_DESC"
@@ -173,14 +173,49 @@ CLASSIFY_SID=$(csa run --sa-mode true --tier tier-2-standard \
    - Cannot generalize to other locations
    - No historical precedent
 
-   Output exactly one line: CLASSIFICATION=BUG_CLASS or CLASSIFICATION=ISOLATED_MISTAKE
-   Then output RATIONALE: <one paragraph explaining why>")
+   Output EXACTLY these lines (one per line, no quoting, no extra whitespace):
+   CLASSIFICATION=BUG_CLASS or CLASSIFICATION=ISOLATED_MISTAKE
+   RATIONALE=<one paragraph explaining why>
+
+   If CLASSIFICATION=BUG_CLASS, also output these ADDITIONAL lines:
+   BUG_CLASS_NAME=<human-readable name, e.g. Unbound Shell Variable>
+   BUG_CLASS_SLUG=<kebab-case slug, e.g. unbound-shell-variable>
+   BUG_CLASS_KEYWORDS=<space-separated grep keywords, e.g. unbound variable set -u>
+   BUG_CLASS_DESCRIPTION=<single-line paragraph describing the bug class>
+   ANTI_PATTERN_EXAMPLES_B64=<base64-encoded multi-line anti-pattern code examples>
+   CORRECT_PATTERN_B64=<base64-encoded multi-line correct pattern code examples>
+
+   If CLASSIFICATION=ISOLATED_MISTAKE, do NOT output the BUG_CLASS_* lines.")
 csa session wait --session "$CLASSIFY_SID"
 
-# Read classifier result and emit CSA_VAR for condition gating
-CLASSIFY_OUTPUT=$(csa session result --session "$CLASSIFY_SID" --section summary 2>/dev/null || true)
+# Read classifier result and emit CSA_VAR for condition gating.
+# When classification is BUG_CLASS, also parse and emit the 6 BUG_CLASS_*
+# fields that Steps 3-5 reference.
+CLASSIFY_OUTPUT=$(csa session result --session "$CLASSIFY_SID" --section summary 2>/dev/null || \
+                  csa session result --session "$CLASSIFY_SID" --full 2>/dev/null || true)
 if echo "$CLASSIFY_OUTPUT" | grep -q "CLASSIFICATION=BUG_CLASS"; then
   echo "CSA_VAR:HAS_BUG_CLASS_FINDINGS=yes"
+
+  # Extract the 6 BUG_CLASS fields from LLM output (one per line, KEY=VALUE format)
+  BC_NAME=$(echo "$CLASSIFY_OUTPUT" | grep -E '^BUG_CLASS_NAME=' | head -1 | sed 's/^BUG_CLASS_NAME=//')
+  BC_SLUG=$(echo "$CLASSIFY_OUTPUT" | grep -E '^BUG_CLASS_SLUG=' | head -1 | sed 's/^BUG_CLASS_SLUG=//')
+  BC_KEYWORDS=$(echo "$CLASSIFY_OUTPUT" | grep -E '^BUG_CLASS_KEYWORDS=' | head -1 | sed 's/^BUG_CLASS_KEYWORDS=//')
+  BC_DESC=$(echo "$CLASSIFY_OUTPUT" | grep -E '^BUG_CLASS_DESCRIPTION=' | head -1 | sed 's/^BUG_CLASS_DESCRIPTION=//')
+  BC_ANTI_B64=$(echo "$CLASSIFY_OUTPUT" | grep -E '^ANTI_PATTERN_EXAMPLES_B64=' | head -1 | sed 's/^ANTI_PATTERN_EXAMPLES_B64=//')
+  BC_CORRECT_B64=$(echo "$CLASSIFY_OUTPUT" | grep -E '^CORRECT_PATTERN_B64=' | head -1 | sed 's/^CORRECT_PATTERN_B64=//')
+
+  # Fallback defaults when LLM omits optional fields
+  : "${BC_NAME:=unknown-bug-class}"
+  : "${BC_SLUG:=unknown-bug-class}"
+  : "${BC_KEYWORDS:=bug class}"
+  : "${BC_DESC:=${FINDING_DESCRIPTION}}"
+
+  echo "CSA_VAR:BUG_CLASS_NAME=$BC_NAME"
+  echo "CSA_VAR:BUG_CLASS_SLUG=$BC_SLUG"
+  echo "CSA_VAR:BUG_CLASS_KEYWORDS=$BC_KEYWORDS"
+  echo "CSA_VAR:BUG_CLASS_DESCRIPTION=$BC_DESC"
+  echo "CSA_VAR:ANTI_PATTERN_EXAMPLES_B64=${BC_ANTI_B64:-}"
+  echo "CSA_VAR:CORRECT_PATTERN_B64=${BC_CORRECT_B64:-}"
 else
   echo "CSA_VAR:HAS_BUG_CLASS_FINDINGS="
 fi
@@ -281,14 +316,30 @@ finding-ids: [<list of finding IDs>]
 
 ```bash
 set -euo pipefail
+
+# Decode base64-encoded multi-line fields from Step 2
+ANTI_PATTERN_DECODED=""
+if [ -n "${ANTI_PATTERN_EXAMPLES_B64:-}" ]; then
+  ANTI_PATTERN_DECODED=$(echo "${ANTI_PATTERN_EXAMPLES_B64}" | base64 -d 2>/dev/null || true)
+fi
+: "${ANTI_PATTERN_DECODED:=No anti-pattern examples provided.}"
+
+CORRECT_PATTERN_DECODED=""
+if [ -n "${CORRECT_PATTERN_B64:-}" ]; then
+  CORRECT_PATTERN_DECODED=$(echo "${CORRECT_PATTERN_B64}" | base64 -d 2>/dev/null || true)
+fi
+: "${CORRECT_PATTERN_DECODED:=No correct pattern examples provided.}"
+
 DRAFT_SID=$(csa run --sa-mode true --tier tier-2-standard \
   --description "draft-rule: ${BUG_CLASS_NAME}" \
   "Generate a coding rule file for the following bug class.
 
    Bug class: ${BUG_CLASS_DESCRIPTION}
    Language: ${LANG}
-   Anti-pattern examples: ${ANTI_PATTERN_EXAMPLES}
-   Correct pattern: ${CORRECT_PATTERN}
+   Anti-pattern examples:
+${ANTI_PATTERN_DECODED}
+   Correct pattern:
+${CORRECT_PATTERN_DECODED}
    PR: #${PR_NUM}
    Fix commit: ${FIX_COMMIT_SHA}
 
@@ -415,8 +466,10 @@ NNN|bug-class-slug|one-line summary of the rule
 - `${BUG_CLASS_KEYWORDS}`: Keywords for grep-based deduplication.
 - `${BUG_CLASS_SLUG}`: URL-safe slug for file naming.
 - `${LANG}`: Target language directory (rust, go, py, ts, all-lang).
-- `${ANTI_PATTERN_EXAMPLES}`: Code examples of the anti-pattern.
-- `${CORRECT_PATTERN}`: Code examples of the correct pattern.
+- `${ANTI_PATTERN_EXAMPLES}`: Code examples of the anti-pattern (deprecated — use B64 variant).
+- `${ANTI_PATTERN_EXAMPLES_B64}`: Base64-encoded multi-line anti-pattern code examples (emitted by Step 2, decoded in Step 4).
+- `${CORRECT_PATTERN}`: Code examples of the correct pattern (deprecated — use B64 variant).
+- `${CORRECT_PATTERN_B64}`: Base64-encoded multi-line correct pattern code examples (emitted by Step 2, decoded in Step 4).
 - `${RULE_CONTENT}`: Generated rule file content (deprecated — use DRAFT_FILE).
 - `${SHOULD_DRAFT}`: Set to "yes" by Step 3 when Step 4 should run (empty on EXACT_MATCH).
 - `${DEDUPE_RESULT}`: Deduplication outcome from Step 3 (EXACT_MATCH|PARTIAL_MATCH|NO_MATCH).

--- a/patterns/rule-extractor/PATTERN.md
+++ b/patterns/rule-extractor/PATTERN.md
@@ -42,26 +42,24 @@ set -euo pipefail
 FINDINGS_RAW=""
 FINDING_EMITTED=""
 if [ -n "${REVIEW_SESSION_ID:-}" ]; then
-  # Extract findings.toml from the review session output directory
-  SESSION_DIR=$(csa session result --session "${REVIEW_SESSION_ID}" --session-dir 2>/dev/null || true)
-  if [ -n "$SESSION_DIR" ] && [ -f "$SESSION_DIR/output/findings.toml" ]; then
-    FINDINGS_RAW=$(cat "$SESSION_DIR/output/findings.toml")
-  else
-    # Fallback: read from session details text
-    FINDINGS_RAW=$(csa session result --session "${REVIEW_SESSION_ID}" --section details 2>/dev/null || true)
-  fi
+  # Read findings from the review session's structured output.
+  # --section details contains the review findings (including findings.toml content
+  # when the review pattern emits it). --full is a broader fallback.
+  FINDINGS_RAW=$(csa session result --session "${REVIEW_SESSION_ID}" --section details 2>/dev/null || \
+                 csa session result --session "${REVIEW_SESSION_ID}" --full 2>/dev/null || true)
 else
   # Fall back to PR comment history for bot findings.
   # Extract severity + description + path from PR comment bodies and emit
   # CSA_VARs directly (comment JSON shape differs from findings.toml).
   PR_COMMENTS=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/comments" 2>/dev/null || true)
   if [ -n "$PR_COMMENTS" ]; then
-    # Pick the first comment whose body mentions a HIGH/CRITICAL/P0/P1 severity
+    # Pick the first bot comment whose body mentions a HIGH/CRITICAL/P0/P1 severity.
+    # Filter by known bot logins to avoid misinterpreting human comments.
     COMMENT_BODY=$(echo "$PR_COMMENTS" \
-      | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .body' \
+      | jq -r '.[] | select(.user.login | test("codex|gemini-pr-bot|coderabbit|github-actions"; "i")) | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .body' \
       | head -1)
     COMMENT_PATH=$(echo "$PR_COMMENTS" \
-      | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .path // "unknown"' \
+      | jq -r '.[] | select(.user.login | test("codex|gemini-pr-bot|coderabbit|github-actions"; "i")) | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .path // "unknown"' \
       | head -1)
     if [ -n "$COMMENT_BODY" ]; then
       # Infer severity from the comment text
@@ -302,7 +300,7 @@ DRAFT_SID=$(csa run --sa-mode true --tier tier-2-standard \
    5. Decision Checklist (2-4 yes/no items)
    6. Case Study: PR #${PR_NUM}
 
-   Add frontmatter: source: pr-bot-finding, pr: #${PR_NUM}, severity: ${SEVERITY},
+   Add frontmatter: source: pr-bot-finding, pr: #${PR_NUM}, severity: ${FINDING_SEVERITY},
    extracted-at: $(date -u +%Y-%m-%d)
 
    Output the complete rule file content between RULE_DRAFT_START and RULE_DRAFT_END markers.")
@@ -380,7 +378,7 @@ gh pr create \
   --body "## Rule Proposal (auto-extracted)
 
 Source PR: #${PR_NUM}
-Severity: ${SEVERITY}
+Severity: ${FINDING_SEVERITY}
 Bug class: ${BUG_CLASS_NAME}
 
 Auto-extracted by rule-extractor pattern (issue #661). Human review required.
@@ -408,7 +406,7 @@ NNN|bug-class-slug|one-line summary of the rule
 - `${PR_NUM}`: Merged PR number.
 - `${REVIEW_SESSION_ID}`: CSA review session ID (optional, for csa review findings).
 - `${FINDING_DESCRIPTION}`: Description of the current finding being processed.
-- `${FINDING_SEVERITY}`: Severity level (HIGH/CRITICAL/P1).
+- `${FINDING_SEVERITY}`: Finding severity (HIGH/CRITICAL/P1), emitted by Step 1, used in frontmatter and PR body.
 - `${FINDING_FILE}`: File path of the finding.
 - `${FIX_COMMIT_SHA}`: Commit SHA of the fix.
 - `${FIX_DIFF_SUMMARY}`: Summary of the fix diff.
@@ -419,7 +417,6 @@ NNN|bug-class-slug|one-line summary of the rule
 - `${LANG}`: Target language directory (rust, go, py, ts, all-lang).
 - `${ANTI_PATTERN_EXAMPLES}`: Code examples of the anti-pattern.
 - `${CORRECT_PATTERN}`: Code examples of the correct pattern.
-- `${SEVERITY}`: Finding severity for frontmatter.
 - `${RULE_CONTENT}`: Generated rule file content (deprecated — use DRAFT_FILE).
 - `${SHOULD_DRAFT}`: Set to "yes" by Step 3 when Step 4 should run (empty on EXACT_MATCH).
 - `${DEDUPE_RESULT}`: Deduplication outcome from Step 3 (EXACT_MATCH|PARTIAL_MATCH|NO_MATCH).

--- a/patterns/rule-extractor/PATTERN.md
+++ b/patterns/rule-extractor/PATTERN.md
@@ -47,9 +47,43 @@ if [ -n "${REVIEW_SESSION_ID:-}" ]; then
     FINDINGS_RAW=$(csa session result --session "${REVIEW_SESSION_ID}" --section details 2>/dev/null || true)
   fi
 else
-  # Fall back to PR comment history for bot findings
-  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/comments" \
-    | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL")) | {id: .id, body: .body, path: .path}'
+  # Fall back to PR comment history for bot findings.
+  # Extract severity + description + path from PR comment bodies and emit
+  # CSA_VARs directly (comment JSON shape differs from findings.toml).
+  PR_COMMENTS=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/comments" 2>/dev/null || true)
+  if [ -n "$PR_COMMENTS" ]; then
+    # Pick the first comment whose body mentions a HIGH/CRITICAL/P0/P1 severity
+    COMMENT_BODY=$(echo "$PR_COMMENTS" \
+      | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .body' \
+      | head -1)
+    COMMENT_PATH=$(echo "$PR_COMMENTS" \
+      | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .path // "unknown"' \
+      | head -1)
+    if [ -n "$COMMENT_BODY" ]; then
+      # Infer severity from the comment text
+      COMMENT_SEV="HIGH"
+      if echo "$COMMENT_BODY" | grep -qi "CRITICAL\|P0"; then
+        COMMENT_SEV="CRITICAL"
+      fi
+      # Use first line of comment body as description (strip markdown headers)
+      COMMENT_DESC=$(echo "$COMMENT_BODY" | grep -v '^#' | grep -v '^\s*$' | head -1 | sed 's/^[[:space:]]*//')
+      echo "CSA_VAR:FINDING_DESCRIPTION=$COMMENT_DESC"
+      echo "CSA_VAR:FINDING_SEVERITY=$COMMENT_SEV"
+      echo "CSA_VAR:FINDING_FILE=${COMMENT_PATH:-unknown}"
+    else
+      echo "WARNING: No HIGH/CRITICAL findings in PR comments"
+      echo "CSA_VAR:FINDING_DESCRIPTION="
+      echo "CSA_VAR:FINDING_SEVERITY="
+      echo "CSA_VAR:FINDING_FILE="
+    fi
+  else
+    echo "WARNING: Could not fetch PR comments"
+    echo "CSA_VAR:FINDING_DESCRIPTION="
+    echo "CSA_VAR:FINDING_SEVERITY="
+    echo "CSA_VAR:FINDING_FILE="
+  fi
+  # Skip the TOML parser below — CSA_VARs already emitted
+  FINDINGS_RAW=""
 fi
 # Parse first HIGH/CRITICAL finding from TOML and emit CSA_VARs
 ```
@@ -280,9 +314,9 @@ fi
 NEXT_NUM=$(printf '%03d' $((10#${LAST_NUM} + 1)))
 RULE_FILE="${NEXT_NUM}-${BUG_CLASS_SLUG}.md"
 
-# Create proposal branch
-SHORT_SHA=$(echo "${FIX_COMMIT_SHA}" | cut -c1-7)
-PROPOSAL_BRANCH="chore/rules-propose-${SHORT_SHA}"
+# Create proposal branch (include BUG_CLASS_SLUG for uniqueness across findings)
+SHORT_SHA=$(echo "${FIX_COMMIT_SHA}" | cut -c1-8)
+PROPOSAL_BRANCH="chore/rules-propose-${SHORT_SHA}-${BUG_CLASS_SLUG}"
 git checkout -b "${PROPOSAL_BRANCH}"
 
 # Copy draft to final rule location

--- a/patterns/rule-extractor/PATTERN.md
+++ b/patterns/rule-extractor/PATTERN.md
@@ -54,8 +54,7 @@ Output: structured list of HIGH/CRITICAL findings with:
 
 ## Step 2: Classify Bug Class vs Isolated Mistake
 
-Tool: csa
-Tier: tier-2-standard
+Tool: bash
 
 For each HIGH/CRITICAL finding, dispatch an LLM classifier to determine
 whether the finding represents a **bug class** (structural anti-pattern
@@ -73,6 +72,7 @@ Classification criteria:
 Only bug classes proceed to Step 3. Isolated mistakes are logged and skipped.
 
 ```bash
+set -euo pipefail
 CLASSIFY_SID=$(csa run --sa-mode true --tier tier-2-standard \
   --description "classify-finding: bug-class-or-isolated" \
   "Classify the following review finding as either BUG_CLASS or ISOLATED_MISTAKE.
@@ -96,49 +96,52 @@ CLASSIFY_SID=$(csa run --sa-mode true --tier tier-2-standard \
    Output exactly one line: CLASSIFICATION=BUG_CLASS or CLASSIFICATION=ISOLATED_MISTAKE
    Then output RATIONALE: <one paragraph explaining why>")
 csa session wait --session "$CLASSIFY_SID"
+
+# Read classifier result and emit CSA_VAR for condition gating
+CLASSIFY_OUTPUT=$(csa session result --session "$CLASSIFY_SID" --section summary 2>/dev/null || true)
+if echo "$CLASSIFY_OUTPUT" | grep -q "CLASSIFICATION=BUG_CLASS"; then
+  echo "CSA_VAR:HAS_BUG_CLASS_FINDINGS=yes"
+else
+  echo "CSA_VAR:HAS_BUG_CLASS_FINDINGS="
+fi
 ```
 
 ## Step 3: Deduplicate Against Existing Rules
 
 Tool: bash
 
-Check whether an existing rule already covers this bug class. Search both
-the shared rules repository and project-local rules.
+Check whether an existing rule already covers this bug class. Search
+project-local rules (`.agents/project-rules-ref/`).
 
 ```bash
-# Search shared rules
-SHARED_RULES_DIR="${HOME}/project/github/t4nature/s/llm/coding/rules"
-if [ -d "${SHARED_RULES_DIR}" ]; then
-  grep -rl "${BUG_CLASS_KEYWORDS}" "${SHARED_RULES_DIR}/" || true
-fi
-
-# Search project-local rules
+set -euo pipefail
 PROJECT_RULES_DIR=".agents/project-rules-ref"
+
+# Keyword grep across project-local rules
+PROJECT_MATCHES=""
 if [ -d "${PROJECT_RULES_DIR}" ]; then
-  grep -rl "${BUG_CLASS_KEYWORDS}" "${PROJECT_RULES_DIR}/" || true
+  PROJECT_MATCHES=$(grep -rl "${BUG_CLASS_KEYWORDS}" "${PROJECT_RULES_DIR}/" 2>/dev/null || true)
 fi
-```
 
-If a matching rule is found:
-- **Exact match**: Skip rule generation. Log "already covered by rule NNN".
-- **Partial match**: Propose an UPDATE to the existing rule (add new case study
-  section) instead of creating a new rule.
-- **No match**: Proceed to Step 4 to generate a new rule.
+if [ -z "${PROJECT_MATCHES}" ]; then
+  echo "EXISTING_RULE_MATCH=none"
+  echo "CSA_VAR:EXISTING_RULE_MATCH=none"
+else
+  echo "Potential matches found:"
+  echo "${PROJECT_MATCHES}"
+  echo "EXISTING_RULE_MATCH=potential"
+  echo "CSA_VAR:EXISTING_RULE_MATCH=potential"
 
-For semantic deduplication beyond keyword grep, dispatch an LLM comparison:
-
-```bash
-DEDUPE_SID=$(csa run --sa-mode true --tier tier-1-quick \
-  --description "dedupe-check: ${BUG_CLASS_NAME}" \
-  "Compare this bug class description against the existing rule below.
-   Are they covering the same anti-pattern?
-
-   Bug class: ${BUG_CLASS_DESCRIPTION}
-   Existing rule: ${EXISTING_RULE_CONTENT}
-
-   Output: DEDUPE_RESULT=EXACT_MATCH|PARTIAL_MATCH|NO_MATCH
-   If PARTIAL_MATCH, output UPDATE_SUGGESTION: <what to add to existing rule>")
-csa session wait --session "$DEDUPE_SID"
+  # Dispatch semantic deduplication for potential matches
+  DEDUPE_SID=$(csa run --sa-mode true --tier tier-1-quick \
+    --description "dedupe-check: ${BUG_CLASS_NAME}" \
+    "Compare this bug class against the existing rule.
+     Bug class: ${BUG_CLASS_DESCRIPTION}
+     Existing rule content: (read from matched file)
+     Output: DEDUPE_RESULT=EXACT_MATCH|PARTIAL_MATCH|NO_MATCH
+     If PARTIAL_MATCH: UPDATE_SUGGESTION: <what to add>")
+  csa session wait --session "$DEDUPE_SID"
+fi
 ```
 
 ## Step 4: Generate Rule Draft
@@ -203,10 +206,19 @@ Create a proposal PR with the rule draft. NEVER auto-commit rules to
 the main rules repository. Human review is mandatory.
 
 ```bash
-# Determine target directory and next rule number
-RULE_DIR="${SHARED_RULES_DIR}/${LANG}"
-NEXT_NUM=$(ls "${RULE_DIR}/" 2>/dev/null | grep -E '^[0-9]{3}-' | sort -n | tail -1 | cut -c1-3)
-NEXT_NUM=$(printf '%03d' $((10#${NEXT_NUM:-0} + 1)))
+set -euo pipefail
+# Determine target directory (project-local, fork-only per rule 030)
+RULE_DIR=".agents/project-rules-ref/${LANG}"
+mkdir -p "${RULE_DIR}"
+
+# Determine next rule number (safe for empty directory)
+EXISTING=$(ls "${RULE_DIR}/" 2>/dev/null | grep -E '^[0-9]{3}-' || true)
+if [ -n "${EXISTING}" ]; then
+  LAST_NUM=$(echo "${EXISTING}" | sort -n | tail -1 | cut -c1-3)
+else
+  LAST_NUM="000"
+fi
+NEXT_NUM=$(printf '%03d' $((10#${LAST_NUM} + 1)))
 RULE_FILE="${NEXT_NUM}-${BUG_CLASS_SLUG}.md"
 
 # Create proposal branch
@@ -214,8 +226,7 @@ SHORT_SHA=$(echo "${FIX_COMMIT_SHA}" | cut -c1-7)
 PROPOSAL_BRANCH="chore/rules-propose-${SHORT_SHA}"
 git checkout -b "${PROPOSAL_BRANCH}"
 
-# Write rule file
-# (RULE_CONTENT extracted from Step 4 output between markers)
+# Write rule file (RULE_CONTENT extracted from Step 4 output between markers)
 echo "${RULE_CONTENT}" > "${RULE_DIR}/${RULE_FILE}"
 
 git add "${RULE_DIR}/${RULE_FILE}"
@@ -234,8 +245,7 @@ Source PR: #${PR_NUM}
 Severity: ${SEVERITY}
 Bug class: ${BUG_CLASS_NAME}
 
-This rule was auto-extracted from a verified HIGH/CRITICAL finding by the
-rule-extractor pattern (issue #661). Human review required before merge.
+Auto-extracted by rule-extractor pattern (issue #661). Human review required.
 
 ### Checklist
 - [ ] Rule accurately describes the bug class
@@ -285,7 +295,7 @@ NNN|bug-class-slug|one-line summary of the rule
 
 - **Invoked by**: pr-bot (post-merge, opt-in) via `csa plan run patterns/rule-extractor/workflow.toml`
 - **Depends on**: pr-bot review artifacts (findings, debate verdicts, fix commits)
-- **Outputs to**: `~/project/github/t4nature/s/llm/coding/rules/<lang>/` (shared rules) or `.agents/project-rules-ref/` (project-local)
+- **Outputs to**: `.agents/project-rules-ref/<lang>/` (project-local, fork-only per rule 030)
 - **Constraint**: NEVER auto-commits. Always proposes via PR for human review.
 - **Constraint**: AGENTS.md rule 030 (fork-only) — PRs target user's fork.
 

--- a/patterns/rule-extractor/PATTERN.md
+++ b/patterns/rule-extractor/PATTERN.md
@@ -1,0 +1,298 @@
+---
+name = "rule-extractor"
+description = "Auto-extract coding rules from HIGH/CRITICAL PR-bot findings (closed-loop learning)"
+allowed-tools = "Bash, Read, Grep, Glob"
+tier = "tier-2-standard"
+version = "0.1.0"
+---
+
+# Rule Extractor: Closed-Loop Learning from PR-Bot Findings
+
+Transforms verified HIGH/CRITICAL review findings into reusable coding rules.
+When pr-bot identifies a structural bug class during review, this pattern
+extracts the lesson into a rule file so the bug class goes extinct — future
+agents see the rule at write-time and avoid the anti-pattern entirely.
+
+**Design choice (Option 2)**: Runs post-merge on pr-bot, not on review
+completion. This ensures rules are extracted from the FINAL fix state, not
+intermediate review iterations. The merged code represents the authoritative
+fix, and the full review history (rounds, false positives, debate results)
+is available for case study generation.
+
+## When to Use
+
+Use this pattern when ALL of these conditions are met:
+1. A PR was **merged successfully** via pr-bot.
+2. The PR's review history contains **HIGH/CRITICAL/P1** severity findings.
+3. The findings were **confirmed real** (not false positives — passed debate arbitration or were fixed).
+4. At least one finding represents a **bug class** (structural pattern), not an isolated mistake.
+
+## Step 1: Collect Findings
+
+Tool: bash
+
+Read the merged PR's review artifacts and extract HIGH/CRITICAL findings.
+
+```bash
+# Collect review findings from the merged PR
+# FINDINGS_SOURCE can be: findings.toml from csa review session, or PR comments
+if [ -n "${REVIEW_SESSION_ID:-}" ]; then
+  csa session result --session "${REVIEW_SESSION_ID}" --section details
+else
+  # Fall back to PR comment history for bot findings
+  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/comments" \
+    | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL")) | {id: .id, body: .body, path: .path}'
+fi
+```
+
+Output: structured list of HIGH/CRITICAL findings with:
+- Finding ID or comment ID
+- Severity (HIGH/CRITICAL/P1)
+- File path and line range
+- Description of the issue
+- Whether it was fixed (commit SHA) or dismissed (debate verdict)
+
+## Step 2: Classify Bug Class vs Isolated Mistake
+
+Tool: csa
+Tier: tier-2-standard
+
+For each HIGH/CRITICAL finding, dispatch an LLM classifier to determine
+whether the finding represents a **bug class** (structural anti-pattern
+that can recur) or an **isolated mistake** (one-off typo, copy-paste error,
+unique to this specific code path).
+
+Classification criteria:
+- **Bug class**: The anti-pattern is reproducible in other code. Two or more
+  examples exist (either in this PR's findings or in historical PRs). The fix
+  required a structural change (new abstraction, pattern switch), not just a
+  line edit.
+- **Isolated mistake**: The fix was a single-line correction. The mistake
+  cannot generalize to other code paths. No historical precedent exists.
+
+Only bug classes proceed to Step 3. Isolated mistakes are logged and skipped.
+
+```bash
+CLASSIFY_SID=$(csa run --sa-mode true --tier tier-2-standard \
+  --description "classify-finding: bug-class-or-isolated" \
+  "Classify the following review finding as either BUG_CLASS or ISOLATED_MISTAKE.
+
+   Finding: ${FINDING_DESCRIPTION}
+   Severity: ${FINDING_SEVERITY}
+   File: ${FINDING_FILE}
+   Fix commit: ${FIX_COMMIT_SHA}
+   Fix diff summary: ${FIX_DIFF_SUMMARY}
+
+   Criteria for BUG_CLASS:
+   - The anti-pattern is reproducible in other code
+   - The fix required a structural change, not just a line edit
+   - Two or more examples exist or could exist in a codebase of this size
+
+   Criteria for ISOLATED_MISTAKE:
+   - Single-line fix, unique to this code path
+   - Cannot generalize to other locations
+   - No historical precedent
+
+   Output exactly one line: CLASSIFICATION=BUG_CLASS or CLASSIFICATION=ISOLATED_MISTAKE
+   Then output RATIONALE: <one paragraph explaining why>")
+csa session wait --session "$CLASSIFY_SID"
+```
+
+## Step 3: Deduplicate Against Existing Rules
+
+Tool: bash
+
+Check whether an existing rule already covers this bug class. Search both
+the shared rules repository and project-local rules.
+
+```bash
+# Search shared rules
+SHARED_RULES_DIR="${HOME}/project/github/t4nature/s/llm/coding/rules"
+if [ -d "${SHARED_RULES_DIR}" ]; then
+  grep -rl "${BUG_CLASS_KEYWORDS}" "${SHARED_RULES_DIR}/" || true
+fi
+
+# Search project-local rules
+PROJECT_RULES_DIR=".agents/project-rules-ref"
+if [ -d "${PROJECT_RULES_DIR}" ]; then
+  grep -rl "${BUG_CLASS_KEYWORDS}" "${PROJECT_RULES_DIR}/" || true
+fi
+```
+
+If a matching rule is found:
+- **Exact match**: Skip rule generation. Log "already covered by rule NNN".
+- **Partial match**: Propose an UPDATE to the existing rule (add new case study
+  section) instead of creating a new rule.
+- **No match**: Proceed to Step 4 to generate a new rule.
+
+For semantic deduplication beyond keyword grep, dispatch an LLM comparison:
+
+```bash
+DEDUPE_SID=$(csa run --sa-mode true --tier tier-1-quick \
+  --description "dedupe-check: ${BUG_CLASS_NAME}" \
+  "Compare this bug class description against the existing rule below.
+   Are they covering the same anti-pattern?
+
+   Bug class: ${BUG_CLASS_DESCRIPTION}
+   Existing rule: ${EXISTING_RULE_CONTENT}
+
+   Output: DEDUPE_RESULT=EXACT_MATCH|PARTIAL_MATCH|NO_MATCH
+   If PARTIAL_MATCH, output UPDATE_SUGGESTION: <what to add to existing rule>")
+csa session wait --session "$DEDUPE_SID"
+```
+
+## Step 4: Generate Rule Draft
+
+Tool: csa
+Tier: tier-2-standard
+
+Generate a rule file following the structure of existing rules
+(e.g., `rust/017-concurrent-file-primitives.md`). The rule must contain:
+
+1. **Core Requirement**: One-paragraph summary of what the rule requires.
+2. **Why This Rule Exists**: Root cause explanation with the concrete failure mode.
+3. **Anti-Patterns (Forbidden)**: Table of code shapes that cause this bug.
+4. **Required Implementation Patterns**: Structurally-safe alternatives with code examples.
+5. **Decision Checklist**: 2-4 yes/no checks an agent can apply at write-time.
+6. **Case Study**: Link to the PR/commit that surfaced this bug class.
+
+The rule file includes frontmatter for traceability:
+
+```yaml
+---
+source: pr-bot-finding
+pr: "#<PR_NUM>"
+severity: <HIGH|CRITICAL>
+extracted-at: <ISO-8601 date>
+finding-ids: [<list of finding IDs>]
+---
+```
+
+```bash
+DRAFT_SID=$(csa run --sa-mode true --tier tier-2-standard \
+  --description "draft-rule: ${BUG_CLASS_NAME}" \
+  "Generate a coding rule file for the following bug class.
+
+   Bug class: ${BUG_CLASS_DESCRIPTION}
+   Language: ${LANG}
+   Anti-pattern examples: ${ANTI_PATTERN_EXAMPLES}
+   Correct pattern: ${CORRECT_PATTERN}
+   PR: #${PR_NUM}
+   Fix commit: ${FIX_COMMIT_SHA}
+
+   Use this structure (mirrors rust/017-concurrent-file-primitives.md):
+   1. Core Requirement (one paragraph)
+   2. Why This Rule Exists (failure mode + root cause)
+   3. Anti-Patterns table (| Anti-pattern | Consequence | Fix |)
+   4. Required Implementation Patterns (code examples)
+   5. Decision Checklist (2-4 yes/no items)
+   6. Case Study: PR #${PR_NUM}
+
+   Add frontmatter: source: pr-bot-finding, pr: #${PR_NUM}, severity: ${SEVERITY},
+   extracted-at: $(date -u +%Y-%m-%d)
+
+   Output the complete rule file content between RULE_DRAFT_START and RULE_DRAFT_END markers.")
+csa session wait --session "$DRAFT_SID"
+```
+
+## Step 5: Propose via PR
+
+Tool: bash
+
+Create a proposal PR with the rule draft. NEVER auto-commit rules to
+the main rules repository. Human review is mandatory.
+
+```bash
+# Determine target directory and next rule number
+RULE_DIR="${SHARED_RULES_DIR}/${LANG}"
+NEXT_NUM=$(ls "${RULE_DIR}/" 2>/dev/null | grep -E '^[0-9]{3}-' | sort -n | tail -1 | cut -c1-3)
+NEXT_NUM=$(printf '%03d' $((10#${NEXT_NUM:-0} + 1)))
+RULE_FILE="${NEXT_NUM}-${BUG_CLASS_SLUG}.md"
+
+# Create proposal branch
+SHORT_SHA=$(echo "${FIX_COMMIT_SHA}" | cut -c1-7)
+PROPOSAL_BRANCH="chore/rules-propose-${SHORT_SHA}"
+git checkout -b "${PROPOSAL_BRANCH}"
+
+# Write rule file
+# (RULE_CONTENT extracted from Step 4 output between markers)
+echo "${RULE_CONTENT}" > "${RULE_DIR}/${RULE_FILE}"
+
+git add "${RULE_DIR}/${RULE_FILE}"
+git commit -m "chore(rules): propose ${LANG}/${RULE_FILE} from PR #${PR_NUM}
+
+Extracted from HIGH/CRITICAL finding in PR #${PR_NUM}.
+Bug class: ${BUG_CLASS_NAME}
+Source: pr-bot-finding auto-extraction (issue #661)"
+
+git push -u origin "${PROPOSAL_BRANCH}"
+gh pr create \
+  --title "chore(rules): propose ${LANG}/${RULE_FILE} — ${BUG_CLASS_NAME}" \
+  --body "## Rule Proposal (auto-extracted)
+
+Source PR: #${PR_NUM}
+Severity: ${SEVERITY}
+Bug class: ${BUG_CLASS_NAME}
+
+This rule was auto-extracted from a verified HIGH/CRITICAL finding by the
+rule-extractor pattern (issue #661). Human review required before merge.
+
+### Checklist
+- [ ] Rule accurately describes the bug class
+- [ ] Anti-patterns are correct and actionable
+- [ ] Preferred patterns are structurally safe
+- [ ] Decision checklist is clear for agents
+- [ ] No overlap with existing rules"
+```
+
+On merge of the proposal PR, the relevant AGENTS.md index is updated
+with one compact line per rule 034:
+
+```
+NNN|bug-class-slug|one-line summary of the rule
+```
+
+## Variables
+
+### Workflow template variables (declared in workflow.toml)
+
+- `${REPO}`: GitHub repository slug (owner/repo).
+- `${PR_NUM}`: Merged PR number.
+- `${REVIEW_SESSION_ID}`: CSA review session ID (optional, for csa review findings).
+- `${FINDING_DESCRIPTION}`: Description of the current finding being processed.
+- `${FINDING_SEVERITY}`: Severity level (HIGH/CRITICAL/P1).
+- `${FINDING_FILE}`: File path of the finding.
+- `${FIX_COMMIT_SHA}`: Commit SHA of the fix.
+- `${FIX_DIFF_SUMMARY}`: Summary of the fix diff.
+- `${BUG_CLASS_NAME}`: Human-readable name of the classified bug class.
+- `${BUG_CLASS_DESCRIPTION}`: Detailed description of the bug class.
+- `${BUG_CLASS_KEYWORDS}`: Keywords for grep-based deduplication.
+- `${BUG_CLASS_SLUG}`: URL-safe slug for file naming.
+- `${LANG}`: Target language directory (rust, go, py, ts, all-lang).
+- `${ANTI_PATTERN_EXAMPLES}`: Code examples of the anti-pattern.
+- `${CORRECT_PATTERN}`: Code examples of the correct pattern.
+- `${SEVERITY}`: Finding severity for frontmatter.
+- `${RULE_CONTENT}`: Generated rule file content.
+
+### Filter criteria (enforced before Step 2)
+
+1. Finding severity is HIGH/CRITICAL/P1.
+2. False-positive check passed (finding was fixed, not dismissed via debate).
+3. Finding is a bug CLASS (Step 2 classification).
+4. Fix is not trivially single-line (structural change required).
+
+## Integration
+
+- **Invoked by**: pr-bot (post-merge, opt-in) via `csa plan run patterns/rule-extractor/workflow.toml`
+- **Depends on**: pr-bot review artifacts (findings, debate verdicts, fix commits)
+- **Outputs to**: `~/project/github/t4nature/s/llm/coding/rules/<lang>/` (shared rules) or `.agents/project-rules-ref/` (project-local)
+- **Constraint**: NEVER auto-commits. Always proposes via PR for human review.
+- **Constraint**: AGENTS.md rule 030 (fork-only) — PRs target user's fork.
+
+## Done Criteria
+
+1. All HIGH/CRITICAL findings from the merged PR classified (bug class vs isolated).
+2. Bug classes deduplicated against existing rules.
+3. New rules drafted with correct structure (anti-patterns, preferred patterns, decision checklist, case study).
+4. Proposal PR(s) created with human review required.
+5. No auto-commits to rules repositories.

--- a/patterns/rule-extractor/skills/rule-extractor/.skill.toml
+++ b/patterns/rule-extractor/skills/rule-extractor/.skill.toml
@@ -1,0 +1,4 @@
+[skill]
+name = "rule-extractor"
+description = "Auto-extract coding rules from HIGH/CRITICAL PR-bot findings"
+version = "0.1.0"

--- a/patterns/rule-extractor/skills/rule-extractor/SKILL.md
+++ b/patterns/rule-extractor/skills/rule-extractor/SKILL.md
@@ -48,14 +48,15 @@ When operating under SA mode, ALL `csa` invocations MUST include `--sa-mode true
    findings from `findings.toml` (via `csa session result`) or PR comments
    (via `gh api`).
 
-2. **Classify each finding**: Dispatch LLM classifier to determine BUG_CLASS vs
-   ISOLATED_MISTAKE. Only bug classes proceed.
+2. **Classify each finding** (bash step): Dispatch LLM classifier via `csa run`
+   to determine BUG_CLASS vs ISOLATED_MISTAKE. Emits
+   `CSA_VAR:HAS_BUG_CLASS_FINDINGS=yes` when bug classes found. Only bug classes proceed.
    - **BUG_CLASS**: Reproducible anti-pattern, structural fix, 2+ examples possible.
    - **ISOLATED_MISTAKE**: Single-line fix, unique to code path, no precedent.
 
-3. **Deduplicate against existing rules**: Search both shared rules
-   (`~/project/github/t4nature/s/llm/coding/rules/<lang>/`) and project-local
-   rules (`.agents/project-rules-ref/`). Use keyword grep + semantic LLM comparison.
+3. **Deduplicate against existing rules**: Search project-local rules
+   (`.agents/project-rules-ref/`). Use keyword grep + semantic LLM comparison
+   (both in a single bash block).
    - EXACT_MATCH → skip.
    - PARTIAL_MATCH → propose update (add case study to existing rule).
    - NO_MATCH → proceed to draft.
@@ -111,8 +112,7 @@ Two-layer dedup prevents rule proliferation:
 
 - **Invoked by**: pr-bot (post-merge, opt-in)
 - **Depends on**: pr-bot review artifacts (findings, debate verdicts, fix commits)
-- **Outputs to**: `~/project/github/t4nature/s/llm/coding/rules/<lang>/` (shared)
-  or `.agents/project-rules-ref/` (project-local)
+- **Outputs to**: `.agents/project-rules-ref/<lang>/` (project-local, fork-only per rule 030)
 - **Constraint**: NEVER auto-commits. Always proposes via PR.
 - **Constraint**: AGENTS.md rule 030 (fork-only) — PRs target user's fork.
 

--- a/patterns/rule-extractor/skills/rule-extractor/SKILL.md
+++ b/patterns/rule-extractor/skills/rule-extractor/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: rule-extractor
+description: "Use when: merged PR had HIGH/CRITICAL findings that represent a bug class — extracts reusable coding rule"
+allowed-tools: Bash, Read, Grep, Glob
+triggers:
+  - "rule-extractor"
+  - "/rule-extractor"
+  - "extract rule"
+  - "extract rules from findings"
+  - "closed-loop learning"
+---
+
+# Rule Extractor: Closed-Loop Learning from PR-Bot Findings
+
+## Purpose
+
+Transform verified HIGH/CRITICAL review findings into reusable coding rules.
+When pr-bot identifies a structural bug class, this skill extracts the lesson
+into a rule file so the bug class goes extinct — agents see the rule at
+write-time and avoid the anti-pattern entirely.
+
+Post-merge extraction (Option 2) ensures rules come from the FINAL fix state,
+not intermediate review iterations.
+
+## When to Activate
+
+This skill activates as a post-merge step in pr-bot when:
+
+1. A PR was merged successfully.
+2. The review history contains HIGH/CRITICAL/P1 findings.
+3. At least one finding was confirmed real (fixed, not dismissed as false positive).
+4. The finding represents a bug class (structural, not isolated mistake).
+
+The orchestrator invokes this skill via:
+```bash
+csa plan run patterns/rule-extractor/workflow.toml
+```
+
+## Execution Protocol (ORCHESTRATOR ONLY)
+
+### SA Mode Propagation (MANDATORY)
+
+When operating under SA mode, ALL `csa` invocations MUST include `--sa-mode true`.
+
+### Step-by-Step
+
+1. **Collect findings**: Read merged PR's review artifacts. Extract HIGH/CRITICAL
+   findings from `findings.toml` (via `csa session result`) or PR comments
+   (via `gh api`).
+
+2. **Classify each finding**: Dispatch LLM classifier to determine BUG_CLASS vs
+   ISOLATED_MISTAKE. Only bug classes proceed.
+   - **BUG_CLASS**: Reproducible anti-pattern, structural fix, 2+ examples possible.
+   - **ISOLATED_MISTAKE**: Single-line fix, unique to code path, no precedent.
+
+3. **Deduplicate against existing rules**: Search both shared rules
+   (`~/project/github/t4nature/s/llm/coding/rules/<lang>/`) and project-local
+   rules (`.agents/project-rules-ref/`). Use keyword grep + semantic LLM comparison.
+   - EXACT_MATCH → skip.
+   - PARTIAL_MATCH → propose update (add case study to existing rule).
+   - NO_MATCH → proceed to draft.
+
+4. **Generate rule draft**: Structure mirrors `rust/017-concurrent-file-primitives.md`:
+   - Core Requirement
+   - Why This Rule Exists (root cause + failure mode)
+   - Anti-Patterns (Forbidden) — table format
+   - Required Implementation Patterns — code examples
+   - Decision Checklist — 2-4 yes/no items
+   - Case Study — link to source PR
+
+   Include frontmatter for traceability:
+   ```yaml
+   ---
+   source: pr-bot-finding
+   pr: "#<PR_NUM>"
+   severity: HIGH|CRITICAL
+   extracted-at: <ISO-8601>
+   finding-ids: [<IDs>]
+   ---
+   ```
+
+5. **Propose via PR**: NEVER auto-commit. Create branch
+   `chore/rules-propose-<shortsha>`, commit rule file, push, open PR.
+   Human review is mandatory before merge.
+
+   On rule-proposal PR merge, update relevant AGENTS.md with one compact line:
+   ```
+   NNN|bug-class-slug|one-line summary
+   ```
+
+### Filter Criteria (Gate Before Classification)
+
+All four must pass before a finding enters the pipeline:
+
+1. Severity is HIGH/CRITICAL/P1 (MEDIUM/LOW/nit excluded).
+2. False-positive check passed (finding was fixed, not debate-dismissed).
+3. Finding is a bug CLASS (structural, not isolated — verified in Step 2).
+4. Fix is not trivially single-line (structural change required).
+
+### Deduplication Strategy
+
+Two-layer dedup prevents rule proliferation:
+
+1. **Keyword grep** (fast, exact): Search existing rule files for bug-class
+   keywords. Catches obvious duplicates.
+2. **Semantic LLM comparison** (slow, fuzzy): When grep finds potential matches,
+   dispatch a tier-1-quick agent to compare the bug class description against
+   the matched rule's content. Catches conceptual overlap that keyword grep misses.
+
+## Integration
+
+- **Invoked by**: pr-bot (post-merge, opt-in)
+- **Depends on**: pr-bot review artifacts (findings, debate verdicts, fix commits)
+- **Outputs to**: `~/project/github/t4nature/s/llm/coding/rules/<lang>/` (shared)
+  or `.agents/project-rules-ref/` (project-local)
+- **Constraint**: NEVER auto-commits. Always proposes via PR.
+- **Constraint**: AGENTS.md rule 030 (fork-only) — PRs target user's fork.
+
+## Done Criteria
+
+1. All HIGH/CRITICAL findings classified (bug class vs isolated).
+2. Bug classes deduplicated against existing rules.
+3. New rules drafted with correct structure.
+4. Proposal PR(s) created with human review required.
+5. No auto-commits to any rules repository.

--- a/patterns/rule-extractor/skills/rule-extractor/SKILL.md
+++ b/patterns/rule-extractor/skills/rule-extractor/SKILL.md
@@ -33,7 +33,7 @@ This skill activates as a post-merge step in pr-bot when:
 
 The orchestrator invokes this skill via:
 ```bash
-csa plan run patterns/rule-extractor/workflow.toml
+csa plan run --sa-mode true patterns/rule-extractor/workflow.toml
 ```
 
 ## Execution Protocol (ORCHESTRATOR ONLY)
@@ -44,9 +44,10 @@ When operating under SA mode, ALL `csa` invocations MUST include `--sa-mode true
 
 ### Step-by-Step
 
-1. **Collect findings**: Read merged PR's review artifacts. Extract HIGH/CRITICAL
-   findings from `findings.toml` (via `csa session result`) or PR comments
-   (via `gh api`).
+1. **Collect findings**: Read merged PR's review artifacts. Parse `findings.toml`
+   from review session output directory (or PR comments as fallback). Emits
+   `CSA_VAR:FINDING_DESCRIPTION`, `CSA_VAR:FINDING_SEVERITY`, `CSA_VAR:FINDING_FILE`
+   for the first HIGH/CRITICAL finding. One finding per invocation.
 
 2. **Classify each finding** (bash step): Dispatch LLM classifier via `csa run`
    to determine BUG_CLASS vs ISOLATED_MISTAKE. Emits
@@ -56,7 +57,8 @@ When operating under SA mode, ALL `csa` invocations MUST include `--sa-mode true
 
 3. **Deduplicate against existing rules**: Search project-local rules
    (`.agents/project-rules-ref/`). Use keyword grep + semantic LLM comparison
-   (both in a single bash block). Emits `CSA_VAR:SHOULD_DRAFT` and `CSA_VAR:DEDUPE_RESULT`.
+   with actual matched file content (both in a single bash block). Emits
+   `CSA_VAR:SHOULD_DRAFT` and `CSA_VAR:DEDUPE_RESULT`.
    - EXACT_MATCH → skip (SHOULD_DRAFT empty).
    - PARTIAL_MATCH → propose update, add case study (SHOULD_DRAFT=yes).
    - NO_MATCH → proceed to draft (SHOULD_DRAFT=yes).

--- a/patterns/rule-extractor/skills/rule-extractor/SKILL.md
+++ b/patterns/rule-extractor/skills/rule-extractor/SKILL.md
@@ -85,7 +85,7 @@ When operating under SA mode, ALL `csa` invocations MUST include `--sa-mode true
    ```
 
 5. **Propose via PR**: NEVER auto-commit. Reads draft from `DRAFT_FILE` (Step 4).
-   Create branch `chore/rules-propose-<shortsha>`, commit rule file, push, open PR.
+   Create branch `chore/rules-propose-<shortsha>-<bug-class-slug>`, commit rule file, push, open PR.
    Human review is mandatory before merge.
 
    On rule-proposal PR merge, update relevant AGENTS.md with one compact line:

--- a/patterns/rule-extractor/skills/rule-extractor/SKILL.md
+++ b/patterns/rule-extractor/skills/rule-extractor/SKILL.md
@@ -56,12 +56,14 @@ When operating under SA mode, ALL `csa` invocations MUST include `--sa-mode true
 
 3. **Deduplicate against existing rules**: Search project-local rules
    (`.agents/project-rules-ref/`). Use keyword grep + semantic LLM comparison
-   (both in a single bash block).
-   - EXACT_MATCH → skip.
-   - PARTIAL_MATCH → propose update (add case study to existing rule).
-   - NO_MATCH → proceed to draft.
+   (both in a single bash block). Emits `CSA_VAR:SHOULD_DRAFT` and `CSA_VAR:DEDUPE_RESULT`.
+   - EXACT_MATCH → skip (SHOULD_DRAFT empty).
+   - PARTIAL_MATCH → propose update, add case study (SHOULD_DRAFT=yes).
+   - NO_MATCH → proceed to draft (SHOULD_DRAFT=yes).
 
-4. **Generate rule draft**: Structure mirrors `rust/017-concurrent-file-primitives.md`:
+4. **Generate rule draft** (bash, dispatches csa run): Structure mirrors `rust/017-concurrent-file-primitives.md`.
+   Captures draft between RULE_DRAFT_START/END markers into `DRAFT_FILE`.
+   Emits `CSA_VAR:DRAFT_FILE` and `CSA_VAR:STEP4_SESSION_ID`:
    - Core Requirement
    - Why This Rule Exists (root cause + failure mode)
    - Anti-Patterns (Forbidden) — table format
@@ -80,8 +82,8 @@ When operating under SA mode, ALL `csa` invocations MUST include `--sa-mode true
    ---
    ```
 
-5. **Propose via PR**: NEVER auto-commit. Create branch
-   `chore/rules-propose-<shortsha>`, commit rule file, push, open PR.
+5. **Propose via PR**: NEVER auto-commit. Reads draft from `DRAFT_FILE` (Step 4).
+   Create branch `chore/rules-propose-<shortsha>`, commit rule file, push, open PR.
    Human review is mandatory before merge.
 
    On rule-proposal PR merge, update relevant AGENTS.md with one compact line:

--- a/patterns/rule-extractor/skills/rule-extractor/SKILL.md
+++ b/patterns/rule-extractor/skills/rule-extractor/SKILL.md
@@ -56,7 +56,7 @@ When operating under SA mode, ALL `csa` invocations MUST include `--sa-mode true
    - **ISOLATED_MISTAKE**: Single-line fix, unique to code path, no precedent.
 
 3. **Deduplicate against existing rules**: Search project-local rules
-   (`.agents/project-rules-ref/`). Use keyword grep + semantic LLM comparison
+   (`docs/rules-proposed/`). Use keyword grep + semantic LLM comparison
    with actual matched file content (both in a single bash block). Emits
    `CSA_VAR:SHOULD_DRAFT` and `CSA_VAR:DEDUPE_RESULT`.
    - EXACT_MATCH → skip (SHOULD_DRAFT empty).
@@ -116,7 +116,7 @@ Two-layer dedup prevents rule proliferation:
 
 - **Invoked by**: pr-bot (post-merge, opt-in)
 - **Depends on**: pr-bot review artifacts (findings, debate verdicts, fix commits)
-- **Outputs to**: `.agents/project-rules-ref/<lang>/` (project-local, fork-only per rule 030)
+- **Outputs to**: `docs/rules-proposed/<lang>/` (project-local, fork-only per rule 030)
 - **Constraint**: NEVER auto-commits. Always proposes via PR.
 - **Constraint**: AGENTS.md rule 030 (fork-only) — PRs target user's fork.
 

--- a/patterns/rule-extractor/workflow.toml
+++ b/patterns/rule-extractor/workflow.toml
@@ -88,6 +88,7 @@ invoke the pattern once per finding for multi-finding PRs.
 set -euo pipefail
 # Collect review findings from the merged PR
 FINDINGS_RAW=""
+FINDING_EMITTED=""
 if [ -n "${REVIEW_SESSION_ID:-}" ]; then
   # Extract findings.toml from the review session output directory
   SESSION_DIR=$(csa session result --session "${REVIEW_SESSION_ID}" --session-dir 2>/dev/null || true)
@@ -121,18 +122,21 @@ else
       echo "CSA_VAR:FINDING_DESCRIPTION=$COMMENT_DESC"
       echo "CSA_VAR:FINDING_SEVERITY=$COMMENT_SEV"
       echo "CSA_VAR:FINDING_FILE=${COMMENT_PATH:-unknown}"
+      FINDING_EMITTED=1
       echo "Extracted finding from PR comment: severity=$COMMENT_SEV file=$COMMENT_PATH"
     else
       echo "WARNING: No HIGH/CRITICAL findings in PR comments"
       echo "CSA_VAR:FINDING_DESCRIPTION="
       echo "CSA_VAR:FINDING_SEVERITY="
       echo "CSA_VAR:FINDING_FILE="
+      FINDING_EMITTED=1
     fi
   else
     echo "WARNING: Could not fetch PR comments"
     echo "CSA_VAR:FINDING_DESCRIPTION="
     echo "CSA_VAR:FINDING_SEVERITY="
     echo "CSA_VAR:FINDING_FILE="
+    FINDING_EMITTED=1
   fi
   # Skip the TOML parser below — CSA_VARs already emitted
   FINDINGS_RAW=""
@@ -157,6 +161,7 @@ if [ -n "$FINDINGS_RAW" ]; then
     echo "CSA_VAR:FINDING_DESCRIPTION=$FIRST_DESC"
     echo "CSA_VAR:FINDING_SEVERITY=${FIRST_SEV:-HIGH}"
     echo "CSA_VAR:FINDING_FILE=${FIRST_FILE:-unknown}"
+    FINDING_EMITTED=1
     echo "Extracted finding: severity=$FIRST_SEV file=$FIRST_FILE"
     echo "Description: $FIRST_DESC"
   else
@@ -164,8 +169,9 @@ if [ -n "$FINDINGS_RAW" ]; then
     echo "CSA_VAR:FINDING_DESCRIPTION="
     echo "CSA_VAR:FINDING_SEVERITY="
     echo "CSA_VAR:FINDING_FILE="
+    FINDING_EMITTED=1
   fi
-else
+elif [ -z "$FINDING_EMITTED" ]; then
   echo "WARNING: No findings data available from session or PR comments"
   echo "CSA_VAR:FINDING_DESCRIPTION="
   echo "CSA_VAR:FINDING_SEVERITY="
@@ -238,8 +244,8 @@ PROJECT_RULES_DIR=".agents/project-rules-ref"
 
 # Keyword grep across project-local rules
 PROJECT_MATCHES=""
-if [ -d "${PROJECT_RULES_DIR}" ]; then
-  PROJECT_MATCHES=$(grep -rl "${BUG_CLASS_KEYWORDS}" "${PROJECT_RULES_DIR}/" 2>/dev/null || true)
+if [ -d "${PROJECT_RULES_DIR}" ] && [ -n "${BUG_CLASS_KEYWORDS:-}" ]; then
+  PROJECT_MATCHES=$(grep -rl "${BUG_CLASS_KEYWORDS:-}" "${PROJECT_RULES_DIR}/" 2>/dev/null || true)
 fi
 
 if [ -z "${PROJECT_MATCHES}" ]; then

--- a/patterns/rule-extractor/workflow.toml
+++ b/patterns/rule-extractor/workflow.toml
@@ -79,22 +79,63 @@ id = 1
 title = "Collect Findings"
 tool = "bash"
 prompt = """
-Read the merged PR's review artifacts and extract HIGH/CRITICAL findings.
+Read the merged PR's review artifacts and extract the first HIGH/CRITICAL finding.
+Emits CSA_VAR:FINDING_DESCRIPTION, CSA_VAR:FINDING_SEVERITY, CSA_VAR:FINDING_FILE
+for consumption by Step 2. This pattern processes one finding per invocation;
+invoke the pattern once per finding for multi-finding PRs.
 
 ```bash
 set -euo pipefail
 # Collect review findings from the merged PR
+FINDINGS_RAW=""
 if [ -n "${REVIEW_SESSION_ID:-}" ]; then
-  csa session result --session "${REVIEW_SESSION_ID}" --section details
+  # Extract findings.toml from the review session output directory
+  SESSION_DIR=$(csa session result --session "${REVIEW_SESSION_ID}" --session-dir 2>/dev/null || true)
+  if [ -n "$SESSION_DIR" ] && [ -f "$SESSION_DIR/output/findings.toml" ]; then
+    FINDINGS_RAW=$(cat "$SESSION_DIR/output/findings.toml")
+  else
+    # Fallback: read from session details text
+    FINDINGS_RAW=$(csa session result --session "${REVIEW_SESSION_ID}" --section details 2>/dev/null || true)
+  fi
 else
   # Fall back to PR comment history for bot findings
   gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/comments" \
     | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL")) | {id: .id, body: .body, path: .path}'
 fi
+
+# Parse findings.toml for first HIGH/CRITICAL finding and emit CSA_VARs.
+# findings.toml uses [[findings]] sections with id, severity, description,
+# and file_ranges (array of {path, start, end}).
+if [ -n "$FINDINGS_RAW" ]; then
+  # Extract severity, description, and file path from first high/critical finding.
+  # The toml structure: severity = "high"|"critical", description = "...",
+  # file_ranges has path = "..." entries.
+  FIRST_SEV=$(echo "$FINDINGS_RAW" | grep -i '^severity' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
+  FIRST_DESC=$(echo "$FINDINGS_RAW" | grep -i '^description' | head -1 | sed 's/.*= *"\(.*\)".*/\1/')
+  FIRST_FILE=$(echo "$FINDINGS_RAW" | grep -i '^path' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
+
+  if [ -n "$FIRST_DESC" ]; then
+    echo "CSA_VAR:FINDING_DESCRIPTION=$FIRST_DESC"
+    echo "CSA_VAR:FINDING_SEVERITY=${FIRST_SEV:-HIGH}"
+    echo "CSA_VAR:FINDING_FILE=${FIRST_FILE:-unknown}"
+    echo "Extracted finding: severity=$FIRST_SEV file=$FIRST_FILE"
+    echo "Description: $FIRST_DESC"
+  else
+    echo "WARNING: No parseable findings in review session output"
+    echo "CSA_VAR:FINDING_DESCRIPTION="
+    echo "CSA_VAR:FINDING_SEVERITY="
+    echo "CSA_VAR:FINDING_FILE="
+  fi
+else
+  echo "WARNING: No findings data available from session or PR comments"
+  echo "CSA_VAR:FINDING_DESCRIPTION="
+  echo "CSA_VAR:FINDING_SEVERITY="
+  echo "CSA_VAR:FINDING_FILE="
+fi
 ```
 
-Output: structured list of HIGH/CRITICAL findings with finding ID, severity,
-file path, description, and fix status."""
+Output: CSA_VAR:FINDING_DESCRIPTION, CSA_VAR:FINDING_SEVERITY, CSA_VAR:FINDING_FILE
+for the first HIGH/CRITICAL finding. Empty values if no findings found."""
 on_fail = "abort"
 
 [[workflow.steps]]
@@ -129,7 +170,10 @@ CLASSIFY_SID=$(csa run --sa-mode true --tier tier-2-standard \
    Then: RATIONALE: <one paragraph>")
 csa session wait --session "$CLASSIFY_SID"
 
-# Read classifier result and emit CSA_VAR
+# NOTE: This bash block emits CSA_VAR:HAS_BUG_CLASS_FINDINGS which gates
+# Step 3 (condition = "${HAS_BUG_CLASS_FINDINGS}"). The CSA_VAR: prefix
+# is the mechanism by which tool=bash steps propagate variables to
+# subsequent workflow steps — this is correct and intentional.
 CLASSIFY_OUTPUT=$(csa session result --session "$CLASSIFY_SID" --section summary 2>/dev/null || true)
 if echo "$CLASSIFY_OUTPUT" | grep -q "CLASSIFICATION=BUG_CLASS"; then
   echo "CSA_VAR:HAS_BUG_CLASS_FINDINGS=yes"
@@ -170,12 +214,23 @@ else
   echo "EXISTING_RULE_MATCH=potential"
   echo "CSA_VAR:EXISTING_RULE_MATCH=potential"
 
+  # Read actual content from matched rule files for semantic comparison
+  MATCHED_CONTENT=""
+  while IFS= read -r match_file; do
+    [ -z "$match_file" ] && continue
+    MATCHED_CONTENT="${MATCHED_CONTENT}
+--- ${match_file} ---
+$(cat "$match_file")
+"
+  done <<< "${PROJECT_MATCHES}"
+
   # Dispatch semantic deduplication for potential matches
   DEDUPE_SID=$(csa run --sa-mode true --tier tier-1-quick \
     --description "dedupe-check: ${BUG_CLASS_NAME}" \
-    "Compare this bug class against the existing rule.
+    "Compare this bug class against the existing rule(s).
      Bug class: ${BUG_CLASS_DESCRIPTION}
-     Existing rule content: (read from matched file)
+     Existing rule content:
+${MATCHED_CONTENT}
      Output: DEDUPE_RESULT=EXACT_MATCH|PARTIAL_MATCH|NO_MATCH
      If PARTIAL_MATCH: UPDATE_SUGGESTION: <what to add>")
   csa session wait --session "$DEDUPE_SID"
@@ -276,6 +331,9 @@ if [ ! -f "${DRAFT_FILE}" ]; then
   exit 1
 fi
 
+# RULE_DIR is project-local (.agents/project-rules-ref/) within the fork repo,
+# so git-add is safe — this path is NOT covered by ~/.gitignore_noai (rule 036).
+# The .agents/project-rules-ref/ directory is fork-only content (rule 030).
 RULE_DIR=".agents/project-rules-ref/${LANG}"
 mkdir -p "${RULE_DIR}"
 

--- a/patterns/rule-extractor/workflow.toml
+++ b/patterns/rule-extractor/workflow.toml
@@ -98,9 +98,44 @@ if [ -n "${REVIEW_SESSION_ID:-}" ]; then
     FINDINGS_RAW=$(csa session result --session "${REVIEW_SESSION_ID}" --section details 2>/dev/null || true)
   fi
 else
-  # Fall back to PR comment history for bot findings
-  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/comments" \
-    | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL")) | {id: .id, body: .body, path: .path}'
+  # Fall back to PR comment history for bot findings.
+  # Extract severity + description + path from PR comment bodies and emit
+  # CSA_VARs directly (comment JSON shape differs from findings.toml).
+  PR_COMMENTS=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/comments" 2>/dev/null || true)
+  if [ -n "$PR_COMMENTS" ]; then
+    # Pick the first comment whose body mentions a HIGH/CRITICAL/P0/P1 severity
+    COMMENT_BODY=$(echo "$PR_COMMENTS" \
+      | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .body' \
+      | head -1)
+    COMMENT_PATH=$(echo "$PR_COMMENTS" \
+      | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .path // "unknown"' \
+      | head -1)
+    if [ -n "$COMMENT_BODY" ]; then
+      # Infer severity from the comment text
+      COMMENT_SEV="HIGH"
+      if echo "$COMMENT_BODY" | grep -qi "CRITICAL\|P0"; then
+        COMMENT_SEV="CRITICAL"
+      fi
+      # Use first line of comment body as description (strip markdown headers)
+      COMMENT_DESC=$(echo "$COMMENT_BODY" | grep -v '^#' | grep -v '^\s*$' | head -1 | sed 's/^[[:space:]]*//')
+      echo "CSA_VAR:FINDING_DESCRIPTION=$COMMENT_DESC"
+      echo "CSA_VAR:FINDING_SEVERITY=$COMMENT_SEV"
+      echo "CSA_VAR:FINDING_FILE=${COMMENT_PATH:-unknown}"
+      echo "Extracted finding from PR comment: severity=$COMMENT_SEV file=$COMMENT_PATH"
+    else
+      echo "WARNING: No HIGH/CRITICAL findings in PR comments"
+      echo "CSA_VAR:FINDING_DESCRIPTION="
+      echo "CSA_VAR:FINDING_SEVERITY="
+      echo "CSA_VAR:FINDING_FILE="
+    fi
+  else
+    echo "WARNING: Could not fetch PR comments"
+    echo "CSA_VAR:FINDING_DESCRIPTION="
+    echo "CSA_VAR:FINDING_SEVERITY="
+    echo "CSA_VAR:FINDING_FILE="
+  fi
+  # Skip the TOML parser below — CSA_VARs already emitted
+  FINDINGS_RAW=""
 fi
 
 # Parse findings.toml for first HIGH/CRITICAL finding and emit CSA_VARs.
@@ -110,9 +145,13 @@ if [ -n "$FINDINGS_RAW" ]; then
   # Extract severity, description, and file path from first high/critical finding.
   # The toml structure: severity = "high"|"critical", description = "...",
   # file_ranges has path = "..." entries.
-  FIRST_SEV=$(echo "$FINDINGS_RAW" | grep -i '^severity' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
-  FIRST_DESC=$(echo "$FINDINGS_RAW" | grep -i '^description' | head -1 | sed 's/.*= *"\(.*\)".*/\1/')
-  FIRST_FILE=$(echo "$FINDINGS_RAW" | grep -i '^path' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
+  # Filter: only consider lines where severity is high or critical
+  FIRST_SEV=$(echo "$FINDINGS_RAW" | grep -iE '^severity\s*=\s*"(high|critical)"' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
+  # Find the description from the same [[findings]] block as the matched severity.
+  # Since findings.toml is flat-ish (severity then description then file_ranges),
+  # we take the description line following the first high/critical severity line.
+  FIRST_DESC=$(echo "$FINDINGS_RAW" | grep -iA 20 '^severity\s*=\s*".*\(high\|critical\)"' | grep -i '^description' | head -1 | sed 's/.*= *"\(.*\)".*/\1/')
+  FIRST_FILE=$(echo "$FINDINGS_RAW" | grep -iA 30 '^severity\s*=\s*".*\(high\|critical\)"' | grep -i '^path' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
 
   if [ -n "$FIRST_DESC" ]; then
     echo "CSA_VAR:FINDING_DESCRIPTION=$FIRST_DESC"
@@ -347,9 +386,9 @@ fi
 NEXT_NUM=$(printf '%03d' $((10#${LAST_NUM} + 1)))
 RULE_FILE="${NEXT_NUM}-${BUG_CLASS_SLUG}.md"
 
-# Create proposal branch
-SHORT_SHA=$(echo "${FIX_COMMIT_SHA}" | cut -c1-7)
-PROPOSAL_BRANCH="chore/rules-propose-${SHORT_SHA}"
+# Create proposal branch (include BUG_CLASS_SLUG for uniqueness across findings)
+SHORT_SHA=$(echo "${FIX_COMMIT_SHA}" | cut -c1-8)
+PROPOSAL_BRANCH="chore/rules-propose-${SHORT_SHA}-${BUG_CLASS_SLUG}"
 git checkout -b "${PROPOSAL_BRANCH}"
 
 # Copy draft to final rule location

--- a/patterns/rule-extractor/workflow.toml
+++ b/patterns/rule-extractor/workflow.toml
@@ -1,0 +1,269 @@
+[workflow]
+name = "rule-extractor"
+description = "Auto-extract coding rules from HIGH/CRITICAL PR-bot findings (closed-loop learning)"
+
+[[workflow.variables]]
+name = "REPO"
+
+[[workflow.variables]]
+name = "PR_NUM"
+
+[[workflow.variables]]
+name = "REVIEW_SESSION_ID"
+
+[[workflow.variables]]
+name = "FINDING_DESCRIPTION"
+
+[[workflow.variables]]
+name = "FINDING_SEVERITY"
+
+[[workflow.variables]]
+name = "FINDING_FILE"
+
+[[workflow.variables]]
+name = "FIX_COMMIT_SHA"
+
+[[workflow.variables]]
+name = "FIX_DIFF_SUMMARY"
+
+[[workflow.variables]]
+name = "BUG_CLASS_NAME"
+
+[[workflow.variables]]
+name = "BUG_CLASS_DESCRIPTION"
+
+[[workflow.variables]]
+name = "BUG_CLASS_KEYWORDS"
+
+[[workflow.variables]]
+name = "BUG_CLASS_SLUG"
+
+[[workflow.variables]]
+name = "LANG"
+
+[[workflow.variables]]
+name = "ANTI_PATTERN_EXAMPLES"
+
+[[workflow.variables]]
+name = "CORRECT_PATTERN"
+
+[[workflow.variables]]
+name = "SEVERITY"
+
+[[workflow.variables]]
+name = "RULE_CONTENT"
+
+[[workflow.variables]]
+name = "HAS_BUG_CLASS_FINDINGS"
+
+[[workflow.variables]]
+name = "EXISTING_RULE_MATCH"
+
+[[workflow.variables]]
+name = "PROPOSAL_BRANCH"
+
+[[workflow.steps]]
+id = 1
+title = "Collect Findings"
+tool = "bash"
+prompt = """
+Read the merged PR's review artifacts and extract HIGH/CRITICAL findings.
+
+```bash
+set -euo pipefail
+# Collect review findings from the merged PR
+if [ -n "${REVIEW_SESSION_ID:-}" ]; then
+  csa session result --session "${REVIEW_SESSION_ID}" --section details
+else
+  # Fall back to PR comment history for bot findings
+  gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/comments" \
+    | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL")) | {id: .id, body: .body, path: .path}'
+fi
+```
+
+Output: structured list of HIGH/CRITICAL findings with finding ID, severity,
+file path, description, and fix status."""
+on_fail = "abort"
+
+[[workflow.steps]]
+id = 2
+title = "Classify Bug Class vs Isolated Mistake"
+tool = "csa"
+prompt = """
+For each HIGH/CRITICAL finding from Step 1, classify as BUG_CLASS or ISOLATED_MISTAKE.
+
+Criteria for BUG_CLASS:
+- The anti-pattern is reproducible in other code
+- The fix required a structural change, not just a line edit
+- Two or more examples exist or could exist
+
+Criteria for ISOLATED_MISTAKE:
+- Single-line fix, unique to this code path
+- Cannot generalize to other locations
+
+```bash
+CLASSIFY_SID=$(csa run --sa-mode true --tier tier-2-standard \
+  --description "classify-finding: bug-class-or-isolated" \
+  "Classify the following review finding as BUG_CLASS or ISOLATED_MISTAKE.
+
+   Finding: ${FINDING_DESCRIPTION}
+   Severity: ${FINDING_SEVERITY}
+   File: ${FINDING_FILE}
+   Fix commit: ${FIX_COMMIT_SHA}
+   Fix diff summary: ${FIX_DIFF_SUMMARY}
+
+   Output: CLASSIFICATION=BUG_CLASS or CLASSIFICATION=ISOLATED_MISTAKE
+   Then: RATIONALE: <one paragraph>")
+csa session wait --session "$CLASSIFY_SID"
+```
+
+Set HAS_BUG_CLASS_FINDINGS to "yes" if any finding classified as BUG_CLASS,
+empty string otherwise. Only BUG_CLASS findings proceed to Step 3."""
+on_fail = "abort"
+
+[[workflow.steps]]
+id = 3
+title = "Deduplicate Against Existing Rules"
+tool = "bash"
+prompt = """
+Check whether an existing rule already covers this bug class.
+
+```bash
+set -euo pipefail
+SHARED_RULES_DIR="${HOME}/project/github/t4nature/s/llm/coding/rules"
+PROJECT_RULES_DIR=".agents/project-rules-ref"
+
+# Keyword grep across shared rules
+SHARED_MATCHES=""
+if [ -d "${SHARED_RULES_DIR}" ]; then
+  SHARED_MATCHES=$(grep -rl "${BUG_CLASS_KEYWORDS}" "${SHARED_RULES_DIR}/" 2>/dev/null || true)
+fi
+
+# Keyword grep across project-local rules
+PROJECT_MATCHES=""
+if [ -d "${PROJECT_RULES_DIR}" ]; then
+  PROJECT_MATCHES=$(grep -rl "${BUG_CLASS_KEYWORDS}" "${PROJECT_RULES_DIR}/" 2>/dev/null || true)
+fi
+
+ALL_MATCHES="${SHARED_MATCHES}${PROJECT_MATCHES}"
+if [ -z "${ALL_MATCHES}" ]; then
+  echo "EXISTING_RULE_MATCH=none"
+else
+  echo "Potential matches found:"
+  echo "${ALL_MATCHES}"
+  echo "EXISTING_RULE_MATCH=potential"
+fi
+```
+
+If keyword grep finds potential matches, dispatch semantic deduplication:
+
+```bash
+DEDUPE_SID=$(csa run --sa-mode true --tier tier-1-quick \
+  --description "dedupe-check: ${BUG_CLASS_NAME}" \
+  "Compare this bug class against the existing rule.
+   Bug class: ${BUG_CLASS_DESCRIPTION}
+   Existing rule content: (read from matched file)
+   Output: DEDUPE_RESULT=EXACT_MATCH|PARTIAL_MATCH|NO_MATCH
+   If PARTIAL_MATCH: UPDATE_SUGGESTION: <what to add>")
+csa session wait --session "$DEDUPE_SID"
+```
+
+EXACT_MATCH: skip rule generation.
+PARTIAL_MATCH: propose update to existing rule (add case study).
+NO_MATCH: proceed to Step 4."""
+on_fail = "skip"
+condition = "${HAS_BUG_CLASS_FINDINGS}"
+
+[[workflow.steps]]
+id = 4
+title = "Generate Rule Draft"
+tool = "csa"
+prompt = """
+Generate a rule file following existing structure (mirrors rust/017-concurrent-file-primitives.md).
+
+```bash
+DRAFT_SID=$(csa run --sa-mode true --tier tier-2-standard \
+  --description "draft-rule: ${BUG_CLASS_NAME}" \
+  "Generate a coding rule file for the following bug class.
+
+   Bug class: ${BUG_CLASS_DESCRIPTION}
+   Language: ${LANG}
+   Anti-pattern examples: ${ANTI_PATTERN_EXAMPLES}
+   Correct pattern: ${CORRECT_PATTERN}
+   PR: #${PR_NUM}
+   Fix commit: ${FIX_COMMIT_SHA}
+
+   Structure:
+   1. Core Requirement (one paragraph)
+   2. Why This Rule Exists (failure mode + root cause)
+   3. Anti-Patterns table (| Anti-pattern | Consequence | Fix |)
+   4. Required Implementation Patterns (code examples)
+   5. Decision Checklist (2-4 yes/no items)
+   6. Case Study: PR #${PR_NUM}
+
+   Frontmatter: source: pr-bot-finding, pr: #${PR_NUM},
+   severity: ${SEVERITY}, extracted-at: $(date -u +%Y-%m-%d)
+
+   Output between RULE_DRAFT_START and RULE_DRAFT_END markers.")
+csa session wait --session "$DRAFT_SID"
+```
+
+Extract RULE_CONTENT from between markers."""
+on_fail = "abort"
+condition = "${HAS_BUG_CLASS_FINDINGS}"
+
+[[workflow.steps]]
+id = 5
+title = "Propose via PR"
+tool = "bash"
+prompt = """
+Create a proposal PR with the rule draft. NEVER auto-commit to main rules.
+
+```bash
+set -euo pipefail
+SHARED_RULES_DIR="${HOME}/project/github/t4nature/s/llm/coding/rules"
+RULE_DIR="${SHARED_RULES_DIR}/${LANG}"
+
+# Determine next rule number
+NEXT_NUM=$(ls "${RULE_DIR}/" 2>/dev/null | grep -E '^[0-9]{3}-' | sort -n | tail -1 | cut -c1-3)
+NEXT_NUM=$(printf '%03d' $((10#${NEXT_NUM:-0} + 1)))
+RULE_FILE="${NEXT_NUM}-${BUG_CLASS_SLUG}.md"
+
+# Create proposal branch
+SHORT_SHA=$(echo "${FIX_COMMIT_SHA}" | cut -c1-7)
+PROPOSAL_BRANCH="chore/rules-propose-${SHORT_SHA}"
+git checkout -b "${PROPOSAL_BRANCH}"
+
+# Write rule file (RULE_CONTENT from Step 4)
+echo "${RULE_CONTENT}" > "${RULE_DIR}/${RULE_FILE}"
+
+git add "${RULE_DIR}/${RULE_FILE}"
+git commit -m "chore(rules): propose ${LANG}/${RULE_FILE} from PR #${PR_NUM}
+
+Extracted from HIGH/CRITICAL finding in PR #${PR_NUM}.
+Bug class: ${BUG_CLASS_NAME}
+Source: pr-bot-finding auto-extraction (issue #661)"
+
+git push -u origin "${PROPOSAL_BRANCH}"
+gh pr create \
+  --title "chore(rules): propose ${LANG}/${RULE_FILE} — ${BUG_CLASS_NAME}" \
+  --body "## Rule Proposal (auto-extracted)
+
+Source PR: #${PR_NUM}
+Severity: ${SEVERITY}
+Bug class: ${BUG_CLASS_NAME}
+
+Auto-extracted by rule-extractor pattern (issue #661). Human review required.
+
+### Checklist
+- [ ] Rule accurately describes the bug class
+- [ ] Anti-patterns are correct and actionable
+- [ ] Preferred patterns are structurally safe
+- [ ] Decision checklist is clear for agents
+- [ ] No overlap with existing rules"
+```
+
+On merge of the proposal PR, update the relevant AGENTS.md index with
+one compact line: NNN|bug-class-slug|one-line summary."""
+on_fail = "abort"
+condition = "${HAS_BUG_CLASS_FINDINGS}"

--- a/patterns/rule-extractor/workflow.toml
+++ b/patterns/rule-extractor/workflow.toml
@@ -240,7 +240,7 @@ Emits CSA_VAR:SHOULD_DRAFT=yes when Step 4 should run.
 
 ```bash
 set -euo pipefail
-PROJECT_RULES_DIR=".agents/project-rules-ref"
+PROJECT_RULES_DIR="docs/rules-proposed"
 
 # Keyword grep across project-local rules
 PROJECT_MATCHES=""
@@ -347,7 +347,7 @@ if [ -z "$DRAFT_CONTENT" ]; then
 fi
 
 # Write draft to a temp file and emit its path
-DRAFT_FILE=".agents/project-rules-ref/.draft-${BUG_CLASS_SLUG}.md"
+DRAFT_FILE="docs/rules-proposed/.draft-${BUG_CLASS_SLUG}.md"
 mkdir -p "$(dirname "$DRAFT_FILE")"
 echo "$DRAFT_CONTENT" > "$DRAFT_FILE"
 echo "CSA_VAR:DRAFT_FILE=$DRAFT_FILE"
@@ -364,7 +364,7 @@ title = "Propose via PR"
 tool = "bash"
 prompt = """
 Create a proposal PR with the rule draft. NEVER auto-commit to main rules.
-Rules are written to project-local .agents/project-rules-ref/ (fork-only, rule 030).
+Rules are written to project-local docs/rules-proposed/ (fork-only, rule 030).
 Reads draft content from DRAFT_FILE produced by Step 4.
 
 ```bash
@@ -376,10 +376,10 @@ if [ ! -f "${DRAFT_FILE}" ]; then
   exit 1
 fi
 
-# RULE_DIR is project-local (.agents/project-rules-ref/) within the fork repo,
+# RULE_DIR is project-local (docs/rules-proposed/) within the fork repo,
 # so git-add is safe — this path is NOT covered by ~/.gitignore_noai (rule 036).
-# The .agents/project-rules-ref/ directory is fork-only content (rule 030).
-RULE_DIR=".agents/project-rules-ref/${LANG}"
+# The docs/rules-proposed/ directory is fork-only content (rule 030).
+RULE_DIR="docs/rules-proposed/${LANG}"
 mkdir -p "${RULE_DIR}"
 
 # Determine next rule number (safe for empty directory)

--- a/patterns/rule-extractor/workflow.toml
+++ b/patterns/rule-extractor/workflow.toml
@@ -60,6 +60,18 @@ name = "HAS_BUG_CLASS_FINDINGS"
 name = "EXISTING_RULE_MATCH"
 
 [[workflow.variables]]
+name = "SHOULD_DRAFT"
+
+[[workflow.variables]]
+name = "DEDUPE_RESULT"
+
+[[workflow.variables]]
+name = "DRAFT_FILE"
+
+[[workflow.variables]]
+name = "STEP4_SESSION_ID"
+
+[[workflow.variables]]
 name = "PROPOSAL_BRANCH"
 
 [[workflow.steps]]
@@ -135,6 +147,7 @@ title = "Deduplicate Against Existing Rules"
 tool = "bash"
 prompt = """
 Check whether an existing rule already covers this bug class.
+Emits CSA_VAR:SHOULD_DRAFT=yes when Step 4 should run.
 
 ```bash
 set -euo pipefail
@@ -149,6 +162,8 @@ fi
 if [ -z "${PROJECT_MATCHES}" ]; then
   echo "EXISTING_RULE_MATCH=none"
   echo "CSA_VAR:EXISTING_RULE_MATCH=none"
+  echo "CSA_VAR:DEDUPE_RESULT=NO_MATCH"
+  echo "CSA_VAR:SHOULD_DRAFT=yes"
 else
   echo "Potential matches found:"
   echo "${PROJECT_MATCHES}"
@@ -164,23 +179,38 @@ else
      Output: DEDUPE_RESULT=EXACT_MATCH|PARTIAL_MATCH|NO_MATCH
      If PARTIAL_MATCH: UPDATE_SUGGESTION: <what to add>")
   csa session wait --session "$DEDUPE_SID"
+
+  # Read dedupe result and decide whether to draft
+  DEDUPE_OUTPUT=$(csa session result --session "$DEDUPE_SID" --section summary 2>/dev/null || true)
+  if echo "$DEDUPE_OUTPUT" | grep -q "DEDUPE_RESULT=EXACT_MATCH"; then
+    echo "CSA_VAR:DEDUPE_RESULT=EXACT_MATCH"
+    echo "CSA_VAR:SHOULD_DRAFT="
+  elif echo "$DEDUPE_OUTPUT" | grep -q "DEDUPE_RESULT=PARTIAL_MATCH"; then
+    echo "CSA_VAR:DEDUPE_RESULT=PARTIAL_MATCH"
+    echo "CSA_VAR:SHOULD_DRAFT=yes"
+  else
+    echo "CSA_VAR:DEDUPE_RESULT=NO_MATCH"
+    echo "CSA_VAR:SHOULD_DRAFT=yes"
+  fi
 fi
 ```
 
-EXACT_MATCH: skip rule generation.
-PARTIAL_MATCH: propose update to existing rule (add case study).
-NO_MATCH: proceed to Step 4."""
+EXACT_MATCH: skip rule generation (SHOULD_DRAFT empty).
+PARTIAL_MATCH: propose update to existing rule (SHOULD_DRAFT=yes).
+NO_MATCH: proceed to Step 4 (SHOULD_DRAFT=yes)."""
 on_fail = "skip"
 condition = "${HAS_BUG_CLASS_FINDINGS}"
 
 [[workflow.steps]]
 id = 4
 title = "Generate Rule Draft"
-tool = "csa"
+tool = "bash"
 prompt = """
 Generate a rule file following existing structure (mirrors rust/017-concurrent-file-primitives.md).
+Dispatches csa run, captures the draft into a file, and emits CSA_VAR:DRAFT_FILE.
 
 ```bash
+set -euo pipefail
 DRAFT_SID=$(csa run --sa-mode true --tier tier-2-standard \
   --description "draft-rule: ${BUG_CLASS_NAME}" \
   "Generate a coding rule file for the following bug class.
@@ -203,13 +233,30 @@ DRAFT_SID=$(csa run --sa-mode true --tier tier-2-standard \
    Frontmatter: source: pr-bot-finding, pr: #${PR_NUM},
    severity: ${SEVERITY}, extracted-at: $(date -u +%Y-%m-%d)
 
-   Output between RULE_DRAFT_START and RULE_DRAFT_END markers.")
+   Output the complete rule file content between RULE_DRAFT_START and RULE_DRAFT_END markers.")
 csa session wait --session "$DRAFT_SID"
+
+# Extract rule content from session output between markers
+DRAFT_RAW=$(csa session result --session "$DRAFT_SID" --section details 2>/dev/null || \
+            csa session result --session "$DRAFT_SID" 2>/dev/null || true)
+DRAFT_CONTENT=$(echo "$DRAFT_RAW" | sed -n '/RULE_DRAFT_START/,/RULE_DRAFT_END/{/RULE_DRAFT_START/d;/RULE_DRAFT_END/d;p}')
+
+if [ -z "$DRAFT_CONTENT" ]; then
+  echo "ERROR: Could not extract rule draft from session $DRAFT_SID"
+  exit 1
+fi
+
+# Write draft to a temp file and emit its path
+DRAFT_FILE=".agents/project-rules-ref/.draft-${BUG_CLASS_SLUG}.md"
+mkdir -p "$(dirname "$DRAFT_FILE")"
+echo "$DRAFT_CONTENT" > "$DRAFT_FILE"
+echo "CSA_VAR:DRAFT_FILE=$DRAFT_FILE"
+echo "CSA_VAR:STEP4_SESSION_ID=$DRAFT_SID"
 ```
 
-Extract RULE_CONTENT from between markers."""
+Extracts RULE_CONTENT from between RULE_DRAFT_START/END markers and writes to DRAFT_FILE."""
 on_fail = "abort"
-condition = "${HAS_BUG_CLASS_FINDINGS}"
+condition = "${SHOULD_DRAFT}"
 
 [[workflow.steps]]
 id = 5
@@ -218,9 +265,17 @@ tool = "bash"
 prompt = """
 Create a proposal PR with the rule draft. NEVER auto-commit to main rules.
 Rules are written to project-local .agents/project-rules-ref/ (fork-only, rule 030).
+Reads draft content from DRAFT_FILE produced by Step 4.
 
 ```bash
 set -euo pipefail
+
+# Read draft content from Step 4 output file
+if [ ! -f "${DRAFT_FILE}" ]; then
+  echo "ERROR: DRAFT_FILE not found at ${DRAFT_FILE}"
+  exit 1
+fi
+
 RULE_DIR=".agents/project-rules-ref/${LANG}"
 mkdir -p "${RULE_DIR}"
 
@@ -239,8 +294,10 @@ SHORT_SHA=$(echo "${FIX_COMMIT_SHA}" | cut -c1-7)
 PROPOSAL_BRANCH="chore/rules-propose-${SHORT_SHA}"
 git checkout -b "${PROPOSAL_BRANCH}"
 
-# Write rule file (RULE_CONTENT from Step 4)
-echo "${RULE_CONTENT}" > "${RULE_DIR}/${RULE_FILE}"
+# Copy draft to final rule location
+cp "${DRAFT_FILE}" "${RULE_DIR}/${RULE_FILE}"
+# Clean up draft file
+rm -f "${DRAFT_FILE}"
 
 git add "${RULE_DIR}/${RULE_FILE}"
 git commit -m "chore(rules): propose ${LANG}/${RULE_FILE} from PR #${PR_NUM}
@@ -271,4 +328,4 @@ Auto-extracted by rule-extractor pattern (issue #661). Human review required.
 On merge of the proposal PR, update the relevant AGENTS.md index with
 one compact line: NNN|bug-class-slug|one-line summary."""
 on_fail = "abort"
-condition = "${HAS_BUG_CLASS_FINDINGS}"
+condition = "${SHOULD_DRAFT}"

--- a/patterns/rule-extractor/workflow.toml
+++ b/patterns/rule-extractor/workflow.toml
@@ -88,20 +88,12 @@ on_fail = "abort"
 [[workflow.steps]]
 id = 2
 title = "Classify Bug Class vs Isolated Mistake"
-tool = "csa"
+tool = "bash"
 prompt = """
 For each HIGH/CRITICAL finding from Step 1, classify as BUG_CLASS or ISOLATED_MISTAKE.
 
-Criteria for BUG_CLASS:
-- The anti-pattern is reproducible in other code
-- The fix required a structural change, not just a line edit
-- Two or more examples exist or could exist
-
-Criteria for ISOLATED_MISTAKE:
-- Single-line fix, unique to this code path
-- Cannot generalize to other locations
-
 ```bash
+set -euo pipefail
 CLASSIFY_SID=$(csa run --sa-mode true --tier tier-2-standard \
   --description "classify-finding: bug-class-or-isolated" \
   "Classify the following review finding as BUG_CLASS or ISOLATED_MISTAKE.
@@ -112,13 +104,29 @@ CLASSIFY_SID=$(csa run --sa-mode true --tier tier-2-standard \
    Fix commit: ${FIX_COMMIT_SHA}
    Fix diff summary: ${FIX_DIFF_SUMMARY}
 
+   Criteria for BUG_CLASS:
+   - The anti-pattern is reproducible in other code
+   - The fix required a structural change, not just a line edit
+   - Two or more examples exist or could exist
+
+   Criteria for ISOLATED_MISTAKE:
+   - Single-line fix, unique to this code path
+   - Cannot generalize to other locations
+
    Output: CLASSIFICATION=BUG_CLASS or CLASSIFICATION=ISOLATED_MISTAKE
    Then: RATIONALE: <one paragraph>")
 csa session wait --session "$CLASSIFY_SID"
+
+# Read classifier result and emit CSA_VAR
+CLASSIFY_OUTPUT=$(csa session result --session "$CLASSIFY_SID" --section summary 2>/dev/null || true)
+if echo "$CLASSIFY_OUTPUT" | grep -q "CLASSIFICATION=BUG_CLASS"; then
+  echo "CSA_VAR:HAS_BUG_CLASS_FINDINGS=yes"
+else
+  echo "CSA_VAR:HAS_BUG_CLASS_FINDINGS="
+fi
 ```
 
-Set HAS_BUG_CLASS_FINDINGS to "yes" if any finding classified as BUG_CLASS,
-empty string otherwise. Only BUG_CLASS findings proceed to Step 3."""
+Only BUG_CLASS findings proceed to Step 3."""
 on_fail = "abort"
 
 [[workflow.steps]]
@@ -130,14 +138,7 @@ Check whether an existing rule already covers this bug class.
 
 ```bash
 set -euo pipefail
-SHARED_RULES_DIR="${HOME}/project/github/t4nature/s/llm/coding/rules"
 PROJECT_RULES_DIR=".agents/project-rules-ref"
-
-# Keyword grep across shared rules
-SHARED_MATCHES=""
-if [ -d "${SHARED_RULES_DIR}" ]; then
-  SHARED_MATCHES=$(grep -rl "${BUG_CLASS_KEYWORDS}" "${SHARED_RULES_DIR}/" 2>/dev/null || true)
-fi
 
 # Keyword grep across project-local rules
 PROJECT_MATCHES=""
@@ -145,27 +146,25 @@ if [ -d "${PROJECT_RULES_DIR}" ]; then
   PROJECT_MATCHES=$(grep -rl "${BUG_CLASS_KEYWORDS}" "${PROJECT_RULES_DIR}/" 2>/dev/null || true)
 fi
 
-ALL_MATCHES="${SHARED_MATCHES}${PROJECT_MATCHES}"
-if [ -z "${ALL_MATCHES}" ]; then
+if [ -z "${PROJECT_MATCHES}" ]; then
   echo "EXISTING_RULE_MATCH=none"
+  echo "CSA_VAR:EXISTING_RULE_MATCH=none"
 else
   echo "Potential matches found:"
-  echo "${ALL_MATCHES}"
+  echo "${PROJECT_MATCHES}"
   echo "EXISTING_RULE_MATCH=potential"
+  echo "CSA_VAR:EXISTING_RULE_MATCH=potential"
+
+  # Dispatch semantic deduplication for potential matches
+  DEDUPE_SID=$(csa run --sa-mode true --tier tier-1-quick \
+    --description "dedupe-check: ${BUG_CLASS_NAME}" \
+    "Compare this bug class against the existing rule.
+     Bug class: ${BUG_CLASS_DESCRIPTION}
+     Existing rule content: (read from matched file)
+     Output: DEDUPE_RESULT=EXACT_MATCH|PARTIAL_MATCH|NO_MATCH
+     If PARTIAL_MATCH: UPDATE_SUGGESTION: <what to add>")
+  csa session wait --session "$DEDUPE_SID"
 fi
-```
-
-If keyword grep finds potential matches, dispatch semantic deduplication:
-
-```bash
-DEDUPE_SID=$(csa run --sa-mode true --tier tier-1-quick \
-  --description "dedupe-check: ${BUG_CLASS_NAME}" \
-  "Compare this bug class against the existing rule.
-   Bug class: ${BUG_CLASS_DESCRIPTION}
-   Existing rule content: (read from matched file)
-   Output: DEDUPE_RESULT=EXACT_MATCH|PARTIAL_MATCH|NO_MATCH
-   If PARTIAL_MATCH: UPDATE_SUGGESTION: <what to add>")
-csa session wait --session "$DEDUPE_SID"
 ```
 
 EXACT_MATCH: skip rule generation.
@@ -218,15 +217,21 @@ title = "Propose via PR"
 tool = "bash"
 prompt = """
 Create a proposal PR with the rule draft. NEVER auto-commit to main rules.
+Rules are written to project-local .agents/project-rules-ref/ (fork-only, rule 030).
 
 ```bash
 set -euo pipefail
-SHARED_RULES_DIR="${HOME}/project/github/t4nature/s/llm/coding/rules"
-RULE_DIR="${SHARED_RULES_DIR}/${LANG}"
+RULE_DIR=".agents/project-rules-ref/${LANG}"
+mkdir -p "${RULE_DIR}"
 
-# Determine next rule number
-NEXT_NUM=$(ls "${RULE_DIR}/" 2>/dev/null | grep -E '^[0-9]{3}-' | sort -n | tail -1 | cut -c1-3)
-NEXT_NUM=$(printf '%03d' $((10#${NEXT_NUM:-0} + 1)))
+# Determine next rule number (safe for empty directory)
+EXISTING=$(ls "${RULE_DIR}/" 2>/dev/null | grep -E '^[0-9]{3}-' || true)
+if [ -n "${EXISTING}" ]; then
+  LAST_NUM=$(echo "${EXISTING}" | sort -n | tail -1 | cut -c1-3)
+else
+  LAST_NUM="000"
+fi
+NEXT_NUM=$(printf '%03d' $((10#${LAST_NUM} + 1)))
 RULE_FILE="${NEXT_NUM}-${BUG_CLASS_SLUG}.md"
 
 # Create proposal branch

--- a/patterns/rule-extractor/workflow.toml
+++ b/patterns/rule-extractor/workflow.toml
@@ -48,9 +48,6 @@ name = "ANTI_PATTERN_EXAMPLES"
 name = "CORRECT_PATTERN"
 
 [[workflow.variables]]
-name = "SEVERITY"
-
-[[workflow.variables]]
 name = "RULE_CONTENT"
 
 [[workflow.variables]]
@@ -90,26 +87,24 @@ set -euo pipefail
 FINDINGS_RAW=""
 FINDING_EMITTED=""
 if [ -n "${REVIEW_SESSION_ID:-}" ]; then
-  # Extract findings.toml from the review session output directory
-  SESSION_DIR=$(csa session result --session "${REVIEW_SESSION_ID}" --session-dir 2>/dev/null || true)
-  if [ -n "$SESSION_DIR" ] && [ -f "$SESSION_DIR/output/findings.toml" ]; then
-    FINDINGS_RAW=$(cat "$SESSION_DIR/output/findings.toml")
-  else
-    # Fallback: read from session details text
-    FINDINGS_RAW=$(csa session result --session "${REVIEW_SESSION_ID}" --section details 2>/dev/null || true)
-  fi
+  # Read findings from the review session's structured output.
+  # --section details contains the review findings (including findings.toml content
+  # when the review pattern emits it). --full is a broader fallback.
+  FINDINGS_RAW=$(csa session result --session "${REVIEW_SESSION_ID}" --section details 2>/dev/null || \
+                 csa session result --session "${REVIEW_SESSION_ID}" --full 2>/dev/null || true)
 else
   # Fall back to PR comment history for bot findings.
   # Extract severity + description + path from PR comment bodies and emit
   # CSA_VARs directly (comment JSON shape differs from findings.toml).
   PR_COMMENTS=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUM}/comments" 2>/dev/null || true)
   if [ -n "$PR_COMMENTS" ]; then
-    # Pick the first comment whose body mentions a HIGH/CRITICAL/P0/P1 severity
+    # Pick the first bot comment whose body mentions a HIGH/CRITICAL/P0/P1 severity.
+    # Filter by known bot logins to avoid misinterpreting human comments.
     COMMENT_BODY=$(echo "$PR_COMMENTS" \
-      | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .body' \
+      | jq -r '.[] | select(.user.login | test("codex|gemini-pr-bot|coderabbit|github-actions"; "i")) | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .body' \
       | head -1)
     COMMENT_PATH=$(echo "$PR_COMMENTS" \
-      | jq -r '.[] | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .path // "unknown"' \
+      | jq -r '.[] | select(.user.login | test("codex|gemini-pr-bot|coderabbit|github-actions"; "i")) | select(.body | test("P0|P1|HIGH|CRITICAL"; "i")) | .path // "unknown"' \
       | head -1)
     if [ -n "$COMMENT_BODY" ]; then
       # Infer severity from the comment text
@@ -331,7 +326,7 @@ DRAFT_SID=$(csa run --sa-mode true --tier tier-2-standard \
    6. Case Study: PR #${PR_NUM}
 
    Frontmatter: source: pr-bot-finding, pr: #${PR_NUM},
-   severity: ${SEVERITY}, extracted-at: $(date -u +%Y-%m-%d)
+   severity: ${FINDING_SEVERITY}, extracted-at: $(date -u +%Y-%m-%d)
 
    Output the complete rule file content between RULE_DRAFT_START and RULE_DRAFT_END markers.")
 csa session wait --session "$DRAFT_SID"
@@ -415,7 +410,7 @@ gh pr create \
   --body "## Rule Proposal (auto-extracted)
 
 Source PR: #${PR_NUM}
-Severity: ${SEVERITY}
+Severity: ${FINDING_SEVERITY}
 Bug class: ${BUG_CLASS_NAME}
 
 Auto-extracted by rule-extractor pattern (issue #661). Human review required.

--- a/patterns/rule-extractor/workflow.toml
+++ b/patterns/rule-extractor/workflow.toml
@@ -45,7 +45,13 @@ name = "LANG"
 name = "ANTI_PATTERN_EXAMPLES"
 
 [[workflow.variables]]
+name = "ANTI_PATTERN_EXAMPLES_B64"
+
+[[workflow.variables]]
 name = "CORRECT_PATTERN"
+
+[[workflow.variables]]
+name = "CORRECT_PATTERN_B64"
 
 [[workflow.variables]]
 name = "RULE_CONTENT"
@@ -109,11 +115,11 @@ else
     if [ -n "$COMMENT_BODY" ]; then
       # Infer severity from the comment text
       COMMENT_SEV="HIGH"
-      if echo "$COMMENT_BODY" | grep -qi "CRITICAL\|P0"; then
+      if echo "$COMMENT_BODY" | grep -qiE "CRITICAL|P0"; then
         COMMENT_SEV="CRITICAL"
       fi
       # Use first line of comment body as description (strip markdown headers)
-      COMMENT_DESC=$(echo "$COMMENT_BODY" | grep -v '^#' | grep -v '^\s*$' | head -1 | sed 's/^[[:space:]]*//')
+      COMMENT_DESC=$(echo "$COMMENT_BODY" | grep -v '^#' | grep -v '^[[:space:]]*$' | head -1 | sed 's/^[[:space:]]*//')
       echo "CSA_VAR:FINDING_DESCRIPTION=$COMMENT_DESC"
       echo "CSA_VAR:FINDING_SEVERITY=$COMMENT_SEV"
       echo "CSA_VAR:FINDING_FILE=${COMMENT_PATH:-unknown}"
@@ -145,12 +151,12 @@ if [ -n "$FINDINGS_RAW" ]; then
   # The toml structure: severity = "high"|"critical", description = "...",
   # file_ranges has path = "..." entries.
   # Filter: only consider lines where severity is high or critical
-  FIRST_SEV=$(echo "$FINDINGS_RAW" | grep -iE '^severity\s*=\s*"(high|critical)"' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
+  FIRST_SEV=$(echo "$FINDINGS_RAW" | grep -iE '^severity[[:space:]]*=[[:space:]]*"(high|critical)"' | head -1 | sed -E 's/.*= *"([^"]*)".*/\\1/')
   # Find the description from the same [[findings]] block as the matched severity.
   # Since findings.toml is flat-ish (severity then description then file_ranges),
   # we take the description line following the first high/critical severity line.
-  FIRST_DESC=$(echo "$FINDINGS_RAW" | grep -iA 20 '^severity\s*=\s*".*\(high\|critical\)"' | grep -i '^description' | head -1 | sed 's/.*= *"\(.*\)".*/\1/')
-  FIRST_FILE=$(echo "$FINDINGS_RAW" | grep -iA 30 '^severity\s*=\s*".*\(high\|critical\)"' | grep -i '^path' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')
+  FIRST_DESC=$(echo "$FINDINGS_RAW" | grep -iEA 20 '^severity[[:space:]]*=[[:space:]]*".*(high|critical)"' | grep -i '^description' | head -1 | sed -E 's/.*= *"(.*)".*/\\1/')
+  FIRST_FILE=$(echo "$FINDINGS_RAW" | grep -iEA 30 '^severity[[:space:]]*=[[:space:]]*".*(high|critical)"' | grep -i '^path' | head -1 | sed -E 's/.*= *"([^"]*)".*/\\1/')
 
   if [ -n "$FIRST_DESC" ]; then
     echo "CSA_VAR:FINDING_DESCRIPTION=$FIRST_DESC"
@@ -206,17 +212,56 @@ CLASSIFY_SID=$(csa run --sa-mode true --tier tier-2-standard \
    - Single-line fix, unique to this code path
    - Cannot generalize to other locations
 
-   Output: CLASSIFICATION=BUG_CLASS or CLASSIFICATION=ISOLATED_MISTAKE
-   Then: RATIONALE: <one paragraph>")
+   Output EXACTLY these lines (one per line, no quoting, no extra whitespace):
+   CLASSIFICATION=BUG_CLASS or CLASSIFICATION=ISOLATED_MISTAKE
+   RATIONALE=<one paragraph explaining why>
+
+   If CLASSIFICATION=BUG_CLASS, also output these ADDITIONAL lines:
+   BUG_CLASS_NAME=<human-readable name, e.g. Unbound Shell Variable>
+   BUG_CLASS_SLUG=<kebab-case slug, e.g. unbound-shell-variable>
+   BUG_CLASS_KEYWORDS=<space-separated grep keywords, e.g. unbound variable set -u>
+   BUG_CLASS_DESCRIPTION=<single-line paragraph describing the bug class>
+   ANTI_PATTERN_EXAMPLES_B64=<base64-encoded multi-line code examples of the anti-pattern>
+   CORRECT_PATTERN_B64=<base64-encoded multi-line code examples of the correct pattern>
+
+   For the base64 fields: write the code examples as plain text, then encode
+   with standard base64 (no line wraps). This avoids CSA_VAR single-line constraint.
+   If CLASSIFICATION=ISOLATED_MISTAKE, do NOT output the BUG_CLASS_* lines.")
 csa session wait --session "$CLASSIFY_SID"
 
 # NOTE: This bash block emits CSA_VAR:HAS_BUG_CLASS_FINDINGS which gates
 # Step 3 (condition = "${HAS_BUG_CLASS_FINDINGS}"). The CSA_VAR: prefix
 # is the mechanism by which tool=bash steps propagate variables to
 # subsequent workflow steps — this is correct and intentional.
-CLASSIFY_OUTPUT=$(csa session result --session "$CLASSIFY_SID" --section summary 2>/dev/null || true)
+#
+# When classification is BUG_CLASS, also emits the 6 BUG_CLASS_* fields
+# that Steps 3-5 reference: NAME, SLUG, KEYWORDS, DESCRIPTION,
+# ANTI_PATTERN_EXAMPLES_B64, CORRECT_PATTERN_B64.
+CLASSIFY_OUTPUT=$(csa session result --session "$CLASSIFY_SID" --section summary 2>/dev/null || \
+                  csa session result --session "$CLASSIFY_SID" --full 2>/dev/null || true)
 if echo "$CLASSIFY_OUTPUT" | grep -q "CLASSIFICATION=BUG_CLASS"; then
   echo "CSA_VAR:HAS_BUG_CLASS_FINDINGS=yes"
+
+  # Extract the 6 BUG_CLASS fields from LLM output (one per line, KEY=VALUE format)
+  BC_NAME=$(echo "$CLASSIFY_OUTPUT" | grep -E '^BUG_CLASS_NAME=' | head -1 | sed 's/^BUG_CLASS_NAME=//')
+  BC_SLUG=$(echo "$CLASSIFY_OUTPUT" | grep -E '^BUG_CLASS_SLUG=' | head -1 | sed 's/^BUG_CLASS_SLUG=//')
+  BC_KEYWORDS=$(echo "$CLASSIFY_OUTPUT" | grep -E '^BUG_CLASS_KEYWORDS=' | head -1 | sed 's/^BUG_CLASS_KEYWORDS=//')
+  BC_DESC=$(echo "$CLASSIFY_OUTPUT" | grep -E '^BUG_CLASS_DESCRIPTION=' | head -1 | sed 's/^BUG_CLASS_DESCRIPTION=//')
+  BC_ANTI_B64=$(echo "$CLASSIFY_OUTPUT" | grep -E '^ANTI_PATTERN_EXAMPLES_B64=' | head -1 | sed 's/^ANTI_PATTERN_EXAMPLES_B64=//')
+  BC_CORRECT_B64=$(echo "$CLASSIFY_OUTPUT" | grep -E '^CORRECT_PATTERN_B64=' | head -1 | sed 's/^CORRECT_PATTERN_B64=//')
+
+  # Fallback defaults when LLM omits optional fields
+  : "${BC_NAME:=unknown-bug-class}"
+  : "${BC_SLUG:=unknown-bug-class}"
+  : "${BC_KEYWORDS:=bug class}"
+  : "${BC_DESC:=${FINDING_DESCRIPTION}}"
+
+  echo "CSA_VAR:BUG_CLASS_NAME=$BC_NAME"
+  echo "CSA_VAR:BUG_CLASS_SLUG=$BC_SLUG"
+  echo "CSA_VAR:BUG_CLASS_KEYWORDS=$BC_KEYWORDS"
+  echo "CSA_VAR:BUG_CLASS_DESCRIPTION=$BC_DESC"
+  echo "CSA_VAR:ANTI_PATTERN_EXAMPLES_B64=${BC_ANTI_B64:-}"
+  echo "CSA_VAR:CORRECT_PATTERN_B64=${BC_CORRECT_B64:-}"
 else
   echo "CSA_VAR:HAS_BUG_CLASS_FINDINGS="
 fi
@@ -306,14 +351,30 @@ Dispatches csa run, captures the draft into a file, and emits CSA_VAR:DRAFT_FILE
 
 ```bash
 set -euo pipefail
+
+# Decode base64-encoded multi-line fields from Step 2
+ANTI_PATTERN_DECODED=""
+if [ -n "${ANTI_PATTERN_EXAMPLES_B64:-}" ]; then
+  ANTI_PATTERN_DECODED=$(echo "${ANTI_PATTERN_EXAMPLES_B64}" | base64 -d 2>/dev/null || true)
+fi
+: "${ANTI_PATTERN_DECODED:=No anti-pattern examples provided.}"
+
+CORRECT_PATTERN_DECODED=""
+if [ -n "${CORRECT_PATTERN_B64:-}" ]; then
+  CORRECT_PATTERN_DECODED=$(echo "${CORRECT_PATTERN_B64}" | base64 -d 2>/dev/null || true)
+fi
+: "${CORRECT_PATTERN_DECODED:=No correct pattern examples provided.}"
+
 DRAFT_SID=$(csa run --sa-mode true --tier tier-2-standard \
   --description "draft-rule: ${BUG_CLASS_NAME}" \
   "Generate a coding rule file for the following bug class.
 
    Bug class: ${BUG_CLASS_DESCRIPTION}
    Language: ${LANG}
-   Anti-pattern examples: ${ANTI_PATTERN_EXAMPLES}
-   Correct pattern: ${CORRECT_PATTERN}
+   Anti-pattern examples:
+${ANTI_PATTERN_DECODED}
+   Correct pattern:
+${CORRECT_PATTERN_DECODED}
    PR: #${PR_NUM}
    Fix commit: ${FIX_COMMIT_SHA}
 


### PR DESCRIPTION
## Summary

Add `patterns/rule-extractor/` scaffold implementing closed-loop learning from PR-bot findings (issue #661, Option 2: post-merge extraction).

### Five-step pipeline

1. **Collect findings** — Read merged PR's review artifacts, extract HIGH/CRITICAL findings from `findings.toml` or PR comments
2. **Classify bug-class vs isolated-mistake** — LLM classifier determines if finding is a structural anti-pattern (rule-worthy) or a one-off mistake (skip)
3. **Deduplicate against existing rules** — Two-layer dedup: keyword grep across `~/project/github/t4nature/s/llm/coding/rules/<lang>/` and `.agents/project-rules-ref/`, then semantic LLM comparison for near-matches
4. **Generate rule draft** — Structure mirrors `rust/017-concurrent-file-primitives.md`: Anti-patterns / Preferred primitives / Decision checklist / Case study with frontmatter for traceability
5. **Propose via PR** — Branch `chore/rules-propose-<shortsha>`, never auto-commit. Human review mandatory. On merge, AGENTS.md index updated with one compact line

### Filter criteria (prevents noise)

- Severity HIGH/CRITICAL/P1 only (MEDIUM/LOW/nit excluded)
- False-positive check passed (finding was fixed, not debate-dismissed)
- Bug CLASS (structural, 2+ examples possible), not isolated single-line mistake
- Fix required structural change, not trivial line edit

### Why Option 2 (post-merge)

Rules are extracted from the FINAL merged fix state, not intermediate review iterations. The merged code is the authoritative fix, and the full review history (rounds, debate results) is available for case study generation.

### Files

- `patterns/rule-extractor/PATTERN.md` — Full pattern documentation
- `patterns/rule-extractor/workflow.toml` — Workflow definition (synced with PATTERN.md per rule 027)
- `patterns/rule-extractor/skills/rule-extractor/SKILL.md` — Skill documentation
- `patterns/rule-extractor/skills/rule-extractor/.skill.toml` — Skill metadata
- `patterns/pr-bot/PATTERN.md` — Integration note added (post-merge extension available, integration pending separate PR)

### Not changed

- `patterns/pr-bot/workflow.toml` — Not modified per task constraints. Integration as post-merge step is deferred to a separate PR

## Test plan

- [x] `just pre-commit` passes (all 28 tests green)
- [x] PATTERN.md ↔ workflow.toml variables and steps are synchronized
- [x] No modifications to `patterns/pr-bot/workflow.toml`
- [ ] Manual review: rule structure mirrors `rust/017-concurrent-file-primitives.md`
- [ ] Manual review: filter criteria match issue #661 specification

Refs: #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)