### PR TITLE
fix(mktd): preserve upstream rc in debate trap (closes #1150)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.582"
+version = "0.1.583"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.581"
+version = "0.1.582"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.581"
+version = "0.1.582"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.582"
+version = "0.1.583"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -392,7 +392,7 @@ identifiers, or other shell-sensitive content.
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
 PROMPT_FILE="$(mktemp)" || exit 1
-trap 'rm -f "$PROMPT_FILE"' EXIT INT TERM
+trap 'rm -f "$PROMPT_FILE"; exit' EXIT INT TERM
 {
   printf '%s\n' "Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate."
   echo ""

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -392,7 +392,7 @@ identifiers, or other shell-sensitive content.
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
 PROMPT_FILE="$(mktemp)" || exit 1
-trap 'rm -f "$PROMPT_FILE"; exit' EXIT INT TERM
+trap 'rc=$?; rm -f "$PROMPT_FILE"; exit $rc' EXIT INT TERM
 {
   printf '%s\n' "Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate."
   echo ""

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -436,7 +436,7 @@ for mechanical validation in Step 11.
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
 PROMPT_FILE="$(mktemp)" || exit 1
-trap 'rm -f "$PROMPT_FILE"' EXIT INT TERM
+trap 'rm -f "$PROMPT_FILE"; exit' EXIT INT TERM
 {
   printf '%s\n' "Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate."
   echo ""

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -436,7 +436,7 @@ for mechanical validation in Step 11.
 ```bash
 LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
 PROMPT_FILE="$(mktemp)" || exit 1
-trap 'rm -f "$PROMPT_FILE"; exit' EXIT INT TERM
+trap 'rc=$?; rm -f "$PROMPT_FILE"; exit $rc' EXIT INT TERM
 {
   printf '%s\n' "Critically evaluate this draft TODO plan, generated spec, and threat model. Act as a devil's advocate."
   echo ""


### PR DESCRIPTION
## Summary

Closes #1150. Fixes the mktd debate prompt cleanup trap to preserve the upstream exit status across signal-induced termination.

The previous form `trap 'rm -f "$PROMPT_FILE"; exit' EXIT INT TERM` had a correctness bug: `exit` (no args) returns the status of the last command in the trap (`rm -f`, typically 0), so INT/TERM signals would falsely report success (exit 0) to the calling pipeline (`csa plan run`).

The fix captures `$?` at trap entry and exits with that preserved status:

```bash
trap 'rc=$?; rm -f "$PROMPT_FILE"; exit $rc' EXIT INT TERM
```

This was caught by round-1 `csa review` (codex reviewer) as a legitimate FAIL — the round-2 commit fixes that finding.

## Commits

- `e1c12b32` fix(mktd): trap explicit exit after cleanup (round 1, addressed #1150 design intent)
- `d3146552` fix(mktd): preserve upstream rc in debate trap (round 2, addresses round-1 review bug)

## Test plan

- [x] cargo test passes
- [x] just pre-commit passes (workspace 0.1.582 → 0.1.583)
- [x] csa review --range main...HEAD review session 01KQ5REME44P17CDP9MH20VTRB; reviewer prose: "Verdict is a clear pass. … No security, contract, or crash issues were introduced." (synthesizer emitted Fail due to known #1145-class verdict-token detection gap, not a real review failure)
- [ ] cloud bot review via pr-bot

## Sync confirmation (rule 027)

- `patterns/mktd/workflow.toml:439` ✓
- `patterns/mktd/PATTERN.md:395` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)