### PR TITLE
fix(dev2merge): align MKTD_TIMEOUT_SECONDS to csa min_timeout (closes #1137)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.575"
+version = "0.1.576"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.575"
+version = "0.1.576"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
@@ -87,8 +87,8 @@ fn dev2merge_plan_step_has_mktd_timeout_seconds_variable() {
         "Step 7 prompt must wrap `csa plan run` with the shell `timeout` command"
     );
     assert!(
-        prompt.contains("MKTD_TIMEOUT_SECONDS:-600"),
-        "MKTD_TIMEOUT_SECONDS must default to 600 seconds"
+        prompt.contains("MKTD_TIMEOUT_SECONDS:-1800"),
+        "MKTD_TIMEOUT_SECONDS must default to 1800 seconds (aligned with execution.min_timeout_seconds per #1137)"
     );
     assert!(
         prompt.contains("124") && prompt.contains("137"),

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -200,7 +200,8 @@ Tool: bash
 OnFail: abort
 
 Generate a TODO plan via mktd. Hard-capped at `MKTD_TIMEOUT_SECONDS`
-(default `600`s) to prevent runaway debate-loop sub-sessions (#1118).
+(default `1800`s, aligned with `execution.min_timeout_seconds` per #1137) to
+prevent runaway debate-loop sub-sessions (#1118).
 Auto-selects intensity based on:
 
 - **Brief specificity** (#1118 part B): if `FEATURE_INPUT` is short
@@ -217,7 +218,7 @@ CURRENT_BRANCH="$(git branch --show-current)"
 FEATURE_INPUT="${FEATURE_INPUT:-${SCOPE:-current branch changes pending merge}}"
 USER_LANGUAGE_OVERRIDE="${CSA_USER_LANGUAGE:-}"
 MKTD_TOOL_EFFECTIVE="${MKTD_TOOL:-${CSA_MKTD_TOOL:-codex}}" # Default codex; gemini-cli ACP blocked by #778/#755
-MKTD_TIMEOUT_SECONDS="${MKTD_TIMEOUT_SECONDS:-600}" # #1118 part A: hard cap on mktd wall-clock
+MKTD_TIMEOUT_SECONDS="${MKTD_TIMEOUT_SECONDS:-1800}" # #1118 part A + #1137: hard cap on mktd wall-clock, aligned with csa CLI execution.min_timeout_seconds (1800s)
 if [ -n "${MKTD_TOOL_EFFECTIVE}" ]; then
   MKTD_TOOL_ARGS=(--tool "${MKTD_TOOL_EFFECTIVE}")
 else

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -268,7 +268,8 @@ title = "Plan with mktd"
 tool = "bash"
 prompt = '''
 Generate a TODO plan via mktd. Hard-capped at MKTD_TIMEOUT_SECONDS (default
-600s) to prevent runaway debate-loop sub-sessions (#1118). Auto-selects
+1800s, aligned with execution.min_timeout_seconds per #1137) to prevent
+runaway debate-loop sub-sessions (#1118). Auto-selects
 intensity based on:
 
 - **Brief specificity** (#1118 part B): if `FEATURE_INPUT` is short (< 4096
@@ -284,7 +285,7 @@ CURRENT_BRANCH="$(git branch --show-current)"
 FEATURE_INPUT="${FEATURE_INPUT:-${SCOPE:-current branch changes pending merge}}"
 USER_LANGUAGE_OVERRIDE="${CSA_USER_LANGUAGE:-}"
 MKTD_TOOL_EFFECTIVE="${MKTD_TOOL:-${CSA_MKTD_TOOL:-codex}}" # Default codex; gemini-cli ACP blocked by #778/#755
-MKTD_TIMEOUT_SECONDS="${MKTD_TIMEOUT_SECONDS:-600}" # #1118 part A: hard cap on mktd wall-clock
+MKTD_TIMEOUT_SECONDS="${MKTD_TIMEOUT_SECONDS:-1800}" # #1118 part A + #1137: hard cap on mktd wall-clock, aligned with csa CLI execution.min_timeout_seconds (1800s)
 if [ -n "${MKTD_TOOL_EFFECTIVE}" ]; then
   MKTD_TOOL_ARGS=(--tool "${MKTD_TOOL_EFFECTIVE}")
 else


### PR DESCRIPTION
## Summary

Fixes #1137 — dev2merge step 7 wrapped the inner `csa plan run patterns/mktd/workflow.toml` in a shell `timeout -k 30 600` SIGTERM cap. The inner csa CLI enforces `execution.min_timeout_seconds = 1800` (HARD MINIMUM 30 min); a shorter outer cap silently SIGKILLs the agent before it can produce its `result.toml`, surfacing as a confusing "step 7 failed at 600.12s" without any signal that the kill came from the dev2merge wrapper.

Encountered live during the PR #1132 dev2merge attempt #3 (csa session `01KQ45FGZS560TWZR3THV616H1`).

### Approach

Picks **Option A** from the issue's three choices:
- ✅ A. Align dev2merge cap to csa CLI minimum (1800s) — this PR
- ⏳ B. Pass `--timeout` down explicitly so both layers agree — followup
- ⏳ C. CSA-level nested-timeout supervisor — long-term, tied to #1130 daemon model

A is the quick fix the issue itself recommends; B/C remain as followup work.

### Changes

- `patterns/dev2merge/workflow.toml`: shell init line + Step 7 prompt doc updated to default `1800`
- `patterns/dev2merge/PATTERN.md`: shell init line + Step 7 doc (rule 027 sync)
- `crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs`: assert default `1800`

## Test plan
- [x] `cargo test --package cli-sub-agent dev2merge_plan_step_has_mktd_timeout_seconds_variable` exit 0
- [x] `just pre-commit` exit 0 (28/28 e2e + 836/836 unit)
- [x] Pre-push `csa review --range main...HEAD --tier tier-4-critical` returns PASS verdict, zero findings (session 01KQ4BJ6MZ58TGXMBPE5NC7YW8)
- [ ] gemini-code-assist cloud review (run via pr-bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)