### PR TITLE
fix(mktd): use mktemp+csa debate --prompt-file for env-var-safe prompt assembly (closes #1147)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.579"
+version = "0.1.580"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.577"
+version = "0.1.578"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.578"
+version = "0.1.579"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.579"
+version = "0.1.580"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.578"
+version = "0.1.579"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.577"
+version = "0.1.578"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -392,7 +392,7 @@ identifiers, or other shell-sensitive content.
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
 PROMPT_FILE="$(mktemp)" || exit 1
-trap 'rm -f "$PROMPT_FILE"' EXIT
+trap 'rm -f "$PROMPT_FILE"' EXIT INT TERM
 {
   printf '%s\n' "Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate."
   echo ""
@@ -411,7 +411,7 @@ trap 'rm -f "$PROMPT_FILE"' EXIT
   echo ""
   printf '%s\n' "## Output Requirements"
   printf '%s\n' "Provide explicit verdict and confidence in your conclusion."
-} > "$PROMPT_FILE"
+} > "$PROMPT_FILE" || { echo "Failed to write prompt file" >&2; exit 1; }
 SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --prompt-file "$PROMPT_FILE") || { echo "csa debate failed" >&2; exit 1; }
 DEBATE_JSON="$(csa session wait --session "$SID" 2>&1)" || { echo "csa debate failed" >&2; exit 1; }
 [[ -n "${DEBATE_JSON:-}" ]] || { echo "empty debate json output" >&2; exit 1; }

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -391,7 +391,7 @@ identifiers, or other shell-sensitive content.
 
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
-PROMPT_FILE="$(mktemp)"
+PROMPT_FILE="$(mktemp)" || exit 1
 trap 'rm -f "$PROMPT_FILE"' EXIT
 {
   printf '%s\n' "Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate."

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -382,27 +382,37 @@ Run explicit adversarial debate via `csa debate`.
 Capture debate stdout, then normalize into a structured evidence packet
 for mechanical validation in Step 11.
 
+The debate prompt is now written to a temporary file created with `mktemp`,
+then passed through `csa debate --prompt-file "$PROMPT_FILE"` instead of
+embedding the full markdown payload as a single shell argument. This avoids
+bash variable-expansion and shell-quoting hazards when the generated TODO,
+spec, or threat model contains markdown with backticks, dollar-prefixed
+identifiers, or other shell-sensitive content.
+
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
-DEBATE_PROMPT="$(printf '%s\n' \
-"Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate." \
-"" \
-"## Draft TODO Plan" \
-"${STEP_7_OUTPUT}" \
-"" \
-"## Generated Spec (Step 8)" \
-"${STEP_8_OUTPUT}" \
-"" \
-"## Threat Model (Step 9)" \
-"${STEP_9_OUTPUT}" \
-"" \
-"## Required Red-Team Coverage" \
-"Enumerate every assumption made in the TODO plan." \
-"For each assumption, construct at least one scenario where it is false and explain the resulting failure mode or missing mitigation." \
-"" \
-"## Output Requirements" \
-"Provide explicit verdict and confidence in your conclusion." )"
-SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout "${DEBATE_PROMPT}") || { echo "csa debate failed" >&2; exit 1; }
+PROMPT_FILE="$(mktemp)"
+trap 'rm -f "$PROMPT_FILE"' EXIT
+{
+  printf '%s\n' "Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate."
+  echo ""
+  printf '%s\n' "## Draft TODO Plan"
+  printf '%s\n' "${STEP_7_OUTPUT}"
+  echo ""
+  printf '%s\n' "## Generated Spec (Step 8)"
+  printf '%s\n' "${STEP_8_OUTPUT}"
+  echo ""
+  printf '%s\n' "## Threat Model (Step 9)"
+  printf '%s\n' "${STEP_9_OUTPUT}"
+  echo ""
+  printf '%s\n' "## Required Red-Team Coverage"
+  printf '%s\n' "Enumerate every assumption made in the TODO plan."
+  printf '%s\n' "For each assumption, construct at least one scenario where it is false and explain the resulting failure mode or missing mitigation."
+  echo ""
+  printf '%s\n' "## Output Requirements"
+  printf '%s\n' "Provide explicit verdict and confidence in your conclusion."
+} > "$PROMPT_FILE"
+SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --prompt-file "$PROMPT_FILE") || { echo "csa debate failed" >&2; exit 1; }
 DEBATE_JSON="$(csa session wait --session "$SID" 2>&1)" || { echo "csa debate failed" >&2; exit 1; }
 [[ -n "${DEBATE_JSON:-}" ]] || { echo "empty debate json output" >&2; exit 1; }
 RAW_VERDICT="$(printf '%s\n' "${DEBATE_JSON}" | jq -r '.verdict // "UNKNOWN"' | tr '[:lower:]' '[:upper:]')"

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -435,7 +435,7 @@ for mechanical validation in Step 11.
 
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
-PROMPT_FILE="$(mktemp)"
+PROMPT_FILE="$(mktemp)" || exit 1
 trap 'rm -f "$PROMPT_FILE"' EXIT
 {
   printf '%s\n' "Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate."

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -456,7 +456,7 @@ trap 'rm -f "$PROMPT_FILE"' EXIT
   printf '%s\n' "## Output Requirements"
   printf '%s\n' "Provide explicit verdict and confidence in your conclusion."
 } > "$PROMPT_FILE"
-SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --file "$PROMPT_FILE") || { echo "csa debate failed" >&2; exit 1; }
+SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --prompt-file "$PROMPT_FILE") || { echo "csa debate failed" >&2; exit 1; }
 DEBATE_JSON="$(csa session wait --session "$SID" 2>&1)" || { echo "csa debate failed" >&2; exit 1; }
 [[ -n "${DEBATE_JSON:-}" ]] || { echo "empty debate json output" >&2; exit 1; }
 RAW_VERDICT="$(printf '%s\n' "${DEBATE_JSON}" | jq -r '.verdict // "UNKNOWN"' | tr '[:lower:]' '[:upper:]')"

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -435,24 +435,26 @@ for mechanical validation in Step 11.
 
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
-DEBATE_PROMPT="$(printf '%s\n' \
-"Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate." \
-"" \
-"## Draft TODO Plan" \
-"${STEP_7_OUTPUT}" \
-"" \
-"## Generated Spec (Step 8)" \
-"${STEP_8_OUTPUT}" \
-"" \
-"## Threat Model (Step 9)" \
-"${STEP_9_OUTPUT}" \
-"" \
-"## Required Red-Team Coverage" \
-"Enumerate every assumption made in the TODO plan." \
-"For each assumption, construct at least one scenario where it is false and explain the resulting failure mode or missing mitigation." \
-"" \
-"## Output Requirements" \
-"Provide explicit verdict and confidence in your conclusion." )"
+DEBATE_PROMPT="$(cat <<'PROMPT_END'
+Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate.
+
+## Draft TODO Plan
+${STEP_7_OUTPUT}
+
+## Generated Spec (Step 8)
+${STEP_8_OUTPUT}
+
+## Threat Model (Step 9)
+${STEP_9_OUTPUT}
+
+## Required Red-Team Coverage
+Enumerate every assumption made in the TODO plan.
+For each assumption, construct at least one scenario where it is false and explain the resulting failure mode or missing mitigation.
+
+## Output Requirements
+Provide explicit verdict and confidence in your conclusion.
+PROMPT_END
+)"
 SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout "${DEBATE_PROMPT}") || { echo "csa debate failed" >&2; exit 1; }
 DEBATE_JSON="$(csa session wait --session "$SID" 2>&1)" || { echo "csa debate failed" >&2; exit 1; }
 [[ -n "${DEBATE_JSON:-}" ]] || { echo "empty debate json output" >&2; exit 1; }

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -436,7 +436,7 @@ for mechanical validation in Step 11.
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
 PROMPT_FILE="$(mktemp)" || exit 1
-trap 'rm -f "$PROMPT_FILE"' EXIT
+trap 'rm -f "$PROMPT_FILE"' EXIT INT TERM
 {
   printf '%s\n' "Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate."
   echo ""
@@ -455,7 +455,7 @@ trap 'rm -f "$PROMPT_FILE"' EXIT
   echo ""
   printf '%s\n' "## Output Requirements"
   printf '%s\n' "Provide explicit verdict and confidence in your conclusion."
-} > "$PROMPT_FILE"
+} > "$PROMPT_FILE" || { echo "Failed to write prompt file" >&2; exit 1; }
 SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --prompt-file "$PROMPT_FILE") || { echo "csa debate failed" >&2; exit 1; }
 DEBATE_JSON="$(csa session wait --session "$SID" 2>&1)" || { echo "csa debate failed" >&2; exit 1; }
 [[ -n "${DEBATE_JSON:-}" ]] || { echo "empty debate json output" >&2; exit 1; }

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -435,27 +435,28 @@ for mechanical validation in Step 11.
 
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
-DEBATE_PROMPT="$(cat <<'PROMPT_END'
-Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate.
-
-## Draft TODO Plan
-${STEP_7_OUTPUT}
-
-## Generated Spec (Step 8)
-${STEP_8_OUTPUT}
-
-## Threat Model (Step 9)
-${STEP_9_OUTPUT}
-
-## Required Red-Team Coverage
-Enumerate every assumption made in the TODO plan.
-For each assumption, construct at least one scenario where it is false and explain the resulting failure mode or missing mitigation.
-
-## Output Requirements
-Provide explicit verdict and confidence in your conclusion.
-PROMPT_END
-)"
-SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout "${DEBATE_PROMPT}") || { echo "csa debate failed" >&2; exit 1; }
+PROMPT_FILE="$(mktemp)"
+trap 'rm -f "$PROMPT_FILE"' EXIT
+{
+  printf '%s\n' "Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate."
+  echo ""
+  printf '%s\n' "## Draft TODO Plan"
+  printf '%s\n' "${STEP_7_OUTPUT}"
+  echo ""
+  printf '%s\n' "## Generated Spec (Step 8)"
+  printf '%s\n' "${STEP_8_OUTPUT}"
+  echo ""
+  printf '%s\n' "## Threat Model (Step 9)"
+  printf '%s\n' "${STEP_9_OUTPUT}"
+  echo ""
+  printf '%s\n' "## Required Red-Team Coverage"
+  printf '%s\n' "Enumerate every assumption made in the TODO plan."
+  printf '%s\n' "For each assumption, construct at least one scenario where it is false and explain the resulting failure mode or missing mitigation."
+  echo ""
+  printf '%s\n' "## Output Requirements"
+  printf '%s\n' "Provide explicit verdict and confidence in your conclusion."
+} > "$PROMPT_FILE"
+SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --file "$PROMPT_FILE") || { echo "csa debate failed" >&2; exit 1; }
 DEBATE_JSON="$(csa session wait --session "$SID" 2>&1)" || { echo "csa debate failed" >&2; exit 1; }
 [[ -n "${DEBATE_JSON:-}" ]] || { echo "empty debate json output" >&2; exit 1; }
 RAW_VERDICT="$(printf '%s\n' "${DEBATE_JSON}" | jq -r '.verdict // "UNKNOWN"' | tr '[:lower:]' '[:upper:]')"


### PR DESCRIPTION
## Summary

Fixes #1147 — Phase 3 Adversarial Debate step in \`patterns/mktd/workflow.toml\` was failing in 0.02s when \`\${STEP_7_OUTPUT}\` (draft TODO), \`\${STEP_8_OUTPUT}\` (spec), or \`\${STEP_9_OUTPUT}\` (threat model) contained markdown inline-code spans (backticks) or \`\$\`-prefixed identifiers.

The original printf chain inside double-quoted args was hitting bash quoting / argv-size hazards once the substituted markdown was large and contained shell-special characters.

## Resolution

Replaced the \`printf '%s\\n' ...\` chain with:

\`\`\`bash
PROMPT_FILE=\$(mktemp)
trap 'rm -f \"\$PROMPT_FILE\"' EXIT
{
  printf '%s\\n' \"...\"
  printf '%s\\n' \"\$STEP_7_OUTPUT\"
  ...
} > \"\$PROMPT_FILE\"
csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --prompt-file \"\$PROMPT_FILE\"
\`\`\`

Why this works:
- \`printf '%s\\n' \"\$VAR\"\` expands env var inside double quotes; backticks/\$-signs in the expanded value remain inert text (bash does NOT recursively re-parse expanded values).
- File path passed via argv (small) — avoids any argv size concerns.
- \`csa debate --prompt-file\` is the canonical primary-prompt input path (\`--file\` is a separate \"attach as supplementary context\" flag, not what we want).

## Iteration trail (for audit)

- 5587e3a1 — first attempt: \`<<'PROMPT_END'\` quoted heredoc. **WRONG** (csa debate session 01KQ5GAKZVX confirmed: bash steps in CSA workflow runner pass \`\${STEP_N_OUTPUT}\` as env vars, not pre-substituted text — single-quoted heredoc captures literal \`\${VAR}\` text → data loss).
- dcf8b68a — Option B (mktemp + \`--file\`). Correct mechanism but wrong flag.
- 3918e200 — \`--file\` → \`--prompt-file\` (verified via \`csa debate --help\`).
- d27dab54 — Sync \`patterns/mktd/PATTERN.md\` to match new workflow.toml (rule 027 mandate).

## Test plan
- [ ] Re-run mktd full pipeline on RFC #1146 (jj sidecar journal)
- [ ] Verify Phase 3 debate completes (no 0.02s exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)