### PR TITLE
docs(pr-bot): anchor SENTINEL-POLICY comment at mktemp site (closes #1105)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.564"
+version = "0.1.565"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.564"
+version = "0.1.565"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -675,6 +675,15 @@ else
 fi
 # shellcheck source=patterns/pr-bot/scripts/pr-bot-quota-cache.sh
 . "${PR_BOT_QUOTA_CACHE_SCRIPT}"
+# SENTINEL-POLICY: rely on mktemp to provide a fresh path; do NOT rm -f beforehand.
+# Decision-anchor: PR #1083 R3 (gemini design-residual).  Race-safe mktemp
+# (`mktemp -t ... -p "$DIR"`) beats stale-cleanup (`rm -f`) because rm -f
+# racing with concurrent pr-bot invocations would clobber a sibling's
+# freshly-created tmpfile.  mktemp guarantees a unique path every call, so
+# there is no "stale leftover" scenario to guard against.
+#
+# If a future csa-review round re-litigates "add rm -f before mktemp",
+# point at this anchor instead of flipping policy.  See also: issue #1105.
 OUTPUT_FILE="$(mktemp -t pr-bot-wait-${PR_NUM}-XXXXXX.json)"
 # mktemp creates a 0-byte sentinel; the wrapper's poll loop below uses
 # [ -s ] (exists AND non-empty) so the empty sentinel does not trip the

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -1115,6 +1115,15 @@ else
 fi
 # shellcheck source=patterns/pr-bot/scripts/pr-bot-quota-cache.sh
 . "${PR_BOT_QUOTA_CACHE_SCRIPT}"
+# SENTINEL-POLICY: rely on mktemp to provide a fresh path; do NOT rm -f beforehand.
+# Decision-anchor: PR #1083 R3 (gemini design-residual).  Race-safe mktemp
+# (`mktemp -t ... -p "$DIR"`) beats stale-cleanup (`rm -f`) because rm -f
+# racing with concurrent pr-bot invocations would clobber a sibling's
+# freshly-created tmpfile.  mktemp guarantees a unique path every call, so
+# there is no "stale leftover" scenario to guard against.
+#
+# If a future csa-review round re-litigates "add rm -f before mktemp",
+# point at this anchor instead of flipping policy.  See also: issue #1105.
 OUTPUT_FILE="$(mktemp -t pr-bot-wait-${PR_NUM}-XXXXXX.json)"
 # mktemp creates a 0-byte sentinel; the wrapper's poll loop below uses
 # [ -s ] (exists AND non-empty) so the empty sentinel does not trip the


### PR DESCRIPTION
Resolves #1105. Adds SENTINEL-POLICY decision-anchor at pr-bot mktemp site documenting the R1-R3 ping-pong outcome (mktemp + no rm -f). PATTERN.md ↔ workflow.toml byte-identical. Push-gate review: PASS, no findings.