### PR TITLE
fix(dev2merge): harden recovery path against silent rule violations (#1121 #1122 #1123)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.568"
+version = "0.1.569"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.568"
+version = "0.1.569"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_result_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_result_contract.rs
@@ -59,6 +59,31 @@ pub(crate) fn enforce_result_toml_path_contract(
         return;
     }
 
+    // Strong-semantic fallback (#1121): an inner `output/result.toml` whose
+    // `[result] status` field is "success" is canonical proof of completion,
+    // independent of what the executor's final assistant line said. This path
+    // emits a more specific diagnostic than the generic TOML-validity fallback
+    // below so post-mortem readers can distinguish "trusted because status was
+    // success" from "trusted because TOML parsed".
+    if result_artifact_status_is_success(&expected_contract_output_path) {
+        let warning = format!(
+            "contract warning: output/summary path mismatch; accepted artifact with [result] status=\"success\" at '{}'",
+            expected_contract_output_path.display()
+        );
+        warn!(
+            summary = %result.summary,
+            artifact = %expected_contract_output_path.display(),
+            "Session output path did not match contract; accepting verified output/result.toml whose [result] status is success"
+        );
+        if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+            result.stderr_output.push('\n');
+        }
+        result.stderr_output.push_str(&warning);
+        result.stderr_output.push('\n');
+        rewrite_contract_output_last_line(result, &expected_contract_output_path);
+        return;
+    }
+
     if sidecar_result_fallback_is_valid(&expected_contract_output_path) {
         let warning = format!(
             "contract warning: output/summary path mismatch; accepted fallback artifact '{}'",
@@ -338,6 +363,32 @@ fn sidecar_result_fallback_is_valid(path: &Path) -> bool {
         toml::from_str::<toml::Value>(&contents),
         Ok(toml::Value::Table(table)) if !table.is_empty()
     )
+}
+
+/// Returns true when the artifact at `path` is a valid result.toml whose
+/// `[result] status` field equals `"success"` (case-insensitive). Used by the
+/// strong-semantic fallback (#1121) so a successful inner artifact is honored
+/// even when the executor's final assistant line is non-path prose.
+///
+/// Accepts both the legacy flat schema (`status = "success"` at top level) and
+/// the canonical nested schema (`[result] status = "success"`).
+fn result_artifact_status_is_success(path: &Path) -> bool {
+    if !expected_contract_file_is_valid(path) {
+        return false;
+    }
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(toml::Value::Table(table)) = toml::from_str::<toml::Value>(&contents) else {
+        return false;
+    };
+    let nested = table
+        .get("result")
+        .and_then(|v| v.as_table())
+        .and_then(|t| t.get("status"))
+        .and_then(|v| v.as_str());
+    let flat = table.get("status").and_then(|v| v.as_str());
+    matches!(nested.or(flat), Some(s) if s.eq_ignore_ascii_case("success"))
 }
 
 /// Validates session-dir result.toml as a disk-based fallback when the path

--- a/crates/cli-sub-agent/src/pipeline_tests_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_contract.rs
@@ -178,6 +178,109 @@ fn result_toml_path_contract_handles_verbose_multiline_output() {
 }
 
 #[test]
+fn result_toml_path_contract_trusts_success_status_artifact_when_last_line_is_prose() {
+    // #1121 regression: dev2merge sub-sessions wrote `output/result.toml` with
+    // `[result] status = "success"` and full `[artifacts]`, but the executor
+    // ended its final assistant message with non-path prose (e.g. "Binary
+    // installed."). The contract MUST honor the artifact's success status
+    // instead of flipping the verdict to failure based on the last line.
+    let session_dir = tempfile::tempdir().unwrap();
+    let output_dir = session_dir.path().join("output");
+    fs::create_dir_all(&output_dir).unwrap();
+    let result_path = output_dir.join("result.toml");
+    fs::write(
+        &result_path,
+        r#"[result]
+status = "success"
+summary = "fix(executor): land mock clock retry queue (#67)"
+
+[artifacts]
+branch = "fix/issue-67-mock-clock-retry-queue"
+commits = ["abc123def456"]
+modified_files = ["crates/mempal-core/src/clock.rs"]
+
+[checks]
+pre_commit = "passed"
+test_added = true
+"#,
+    )
+    .unwrap();
+
+    let mut result = ExecutionResult {
+        // Verbose progress trail ending in non-path prose — exact shape of the
+        // three failed mempal sessions cited in #1121.
+        output: "Step 1: implemented mock clock retry queue\n\
+                 Step 2: ran just pre-commit\n\
+                 Step 3: committed changes\n\
+                 - binary installed to `/usr/local/bin/mempal`\n"
+            .to_string(),
+        stderr_output: String::new(),
+        summary: "Binary install running in background.".to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+    };
+
+    enforce_result_toml_contract_now(
+        "CSA_RESULT_TOML_PATH_CONTRACT=1",
+        "",
+        session_dir.path(),
+        &mut result,
+    );
+
+    assert_eq!(
+        result.exit_code, 0,
+        "artifact with [result] status=\"success\" must satisfy contract regardless of last assistant line"
+    );
+    assert!(
+        result.stderr_output.contains("[result] status=\"success\""),
+        "diagnostic must explicitly cite the success status to distinguish from generic TOML-validity fallback; got: {}",
+        result.stderr_output
+    );
+    assert_eq!(
+        result.output.lines().last(),
+        Some(result_path.to_string_lossy().as_ref()),
+        "accepted artifact path must become the final output line so managers consume the verified path"
+    );
+}
+
+#[test]
+fn result_toml_path_contract_accepts_flat_schema_status_success_artifact() {
+    // Defensive coverage for the legacy flat schema (top-level `status = "..."`
+    // without a [result] table). The strong-semantic fallback must accept both
+    // schemas so older patterns/skills do not regress.
+    let session_dir = tempfile::tempdir().unwrap();
+    let output_dir = session_dir.path().join("output");
+    fs::create_dir_all(&output_dir).unwrap();
+    let result_path = output_dir.join("result.toml");
+    fs::write(
+        &result_path,
+        "status = \"success\"\nsummary = \"flat schema artifact\"\n",
+    )
+    .unwrap();
+
+    let mut result = ExecutionResult {
+        output: "trailing prose without any path\n".to_string(),
+        stderr_output: String::new(),
+        summary: "trailing prose summary".to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+    };
+
+    enforce_result_toml_contract_now(
+        "CSA_RESULT_TOML_PATH_CONTRACT=1",
+        "",
+        session_dir.path(),
+        &mut result,
+    );
+
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.stderr_output.contains("[result] status=\"success\""),
+        "flat-schema status=success must take the strong-semantic fallback path"
+    );
+}
+
+#[test]
 fn result_toml_path_contract_accepts_disk_fallback_when_output_and_summary_are_empty() {
     let temp = tempfile::tempdir().unwrap();
     let result_path = temp.path().join("result.toml");

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -22,6 +22,56 @@ the PR manually or via `gh pr merge`. The pr-bot workflow handles the merge.
 Agents that stop after Step 13 leave the PR unmerged — this is a known failure
 mode that this invariant exists to prevent.
 
+### ABSOLUTE PROHIBITIONS
+
+These prohibitions apply at EVERY level of dev2merge (orchestrator, mktsk
+executor, fix-loop). They are the recovery-path rules whose violation
+produced #1121, #1122, and #1123. Surface failures upward instead of
+escalating to any prohibited primitive.
+
+#### Hook-bypass primitives (#1123)
+
+FORBIDDEN — all of these silently disable registered git hooks:
+
+- `git commit --no-verify` / `-n`
+- `git push --no-verify`
+- `LEFTHOOK=0`, `LEFTHOOK_DISABLED=1`
+- `HUSKY=0`, `HUSKY_DISABLE=1`
+- `SKIP_HOOKS=1`, `SKIP_GIT_HOOKS=1`
+- `--no-gpg-sign`
+- ANY equivalent env var or CLI flag that disables a registered hook
+
+**Re-stage recovery primitive** (when `git commit` fails because lefthook
+re-staged auto-formatted files):
+
+1. `git diff --staged --quiet` — exit 0 means clean (rare)
+2. `git add -u` — re-stage the formatter's output
+3. Retry `git commit -m "..."` — hooks accept the formatted version on the second pass
+4. If recovery loops >=3 iterations without converging, surface `recovery_loop_exhausted`. NEVER escalate to bypass.
+
+#### Squash-merge primitives (#1122)
+
+FORBIDDEN — all of these destroy per-commit audit trails:
+
+- `gh pr merge --squash`
+- `gh pr merge -s`
+- `git merge --squash`
+- GitHub Web UI "Squash and merge"
+- ANY `--squash` flag on a merge command
+
+**Empty-diff structural guard**: Before any merge (or before delegating to
+pr-bot), verify `gh pr diff <PR>` is non-empty AND the branch has commits
+ahead of main with a non-empty cumulative diff. An empty-diff PR is the
+structural fingerprint of the lefthook re-stage race documented in #1122 —
+when seen, surface `merge_blocked_empty_diff` instead of pushing through.
+Squash-merging an empty-diff PR produces an empty squash commit on main;
+this is the exact corruption #1122 documents.
+
+dev2merge delegates merging to pr-bot (Step 14), which reads
+`pr_review.merge_strategy` from config (default `merge`). Even if a normal
+`--merge` fails, DO NOT escalate to `--squash`. Surface `merge_blocked` to
+the orchestrator.
+
 Sub-workflows are included via `## INCLUDE`, not inlined.
 
 ## Step 1: Validate Branch
@@ -299,7 +349,15 @@ for the current run.
 Tool: bash
 OnFail: abort
 
-Hard gate: REVIEW_COMPLETED must be true before any push.
+Hard gates before any push:
+
+1. `REVIEW_COMPLETED` must be true.
+2. **Empty-diff structural guard (#1122)**: branch must have at least one
+   commit ahead of base AND the cumulative diff vs base must be non-empty.
+   An empty-diff branch is the lefthook-race fingerprint — it produces an
+   empty PR which can be silently squashed into an empty commit on main.
+   Aborting here surfaces `merge_blocked_empty_diff` to the orchestrator
+   instead of letting it propagate to pr-bot.
 
 ```bash
 if [ "${REVIEW_COMPLETED:-}" != "true" ]; then
@@ -308,6 +366,19 @@ if [ "${REVIEW_COMPLETED:-}" != "true" ]; then
   exit 1
 fi
 BRANCH="$(git branch --show-current)"
+COMMITS_AHEAD="$(git rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
+if [ "${COMMITS_AHEAD}" -eq 0 ]; then
+  echo "ERROR: merge_blocked_empty_diff — branch has 0 commits ahead of ${DEFAULT_BRANCH}."
+  echo "Refusing to push an empty branch (#1122 structural guard)."
+  exit 1
+fi
+DIFF_LINES="$(git diff "${DEFAULT_BRANCH}...HEAD" --shortstat 2>/dev/null | grep -oE '[0-9]+ (insertion|deletion)' | wc -l)"
+if [ "${DIFF_LINES}" -eq 0 ]; then
+  echo "ERROR: merge_blocked_empty_diff — cumulative diff vs ${DEFAULT_BRANCH} is empty."
+  echo "Branch has commits but no actual changes — likely lefthook re-stage drift (#1122)."
+  echo "Investigate the working tree and the failed commit's intended files; do NOT escalate to squash merge."
+  exit 1
+fi
 git push -u origin "${BRANCH}" --force-with-lease
 echo "CSA_VAR:PUSHED=true"
 echo '<!-- CSA:NEXT_STEP cmd="create or reuse PR (Step 13)" required=true -->'

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -40,8 +40,41 @@ Push Gate → PR Creation → pr-bot Hard Gate → Post-Merge Sync.
 
 ## Execution Protocol (ORCHESTRATOR ONLY)
 
-<prompt-guard name="no-verify-forbidden">
-ABSOLUTE PROHIBITION: You MUST NOT use `--no-verify` or `-n` with any `git commit` or `git push` command. All quality hooks (pre-commit, etc.) MUST be allowed to run. Bypassing hooks is a critical SOP violation. If hooks fail, fix the underlying code issues instead of bypassing.
+<prompt-guard name="hook-bypass-forbidden">
+ABSOLUTE PROHIBITION (#1123): All hook-bypass primitives are FORBIDDEN. Each disables registered git hooks (pre-commit / pre-push / commit-msg) and silently violates SOP:
+
+- `git commit --no-verify` / `-n`
+- `git push --no-verify`
+- `LEFTHOOK=0`, `LEFTHOOK_DISABLED=1`
+- `HUSKY=0`, `HUSKY_DISABLE=1`
+- `SKIP_HOOKS=1`, `SKIP_GIT_HOOKS=1`, `PRE_COMMIT_ALLOW_NO_CONFIG=1` (when used to skip)
+- `--no-gpg-sign` (signing bypass)
+- ANY equivalent env var or CLI flag that disables a registered hook
+
+If hooks fail, fix the underlying code issue. If `git commit` fails because lefthook (or another formatter hook) auto-formatted and re-staged files, the correct re-stage recovery primitive is:
+
+1. `git diff --staged --quiet` -- exit 0 means staging is clean (rare; normally files were re-staged)
+2. `git add -u` -- re-stage the formatted versions of already-tracked files
+3. Retry `git commit -m "..."` -- hooks accept the formatted version on the second pass
+4. If the recovery loop runs >=3 iterations without converging, surface `recovery_loop_exhausted` to the orchestrator. DO NOT escalate to any bypass primitive above.
+
+Bypassing hooks is a critical SOP violation. If you encounter this scenario, follow the re-stage recipe above. NEVER use any of the FORBIDDEN bypass primitives.
+</prompt-guard>
+
+<prompt-guard name="squash-merge-forbidden">
+ABSOLUTE PROHIBITION (#1122): Squash-merge primitives are FORBIDDEN at every level of dev2merge. Each destroys per-commit AI Reviewer Metadata, lefthook-gate evidence, author attribution (codex / gemini / main-agent split), and the iteration trail (review-then-fix rounds become invisible).
+
+- `gh pr merge --squash`
+- `gh pr merge -s` (short form)
+- `git merge --squash`
+- GitHub Web UI "Squash and merge" button
+- ANY `--squash` flag passed to a merge command
+
+dev2merge delegates the actual merge to pr-bot (Step 14). pr-bot reads `pr_review.merge_strategy` from config (default `merge`). If a normal `gh pr merge --merge` fails (e.g. lefthook re-stage race producing an empty-diff PR, or upstream advancing during the wait), DO NOT escalate to `--squash`. Surface `merge_blocked` (or the structural variant `merge_blocked_empty_diff`) to the orchestrator.
+
+EMPTY-DIFF GUARD: Before any merge, verify `gh pr diff <PR>` is non-empty. An empty-diff PR is the structural fingerprint of the lefthook-race scenario in #1122 -- the branch tip drifted, the PR body still references the intended fix, but the actual diff vs main is empty. Aborting at the empty-diff signal is the correct behavior. Squash-merging an empty-diff PR produces an empty squash commit on main and corrupts the audit trail; this is the exact bug #1122 documents.
+
+Once squashed, the original commits cannot be reconstructed from main. The audit cost is irreversible and silent.
 </prompt-guard>
 
 ### Prerequisites

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -9,6 +9,9 @@ name = "BRANCH"
 name = "CODE_FILES"
 
 [[workflow.variables]]
+name = "COMMITS_AHEAD"
+
+[[workflow.variables]]
 name = "COMMIT_MSG"
 
 [[workflow.variables]]
@@ -25,6 +28,9 @@ name = "CURRENT_BRANCH"
 
 [[workflow.variables]]
 name = "DEFAULT_BRANCH"
+
+[[workflow.variables]]
+name = "DIFF_LINES"
 
 [[workflow.variables]]
 name = "DONE_MARKER"
@@ -66,7 +72,16 @@ name = "MARKER_BASE"
 name = "MARKER_DIR"
 
 [[workflow.variables]]
+name = "MKTD_EXIT"
+
+[[workflow.variables]]
+name = "MKTD_FAILURE_CONTEXT"
+
+[[workflow.variables]]
 name = "MKTD_INTENSITY"
+
+[[workflow.variables]]
+name = "MKTD_OUTPUT"
 
 [[workflow.variables]]
 name = "MKTD_TODO_TIMESTAMP"
@@ -102,25 +117,16 @@ name = "REMOTE_SHA"
 name = "REPO_SLUG"
 
 [[workflow.variables]]
-name = "REVIEW_OUTPUT"
-
-[[workflow.variables]]
-name = "REVIEW_OUTPUT_FILE"
-
-[[workflow.variables]]
-name = "REVIEW_STATUS"
-
-[[workflow.variables]]
 name = "TODO_PATH"
+
+[[workflow.variables]]
+name = "TOTAL_FILES"
 
 [[workflow.variables]]
 name = "TOTAL_INSERTIONS"
 
 [[workflow.variables]]
 name = "USER_LANGUAGE_OVERRIDE"
-
-[[workflow.variables]]
-name = "VERDICT_LINE"
 
 [[workflow.variables]]
 name = "VERSION"
@@ -158,7 +164,9 @@ title = "FAST_PATH Detection"
 tool = "bash"
 prompt = '''
 Detect whether changes are docs/config-only. When FAST_PATH=true,
-skip mktd/mktsk/debate but keep L1/L2 quality checks.
+skip mktd/mktsk/debate but keep L1/L2 quality checks. An empty diff
+vs the base branch is NOT docs-only; it must stay on the full plan
+path to avoid no-op commit/version-bump steps.
 
 ```bash
 set -euo pipefail
@@ -400,7 +408,12 @@ bash scripts/csa/cumulative-review-batch.sh --default-branch "${DEFAULT_BRANCH}"
   csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD"
 echo "CSA_VAR:REVIEW_COMPLETED=true"
 echo '<!-- CSA:NEXT_STEP cmd="push to origin (Step 12)" required=true -->'
-```'''
+```
+
+When global config sets `[review].batch_commits >= 2`, intermediate cumulative
+reviews can be skipped until the branch accumulates enough new commits after
+the last passed `main...HEAD` review. Set `CSA_REVIEW_NOW=1` to bypass batching
+for the current run.'''
 on_fail = "abort"
 condition = "!(${FAST_PATH})"
 
@@ -409,7 +422,15 @@ id = 12
 title = "Push Gate"
 tool = "bash"
 prompt = '''
-Hard gate: REVIEW_COMPLETED must be true before any push.
+Hard gates before any push:
+
+1. `REVIEW_COMPLETED` must be true.
+2. **Empty-diff structural guard (#1122)**: branch must have at least one
+   commit ahead of base AND the cumulative diff vs base must be non-empty.
+   An empty-diff branch is the lefthook-race fingerprint — it produces an
+   empty PR which can be silently squashed into an empty commit on main.
+   Aborting here surfaces `merge_blocked_empty_diff` to the orchestrator
+   instead of letting it propagate to pr-bot.
 
 ```bash
 if [ "${REVIEW_COMPLETED:-}" != "true" ]; then
@@ -418,6 +439,19 @@ if [ "${REVIEW_COMPLETED:-}" != "true" ]; then
   exit 1
 fi
 BRANCH="$(git branch --show-current)"
+COMMITS_AHEAD="$(git rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
+if [ "${COMMITS_AHEAD}" -eq 0 ]; then
+  echo "ERROR: merge_blocked_empty_diff — branch has 0 commits ahead of ${DEFAULT_BRANCH}."
+  echo "Refusing to push an empty branch (#1122 structural guard)."
+  exit 1
+fi
+DIFF_LINES="$(git diff "${DEFAULT_BRANCH}...HEAD" --shortstat 2>/dev/null | grep -oE '[0-9]+ (insertion|deletion)' | wc -l)"
+if [ "${DIFF_LINES}" -eq 0 ]; then
+  echo "ERROR: merge_blocked_empty_diff — cumulative diff vs ${DEFAULT_BRANCH} is empty."
+  echo "Branch has commits but no actual changes — likely lefthook re-stage drift (#1122)."
+  echo "Investigate the working tree and the failed commit's intended files; do NOT escalate to squash merge."
+  exit 1
+fi
 git push -u origin "${BRANCH}" --force-with-lease
 echo "CSA_VAR:PUSHED=true"
 echo '<!-- CSA:NEXT_STEP cmd="create or reuse PR (Step 13)" required=true -->'


### PR DESCRIPTION
## Summary

Three dev2merge silent-failure bugs filed today against csa 0.1.566 reproductions on RyderFreeman4Logos/mempal. All share the same root: when dev2merge's recovery path hits friction, it falls back to behaviors that violate explicit user rules without surfacing failure to the orchestrator.

### #1121 — final-line==result.toml.path contract is brittle

Daemon completion-detection treated the last line of the executor's final assistant message as authoritative for success/failure. When the executor's last line was prose (e.g. ` - binary 已安装到 …`) instead of the verbatim absolute path of `$CSA_RESULT_TOML_PATH_CONTRACT`, the daemon flipped the verdict to failure even when the inner `output/result.toml` reported `[result] status="success"` and the work had landed (PRs were merged). 3-for-3 false-failures observed. This PR honors the inner artifact as the authoritative truth and downgrades the last-line transcript check from gate to advisory signal.

### #1122 — silent squash merge fallback

When the lefthook pre-commit hook auto-formatted and re-staged files, the dev2merge skill body's recovery branch reached for `gh pr merge --squash` even though the dispatch prompt explicitly forbade squash (rule 039). Effect on mempal#67: PR #74 landed an empty squash commit on main; PR #75 had to be opened to re-apply the actual fix. This PR hard-bans `--squash`/`squash and merge`/`git merge --squash` in the skill body and adds a structural empty-diff guard before merge (`gh pr diff <PR>` empty → abort with `merge_blocked_empty_diff`).

### #1123 — LEFTHOOK=0 bypass (=== --no-verify)

Same session as #1122. Recovery path used `LEFTHOOK=0 git commit ...` to escape the auto-format re-stage cycle. `LEFTHOOK=0` is the env-var equivalent of `--no-verify`, which the dispatch prompt forbade (rule 015). This PR hard-bans `LEFTHOOK=0`/`LEFTHOOK_DISABLED=1`/`HUSKY=0`/`HUSKY_DISABLE=1`/`SKIP_HOOKS=1`/`--no-verify`/`--no-gpg-sign` in the skill body and documents the correct re-stage recovery primitive (`git diff --staged --quiet` check + `git add -u` retry).

## Why one combined PR

All three bugs share the same recovery-path code surface in dev2merge skill body + completion-detection. Splitting into three PRs would have risked landing inconsistent recovery semantics across the rounds. The combined PR keeps the recovery contract atomic.

## Verification

- `just pre-commit` exits 0 on this branch
- New tests in `crates/cli-sub-agent/src/pipeline_tests_contract.rs` cover the relaxed completion contract
- Skill body changes are textual; rule 027 PATTERN.md ↔ workflow.toml sync verified

## Out of scope

- #1118 (dev2merge mktd runaway) — separate PR coming
- #760 (long-term CLI-only transport explore) — long-term

Closes #1121
Closes #1122
Closes #1123
Refs: #1118 #1124 #760
