### PR TITLE
fix(executor): pre_session hook uses session.project_path as cwd (closes #1099)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.562"
+version = "0.1.563"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.562"
+version = "0.1.563"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/executor_pre_session.rs
+++ b/crates/csa-executor/src/executor_pre_session.rs
@@ -31,9 +31,13 @@ impl Executor {
             tracing::debug!("pre_session hook already fired for this invocation");
             return Cow::Borrowed(prompt);
         }
-        let working_dir = std::env::current_dir()
-            .map(|path| path.display().to_string())
-            .unwrap_or_else(|_| session.project_path.clone());
+        let working_dir = if session.project_path.is_empty() {
+            std::env::current_dir()
+                .map(|path| path.display().to_string())
+                .unwrap_or_default()
+        } else {
+            session.project_path.clone()
+        };
         let context = csa_hooks::PreSessionHookContext {
             session_id: &session.meta_session_id,
             transport: self.tool_name(),
@@ -62,7 +66,7 @@ mod tests {
         MetaSessionState {
             meta_session_id: "01PRESESSION00000000000000".to_string(),
             description: Some("pre-session test".to_string()),
-            project_path: "/tmp/pre-session-test".to_string(),
+            project_path: "/tmp".to_string(),
             branch: None,
             created_at: now,
             last_accessed: now,
@@ -87,6 +91,40 @@ mod tests {
             vcs_identity: None,
             identity_version: 1,
         }
+    }
+
+    #[tokio::test]
+    async fn pre_session_hook_uses_session_project_path_as_cwd() {
+        // session.project_path should be preferred over std::env::current_dir()
+        // when determining hook working directory.
+        let config = csa_hooks::PreSessionHookConfig {
+            command: Some("pwd".to_string()),
+            transports: vec!["codex".to_string()],
+            timeout_seconds: 2,
+            ..Default::default()
+        };
+        let invocation = csa_hooks::PreSessionHookInvocation::new(config);
+        let options =
+            ExecuteOptions::new(StreamMode::BufferOnly, 60).with_pre_session_hook(invocation);
+        let executor = Executor::Codex {
+            model_override: None,
+            thinking_budget: None,
+            runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
+        };
+        let mut session = test_session();
+        // Use /tmp which always exists and differs from process cwd
+        session.project_path = "/tmp".to_string();
+
+        let result = executor
+            .apply_pre_session_hook("hello", &session, &options)
+            .await;
+
+        // The hook output should contain /tmp (the session project_path),
+        // not the process's current working directory.
+        assert!(
+            result.contains("/tmp"),
+            "hook cwd should be session.project_path (/tmp), got: {result}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Resolves #1099. Pre-session hook cwd now derives from session.project_path (with current_dir fallback for empty Default case). Aligns hook context with --cd resolved session. New unit test. Push-gate review: PASS, no findings.