### PR TITLE
fix(dev2merge): #1148 FAST_PATH Commit idempotent + untracked-aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.587"
+version = "0.1.588"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.586"
+version = "0.1.587"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.586"
+version = "0.1.587"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.587"
+version = "0.1.588"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -151,9 +151,21 @@ stage, generate message, commit. No mktd/mktsk/security-audit overhead.
 ```bash
 set -euo pipefail
 just test
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+if git diff --cached --quiet && git diff --quiet; then
+  COMMITS_AHEAD="$(git rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
+  if [ "${COMMITS_AHEAD}" -gt 0 ]; then
+    echo "FAST_PATH Commit: existing commits detected, working tree clean — skipping commit step"
+    echo "CSA_VAR:FAST_PATH_COMMITTED=true"
+    exit 0
+  else
+    echo "ERROR: No commits and no staged files."
+    exit 1
+  fi
+fi
 git add -A
 if ! git diff --cached --name-only | grep -q .; then
-  echo "ERROR: No staged files."
+  echo "ERROR: No staged files after staging dirty working tree."
   exit 1
 fi
 COMMIT_MSG="$(scripts/gen_commit_msg.sh "${SCOPE:-}" 2>/dev/null || echo "docs: update documentation")"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -152,7 +152,7 @@ stage, generate message, commit. No mktd/mktsk/security-audit overhead.
 set -euo pipefail
 just test
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
-if git diff --cached --quiet && git diff --quiet; then
+if [ -z "$(git status --porcelain)" ]; then
   COMMITS_AHEAD="$(git rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
   if [ "${COMMITS_AHEAD}" -gt 0 ]; then
     echo "FAST_PATH Commit: existing commits detected, working tree clean — skipping commit step"

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -216,7 +216,7 @@ stage, generate message, commit. No mktd/mktsk/security-audit overhead.
 set -euo pipefail
 just test
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
-if git diff --cached --quiet && git diff --quiet; then
+if [ -z "$(git status --porcelain)" ]; then
   COMMITS_AHEAD="$(git rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
   if [ "${COMMITS_AHEAD}" -gt 0 ]; then
     echo "FAST_PATH Commit: existing commits detected, working tree clean — skipping commit step"

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -215,9 +215,21 @@ stage, generate message, commit. No mktd/mktsk/security-audit overhead.
 ```bash
 set -euo pipefail
 just test
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+if git diff --cached --quiet && git diff --quiet; then
+  COMMITS_AHEAD="$(git rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
+  if [ "${COMMITS_AHEAD}" -gt 0 ]; then
+    echo "FAST_PATH Commit: existing commits detected, working tree clean — skipping commit step"
+    echo "CSA_VAR:FAST_PATH_COMMITTED=true"
+    exit 0
+  else
+    echo "ERROR: No commits and no staged files."
+    exit 1
+  fi
+fi
 git add -A
 if ! git diff --cached --name-only | grep -q .; then
-  echo "ERROR: No staged files."
+  echo "ERROR: No staged files after staging dirty working tree."
   exit 1
 fi
 COMMIT_MSG="$(scripts/gen_commit_msg.sh "${SCOPE:-}" 2>/dev/null || echo "docs: update documentation")"


### PR DESCRIPTION
## Summary
- Step 4 'FAST_PATH Commit' in `patterns/dev2merge/workflow.toml` now treats `working tree clean + commits ahead of main` as success (skip), so dev2merge no longer aborts when the writer used `/commit` skill before reaching the gate.
- Cleanliness check uses `git status --porcelain`, so **untracked files are correctly classified as dirty** (round-1 high finding).
- `patterns/dev2merge/PATTERN.md` mirrors the workflow change verbatim per AGENTS.md rule 027.

Closes #1148.

## Behavior
- Dirty tree (staged / unstaged / untracked): existing path — `git add -A && git commit`.
- Clean tree + commits ahead of `${DEFAULT_BRANCH:-main}`: print skip message + `CSA_VAR:FAST_PATH_COMMITTED=true`, exit 0.
- Clean tree + no commits ahead: error "No commits and no staged files."

## Verification
- `just bump-patch` → 0.1.588
- `just pre-commit` → exit 0 (workspace clippy + 4258/4286 nextest + 28 e2e)
- `csa review --branch main` round-1 found a high-severity untracked-file gap (`git diff` ignores untracked); round-2 PASS, zero findings.

## Test plan
- [x] Local pre-commit gate green
- [x] csa review round-2 PASS
- [ ] Cloud bot review on PR page