### PR TITLE
feat(sa-guard): #1143 narrow trivial-fix carve-out for orchestration loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.588"
+version = "0.1.589"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.588"
+version = "0.1.589"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_prompt_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_prompt_guard.rs
@@ -106,6 +106,18 @@ FORBIDDEN (SA contract violation — do NOT perform these actions):
 • Inspect diffs or code content (git diff, git show, etc.)
 • Read CSA transcripts or artifact contents directly
 
+NARROW EXCEPTION (orchestration loops only — pr-bot, dev2merge, similar):
+• <=5-line mechanical fixes prescribed verbatim by cloud-bot/reviewer findings
+  ('add this line', 'tighten this match', 'rename for consistency') MAY be
+  applied directly when CSA cold-start cost would dwarf the actual change.
+  Includes bot-prescribed test cleanup additions, mechanical case-sensitivity
+  tightening, obvious typo fixes.
+• Direct Edit is STILL FORBIDDEN for: (a) >5 lines, (b) cross-file changes,
+  (c) any design judgment (which approach? which abstraction?),
+  (d) substantive feature implementation, (e) when the user explicitly
+  invoked /sa or csa run --sa-mode true as the top-level dispatch
+  (they're paying for the audit).
+
 ALLOWED:
 • Dispatch work via `csa run --sa-mode true`
 • Read result.toml (structured report from CSA session)

--- a/crates/cli-sub-agent/src/sa_mode_tests.rs
+++ b/crates/cli-sub-agent/src/sa_mode_tests.rs
@@ -212,6 +212,14 @@ mod tests {
             "missing closing tag"
         );
         assert!(guard.contains("FORBIDDEN"), "missing FORBIDDEN section");
+        assert!(
+            guard.contains("NARROW EXCEPTION"),
+            "missing narrow exception section"
+        );
+        assert!(
+            guard.contains("<=5-line mechanical fixes"),
+            "missing trivial-fix carve-out"
+        );
         assert!(guard.contains("ALLOWED"), "missing ALLOWED section");
         assert!(guard.contains("Layer 0 Manager"), "missing role identifier");
         assert!(


### PR DESCRIPTION
## Summary
- `SA_MODE_CALLER_GUARD` (`pipeline_prompt_guard.rs`) preserves the strict default `FORBIDDEN: Read/edit/write source code files` clause and adds a NARROW EXCEPTION clause for orchestration loops (`pr-bot`, `dev2merge`, similar) where ≤5-line mechanical bot-prescribed fixes may be applied directly when CSA cold-start cost would dwarf the change.
- Direct Edit remains FORBIDDEN for: >5 lines, cross-file changes, design judgment, substantive feature work, or when the user explicitly invoked `/sa` / `csa run --sa-mode true` as the top-level dispatch.
- Test in `sa_mode_tests.rs` updated to assert the carve-out marker is present so the contract is locked in.

Closes #1143.

## Why
- Cost ratio of CSA cold-start vs trivial fix is ~1000:1 (50K-100K tokens + 2-3 min wall-clock vs 50-500 tokens / 30 sec).
- Per-user memory `feedback_sa_mode.md` already encodes the cost-benefit, but contradicting source-of-truth in code creates runtime conflict.
- Companion to issue #1142 (tool-layer enforcement gap — out of cli-sub-agent scope, requires Claude Code harness changes).

## Verification
- `just bump-patch` → 0.1.589
- `just pre-commit` → exit 0
- `csa review --branch main` PASS, zero findings.

## Test plan
- [x] Local pre-commit gate green
- [x] csa review PASS
- [ ] Cloud bot review on PR page