### PR TITLE
fix(review): #1144 verdict synthesis — Fail meta + zero severity + PASS prose → Pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.580"
+version = "0.1.581"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.580"
+version = "0.1.581"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -551,14 +551,10 @@ fn parse_overall_risk_from_text(text: &str) -> Option<String> {
         .map(|level| level.as_str().to_ascii_lowercase())
 }
 
-/// Derive the review decision from structured severity counts.
-///
-/// Core invariant (#1045): the decision is derived from `severity_counts`, not from
-/// summary-text keywords or stale `meta.decision` values.
-///
-/// - critical > 0 or high > 0 or medium > 0 → `Fail` / `HAS_ISSUES`
-/// - low > 0 only → `Pass` / `CLEAN` (LOWs don't block merge)
-/// - all zero + findings empty → `Pass` / `CLEAN`
+/// Derive the review decision from structured severity counts, not summary-text
+/// keywords or stale `meta.decision` values (#1045).
+/// Blocking severities fail; low-only findings pass; zero findings and zero
+/// severity counts defer to the explicit tie-break rules below.
 fn derive_decision_from_severity_counts(
     severity_counts: &std::collections::BTreeMap<Severity, u32>,
     findings_empty: bool,
@@ -583,8 +579,6 @@ fn derive_decision_from_severity_counts(
         return Ok(ReviewDecision::Fail);
     }
 
-    // From here: findings list is empty AND severity_counts are all zero.
-
     // Honour overall_risk as a fail-closed signal when it's severe.
     if overall_risk.is_some_and(|risk| {
         risk.eq_ignore_ascii_case("high") || risk.eq_ignore_ascii_case("critical")
@@ -596,14 +590,21 @@ fn derive_decision_from_severity_counts(
     if let Some(meta @ (ReviewDecision::Skip | ReviewDecision::Unavailable)) = meta_decision {
         return Ok(meta);
     }
-    // Uncertain (#1140): downgrade to Pass only when prose clearly says
-    // PASS/CLEAN; otherwise preserve Uncertain so callers don't merge on
-    // incomplete evidence.
-    if meta_decision == Some(ReviewDecision::Uncertain) {
+    let severity_counts_total: u32 = severity_counts.values().copied().sum();
+    let needs_prose_tiebreak = matches!(
+        meta_decision,
+        Some(ReviewDecision::Uncertain | ReviewDecision::Fail)
+    ) && severity_counts_total == 0;
+
+    // #1140/#1144: when meta.decision is Uncertain or legacy Fail but the
+    // structured findings are empty and severity counts are all zero, trust
+    // explicit PASS/CLEAN prose as the tiebreaker; otherwise preserve the
+    // caller-provided meta decision.
+    if needs_prose_tiebreak {
         return Ok(if prose_clean_check()? {
             ReviewDecision::Pass
         } else {
-            ReviewDecision::Uncertain
+            meta_decision.unwrap_or(ReviewDecision::Uncertain)
         });
     }
 
@@ -614,10 +615,9 @@ fn derive_decision_from_severity_counts(
         return Ok(ReviewDecision::Pass);
     }
 
-    // No findings, no prose clean marker, meta_decision is Fail or None.
-    // Zero findings + meta_decision=fail is the exact bug scenario (#1045):
-    // the caller parsed "fail" from summary prose, but there are no actual findings.
-    // The invariant says: zero severity_counts → pass.
+    // No findings, no prose clean marker, meta_decision is Fail or None:
+    // keep the legacy zero-findings fallback as Pass unless the tie-break above
+    // already preserved an explicit Fail/Uncertain meta decision.
     Ok(ReviewDecision::Pass)
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -30,8 +30,22 @@ pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
 fn verdict_token_pass_or_clean(text: &str) -> bool {
     text.lines().any(|line| {
         let trimmed = line.trim();
-        is_verdict_token(trimmed) || line_has_labeled_verdict_token(trimmed)
+        let unwrapped = strip_markdown_emphasis(trimmed);
+        is_verdict_token(trimmed)
+            || is_verdict_token(unwrapped)
+            || has_emphasized_verdict_token_prefix(trimmed)
+            || line_has_labeled_verdict_token(trimmed)
     })
+}
+
+fn strip_markdown_emphasis(text: &str) -> &str {
+    text.strip_prefix("**")
+        .and_then(|inner| inner.strip_suffix("**"))
+        .or_else(|| {
+            text.strip_prefix("__")
+                .and_then(|inner| inner.strip_suffix("__"))
+        })
+        .unwrap_or(text)
 }
 
 fn is_verdict_token(text: &str) -> bool {
@@ -71,6 +85,25 @@ fn has_verdict_token_prefix(text: &str) -> bool {
         rest.chars()
             .next()
             .is_none_or(|next| !is_verdict_token_continuation(next))
+    })
+}
+
+fn has_emphasized_verdict_token_prefix(text: &str) -> bool {
+    ["**", "__"].iter().any(|marker| {
+        ["PASS", "CLEAN"].iter().any(|token| {
+            let Some(rest) = text.strip_prefix(marker) else {
+                return false;
+            };
+            let Some(rest) = rest.strip_prefix(token) else {
+                return false;
+            };
+            let Some(rest) = rest.strip_prefix(marker) else {
+                return false;
+            };
+            rest.chars()
+                .next()
+                .is_none_or(|next| !is_verdict_token_continuation(next))
+        })
     })
 }
 
@@ -222,6 +255,13 @@ mod tests {
     #[test]
     fn verdict_token_standalone_pass_line_matches() {
         assert!(verdict_token_pass_or_clean("details\nPASS\nnotes"));
+    }
+
+    #[test]
+    fn verdict_token_markdown_emphasized_pass_matches() {
+        assert!(verdict_token_pass_or_clean("**PASS**"));
+        assert!(verdict_token_pass_or_clean("__CLEAN__"));
+        assert!(verdict_token_pass_or_clean("**PASS** — clean fix"));
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
@@ -71,9 +71,9 @@ fn persist_review_verdict_empty_findings_with_chinese_prose_clean_summary_emits_
 }
 
 #[test]
-fn persist_review_verdict_empty_findings_without_prose_clean_marker_emits_pass() {
-    // #1045: zero findings + zero severity_counts MUST yield Pass regardless
-    // of whether the summary contains a prose-clean phrase.
+fn persist_review_verdict_fail_meta_without_prose_clean_marker_preserves_fail() {
+    // #1144 inverse: zero findings alone are not enough to override a legacy
+    // Fail meta decision. We only downgrade when prose clearly says PASS/CLEAN.
     let session_id = "01TESTNOPROSECLEAN000000000";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("persist-review-verdict-no-prose-clean", session_id);
@@ -100,8 +100,8 @@ fn persist_review_verdict_empty_findings_without_prose_clean_marker_emits_pass()
     let artifact: ReviewVerdictArtifact =
         serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
             .expect("parse verdict");
-    assert_eq!(artifact.decision, ReviewDecision::Pass);
-    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    ToolReviewFailureKind, derive_decision_from_text, detect_tool_review_failure,
-    ensure_review_summary_artifact, extract_review_text, persist_review_verdict,
+    ToolReviewFailureKind, derive_decision_from_severity_counts, derive_decision_from_text,
+    detect_tool_review_failure, ensure_review_summary_artifact, extract_review_text,
+    persist_review_verdict,
 };
 use crate::review_cmd::output::artifacts::PersistedReviewArtifact;
 use crate::test_env_lock::TEST_ENV_LOCK;
@@ -115,6 +116,24 @@ fn derive_decision_from_text_clean_phrase_without_skip_stays_pass() {
     );
 
     assert_eq!(decision, ReviewDecision::Pass);
+}
+
+#[test]
+fn derive_decision_fail_meta_with_zero_severity_and_pass_prose_emits_pass() {
+    let decision = derive_decision_from_severity_counts(
+        &BTreeMap::new(),
+        true,
+        Some("low"),
+        Some(ReviewDecision::Fail),
+        || Ok(true),
+    )
+    .expect("derive decision");
+
+    assert_eq!(
+        decision,
+        ReviewDecision::Pass,
+        "Fail meta + zero severity + PASS/CLEAN prose must downgrade to Pass"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1144 verdict synthesis bug: `Fail`/`Uncertain` meta decision with zero severity findings only downgrades to `Pass` when summary prose explicitly contains `PASS`/`CLEAN`. Also recognizes markdown-emphasized verdict tokens (`**PASS**`, `__CLEAN__`).

Without this fix, a perfectly clean review (no findings, summary says PASS) could still emit a `Fail` verdict if the meta block was stale, blocking merges.

## Commits

- `9409a949` fix(review): downgrade Fail meta with zero severity + PASS prose to Pass (closes #1144)

## Test plan

- [x] cargo test passes (acceptance test added: `derive_decision_fail_meta_with_zero_severity_and_pass_prose_emits_pass`)
- [x] just pre-commit passes
- [x] csa review --range main...HEAD verdict: PASS, zero findings (session 01KQ5PCWFF61411MDJDAHCTH49)
- [ ] cloud bot review via pr-bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)