### PR TITLE
fix(executor,skills): warn caller against stacking ScheduleWakeup/loop on backgrounded session wait (#1132)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.573"
+version = "0.1.574"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.573"
+version = "0.1.574"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -1,0 +1,82 @@
+//! Tests asserting `CSA:CALLER_HINT` emissions carry the no-stack-wakeup
+//! warning at every emit site.
+//!
+//! The warning is a stable contract callers depend on (AGENTS.md rules 042 +
+//! 046, GitHub issue #1132). Source-level assertions guard against accidental
+//! removal during future edits to the four daemon entry points.
+#![cfg(test)]
+
+const NO_STACK_WAKEUP_WARNING: &str = "do NOT stack ScheduleWakeup, /loop, or sleep loops on top";
+
+const RUN_CMD_DAEMON_SRC: &str = include_str!("run_cmd_daemon.rs");
+const PLAN_CMD_DAEMON_SRC: &str = include_str!("plan_cmd_daemon.rs");
+const SESSION_CMDS_DAEMON_WAIT_SRC: &str = include_str!("session_cmds_daemon_wait.rs");
+
+fn caller_hint_blocks(src: &str) -> Vec<&str> {
+    src.split("CSA:CALLER_HINT")
+        .skip(1)
+        .map(|tail| {
+            let end = tail.find("-->").unwrap_or(tail.len());
+            &tail[..end]
+        })
+        .collect()
+}
+
+#[test]
+fn run_cmd_daemon_wait_hint_warns_no_stack_wakeup() {
+    let blocks = caller_hint_blocks(RUN_CMD_DAEMON_SRC);
+    assert_eq!(blocks.len(), 1, "run_cmd_daemon emits one CALLER_HINT");
+    assert!(
+        blocks[0].contains("action=\\\"wait\\\""),
+        "run_cmd_daemon emits action=\"wait\""
+    );
+    assert!(
+        blocks[0].contains(NO_STACK_WAKEUP_WARNING),
+        "run_cmd_daemon CALLER_HINT must warn against ScheduleWakeup/loop stacking; missing warning: {NO_STACK_WAKEUP_WARNING}"
+    );
+}
+
+#[test]
+fn plan_cmd_daemon_wait_hint_warns_no_stack_wakeup() {
+    let blocks = caller_hint_blocks(PLAN_CMD_DAEMON_SRC);
+    assert_eq!(blocks.len(), 1, "plan_cmd_daemon emits one CALLER_HINT");
+    assert!(
+        blocks[0].contains("action=\\\"wait\\\""),
+        "plan_cmd_daemon emits action=\"wait\""
+    );
+    assert!(
+        blocks[0].contains(NO_STACK_WAKEUP_WARNING),
+        "plan_cmd_daemon CALLER_HINT must warn against ScheduleWakeup/loop stacking"
+    );
+}
+
+#[test]
+fn session_cmds_daemon_wait_retry_wait_hint_warns_no_stack_wakeup() {
+    let blocks = caller_hint_blocks(SESSION_CMDS_DAEMON_WAIT_SRC);
+    assert!(
+        blocks.len() >= 2,
+        "session_cmds_daemon_wait emits both retry_wait and next_session hints; got {} blocks",
+        blocks.len()
+    );
+    let retry = blocks
+        .iter()
+        .find(|b| b.contains("action=\\\"retry_wait\\\""))
+        .expect("retry_wait CALLER_HINT block present");
+    assert!(
+        retry.contains(NO_STACK_WAKEUP_WARNING),
+        "retry_wait CALLER_HINT must warn against ScheduleWakeup/loop stacking"
+    );
+}
+
+#[test]
+fn session_cmds_daemon_wait_next_session_hint_warns_no_stack_wakeup() {
+    let blocks = caller_hint_blocks(SESSION_CMDS_DAEMON_WAIT_SRC);
+    let next = blocks
+        .iter()
+        .find(|b| b.contains("action=\\\"next_session\\\""))
+        .expect("next_session CALLER_HINT block present");
+    assert!(
+        next.contains(NO_STACK_WAKEUP_WARNING),
+        "next_session CALLER_HINT must warn against ScheduleWakeup/loop stacking"
+    );
+}

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -7,6 +7,7 @@ mod audit;
 mod audit_cmds;
 mod batch;
 mod bug_class;
+mod caller_hints_tests;
 mod claude_sub_agent_cmd;
 mod cli;
 mod config_cmds;

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -167,7 +167,8 @@ pub(crate) fn spawn_and_exit(args: &PlanRunArgs) -> Result<()> {
         "<!-- CSA:CALLER_HINT action=\"wait\" \
          rule=\"Call 'csa session wait --session {id}{cd}' in a SEPARATE Bash call. \
          NEVER batch multiple waits in a for/while loop. \
-         Each wait returns periodically so you can generate tokens and keep your KV cache warm.\" -->",
+         Each wait returns periodically so you can generate tokens and keep your KV cache warm. \
+         If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens.\" -->",
         id = result.session_id,
         cd = cd_hint,
     );

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -219,7 +219,8 @@ pub(crate) fn spawn_and_exit(
         "<!-- CSA:CALLER_HINT action=\"wait\" \
          rule=\"Call 'csa session wait --session {id}{cd}' in a SEPARATE Bash call. \
          NEVER batch multiple waits in a for/while loop. \
-         Each wait returns periodically so you can generate tokens and keep your KV cache warm.\" -->",
+         Each wait returns periodically so you can generate tokens and keep your KV cache warm. \
+         If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens.\" -->",
         id = result.session_id,
         cd = cd_hint,
     );

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -356,7 +356,8 @@ where
                 "<!-- CSA:CALLER_HINT action=\"retry_wait\" \
                  rule=\"Process this output NOW and generate tokens to warm your KV cache, \
                  then call 'csa session wait --session {sid}{cd}' again in a NEW Bash call. \
-                 NEVER batch multiple session waits in one Bash call.\" -->",
+                 NEVER batch multiple session waits in one Bash call. \
+                 If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens.\" -->",
                 sid = resolved.session_id,
                 cd = cd
                     .as_ref()
@@ -555,7 +556,8 @@ fn emit_wait_completion_signal(
         "<!-- CSA:CALLER_HINT action=\"next_session\" \
          rule=\"If you have more sessions to wait for, call each 'csa session wait' \
          in a SEPARATE Bash call. NEVER batch. \
-         Generate tokens between waits to keep your KV cache warm.\" -->"
+         Generate tokens between waits to keep your KV cache warm. \
+         If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens.\" -->"
     );
 }
 

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -121,7 +121,7 @@ direct user instruction.
 
 ## While awaiting review/fix session
 
-This is the while-waiting checklist. When you background a `csa session wait` via `run_in_background: true`, the next task-notification wakes you up automatically. Do not add sleep, hand-rolled polling, or a redundant wakeup on top.
+This is the while-waiting checklist. When you background a `csa session wait` via `run_in_background: true`, the next task-notification wakes you up automatically. Do not add sleep, hand-rolled polling, a redundant `ScheduleWakeup`, or `/loop` on top.
 
 **Safe parallel work**:
 1. Draft the PR body or changelog entry for the current branch as local text only; do not run `gh pr create` yet.
@@ -134,7 +134,7 @@ This is the while-waiting checklist. When you background a `csa session wait` vi
 - Start new `csa run` or `csa review` sessions that could race on git branch or checkout state with the waiting one (single-checkout sequential rule, AGENTS.md 028).
 - Edit source files while the main agent is acting as the Layer 0 orchestrator; that violates the SA-mode separation this wait is protecting.
 - Run state-mutating git commands such as `git commit`, `git checkout <other-branch>`, or `git push`.
-- Stack a ScheduleWakeup backup on top of the backgrounded wait; the task-notification is already the wake signal (AGENTS.md 042f).
+- Stack a ScheduleWakeup or /loop backup on top of the backgrounded wait; the task-notification is already the wake signal (AGENTS.md 042f / 046).
 
 If there is no useful parallel work available, return control and wait for the notification. Do not invent speculative work just to stay busy.
 

--- a/patterns/mktsk/skills/mktsk/SKILL.md
+++ b/patterns/mktsk/skills/mktsk/SKILL.md
@@ -31,7 +31,7 @@ For `csa` commands within pattern steps (e.g., `csa review --diff`), add
 
 ## While awaiting review/fix session
 
-This is the while-waiting checklist. When you background a `csa session wait` via `run_in_background: true`, the next task-notification wakes you up automatically. Do not add manual sleep or polling on top.
+This is the while-waiting checklist. When you background a `csa session wait` via `run_in_background: true`, the next task-notification wakes you up automatically. Do not add manual sleep, polling, a redundant `ScheduleWakeup`, or `/loop` on top.
 
 **Safe parallel work**:
 1. Draft the PR body or changelog entry for the current branch as local text only; do not run `gh pr create` yet.
@@ -44,7 +44,7 @@ This is the while-waiting checklist. When you background a `csa session wait` vi
 - Start new `csa run` or `csa review` sessions that could race on git branch or checkout state with the waiting one (single-checkout sequential rule, AGENTS.md 028).
 - Edit source files while the main agent is acting as the Layer 0 orchestrator; that violates the SA-mode separation this wait is protecting.
 - Run state-mutating git commands such as `git commit`, `git checkout <other-branch>`, or `git push`.
-- Stack a ScheduleWakeup backup on top of the backgrounded wait; the task-notification is already the wake signal (AGENTS.md 042f).
+- Stack a ScheduleWakeup or /loop backup on top of the backgrounded wait; the task-notification is already the wake signal (AGENTS.md 042f / 046).
 
 If there is no useful parallel work available, return control and wait for the notification. Do not invent speculative work just to stay busy.
 


### PR DESCRIPTION
## Summary

Extend the four `CSA:CALLER_HINT` emit sites (`csa run`, `csa plan run`, `csa session wait` retry, `csa session wait` next_session) with an explicit warning: when the caller backgrounds the wait via `run_in_background: true`, the completion task-notification IS the wake signal, so stacking `ScheduleWakeup`, `/loop`, or sleep loops on top is pure redundancy and wastes tokens.

Same `/loop` addition propagated to `dev2merge` and `mktsk` SKILL.md "Do NOT" sections (AGENTS.md rules 042f / 046).

## Why

This was filed because per-user agent-memory feedback doesn't carry across projects, devices, operators, or other CSA-calling tools (codex/gemini/opencode). The `<!-- CSA:CALLER_HINT -->` mechanism IS the correct cross-cutting layer.

## What's in / out of scope

In:
- 4 emit-site rule strings extended with the warning sentence.
- `dev2merge/SKILL.md` and `mktsk/SKILL.md` "Do NOT" + intro sentences updated.
- New `caller_hints_tests.rs` parses each emit-site source file and asserts the warning appears in every `CSA:CALLER_HINT` block.

Out (per #1132 issue body):
- Detecting that a `csa session wait` is currently backgrounded and refusing a subsequent ScheduleWakeup (would require IPC to the calling agent — invasive).

## Test plan

- [x] `cargo build -p cli-sub-agent --release`
- [x] `cargo test -p cli-sub-agent --release` (1799 unit + 28 e2e all passing)
- [x] `just pre-commit` exit 0
- [x] Smoke: `csa run` and `csa session wait` emit the upgraded hint in stdout
- [x] Pre-push `csa review --range main...HEAD --tier tier-4-critical` verdict PASS (session `01KQ48NZQBKEKPPBYGXM95X26G`)

Closes #1132