### PR TITLE
docs(config): list max alias + unify token count wording in thinking doc (closes #1092)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.559"
+version = "0.1.560"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.559"
+version = "0.1.560"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -266,7 +266,8 @@ pub struct ReviewConfig {
     /// With an active review tier, the tier model spec remains authoritative unless CLI `--model` is provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
-    /// Default thinking budget for `csa review` (`low`, `medium`, `high`, `xhigh`).
+    /// Default thinking budget for `csa review` (`low`, `medium`, `high`, `xhigh`, `max`,
+    /// or a token count).
     /// `csa review --thinking <LEVEL>` (when supported) overrides this.
     /// With an active review tier, the tier thinking budget remains authoritative unless CLI `--thinking` is provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -390,7 +391,8 @@ pub struct DebateConfig {
     /// With an active debate tier, the tier model spec remains authoritative unless CLI `--model` is provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
-    /// Default thinking budget for `csa debate` (`low`, `medium`, `high`, `xhigh`).
+    /// Default thinking budget for `csa debate` (`low`, `medium`, `high`, `xhigh`, `max`,
+    /// or a token count).
     /// `csa debate --thinking <LEVEL>` overrides this per invocation.
     /// With an active debate tier, the tier thinking budget remains authoritative unless CLI `--thinking` is provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Resolves #1092. Updates ReviewConfig::thinking + DebateConfig::thinking doc-strings to list 'max' alias and unify 'token count' wording. Docs-only, no behavior change. Push-gate review tier-4-critical: PASS, no findings.