### PR TITLE
fix(retry): unify idle-disconnect classification + Max downshift effective on codex (closes #1101)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.563"
+version = "0.1.564"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.563"
+version = "0.1.564"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -118,12 +118,15 @@ impl ThinkingBudget {
 
     /// One-level downshift target when an ACP idle disconnect is detected.
     ///
-    /// Steps down one tier: Max→Xhigh, Xhigh→High, High→Medium, Medium→Low.
+    /// Steps down: Max→High (skips Xhigh — on codex both map to "xhigh" effort,
+    /// so Max→Xhigh would be a no-op), Xhigh→High, High→Medium, Medium→Low.
     /// Returns `None` for Low/DefaultBudget/Custom (already minimal; downshifting
     /// further would not help and the idle disconnect should propagate as-is).
     pub fn idle_disconnect_downshift(&self) -> Option<ThinkingBudget> {
         match self {
-            Self::Max => Some(ThinkingBudget::Xhigh),
+            // Skip Xhigh: codex_effort() maps both Max and Xhigh to "xhigh",
+            // so Max→Xhigh is a no-op on codex (#1101).
+            Self::Max => Some(ThinkingBudget::High),
             Self::Xhigh => Some(ThinkingBudget::High),
             Self::High => Some(ThinkingBudget::Medium),
             Self::Medium => Some(ThinkingBudget::Low),

--- a/crates/csa-executor/src/transport_acp_crash_retry.rs
+++ b/crates/csa-executor/src/transport_acp_crash_retry.rs
@@ -546,8 +546,9 @@ pub(super) async fn execute_with_crash_retry(
                              downshifted thinking budget (#766)"
                         );
                         tokio::time::sleep(Duration::from_secs(ACP_CRASH_RETRY_DELAY_SECS)).await;
-                        // Single retry with downshifted args.
-                        let retry_result = transport
+                        // Single retry with downshifted args — route through
+                        // classification instead of returning early (#1101).
+                        match transport
                             .execute_acp_attempt(
                                 prompt,
                                 session,
@@ -556,8 +557,42 @@ pub(super) async fn execute_with_crash_retry(
                                 &downshifted_args,
                                 None, // fresh process, no resume
                             )
-                            .await;
-                        return retry_result;
+                            .await
+                        {
+                            Ok(tr) => return Ok(tr),
+                            Err(error) => {
+                                let error_display = format!("{error:#}");
+                                let memory_max_mb = options
+                                    .sandbox
+                                    .and_then(|sandbox| sandbox.isolation_plan.memory_max_mb);
+                                if is_auth_error(&error_display) {
+                                    return Err(format_auth_failure(error, &transport.tool_name));
+                                }
+                                if transport.tool_name == "codex"
+                                    && is_crash_lowered(&error_display.to_lowercase())
+                                {
+                                    let classification = classify_codex_acp_crash(
+                                        &error_display,
+                                        extract_crash_exit_code(&error_display),
+                                        None,
+                                        memory_max_mb,
+                                    );
+                                    return Err(format_codex_acp_crash(
+                                        &classification,
+                                        error,
+                                        attempt + 1,
+                                    ));
+                                }
+                                if is_oom_error(&error_display) {
+                                    return Err(format_oom_crash(
+                                        error,
+                                        &transport.tool_name,
+                                        memory_max_mb,
+                                    ));
+                                }
+                                return Err(error);
+                            }
+                        }
                     }
                     // No downshift target (already at lowest) — fall through to return as-is.
                     tracing::warn!(

--- a/crates/csa-executor/src/transport_tests_acp_crash_retry.rs
+++ b/crates/csa-executor/src/transport_tests_acp_crash_retry.rs
@@ -540,10 +540,10 @@ fn build_downshifted_args_replaces_existing_effort() {
 fn idle_disconnect_downshift_covers_all_levels() {
     use crate::model_spec::ThinkingBudget;
 
-    // Max → Xhigh
+    // Max → High (skips Xhigh — both map to "xhigh" in codex_effort, #1101)
     assert!(matches!(
         ThinkingBudget::Max.idle_disconnect_downshift(),
-        Some(ThinkingBudget::Xhigh)
+        Some(ThinkingBudget::High)
     ));
     // Xhigh → High
     assert!(matches!(
@@ -574,4 +574,23 @@ fn idle_disconnect_downshift_covers_all_levels() {
             .idle_disconnect_downshift()
             .is_none()
     );
+}
+
+/// Verify that Max.downshift() actually changes codex_effort() (#1101).
+#[test]
+fn max_downshift_changes_codex_effort() {
+    use crate::model_spec::ThinkingBudget;
+
+    let max_effort = ThinkingBudget::Max.codex_effort();
+    let downshifted = ThinkingBudget::Max
+        .idle_disconnect_downshift()
+        .expect("Max should have a downshift target");
+    let downshifted_effort = downshifted.codex_effort();
+
+    assert_ne!(
+        max_effort, downshifted_effort,
+        "Max.downshift() must produce a different codex_effort; \
+         both were '{max_effort}' — the downshift is a no-op on codex"
+    );
+    assert_eq!(downshifted_effort, "high");
 }


### PR DESCRIPTION
Resolves #1101 (PR #1100 codex P2). (1) Idle-disconnect retry routes through is_auth_error/classify_codex_acp_crash/is_oom_error classification path (was raw). (2) Max.idle_disconnect_downshift() → High (was Xhigh; codex_effort maps both Max+Xhigh to 'xhigh' making prev a no-op). New regression test asserts downshift changes codex effort. Push-gate review: PASS, 1 LOW non-blocking observability note.