### PR TITLE
fix(review): downgrade Uncertain meta to Pass when prose says PASS/CLEAN (closes #1140)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.576"
+version = "0.1.577"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.576"
+version = "0.1.577"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -592,13 +592,19 @@ fn derive_decision_from_severity_counts(
         return Ok(ReviewDecision::Fail);
     }
 
-    // Preserve non-fail meta decisions (skip, uncertain, unavailable) as-is:
-    // these represent infrastructure/scope signals, not finding-based verdicts.
-    if let Some(
-        meta @ (ReviewDecision::Skip | ReviewDecision::Uncertain | ReviewDecision::Unavailable),
-    ) = meta_decision
-    {
+    // Skip/Unavailable: deliberate infrastructure signals, propagate as-is.
+    if let Some(meta @ (ReviewDecision::Skip | ReviewDecision::Unavailable)) = meta_decision {
         return Ok(meta);
+    }
+    // Uncertain (#1140): downgrade to Pass only when prose clearly says
+    // PASS/CLEAN; otherwise preserve Uncertain so callers don't merge on
+    // incomplete evidence.
+    if meta_decision == Some(ReviewDecision::Uncertain) {
+        return Ok(if prose_clean_check()? {
+            ReviewDecision::Pass
+        } else {
+            ReviewDecision::Uncertain
+        });
     }
 
     // At this point: zero severity counts, empty findings, non-severe overall_risk,

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -24,6 +24,12 @@ pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
             ]
             .iter()
             .any(|noun| lower.contains(noun)))
+        || verdict_token_pass_or_clean(text)
+}
+
+fn verdict_token_pass_or_clean(text: &str) -> bool {
+    text.split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .any(|part| part.eq_ignore_ascii_case("PASS") || part.eq_ignore_ascii_case("CLEAN"))
 }
 
 pub(super) fn review_contains_prose_clean_conclusion(session_dir: &Path) -> Result<bool> {

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -28,8 +28,12 @@ pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
 }
 
 fn verdict_token_pass_or_clean(text: &str) -> bool {
+    // Strict uppercase match: avoid false positives in negative prose like
+    // "cannot pass yet" / "result is not clean" where the token appears
+    // lowercase. Real verdict prose ("Verdict: PASS", "The review is PASS")
+    // uppercases the token.
     text.split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
-        .any(|part| part.eq_ignore_ascii_case("PASS") || part.eq_ignore_ascii_case("CLEAN"))
+        .any(|part| part == "PASS" || part == "CLEAN")
 }
 
 pub(super) fn review_contains_prose_clean_conclusion(session_dir: &Path) -> Result<bool> {
@@ -143,4 +147,42 @@ fn contains_positive_no_issue_clause(lower: &str) -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::verdict_token_pass_or_clean;
+
+    #[test]
+    fn verdict_token_uppercase_pass_matches() {
+        assert!(verdict_token_pass_or_clean("Verdict: PASS"));
+        assert!(verdict_token_pass_or_clean("The review is PASS."));
+        assert!(verdict_token_pass_or_clean("PASS"));
+    }
+
+    #[test]
+    fn verdict_token_uppercase_clean_matches() {
+        assert!(verdict_token_pass_or_clean("Verdict: CLEAN"));
+        assert!(verdict_token_pass_or_clean("Status: CLEAN."));
+        assert!(verdict_token_pass_or_clean("CLEAN"));
+    }
+
+    #[test]
+    fn verdict_token_lowercase_negative_prose_does_not_match() {
+        // codex finding: prior eq_ignore_ascii_case impl misclassified these
+        // as clean conclusions and unblocked merges on uncertain evidence.
+        assert!(!verdict_token_pass_or_clean(
+            "review incomplete, cannot pass yet"
+        ));
+        assert!(!verdict_token_pass_or_clean("result is not clean"));
+        assert!(!verdict_token_pass_or_clean(
+            "I'll pass on judging this until tests run"
+        ));
+    }
+
+    #[test]
+    fn verdict_token_mixed_case_does_not_match() {
+        assert!(!verdict_token_pass_or_clean("Verdict: Pass"));
+        assert!(!verdict_token_pass_or_clean("Status: Clean"));
+    }
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -28,12 +28,58 @@ pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
 }
 
 fn verdict_token_pass_or_clean(text: &str) -> bool {
-    // Strict uppercase match: avoid false positives in negative prose like
-    // "cannot pass yet" / "result is not clean" where the token appears
-    // lowercase. Real verdict prose ("Verdict: PASS", "The review is PASS")
-    // uppercases the token.
-    text.split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
-        .any(|part| part == "PASS" || part == "CLEAN")
+    text.lines().any(|line| {
+        let trimmed = line.trim();
+        is_verdict_token(trimmed) || line_has_labeled_verdict_token(trimmed)
+    })
+}
+
+fn is_verdict_token(text: &str) -> bool {
+    matches!(text, "PASS" | "CLEAN")
+}
+
+fn line_has_labeled_verdict_token(line: &str) -> bool {
+    const LABELS: &[&str] = &["Verdict:", "Decision:", "Status:", "Result:", "Review:"];
+
+    let bytes = line.as_bytes();
+    for index in 0..bytes.len() {
+        if index > 0 && is_ascii_word_byte(bytes[index - 1]) {
+            continue;
+        }
+
+        for label in LABELS {
+            let label_bytes = label.as_bytes();
+            if bytes[index..].len() < label_bytes.len() {
+                continue;
+            }
+            if bytes[index..index + label_bytes.len()].eq_ignore_ascii_case(label_bytes)
+                && has_verdict_token_prefix(line[index + label_bytes.len()..].trim_start())
+            {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn has_verdict_token_prefix(text: &str) -> bool {
+    ["PASS", "CLEAN"].iter().any(|token| {
+        let Some(rest) = text.strip_prefix(token) else {
+            return false;
+        };
+        rest.chars()
+            .next()
+            .is_none_or(|next| !is_verdict_token_continuation(next))
+    })
+}
+
+fn is_verdict_token_continuation(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '-'
+}
+
+fn is_ascii_word_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 pub(super) fn review_contains_prose_clean_conclusion(session_dir: &Path) -> Result<bool> {
@@ -156,7 +202,6 @@ mod tests {
     #[test]
     fn verdict_token_uppercase_pass_matches() {
         assert!(verdict_token_pass_or_clean("Verdict: PASS"));
-        assert!(verdict_token_pass_or_clean("The review is PASS."));
         assert!(verdict_token_pass_or_clean("PASS"));
     }
 
@@ -168,9 +213,27 @@ mod tests {
     }
 
     #[test]
+    fn verdict_token_label_is_case_insensitive() {
+        assert!(verdict_token_pass_or_clean("decision: PASS"));
+        assert!(verdict_token_pass_or_clean("RESULT: CLEAN"));
+        assert!(verdict_token_pass_or_clean("Review: PASS"));
+    }
+
+    #[test]
+    fn verdict_token_standalone_pass_line_matches() {
+        assert!(verdict_token_pass_or_clean("details\nPASS\nnotes"));
+    }
+
+    #[test]
+    fn verdict_token_labeled_clean_with_punctuation_matches() {
+        assert!(verdict_token_pass_or_clean("Status: CLEAN."));
+    }
+
+    #[test]
     fn verdict_token_lowercase_negative_prose_does_not_match() {
         // codex finding: prior eq_ignore_ascii_case impl misclassified these
         // as clean conclusions and unblocked merges on uncertain evidence.
+        assert!(!verdict_token_pass_or_clean("cannot pass yet"));
         assert!(!verdict_token_pass_or_clean(
             "review incomplete, cannot pass yet"
         ));
@@ -184,5 +247,34 @@ mod tests {
     fn verdict_token_mixed_case_does_not_match() {
         assert!(!verdict_token_pass_or_clean("Verdict: Pass"));
         assert!(!verdict_token_pass_or_clean("Status: Clean"));
+    }
+
+    #[test]
+    fn verdict_token_hyphenated_bypass_does_not_match() {
+        assert!(!verdict_token_pass_or_clean("BY-PASS"));
+    }
+
+    #[test]
+    fn verdict_token_hyphenated_pass_fail_does_not_match() {
+        assert!(!verdict_token_pass_or_clean("PASS-FAIL criteria"));
+    }
+
+    #[test]
+    fn verdict_token_unlabeled_pass_sentence_does_not_match() {
+        assert!(!verdict_token_pass_or_clean("The review is PASS."));
+        assert!(!verdict_token_pass_or_clean("The test PASS rate is 100%"));
+    }
+
+    #[test]
+    fn verdict_token_unlabeled_clean_imperative_does_not_match() {
+        assert!(!verdict_token_pass_or_clean(
+            "Please CLEAN the build directory"
+        ));
+    }
+
+    #[test]
+    fn verdict_token_labeled_compound_does_not_match() {
+        assert!(!verdict_token_pass_or_clean("Verdict: PASS-FAIL"));
+        assert!(!verdict_token_pass_or_clean("Status: CLEAN_UP"));
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -75,7 +75,7 @@ fn has_verdict_token_prefix(text: &str) -> bool {
 }
 
 fn is_verdict_token_continuation(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '_' || c == '-'
+    c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '/'
 }
 
 fn is_ascii_word_byte(byte: u8) -> bool {
@@ -276,5 +276,13 @@ mod tests {
     fn verdict_token_labeled_compound_does_not_match() {
         assert!(!verdict_token_pass_or_clean("Verdict: PASS-FAIL"));
         assert!(!verdict_token_pass_or_clean("Status: CLEAN_UP"));
+    }
+
+    #[test]
+    fn verdict_token_labeled_slash_compound_does_not_match() {
+        // gemini round-2 finding: PASS/FAIL list-of-criteria phrasing must not
+        // be treated as a verdict declaration.
+        assert!(!verdict_token_pass_or_clean("Verdict: PASS/FAIL"));
+        assert!(!verdict_token_pass_or_clean("Status: CLEAN/DIRTY"));
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
@@ -196,6 +196,8 @@ fn persist_review_verdict_uncertain_meta_without_pass_prose_preserves_uncertain(
         ReviewDecision::Uncertain,
         "Uncertain meta with no PASS/CLEAN prose must remain Uncertain (no silent merge)"
     );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
@@ -107,6 +107,98 @@ fn persist_review_verdict_empty_findings_without_prose_clean_marker_emits_pass()
 }
 
 #[test]
+fn persist_review_verdict_uncertain_meta_with_pass_prose_emits_pass_post_crash() {
+    // #1140: when an upstream crash (e.g. claude-code reviewer-1 EROFS writing
+    // /home/obj/.claude.json after the structured verdict has already been
+    // emitted) flips meta.decision to Uncertain, the synthesizer must trust
+    // the existing severity_counts (all zero) + findings.toml (empty) +
+    // explicit "Verdict: PASS" prose to recover the real verdict. Previously
+    // any Uncertain meta short-circuited the synthesizer and propagated as
+    // Uncertain regardless of the unambiguous structured signals.
+    let session_id = "01TESTUNCERTAINPASSCRASH000";
+    let (_env_lock, project_root, session_dir) = lock_test_session(
+        "persist-review-verdict-uncertain-meta-pass-prose",
+        session_id,
+    );
+    let artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary::default(),
+        "overall_risk": "low"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
+    )
+    .expect("write findings artifact");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nVerdict: PASS. The commit aligns the default timeout with the policy across tests, PATTERN.md, and workflow.toml.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let mut meta = make_review_meta(session_id);
+    meta.decision = ReviewDecision::Uncertain.as_str().to_string();
+    meta.verdict = "UNCERTAIN".to_string();
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "Uncertain meta + zero severity + empty findings + 'Verdict: PASS' prose must downgrade to Pass"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|value| *value == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn persist_review_verdict_uncertain_meta_without_pass_prose_preserves_uncertain() {
+    // #1140 inverse: when meta.decision is Uncertain AND prose offers no
+    // PASS/CLEAN signal, the synthesizer must NOT silently downgrade to Pass.
+    // Preserves the deliberate-uncertainty path for the caller to handle.
+    let session_id = "01TESTUNCERTAINNOSIGNAL0000";
+    let (_env_lock, project_root, session_dir) = lock_test_session(
+        "persist-review-verdict-uncertain-meta-no-signal",
+        session_id,
+    );
+    let artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary::default(),
+        "overall_risk": "low"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
+    )
+    .expect("write findings artifact");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nReview ambiguous; insufficient signal to classify.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let mut meta = make_review_meta(session_id);
+    meta.decision = ReviewDecision::Uncertain.as_str().to_string();
+    meta.verdict = "UNCERTAIN".to_string();
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Uncertain,
+        "Uncertain meta with no PASS/CLEAN prose must remain Uncertain (no silent merge)"
+    );
+}
+
+#[test]
 fn persist_review_verdict_findings_dominate_prose_clean_summary() {
     let session_id = "01TESTFINDINGSDOMINATE000000";
     let (_env_lock, project_root, session_dir) =


### PR DESCRIPTION
## Summary

- Closes #1140: when an upstream crash (e.g. claude-code reviewer-1 EROFS writing `/home/obj/.claude.json` after the structured verdict was already produced) flips `meta.decision` to `Uncertain`, the verdict synthesizer previously short-circuited and propagated `Uncertain` regardless of unambiguous structured signals (zero severity counts, empty `findings.toml`, and explicit "Verdict: PASS" prose). Legitimate green PRs were blocked from ever reaching pr-bot.
- Implements options C+D from the issue: extend prose-clean detection to recognize standalone `PASS`/`CLEAN` verdict tokens, AND make `Uncertain` meta defer to the prose-clean check rather than early-returning.
- `Skip` / `Unavailable` (deliberate infrastructure signals) still propagate as-is — only `Uncertain` participates in the prose tiebreaker.

## Test plan

- [x] `cargo test --bin csa persist_review_verdict_uncertain` — 2 new tests pass.
- [x] `cargo test --bin csa persist_review_verdict` — all 19 tests pass (no regressions).
- [x] `just pre-commit` — full pipeline green (4268 unit + 28 e2e).
- [x] Pre-push `csa review --range main...HEAD --tier tier-4-critical` — PASS gate.
- [ ] `/pr-bot pr=<N>` cloud review — green merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)