### PR TITLE
fix(executor): emit --effort instead of removed --thinking-budget for claude-code CLI (#1124)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.567"
+version = "0.1.568"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.567"
+version = "0.1.568"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -761,9 +761,16 @@ impl Executor {
                 if let Some(model) = model_override {
                     cmd.arg("--model").arg(model);
                 }
-                if let Some(budget) = thinking_budget {
-                    cmd.arg("--thinking-budget")
-                        .arg(budget.token_count().to_string());
+                // claude-code 2.x exposes thinking control via `--effort
+                // <level>` (low/medium/high/xhigh/max); the legacy
+                // `--thinking-budget <tokens>` flag was removed and any
+                // emission of it makes the binary exit with `unknown option`
+                // (#1124). `DefaultBudget` deliberately omits the flag so the
+                // tool applies its built-in default.
+                if let Some(budget) = thinking_budget
+                    && let Some(level) = budget.claude_effort()
+                {
+                    cmd.arg("--effort").arg(level);
                 }
             }
             Self::OpenaiCompat { .. } => {} // HTTP-only: model/thinking via API body

--- a/crates/csa-executor/src/executor_build_cmd_tests.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests.rs
@@ -550,13 +550,20 @@ fn test_build_command_claude_args_structure() {
         args.contains(&"claude-opus".to_string()),
         "Should have model name"
     );
+    // claude-code 2.x: thinking is exposed via --effort <level>, not
+    // --thinking-budget <tokens>. The old flag must not be emitted because
+    // claude rejects it as an unknown option (#1124).
     assert!(
-        args.contains(&"--thinking-budget".to_string()),
-        "Should have --thinking-budget"
+        !args.contains(&"--thinking-budget".to_string()),
+        "Should not emit removed --thinking-budget flag (#1124)"
     );
     assert!(
-        args.contains(&"8192".to_string()),
-        "Medium budget = 8192 tokens"
+        args.contains(&"--effort".to_string()),
+        "Should have --effort"
+    );
+    assert!(
+        args.contains(&"medium".to_string()),
+        "ThinkingBudget::Medium maps to --effort medium"
     );
     assert!(args.contains(&"-p".to_string()), "Should have -p flag");
     assert!(args.contains(&"do stuff".to_string()), "Should have prompt");

--- a/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
@@ -186,7 +186,11 @@ fn test_build_command_no_model_override_omits_model_flag() {
     );
     assert!(
         !args.contains(&"--thinking-budget".to_string()),
-        "Should not have --thinking-budget when thinking_budget is None"
+        "Should not have removed --thinking-budget flag (#1124)"
+    );
+    assert!(
+        !args.contains(&"--effort".to_string()),
+        "Should not have --effort when thinking_budget is None"
     );
 }
 

--- a/crates/csa-executor/src/executor_tests.rs
+++ b/crates/csa-executor/src/executor_tests.rs
@@ -447,8 +447,21 @@ fn test_thinking_budget_custom_value() {
     exec.append_tool_args(&mut cmd, "test prompt", None);
 
     let debug_str = format!("{cmd:?}");
-    assert!(debug_str.contains("--thinking-budget"));
-    assert!(debug_str.contains("10000"));
+    // claude-code 2.x exposes thinking via `--effort <level>`, not the
+    // removed `--thinking-budget <tokens>` flag (#1124). `Custom(n)` has no
+    // direct level so it folds into "high" (mirrors codex_effort).
+    assert!(
+        !debug_str.contains("--thinking-budget"),
+        "Should not emit removed --thinking-budget flag (#1124): {debug_str}"
+    );
+    assert!(
+        debug_str.contains("--effort"),
+        "Should emit --effort: {debug_str}"
+    );
+    assert!(
+        debug_str.contains("high"),
+        "Custom(10000) maps to --effort high: {debug_str}"
+    );
 }
 
 #[test]
@@ -669,9 +682,15 @@ fn test_execute_in_preserves_model_override() {
                     debug_str.contains("claude-opus"),
                     "ClaudeCode missing model: {debug_str}"
                 );
+                // claude-code 2.x: thinking control via --effort <level>,
+                // not the removed --thinking-budget <tokens> (#1124).
                 assert!(
-                    debug_str.contains("--thinking-budget"),
-                    "ClaudeCode missing thinking: {debug_str}"
+                    !debug_str.contains("--thinking-budget"),
+                    "ClaudeCode must not emit removed --thinking-budget (#1124): {debug_str}"
+                );
+                assert!(
+                    debug_str.contains("--effort"),
+                    "ClaudeCode missing thinking effort flag: {debug_str}"
                 );
             }
             Executor::Opencode { .. } => {

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -148,6 +148,29 @@ impl ThinkingBudget {
             Self::Custom(_) => "high", // custom values map to high
         }
     }
+
+    /// Returns the effort level keyword for claude-code 2.x's `--effort` flag.
+    ///
+    /// claude-code 2.1.119 accepts `--effort <level>` with `low/medium/high/
+    /// xhigh/max` (no token-count form like the legacy `--thinking-budget`).
+    /// `DefaultBudget` returns `None` so callers can omit the flag and let
+    /// claude-code apply its built-in default. Numeric `Custom(n)` values have
+    /// no direct level equivalent and map to `high` (mirroring `codex_effort`'s
+    /// treatment for the same case).
+    ///
+    /// Replaces the pre-PR-#1120 `--thinking-budget <tokens>` emission, which
+    /// claude-code 2.x rejects as `unknown option` (see issue #1124).
+    pub fn claude_effort(&self) -> Option<&'static str> {
+        match self {
+            Self::DefaultBudget => None,
+            Self::Low => Some("low"),
+            Self::Medium => Some("medium"),
+            Self::High => Some("high"),
+            Self::Xhigh => Some("xhigh"),
+            Self::Max => Some("max"),
+            Self::Custom(_) => Some("high"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -288,6 +311,21 @@ mod tests {
         assert_eq!(ThinkingBudget::High.codex_effort(), "high");
         assert_eq!(ThinkingBudget::Xhigh.codex_effort(), "xhigh");
         assert_eq!(ThinkingBudget::Custom(10000).codex_effort(), "high"); // fallback to high
+    }
+
+    #[test]
+    fn test_thinking_budget_claude_effort() {
+        // DefaultBudget = "let claude-code apply its own default" =>
+        // omit the flag entirely (None).
+        assert_eq!(ThinkingBudget::DefaultBudget.claude_effort(), None);
+        assert_eq!(ThinkingBudget::Low.claude_effort(), Some("low"));
+        assert_eq!(ThinkingBudget::Medium.claude_effort(), Some("medium"));
+        assert_eq!(ThinkingBudget::High.claude_effort(), Some("high"));
+        assert_eq!(ThinkingBudget::Xhigh.claude_effort(), Some("xhigh"));
+        assert_eq!(ThinkingBudget::Max.claude_effort(), Some("max"));
+        // Custom(n) has no level form in claude-code 2.x's --effort flag;
+        // mirror codex_effort and pick "high" so the value stays accepted.
+        assert_eq!(ThinkingBudget::Custom(10000).claude_effort(), Some("high"));
     }
 
     #[test]

--- a/crates/csa-executor/src/transport_cli.rs
+++ b/crates/csa-executor/src/transport_cli.rs
@@ -84,7 +84,7 @@ impl ClaudeCodeCliTransport {
     /// Build the argv for a prompt invocation.
     ///
     /// Layout: `claude <yolo> --output-format stream-json --verbose
-    /// [--model <model>] [--thinking-budget <tokens>] -p <prompt>
+    /// [--model <model>] [--effort <level>] -p <prompt>
     /// [--resume <session-id>]`.
     ///
     /// `--verbose` is required by the claude CLI as a precondition for
@@ -94,11 +94,14 @@ impl ClaudeCodeCliTransport {
     /// without measurably improving downstream consumer behaviour at this
     /// stage.
     ///
-    /// `--model` and `--thinking-budget` are sourced from the [`Executor`]
-    /// to mirror what the legacy CLI path emits via
+    /// `--model` and `--effort` are sourced from the [`Executor`] to mirror
+    /// what the legacy CLI path emits via
     /// [`crate::executor::Executor::append_model_args`]; without them, tier
     /// model selection silently degrades to the claude default and thinking
     /// budgets configured in CSA tiers are dropped entirely.
+    /// claude-code 2.x replaced the older `--thinking-budget <tokens>` flag
+    /// with `--effort <level>`; emitting the old flag fails with `unknown
+    /// option` (#1124).
     pub(crate) fn build_argv(
         executor: &Executor,
         prompt: &str,
@@ -344,12 +347,18 @@ fn sandbox_components(sandbox: Option<&SandboxTransportConfig>) -> SandboxCompon
     }
 }
 
-/// Emit the model / thinking-budget flag pairs for a `claude` CLI invocation.
+/// Emit the model / effort flag pairs for a `claude` CLI invocation.
 ///
 /// Mirrors [`crate::executor::Executor::append_model_args`] for the
 /// [`Executor::ClaudeCode`] arm: any non-`ClaudeCode` executor handed in here
 /// returns an empty list (Phase 3 only routes `claude-code` through this
 /// transport, but defensive emptiness keeps Phase 4 widening safe).
+///
+/// claude-code 2.x exposes thinking control via `--effort <level>`
+/// (low/medium/high/xhigh/max); the legacy `--thinking-budget <tokens>` flag
+/// was removed and any emission of it makes the binary exit with `unknown
+/// option` (#1124). `DefaultBudget` deliberately omits the flag so the tool
+/// applies its built-in default.
 fn claude_model_args(executor: &Executor) -> Vec<String> {
     let mut out = Vec::with_capacity(4);
     if let Executor::ClaudeCode {
@@ -362,9 +371,11 @@ fn claude_model_args(executor: &Executor) -> Vec<String> {
             out.push("--model".to_string());
             out.push(model.clone());
         }
-        if let Some(budget) = thinking_budget {
-            out.push("--thinking-budget".to_string());
-            out.push(budget.token_count().to_string());
+        if let Some(budget) = thinking_budget
+            && let Some(level) = budget.claude_effort()
+        {
+            out.push("--effort".to_string());
+            out.push(level.to_string());
         }
     }
     out

--- a/crates/csa-executor/src/transport_cli_tests.rs
+++ b/crates/csa-executor/src/transport_cli_tests.rs
@@ -311,17 +311,21 @@ fn test_sandbox_passthrough() {
     assert_eq!(components.session_id, "01HSANDBOXPASSTHROUGH00000001");
 }
 
-// ---- Codex P1 review fix: model + thinking-budget flags (Bug 2) ----
+// ---- Codex P1 review fix: model + effort flags (Bug 2, updated for #1124) ----
 
-/// `build_argv` MUST emit `--model <model>` and `--thinking-budget
-/// <tokens>` flag pairs when the [`Executor`] carries them, mirroring the
-/// legacy `Executor::append_model_args` path.  Before this fix, both
-/// flags were silently dropped because `build_argv` hardcoded only
+/// `build_argv` MUST emit `--model <model>` and `--effort <level>` flag pairs
+/// when the [`Executor`] carries them, mirroring the legacy
+/// `Executor::append_model_args` path.  Before the original P1 review fix,
+/// both flags were silently dropped because `build_argv` hardcoded only
 /// `--dangerously-skip-permissions`/`--output-format`/`--verbose`/`-p` and
 /// never consulted the executor — so tier model selection and thinking
 /// budgets had no effect on the actual claude CLI invocation.
+///
+/// claude-code 2.x replaced the older `--thinking-budget <tokens>` form with
+/// `--effort <level>`; emitting the old flag now fails with `unknown option`,
+/// breaking every CSA-spawned claude-code invocation post PR #1120 (#1124).
 #[test]
-fn test_argv_includes_model_and_thinking() {
+fn test_argv_includes_model_and_effort() {
     let executor = make_executor_with_model_and_thinking("claude-opus-4-7", ThinkingBudget::High);
     let argv = ClaudeCodeCliTransport::build_argv(&executor, "hi", None);
 
@@ -335,20 +339,22 @@ fn test_argv_includes_model_and_thinking() {
         "model name must follow --model directly: {argv:?}"
     );
 
-    let budget_index = argv
+    let effort_index = argv
         .iter()
-        .position(|a| a == "--thinking-budget")
-        .expect("--thinking-budget must appear in argv when Executor has thinking_budget set");
-    // High budget converts to a numeric token count via
-    // `ThinkingBudget::token_count()`; we only care that the value is
-    // numeric (matches the legacy CLI flag spelling) — not the exact
-    // mapping, which is owned by the model_spec module.
-    let budget_value = argv
-        .get(budget_index + 1)
-        .expect("--thinking-budget must be followed by a value");
+        .position(|a| a == "--effort")
+        .expect("--effort must appear in argv when Executor has thinking_budget set");
+    // ThinkingBudget::High maps to claude-code 2.x's "high" effort level.
+    assert_eq!(
+        argv.get(effort_index + 1).map(String::as_str),
+        Some("high"),
+        "ThinkingBudget::High must produce --effort high: {argv:?}"
+    );
+
+    // The removed --thinking-budget flag must not be present (#1124 regression
+    // guard): claude-code 2.x rejects it as `unknown option`.
     assert!(
-        budget_value.parse::<u32>().is_ok(),
-        "--thinking-budget value must be numeric (token count); got {budget_value:?}"
+        !argv.iter().any(|a| a == "--thinking-budget"),
+        "--thinking-budget must not be emitted (claude-code 2.x rejects it, #1124): {argv:?}"
     );
 
     // Backwards-compat sanity: the streaming flags must still be present.
@@ -357,11 +363,12 @@ fn test_argv_includes_model_and_thinking() {
 }
 
 /// When the [`Executor`] has neither model nor thinking budget set, the
-/// argv MUST NOT contain `--model` or `--thinking-budget` (so the claude
-/// CLI uses its built-in defaults).  Guards against an over-eager fix
-/// that always emits the flags with empty / zero values.
+/// argv MUST NOT contain `--model`, `--effort`, or the obsolete
+/// `--thinking-budget` (so the claude CLI uses its built-in defaults).
+/// Guards against an over-eager fix that always emits the flags with empty
+/// / zero values.
 #[test]
-fn test_argv_omits_model_and_thinking_when_executor_has_none() {
+fn test_argv_omits_model_and_effort_when_executor_has_none() {
     let executor = make_executor();
     let argv = ClaudeCodeCliTransport::build_argv(&executor, "hi", None);
     assert!(
@@ -369,9 +376,64 @@ fn test_argv_omits_model_and_thinking_when_executor_has_none() {
         "--model must be absent when Executor.model_override is None: {argv:?}"
     );
     assert!(
-        !argv.iter().any(|a| a == "--thinking-budget"),
-        "--thinking-budget must be absent when Executor.thinking_budget is None: {argv:?}"
+        !argv.iter().any(|a| a == "--effort"),
+        "--effort must be absent when Executor.thinking_budget is None: {argv:?}"
     );
+    assert!(
+        !argv.iter().any(|a| a == "--thinking-budget"),
+        "--thinking-budget must never be emitted (#1124): {argv:?}"
+    );
+}
+
+/// `ThinkingBudget::DefaultBudget` carries explicit "use the tool's default"
+/// semantics, so even when a thinking budget is set in the executor, no
+/// `--effort` flag should be emitted — claude-code is free to apply its own
+/// default. Guards against `DefaultBudget` accidentally mapping to a concrete
+/// effort level. Companion to `ThinkingBudget::claude_effort` returning
+/// `None` for `DefaultBudget`.
+#[test]
+fn test_argv_omits_effort_for_default_budget() {
+    let executor =
+        make_executor_with_model_and_thinking("claude-opus-4-7", ThinkingBudget::DefaultBudget);
+    let argv = ClaudeCodeCliTransport::build_argv(&executor, "hi", None);
+    assert!(
+        argv.iter().any(|a| a == "--model"),
+        "--model must still appear for DefaultBudget: {argv:?}"
+    );
+    assert!(
+        !argv.iter().any(|a| a == "--effort"),
+        "--effort must be omitted for ThinkingBudget::DefaultBudget: {argv:?}"
+    );
+}
+
+/// Each `ThinkingBudget` keyword must map to exactly the claude-code 2.x
+/// `--effort` level the tool accepts (`low/medium/high/xhigh/max`). Guards
+/// against silent drift in `ThinkingBudget::claude_effort` causing
+/// rejections at runtime.
+#[test]
+fn test_argv_effort_levels_for_each_budget() {
+    let cases: &[(ThinkingBudget, &str)] = &[
+        (ThinkingBudget::Low, "low"),
+        (ThinkingBudget::Medium, "medium"),
+        (ThinkingBudget::High, "high"),
+        (ThinkingBudget::Xhigh, "xhigh"),
+        (ThinkingBudget::Max, "max"),
+        // Custom(n) has no native level — mirror codex_effort and pick "high".
+        (ThinkingBudget::Custom(123), "high"),
+    ];
+    for (budget, expected_level) in cases {
+        let executor = make_executor_with_model_and_thinking("claude-opus-4-7", budget.clone());
+        let argv = ClaudeCodeCliTransport::build_argv(&executor, "hi", None);
+        let idx = argv
+            .iter()
+            .position(|a| a == "--effort")
+            .unwrap_or_else(|| panic!("--effort must be emitted for {budget:?}: {argv:?}"));
+        assert_eq!(
+            argv.get(idx + 1).map(String::as_str),
+            Some(*expected_level),
+            "ThinkingBudget::{budget:?} must map to --effort {expected_level}: {argv:?}"
+        );
+    }
 }
 
 // ---- Codex P1 review fix: extract Bash command for execute title (Bug 3) ----


### PR DESCRIPTION
## Summary

claude-code 2.1.119 removed `--thinking-budget` and replaced it with `--effort <level>` (levels: low/medium/high/xhigh/max). CSA's CLI transport was still emitting the old flag, which made every `csa run --model-spec claude-code/...` invocation fail at turn 1 with `error: unknown option '--thinking-budget'`. This bug landed in production via PR #1120's default-flip of claude-code transport from ACP to CLI.

This PR renames the flag to `--effort` and preserves the existing CSA-side thinking budget validation + level mapping. No behavior change for codex / gemini-cli / opencode (they have their own thinking config paths and were not using `--thinking-budget`).

## Changes

- `crates/csa-executor/src/transport_cli.rs` — emit `--effort` instead of `--thinking-budget`
- `crates/csa-executor/src/executor.rs` — same for legacy CLI path
- `crates/csa-executor/src/model_spec.rs` — added `ThinkingBudget::claude_effort` helper for level mapping
- 4 test files updated/added covering the rename, no-flag-when-None, and level mapping

## Verification

- `just pre-commit` exits 0 on this branch (4223 unit + 28 e2e tests green, 132.85s)
- Smoke test: `csa run --model-spec claude-code/anthropic/opus-4.6/xhigh ...` no longer hits `--thinking-budget` rejection. Session `01KQ38VPS5XKK4HK5HBWF20TTG` proves the flag-translation fix.
- `csa --version` reports `0.1.568 (397ec6ea)` (workspace version bumped)

## Out of scope

- Model name resolution issue (`opus-4.6` 404 from Anthropic API) — separate from this transport-layer fix
- Long-term CLI-vs-ACP transport architecture (#760)

Closes #1124
Refs: #1120 #1103 #760