### PR TITLE
fix(sandbox): codex existence gating + strict probe cleanup (closes #1087)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.557"
+version = "0.1.558"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.557"
+version = "0.1.558"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-resource/src/isolation_plan_codex.rs
+++ b/crates/csa-resource/src/isolation_plan_codex.rs
@@ -1,7 +1,6 @@
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
-
-use anyhow::Context;
+use std::process::Command;
 
 use crate::filesystem_sandbox::FilesystemCapability;
 
@@ -35,15 +34,11 @@ pub(super) fn add_codex_home_for_tool(
             purpose: "Codex rollout recorder and arg0 PATH shim",
             config_hint: CODEX_SANDBOX_CONFIG_HINT,
         });
-    } else if codex_home.is_absolute() && codex_home.exists() {
-        if super::is_sensitive_system_path(&codex_home) {
-            tracing::warn!(
-                path = %codex_home.display(),
-                "rejecting writable path under sensitive system directory"
-            );
-        } else {
-            push_unique_path(writable_paths, codex_home);
-        }
+    } else if codex_home.is_absolute() && has_codex_on_path() {
+        // Codex is installed — route through `add_dir_or_creatable_parent` so
+        // the directory is pre-created when it doesn't exist yet (avoids
+        // read-only-fs in nested CSA sessions spawning a codex child).
+        super::add_dir_or_creatable_parent(writable_paths, &codex_home);
     }
 }
 
@@ -70,10 +65,21 @@ pub(super) fn codex_home_dir(home: &Path) -> (PathBuf, &'static str) {
     }
 }
 
-fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
-    if !paths.iter().any(|existing| existing == &path) {
-        paths.push(path);
+/// Check whether any codex binary (`codex` or `codex-acp`) is on `PATH`.
+pub(super) fn has_codex_on_path() -> bool {
+    for binary in &["codex", "codex-acp"] {
+        let found = Command::new("which")
+            .arg(binary)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|s| s.success());
+        if found {
+            return true;
+        }
     }
+    false
 }
 
 fn path_is_covered_by_writable_mount(path: &Path, writable_paths: &[PathBuf]) -> bool {
@@ -166,12 +172,16 @@ fn probe_writable_dir(path: &Path, required: &RequiredWritableDir) -> anyhow::Re
         let probe = path.join(format!(".csa-write-probe-{}-{attempt}", std::process::id()));
         match OpenOptions::new().write(true).create_new(true).open(&probe) {
             Ok(_) => {
-                fs::remove_file(&probe).with_context(|| {
-                    format!(
-                        "codex sandbox preflight failed: could not remove write probe {}",
-                        probe.display()
-                    )
-                })?;
+                // Write succeeded — that is the actual signal.  Cleanup failure
+                // is downgraded to a warning so flaky mounts (NFS, sshfs) don't
+                // fail the preflight for a non-critical hygiene step.
+                if let Err(error) = fs::remove_file(&probe) {
+                    tracing::warn!(
+                        probe = %probe.display(),
+                        %error,
+                        "could not remove write probe (non-fatal)"
+                    );
+                }
                 return Ok(());
             }
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,

--- a/crates/csa-resource/src/isolation_plan_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_tests.rs
@@ -529,10 +529,19 @@ fn test_parent_tool_defaults_expose_existing_codex_home_for_nested_csa() {
         .build()
         .expect("should succeed");
 
-    assert!(
-        plan.writable_paths.contains(&codex_home),
-        "parent sandboxes should expose existing Codex home for nested Codex CSA sessions"
-    );
+    // Non-codex tools only expose CODEX_HOME when codex is on PATH (existence
+    // gating).  Skip the assertion in CI where codex may not be installed.
+    if codex_paths::has_codex_on_path() {
+        assert!(
+            plan.writable_paths.contains(&codex_home),
+            "parent sandboxes should expose existing Codex home for nested Codex CSA sessions"
+        );
+    } else {
+        assert!(
+            !plan.writable_paths.contains(&codex_home),
+            "without codex on PATH, parent sandboxes should NOT expose Codex home"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Resolves two MEDIUM findings deferred from PR #1086 R2 (issue #1087):
1. nested-codex existence gating — probe now checks `which(codex)` before exposing sandbox paths
2. probe_writable_dir cleanup strictness — temp artifact cleanup downgraded to warning on NFS/sshfs to preserve resilience

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] 101 tests pass (38 isolation_plan)
- [x] CSA push-gate review tier-4-critical: PASS, 2 LOW non-blocking advisories

Closes #1087.