### PR TITLE
fix(dev2merge): guard step 7 brief-specificity grep against pipefail (closes #1133)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.572"
+version = "0.1.573"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.572"
+version = "0.1.573"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -232,7 +232,7 @@ PLAN_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail
 # pins down concrete file:line targets, the planner does not need a debate-
 # loop to decide change shape — light intensity is enough.
 FEATURE_INPUT_LEN=${#FEATURE_INPUT}
-FEATURE_FILE_LINE_HITS="$(printf '%s' "${FEATURE_INPUT}" | grep -oE '[A-Za-z0-9_./-]+\.(rs|toml|md):[0-9]+' | wc -l | xargs)"
+FEATURE_FILE_LINE_HITS="$(printf '%s' "${FEATURE_INPUT}" | grep -oE '[A-Za-z0-9_./-]+\.(rs|toml|md):[0-9]+' | wc -l | xargs || true)"
 # Audit note: empty diff also lands in "light", but that is fine here because this
 # block only chooses mktd intensity after Step 2 has already forced the full plan path.
 if [ "${FEATURE_INPUT_LEN}" -lt 4096 ] && [ "${FEATURE_FILE_LINE_HITS}" -ge 2 ]; then

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -299,7 +299,7 @@ PLAN_INSERTIONS="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | tail
 # pins down concrete file:line targets, the planner does not need a debate-
 # loop to decide change shape — light intensity is enough.
 FEATURE_INPUT_LEN=${#FEATURE_INPUT}
-FEATURE_FILE_LINE_HITS="$(printf '%s' "${FEATURE_INPUT}" | grep -oE '[A-Za-z0-9_./-]+\.(rs|toml|md):[0-9]+' | wc -l | xargs)"
+FEATURE_FILE_LINE_HITS="$(printf '%s' "${FEATURE_INPUT}" | grep -oE '[A-Za-z0-9_./-]+\.(rs|toml|md):[0-9]+' | wc -l | xargs || true)"
 # Audit note: empty diff also lands in "light", but that is fine here because this
 # block only chooses mktd intensity after Step 2 has already forced the full plan path.
 if [ "${FEATURE_INPUT_LEN}" -lt 4096 ] && [ "${FEATURE_FILE_LINE_HITS}" -ge 2 ]; then


### PR DESCRIPTION
## Summary

`patterns/dev2merge/workflow.toml` step 7's brief-specificity heuristic dies in <0.1s when the FEATURE_INPUT brief contains no `path/file.{rs,toml,md}:NUM` patterns. Cause: `set -euo pipefail` + an un-guarded `grep -oE | wc -l | xargs` chain. Fix: append `|| true` to the substitution.

## Why

dev2merge is the canonical user pipeline pinned in CLAUDE.md. Briefs written with English narrative file references ("see SKILL.md line 124") instead of `SKILL.md:124` format trip pipefail and crash before mktd is even invoked. The sibling `PLAN_CODE_FILES` and `PLAN_INSERTIONS` heuristics already have guards (`|| true`, `|| echo 0`); the brief-specificity heuristic was added later without one.

Hit while clearing #1132 — the brief used markdown narrative format, dev2merge died at step 7 with no actionable diagnostic.

## Changes

- `patterns/dev2merge/workflow.toml` step 7 — add `|| true` at the end of the `FEATURE_FILE_LINE_HITS` substitution.
- `patterns/dev2merge/PATTERN.md` — sync per rule 027 if it documents the heuristic; otherwise no doc change needed.

## Verification

- `cargo build --workspace` ✓
- `just pre-commit` ✓
- Pre-PR local review: PASS (gemini-cli, 1 iteration, session `01KQ4504MGE085RMQ139Z35KN4`)
- Smoke (manual after merge): brief without `file.ext:NUM` patterns no longer crashes step 7

## Out of scope

- mktd step 13 (Save TODO) 0.00s fail observed in light mode — separate bug, will be filed separately.
- PR-1 daemon flip (#1130 / #1131) — works correctly; this bug is upstream of nested csa plan run.

Closes #1133