### PR TITLE
fix(routing): drain frontmatter strip + tail-comment trim in difficulty parse (closes #1097)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.561"
+version = "0.1.562"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.561"
+version = "0.1.562"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/difficulty_routing.rs
+++ b/crates/cli-sub-agent/src/difficulty_routing.rs
@@ -21,10 +21,9 @@ pub(crate) fn strip_difficulty_frontmatter(prompt: String) -> Result<ParsedPromp
         if line.trim_end() == "---" {
             let frontmatter = &prompt[body_start..line_start];
             let difficulty = parse_frontmatter_difficulty(frontmatter)?;
-            return Ok(ParsedPromptDifficulty {
-                difficulty,
-                prompt: prompt[line_end..].to_string(),
-            });
+            let mut prompt = prompt;
+            prompt.drain(..line_end);
+            return Ok(ParsedPromptDifficulty { difficulty, prompt });
         }
         line_start = line_end;
     }
@@ -54,13 +53,41 @@ fn parse_frontmatter_difficulty(frontmatter: &str) -> Result<Option<String>> {
         if key.trim() != "difficulty" {
             continue;
         }
-        let label = unquote_yaml_scalar(value.trim());
+        let value = strip_yaml_trailing_comment(value.trim());
+        let label = unquote_yaml_scalar(value);
         if label.trim().is_empty() {
             anyhow::bail!("Malformed YAML frontmatter: difficulty value cannot be empty");
         }
         difficulty = Some(label.to_string());
     }
     Ok(difficulty)
+}
+
+/// Strip a trailing `# comment` from a YAML scalar value, skipping `#` inside
+/// single- or double-quoted regions. Returns the trimmed value slice.
+fn strip_yaml_trailing_comment(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' | b'\'' => {
+                let quote = bytes[i];
+                i += 1;
+                while i < bytes.len() && bytes[i] != quote {
+                    i += 1;
+                }
+                // skip closing quote
+                i += 1;
+            }
+            b'#' => {
+                return value[..i].trim_end();
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    value
 }
 
 fn unquote_yaml_scalar(value: &str) -> &str {
@@ -300,6 +327,55 @@ mod tests {
         assert!(msg.contains("Difficulty hint 'security_audit' not found in [tier_mapping]"));
         assert!(msg.contains("bug_fix"));
         assert!(msg.contains("quick_question"));
+    }
+
+    #[test]
+    fn strip_frontmatter_drains_in_place() {
+        let original = "---\ndifficulty: bug_fix\n---\nthe body here".to_string();
+        let original_ptr = original.as_ptr();
+        let parsed = strip_difficulty_frontmatter(original).expect("valid frontmatter");
+
+        assert_eq!(parsed.difficulty.as_deref(), Some("bug_fix"));
+        assert_eq!(parsed.prompt, "the body here");
+        // The returned string reuses the original allocation (drain in-place).
+        assert_eq!(parsed.prompt.as_ptr(), original_ptr);
+    }
+
+    #[test]
+    fn frontmatter_strips_trailing_yaml_comment() {
+        let parsed = strip_difficulty_frontmatter(
+            "---\ndifficulty: quick_question # 30%\n---\nbody".to_string(),
+        )
+        .expect("trailing comment should be stripped");
+
+        assert_eq!(parsed.difficulty.as_deref(), Some("quick_question"));
+        assert_eq!(parsed.prompt, "body");
+    }
+
+    #[test]
+    fn frontmatter_preserves_hash_inside_quotes() {
+        // Single-quoted value containing '#' must NOT be stripped.
+        let parsed = strip_difficulty_frontmatter(
+            "---\ndifficulty: 'quick#question'\n---\nbody".to_string(),
+        )
+        .expect("hash inside quotes must be preserved");
+        assert_eq!(parsed.difficulty.as_deref(), Some("quick#question"));
+
+        // Double-quoted value containing '#' must NOT be stripped.
+        let parsed = strip_difficulty_frontmatter(
+            "---\ndifficulty: \"quick#question\"\n---\nbody".to_string(),
+        )
+        .expect("hash inside double quotes must be preserved");
+        assert_eq!(parsed.difficulty.as_deref(), Some("quick#question"));
+    }
+
+    #[test]
+    fn frontmatter_quoted_value_with_trailing_comment() {
+        let parsed = strip_difficulty_frontmatter(
+            "---\ndifficulty: 'bug_fix' # a comment\n---\nbody".to_string(),
+        )
+        .expect("quoted value with trailing comment");
+        assert_eq!(parsed.difficulty.as_deref(), Some("bug_fix"));
     }
 
     #[test]


### PR DESCRIPTION
Resolves #1097 (PR #1096 R2 MEDIUMs). In-place drain replaces clone+slice; trailing YAML '#' comment trimmed with quote awareness. 4 new tests, 14/14 pass. Push-gate review: PASS, no findings.