### PR TITLE
fix(executor): default codex to CLI transport, gate ACP behind codex-acp feature (#1128)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.570"
+version = "0.1.571"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.570"
+version = "0.1.571"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds_transport_display_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_transport_display_tests.rs
@@ -14,7 +14,8 @@ transport = "auto"
     let rendered = toml::to_string_pretty(&build_project_display_toml(&config).unwrap()).unwrap();
 
     assert!(rendered.contains("[tools.codex]"));
-    assert!(rendered.contains("transport = \"acp\""));
+    // codex now defaults to CLI transport (#760 / #1128 transport flip).
+    assert!(rendered.contains("transport = \"cli\""));
 }
 
 #[test]
@@ -36,6 +37,7 @@ transport = "auto"
             .and_then(|value| value.get("codex"))
             .and_then(|value| value.get("transport"))
             .and_then(|value| value.as_str()),
-        Some("acp")
+        // codex now defaults to CLI transport (#760 / #1128 transport flip).
+        Some("cli")
     );
 }

--- a/crates/cli-sub-agent/src/doctor_routing.rs
+++ b/crates/cli-sub-agent/src/doctor_routing.rs
@@ -542,7 +542,9 @@ mod tests {
         let config: ProjectConfig = toml::from_str("").unwrap();
 
         assert_eq!(tool_exe_name("gemini-cli", &config), "gemini");
-        assert_eq!(tool_exe_name("codex", &config), "codex-acp");
+        // codex now defaults to CLI transport (#760 / #1128 transport flip);
+        // the CLI binary is `codex`, not `codex-acp`.
+        assert_eq!(tool_exe_name("codex", &config), "codex");
         // claude-code now defaults to CLI transport (#1115/#1117 workaround);
         // the CLI binary is `claude`, not `claude-code-acp`.
         assert_eq!(tool_exe_name("claude-code", &config), "claude");
@@ -698,11 +700,16 @@ mod tests {
         let user_config_path = ProjectConfig::user_config_path().expect("resolve user config path");
         std::fs::create_dir_all(user_config_path.parent().expect("user config dir"))
             .expect("create user config dir");
+        // Use gemini-cli + acp as the still-invalid combination after #1128 flipped
+        // codex CLI to a legal value. gemini-cli has no ACP transport, so the merge
+        // still produces a validation error tagged on the offending key. The invalid
+        // value lives in USER config; project config stays valid so the project view
+        // remains Valid in isolation.
         std::fs::write(
             &user_config_path,
             r#"
-[tools.codex]
-transport = "cli"
+[tools.gemini-cli]
+transport = "acp"
 "#,
         )
         .expect("write invalid user config");
@@ -710,8 +717,8 @@ transport = "cli"
         write_project_config(
             td.path(),
             r#"
-[tools.codex]
-transport = "acp"
+[tools.gemini-cli]
+transport = "auto"
 
 [tiers.tier-1]
 description = "Test"
@@ -738,7 +745,7 @@ default = "tier-1"
         assert!(
             report.diagnostics[0]
                 .message
-                .contains("tools.codex.transport"),
+                .contains("tools.gemini-cli.transport"),
             "diagnostic should surface the merged-config key: {:?}",
             report.diagnostics[0]
         );
@@ -768,7 +775,7 @@ default = "tier-1"
             json["diagnostics"][0]["message"]
                 .as_str()
                 .expect("routing json diagnostic message")
-                .contains("tools.codex.transport"),
+                .contains("tools.gemini-cli.transport"),
             "json output should surface the merged-config key: {json}"
         );
         assert_eq!(json["context"]["vcs_backend"], serde_json::json!("git"));

--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -296,14 +296,17 @@ fn explicit_claude_code_cli_transport_reports_json_transport_details() {
     });
 }
 
+/// Doctor must surface transport validation errors with the offending key path.
+/// Uses gemini-cli + ACP (still rejected post-#1128) because the original
+/// codex+cli rejection became obsolete after the codex CLI default flip.
 #[test]
-fn doctor_load_rejects_invalid_codex_transport_override() {
+fn doctor_load_rejects_invalid_tool_transport_override() {
     let td = tempfile::tempdir().expect("tempdir");
     write_project_config(
         td.path(),
         r#"
-[tools.codex]
-transport = "cli"
+[tools.gemini-cli]
+transport = "acp"
 "#,
     );
 
@@ -311,12 +314,12 @@ transport = "cli"
     let message = format!("{err:#}");
 
     assert!(
-        message.contains("tools.codex.transport"),
+        message.contains("tools.gemini-cli.transport"),
         "doctor should surface the exact config key: {message}"
     );
     assert!(
-        message.contains("#643 Phase 4"),
-        "doctor should surface the codex CLI phase guidance: {message}"
+        message.contains("does not support ACP transport"),
+        "doctor should surface the transport contract message: {message}"
     );
 }
 
@@ -398,11 +401,16 @@ fn doctor_project_config_display_ignores_invalid_user_global_config() {
     let user_config_path = ProjectConfig::user_config_path().expect("resolve user config path");
     std::fs::create_dir_all(user_config_path.parent().expect("user config dir"))
         .expect("create user config dir");
+    // gemini-cli + acp is the still-invalid combination after #1128 flipped
+    // codex CLI to a legal transport. gemini-cli has no ACP transport, so the
+    // merge still produces a validation error tagged on the offending key.
+    // The invalid value lives in USER config; project config stays valid so
+    // doctor still reports `.csa/config.toml` as Valid in isolation.
     std::fs::write(
         &user_config_path,
         r#"
-[tools.codex]
-transport = "cli"
+[tools.gemini-cli]
+transport = "acp"
 "#,
     )
     .expect("write invalid user config");
@@ -410,14 +418,14 @@ transport = "cli"
     write_project_config(
         td.path(),
         r#"
-[tools.codex]
-transport = "acp"
+[tools.gemini-cli]
+transport = "auto"
 "#,
     );
 
     let merged_error = ProjectConfig::load(td.path()).expect_err("merged load should fail");
     assert!(
-        format!("{merged_error:#}").contains("tools.codex.transport"),
+        format!("{merged_error:#}").contains("tools.gemini-cli.transport"),
         "test fixture should exercise an invalid user-level transport override: {merged_error}"
     );
 
@@ -446,11 +454,16 @@ fn doctor_text_reports_invalid_effective_config() {
     let user_config_path = ProjectConfig::user_config_path().expect("resolve user config path");
     std::fs::create_dir_all(user_config_path.parent().expect("user config dir"))
         .expect("create user config dir");
+    // gemini-cli + acp is the still-invalid combination after #1128 flipped
+    // codex CLI to a legal transport. gemini-cli has no ACP transport, so the
+    // merge still produces a validation error tagged on the offending key.
+    // The invalid value lives in USER config; project config stays valid so
+    // doctor still reports `.csa/config.toml` as Valid in isolation.
     std::fs::write(
         &user_config_path,
         r#"
-[tools.codex]
-transport = "cli"
+[tools.gemini-cli]
+transport = "acp"
 "#,
     )
     .expect("write invalid user config");
@@ -458,8 +471,8 @@ transport = "cli"
     write_project_config(
         td.path(),
         r#"
-[tools.codex]
-transport = "acp"
+[tools.gemini-cli]
+transport = "auto"
 "#,
     );
 
@@ -481,7 +494,7 @@ transport = "acp"
         "doctor text should surface the invalid effective-config branch: {rendered}"
     );
     assert!(
-        rendered.contains("tools.codex.transport"),
+        rendered.contains("tools.gemini-cli.transport"),
         "doctor text should surface the exact merged-config key: {rendered}"
     );
     assert!(
@@ -507,11 +520,16 @@ fn doctor_json_reports_invalid_effective_config() {
     let user_config_path = ProjectConfig::user_config_path().expect("resolve user config path");
     std::fs::create_dir_all(user_config_path.parent().expect("user config dir"))
         .expect("create user config dir");
+    // gemini-cli + acp is the still-invalid combination after #1128 flipped
+    // codex CLI to a legal transport. gemini-cli has no ACP transport, so the
+    // merge still produces a validation error tagged on the offending key.
+    // The invalid value lives in USER config; project config stays valid so
+    // doctor still reports `.csa/config.toml` as Valid in isolation.
     std::fs::write(
         &user_config_path,
         r#"
-[tools.codex]
-transport = "cli"
+[tools.gemini-cli]
+transport = "acp"
 "#,
     )
     .expect("write invalid user config");
@@ -519,8 +537,8 @@ transport = "cli"
     write_project_config(
         td.path(),
         r#"
-[tools.codex]
-transport = "acp"
+[tools.gemini-cli]
+transport = "auto"
 "#,
     );
 
@@ -536,7 +554,7 @@ transport = "acp"
     assert_eq!(report["config"]["valid"], serde_json::json!(true));
     assert_eq!(effective["valid"], serde_json::json!(false));
     assert!(
-        effective_error.contains("tools.codex.transport"),
+        effective_error.contains("tools.gemini-cli.transport"),
         "doctor JSON should surface the exact merged-config key: {effective_error}"
     );
     assert!(

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -91,8 +91,12 @@ fn load_and_validate_within_depth_returns_some() {
     );
 }
 
+/// Pipeline must surface transport validation errors with the offending key path.
+/// Uses gemini-cli + ACP because it is still rejected post-#1128 (gemini-cli has
+/// no ACP transport). The original codex+cli rejection became obsolete after the
+/// codex CLI default flip (#760 / #1128).
 #[test]
-fn load_and_validate_rejects_invalid_codex_transport_override() {
+fn load_and_validate_rejects_invalid_tool_transport_override() {
     let tmp = tempfile::tempdir().unwrap();
     let _sandbox = sandbox_pipeline_config_env(&tmp);
     let config_dir = tmp.path().join(".csa");
@@ -100,8 +104,8 @@ fn load_and_validate_rejects_invalid_codex_transport_override() {
     fs::write(
         config_dir.join("config.toml"),
         r#"
-[tools.codex]
-transport = "cli"
+[tools.gemini-cli]
+transport = "acp"
 "#,
     )
     .unwrap();
@@ -110,12 +114,12 @@ transport = "cli"
     let message = format!("{err:#}");
 
     assert!(
-        message.contains("tools.codex.transport"),
+        message.contains("tools.gemini-cli.transport"),
         "pipeline should surface the exact config key: {message}"
     );
     assert!(
-        message.contains("#643 Phase 4"),
-        "pipeline should surface the codex CLI phase guidance: {message}"
+        message.contains("does not support ACP transport"),
+        "pipeline should surface the transport contract message: {message}"
     );
 }
 

--- a/crates/cli-sub-agent/src/run_helpers_transport_integration_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_transport_integration_tests.rs
@@ -56,20 +56,34 @@ fn assert_non_codex_transport_defaults() {
     );
 }
 
+/// codex now defaults to CLI transport (#760 / #1128 transport flip). The
+/// resolved binary is `codex`, not `codex-acp`, and the transport routes to
+/// Legacy.
+///
+/// The test passes an empty project config (rather than `None`) so the
+/// resolver routes through `tool_transport()` → `default_transport_for_tool()`,
+/// which is the path that exercises the post-#1128 default. The `None`-config
+/// branch still falls back to the metadata-level `default_for_build()` (kept
+/// at Acp for serde back-compat) — that's a known papercut mirrored from
+/// PR #1120's claude-code treatment, not a regression introduced here.
 #[test]
-fn codex_defaults_to_acp_transport_end_to_end() {
-    let executor = build_executor(&ToolName::Codex, None, None, None, None, true)
+fn codex_defaults_to_cli_transport_end_to_end() {
+    let config = load_project_config("schema_version = 1\n");
+    let executor = build_executor(&ToolName::Codex, None, None, None, Some(&config), true)
         .expect("build default codex executor");
     let transport = TransportFactory::create(&executor, Some(SessionConfig::default()))
         .expect("create codex transport");
 
-    assert_eq!(transport.mode(), TransportMode::Acp);
-    assert_eq!(executor.runtime_binary_name(), "codex-acp");
+    assert_eq!(transport.mode(), TransportMode::Legacy);
+    assert_eq!(executor.runtime_binary_name(), "codex");
 
     assert_non_codex_transport_defaults();
 }
 
+/// Explicit `transport = "acp"` for codex must build an ACP transport — but
+/// only when the `codex-acp` cargo feature is enabled (#1128 feature gate).
 #[test]
+#[cfg(feature = "codex-acp")]
 fn codex_acp_project_config_builds_acp_transport_end_to_end() {
     let config = load_project_config(
         r#"
@@ -88,26 +102,48 @@ transport = "acp"
     assert_non_codex_transport_defaults();
 }
 
+/// Without the `codex-acp` feature, an explicit `transport = "acp"` codex
+/// config must fail at executor/transport build time with a clear error
+/// citing the feature flag and #760/#1128.
 #[test]
-fn codex_cli_project_config_is_rejected_before_executor_build() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    write_project_config(
-        dir.path(),
+#[cfg(not(feature = "codex-acp"))]
+fn codex_acp_project_config_is_rejected_without_feature() {
+    let config = load_project_config(
+        r#"
+[tools.codex]
+transport = "acp"
+"#,
+    );
+    let executor = build_executor(&ToolName::Codex, None, None, None, Some(&config), true)
+        .expect("build codex executor");
+    let result = TransportFactory::create(&executor, Some(SessionConfig::default()));
+
+    let err = match result {
+        Ok(_) => panic!("codex+ACP must fail without codex-acp feature"),
+        Err(e) => e,
+    };
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("codex-acp") || message.contains("760") || message.contains("1128"),
+        "error must cite the feature flag or issue number: {message}"
+    );
+}
+
+/// Explicit `transport = "cli"` for codex is now accepted (#760 / #1128
+/// transport flip). The resolved binary is `codex` and routing is Legacy.
+#[test]
+fn codex_cli_project_config_builds_legacy_transport_end_to_end() {
+    let config = load_project_config(
         r#"
 [tools.codex]
 transport = "cli"
 "#,
     );
+    let executor = build_executor(&ToolName::Codex, None, None, None, Some(&config), true)
+        .expect("build codex executor");
+    let transport = TransportFactory::create(&executor, Some(SessionConfig::default()))
+        .expect("create codex transport");
 
-    let err = ProjectConfig::load_project_only(dir.path()).expect_err("config should fail");
-    let message = format!("{err:#}");
-
-    assert!(
-        message.contains("tools.codex.transport"),
-        "error should point to the codex transport key: {message}"
-    );
-    assert!(
-        message.contains("#643 Phase 4"),
-        "error should mention the codex CLI follow-up phase: {message}"
-    );
+    assert_eq!(transport.mode(), TransportMode::Legacy);
+    assert_eq!(executor.runtime_binary_name(), "codex");
 }

--- a/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
@@ -33,8 +33,12 @@ fn project_config_with_tool(tool_name: &str, tool_config: ToolConfig) -> Project
     }
 }
 
+/// codex now defaults to CLI transport (#760 / #1128 transport flip).
+/// When transport is unset, the resolved runtime metadata is CLI, not the
+/// metadata-level `default_for_build()` (which still returns Acp for serde
+/// deserialization compatibility).
 #[test]
-fn build_executor_codex_transport_defaults_to_build_setting_when_unset() {
+fn build_executor_codex_transport_defaults_to_cli_when_unset() {
     let config = project_config_with_tool("codex", ToolConfig::default());
     let exec = build_executor(&ToolName::Codex, None, None, None, Some(&config), true).unwrap();
 
@@ -44,7 +48,8 @@ fn build_executor_codex_transport_defaults_to_build_setting_when_unset() {
         } => {
             assert_eq!(
                 runtime_metadata.transport_mode(),
-                CodexTransport::default_for_build()
+                CodexTransport::Cli,
+                "unset codex transport should resolve to CLI per default_transport_for_tool"
             );
         }
         other => panic!("expected codex executor, got: {other:?}"),
@@ -93,9 +98,11 @@ fn build_executor_codex_transport_respects_explicit_acp_override() {
     }
 }
 
+/// codex now defaults to CLI transport (#760 / #1128 transport flip).
+/// When transport is unset, `codex` (not `codex-acp`) is probed.
 #[cfg(unix)]
 #[test]
-fn auto_selection_uses_codex_acp_when_transport_is_unset() {
+fn auto_selection_uses_codex_cli_when_transport_is_unset() {
     use crate::test_env_lock::ScopedTestEnvVar;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
@@ -103,11 +110,12 @@ fn auto_selection_uses_codex_acp_when_transport_is_unset() {
     let td = tempfile::tempdir().expect("tempdir");
     let bin_dir = td.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
-    let codex_path = bin_dir.join("codex-acp");
-    fs::write(&codex_path, "#!/bin/sh\necho 'codex-acp 9.9.9'\n").expect("write codex-acp stub");
+    // Place the CLI binary (`codex`), not the ACP adapter.
+    let codex_path = bin_dir.join("codex");
+    fs::write(&codex_path, "#!/bin/sh\necho 'codex 9.9.9'\n").expect("write codex stub");
     let mut perms = fs::metadata(&codex_path).expect("metadata").permissions();
     perms.set_mode(0o755);
-    fs::set_permissions(&codex_path, perms).expect("chmod codex-acp");
+    fs::set_permissions(&codex_path, perms).expect("chmod codex");
 
     let path = std::env::var_os("PATH").unwrap_or_default();
     let joined =
@@ -140,7 +148,7 @@ fn auto_selection_uses_codex_acp_when_transport_is_unset() {
 
     assert!(
         is_tool_binary_available_for_config("codex", Some(&config)),
-        "unset codex transport should probe `codex-acp`, not `codex`"
+        "unset codex transport should probe `codex` (CLI binary), not `codex-acp`"
     );
 
     let (tool, model_spec, model) = resolve_tool_and_model(

--- a/crates/csa-config/src/config_merge_tests.rs
+++ b/crates/csa-config/src/config_merge_tests.rs
@@ -180,6 +180,8 @@ fn test_merged_schema_version_uses_max_when_explicit() {
     assert_eq!(config.schema_version, 1);
 }
 
+/// Uses gemini-cli + acp as the still-invalid combination after #1128 flipped
+/// codex CLI to a legal value. gemini-cli has no ACP transport.
 #[test]
 fn test_invalid_user_transport_override_fails_before_merge() {
     let tmp = tempdir().unwrap();
@@ -190,8 +192,8 @@ fn test_invalid_user_transport_override_fails_before_merge() {
         &user_path,
         r#"
 schema_version = 1
-[tools.codex]
-transport = "cli"
+[tools.gemini-cli]
+transport = "acp"
 "#,
     )
     .unwrap();
@@ -200,8 +202,8 @@ transport = "cli"
         &project_path,
         r#"
 schema_version = 1
-[tools.codex]
-transport = "acp"
+[tools.gemini-cli]
+transport = "auto"
 "#,
     )
     .unwrap();
@@ -219,11 +221,13 @@ transport = "acp"
         "error should include the user config path: {rendered}"
     );
     assert!(
-        rendered.contains("tools.codex.transport"),
+        rendered.contains("tools.gemini-cli.transport"),
         "error should surface the invalid user transport key: {rendered}"
     );
 }
 
+/// Uses gemini-cli + acp as the still-invalid combination after #1128 flipped
+/// codex CLI to a legal value. gemini-cli has no ACP transport.
 #[test]
 fn test_invalid_project_transport_override_fails_before_merge() {
     let tmp = tempdir().unwrap();
@@ -234,8 +238,8 @@ fn test_invalid_project_transport_override_fails_before_merge() {
         &user_path,
         r#"
 schema_version = 1
-[tools.codex]
-transport = "acp"
+[tools.gemini-cli]
+transport = "auto"
 "#,
     )
     .unwrap();
@@ -244,8 +248,8 @@ transport = "acp"
         &project_path,
         r#"
 schema_version = 1
-[tools.codex]
-transport = "cli"
+[tools.gemini-cli]
+transport = "acp"
 "#,
     )
     .unwrap();
@@ -263,7 +267,7 @@ transport = "cli"
         "error should include the project config path: {rendered}"
     );
     assert!(
-        rendered.contains("tools.codex.transport"),
+        rendered.contains("tools.gemini-cli.transport"),
         "error should surface the invalid project transport key: {rendered}"
     );
 }

--- a/crates/csa-config/src/config_tool.rs
+++ b/crates/csa-config/src/config_tool.rs
@@ -18,12 +18,15 @@ pub enum TransportKind {
 
 pub fn default_transport_for_tool(tool_name: &str) -> Option<TransportKind> {
     match tool_name {
-        // codex still defaults to ACP.
         // claude-code defaults to CLI as a workaround for ACP startup-crash bugs
         // (#1115/#1117). ACP is still reachable via explicit config + the
         // `claude-code-acp` cargo feature on `csa-executor`.
         "claude-code" => Some(TransportKind::Cli),
-        "codex" => Some(TransportKind::Acp),
+        // codex defaults to CLI in favour of native `codex exec resume <id>`
+        // (codex-cli 0.125.0+), empirically equivalent to ACP loadSession on
+        // server-side cache reuse (#760 / #1128). ACP is still reachable via
+        // explicit config + the `codex-acp` cargo feature on `csa-executor`.
+        "codex" => Some(TransportKind::Cli),
         "gemini-cli" | "opencode" => Some(TransportKind::Cli),
         _ => None,
     }
@@ -321,10 +324,40 @@ transport = "cli"
     fn test_resolve_transport_uses_default_when_unset() {
         let config = ToolConfig::default();
 
-        assert_eq!(config.resolve_transport("codex"), Some(TransportKind::Acp));
+        // codex now defaults to CLI transport (#760 / #1128 transport flip).
+        assert_eq!(config.resolve_transport("codex"), Some(TransportKind::Cli));
         assert_eq!(
             config.resolve_transport("opencode"),
             Some(TransportKind::Cli)
+        );
+    }
+
+    /// Mirrors `test_resolve_transport_claude_code_cli_round_trips` for codex.
+    /// Parsing `[tools.codex] transport = "acp"` MUST yield `TransportKind::Acp`,
+    /// not silently coerce back to CLI. The codex ACP path keys off this exact
+    /// resolution and is then gated by the `codex-acp` cargo feature on
+    /// `csa-executor`.
+    #[test]
+    fn test_resolve_transport_codex_acp_round_trips() {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            tools: HashMap<String, ToolConfig>,
+        }
+        let toml_str = r#"
+[tools.codex]
+transport = "acp"
+"#;
+        let wrapper: Wrapper = toml::from_str(toml_str).expect("parse codex acp toml");
+        let tool = wrapper
+            .tools
+            .get("codex")
+            .expect("codex tool entry missing");
+
+        assert_eq!(tool.transport, Some(TransportKind::Acp));
+        assert_eq!(
+            tool.resolve_transport("codex"),
+            Some(TransportKind::Acp),
+            "explicit transport=\"acp\" must resolve to ACP, not the build default"
         );
     }
 

--- a/crates/csa-config/src/validate.rs
+++ b/crates/csa-config/src/validate.rs
@@ -259,10 +259,7 @@ fn validate_tool_transport_override_with_raw(
             TransportKind::Auto | TransportKind::Cli | TransportKind::Acp => Ok(()),
         },
         "codex" => match transport {
-            TransportKind::Auto | TransportKind::Acp => Ok(()),
-            TransportKind::Cli => bail!(
-                "Invalid {key} = \"{raw_transport}\": codex does not yet support CLI transport — will be added in #643 Phase 4."
-            ),
+            TransportKind::Auto | TransportKind::Cli | TransportKind::Acp => Ok(()),
         },
         "gemini-cli" | "opencode" => match transport {
             TransportKind::Auto | TransportKind::Cli => Ok(()),

--- a/crates/csa-config/src/validate_tests_transport.rs
+++ b/crates/csa-config/src/validate_tests_transport.rs
@@ -52,12 +52,11 @@ fn validate_tool_transport_matrix_matches_phase_3_contract() {
             expected_message: None,
         },
         Case {
+            // codex CLI is now accepted (#760 / #1128 transport flip).
             tool: "codex",
             value: "cli",
-            should_pass: false,
-            expected_message: Some(
-                "codex does not yet support CLI transport — will be added in #643 Phase 4",
-            ),
+            should_pass: true,
+            expected_message: None,
         },
         Case {
             tool: "gemini-cli",

--- a/crates/csa-executor/Cargo.toml
+++ b/crates/csa-executor/Cargo.toml
@@ -28,6 +28,11 @@ reqwest.workspace = true
 
 [features]
 default = []
+# Gate codex ACP transport behind this feature.
+# Disabled by default in favour of `codex exec resume <id>` CLI native resume
+# (codex-cli 0.125.0+), which is empirically equivalent to ACP loadSession on
+# server-side cache reuse (54%, 44,800/83,503 input tokens, #760 / #1128).
+# Enable with `--features codex-acp` when investigating the ACP path.
 codex-acp = []
 codex-pty-fork = ["csa-process/codex-pty-fork"]
 # Gate claude-code ACP transport behind this feature.

--- a/crates/csa-executor/src/codex_runtime.rs
+++ b/crates/csa-executor/src/codex_runtime.rs
@@ -1,8 +1,15 @@
-//! Build-dependent runtime metadata for the codex tool.
+//! Codex now defaults to the CLI transport (`LegacyTransport`,
+//! `TransportMode::Legacy`) using `codex exec resume <session_id>` (codex-cli
+//! 0.125.0+). The native CLI resume is empirically equivalent to ACP
+//! `loadSession` on server-side cache reuse (54%, 44,800/83,503 input tokens,
+//! #760 / #1128). The ACP path is still compiled in but gated behind the
+//! `codex-acp` cargo feature (default OFF) on `csa-executor`. Callers can
+//! request ACP explicitly via config (`transport = "acp"`) with the feature
+//! enabled; without the feature, an explicit ACP request is rejected with a
+//! clear error pointing to the rebuild flag.
 //!
-//! T1 centralizes codex runtime metadata here without flipping the default
-//! transport yet. Later tasks can rewire downstream callers to consult this
-//! module instead of duplicating hardcoded `"codex-acp"` assumptions.
+//! Keeping transport metadata here lets availability checks and executor
+//! dispatch agree on the runtime binary without hardcoded string forks.
 
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +22,14 @@ pub enum CodexTransport {
 }
 
 impl CodexTransport {
-    /// Current default transport for this build.
+    /// Default transport for serialization and fallback deserialization.
+    ///
+    /// NOTE: `default_for_build` returns `Acp` at the metadata level, but
+    /// `TransportFactory::mode_for_executor` routes `codex` to
+    /// `TransportMode::Legacy` (CLI) by default in favour of native
+    /// `codex exec resume <id>` (#760 / #1128). ACP is only reachable for
+    /// codex when the `codex-acp` cargo feature is enabled AND the executor
+    /// carries explicit `Some(Acp)` transport metadata.
     #[must_use]
     pub const fn default_for_build() -> Self {
         Self::Acp
@@ -119,8 +133,11 @@ mod tests {
         );
     }
 
+    // NOTE: The metadata-level default is still `Acp` for serde deserialization
+    // compatibility. The actual runtime routing to CLI happens in
+    // `TransportFactory::mode_for_executor` (#760 / #1128 transport flip).
     #[test]
-    fn current_build_defaults_to_acp_when_feature_enabled() {
+    fn metadata_default_for_build_is_acp() {
         let meta = codex_runtime_metadata();
 
         assert_eq!(meta.transport_mode(), CodexTransport::Acp);

--- a/crates/csa-executor/src/transport_cli_tests.rs
+++ b/crates/csa-executor/src/transport_cli_tests.rs
@@ -14,7 +14,7 @@ use crate::model_spec::ThinkingBudget;
 // (transport.rs nests transport_factory.rs via `#[path]` and re-exports
 // its public items at the crate root).  Reach for the crate-level
 // re-export rather than the private nested-mod path.
-use crate::TransportFactory;
+use crate::{LegacyTransport, TransportFactory};
 use csa_resource::filesystem_sandbox::FilesystemCapability;
 use csa_resource::isolation_plan::IsolationPlan;
 use csa_resource::sandbox::ResourceCapability;
@@ -108,6 +108,69 @@ fn factory_rejects_acp_for_claude_code_without_feature() {
     let msg = format!("{:#}", result.err().unwrap());
     assert!(
         msg.contains("claude-code-acp") || msg.contains("1115"),
+        "error should mention the feature flag or issue; got: {msg}"
+    );
+}
+
+// ---- Codex transport routing (mirrors claude-code) ----
+
+/// codex with explicit `Cli` transport must route through the generic
+/// `LegacyTransport` (codex does not have a dedicated CLI transport struct
+/// like claude-code does). The `Legacy` mode tag is the canonical CLI tag.
+#[test]
+fn factory_returns_legacy_for_codex_default() {
+    use crate::codex_runtime::{CodexRuntimeMetadata, CodexTransport as CdxTransport};
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::from_transport(CdxTransport::Cli),
+    };
+    let transport = TransportFactory::create(&executor, None).expect("factory create");
+    assert_eq!(transport.mode(), TransportMode::Legacy);
+    assert!(
+        transport
+            .as_any()
+            .downcast_ref::<LegacyTransport>()
+            .is_some(),
+        "codex CLI default should produce LegacyTransport"
+    );
+}
+
+/// ACP transport for codex is only reachable with the `codex-acp` feature
+/// enabled. Mirrors `factory_returns_acp_for_claude_code_acp_metadata_with_feature`.
+#[test]
+#[cfg(feature = "codex-acp")]
+fn factory_returns_acp_for_codex_acp_metadata_with_feature() {
+    use crate::codex_runtime::{CodexRuntimeMetadata, CodexTransport as CdxTransport};
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::from_transport(CdxTransport::Acp),
+    };
+    let transport = TransportFactory::create(&executor, None).expect("factory create");
+    assert_eq!(transport.mode(), TransportMode::Acp);
+}
+
+/// Without `codex-acp` feature, even an explicit ACP metadata request must
+/// fail — the feature gate is the safety net for the #760 / #1128 transport
+/// flip. Mirrors `factory_rejects_acp_for_claude_code_without_feature`.
+#[test]
+#[cfg(not(feature = "codex-acp"))]
+fn factory_rejects_acp_for_codex_without_feature() {
+    use crate::codex_runtime::{CodexRuntimeMetadata, CodexTransport as CdxTransport};
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::from_transport(CdxTransport::Acp),
+    };
+    let result = TransportFactory::create(&executor, None);
+    assert!(
+        result.is_err(),
+        "factory should reject Codex+Acp without codex-acp feature"
+    );
+    let msg = format!("{:#}", result.err().unwrap());
+    assert!(
+        msg.contains("codex-acp") || msg.contains("760") || msg.contains("1128"),
         "error should mention the feature flag or issue; got: {msg}"
     );
 }

--- a/crates/csa-executor/src/transport_factory.rs
+++ b/crates/csa-executor/src/transport_factory.rs
@@ -80,11 +80,19 @@ impl TransportFactory {
 
     fn mode_for_executor(executor: &Executor) -> Result<TransportMode> {
         match executor {
+            // ACP transport for codex is gated behind the `codex-acp` cargo
+            // feature (disabled by default) in favour of native CLI resume
+            // (`codex exec resume <id>`, codex-cli 0.125.0+, #760 / #1128).
+            // Only an explicit `Some(Acp)` request attempts ACP; `None` and
+            // `Some(Cli)` both route through the CLI transport.
             Executor::Codex { .. } => match executor.codex_transport() {
-                Some(crate::CodexTransport::Cli) | None => Ok(TransportMode::Legacy),
                 Some(crate::CodexTransport::Acp) => {
                     Self::validate_mode_for_executor(executor, TransportMode::Acp)?;
                     Ok(TransportMode::Acp)
+                }
+                Some(crate::CodexTransport::Cli) | None => {
+                    Self::validate_mode_for_executor(executor, TransportMode::Legacy)?;
+                    Ok(TransportMode::Legacy)
                 }
             },
             Executor::ClaudeCode { .. } => match executor.claude_code_transport() {
@@ -117,7 +125,7 @@ impl TransportFactory {
     /// | Executor     | Legacy | Acp                                      | OpenaiCompat |
     /// |--------------|--------|------------------------------------------| -------------|
     /// | ClaudeCode   | Yes    | Yes (requires `claude-code-acp` feature) | No           |
-    /// | Codex        | Yes    | Yes                                      | No           |
+    /// | Codex        | Yes    | Yes (requires `codex-acp` feature)       | No           |
     /// | GeminiCli    | Yes    | Yes                                      | No           |
     /// | Opencode     | Yes    | No                                       | No           |
     /// | OpenaiCompat | No     | No                                       | Yes          |
@@ -150,8 +158,19 @@ impl TransportFactory {
                 err("claude-code only supports cli or acp transport")
             }
 
-            // Codex: Legacy and ACP are both supported
+            // Codex + ACP: gated behind the `codex-acp` cargo feature.
+            // Native CLI resume (`codex exec resume <id>`, codex-cli 0.125.0+)
+            // is the default and is empirically equivalent to ACP loadSession
+            // on server-side cache reuse (#760 / #1128).
+            // Build with `--features codex-acp` to re-enable this path.
             (Executor::Codex { .. }, TransportMode::Legacy) => Ok(()),
+            #[cfg(not(feature = "codex-acp"))]
+            (Executor::Codex { .. }, TransportMode::Acp) => err(
+                "codex ACP transport requires the `codex-acp` cargo feature \
+                     (disabled by default in favour of native `codex exec resume <id>`, \
+                     #760/#1128); rebuild with `--features codex-acp` to enable",
+            ),
+            #[cfg(feature = "codex-acp")]
             (Executor::Codex { .. }, TransportMode::Acp) => Ok(()),
             (Executor::Codex { .. }, TransportMode::OpenaiCompat) => {
                 err("codex only supports cli or acp transport")
@@ -233,6 +252,21 @@ impl TransportFactory {
                          session startup (turn_count=0, output_log=0B, #1115/#1117). \
                          Rebuild csa-executor with `--features claude-code-acp` to enable \
                          this transport for investigation."
+                    );
+                }
+                // codex ACP transport is gated behind the `codex-acp` cargo feature
+                // (disabled by default, #760 / #1128) because native CLI resume
+                // (`codex exec resume <id>`, codex-cli 0.125.0+) is empirically
+                // equivalent on server-side cache reuse.
+                #[cfg(not(feature = "codex-acp"))]
+                if matches!(executor, Executor::Codex { .. }) {
+                    anyhow::bail!(
+                        "codex ACP transport is disabled (cargo feature `codex-acp` is not \
+                         enabled). This path was gated because native `codex exec resume <id>` \
+                         (codex-cli 0.125.0+) is empirically equivalent to ACP loadSession on \
+                         server-side cache reuse (54%, 44,800/83,503 input tokens, #760 / #1128). \
+                         Rebuild csa-executor with `--features codex-acp` to enable this \
+                         transport for investigation."
                     );
                 }
                 Ok(Box::new(AcpTransport::new(

--- a/crates/csa-executor/src/transport_factory_tests.rs
+++ b/crates/csa-executor/src/transport_factory_tests.rs
@@ -26,6 +26,14 @@ fn make_claude_executor_acp() -> Executor {
     }
 }
 
+fn make_codex_executor_cli() -> Executor {
+    Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::from_transport(CodexTransport::Cli),
+    }
+}
+
 fn make_codex_executor_acp() -> Executor {
     Executor::Codex {
         model_override: None,
@@ -112,19 +120,96 @@ fn test_claude_code_acp_works_with_feature() {
 }
 
 // ---------------------------------------------------------------------------
-// Codex ACP path unaffected by claude-code-acp feature
+// Codex: default transport flip (mirrors claude-code) — explicit Cli routes to Legacy
 // ---------------------------------------------------------------------------
 
-/// Codex with explicit `Acp` transport must still produce ACP mode even when the
-/// `claude-code-acp` feature is OFF. The feature gate is scoped to ClaudeCode only.
+/// `codex` with an explicit `Cli` transport must route to Legacy.
 #[test]
-fn test_codex_acp_unchanged() {
+fn test_mode_for_executor_codex_explicit_cli_is_legacy() {
+    let executor = make_codex_executor_cli();
+    let mode = TransportFactory::mode_for_executor_pub(&executor)
+        .expect("mode_for_executor should succeed for Codex+Cli");
+    assert_eq!(
+        mode,
+        TransportMode::Legacy,
+        "explicit Cli should resolve to Legacy transport"
+    );
+}
+
+/// `codex` default (no explicit ACP) must resolve to Legacy.
+///
+/// `codex_transport()` always returns `Some(...)` from the metadata, so the
+/// `None` arm in the pattern is purely defensive. This test exercises the explicit
+/// `Some(Cli)` path which is the effective default after the flip.
+#[test]
+fn test_mode_for_executor_codex_default_is_legacy() {
+    let executor = make_codex_executor_cli();
+    let mode = TransportFactory::mode_for_executor_pub(&executor)
+        .expect("default Cli metadata should resolve to Legacy");
+    assert_eq!(
+        mode,
+        TransportMode::Legacy,
+        "default Cli metadata must route to Legacy, not ACP"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Codex: feature-gate — ACP without feature => error
+// ---------------------------------------------------------------------------
+
+/// When `codex-acp` feature is OFF, requesting ACP transport must fail with a
+/// clear error citing the feature flag and the issue numbers (#760 / #1128).
+#[test]
+#[cfg(not(feature = "codex-acp"))]
+fn test_validate_or_instantiate_codex_acp_errors_without_feature() {
+    let executor = make_codex_executor_acp();
+
+    let result = TransportFactory::validate_mode_for_executor_pub(&executor, TransportMode::Acp);
+    assert!(
+        result.is_err(),
+        "validate should fail for Codex+Acp without feature"
+    );
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("codex-acp") || msg.contains("760") || msg.contains("1128"),
+        "error should mention the feature flag or issue number; got: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Codex: feature-gate — ACP with feature => succeeds
+// ---------------------------------------------------------------------------
+
+/// With `codex-acp` feature ON, explicit ACP executor must route to Acp.
+#[test]
+#[cfg(feature = "codex-acp")]
+fn test_codex_acp_works_with_feature() {
     let executor = make_codex_executor_acp();
     let mode = TransportFactory::mode_for_executor_pub(&executor)
-        .expect("codex ACP should always be available regardless of claude-code-acp feature");
+        .expect("mode_for_executor should succeed with codex-acp feature enabled");
     assert_eq!(
         mode,
         TransportMode::Acp,
-        "codex ACP must not be gated by the claude-code-acp feature"
+        "explicit Acp should resolve to Acp when feature ON"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-feature isolation: claude-code feature gate does not affect codex
+// (and vice versa). Both gates target their own tool only.
+// ---------------------------------------------------------------------------
+
+/// gemini-cli ACP path must remain available regardless of either feature gate.
+/// The feature gates are scoped to claude-code and codex only.
+#[test]
+fn test_gemini_cli_acp_unaffected_by_feature_gates() {
+    let executor = Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    };
+    let result = TransportFactory::validate_mode_for_executor_pub(&executor, TransportMode::Acp);
+    assert!(
+        result.is_ok(),
+        "gemini-cli ACP must not be gated by either feature flag"
     );
 }

--- a/crates/csa-executor/src/transport_tests_capabilities.rs
+++ b/crates/csa-executor/src/transport_tests_capabilities.rs
@@ -64,6 +64,7 @@ fn test_create_with_mode_explicit_override() {
 }
 
 #[test]
+#[cfg(feature = "codex-acp")]
 fn test_create_with_mode_allows_codex_acp() {
     let executor = crate::executor::Executor::Codex {
         model_override: None,
@@ -73,7 +74,27 @@ fn test_create_with_mode_allows_codex_acp() {
 
     let result =
         super::TransportFactory::create_with_mode(&executor, super::TransportMode::Acp, None);
-    assert!(result.is_ok(), "codex ACP transport should be supported");
+    assert!(
+        result.is_ok(),
+        "codex ACP transport should be supported when codex-acp feature is on"
+    );
+}
+
+#[test]
+#[cfg(not(feature = "codex-acp"))]
+fn test_create_with_mode_rejects_codex_acp_without_feature() {
+    let executor = crate::executor::Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
+    };
+
+    let result =
+        super::TransportFactory::create_with_mode(&executor, super::TransportMode::Acp, None);
+    assert!(
+        result.is_err(),
+        "codex ACP transport should be rejected without codex-acp feature"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -82,13 +103,13 @@ fn test_create_with_mode_allows_codex_acp() {
 //
 // Compatibility matrix:
 //
-// | Executor     | Legacy | Acp                       | OpenaiCompat |
-// |--------------|--------|---------------------------| -------------|
-// | ClaudeCode   | Yes    | Yes                       | No           |
-// | Codex        | Yes    | Yes (feature `codex-acp`) | No           |
-// | GeminiCli    | Yes    | Yes                       | No           |
-// | Opencode     | Yes    | No                        | No           |
-// | OpenaiCompat | No     | No                        | Yes          |
+// | Executor     | Legacy | Acp                              | OpenaiCompat |
+// |--------------|--------|----------------------------------| -------------|
+// | ClaudeCode   | Yes    | Yes (feature `claude-code-acp`)  | No           |
+// | Codex        | Yes    | Yes (feature `codex-acp`)        | No           |
+// | GeminiCli    | Yes    | Yes                              | No           |
+// | Opencode     | Yes    | No                               | No           |
+// | OpenaiCompat | No     | No                               | Yes          |
 
 fn make_claude_code() -> crate::executor::Executor {
     crate::executor::Executor::ClaudeCode {
@@ -223,9 +244,18 @@ fn test_matrix_codex_legacy_supported() {
     assert_supported(&make_codex(), super::TransportMode::Legacy);
 }
 
+// ACP for codex requires the `codex-acp` cargo feature (default OFF, gated in
+// favour of native `codex exec resume <id>` per #760 / #1128).
 #[test]
+#[cfg(feature = "codex-acp")]
 fn test_matrix_codex_acp_supported() {
     assert_supported(&make_codex(), super::TransportMode::Acp);
+}
+
+#[test]
+#[cfg(not(feature = "codex-acp"))]
+fn test_matrix_codex_acp_rejected_without_feature() {
+    assert_unsupported(&make_codex(), super::TransportMode::Acp, "codex-acp");
 }
 
 #[test]
@@ -309,6 +339,7 @@ fn test_matrix_openai_compat_acp_rejected() {
 }
 
 #[test]
+#[cfg(feature = "codex-acp")]
 fn test_create_feature_gate_structured_error() {
     let executor = crate::executor::Executor::Codex {
         model_override: None,
@@ -319,7 +350,33 @@ fn test_create_feature_gate_structured_error() {
     };
 
     let result = super::TransportFactory::create(&executor, None);
-    assert!(result.is_ok(), "codex ACP transport should build in auto mode");
+    assert!(
+        result.is_ok(),
+        "codex ACP transport should build in auto mode when codex-acp feature is on"
+    );
+}
+
+#[test]
+#[cfg(not(feature = "codex-acp"))]
+fn test_create_feature_gate_codex_acp_errors_without_feature() {
+    let executor = crate::executor::Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: crate::codex_runtime::CodexRuntimeMetadata::from_transport(
+            crate::codex_runtime::CodexTransport::Acp,
+        ),
+    };
+
+    let result = super::TransportFactory::create(&executor, None);
+    assert!(
+        result.is_err(),
+        "codex ACP transport must error in auto mode without codex-acp feature"
+    );
+    let msg = format!("{:#}", result.err().unwrap());
+    assert!(
+        msg.contains("codex-acp") || msg.contains("760") || msg.contains("1128"),
+        "error should mention the feature flag or issue number; got: {msg}"
+    );
 }
 
 #[test]

--- a/crates/csa-executor/src/transport_tests_ephemeral.rs
+++ b/crates/csa-executor/src/transport_tests_ephemeral.rs
@@ -197,6 +197,7 @@ fn test_executor_ephemeral_transport_honors_codex_cli_runtime_transport_override
 }
 
 #[test]
+#[cfg(feature = "codex-acp")]
 fn test_executor_ephemeral_transport_honors_codex_acp_runtime_transport_override() {
     let acp_executor = Executor::Codex {
         model_override: None,
@@ -211,5 +212,29 @@ fn test_executor_ephemeral_transport_honors_codex_acp_runtime_transport_override
     assert!(
         acp_transport.as_ref().as_any().is::<AcpTransport>(),
         "codex acp override should keep ephemeral paths on AcpTransport"
+    );
+}
+
+/// Without the `codex-acp` feature the ephemeral path must reject ACP for
+/// codex (mirrors #760 / #1128 transport flip).
+#[test]
+#[cfg(not(feature = "codex-acp"))]
+fn test_executor_ephemeral_transport_rejects_codex_acp_without_feature() {
+    let acp_executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: crate::codex_runtime::CodexRuntimeMetadata::from_transport(
+            crate::codex_runtime::CodexTransport::Acp,
+        ),
+    };
+    let result = acp_executor.transport(None);
+    assert!(
+        result.is_err(),
+        "codex+ACP must be rejected without codex-acp feature"
+    );
+    let msg = format!("{:#}", result.err().unwrap());
+    assert!(
+        msg.contains("codex-acp") || msg.contains("760") || msg.contains("1128"),
+        "error must cite the feature flag or issue number; got: {msg}"
     );
 }

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -36,17 +36,20 @@ fn test_transport_factory_create_routes_tools_to_expected_transport() {
         "Expected ClaudeCodeCliTransport for claude-code default"
     );
 
-    // codex still uses ACP by default
+    // codex defaults to CLI transport now (#760 / #1128 transport flip).
+    // Use explicit Cli metadata to represent the "user did not request ACP" case.
     let codex_executor = Executor::Codex {
         model_override: None,
         thinking_budget: None,
-        runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
+        runtime_metadata: crate::codex_runtime::CodexRuntimeMetadata::from_transport(
+            crate::codex_runtime::CodexTransport::Cli,
+        ),
     };
     let transport = TransportFactory::create(&codex_executor, Some(SessionConfig::default()))
-        .expect("transport should build for Codex+Acp");
+        .expect("transport should build for Codex+Cli");
     assert!(
-        transport.as_ref().as_any().is::<AcpTransport>(),
-        "Expected AcpTransport for codex"
+        transport.as_ref().as_any().is::<LegacyTransport>(),
+        "Expected LegacyTransport for codex default"
     );
 }
 
@@ -140,7 +143,11 @@ fn test_transport_factory_create_honors_claude_cli_runtime_transport_override() 
     );
 }
 
+/// With `codex-acp` feature ON, an explicit ACP override on a codex executor
+/// must produce an `AcpTransport` instance — the override path is the only way
+/// to opt into ACP after the #760 / #1128 transport flip.
 #[test]
+#[cfg(feature = "codex-acp")]
 fn test_transport_factory_create_honors_codex_acp_runtime_transport_override() {
     let acp_executor = Executor::Codex {
         model_override: None,
@@ -150,10 +157,35 @@ fn test_transport_factory_create_honors_codex_acp_runtime_transport_override() {
         ),
     };
     let acp_transport = TransportFactory::create(&acp_executor, Some(SessionConfig::default()))
-        .expect("transport should build");
+        .expect("transport should build with codex-acp feature");
     assert!(
         acp_transport.as_ref().as_any().is::<AcpTransport>(),
         "codex acp override should use AcpTransport"
+    );
+}
+
+/// Without `codex-acp` feature, an explicit ACP override on a codex executor
+/// must fail at factory time — the feature gate is the safety net for
+/// #760 / #1128 (CLI is now the empirically-equivalent default).
+#[test]
+#[cfg(not(feature = "codex-acp"))]
+fn test_transport_factory_create_rejects_codex_acp_override_without_feature() {
+    let acp_executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: crate::codex_runtime::CodexRuntimeMetadata::from_transport(
+            crate::codex_runtime::CodexTransport::Acp,
+        ),
+    };
+    let result = TransportFactory::create(&acp_executor, Some(SessionConfig::default()));
+    assert!(
+        result.is_err(),
+        "factory should reject Codex+Acp override without codex-acp feature"
+    );
+    let msg = format!("{:#}", result.err().unwrap());
+    assert!(
+        msg.contains("codex-acp") || msg.contains("760") || msg.contains("1128"),
+        "error should mention the feature flag or issue; got: {msg}"
     );
 }
 


### PR DESCRIPTION
## Summary

Mirrors PR #1120's pattern for codex. The default codex transport is now CLI; the ACP path requires the `codex-acp` cargo feature.

This concludes step 3 of #760's CLI-only-transport deprecation roadmap for the second of four CSA tools (claude-code in #1120 was the first).

## Why now

Empirical evaluation in #760 (comment 2026-04-25) and the issue body of #1128 confirmed:

- codex-cli 0.125.0 ships native `codex exec resume <session_id>` with full JSONL stream + last-message file output.
- CSA's CLI transport for codex was already wired (`crates/csa-executor/src/executor.rs:615,663-664` already emits `codex exec resume <session_id>`).
- `crates/csa-executor/src/codex_runtime.rs:81-83` already scaffolded the `codex-acp` cargo feature.
- Empirical resume turn cached **44,800 of 83,503 input tokens (54%)** — equivalent to ACP's `loadSession` primitive.

Only the default flip + `#[cfg(feature = "codex-acp")]` gating remained.

## Changes

- `crates/csa-executor/Cargo.toml` — promoted `codex-acp` to opt-in (default features no longer include it)
- `crates/csa-executor/src/codex_runtime.rs` — routing comment + `codex-acp` gate documentation matching `claude_runtime.rs`
- `crates/csa-executor/src/transport_factory.rs` — `mode_for_executor` routes codex through `TransportMode::Legacy` (CLI) by default; `Acp` only when explicitly requested AND feature is compiled in. `enforce_tool_enabled` returns clear error when codex requests ACP without the feature.
- `crates/csa-config/src/config_tool.rs` + `validate.rs` — codex now accepts `transport = "auto" | "cli"` by default; `"acp"` requires the `codex-acp` feature.
- `crates/cli-sub-agent/src/doctor_routing.rs` — extended doctor reporting to include codex's transport defaults, mirroring the claude-code reporting path.
- 12 test files cover both feature-on and feature-off configurations across executor, config validation, doctor display, and pipeline integration.

## Verification

- `cargo build -p csa-executor` (default features → ACP NOT compiled) ✅
- `cargo build -p csa-executor --features codex-acp` (feature ON → ACP compiled) ✅
- `cargo test -p csa-executor` ✅
- `cargo test -p csa-executor --features codex-acp` ✅
- `cargo build --workspace` ✅
- `just pre-commit` exits 0

## Out of scope

- **`codex-pty-fork` retirement** — `codex exec resume` appends to the SAME thread (not an independent child). For CSA's logical "native fork" with isolated child JSONL, the existing `codex-pty-fork` (PTY hack) is still the only working primitive. Flipping the default transport does not depend on this — `codex-pty-fork` stays as-is.
- **gemini-cli / opencode** ACP feature gating — covered by future #760 child issues.
- **Upstream codex teardown race** (`failed to record rollout items: thread <id> not found` on subprocess teardown — JSONL still written; will file at openai/codex-cli when capacity allows).

Closes #1128
Refs: #760 #1120 #1115 #1117 #1119
