### PR TITLE
test(caller_hints): harden caller_hint_blocks helper against spurious comment matches (closes #1136)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.574"
+version = "0.1.575"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.574"
+version = "0.1.575"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -12,14 +12,47 @@ const RUN_CMD_DAEMON_SRC: &str = include_str!("run_cmd_daemon.rs");
 const PLAN_CMD_DAEMON_SRC: &str = include_str!("plan_cmd_daemon.rs");
 const SESSION_CMDS_DAEMON_WAIT_SRC: &str = include_str!("session_cmds_daemon_wait.rs");
 
+/// Extract the body of every `<!-- CSA:CALLER_HINT action=... -->` block in a
+/// source string.
+///
+/// Splits on the literal prefix `<!-- CSA:CALLER_HINT` (the emitted marker is
+/// the only legitimate occurrence of this exact prefix) so that incidental
+/// mentions of `CSA:CALLER_HINT` in comments or doc-strings cannot produce
+/// spurious matches and break the contract assertions in this module.
 fn caller_hint_blocks(src: &str) -> Vec<&str> {
-    src.split("CSA:CALLER_HINT")
+    src.split("<!-- CSA:CALLER_HINT")
         .skip(1)
         .map(|tail| {
             let end = tail.find("-->").unwrap_or(tail.len());
             &tail[..end]
         })
         .collect()
+}
+
+#[test]
+fn caller_hint_blocks_ignores_unrelated_mentions_in_comments() {
+    // A doc/line comment that mentions the marker name MUST NOT be parsed
+    // as a hint block; only the exact emitted marker prefix counts.
+    let src = r#"
+        // see CSA:CALLER_HINT for the wire-format spec
+        /// CSA:CALLER_HINT action="wait" — described elsewhere in docs
+        fn emit() {
+            eprintln!(
+                "<!-- CSA:CALLER_HINT action=\"wait\" \
+                 rule=\"do NOT stack ScheduleWakeup, /loop, or sleep loops on top\" -->"
+            );
+        }
+    "#;
+    let blocks = caller_hint_blocks(src);
+    assert_eq!(
+        blocks.len(),
+        1,
+        "only the eprintln-emitted hint block must be parsed; comments must be ignored"
+    );
+    assert!(
+        blocks[0].contains("action=\\\"wait\\\""),
+        "the parsed block is the real hint, not a comment"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1136 — gemini-code-assist caller_hints_tests.rs review followup from PR #1135.

The original `caller_hint_blocks()` helper split source on the bare string `"CSA:CALLER_HINT"`, which would also match incidental references inside Rust line/doc comments (e.g., a comment that mentions the wire-format spec name). This makes the helper coupling between contract and test fragile to documentation drift.

### Changes
- Switch the split delimiter from `"CSA:CALLER_HINT"` to the more discriminating `"<!-- CSA:CALLER_HINT"` literal — the prefix that is only emitted in real `eprintln!` calls, never in line/doc comments.
- Add regression test `caller_hint_blocks_ignores_unrelated_mentions_in_comments` that covers the exact failure mode (mixing real emissions with `// see CSA:CALLER_HINT` and `/// CSA:CALLER_HINT action="wait"` comments) so future edits can't regress this.

### Why MEDIUM, not blocking PR #1135
Per project severity-tier review policy (HIGH/CRITICAL/P1 block merge; MEDIUM → followup issue; LOW/nit → ignore), gemini-code-assist's MEDIUM finding correctly fed into a followup issue rather than blocking PR #1135's merge. This is the followup PR.

## Test plan
- [x] `cargo test --package cli-sub-agent caller_hints_tests` exit 0 (5 tests pass: 1 new regression + 4 pre-existing source-level assertions)
- [x] `just pre-commit` exit 0 on local
- [x] Push-gate `csa review --range main...HEAD --tier tier-4-critical` returns zero findings at all severities
- [ ] gemini-code-assist cloud review (run via pr-bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)