### PR TITLE
feat(executor): add CLI transport for claude-code (#1103 Phase 3 PoC)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -812,11 +812,12 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "which 8.0.2",
 ]
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "chrono",
@@ -833,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "chrono",
@@ -845,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "axum",
@@ -868,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "chrono",
@@ -905,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -921,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "chrono",
@@ -939,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4490,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.565"
+version = "0.1.566"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.565"
+version = "0.1.566"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-config/src/config_tool.rs
+++ b/crates/csa-config/src/config_tool.rs
@@ -321,4 +321,33 @@ transport = "cli"
             Some(TransportKind::Cli)
         );
     }
+
+    /// Phase 3 PoC contract for #1103: parsing
+    /// `[tools.claude-code] transport = "cli"` MUST yield
+    /// `TransportKind::Cli`, not silently coerce back to ACP.  The
+    /// `ClaudeCodeCliTransport` in `csa-executor` keys off this exact
+    /// resolution.
+    #[test]
+    fn test_resolve_transport_claude_code_cli_round_trips() {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            tools: HashMap<String, ToolConfig>,
+        }
+        let toml_str = r#"
+[tools.claude-code]
+transport = "cli"
+"#;
+        let wrapper: Wrapper = toml::from_str(toml_str).expect("parse claude-code cli toml");
+        let tool = wrapper
+            .tools
+            .get("claude-code")
+            .expect("claude-code tool entry missing");
+
+        assert_eq!(tool.transport, Some(TransportKind::Cli));
+        assert_eq!(
+            tool.resolve_transport("claude-code"),
+            Some(TransportKind::Cli),
+            "explicit transport=\"cli\" must resolve to CLI, not the build default"
+        );
+    }
 }

--- a/crates/csa-executor/Cargo.toml
+++ b/crates/csa-executor/Cargo.toml
@@ -34,3 +34,4 @@ codex-pty-fork = ["csa-process/codex-pty-fork"]
 [dev-dependencies]
 tempfile.workspace = true
 tracing-subscriber.workspace = true
+which.workspace = true

--- a/crates/csa-executor/src/lib.rs
+++ b/crates/csa-executor/src/lib.rs
@@ -33,12 +33,13 @@ pub use logging::create_session_log_writer;
 pub use model_spec::{ModelSpec, ThinkingBudget};
 pub use session_id::{extract_session_id, extract_session_id_from_transport};
 pub use transport::{
-    AcpTransport, CODEX_EXEC_INITIAL_STALL_REASON, DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS,
-    LegacyTransport, PeakMemoryContext, ResolvedTimeout, SandboxTransportConfig, Transport,
-    TransportCapabilities, TransportFactory, TransportFactoryError, TransportMode,
-    TransportOptions, TransportResult, apply_codex_exec_initial_stall_summary,
-    classify_codex_exec_initial_stall, contains_gemini_oauth_prompt, normalize_gemini_prompt_text,
-    resolve_initial_response_timeout, strip_ansi_escape_sequences,
+    AcpTransport, CODEX_EXEC_INITIAL_STALL_REASON, ClaudeCodeCliTransport,
+    DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS, LegacyTransport, PeakMemoryContext,
+    ResolvedTimeout, SandboxTransportConfig, Transport, TransportCapabilities, TransportFactory,
+    TransportFactoryError, TransportMode, TransportOptions, TransportResult,
+    apply_codex_exec_initial_stall_summary, classify_codex_exec_initial_stall,
+    contains_gemini_oauth_prompt, normalize_gemini_prompt_text, resolve_initial_response_timeout,
+    strip_ansi_escape_sequences,
 };
 
 // Re-export session config types from csa-acp for pipeline integration.

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -68,6 +68,9 @@ pub use transport_fork::{ForkInfo, ForkMethod, ForkRequest};
 #[path = "transport_factory.rs"]
 mod transport_factory;
 pub use transport_factory::{TransportFactory, TransportFactoryError, TransportMode};
+#[path = "transport_cli.rs"]
+mod transport_cli;
+pub use transport_cli::ClaudeCodeCliTransport;
 #[path = "transport_acp_payload_debug.rs"]
 mod transport_acp_payload_debug;
 use transport_acp_payload_debug::{AcpPayloadDebugRequest, maybe_write_acp_payload_debug};

--- a/crates/csa-executor/src/transport_cli.rs
+++ b/crates/csa-executor/src/transport_cli.rs
@@ -1,0 +1,711 @@
+//! Claude Code CLI transport (Phase 3 PoC for #1103 / #760).
+//!
+//! Implements the [`Transport`] trait by spawning the native `claude` CLI
+//! binary directly, bypassing the ACP adapter (`claude-code-acp`).  This is
+//! the strongest-CLI-support tool of the four CSA wraps, and the natural
+//! starting point for the multi-phase migration toward CLI-only transports.
+//!
+//! ## Capabilities (vs ACP)
+//!
+//! - `streaming = true` (best-effort): claude CLI supports
+//!   `--output-format stream-json` which emits one JSON object per line for
+//!   live tool calls / agent messages / plan updates.  We parse that stream
+//!   and synthesize [`SessionEvent`] values matching the ACP shape so
+//!   downstream consumers (`csa session result`, `csa review`) see the same
+//!   event vocabulary.
+//! - `session_resume = true`: `claude --resume <session-id>`.
+//! - `session_fork = true`: `claude --resume <id> --fork-session` produces a
+//!   provider-level fork.  The transport itself doesn't drive the fork (that
+//!   is owned by [`crate::transport_fork`] / `csa-acp::connection_fork`); it
+//!   simply declares the capability as supported.
+//! - `typed_events = true` (best-effort): same caveat as `streaming`.
+//!
+//! ## Phase 3 PoC limitations (Phase 5 TODO)
+//!
+//! - **No mid-session interrupt monitoring beyond idle-timeout / liveness**:
+//!   ACP keeps a JSON-RPC connection alive and can poll a 200 ms event-loop;
+//!   the CLI path can only watch stdout silence and process liveness.
+//! - **No persistent connection across multiple prompts**: every prompt is a
+//!   fresh `claude --print` invocation with `--resume <id>`.  This means
+//!   higher cold-start latency for multi-turn sessions; we have not measured
+//!   the cost yet (TODO benchmarks).
+//! - **No mid-session ACP crash retry**: ACP-specific OOM/auth/init failure
+//!   classification (`transport_acp_crash_retry.rs`) is not applied.  The CLI
+//!   transport surfaces non-zero exit codes directly.
+//! - **`SessionEvent` lives in `csa-acp`**: when Phase 5 feature-gates ACP
+//!   under `acp-transport`, this type must move to `csa-executor` or
+//!   `csa-core`.  The CLI transport already depends on it via the public
+//!   [`TransportResult.events`] field, so the move is structural, not
+//!   semantic.
+//! - **Sandbox integration**: spawn-time sandboxing (cgroup / bwrap /
+//!   landlock) is wired through `spawn_tool_sandboxed` the same way
+//!   [`super::LegacyTransport`] does it; this transport delegates to the
+//!   shared `csa-process` helper rather than re-implementing.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Stdio;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use csa_acp::{SessionEvent, StreamingMetadata};
+use csa_process::{
+    SpawnOptions, StreamMode, spawn_tool_with_options, wait_and_capture_with_idle_timeout,
+};
+use csa_session::state::{MetaSessionState, ToolState};
+use serde::Deserialize;
+use tokio::process::Command;
+
+use crate::executor::Executor;
+
+use super::{
+    ResolvedTimeout, Transport, TransportCapabilities, TransportMode, TransportOptions,
+    TransportResult,
+};
+
+/// Native `claude` CLI transport — the Phase 3 PoC alternative to
+/// [`super::AcpTransport`] for the `claude-code` tool.
+#[derive(Debug, Clone)]
+pub struct ClaudeCodeCliTransport {
+    executor: Executor,
+}
+
+impl ClaudeCodeCliTransport {
+    /// Construct from an [`Executor`].  Caller must guarantee
+    /// `executor.tool_name() == "claude-code"`; otherwise the transport will
+    /// still spawn whichever binary the executor names, but the resulting
+    /// argv is undefined (Phase 4 will widen this for codex etc.).
+    #[must_use]
+    pub fn new(executor: Executor) -> Self {
+        Self { executor }
+    }
+
+    /// Build the argv for a prompt invocation.
+    ///
+    /// Layout: `claude <yolo> --output-format stream-json --verbose -p <prompt>
+    /// [--resume <session-id>]`.
+    ///
+    /// `--verbose` is required by the claude CLI as a precondition for
+    /// `--output-format=stream-json` together with `-p/--print`; without it
+    /// the binary refuses to stream.  `--include-partial-messages` is left
+    /// off for Phase 3 — partial chunks would inflate the event stream
+    /// without measurably improving downstream consumer behaviour at this
+    /// stage.
+    pub(crate) fn build_argv(prompt: &str, resume_session_id: Option<&str>) -> Vec<String> {
+        let mut args = Vec::with_capacity(8);
+        args.push("--dangerously-skip-permissions".to_string());
+        args.push("--output-format".to_string());
+        args.push("stream-json".to_string());
+        args.push("--verbose".to_string());
+        args.push("-p".to_string());
+        args.push(prompt.to_string());
+        if let Some(id) = resume_session_id {
+            args.push("--resume".to_string());
+            args.push(id.to_string());
+        }
+        args
+    }
+
+    fn build_command(
+        &self,
+        prompt: &str,
+        work_dir: &Path,
+        resume_session_id: Option<&str>,
+        extra_env: Option<&HashMap<String, String>>,
+    ) -> Command {
+        let mut cmd = Command::new(self.executor.executable_name());
+        cmd.current_dir(work_dir);
+        // Mirror the env-stripping rule used by both the legacy CLI path and
+        // the ACP path so a CSA-spawned `claude` does not trip its own
+        // recursion guard or inherit lefthook bypass markers.
+        for var in CLI_TRANSPORT_STRIPPED_ENV_VARS {
+            cmd.env_remove(var);
+        }
+        if let Some(env) = extra_env {
+            for (key, value) in env {
+                cmd.env(key, value);
+            }
+        }
+        for arg in Self::build_argv(prompt, resume_session_id) {
+            cmd.arg(arg);
+        }
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        cmd
+    }
+
+    async fn execute_once(&self, request: ExecuteOnceRequest<'_>) -> Result<TransportResult> {
+        let cmd = self.build_command(
+            request.prompt,
+            request.work_dir,
+            request.resume_session_id,
+            request.extra_env,
+        );
+        let child = spawn_tool_with_options(cmd, None, request.spawn_options).await?;
+        let execution = wait_and_capture_with_idle_timeout(
+            child,
+            request.stream_mode,
+            std::time::Duration::from_secs(request.idle_timeout_seconds),
+            std::time::Duration::from_secs(csa_process::DEFAULT_LIVENESS_DEAD_SECS),
+            std::time::Duration::from_secs(csa_process::DEFAULT_TERMINATION_GRACE_PERIOD_SECS),
+            request.output_spool,
+            request.spawn_options,
+            request
+                .initial_response_timeout
+                .as_option()
+                .filter(|&seconds| seconds > 0)
+                .map(std::time::Duration::from_secs),
+        )
+        .await?;
+
+        let parsed = parse_stream_json(&execution.output);
+        Ok(TransportResult {
+            execution,
+            provider_session_id: parsed.provider_session_id,
+            events: parsed.events,
+            metadata: parsed.metadata,
+        })
+    }
+}
+
+/// Single-attempt execution request for [`ClaudeCodeCliTransport::execute_once`].
+///
+/// Grouping the parameters into a struct keeps the call sites readable (the
+/// `Transport` trait has both `execute` and `execute_in` entry points) and
+/// avoids a `clippy::too_many_arguments` workaround.
+struct ExecuteOnceRequest<'a> {
+    prompt: &'a str,
+    work_dir: &'a Path,
+    resume_session_id: Option<&'a str>,
+    extra_env: Option<&'a HashMap<String, String>>,
+    stream_mode: StreamMode,
+    idle_timeout_seconds: u64,
+    initial_response_timeout: ResolvedTimeout,
+    spawn_options: SpawnOptions,
+    output_spool: Option<&'a Path>,
+}
+
+#[async_trait]
+impl Transport for ClaudeCodeCliTransport {
+    fn mode(&self) -> TransportMode {
+        TransportMode::Legacy
+    }
+
+    fn capabilities(&self) -> TransportCapabilities {
+        // Phase 3 PoC: best-effort streaming via `--output-format stream-json`.
+        // Capability matrix records the *aspirational* shape so consumers can
+        // route the right way; if stream-json parsing fails on a future claude
+        // release, downstream code degrades to the embedded ExecutionResult
+        // text without breaking the [`TransportResult`] invariant.
+        TransportCapabilities {
+            streaming: true,
+            session_resume: true,
+            session_fork: true,
+            typed_events: true,
+        }
+    }
+
+    async fn execute(
+        &self,
+        prompt: &str,
+        tool_state: Option<&ToolState>,
+        session: &MetaSessionState,
+        extra_env: Option<&HashMap<String, String>>,
+        options: TransportOptions<'_>,
+    ) -> Result<TransportResult> {
+        let work_dir = Path::new(&session.project_path).to_path_buf();
+        let resume_session_id = tool_state.and_then(|s| s.provider_session_id.as_deref());
+
+        let spawn_options = SpawnOptions {
+            stdin_write_timeout: std::time::Duration::from_secs(
+                options.stdin_write_timeout_seconds,
+            ),
+            keep_stdin_open: false,
+            spool_max_bytes: options.output_spool_max_bytes,
+            keep_rotated_spool: options.output_spool_keep_rotated,
+        };
+
+        self.execute_once(ExecuteOnceRequest {
+            prompt,
+            work_dir: &work_dir,
+            resume_session_id,
+            extra_env,
+            stream_mode: options.stream_mode,
+            idle_timeout_seconds: options.idle_timeout_seconds,
+            initial_response_timeout: options.initial_response_timeout,
+            spawn_options,
+            output_spool: options.output_spool,
+        })
+        .await
+    }
+
+    async fn execute_in(
+        &self,
+        prompt: &str,
+        work_dir: &Path,
+        extra_env: Option<&HashMap<String, String>>,
+        stream_mode: StreamMode,
+        idle_timeout_seconds: u64,
+        initial_response_timeout: ResolvedTimeout,
+    ) -> Result<TransportResult> {
+        self.execute_once(ExecuteOnceRequest {
+            prompt,
+            work_dir,
+            resume_session_id: None,
+            extra_env,
+            stream_mode,
+            idle_timeout_seconds,
+            initial_response_timeout,
+            spawn_options: SpawnOptions::default(),
+            output_spool: None,
+        })
+        .await
+    }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Environment variable allowlist for the CLI transport.
+///
+/// Identical to `Executor::STRIPPED_ENV_VARS`; replicated here because that
+/// constant is `pub(crate)` to `csa-executor::executor` and we don't want a
+/// cross-module dependency for two strings.  Out of scope for Phase 3 but
+/// flagged for Phase 5: consolidate into a single workspace-level list.
+const CLI_TRANSPORT_STRIPPED_ENV_VARS: &[&str] = &[
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "LEFTHOOK",
+    "LEFTHOOK_SKIP",
+];
+
+/// Result of parsing a `claude --output-format stream-json` byte stream.
+#[derive(Debug, Default)]
+struct StreamParseResult {
+    provider_session_id: Option<String>,
+    events: Vec<SessionEvent>,
+    metadata: StreamingMetadata,
+}
+
+/// Minimal stream-json envelope used for Phase 3 PoC parsing.
+///
+/// Claude's stream-json shape (best-effort, observed live; not formally
+/// specified) emits objects of the form
+/// `{"type": "...", "session_id": "...", "message": {...}, ...}` per line.
+/// We capture the `type` discriminator and use field-presence heuristics to
+/// map each event to a [`SessionEvent`].  Unknown or partially-populated
+/// envelopes degrade to [`SessionEvent::Other`] with the original raw line so
+/// no information is lost.
+#[derive(Debug, Deserialize)]
+struct StreamEnvelope {
+    #[serde(rename = "type")]
+    event_type: Option<String>,
+    session_id: Option<String>,
+    #[serde(rename = "sessionId")]
+    session_id_camel: Option<String>,
+    subtype: Option<String>,
+    message: Option<serde_json::Value>,
+    text: Option<String>,
+    plan: Option<serde_json::Value>,
+    tool: Option<String>,
+    tool_use_id: Option<String>,
+    name: Option<String>,
+    status: Option<String>,
+}
+
+/// Parse a stream-json output buffer into a [`StreamParseResult`].
+///
+/// Every line is parsed independently — a malformed line is logged via
+/// `tracing::debug!` and skipped, never panicked on.  Returns the final
+/// `provider_session_id` observed (claude emits one on the initial `system`
+/// envelope, occasionally repeated on later envelopes).
+fn parse_stream_json(buffer: &str) -> StreamParseResult {
+    let mut result = StreamParseResult::default();
+
+    for raw_line in buffer.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if !(line.starts_with('{') && line.ends_with('}')) {
+            // Not a JSON envelope (e.g., interleaved log noise from `--verbose`
+            // before the JSON stream starts).  Drop quietly; the raw text is
+            // still accessible via `ExecutionResult.output`.
+            continue;
+        }
+        let envelope: StreamEnvelope = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(error) => {
+                tracing::debug!(
+                    %error,
+                    line_len = line.len(),
+                    "stream-json parse skipped malformed line",
+                );
+                continue;
+            }
+        };
+
+        if let Some(session_id) = envelope
+            .session_id
+            .clone()
+            .or_else(|| envelope.session_id_camel.clone())
+            && !session_id.is_empty()
+        {
+            result.provider_session_id = Some(session_id);
+        }
+
+        let event = envelope_to_event(&envelope, line);
+        result.metadata.total_events_count += 1;
+        match &event {
+            SessionEvent::ToolCallStarted { kind, title, .. } => {
+                result.metadata.has_tool_calls = true;
+                if kind.eq_ignore_ascii_case("execute") {
+                    result.metadata.has_execute_tool_calls = true;
+                    result.metadata.extracted_commands.push(title.clone());
+                }
+            }
+            SessionEvent::PlanUpdate(_) => {
+                result.metadata.has_plan_updates = true;
+            }
+            SessionEvent::AgentMessage(text) => {
+                result.metadata.message_text.push_str(text);
+            }
+            SessionEvent::AgentThought(text) => {
+                result.metadata.thought_text.push_str(text);
+            }
+            _ => {}
+        }
+        result.events.push(event);
+    }
+
+    if result.metadata.message_text.is_empty() && !result.metadata.thought_text.is_empty() {
+        result.metadata.has_thought_fallback = true;
+    }
+
+    result
+}
+
+fn envelope_to_event(envelope: &StreamEnvelope, raw_line: &str) -> SessionEvent {
+    let event_type = envelope.event_type.as_deref().unwrap_or("");
+
+    match event_type {
+        "assistant" | "assistant_message" => {
+            let text = extract_message_text(&envelope.message)
+                .or_else(|| envelope.text.clone())
+                .unwrap_or_default();
+            SessionEvent::AgentMessage(text)
+        }
+        "thinking" | "agent_thought" => {
+            let text = extract_message_text(&envelope.message)
+                .or_else(|| envelope.text.clone())
+                .unwrap_or_default();
+            SessionEvent::AgentThought(text)
+        }
+        "tool_use" | "tool_call" => {
+            let id = envelope
+                .tool_use_id
+                .clone()
+                .unwrap_or_else(|| envelope.name.clone().unwrap_or_default());
+            let title = envelope
+                .name
+                .clone()
+                .or_else(|| envelope.tool.clone())
+                .unwrap_or_default();
+            let kind = envelope.subtype.clone().unwrap_or_else(|| "tool".into());
+            SessionEvent::ToolCallStarted { id, title, kind }
+        }
+        "tool_result" | "tool_call_result" => {
+            let id = envelope.tool_use_id.clone().unwrap_or_default();
+            let status = envelope
+                .status
+                .clone()
+                .unwrap_or_else(|| "completed".into());
+            SessionEvent::ToolCallCompleted { id, status }
+        }
+        "plan" | "plan_update" => {
+            let text = envelope
+                .plan
+                .as_ref()
+                .map(|v| v.to_string())
+                .or_else(|| envelope.text.clone())
+                .unwrap_or_default();
+            SessionEvent::PlanUpdate(text)
+        }
+        // `system` envelopes carry the session id and config; they have no
+        // direct ACP equivalent so we surface them as Other for transparency.
+        // Same for `result`/`final` envelopes that close the stream.
+        _ => SessionEvent::Other(raw_line.to_string()),
+    }
+}
+
+/// Extract the textual content from a claude `message` payload.
+///
+/// Claude emits `message.content` either as a plain string or as an array of
+/// content blocks `[{"type": "text", "text": "..."}, ...]`.  We concatenate
+/// all text blocks and ignore non-text blocks — they appear separately as
+/// `tool_use` envelopes anyway.
+fn extract_message_text(message: &Option<serde_json::Value>) -> Option<String> {
+    let value = message.as_ref()?;
+    if let Some(content) = value.get("content") {
+        if let Some(s) = content.as_str() {
+            return Some(s.to_string());
+        }
+        if let Some(arr) = content.as_array() {
+            let mut buf = String::new();
+            for block in arr {
+                if block.get("type").and_then(serde_json::Value::as_str) == Some("text")
+                    && let Some(text) = block.get("text").and_then(serde_json::Value::as_str)
+                {
+                    buf.push_str(text);
+                }
+            }
+            if !buf.is_empty() {
+                return Some(buf);
+            }
+        }
+    }
+    if let Some(text) = value.get("text").and_then(serde_json::Value::as_str) {
+        return Some(text.to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::claude_runtime::{ClaudeCodeRuntimeMetadata, ClaudeCodeTransport as CcTransport};
+    use crate::executor::Executor;
+    // `TransportFactory` is re-exported from `csa-executor::transport`
+    // (transport.rs nests transport_factory.rs via `#[path]` and re-exports
+    // its public items at the crate root).  Reach for the crate-level
+    // re-export rather than the private nested-mod path.
+    use crate::TransportFactory;
+
+    fn make_executor() -> Executor {
+        Executor::ClaudeCode {
+            model_override: None,
+            thinking_budget: None,
+            runtime_metadata: ClaudeCodeRuntimeMetadata::from_transport(CcTransport::Cli),
+        }
+    }
+
+    // ---- Construction wiring ----
+
+    #[test]
+    fn factory_returns_cli_transport_for_claude_code_cli_mode() {
+        let executor = make_executor();
+        let transport = TransportFactory::create(&executor, None).expect("factory create");
+
+        // The transport must declare Legacy mode (the canonical CLI mode tag),
+        // not ACP, so downstream consumers do not double-spawn an ACP adapter.
+        assert_eq!(transport.mode(), TransportMode::Legacy);
+
+        // And it must be specifically ClaudeCodeCliTransport, not the generic
+        // LegacyTransport — these have different capability matrices and fork
+        // semantics.
+        let cli_transport = transport
+            .as_any()
+            .downcast_ref::<ClaudeCodeCliTransport>()
+            .expect("factory should return ClaudeCodeCliTransport for claude-code + cli");
+        // The downcasted handle should still report Legacy mode (idempotent).
+        assert_eq!(cli_transport.mode(), TransportMode::Legacy);
+    }
+
+    #[test]
+    fn factory_returns_acp_for_claude_code_default() {
+        // Default (no explicit transport override) MUST stay on ACP — the
+        // PoC change must NOT regress existing claude-code users.
+        let executor = Executor::ClaudeCode {
+            model_override: None,
+            thinking_budget: None,
+            runtime_metadata: ClaudeCodeRuntimeMetadata::from_transport(CcTransport::Acp),
+        };
+        let transport = TransportFactory::create(&executor, None).expect("factory create");
+        assert_eq!(transport.mode(), TransportMode::Acp);
+    }
+
+    #[test]
+    fn capabilities_advertise_resume_fork_streaming() {
+        let transport = ClaudeCodeCliTransport::new(make_executor());
+        let caps = transport.capabilities();
+        assert!(caps.session_resume, "claude --resume <id> works");
+        assert!(caps.session_fork, "claude --fork-session works");
+        assert!(caps.streaming, "claude --output-format stream-json works");
+        assert!(caps.typed_events, "stream-json yields typed events");
+    }
+
+    // ---- Resume-id propagation ----
+
+    #[test]
+    fn build_argv_no_resume_omits_resume_flag() {
+        let argv = ClaudeCodeCliTransport::build_argv("hello", None);
+        assert!(
+            !argv.iter().any(|a| a == "--resume"),
+            "no resume id => --resume must not appear in argv: {argv:?}"
+        );
+        assert!(argv.iter().any(|a| a == "-p"));
+        assert!(argv.iter().any(|a| a == "stream-json"));
+    }
+
+    #[test]
+    fn build_argv_with_resume_includes_flag_and_id() {
+        let argv = ClaudeCodeCliTransport::build_argv("ping", Some("abc-123"));
+        let resume_index = argv
+            .iter()
+            .position(|a| a == "--resume")
+            .expect("--resume must be present when resume id is given");
+        assert_eq!(
+            argv.get(resume_index + 1).map(String::as_str),
+            Some("abc-123"),
+            "session id must follow --resume directly: {argv:?}"
+        );
+    }
+
+    #[test]
+    fn build_argv_includes_streaming_flags() {
+        let argv = ClaudeCodeCliTransport::build_argv(".", None);
+        assert!(argv.iter().any(|a| a == "--output-format"));
+        assert!(argv.iter().any(|a| a == "stream-json"));
+        assert!(
+            argv.iter().any(|a| a == "--verbose"),
+            "stream-json requires --verbose per claude CLI; argv={argv:?}"
+        );
+    }
+
+    // ---- stream-json parsing ----
+
+    #[test]
+    fn parse_stream_json_happy_path_emits_events() {
+        let stream = concat!(
+            r#"{"type":"system","session_id":"sess-1","subtype":"init"}"#,
+            "\n",
+            r#"{"type":"assistant","session_id":"sess-1","message":{"content":[{"type":"text","text":"Hello"}]}}"#,
+            "\n",
+            r#"{"type":"tool_use","session_id":"sess-1","tool_use_id":"tu-1","name":"Bash","subtype":"execute"}"#,
+            "\n",
+            r#"{"type":"tool_result","session_id":"sess-1","tool_use_id":"tu-1","status":"success"}"#,
+            "\n",
+            r#"{"type":"result","session_id":"sess-1","subtype":"final"}"#,
+            "\n",
+        );
+        let parsed = parse_stream_json(stream);
+        assert_eq!(parsed.provider_session_id.as_deref(), Some("sess-1"));
+        assert_eq!(parsed.events.len(), 5, "5 envelopes => 5 events");
+
+        // The assistant envelope must lift to AgentMessage with the inner text.
+        let msg_count = parsed
+            .events
+            .iter()
+            .filter(|e| matches!(e, SessionEvent::AgentMessage(text) if text == "Hello"))
+            .count();
+        assert_eq!(msg_count, 1, "one AgentMessage with text 'Hello'");
+
+        // The tool_use envelope must lift to ToolCallStarted, with the
+        // execute subtype reflected so downstream consumers can extract the
+        // command.
+        let exec_started = parsed.events.iter().any(|e| {
+            matches!(
+                e,
+                SessionEvent::ToolCallStarted { kind, .. } if kind.eq_ignore_ascii_case("execute")
+            )
+        });
+        assert!(exec_started, "execute tool call must be detected");
+
+        assert!(parsed.metadata.has_tool_calls);
+        assert!(parsed.metadata.has_execute_tool_calls);
+        assert_eq!(parsed.metadata.total_events_count, 5);
+        assert_eq!(parsed.metadata.message_text, "Hello");
+    }
+
+    #[test]
+    fn parse_stream_json_malformed_line_is_skipped_not_panicked() {
+        let stream = concat!(
+            r#"{"type":"assistant","session_id":"sess-9","message":{"content":[{"type":"text","text":"a"}]}}"#,
+            "\n",
+            "this is not json at all\n",
+            r#"{not even valid json"#,
+            "\n",
+            r#"{"type":"assistant","session_id":"sess-9","message":{"content":[{"type":"text","text":"b"}]}}"#,
+            "\n",
+        );
+        let parsed = parse_stream_json(stream);
+
+        // The two well-formed lines must produce events; the two garbage
+        // lines must be skipped without panicking.
+        assert_eq!(
+            parsed.events.len(),
+            2,
+            "only well-formed lines yield events"
+        );
+        assert_eq!(parsed.provider_session_id.as_deref(), Some("sess-9"));
+        let messages: Vec<&str> = parsed
+            .events
+            .iter()
+            .filter_map(|e| match e {
+                SessionEvent::AgentMessage(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(messages, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn parse_stream_json_empty_buffer_returns_empty_result() {
+        let parsed = parse_stream_json("");
+        assert!(parsed.events.is_empty());
+        assert!(parsed.provider_session_id.is_none());
+        assert_eq!(parsed.metadata.total_events_count, 0);
+    }
+
+    #[test]
+    fn parse_stream_json_unknown_event_type_falls_through_to_other() {
+        let stream =
+            r#"{"type":"future_event_kind_xyz","session_id":"s","note":"new in claude 9999"}"#;
+        let parsed = parse_stream_json(stream);
+        assert_eq!(parsed.events.len(), 1);
+        assert!(matches!(&parsed.events[0], SessionEvent::Other(_)));
+    }
+
+    #[test]
+    fn parse_stream_json_session_id_camel_case_accepted() {
+        let stream = r#"{"type":"system","sessionId":"camel-id"}"#;
+        let parsed = parse_stream_json(stream);
+        assert_eq!(parsed.provider_session_id.as_deref(), Some("camel-id"));
+    }
+
+    // ---- Optional integration test (gated; CI-friendly) ----
+
+    /// Optional: actually spawn `claude` and verify the CLI transport produces
+    /// a non-error result.  Skipped when the binary isn't installed (so this
+    /// test never causes false-red on CI without claude).
+    #[ignore = "requires claude CLI installed; run manually with `cargo test -p csa-executor -- --ignored claude_cli_smoke`"]
+    #[tokio::test]
+    async fn claude_cli_smoke() {
+        if which::which("claude").is_err() {
+            eprintln!("claude binary not on PATH; skipping smoke");
+            return;
+        }
+        let executor = make_executor();
+        let transport = ClaudeCodeCliTransport::new(executor);
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let result = transport
+            .execute_in(
+                "say 'hello from cli transport'",
+                tmp.path(),
+                None,
+                StreamMode::BufferOnly,
+                30,
+                ResolvedTimeout::of(60),
+            )
+            .await;
+        // We don't assert on content (depends on user auth and network); we
+        // only assert the call did not bubble an unrelated error.
+        assert!(
+            result.is_ok(),
+            "smoke: transport.execute_in failed: {result:?}"
+        );
+    }
+}

--- a/crates/csa-executor/src/transport_cli.rs
+++ b/crates/csa-executor/src/transport_cli.rs
@@ -50,8 +50,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use csa_acp::{SessionEvent, StreamingMetadata};
 use csa_process::{
-    SpawnOptions, StreamMode, spawn_tool_with_options, wait_and_capture_with_idle_timeout,
+    SpawnOptions, StreamMode, spawn_tool_sandboxed, wait_and_capture_with_idle_timeout,
 };
+use csa_resource::isolation_plan::IsolationPlan;
 use csa_session::state::{MetaSessionState, ToolState};
 use serde::Deserialize;
 use tokio::process::Command;
@@ -59,8 +60,8 @@ use tokio::process::Command;
 use crate::executor::Executor;
 
 use super::{
-    ResolvedTimeout, Transport, TransportCapabilities, TransportMode, TransportOptions,
-    TransportResult,
+    ResolvedTimeout, SandboxTransportConfig, Transport, TransportCapabilities, TransportMode,
+    TransportOptions, TransportResult,
 };
 
 /// Native `claude` CLI transport — the Phase 3 PoC alternative to
@@ -82,7 +83,8 @@ impl ClaudeCodeCliTransport {
 
     /// Build the argv for a prompt invocation.
     ///
-    /// Layout: `claude <yolo> --output-format stream-json --verbose -p <prompt>
+    /// Layout: `claude <yolo> --output-format stream-json --verbose
+    /// [--model <model>] [--thinking-budget <tokens>] -p <prompt>
     /// [--resume <session-id>]`.
     ///
     /// `--verbose` is required by the claude CLI as a precondition for
@@ -91,12 +93,25 @@ impl ClaudeCodeCliTransport {
     /// off for Phase 3 — partial chunks would inflate the event stream
     /// without measurably improving downstream consumer behaviour at this
     /// stage.
-    pub(crate) fn build_argv(prompt: &str, resume_session_id: Option<&str>) -> Vec<String> {
-        let mut args = Vec::with_capacity(8);
+    ///
+    /// `--model` and `--thinking-budget` are sourced from the [`Executor`]
+    /// to mirror what the legacy CLI path emits via
+    /// [`crate::executor::Executor::append_model_args`]; without them, tier
+    /// model selection silently degrades to the claude default and thinking
+    /// budgets configured in CSA tiers are dropped entirely.
+    pub(crate) fn build_argv(
+        executor: &Executor,
+        prompt: &str,
+        resume_session_id: Option<&str>,
+    ) -> Vec<String> {
+        let mut args = Vec::with_capacity(12);
         args.push("--dangerously-skip-permissions".to_string());
         args.push("--output-format".to_string());
         args.push("stream-json".to_string());
         args.push("--verbose".to_string());
+        for arg in claude_model_args(executor) {
+            args.push(arg);
+        }
         args.push("-p".to_string());
         args.push(prompt.to_string());
         if let Some(id) = resume_session_id {
@@ -126,7 +141,7 @@ impl ClaudeCodeCliTransport {
                 cmd.env(key, value);
             }
         }
-        for arg in Self::build_argv(prompt, resume_session_id) {
+        for arg in Self::build_argv(&self.executor, prompt, resume_session_id) {
             cmd.arg(arg);
         }
         cmd.stdin(Stdio::null())
@@ -142,7 +157,26 @@ impl ClaudeCodeCliTransport {
             request.resume_session_id,
             request.extra_env,
         );
-        let child = spawn_tool_with_options(cmd, None, request.spawn_options).await?;
+        // Mirror `LegacyTransport::execute_single_attempt` (transport.rs L313):
+        // route every spawn through `spawn_tool_sandboxed` so cgroup/bwrap/
+        // landlock isolation from `TransportOptions.sandbox` is honoured even
+        // when this transport is selected.  Calling `spawn_tool_with_options`
+        // directly silently dropped the sandbox plan and let CLI-mode sessions
+        // run unisolated even when callers had configured an isolation plan.
+        let SandboxComponents {
+            isolation_plan,
+            tool_name,
+            session_id,
+        } = sandbox_components(request.sandbox);
+        let (child, _sandbox_handle) = spawn_tool_sandboxed(
+            cmd,
+            None,
+            request.spawn_options,
+            isolation_plan,
+            tool_name,
+            session_id,
+        )
+        .await?;
         let execution = wait_and_capture_with_idle_timeout(
             child,
             request.stream_mode,
@@ -184,6 +218,10 @@ struct ExecuteOnceRequest<'a> {
     initial_response_timeout: ResolvedTimeout,
     spawn_options: SpawnOptions,
     output_spool: Option<&'a Path>,
+    /// Sandbox configuration propagated from [`TransportOptions::sandbox`].
+    /// `None` matches the unsandboxed `execute_in` (testing) path; `Some`
+    /// matches the production `execute` path when a sandbox is configured.
+    sandbox: Option<&'a SandboxTransportConfig>,
 }
 
 #[async_trait]
@@ -236,6 +274,7 @@ impl Transport for ClaudeCodeCliTransport {
             initial_response_timeout: options.initial_response_timeout,
             spawn_options,
             output_spool: options.output_spool,
+            sandbox: options.sandbox,
         })
         .await
     }
@@ -259,6 +298,7 @@ impl Transport for ClaudeCodeCliTransport {
             initial_response_timeout,
             spawn_options: SpawnOptions::default(),
             output_spool: None,
+            sandbox: None,
         })
         .await
     }
@@ -267,6 +307,67 @@ impl Transport for ClaudeCodeCliTransport {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+}
+
+/// Decomposition of [`SandboxTransportConfig`] into the four positional
+/// arguments that [`csa_process::spawn_tool_sandboxed`] consumes.
+///
+/// Extracted as a named helper so unit tests can assert that
+/// `TransportOptions.sandbox` is threaded all the way to the spawn call —
+/// without actually spawning a child process.
+struct SandboxComponents<'a> {
+    isolation_plan: Option<&'a IsolationPlan>,
+    tool_name: &'a str,
+    session_id: &'a str,
+}
+
+/// Decompose `Option<&SandboxTransportConfig>` into the positional arguments
+/// expected by `spawn_tool_sandboxed`.
+///
+/// Mirrors the LegacyTransport contract (`transport.rs` L292-L299): when the
+/// caller passes `Some(SandboxTransportConfig)`, the isolation plan is honoured
+/// and the tool/session identifiers are propagated for cgroup scope naming;
+/// when the caller passes `None`, the spawn proceeds unsandboxed and the
+/// downstream call ends up equivalent to `spawn_tool_with_options`.
+fn sandbox_components(sandbox: Option<&SandboxTransportConfig>) -> SandboxComponents<'_> {
+    match sandbox {
+        Some(s) => SandboxComponents {
+            isolation_plan: Some(&s.isolation_plan),
+            tool_name: s.tool_name.as_str(),
+            session_id: s.session_id.as_str(),
+        },
+        None => SandboxComponents {
+            isolation_plan: None,
+            tool_name: "",
+            session_id: "",
+        },
+    }
+}
+
+/// Emit the model / thinking-budget flag pairs for a `claude` CLI invocation.
+///
+/// Mirrors [`crate::executor::Executor::append_model_args`] for the
+/// [`Executor::ClaudeCode`] arm: any non-`ClaudeCode` executor handed in here
+/// returns an empty list (Phase 3 only routes `claude-code` through this
+/// transport, but defensive emptiness keeps Phase 4 widening safe).
+fn claude_model_args(executor: &Executor) -> Vec<String> {
+    let mut out = Vec::with_capacity(4);
+    if let Executor::ClaudeCode {
+        model_override,
+        thinking_budget,
+        ..
+    } = executor
+    {
+        if let Some(model) = model_override {
+            out.push("--model".to_string());
+            out.push(model.clone());
+        }
+        if let Some(budget) = thinking_budget {
+            out.push("--thinking-budget".to_string());
+            out.push(budget.token_count().to_string());
+        }
+    }
+    out
 }
 
 /// Environment variable allowlist for the CLI transport.
@@ -314,6 +415,16 @@ struct StreamEnvelope {
     tool_use_id: Option<String>,
     name: Option<String>,
     status: Option<String>,
+    /// Tool-call payload for `tool_use` envelopes.
+    ///
+    /// Claude's stream-json emits Bash-class tool calls as
+    /// `{"type":"tool_use","name":"Bash","input":{"command":"git ..."}}`.
+    /// Without capturing this, the title for `tool_use` events degrades to
+    /// the bare tool name (e.g., `"Bash"`) and `extracted_commands` records
+    /// the tool name instead of the actual command text — defeating the
+    /// downstream forbidden-command policy that scans the command ring buffer
+    /// for `git commit --no-verify`-class commands.
+    input: Option<serde_json::Value>,
 }
 
 /// Parse a stream-json output buffer into a [`StreamParseResult`].
@@ -409,9 +520,18 @@ fn envelope_to_event(envelope: &StreamEnvelope, raw_line: &str) -> SessionEvent 
                 .tool_use_id
                 .clone()
                 .unwrap_or_else(|| envelope.name.clone().unwrap_or_default());
-            let title = envelope
-                .name
-                .clone()
+            // Prefer the actual command string from `input.command` for
+            // Bash-class tool calls so downstream
+            // `metadata.extracted_commands` captures the real command text
+            // (e.g., `git commit --no-verify`) rather than the tool name
+            // ("Bash").  Without this, the post-run forbidden-command policy
+            // sees "Bash" and lets unsafe commands through.
+            //
+            // Falls back to `name`/`tool` when `input.command` is absent —
+            // matches the previous behaviour for non-Bash tool calls
+            // (Edit/Read/etc.) whose payload schema differs.
+            let title = extract_tool_input_command(envelope.input.as_ref())
+                .or_else(|| envelope.name.clone())
                 .or_else(|| envelope.tool.clone())
                 .unwrap_or_default();
             let kind = envelope.subtype.clone().unwrap_or_else(|| "tool".into());
@@ -438,6 +558,26 @@ fn envelope_to_event(envelope: &StreamEnvelope, raw_line: &str) -> SessionEvent 
         // direct ACP equivalent so we surface them as Other for transparency.
         // Same for `result`/`final` envelopes that close the stream.
         _ => SessionEvent::Other(raw_line.to_string()),
+    }
+}
+
+/// Extract the command string from a tool_use `input` payload, when present.
+///
+/// Claude's stream-json represents Bash-class tool calls as
+/// `{"input": {"command": "..."}}`.  This helper returns the inner
+/// `command` value when it is a non-empty string, and `None` otherwise (e.g.,
+/// non-Bash tools like `Edit` whose `input` is `{"file_path": ..., ...}`).
+///
+/// Trimming is applied to defeat trailing whitespace that would otherwise
+/// confuse the downstream `command_looks_like_no_verify_commit` heuristic in
+/// `csa-acp::client`.
+fn extract_tool_input_command(input: Option<&serde_json::Value>) -> Option<String> {
+    let value = input?;
+    let command = value.get("command")?.as_str()?.trim();
+    if command.is_empty() {
+        None
+    } else {
+        Some(command.to_string())
     }
 }
 
@@ -474,238 +614,5 @@ fn extract_message_text(message: &Option<serde_json::Value>) -> Option<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::claude_runtime::{ClaudeCodeRuntimeMetadata, ClaudeCodeTransport as CcTransport};
-    use crate::executor::Executor;
-    // `TransportFactory` is re-exported from `csa-executor::transport`
-    // (transport.rs nests transport_factory.rs via `#[path]` and re-exports
-    // its public items at the crate root).  Reach for the crate-level
-    // re-export rather than the private nested-mod path.
-    use crate::TransportFactory;
-
-    fn make_executor() -> Executor {
-        Executor::ClaudeCode {
-            model_override: None,
-            thinking_budget: None,
-            runtime_metadata: ClaudeCodeRuntimeMetadata::from_transport(CcTransport::Cli),
-        }
-    }
-
-    // ---- Construction wiring ----
-
-    #[test]
-    fn factory_returns_cli_transport_for_claude_code_cli_mode() {
-        let executor = make_executor();
-        let transport = TransportFactory::create(&executor, None).expect("factory create");
-
-        // The transport must declare Legacy mode (the canonical CLI mode tag),
-        // not ACP, so downstream consumers do not double-spawn an ACP adapter.
-        assert_eq!(transport.mode(), TransportMode::Legacy);
-
-        // And it must be specifically ClaudeCodeCliTransport, not the generic
-        // LegacyTransport — these have different capability matrices and fork
-        // semantics.
-        let cli_transport = transport
-            .as_any()
-            .downcast_ref::<ClaudeCodeCliTransport>()
-            .expect("factory should return ClaudeCodeCliTransport for claude-code + cli");
-        // The downcasted handle should still report Legacy mode (idempotent).
-        assert_eq!(cli_transport.mode(), TransportMode::Legacy);
-    }
-
-    #[test]
-    fn factory_returns_acp_for_claude_code_default() {
-        // Default (no explicit transport override) MUST stay on ACP — the
-        // PoC change must NOT regress existing claude-code users.
-        let executor = Executor::ClaudeCode {
-            model_override: None,
-            thinking_budget: None,
-            runtime_metadata: ClaudeCodeRuntimeMetadata::from_transport(CcTransport::Acp),
-        };
-        let transport = TransportFactory::create(&executor, None).expect("factory create");
-        assert_eq!(transport.mode(), TransportMode::Acp);
-    }
-
-    #[test]
-    fn capabilities_advertise_resume_fork_streaming() {
-        let transport = ClaudeCodeCliTransport::new(make_executor());
-        let caps = transport.capabilities();
-        assert!(caps.session_resume, "claude --resume <id> works");
-        assert!(caps.session_fork, "claude --fork-session works");
-        assert!(caps.streaming, "claude --output-format stream-json works");
-        assert!(caps.typed_events, "stream-json yields typed events");
-    }
-
-    // ---- Resume-id propagation ----
-
-    #[test]
-    fn build_argv_no_resume_omits_resume_flag() {
-        let argv = ClaudeCodeCliTransport::build_argv("hello", None);
-        assert!(
-            !argv.iter().any(|a| a == "--resume"),
-            "no resume id => --resume must not appear in argv: {argv:?}"
-        );
-        assert!(argv.iter().any(|a| a == "-p"));
-        assert!(argv.iter().any(|a| a == "stream-json"));
-    }
-
-    #[test]
-    fn build_argv_with_resume_includes_flag_and_id() {
-        let argv = ClaudeCodeCliTransport::build_argv("ping", Some("abc-123"));
-        let resume_index = argv
-            .iter()
-            .position(|a| a == "--resume")
-            .expect("--resume must be present when resume id is given");
-        assert_eq!(
-            argv.get(resume_index + 1).map(String::as_str),
-            Some("abc-123"),
-            "session id must follow --resume directly: {argv:?}"
-        );
-    }
-
-    #[test]
-    fn build_argv_includes_streaming_flags() {
-        let argv = ClaudeCodeCliTransport::build_argv(".", None);
-        assert!(argv.iter().any(|a| a == "--output-format"));
-        assert!(argv.iter().any(|a| a == "stream-json"));
-        assert!(
-            argv.iter().any(|a| a == "--verbose"),
-            "stream-json requires --verbose per claude CLI; argv={argv:?}"
-        );
-    }
-
-    // ---- stream-json parsing ----
-
-    #[test]
-    fn parse_stream_json_happy_path_emits_events() {
-        let stream = concat!(
-            r#"{"type":"system","session_id":"sess-1","subtype":"init"}"#,
-            "\n",
-            r#"{"type":"assistant","session_id":"sess-1","message":{"content":[{"type":"text","text":"Hello"}]}}"#,
-            "\n",
-            r#"{"type":"tool_use","session_id":"sess-1","tool_use_id":"tu-1","name":"Bash","subtype":"execute"}"#,
-            "\n",
-            r#"{"type":"tool_result","session_id":"sess-1","tool_use_id":"tu-1","status":"success"}"#,
-            "\n",
-            r#"{"type":"result","session_id":"sess-1","subtype":"final"}"#,
-            "\n",
-        );
-        let parsed = parse_stream_json(stream);
-        assert_eq!(parsed.provider_session_id.as_deref(), Some("sess-1"));
-        assert_eq!(parsed.events.len(), 5, "5 envelopes => 5 events");
-
-        // The assistant envelope must lift to AgentMessage with the inner text.
-        let msg_count = parsed
-            .events
-            .iter()
-            .filter(|e| matches!(e, SessionEvent::AgentMessage(text) if text == "Hello"))
-            .count();
-        assert_eq!(msg_count, 1, "one AgentMessage with text 'Hello'");
-
-        // The tool_use envelope must lift to ToolCallStarted, with the
-        // execute subtype reflected so downstream consumers can extract the
-        // command.
-        let exec_started = parsed.events.iter().any(|e| {
-            matches!(
-                e,
-                SessionEvent::ToolCallStarted { kind, .. } if kind.eq_ignore_ascii_case("execute")
-            )
-        });
-        assert!(exec_started, "execute tool call must be detected");
-
-        assert!(parsed.metadata.has_tool_calls);
-        assert!(parsed.metadata.has_execute_tool_calls);
-        assert_eq!(parsed.metadata.total_events_count, 5);
-        assert_eq!(parsed.metadata.message_text, "Hello");
-    }
-
-    #[test]
-    fn parse_stream_json_malformed_line_is_skipped_not_panicked() {
-        let stream = concat!(
-            r#"{"type":"assistant","session_id":"sess-9","message":{"content":[{"type":"text","text":"a"}]}}"#,
-            "\n",
-            "this is not json at all\n",
-            r#"{not even valid json"#,
-            "\n",
-            r#"{"type":"assistant","session_id":"sess-9","message":{"content":[{"type":"text","text":"b"}]}}"#,
-            "\n",
-        );
-        let parsed = parse_stream_json(stream);
-
-        // The two well-formed lines must produce events; the two garbage
-        // lines must be skipped without panicking.
-        assert_eq!(
-            parsed.events.len(),
-            2,
-            "only well-formed lines yield events"
-        );
-        assert_eq!(parsed.provider_session_id.as_deref(), Some("sess-9"));
-        let messages: Vec<&str> = parsed
-            .events
-            .iter()
-            .filter_map(|e| match e {
-                SessionEvent::AgentMessage(t) => Some(t.as_str()),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(messages, vec!["a", "b"]);
-    }
-
-    #[test]
-    fn parse_stream_json_empty_buffer_returns_empty_result() {
-        let parsed = parse_stream_json("");
-        assert!(parsed.events.is_empty());
-        assert!(parsed.provider_session_id.is_none());
-        assert_eq!(parsed.metadata.total_events_count, 0);
-    }
-
-    #[test]
-    fn parse_stream_json_unknown_event_type_falls_through_to_other() {
-        let stream =
-            r#"{"type":"future_event_kind_xyz","session_id":"s","note":"new in claude 9999"}"#;
-        let parsed = parse_stream_json(stream);
-        assert_eq!(parsed.events.len(), 1);
-        assert!(matches!(&parsed.events[0], SessionEvent::Other(_)));
-    }
-
-    #[test]
-    fn parse_stream_json_session_id_camel_case_accepted() {
-        let stream = r#"{"type":"system","sessionId":"camel-id"}"#;
-        let parsed = parse_stream_json(stream);
-        assert_eq!(parsed.provider_session_id.as_deref(), Some("camel-id"));
-    }
-
-    // ---- Optional integration test (gated; CI-friendly) ----
-
-    /// Optional: actually spawn `claude` and verify the CLI transport produces
-    /// a non-error result.  Skipped when the binary isn't installed (so this
-    /// test never causes false-red on CI without claude).
-    #[ignore = "requires claude CLI installed; run manually with `cargo test -p csa-executor -- --ignored claude_cli_smoke`"]
-    #[tokio::test]
-    async fn claude_cli_smoke() {
-        if which::which("claude").is_err() {
-            eprintln!("claude binary not on PATH; skipping smoke");
-            return;
-        }
-        let executor = make_executor();
-        let transport = ClaudeCodeCliTransport::new(executor);
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let result = transport
-            .execute_in(
-                "say 'hello from cli transport'",
-                tmp.path(),
-                None,
-                StreamMode::BufferOnly,
-                30,
-                ResolvedTimeout::of(60),
-            )
-            .await;
-        // We don't assert on content (depends on user auth and network); we
-        // only assert the call did not bubble an unrelated error.
-        assert!(
-            result.is_ok(),
-            "smoke: transport.execute_in failed: {result:?}"
-        );
-    }
-}
+#[path = "transport_cli_tests.rs"]
+mod tests;

--- a/crates/csa-executor/src/transport_cli_tests.rs
+++ b/crates/csa-executor/src/transport_cli_tests.rs
@@ -1,0 +1,447 @@
+//! Unit tests for [`super::ClaudeCodeCliTransport`].
+//!
+//! Extracted into a sibling file (referenced via `#[cfg(test)] #[path =
+//! "transport_cli_tests.rs"] mod tests` in the parent) to keep
+//! `transport_cli.rs` under the workspace 800-line monolith guard.  Test
+//! identity is preserved — the module path is still
+//! `transport::transport_cli::tests::*` because `mod tests` is declared in the
+//! parent.
+use super::*;
+use crate::claude_runtime::{ClaudeCodeRuntimeMetadata, ClaudeCodeTransport as CcTransport};
+use crate::executor::Executor;
+use crate::model_spec::ThinkingBudget;
+// `TransportFactory` is re-exported from `csa-executor::transport`
+// (transport.rs nests transport_factory.rs via `#[path]` and re-exports
+// its public items at the crate root).  Reach for the crate-level
+// re-export rather than the private nested-mod path.
+use crate::TransportFactory;
+use csa_resource::filesystem_sandbox::FilesystemCapability;
+use csa_resource::isolation_plan::IsolationPlan;
+use csa_resource::sandbox::ResourceCapability;
+use std::collections::HashMap as StdHashMap;
+
+fn make_executor() -> Executor {
+    Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::from_transport(CcTransport::Cli),
+    }
+}
+
+fn make_executor_with_model_and_thinking(model: &str, budget: ThinkingBudget) -> Executor {
+    Executor::ClaudeCode {
+        model_override: Some(model.to_string()),
+        thinking_budget: Some(budget),
+        runtime_metadata: ClaudeCodeRuntimeMetadata::from_transport(CcTransport::Cli),
+    }
+}
+
+fn make_test_isolation_plan() -> IsolationPlan {
+    IsolationPlan {
+        resource: ResourceCapability::None,
+        filesystem: FilesystemCapability::Bwrap,
+        writable_paths: Vec::new(),
+        readable_paths: Vec::new(),
+        env_overrides: StdHashMap::new(),
+        degraded_reasons: Vec::new(),
+        memory_max_mb: Some(2048),
+        memory_swap_max_mb: None,
+        pids_max: None,
+        readonly_project_root: false,
+        project_root: None,
+        soft_limit_percent: None,
+        memory_monitor_interval_seconds: None,
+    }
+}
+
+// ---- Construction wiring ----
+
+#[test]
+fn factory_returns_cli_transport_for_claude_code_cli_mode() {
+    let executor = make_executor();
+    let transport = TransportFactory::create(&executor, None).expect("factory create");
+
+    // The transport must declare Legacy mode (the canonical CLI mode tag),
+    // not ACP, so downstream consumers do not double-spawn an ACP adapter.
+    assert_eq!(transport.mode(), TransportMode::Legacy);
+
+    // And it must be specifically ClaudeCodeCliTransport, not the generic
+    // LegacyTransport — these have different capability matrices and fork
+    // semantics.
+    let cli_transport = transport
+        .as_any()
+        .downcast_ref::<ClaudeCodeCliTransport>()
+        .expect("factory should return ClaudeCodeCliTransport for claude-code + cli");
+    // The downcasted handle should still report Legacy mode (idempotent).
+    assert_eq!(cli_transport.mode(), TransportMode::Legacy);
+}
+
+#[test]
+fn factory_returns_acp_for_claude_code_default() {
+    // Default (no explicit transport override) MUST stay on ACP — the
+    // PoC change must NOT regress existing claude-code users.
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::from_transport(CcTransport::Acp),
+    };
+    let transport = TransportFactory::create(&executor, None).expect("factory create");
+    assert_eq!(transport.mode(), TransportMode::Acp);
+}
+
+#[test]
+fn capabilities_advertise_resume_fork_streaming() {
+    let transport = ClaudeCodeCliTransport::new(make_executor());
+    let caps = transport.capabilities();
+    assert!(caps.session_resume, "claude --resume <id> works");
+    assert!(caps.session_fork, "claude --fork-session works");
+    assert!(caps.streaming, "claude --output-format stream-json works");
+    assert!(caps.typed_events, "stream-json yields typed events");
+}
+
+// ---- Resume-id propagation ----
+
+#[test]
+fn build_argv_no_resume_omits_resume_flag() {
+    let executor = make_executor();
+    let argv = ClaudeCodeCliTransport::build_argv(&executor, "hello", None);
+    assert!(
+        !argv.iter().any(|a| a == "--resume"),
+        "no resume id => --resume must not appear in argv: {argv:?}"
+    );
+    assert!(argv.iter().any(|a| a == "-p"));
+    assert!(argv.iter().any(|a| a == "stream-json"));
+}
+
+#[test]
+fn build_argv_with_resume_includes_flag_and_id() {
+    let executor = make_executor();
+    let argv = ClaudeCodeCliTransport::build_argv(&executor, "ping", Some("abc-123"));
+    let resume_index = argv
+        .iter()
+        .position(|a| a == "--resume")
+        .expect("--resume must be present when resume id is given");
+    assert_eq!(
+        argv.get(resume_index + 1).map(String::as_str),
+        Some("abc-123"),
+        "session id must follow --resume directly: {argv:?}"
+    );
+}
+
+#[test]
+fn build_argv_includes_streaming_flags() {
+    let executor = make_executor();
+    let argv = ClaudeCodeCliTransport::build_argv(&executor, ".", None);
+    assert!(argv.iter().any(|a| a == "--output-format"));
+    assert!(argv.iter().any(|a| a == "stream-json"));
+    assert!(
+        argv.iter().any(|a| a == "--verbose"),
+        "stream-json requires --verbose per claude CLI; argv={argv:?}"
+    );
+}
+
+// ---- stream-json parsing ----
+
+#[test]
+fn parse_stream_json_happy_path_emits_events() {
+    let stream = concat!(
+        r#"{"type":"system","session_id":"sess-1","subtype":"init"}"#,
+        "\n",
+        r#"{"type":"assistant","session_id":"sess-1","message":{"content":[{"type":"text","text":"Hello"}]}}"#,
+        "\n",
+        r#"{"type":"tool_use","session_id":"sess-1","tool_use_id":"tu-1","name":"Bash","subtype":"execute"}"#,
+        "\n",
+        r#"{"type":"tool_result","session_id":"sess-1","tool_use_id":"tu-1","status":"success"}"#,
+        "\n",
+        r#"{"type":"result","session_id":"sess-1","subtype":"final"}"#,
+        "\n",
+    );
+    let parsed = parse_stream_json(stream);
+    assert_eq!(parsed.provider_session_id.as_deref(), Some("sess-1"));
+    assert_eq!(parsed.events.len(), 5, "5 envelopes => 5 events");
+
+    // The assistant envelope must lift to AgentMessage with the inner text.
+    let msg_count = parsed
+        .events
+        .iter()
+        .filter(|e| matches!(e, SessionEvent::AgentMessage(text) if text == "Hello"))
+        .count();
+    assert_eq!(msg_count, 1, "one AgentMessage with text 'Hello'");
+
+    // The tool_use envelope must lift to ToolCallStarted, with the
+    // execute subtype reflected so downstream consumers can extract the
+    // command.
+    let exec_started = parsed.events.iter().any(|e| {
+        matches!(
+            e,
+            SessionEvent::ToolCallStarted { kind, .. } if kind.eq_ignore_ascii_case("execute")
+        )
+    });
+    assert!(exec_started, "execute tool call must be detected");
+
+    assert!(parsed.metadata.has_tool_calls);
+    assert!(parsed.metadata.has_execute_tool_calls);
+    assert_eq!(parsed.metadata.total_events_count, 5);
+    assert_eq!(parsed.metadata.message_text, "Hello");
+}
+
+#[test]
+fn parse_stream_json_malformed_line_is_skipped_not_panicked() {
+    let stream = concat!(
+        r#"{"type":"assistant","session_id":"sess-9","message":{"content":[{"type":"text","text":"a"}]}}"#,
+        "\n",
+        "this is not json at all\n",
+        r#"{not even valid json"#,
+        "\n",
+        r#"{"type":"assistant","session_id":"sess-9","message":{"content":[{"type":"text","text":"b"}]}}"#,
+        "\n",
+    );
+    let parsed = parse_stream_json(stream);
+
+    // The two well-formed lines must produce events; the two garbage
+    // lines must be skipped without panicking.
+    assert_eq!(
+        parsed.events.len(),
+        2,
+        "only well-formed lines yield events"
+    );
+    assert_eq!(parsed.provider_session_id.as_deref(), Some("sess-9"));
+    let messages: Vec<&str> = parsed
+        .events
+        .iter()
+        .filter_map(|e| match e {
+            SessionEvent::AgentMessage(t) => Some(t.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(messages, vec!["a", "b"]);
+}
+
+#[test]
+fn parse_stream_json_empty_buffer_returns_empty_result() {
+    let parsed = parse_stream_json("");
+    assert!(parsed.events.is_empty());
+    assert!(parsed.provider_session_id.is_none());
+    assert_eq!(parsed.metadata.total_events_count, 0);
+}
+
+#[test]
+fn parse_stream_json_unknown_event_type_falls_through_to_other() {
+    let stream = r#"{"type":"future_event_kind_xyz","session_id":"s","note":"new in claude 9999"}"#;
+    let parsed = parse_stream_json(stream);
+    assert_eq!(parsed.events.len(), 1);
+    assert!(matches!(&parsed.events[0], SessionEvent::Other(_)));
+}
+
+#[test]
+fn parse_stream_json_session_id_camel_case_accepted() {
+    let stream = r#"{"type":"system","sessionId":"camel-id"}"#;
+    let parsed = parse_stream_json(stream);
+    assert_eq!(parsed.provider_session_id.as_deref(), Some("camel-id"));
+}
+
+// ---- Codex P1 review fix: sandbox passthrough (Bug 1) ----
+
+/// `TransportOptions.sandbox` MUST be threaded all the way to the
+/// `spawn_tool_sandboxed` call so cgroup/bwrap/landlock isolation plans
+/// are honoured in CLI-mode sessions.  Before this fix, `execute_once`
+/// called `spawn_tool_with_options` directly, silently dropping the
+/// sandbox plan and letting CLI-mode sessions run unisolated.
+///
+/// We assert via the `sandbox_components` helper that the same isolation
+/// plan, tool name, and session id that were placed on
+/// `TransportOptions.sandbox` reappear in the four positional arguments
+/// `spawn_tool_sandboxed` consumes.  This is the testable seam — the
+/// actual spawn would require a child binary on PATH.
+#[test]
+fn test_sandbox_passthrough() {
+    let isolation_plan = make_test_isolation_plan();
+    let sandbox_cfg = SandboxTransportConfig {
+        isolation_plan: isolation_plan.clone(),
+        tool_name: "claude-code".to_string(),
+        best_effort: false,
+        session_id: "01HSANDBOXPASSTHROUGH00000001".to_string(),
+    };
+
+    let none_components = sandbox_components(None);
+    assert!(
+        none_components.isolation_plan.is_none(),
+        "None sandbox config => no isolation plan threaded through"
+    );
+    assert_eq!(none_components.tool_name, "");
+    assert_eq!(none_components.session_id, "");
+
+    let components = sandbox_components(Some(&sandbox_cfg));
+    let plan = components
+        .isolation_plan
+        .expect("sandbox config Some => isolation_plan must be Some");
+    // The plan must point at the same plan we placed on the
+    // SandboxTransportConfig (matching memory_max_mb is enough — the plan
+    // is not Eq, but its memory_max_mb survives the threading).
+    assert_eq!(
+        plan.memory_max_mb,
+        Some(2048),
+        "sandbox isolation_plan.memory_max_mb must survive threading from TransportOptions.sandbox"
+    );
+    assert_eq!(plan.filesystem, FilesystemCapability::Bwrap);
+    assert_eq!(components.tool_name, "claude-code");
+    assert_eq!(components.session_id, "01HSANDBOXPASSTHROUGH00000001");
+}
+
+// ---- Codex P1 review fix: model + thinking-budget flags (Bug 2) ----
+
+/// `build_argv` MUST emit `--model <model>` and `--thinking-budget
+/// <tokens>` flag pairs when the [`Executor`] carries them, mirroring the
+/// legacy `Executor::append_model_args` path.  Before this fix, both
+/// flags were silently dropped because `build_argv` hardcoded only
+/// `--dangerously-skip-permissions`/`--output-format`/`--verbose`/`-p` and
+/// never consulted the executor — so tier model selection and thinking
+/// budgets had no effect on the actual claude CLI invocation.
+#[test]
+fn test_argv_includes_model_and_thinking() {
+    let executor = make_executor_with_model_and_thinking("claude-opus-4-7", ThinkingBudget::High);
+    let argv = ClaudeCodeCliTransport::build_argv(&executor, "hi", None);
+
+    let model_index = argv
+        .iter()
+        .position(|a| a == "--model")
+        .expect("--model must appear in argv when Executor has model_override set");
+    assert_eq!(
+        argv.get(model_index + 1).map(String::as_str),
+        Some("claude-opus-4-7"),
+        "model name must follow --model directly: {argv:?}"
+    );
+
+    let budget_index = argv
+        .iter()
+        .position(|a| a == "--thinking-budget")
+        .expect("--thinking-budget must appear in argv when Executor has thinking_budget set");
+    // High budget converts to a numeric token count via
+    // `ThinkingBudget::token_count()`; we only care that the value is
+    // numeric (matches the legacy CLI flag spelling) — not the exact
+    // mapping, which is owned by the model_spec module.
+    let budget_value = argv
+        .get(budget_index + 1)
+        .expect("--thinking-budget must be followed by a value");
+    assert!(
+        budget_value.parse::<u32>().is_ok(),
+        "--thinking-budget value must be numeric (token count); got {budget_value:?}"
+    );
+
+    // Backwards-compat sanity: the streaming flags must still be present.
+    assert!(argv.iter().any(|a| a == "stream-json"));
+    assert!(argv.iter().any(|a| a == "--verbose"));
+}
+
+/// When the [`Executor`] has neither model nor thinking budget set, the
+/// argv MUST NOT contain `--model` or `--thinking-budget` (so the claude
+/// CLI uses its built-in defaults).  Guards against an over-eager fix
+/// that always emits the flags with empty / zero values.
+#[test]
+fn test_argv_omits_model_and_thinking_when_executor_has_none() {
+    let executor = make_executor();
+    let argv = ClaudeCodeCliTransport::build_argv(&executor, "hi", None);
+    assert!(
+        !argv.iter().any(|a| a == "--model"),
+        "--model must be absent when Executor.model_override is None: {argv:?}"
+    );
+    assert!(
+        !argv.iter().any(|a| a == "--thinking-budget"),
+        "--thinking-budget must be absent when Executor.thinking_budget is None: {argv:?}"
+    );
+}
+
+// ---- Codex P1 review fix: extract Bash command for execute title (Bug 3) ----
+
+/// `tool_use` envelopes for Bash-class tools MUST surface the actual
+/// command text in the `ToolCallStarted.title`, sourced from
+/// `input.command`.  Before this fix, `envelope_to_event` set
+/// `title = envelope.name` (e.g., `"Bash"`), so `extracted_commands`
+/// recorded `"Bash"` instead of the real command — defeating the
+/// downstream forbidden-command policy that scans the command ring buffer
+/// for `git commit --no-verify`-class commands.
+#[test]
+fn test_envelope_to_event_extracts_bash_command() {
+    // ---- Happy path: tool_use with input.command ----
+    let envelope_with_command: StreamEnvelope = serde_json::from_str(
+        r#"{"type":"tool_use","tool_use_id":"tu-bash-1","name":"Bash","subtype":"execute","input":{"command":"echo hi"}}"#,
+    )
+    .expect("happy-path tool_use envelope must parse");
+
+    let event = envelope_to_event(&envelope_with_command, "<raw>");
+    match event {
+        SessionEvent::ToolCallStarted { title, .. } => {
+            assert_eq!(
+                title, "echo hi",
+                "Bash tool_use title MUST be the command text from input.command, not the tool name"
+            );
+        }
+        other => panic!("expected ToolCallStarted, got {other:?}"),
+    }
+
+    // ---- Fallback path: tool_use without input ----
+    // For non-Bash tools (Edit/Read/etc.), where the input shape is
+    // different and there is no command field, the title MUST fall back
+    // to the tool name so the existing per-tool dashboards keep working.
+    let envelope_no_input: StreamEnvelope = serde_json::from_str(
+        r#"{"type":"tool_use","tool_use_id":"tu-edit-1","name":"Edit","subtype":"edit"}"#,
+    )
+    .expect("input-less tool_use envelope must parse");
+    let event = envelope_to_event(&envelope_no_input, "<raw>");
+    match event {
+        SessionEvent::ToolCallStarted { title, .. } => {
+            assert_eq!(
+                title, "Edit",
+                "input-less tool_use must fall back to tool name (preserves prior behaviour)"
+            );
+        }
+        other => panic!("expected ToolCallStarted, got {other:?}"),
+    }
+
+    // ---- Integrated path: parse_stream_json must record the real
+    // command in `extracted_commands`, not the tool name ----
+    let stream = r#"{"type":"tool_use","session_id":"sess-bash","tool_use_id":"tu-bash-2","name":"Bash","subtype":"execute","input":{"command":"git commit --no-verify -m wip"}}"#;
+    let parsed = parse_stream_json(stream);
+    assert_eq!(parsed.metadata.extracted_commands.len(), 1);
+    assert_eq!(
+        parsed.metadata.extracted_commands[0], "git commit --no-verify -m wip",
+        "extracted_commands MUST capture the actual command text so the forbidden-command policy can flag --no-verify"
+    );
+    assert!(
+        parsed.metadata.has_execute_tool_calls,
+        "execute tool_use must still flip has_execute_tool_calls"
+    );
+}
+
+// ---- Optional integration test (gated; CI-friendly) ----
+
+/// Optional: actually spawn `claude` and verify the CLI transport produces
+/// a non-error result.  Skipped when the binary isn't installed (so this
+/// test never causes false-red on CI without claude).
+#[ignore = "requires claude CLI installed; run manually with `cargo test -p csa-executor -- --ignored claude_cli_smoke`"]
+#[tokio::test]
+async fn claude_cli_smoke() {
+    if which::which("claude").is_err() {
+        eprintln!("claude binary not on PATH; skipping smoke");
+        return;
+    }
+    let executor = make_executor();
+    let transport = ClaudeCodeCliTransport::new(executor);
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let result = transport
+        .execute_in(
+            "say 'hello from cli transport'",
+            tmp.path(),
+            None,
+            StreamMode::BufferOnly,
+            30,
+            ResolvedTimeout::of(60),
+        )
+        .await;
+    // We don't assert on content (depends on user auth and network); we
+    // only assert the call did not bubble an unrelated error.
+    assert!(
+        result.is_ok(),
+        "smoke: transport.execute_in failed: {result:?}"
+    );
+}

--- a/crates/csa-executor/src/transport_factory.rs
+++ b/crates/csa-executor/src/transport_factory.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 use crate::executor::Executor;
 use csa_acp::SessionConfig;
 
-use super::{AcpTransport, LegacyTransport, Transport, TransportCapabilities};
+use super::{
+    AcpTransport, ClaudeCodeCliTransport, LegacyTransport, Transport, TransportCapabilities,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -194,7 +196,18 @@ impl TransportFactory {
         session_config: Option<SessionConfig>,
     ) -> Result<Box<dyn Transport>> {
         match mode {
-            TransportMode::Legacy => Ok(Box::new(LegacyTransport::new(executor.clone()))),
+            // Claude-code in CLI mode goes through the dedicated
+            // ClaudeCodeCliTransport (Phase 3 PoC of #1103/#760), which
+            // advertises CLI-specific capabilities (resume + native fork +
+            // best-effort streaming via `--output-format stream-json`).
+            // Other tools' Legacy mode keeps using LegacyTransport — Phase 4
+            // will narrow per-tool as more dedicated CLI transports land.
+            TransportMode::Legacy => match executor {
+                Executor::ClaudeCode { .. } => {
+                    Ok(Box::new(ClaudeCodeCliTransport::new(executor.clone())))
+                }
+                _ => Ok(Box::new(LegacyTransport::new(executor.clone()))),
+            },
             TransportMode::Acp => Ok(Box::new(AcpTransport::new(
                 executor.tool_name(),
                 session_config,

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -98,9 +98,16 @@ fn test_transport_factory_create_honors_claude_cli_runtime_transport_override() 
     };
     let cli_transport = TransportFactory::create(&cli_executor, Some(SessionConfig::default()))
         .expect("transport should build");
+    // Phase 3 PoC of #1103/#760: claude-code in CLI mode now routes through
+    // the dedicated ClaudeCodeCliTransport (which advertises
+    // streaming=true / session_fork=true), NOT the generic LegacyTransport
+    // path used by gemini-cli/opencode.
     assert!(
-        cli_transport.as_ref().as_any().is::<LegacyTransport>(),
-        "claude-code cli override should use LegacyTransport"
+        cli_transport
+            .as_ref()
+            .as_any()
+            .is::<crate::ClaudeCodeCliTransport>(),
+        "claude-code cli override should use the dedicated ClaudeCodeCliTransport"
     );
 }
 


### PR DESCRIPTION
## Summary
- New `ClaudeCodeCliTransport` impl of `Transport` (crates/csa-executor/src/transport_cli.rs) — spawns `claude` subprocess with `--resume`/`--fork-session` and parses `--output-format stream-json`.
- Config wiring: `[tools.claude-code].transport = "cli"` is now accepted and routed by `transport_factory.rs`. `"auto"` keeps picking ACP — no behaviour regression.
- Drafts benchmark methodology at `drafts/t1103-cli-transport-benchmark.md` (numbers TODO, gated by an `#[ignore]`d smoke test).

Closes #1103.
Phase 3 of multi-phase research issue #760 (Phases 4-5 left open).

## Implementation notes
- `parse_stream_json` + `envelope_to_event` + `extract_message_text` cover happy-path, empty-line, and malformed-line cases. Malformed lines are logged and skipped, never panic.
- Resume id propagation tested via `build_argv_with_resume`.
- Integration smoke test `claude_cli_smoke` is `#[ignore]`d behind `which::which("claude")` to keep CI green when the binary isn't installed.

## Phase 5 follow-ups (deferred per #760 plan)
- `SessionEvent` + `StreamingMetadata` still live in `csa-acp::client`; should move to a shared crate so CLI transport has no ACP dependency.
- `--no-project-context` flag plumbing not yet wired (parity with ACP fork-context behaviour).
- ACP transport not yet feature-gated; flip planned once benchmark validates CLI parity.

## Test plan
- [x] `cargo build --release` exit 0
- [x] `cargo test --release -p csa-executor transport_cli` — 11 passed, 1 ignored
- [x] `cargo test --release -p csa-config` — 531 passed (incl. new round-trip test)
- [x] `cargo clippy -p csa-executor --all-features -- -D warnings` exit 0
- [x] `just pre-commit` exit 0 (4210 main + 28 e2e)
- [x] csa-review push-gate verdict: **PASS** (session `01KQ1HCV6134Z1GDNJTJ0NYMCG`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)