### PR TITLE
fix(config): atomic write via tempfile+rename in config set (closes #1094)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.560"
+version = "0.1.561"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.560"
+version = "0.1.561"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds_set.rs
+++ b/crates/cli-sub-agent/src/config_cmds_set.rs
@@ -44,10 +44,26 @@ fn write_config_value(path: &std::path::Path, key: &str, value: &str) -> Result<
 
     set_document_config_value(&mut doc, key, value)?;
 
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("config path has no parent directory"))?;
+    std::fs::create_dir_all(parent)?;
+
+    // Preserve original file permissions if the file already exists.
+    let original_permissions = std::fs::metadata(path).ok().map(|m| m.permissions());
+
+    let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(|err| {
+        anyhow::anyhow!("failed to create temp file in {}: {err}", parent.display())
+    })?;
+    std::io::Write::write_all(&mut tmp, doc.to_string().as_bytes())?;
+
+    if let Some(perms) = original_permissions {
+        tmp.as_file().set_permissions(perms)?;
     }
-    std::fs::write(path, doc.to_string())?;
+
+    tmp.persist(path)
+        .map_err(|err| anyhow::anyhow!("failed to atomically rename config: {err}"))?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Resolves #1094. config_cmds_set.rs now writes via NamedTempFile + persist (atomic POSIX rename), preserving original permission bits. 6 unit tests + full nextest pass. Push-gate review tier-4-critical: PASS, 2 LOW non-blocking notes.