### PR TITLE
feat(vcs): SnapshotJournal trait + JjJournal sidecar (#1146 Phase 1-A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "chrono",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "axum",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "chrono",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "chrono",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,12 +959,13 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
+ "trybuild",
  "ulid",
 ]
 
 [[package]]
 name = "csa-todo"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3755,6 +3756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4229,6 +4236,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4491,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.589"
+version = "0.1.590"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,7 @@ version = "0.1.590"
 dependencies = [
  "anyhow",
  "chrono",
+ "directories",
  "libc",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.589"
+version = "0.1.590"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-core/src/vcs.rs
+++ b/crates/csa-core/src/vcs.rs
@@ -96,6 +96,69 @@ impl std::fmt::Display for VcsIdentity {
     }
 }
 
+/// Opaque journal revision identifier.
+///
+/// This is intentionally distinct from [`VcsIdentity`]: snapshot journals only
+/// need a stable handle for their sidecar history, while canonical repository
+/// operations may need richer git/jj identity metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RevisionId(pub String);
+
+impl RevisionId {
+    /// Returns the underlying revision identifier as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for RevisionId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for RevisionId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl std::fmt::Display for RevisionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Errors returned by snapshot journal implementations.
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum JournalError {
+    /// The configured journal backend is unavailable in the current environment.
+    #[error("snapshot journal unavailable: {0}")]
+    Unavailable(String),
+
+    /// An operating-system or filesystem failure occurred.
+    #[error("snapshot journal I/O failure: {0}")]
+    Io(String),
+
+    /// The journal command failed.
+    #[error("{command} failed: {message}")]
+    CommandFailed { command: String, message: String },
+
+    /// The journal state file contents were invalid.
+    #[error("snapshot journal state invalid: {0}")]
+    InvalidState(String),
+
+    /// The requested snapshot message was invalid after sanitization.
+    #[error("snapshot journal message invalid: {0}")]
+    InvalidMessage(String),
+}
+
+impl From<std::io::Error> for JournalError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value.to_string())
+    }
+}
+
 /// Common VCS operations required by CSA session and todo management.
 ///
 /// Each method returns `Result<T, String>` since csa-core does not depend on anyhow.
@@ -139,6 +202,18 @@ pub trait VcsBackend: Send + Sync {
             op_id: None,
         })
     }
+}
+
+/// Sidecar snapshot journaling contract.
+///
+/// [`VcsBackend`] handles canonical repository operations; `SnapshotJournal` is
+/// a parallel sidecar contract for journaling. They are NOT supertypes.
+pub trait SnapshotJournal: Send + Sync {
+    /// Capture the current working-tree state into the sidecar journal.
+    fn snapshot(&self, message: &str) -> Result<RevisionId, JournalError>;
+
+    /// Return the first journal revision recorded for the current session, if any.
+    fn session_start_revision(&self) -> Result<Option<RevisionId>, JournalError>;
 }
 
 /// Detect which VCS backend to use for the given project root.
@@ -258,5 +333,39 @@ mod tests {
         let json = serde_json::to_string(&id).unwrap();
         let roundtripped: VcsIdentity = serde_json::from_str(&json).unwrap();
         assert_eq!(id, roundtripped);
+    }
+
+    #[derive(Default)]
+    struct DummyJournal;
+
+    impl SnapshotJournal for DummyJournal {
+        fn snapshot(&self, message: &str) -> Result<RevisionId, JournalError> {
+            Ok(RevisionId::from(format!("snap:{message}")))
+        }
+
+        fn session_start_revision(&self) -> Result<Option<RevisionId>, JournalError> {
+            Ok(Some(RevisionId::from("start-rev")))
+        }
+    }
+
+    #[test]
+    fn snapshot_journal_trait_surface_roundtrips_revision_ids() {
+        let journal: &dyn SnapshotJournal = &DummyJournal;
+        let revision = journal.snapshot("hello").expect("snapshot should succeed");
+        let start = journal
+            .session_start_revision()
+            .expect("state read should succeed")
+            .expect("start revision should exist");
+
+        assert_eq!(revision.as_str(), "snap:hello");
+        assert_eq!(start.as_str(), "start-rev");
+    }
+
+    #[test]
+    fn revision_id_serde_roundtrip() {
+        let revision = RevisionId::from("kqosnzyt");
+        let json = serde_json::to_string(&revision).expect("serialize revision id");
+        let decoded: RevisionId = serde_json::from_str(&json).expect("deserialize revision id");
+        assert_eq!(decoded, revision);
     }
 }

--- a/crates/csa-lock/Cargo.toml
+++ b/crates/csa-lock/Cargo.toml
@@ -12,6 +12,7 @@ serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
 sha2.workspace = true
+directories.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/csa-lock/Cargo.toml
+++ b/crates/csa-lock/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -14,6 +14,7 @@ pub mod slot;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::io::AsRawFd;
@@ -86,7 +87,11 @@ fn sanitize_lock_component(input: &str) -> String {
     }
 }
 
-fn acquire_lock_at_path(lock_path: &Path, lock_name: &str, reason: &str) -> Result<SessionLock> {
+pub fn acquire_lock_at_path(
+    lock_path: &Path,
+    lock_name: &str,
+    reason: &str,
+) -> Result<SessionLock> {
     if let Some(parent) = lock_path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create locks directory: {}", parent.display()))?;
@@ -195,11 +200,92 @@ pub fn acquire_parent_fork_lock(
     acquire_lock_at_path(&lock_path, &lock_name, reason)
 }
 
+fn resolve_state_root() -> Result<PathBuf> {
+    if let Some(state_root) = std::env::var_os("XDG_STATE_HOME") {
+        return Ok(PathBuf::from(state_root));
+    }
+
+    let home = std::env::var_os("HOME")
+        .ok_or_else(|| anyhow::anyhow!("XDG_STATE_HOME and HOME are both unset"))?;
+    Ok(PathBuf::from(home).join(".local/state"))
+}
+
+/// Acquire a per-project resource lock for cross-session coordination.
+///
+/// Lock path:
+/// `${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/<resource_kind>-locks/<sha256(canonical(project_root))>/<tool_name>.lock`
+///
+/// Used when two CSA sessions in the same project_root must serialize on a
+/// shared resource (e.g., the underlying jj or git repository).
+pub fn acquire_project_resource_lock(
+    project_root: &Path,
+    resource_kind: &str,
+    tool_name: &str,
+    reason: &str,
+) -> Result<SessionLock> {
+    let kind = resource_kind.trim();
+    if kind.is_empty() {
+        anyhow::bail!("resource kind cannot be empty");
+    }
+
+    let tool = tool_name.trim();
+    if tool.is_empty() {
+        anyhow::bail!("tool name cannot be empty");
+    }
+
+    let canonical = fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_os_str().as_encoded_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    let safe_kind = sanitize_lock_component(kind);
+    let safe_tool = sanitize_lock_component(tool);
+    let lock_path = resolve_state_root()?
+        .join("cli-sub-agent")
+        .join(format!("{safe_kind}-locks"))
+        .join(digest)
+        .join(format!("{safe_tool}.lock"));
+    let lock_name = format!("{kind}:{tool}");
+    acquire_lock_at_path(&lock_path, &lock_name, reason)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::fs;
     use tempfile::tempdir;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set_os(key: &'static str, value: &Path) -> Self {
+            let original = std::env::var_os(key);
+            // SAFETY: test-scoped env mutation is isolated to the current test.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let original = std::env::var_os(key);
+            // SAFETY: test-scoped env mutation is isolated to the current test.
+            unsafe { std::env::remove_var(key) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                // SAFETY: test-scoped env restoration is isolated to the current test.
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                // SAFETY: test-scoped env restoration is isolated to the current test.
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
 
     #[test]
     fn test_acquire_lock_succeeds() {
@@ -403,6 +489,50 @@ mod tests {
 
         let lock_a = acquire_parent_fork_lock(state_root, "01PARENTA", "fork-call");
         let lock_b = acquire_parent_fork_lock(state_root, "01PARENTB", "fork-call");
+
+        assert!(lock_a.is_ok());
+        assert!(lock_b.is_ok());
+    }
+
+    #[test]
+    fn test_project_resource_lock_conflicts_for_same_project_root() {
+        let home_dir = tempdir().expect("home tempdir");
+        let _home_guard = EnvVarGuard::set_os("HOME", home_dir.path());
+        let _xdg_guard = EnvVarGuard::unset("XDG_STATE_HOME");
+
+        let project_root = tempdir().expect("project tempdir");
+        let _lock1 = acquire_project_resource_lock(
+            project_root.path(),
+            "jj-journal",
+            "snapshot",
+            "first snapshot",
+        )
+        .expect("first project lock should succeed");
+
+        let err = acquire_project_resource_lock(
+            project_root.path(),
+            "jj-journal",
+            "snapshot",
+            "second snapshot",
+        )
+        .expect_err("second project lock on same project_root should fail")
+        .to_string();
+
+        assert!(err.contains("jj-journal:snapshot"));
+    }
+
+    #[test]
+    fn test_project_resource_lock_allows_different_project_roots() {
+        let state_home = tempdir().expect("state-home tempdir");
+        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+        let project_a = tempdir().expect("project a tempdir");
+        let project_b = tempdir().expect("project b tempdir");
+
+        let lock_a =
+            acquire_project_resource_lock(project_a.path(), "jj-journal", "snapshot", "first");
+        let lock_b =
+            acquire_project_resource_lock(project_b.path(), "jj-journal", "snapshot", "second");
 
         assert!(lock_a.is_ok());
         assert!(lock_b.is_ok());

--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -232,9 +232,14 @@ pub fn acquire_project_resource_lock(
         anyhow::bail!("tool name cannot be empty");
     }
 
-    let canonical = fs::canonicalize(project_root).unwrap_or_else(|_| {
-        std::path::absolute(project_root).unwrap_or_else(|_| project_root.to_path_buf())
-    });
+    let canonical = fs::canonicalize(project_root)
+        .or_else(|_| std::path::absolute(project_root))
+        .with_context(|| {
+            format!(
+                "could not resolve project root to absolute path: {}",
+                project_root.display()
+            )
+        })?;
     let mut hasher = Sha256::new();
     hasher.update(canonical.as_os_str().as_encoded_bytes());
     let digest = format!("{:x}", hasher.finalize());

--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -254,7 +254,21 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
     use std::fs;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::tempdir;
+
+    /// Process-wide mutex serializing tests that mutate `HOME` / `XDG_STATE_HOME`.
+    ///
+    /// `std::env::set_var` / `std::env::remove_var` are not thread-safe; cargo runs
+    /// tests in parallel within one binary, so env-mutating tests would race
+    /// without this guard.
+    fn env_test_lock() -> MutexGuard<'static, ()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     struct EnvVarGuard {
         key: &'static str,
@@ -497,6 +511,7 @@ mod tests {
 
     #[test]
     fn test_project_resource_lock_conflicts_for_same_project_root() {
+        let _env_lock = env_test_lock();
         let home_dir = tempdir().expect("home tempdir");
         let _home_guard = EnvVarGuard::set_os("HOME", home_dir.path());
         let _xdg_guard = EnvVarGuard::unset("XDG_STATE_HOME");
@@ -524,6 +539,7 @@ mod tests {
 
     #[test]
     fn test_project_resource_lock_allows_different_project_roots() {
+        let _env_lock = env_test_lock();
         let state_home = tempdir().expect("state-home tempdir");
         let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 

--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -201,13 +201,12 @@ pub fn acquire_parent_fork_lock(
 }
 
 fn resolve_state_root() -> Result<PathBuf> {
-    if let Some(state_root) = std::env::var_os("XDG_STATE_HOME") {
-        return Ok(PathBuf::from(state_root));
-    }
-
-    let home = std::env::var_os("HOME")
-        .ok_or_else(|| anyhow::anyhow!("XDG_STATE_HOME and HOME are both unset"))?;
-    Ok(PathBuf::from(home).join(".local/state"))
+    let base_dirs = directories::BaseDirs::new()
+        .ok_or_else(|| anyhow::anyhow!("could not determine platform base directories"))?;
+    Ok(base_dirs
+        .state_dir()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| base_dirs.data_local_dir().to_path_buf()))
 }
 
 /// Acquire a per-project resource lock for cross-session coordination.

--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -233,7 +233,9 @@ pub fn acquire_project_resource_lock(
         anyhow::bail!("tool name cannot be empty");
     }
 
-    let canonical = fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let canonical = fs::canonicalize(project_root).unwrap_or_else(|_| {
+        std::path::absolute(project_root).unwrap_or_else(|_| project_root.to_path_buf())
+    });
     let mut hasher = Sha256::new();
     hasher.update(canonical.as_os_str().as_encoded_bytes());
     let digest = format!("{:x}", hasher.finalize());

--- a/crates/csa-session/Cargo.toml
+++ b/crates/csa-session/Cargo.toml
@@ -26,3 +26,4 @@ tempfile.workspace = true
 
 [dev-dependencies]
 tracing-subscriber.workspace = true
+trybuild = "1.0"

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -135,13 +135,12 @@ impl JjJournal {
                     message: err.to_string(),
                 })?;
 
-        let current_state = self.read_state()?.unwrap_or_default();
+        let mut current_state = self.read_state()?.unwrap_or_default();
         let revision = revision_supplier(message)?;
 
         if current_state.session_start_revision.is_none() {
-            self.write_state(&JournalState {
-                session_start_revision: Some(revision.clone()),
-            })?;
+            current_state.session_start_revision = Some(revision.clone());
+            self.write_state(&current_state)?;
         }
 
         Ok(revision)

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -5,8 +5,8 @@
 //! optional sidecar journal.
 
 use csa_core::vcs::{JournalError, RevisionId, SnapshotJournal};
+use csa_lock::acquire_lock;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use std::ffi::OsString;
 use std::fs;
 use std::io::Write;
@@ -30,13 +30,13 @@ struct JournalState {
 }
 
 impl JjJournal {
-    pub fn new(project_root: impl AsRef<Path>) -> Self {
+    pub fn new(project_root: impl AsRef<Path>) -> Result<Self, JournalError> {
         let project_root = project_root.as_ref().to_path_buf();
-        let state_path = derive_state_path(&project_root);
-        Self {
+        let state_path = derive_state_path()?;
+        Ok(Self {
             project_root,
             state_path,
-        }
+        })
     }
 
     #[cfg(test)]
@@ -115,6 +115,42 @@ impl JjJournal {
         write_state_atomically(&self.state_path, state)
     }
 
+    fn snapshot_with_revision_supplier<F>(
+        &self,
+        message: &str,
+        revision_supplier: F,
+    ) -> Result<RevisionId, JournalError>
+    where
+        F: FnOnce(&str) -> Result<RevisionId, JournalError>,
+    {
+        let sanitized = sanitize_snapshot_message(message)?;
+        let session_dir = self.state_path.parent().ok_or_else(|| {
+            JournalError::InvalidState(format!(
+                "state path has no parent: {}",
+                self.state_path.display()
+            ))
+        })?;
+        let truncated_reason: String = sanitized.chars().take(64).collect();
+        let reason = format!("snapshot: {truncated_reason}");
+        let _lock = acquire_lock(session_dir, "jj-journal-snapshot", &reason).map_err(|err| {
+            JournalError::CommandFailed {
+                command: "acquire_lock(jj-journal-snapshot)".to_string(),
+                message: err.to_string(),
+            }
+        })?;
+
+        let current_state = self.read_state()?.unwrap_or_default();
+        let revision = revision_supplier(message)?;
+
+        if current_state.session_start_revision.is_none() {
+            self.write_state(&JournalState {
+                session_start_revision: Some(revision.clone()),
+            })?;
+        }
+
+        Ok(revision)
+    }
+
     #[cfg(test)]
     fn write_state_with_fault_injection(
         &self,
@@ -127,16 +163,7 @@ impl JjJournal {
 
 impl SnapshotJournal for JjJournal {
     fn snapshot(&self, message: &str) -> Result<RevisionId, JournalError> {
-        let revision = self.capture_snapshot_revision(message)?;
-        let current_state = self.read_state()?.unwrap_or_default();
-
-        if current_state.session_start_revision.is_none() {
-            self.write_state(&JournalState {
-                session_start_revision: Some(revision.clone()),
-            })?;
-        }
-
-        Ok(revision)
+        self.snapshot_with_revision_supplier(message, |msg| self.capture_snapshot_revision(msg))
     }
 
     fn session_start_revision(&self) -> Result<Option<RevisionId>, JournalError> {
@@ -170,20 +197,15 @@ fn sanitize_snapshot_message(message: &str) -> Result<String, JournalError> {
     Ok(bounded)
 }
 
-fn derive_state_path(project_root: &Path) -> PathBuf {
-    if let Some(session_dir) = std::env::var_os(SESSION_DIR_ENV) {
-        return PathBuf::from(session_dir).join(STATE_FILE_NAME);
-    }
-
-    let digest = Sha256::digest(project_root.as_os_str().as_encoded_bytes());
-    let hash = digest
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>();
-    std::env::temp_dir()
-        .join("csa-jj-journal")
-        .join(hash)
-        .join(STATE_FILE_NAME)
+fn derive_state_path() -> Result<PathBuf, JournalError> {
+    std::env::var_os(SESSION_DIR_ENV)
+        .map(|session_dir| PathBuf::from(session_dir).join(STATE_FILE_NAME))
+        .ok_or_else(|| {
+            JournalError::Unavailable(
+                "CSA_SESSION_DIR not set; sidecar jj snapshot journal requires CSA session context"
+                    .to_string(),
+            )
+        })
 }
 
 fn temp_state_path(path: &Path) -> Result<PathBuf, JournalError> {
@@ -233,6 +255,8 @@ mod tests {
     use crate::test_env::TEST_ENV_LOCK;
     use csa_core::vcs::SnapshotJournal;
     use std::os::unix::fs::PermissionsExt;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
     use tempfile::tempdir;
 
     fn make_fake_jj(bin_dir: &Path, script_body: &str) -> PathBuf {
@@ -257,6 +281,67 @@ mod tests {
             // SAFETY: guarded by TEST_ENV_LOCK; see set_path_for_test().
             None => unsafe { std::env::remove_var("PATH") },
         }
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set_os(key: &'static str, value: &Path) -> Self {
+            let original = std::env::var_os(key);
+            // SAFETY: test-scoped env mutation is guarded by TEST_ENV_LOCK.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let original = std::env::var_os(key);
+            // SAFETY: test-scoped env mutation is guarded by TEST_ENV_LOCK.
+            unsafe { std::env::remove_var(key) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                // SAFETY: test-scoped env restoration is guarded by TEST_ENV_LOCK.
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                // SAFETY: test-scoped env restoration is guarded by TEST_ENV_LOCK.
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn new_fails_when_session_dir_missing() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock env");
+        let _session_dir = EnvVarGuard::unset(SESSION_DIR_ENV);
+        let repo = tempdir().expect("repo tempdir");
+
+        let error = JjJournal::new(repo.path()).expect_err("new should fail without session dir");
+
+        assert_eq!(
+            error,
+            JournalError::Unavailable(
+                "CSA_SESSION_DIR not set; sidecar jj snapshot journal requires CSA session context"
+                    .to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn new_succeeds_when_session_dir_set() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock env");
+        let session_dir = tempdir().expect("session tempdir");
+        let _session_dir = EnvVarGuard::set_os(SESSION_DIR_ENV, session_dir.path());
+        let repo = tempdir().expect("repo tempdir");
+
+        let journal = JjJournal::new(repo.path()).expect("new should succeed");
+
+        assert_eq!(journal.state_path, session_dir.path().join(STATE_FILE_NAME),);
     }
 
     #[test]
@@ -378,6 +463,55 @@ mod tests {
         assert!(
             temp_state_path(&state_path).expect("tmp path").exists(),
             "temporary file should remain for crash observability"
+        );
+    }
+
+    #[test]
+    fn concurrent_snapshot_rejected_by_lock() {
+        let repo = tempdir().expect("repo tempdir");
+        let session_dir = tempdir().expect("session tempdir");
+        let journal = Arc::new(JjJournal::with_state_path(
+            repo.path(),
+            session_dir.path().join(STATE_FILE_NAME),
+        ));
+        let entered_lock = Arc::new(Barrier::new(2));
+        let release_lock = Arc::new(Barrier::new(2));
+
+        let first_journal = Arc::clone(&journal);
+        let first_entered = Arc::clone(&entered_lock);
+        let first_release = Arc::clone(&release_lock);
+        let first = thread::spawn(move || {
+            first_journal.snapshot_with_revision_supplier("first snapshot", |_| {
+                first_entered.wait();
+                first_release.wait();
+                Ok(RevisionId::from("rev-first"))
+            })
+        });
+
+        entered_lock.wait();
+
+        let error = journal
+            .snapshot_with_revision_supplier("second snapshot", |_| Ok(RevisionId::from("rev-2")))
+            .expect_err("second snapshot should fail on lock contention");
+
+        assert!(matches!(
+            error,
+            JournalError::CommandFailed { ref command, .. }
+                if command == "acquire_lock(jj-journal-snapshot)"
+        ));
+
+        release_lock.wait();
+
+        let first_revision = first
+            .join()
+            .expect("first snapshot thread should not panic")
+            .expect("first snapshot should succeed");
+        assert_eq!(first_revision, RevisionId::from("rev-first"));
+        assert_eq!(
+            journal
+                .session_start_revision()
+                .expect("state read should succeed"),
+            Some(RevisionId::from("rev-first"))
         );
     }
 }

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -230,7 +230,7 @@ fn write_state_atomically_inner(
 
     let mut tmp_file = fs::File::create(&tmp_path)?;
     tmp_file.write_all(&encoded)?;
-    tmp_file.flush()?;
+    tmp_file.sync_all()?;
     drop(tmp_file);
 
     if fail_after_write {

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -48,9 +48,11 @@ impl JjJournal {
         }
     }
 
-    fn capture_snapshot_revision(&self, message: &str) -> Result<RevisionId, JournalError> {
-        let sanitized = sanitize_snapshot_message(message)?;
-        self.run_jj(["describe", "-m", sanitized.as_str()])?;
+    fn capture_snapshot_revision(
+        &self,
+        sanitized_message: &str,
+    ) -> Result<RevisionId, JournalError> {
+        self.run_jj(["describe", "-m", sanitized_message])?;
         self.run_jj(["new", "--no-edit"])?;
 
         let output = self.run_jj(["log", "--no-graph", "-r", "@-", "-T", "change_id"])?;
@@ -69,7 +71,7 @@ impl JjJournal {
         I: IntoIterator<Item = S>,
         S: Into<OsString>,
     {
-        let mut collected: Vec<OsString> = vec!["--no-pager".into()];
+        let mut collected: Vec<OsString> = vec!["--no-pager".into(), "--color=never".into()];
         collected.extend(args.into_iter().map(Into::into));
         let output = Command::new("jj")
             .args(&collected)
@@ -104,13 +106,15 @@ impl JjJournal {
     }
 
     fn read_state(&self) -> Result<Option<JournalState>, JournalError> {
-        if !self.state_path.exists() {
-            return Ok(None);
+        match fs::read_to_string(&self.state_path) {
+            Ok(raw) => {
+                let state = serde_json::from_str::<JournalState>(&raw)
+                    .map_err(|err| JournalError::InvalidState(err.to_string()))?;
+                Ok(Some(state))
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err.into()),
         }
-        let raw = fs::read_to_string(&self.state_path)?;
-        let state = serde_json::from_str::<JournalState>(&raw)
-            .map_err(|err| JournalError::InvalidState(err.to_string()))?;
-        Ok(Some(state))
     }
 
     fn write_state(&self, state: &JournalState) -> Result<(), JournalError> {
@@ -136,7 +140,7 @@ impl JjJournal {
                 })?;
 
         let mut current_state = self.read_state()?.unwrap_or_default();
-        let revision = revision_supplier(message)?;
+        let revision = revision_supplier(&sanitized)?;
 
         if current_state.session_start_revision.is_none() {
             current_state.session_start_revision = Some(revision.clone());
@@ -380,7 +384,7 @@ mod tests {
         assert!(matches!(
             error,
             JournalError::CommandFailed { ref command, ref message }
-                if command == "jj --no-pager describe -m snapshot me"
+                if command == "jj --no-pager --color=never describe -m snapshot me"
                     && message.contains("mock jj unavailable")
         ));
         assert!(
@@ -397,7 +401,7 @@ mod tests {
         let arg_log = repo.path().join("jj-args.bin");
         let script = format!(
             "#!/bin/sh\n\
-             if [ \"$2\" = \"log\" ]; then\n\
+             if [ \"$3\" = \"log\" ]; then\n\
                printf 'rev-from-log\\n'\n\
                exit 0\n\
              fi\n\
@@ -435,12 +439,13 @@ mod tests {
             .map(|chunk| String::from_utf8_lossy(chunk).to_string())
             .collect::<Vec<_>>();
 
-        assert!(parts.windows(5).any(|window| {
+        assert!(parts.windows(6).any(|window| {
             window[0] == "CALL"
                 && window[1] == "--no-pager"
-                && window[2] == "describe"
-                && window[3] == "-m"
-                && window[4] == "msg;$(touch hacked)`echo no` / second line"
+                && window[2] == "--color=never"
+                && window[3] == "describe"
+                && window[4] == "-m"
+                && window[5] == "msg;$(touch hacked)`echo no` / second line"
         }));
         assert!(
             !repo.path().join("hacked").exists(),

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -1,0 +1,383 @@
+//! Sidecar jj snapshot journaling.
+//!
+//! This module intentionally does not participate in canonical repository
+//! operations. Git remains the canonical backend; jj is only used as an
+//! optional sidecar journal.
+
+use csa_core::vcs::{JournalError, RevisionId, SnapshotJournal};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::ffi::OsString;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SESSION_DIR_ENV: &str = "CSA_SESSION_DIR";
+const STATE_FILE_NAME: &str = "jj-journal-state.json";
+const MAX_SNAPSHOT_MESSAGE_LEN: usize = 4096;
+
+#[derive(Debug, Clone)]
+pub struct JjJournal {
+    project_root: PathBuf,
+    state_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+struct JournalState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    session_start_revision: Option<RevisionId>,
+}
+
+impl JjJournal {
+    pub fn new(project_root: impl AsRef<Path>) -> Self {
+        let project_root = project_root.as_ref().to_path_buf();
+        let state_path = derive_state_path(&project_root);
+        Self {
+            project_root,
+            state_path,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_state_path(project_root: impl AsRef<Path>, state_path: impl AsRef<Path>) -> Self {
+        Self {
+            project_root: project_root.as_ref().to_path_buf(),
+            state_path: state_path.as_ref().to_path_buf(),
+        }
+    }
+
+    fn capture_snapshot_revision(&self, message: &str) -> Result<RevisionId, JournalError> {
+        let sanitized = sanitize_snapshot_message(message)?;
+        self.run_jj(["describe", "-m", sanitized.as_str()])?;
+        self.run_jj(["new", "--no-edit"])?;
+
+        let output = self.run_jj(["log", "--no-graph", "-r", "@-", "-T", "change_id"])?;
+        let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if revision.is_empty() {
+            return Err(JournalError::CommandFailed {
+                command: "jj log --no-graph -r @- -T change_id".to_string(),
+                message: "snapshot revision id was empty".to_string(),
+            });
+        }
+        Ok(RevisionId::from(revision))
+    }
+
+    fn run_jj<I, S>(&self, args: I) -> Result<std::process::Output, JournalError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        let collected: Vec<OsString> = args.into_iter().map(Into::into).collect();
+        let output = Command::new("jj")
+            .args(&collected)
+            .current_dir(&self.project_root)
+            .output()
+            .map_err(|err| match err.kind() {
+                std::io::ErrorKind::NotFound => JournalError::Unavailable(
+                    "jj binary not found; git fallback is intentionally disabled".to_string(),
+                ),
+                _ => JournalError::Io(format!("failed to run jj: {err}")),
+            })?;
+
+        if !output.status.success() {
+            let command = format!(
+                "jj {}",
+                collected
+                    .iter()
+                    .map(|arg| arg.to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            );
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let message = if stderr.is_empty() {
+                format!("exit status {}", output.status)
+            } else {
+                stderr
+            };
+            return Err(JournalError::CommandFailed { command, message });
+        }
+
+        Ok(output)
+    }
+
+    fn read_state(&self) -> Result<Option<JournalState>, JournalError> {
+        if !self.state_path.exists() {
+            return Ok(None);
+        }
+        let raw = fs::read_to_string(&self.state_path)?;
+        let state = serde_json::from_str::<JournalState>(&raw)
+            .map_err(|err| JournalError::InvalidState(err.to_string()))?;
+        Ok(Some(state))
+    }
+
+    fn write_state(&self, state: &JournalState) -> Result<(), JournalError> {
+        write_state_atomically(&self.state_path, state)
+    }
+
+    #[cfg(test)]
+    fn write_state_with_fault_injection(
+        &self,
+        state: &JournalState,
+        fail_after_write: bool,
+    ) -> Result<(), JournalError> {
+        write_state_atomically_inner(&self.state_path, state, fail_after_write)
+    }
+}
+
+impl SnapshotJournal for JjJournal {
+    fn snapshot(&self, message: &str) -> Result<RevisionId, JournalError> {
+        let revision = self.capture_snapshot_revision(message)?;
+        let current_state = self.read_state()?.unwrap_or_default();
+
+        if current_state.session_start_revision.is_none() {
+            self.write_state(&JournalState {
+                session_start_revision: Some(revision.clone()),
+            })?;
+        }
+
+        Ok(revision)
+    }
+
+    fn session_start_revision(&self) -> Result<Option<RevisionId>, JournalError> {
+        Ok(self
+            .read_state()?
+            .and_then(|state| state.session_start_revision))
+    }
+}
+
+fn sanitize_snapshot_message(message: &str) -> Result<String, JournalError> {
+    if message.contains('\0') {
+        return Err(JournalError::InvalidMessage(
+            "message contains null byte".to_string(),
+        ));
+    }
+
+    let normalized = message.replace("\r\n", "\n").replace('\r', "\n");
+    let collapsed = normalized
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" / ");
+
+    let bounded: String = collapsed.chars().take(MAX_SNAPSHOT_MESSAGE_LEN).collect();
+    if bounded.is_empty() {
+        return Err(JournalError::InvalidMessage(
+            "message empty after sanitization".to_string(),
+        ));
+    }
+    Ok(bounded)
+}
+
+fn derive_state_path(project_root: &Path) -> PathBuf {
+    if let Some(session_dir) = std::env::var_os(SESSION_DIR_ENV) {
+        return PathBuf::from(session_dir).join(STATE_FILE_NAME);
+    }
+
+    let digest = Sha256::digest(project_root.as_os_str().as_encoded_bytes());
+    let hash = digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    std::env::temp_dir()
+        .join("csa-jj-journal")
+        .join(hash)
+        .join(STATE_FILE_NAME)
+}
+
+fn temp_state_path(path: &Path) -> Result<PathBuf, JournalError> {
+    let file_name = path.file_name().ok_or_else(|| {
+        JournalError::InvalidState(format!("state path has no file name: {}", path.display()))
+    })?;
+    let mut tmp_name = file_name.to_os_string();
+    tmp_name.push(".tmp");
+    Ok(path.with_file_name(tmp_name))
+}
+
+fn write_state_atomically(path: &Path, state: &JournalState) -> Result<(), JournalError> {
+    write_state_atomically_inner(path, state, false)
+}
+
+fn write_state_atomically_inner(
+    path: &Path,
+    state: &JournalState,
+    fail_after_write: bool,
+) -> Result<(), JournalError> {
+    let parent = path.parent().ok_or_else(|| {
+        JournalError::InvalidState(format!("state path has no parent: {}", path.display()))
+    })?;
+    fs::create_dir_all(parent)?;
+    let tmp_path = temp_state_path(path)?;
+    let encoded = serde_json::to_vec_pretty(state)
+        .map_err(|err| JournalError::InvalidState(err.to_string()))?;
+
+    let mut tmp_file = fs::File::create(&tmp_path)?;
+    tmp_file.write_all(&encoded)?;
+    tmp_file.flush()?;
+    drop(tmp_file);
+
+    if fail_after_write {
+        return Err(JournalError::Io(
+            "simulated crash after temp write".to_string(),
+        ));
+    }
+
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env::TEST_ENV_LOCK;
+    use csa_core::vcs::SnapshotJournal;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
+
+    fn make_fake_jj(bin_dir: &Path, script_body: &str) -> PathBuf {
+        let path = bin_dir.join("jj");
+        fs::write(&path, script_body).expect("write fake jj");
+        let mut perms = fs::metadata(&path).expect("stat fake jj").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).expect("chmod fake jj");
+        path
+    }
+
+    fn set_path_for_test(path: &Path) {
+        // SAFETY: these tests hold TEST_ENV_LOCK for the full mutation window,
+        // so no concurrent environment access can race with PATH changes.
+        unsafe { std::env::set_var("PATH", path) };
+    }
+
+    fn restore_path_for_test(original_path: Option<OsString>) {
+        match original_path {
+            // SAFETY: guarded by TEST_ENV_LOCK; see set_path_for_test().
+            Some(path) => unsafe { std::env::set_var("PATH", path) },
+            // SAFETY: guarded by TEST_ENV_LOCK; see set_path_for_test().
+            None => unsafe { std::env::remove_var("PATH") },
+        }
+    }
+
+    #[test]
+    fn no_git_fallback_when_jj_missing() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock env");
+        let repo = tempdir().expect("repo tempdir");
+        let bin_dir = tempdir().expect("bin tempdir");
+        let git_marker = repo.path().join("git-invoked");
+        let git_script = format!(
+            "#!/bin/sh\nprintf invoked > \"{}\"\nexit 0\n",
+            git_marker.display()
+        );
+        let git_path = bin_dir.path().join("git");
+        fs::write(&git_path, git_script).expect("write fake git");
+        let mut perms = fs::metadata(&git_path)
+            .expect("stat fake git")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&git_path, perms).expect("chmod fake git");
+
+        let original_path = std::env::var_os("PATH");
+        set_path_for_test(bin_dir.path());
+
+        let journal = JjJournal::with_state_path(
+            repo.path(),
+            repo.path().join("state").join(STATE_FILE_NAME),
+        );
+        let error = journal
+            .snapshot("snapshot me")
+            .expect_err("jj should be missing");
+
+        assert!(matches!(error, JournalError::Unavailable(_)));
+        assert!(!git_marker.exists(), "git fallback must not run");
+
+        restore_path_for_test(original_path);
+    }
+
+    #[test]
+    fn shell_metacharacters_in_message_are_safe() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock env");
+        let repo = tempdir().expect("repo tempdir");
+        let bin_dir = tempdir().expect("bin tempdir");
+        let arg_log = repo.path().join("jj-args.bin");
+        let script = format!(
+            "#!/bin/sh\n\
+             if [ \"$1\" = \"log\" ]; then\n\
+               printf 'rev-from-log\\n'\n\
+               exit 0\n\
+             fi\n\
+             printf 'CALL\\0' >> \"{}\"\n\
+             for arg in \"$@\"; do\n\
+               printf '%s\\0' \"$arg\" >> \"{}\"\n\
+             done\n",
+            arg_log.display(),
+            arg_log.display()
+        );
+        make_fake_jj(bin_dir.path(), &script);
+
+        let original_path = std::env::var_os("PATH");
+        set_path_for_test(bin_dir.path());
+
+        let journal = JjJournal::with_state_path(
+            repo.path(),
+            repo.path().join("state").join(STATE_FILE_NAME),
+        );
+        let unsafe_message = "msg;$(touch hacked)`echo no`\nsecond line";
+        let revision = journal
+            .snapshot(unsafe_message)
+            .expect("snapshot should succeed");
+        let start_revision = journal
+            .session_start_revision()
+            .expect("state read should succeed")
+            .expect("start revision should be persisted");
+
+        assert_eq!(revision.as_str(), "rev-from-log");
+        assert_eq!(start_revision, revision);
+
+        let raw = fs::read(&arg_log).expect("read arg log");
+        let parts = raw
+            .split(|byte| *byte == 0)
+            .filter(|chunk| !chunk.is_empty())
+            .map(|chunk| String::from_utf8_lossy(chunk).to_string())
+            .collect::<Vec<_>>();
+
+        assert!(parts.windows(4).any(|window| {
+            window[0] == "CALL"
+                && window[1] == "describe"
+                && window[2] == "-m"
+                && window[3] == "msg;$(touch hacked)`echo no` / second line"
+        }));
+        assert!(
+            !repo.path().join("hacked").exists(),
+            "metacharacters must not execute"
+        );
+
+        restore_path_for_test(original_path);
+    }
+
+    #[test]
+    fn atomic_state_write() {
+        let repo = tempdir().expect("repo tempdir");
+        let state_path = repo.path().join("state").join(STATE_FILE_NAME);
+        let journal = JjJournal::with_state_path(repo.path(), &state_path);
+
+        let error = journal
+            .write_state_with_fault_injection(
+                &JournalState {
+                    session_start_revision: Some(RevisionId::from("rev-123")),
+                },
+                true,
+            )
+            .expect_err("fault injection should abort before rename");
+
+        assert!(matches!(error, JournalError::Io(_)));
+        assert!(
+            !state_path.exists(),
+            "final state file must be absent after pre-rename crash"
+        );
+        assert!(
+            temp_state_path(&state_path).expect("tmp path").exists(),
+            "temporary file should remain for crash observability"
+        );
+    }
+}

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -31,7 +31,7 @@ struct JournalState {
 
 impl JjJournal {
     pub fn new(project_root: impl AsRef<Path>) -> Result<Self, JournalError> {
-        let project_root = project_root.as_ref().to_path_buf();
+        let project_root = absolutize_project_root(project_root.as_ref())?;
         let state_path = derive_state_path()?;
         Ok(Self {
             project_root,
@@ -42,7 +42,8 @@ impl JjJournal {
     #[cfg(test)]
     fn with_state_path(project_root: impl AsRef<Path>, state_path: impl AsRef<Path>) -> Self {
         Self {
-            project_root: project_root.as_ref().to_path_buf(),
+            project_root: std::path::absolute(project_root.as_ref())
+                .unwrap_or_else(|_| project_root.as_ref().to_path_buf()),
             state_path: state_path.as_ref().to_path_buf(),
         }
     }
@@ -192,6 +193,11 @@ fn sanitize_snapshot_message(message: &str) -> Result<String, JournalError> {
     Ok(bounded)
 }
 
+fn absolutize_project_root(project_root: &Path) -> Result<PathBuf, JournalError> {
+    std::path::absolute(project_root)
+        .map_err(|err| JournalError::Io(format!("failed to resolve project root: {err}")))
+}
+
 fn derive_state_path() -> Result<PathBuf, JournalError> {
     std::env::var_os(SESSION_DIR_ENV)
         .map(|session_dir| PathBuf::from(session_dir).join(STATE_FILE_NAME))
@@ -241,6 +247,9 @@ fn write_state_atomically_inner(
     }
 
     fs::rename(&tmp_path, path)?;
+    if let Ok(dir) = fs::File::open(parent) {
+        let _ = dir.sync_all();
+    }
     Ok(())
 }
 

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -68,7 +68,8 @@ impl JjJournal {
         I: IntoIterator<Item = S>,
         S: Into<OsString>,
     {
-        let collected: Vec<OsString> = args.into_iter().map(Into::into).collect();
+        let mut collected: Vec<OsString> = vec!["--no-pager".into()];
+        collected.extend(args.into_iter().map(Into::into));
         let output = Command::new("jj")
             .args(&collected)
             .current_dir(&self.project_root)
@@ -371,7 +372,7 @@ mod tests {
         assert!(matches!(
             error,
             JournalError::CommandFailed { ref command, ref message }
-                if command == "jj describe -m snapshot me"
+                if command == "jj --no-pager describe -m snapshot me"
                     && message.contains("mock jj unavailable")
         ));
         assert!(
@@ -388,7 +389,7 @@ mod tests {
         let arg_log = repo.path().join("jj-args.bin");
         let script = format!(
             "#!/bin/sh\n\
-             if [ \"$1\" = \"log\" ]; then\n\
+             if [ \"$2\" = \"log\" ]; then\n\
                printf 'rev-from-log\\n'\n\
                exit 0\n\
              fi\n\
@@ -426,11 +427,12 @@ mod tests {
             .map(|chunk| String::from_utf8_lossy(chunk).to_string())
             .collect::<Vec<_>>();
 
-        assert!(parts.windows(4).any(|window| {
+        assert!(parts.windows(5).any(|window| {
             window[0] == "CALL"
-                && window[1] == "describe"
-                && window[2] == "-m"
-                && window[3] == "msg;$(touch hacked)`echo no` / second line"
+                && window[1] == "--no-pager"
+                && window[2] == "describe"
+                && window[3] == "-m"
+                && window[4] == "msg;$(touch hacked)`echo no` / second line"
         }));
         assert!(
             !repo.path().join("hacked").exists(),

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -5,7 +5,7 @@
 //! optional sidecar journal.
 
 use csa_core::vcs::{JournalError, RevisionId, SnapshotJournal};
-use csa_lock::acquire_lock;
+use csa_lock::acquire_project_resource_lock;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
 use std::fs;
@@ -124,20 +124,14 @@ impl JjJournal {
         F: FnOnce(&str) -> Result<RevisionId, JournalError>,
     {
         let sanitized = sanitize_snapshot_message(message)?;
-        let session_dir = self.state_path.parent().ok_or_else(|| {
-            JournalError::InvalidState(format!(
-                "state path has no parent: {}",
-                self.state_path.display()
-            ))
-        })?;
         let truncated_reason: String = sanitized.chars().take(64).collect();
         let reason = format!("snapshot: {truncated_reason}");
-        let _lock = acquire_lock(session_dir, "jj-journal-snapshot", &reason).map_err(|err| {
-            JournalError::CommandFailed {
-                command: "acquire_lock(jj-journal-snapshot)".to_string(),
-                message: err.to_string(),
-            }
-        })?;
+        let _lock =
+            acquire_project_resource_lock(&self.project_root, "jj-journal", "snapshot", &reason)
+                .map_err(|err| JournalError::CommandFailed {
+                    command: "acquire_project_resource_lock(jj-journal/snapshot)".to_string(),
+                    message: err.to_string(),
+                })?;
 
         let current_state = self.read_state()?.unwrap_or_default();
         let revision = revision_supplier(message)?;
@@ -268,18 +262,33 @@ mod tests {
         path
     }
 
-    fn set_path_for_test(path: &Path) {
-        // SAFETY: these tests hold TEST_ENV_LOCK for the full mutation window,
-        // so no concurrent environment access can race with PATH changes.
-        unsafe { std::env::set_var("PATH", path) };
+    struct PathGuard {
+        original: Option<OsString>,
     }
 
-    fn restore_path_for_test(original_path: Option<OsString>) {
-        match original_path {
-            // SAFETY: guarded by TEST_ENV_LOCK; see set_path_for_test().
-            Some(path) => unsafe { std::env::set_var("PATH", path) },
-            // SAFETY: guarded by TEST_ENV_LOCK; see set_path_for_test().
-            None => unsafe { std::env::remove_var("PATH") },
+    impl PathGuard {
+        fn prepend(bin_dir: &Path) -> Self {
+            let original = std::env::var_os("PATH");
+            let mut paths = vec![bin_dir.to_path_buf()];
+            if let Some(existing) = original.as_ref() {
+                paths.extend(std::env::split_paths(existing));
+            }
+            let joined = std::env::join_paths(paths).expect("join PATH");
+            // SAFETY: these tests hold TEST_ENV_LOCK for the full mutation window,
+            // so no concurrent environment access can race with PATH changes.
+            unsafe { std::env::set_var("PATH", joined) };
+            Self { original }
+        }
+    }
+
+    impl Drop for PathGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                // SAFETY: guarded by TEST_ENV_LOCK; see PathGuard::prepend().
+                Some(path) => unsafe { std::env::set_var("PATH", path) },
+                // SAFETY: guarded by TEST_ENV_LOCK; see PathGuard::prepend().
+                None => unsafe { std::env::remove_var("PATH") },
+            }
         }
     }
 
@@ -349,34 +358,26 @@ mod tests {
         let _guard = TEST_ENV_LOCK.lock().expect("lock env");
         let repo = tempdir().expect("repo tempdir");
         let bin_dir = tempdir().expect("bin tempdir");
-        let git_marker = repo.path().join("git-invoked");
-        let git_script = format!(
-            "#!/bin/sh\nprintf invoked > \"{}\"\nexit 0\n",
-            git_marker.display()
-        );
-        let git_path = bin_dir.path().join("git");
-        fs::write(&git_path, git_script).expect("write fake git");
-        let mut perms = fs::metadata(&git_path)
-            .expect("stat fake git")
-            .permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&git_path, perms).expect("chmod fake git");
+        let fake_jj = "#!/bin/sh\nprintf 'mock jj unavailable\\n' >&2\nexit 127\n";
+        make_fake_jj(bin_dir.path(), fake_jj);
+        let _path_guard = PathGuard::prepend(bin_dir.path());
+        let state_path = repo.path().join("state").join(STATE_FILE_NAME);
 
-        let original_path = std::env::var_os("PATH");
-        set_path_for_test(bin_dir.path());
-
-        let journal = JjJournal::with_state_path(
-            repo.path(),
-            repo.path().join("state").join(STATE_FILE_NAME),
-        );
+        let journal = JjJournal::with_state_path(repo.path(), &state_path);
         let error = journal
             .snapshot("snapshot me")
-            .expect_err("jj should be missing");
+            .expect_err("fake jj should fail before any fallback");
 
-        assert!(matches!(error, JournalError::Unavailable(_)));
-        assert!(!git_marker.exists(), "git fallback must not run");
-
-        restore_path_for_test(original_path);
+        assert!(matches!(
+            error,
+            JournalError::CommandFailed { ref command, ref message }
+                if command == "jj describe -m snapshot me"
+                    && message.contains("mock jj unavailable")
+        ));
+        assert!(
+            !state_path.exists(),
+            "failed jj snapshot must not persist session state"
+        );
     }
 
     #[test]
@@ -400,8 +401,7 @@ mod tests {
         );
         make_fake_jj(bin_dir.path(), &script);
 
-        let original_path = std::env::var_os("PATH");
-        set_path_for_test(bin_dir.path());
+        let _path_guard = PathGuard::prepend(bin_dir.path());
 
         let journal = JjJournal::with_state_path(
             repo.path(),
@@ -436,8 +436,6 @@ mod tests {
             !repo.path().join("hacked").exists(),
             "metacharacters must not execute"
         );
-
-        restore_path_for_test(original_path);
     }
 
     #[test]
@@ -469,19 +467,22 @@ mod tests {
     #[test]
     fn concurrent_snapshot_rejected_by_lock() {
         let repo = tempdir().expect("repo tempdir");
-        let session_dir = tempdir().expect("session tempdir");
-        let journal = Arc::new(JjJournal::with_state_path(
+        let session_dir_a = tempdir().expect("session A tempdir");
+        let session_dir_b = tempdir().expect("session B tempdir");
+        let first_journal = Arc::new(JjJournal::with_state_path(
             repo.path(),
-            session_dir.path().join(STATE_FILE_NAME),
+            session_dir_a.path().join(STATE_FILE_NAME),
         ));
+        let second_journal =
+            JjJournal::with_state_path(repo.path(), session_dir_b.path().join(STATE_FILE_NAME));
         let entered_lock = Arc::new(Barrier::new(2));
         let release_lock = Arc::new(Barrier::new(2));
 
-        let first_journal = Arc::clone(&journal);
+        let first_snapshot_journal = Arc::clone(&first_journal);
         let first_entered = Arc::clone(&entered_lock);
         let first_release = Arc::clone(&release_lock);
         let first = thread::spawn(move || {
-            first_journal.snapshot_with_revision_supplier("first snapshot", |_| {
+            first_snapshot_journal.snapshot_with_revision_supplier("first snapshot", |_| {
                 first_entered.wait();
                 first_release.wait();
                 Ok(RevisionId::from("rev-first"))
@@ -490,14 +491,14 @@ mod tests {
 
         entered_lock.wait();
 
-        let error = journal
+        let error = second_journal
             .snapshot_with_revision_supplier("second snapshot", |_| Ok(RevisionId::from("rev-2")))
             .expect_err("second snapshot should fail on lock contention");
 
         assert!(matches!(
             error,
             JournalError::CommandFailed { ref command, .. }
-                if command == "acquire_lock(jj-journal-snapshot)"
+                if command.contains("acquire_project_resource_lock")
         ));
 
         release_lock.wait();
@@ -508,7 +509,7 @@ mod tests {
             .expect("first snapshot should succeed");
         assert_eq!(first_revision, RevisionId::from("rev-first"));
         assert_eq!(
-            journal
+            first_journal
                 .session_start_revision()
                 .expect("state read should succeed"),
             Some(RevisionId::from("rev-first"))

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -52,8 +52,11 @@ impl JjJournal {
         &self,
         sanitized_message: &str,
     ) -> Result<RevisionId, JournalError> {
+        let desc_output = self.run_jj(["log", "--no-graph", "-r", "@", "-T", "description"])?;
+        let preserved_description = String::from_utf8_lossy(&desc_output.stdout).to_string();
+
         self.run_jj(["describe", "-m", sanitized_message])?;
-        self.run_jj(["new", "--no-edit"])?;
+        self.run_jj(["new", "-m", preserved_description.as_str()])?;
 
         let output = self.run_jj(["log", "--no-graph", "-r", "@-", "-T", "change_id"])?;
         let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -384,7 +387,7 @@ mod tests {
         assert!(matches!(
             error,
             JournalError::CommandFailed { ref command, ref message }
-                if command == "jj --no-pager --color=never describe -m snapshot me"
+                if command == "jj --no-pager --color=never log --no-graph -r @ -T description"
                     && message.contains("mock jj unavailable")
         ));
         assert!(

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -7,6 +7,7 @@ pub mod event_writer;
 pub mod finding_id;
 pub mod genealogy;
 pub mod git;
+pub mod jj_journal;
 pub mod manager;
 pub mod metadata;
 pub mod output_parser;
@@ -57,6 +58,7 @@ pub use metadata::SessionMetadata;
 
 pub use event_writer::{EventWriteStats, EventWriter};
 pub use finding_id::{FindingId, anchor_hash, normalize_path};
+pub use jj_journal::JjJournal;
 pub use output_parser::{
     estimate_tokens, load_output_index, parse_return_packet, persist_structured_output,
     persist_structured_output_from_file, read_all_sections, read_section,

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -399,132 +399,6 @@ fn is_sensitive_key(key: &str) -> bool {
     )
 }
 
-#[cfg(test)]
-mod tests {
-    use super::redact_result_sidecar_value;
-    use super::*;
-    use chrono::Utc;
-    use tempfile::tempdir;
-
-    #[test]
-    fn manager_result_redaction_preserves_toml_datetime_values() {
-        let sidecar = toml::toml! {
-            started_at = 2026-04-19T12:34:56Z
-            [auth]
-            token = "secret-token"
-        }
-        .into();
-
-        let redacted = redact_result_sidecar_value(&sidecar).expect("redacted sidecar");
-
-        assert!(matches!(
-            redacted.get("started_at"),
-            Some(toml::Value::Datetime(_))
-        ));
-        assert_eq!(
-            redacted
-                .get("auth")
-                .and_then(toml::Value::as_table)
-                .and_then(|table| table.get("token")),
-            Some(&toml::Value::String("[REDACTED]".to_string()))
-        );
-    }
-
-    #[test]
-    fn manager_result_redaction_preserves_nested_json_string_redaction() {
-        let sidecar = toml::toml! {
-            payload = "{\"secret\":\"top-secret\"}"
-        }
-        .into();
-
-        let redacted = redact_result_sidecar_value(&sidecar).expect("redacted sidecar");
-        let payload = redacted
-            .get("payload")
-            .and_then(toml::Value::as_str)
-            .expect("payload string");
-
-        assert!(!payload.contains("top-secret"));
-        assert!(payload.contains("[REDACTED]"));
-    }
-
-    #[test]
-    fn load_result_in_ignores_orphaned_sidecar() {
-        let td = tempdir().expect("tempdir");
-        let session_id = crate::validate::new_session_id();
-        let session_dir = super::super::get_session_dir_in(td.path(), &session_id);
-        std::fs::create_dir_all(session_dir.join("output")).expect("create output dir");
-        let result_path = session_dir.join(RESULT_FILE_NAME);
-
-        let now = Utc::now();
-        let turn_1_result = SessionResult {
-            status: "success".to_string(),
-            exit_code: 0,
-            summary: "turn 1".to_string(),
-            tool: "codex".to_string(),
-            started_at: now,
-            completed_at: now,
-            events_count: 1,
-            artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
-            peak_memory_mb: None,
-            manager_fields: crate::result::SessionManagerFields {
-                report: Some(
-                    toml::toml! {
-                        [repo_write_audit]
-                        added = ["turn-1.txt"]
-                    }
-                    .into(),
-                ),
-                ..Default::default()
-            },
-        };
-        save_result_in(
-            td.path(),
-            &session_id,
-            &turn_1_result,
-            SaveOptions::default(),
-        )
-        .expect("save turn 1");
-
-        let turn_2_result = SessionResult {
-            summary: "turn 2".to_string(),
-            manager_fields: Default::default(),
-            ..turn_1_result
-        };
-        save_result_in(
-            td.path(),
-            &session_id,
-            &turn_2_result,
-            SaveOptions::default(),
-        )
-        .expect("save turn 2");
-
-        let mut turn_2_envelope: SessionResult =
-            toml::from_str(&std::fs::read_to_string(&result_path).expect("read turn 2 envelope"))
-                .expect("parse turn 2 envelope");
-        turn_2_envelope
-            .artifacts
-            .retain(|artifact| artifact.path != CONTRACT_RESULT_ARTIFACT_PATH);
-        let contents =
-            toml::to_string_pretty(&turn_2_envelope).expect("serialize orphaned envelope");
-        write_file_atomically(&result_path, &contents).expect("persist orphaned envelope");
-
-        let reloaded = load_result_in(td.path(), &session_id)
-            .expect("load result")
-            .expect("result should exist");
-        assert!(
-            reloaded
-                .artifacts
-                .iter()
-                .all(|artifact| artifact.path != CONTRACT_RESULT_ARTIFACT_PATH),
-            "turn 2 envelope must not advertise the manager sidecar"
-        );
-        assert!(
-            reloaded.manager_fields.as_sidecar().is_none(),
-            "orphaned sidecar must not leak prior manager fields into turn 2"
-        );
-    }
-}
-
 /// Load a session result
 pub fn load_result(project_path: &Path, session_id: &str) -> Result<Option<SessionResult>> {
     let base_dir = super::resolve_read_base_dir(project_path, Some(session_id))?;
@@ -654,4 +528,130 @@ pub(crate) fn list_artifacts_in(base_dir: &Path, session_id: &str) -> Result<Vec
     }
     artifacts.sort();
     Ok(artifacts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_result_sidecar_value;
+    use super::*;
+    use chrono::Utc;
+    use tempfile::tempdir;
+
+    #[test]
+    fn manager_result_redaction_preserves_toml_datetime_values() {
+        let sidecar = toml::toml! {
+            started_at = 2026-04-19T12:34:56Z
+            [auth]
+            token = "secret-token"
+        }
+        .into();
+
+        let redacted = redact_result_sidecar_value(&sidecar).expect("redacted sidecar");
+
+        assert!(matches!(
+            redacted.get("started_at"),
+            Some(toml::Value::Datetime(_))
+        ));
+        assert_eq!(
+            redacted
+                .get("auth")
+                .and_then(toml::Value::as_table)
+                .and_then(|table| table.get("token")),
+            Some(&toml::Value::String("[REDACTED]".to_string()))
+        );
+    }
+
+    #[test]
+    fn manager_result_redaction_preserves_nested_json_string_redaction() {
+        let sidecar = toml::toml! {
+            payload = "{\"secret\":\"top-secret\"}"
+        }
+        .into();
+
+        let redacted = redact_result_sidecar_value(&sidecar).expect("redacted sidecar");
+        let payload = redacted
+            .get("payload")
+            .and_then(toml::Value::as_str)
+            .expect("payload string");
+
+        assert!(!payload.contains("top-secret"));
+        assert!(payload.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn load_result_in_ignores_orphaned_sidecar() {
+        let td = tempdir().expect("tempdir");
+        let session_id = crate::validate::new_session_id();
+        let session_dir = super::super::get_session_dir_in(td.path(), &session_id);
+        std::fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+        let result_path = session_dir.join(RESULT_FILE_NAME);
+
+        let now = Utc::now();
+        let turn_1_result = SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "turn 1".to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            events_count: 1,
+            artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
+            peak_memory_mb: None,
+            manager_fields: crate::result::SessionManagerFields {
+                report: Some(
+                    toml::toml! {
+                        [repo_write_audit]
+                        added = ["turn-1.txt"]
+                    }
+                    .into(),
+                ),
+                ..Default::default()
+            },
+        };
+        save_result_in(
+            td.path(),
+            &session_id,
+            &turn_1_result,
+            SaveOptions::default(),
+        )
+        .expect("save turn 1");
+
+        let turn_2_result = SessionResult {
+            summary: "turn 2".to_string(),
+            manager_fields: Default::default(),
+            ..turn_1_result
+        };
+        save_result_in(
+            td.path(),
+            &session_id,
+            &turn_2_result,
+            SaveOptions::default(),
+        )
+        .expect("save turn 2");
+
+        let mut turn_2_envelope: SessionResult =
+            toml::from_str(&std::fs::read_to_string(&result_path).expect("read turn 2 envelope"))
+                .expect("parse turn 2 envelope");
+        turn_2_envelope
+            .artifacts
+            .retain(|artifact| artifact.path != CONTRACT_RESULT_ARTIFACT_PATH);
+        let contents =
+            toml::to_string_pretty(&turn_2_envelope).expect("serialize orphaned envelope");
+        write_file_atomically(&result_path, &contents).expect("persist orphaned envelope");
+
+        let reloaded = load_result_in(td.path(), &session_id)
+            .expect("load result")
+            .expect("result should exist");
+        assert!(
+            reloaded
+                .artifacts
+                .iter()
+                .all(|artifact| artifact.path != CONTRACT_RESULT_ARTIFACT_PATH),
+            "turn 2 envelope must not advertise the manager sidecar"
+        );
+        assert!(
+            reloaded.manager_fields.as_sidecar().is_none(),
+            "orphaned sidecar must not leak prior manager fields into turn 2"
+        );
+    }
 }

--- a/crates/csa-session/tests/ui/jj_journal_not_vcs_backend.rs
+++ b/crates/csa-session/tests/ui/jj_journal_not_vcs_backend.rs
@@ -5,6 +5,6 @@ use std::path::Path;
 fn needs_vcs_backend(_backend: &dyn VcsBackend) {}
 
 fn main() {
-    let journal = JjJournal::new(Path::new("."));
+    let journal = JjJournal::new(Path::new(".")).expect("journal should construct");
     needs_vcs_backend(&journal);
 }

--- a/crates/csa-session/tests/ui/jj_journal_not_vcs_backend.rs
+++ b/crates/csa-session/tests/ui/jj_journal_not_vcs_backend.rs
@@ -1,0 +1,10 @@
+use csa_core::vcs::VcsBackend;
+use csa_session::JjJournal;
+use std::path::Path;
+
+fn needs_vcs_backend(_backend: &dyn VcsBackend) {}
+
+fn main() {
+    let journal = JjJournal::new(Path::new("."));
+    needs_vcs_backend(&journal);
+}

--- a/crates/csa-session/tests/ui/jj_journal_not_vcs_backend.stderr
+++ b/crates/csa-session/tests/ui/jj_journal_not_vcs_backend.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `JjJournal: VcsBackend` is not satisfied
+ --> tests/ui/jj_journal_not_vcs_backend.rs:9:23
+  |
+9 |     needs_vcs_backend(&journal);
+  |                       ^^^^^^^^ the trait `VcsBackend` is not implemented for `JjJournal`
+  |
+help: the following other types implement trait `VcsBackend`
+ --> src/vcs_backends.rs
+  |
+  | impl VcsBackend for GitBackend {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `GitBackend`
+...
+  | impl VcsBackend for JjBackend {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `JjBackend`
+  = note: required for the cast from `&JjJournal` to `&dyn VcsBackend`

--- a/crates/csa-session/tests/vcs_journal_compile_fail.rs
+++ b/crates/csa-session/tests/vcs_journal_compile_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn vcs_backend_and_journal_are_separate_traits() {
+    let cases = trybuild::TestCases::new();
+    cases.compile_fail("tests/ui/jj_journal_not_vcs_backend.rs");
+}


### PR DESCRIPTION
## Summary

Phase 1-A of the **#1146 jj sidecar snapshot journal** MVP. Adds the `SnapshotJournal` trait (parallel sidecar contract — explicitly NOT a `VcsBackend` supertype) and the `JjJournal` implementation. This is the foundation for subsequent phases; PostRun integration, the `[vcs].auto_snapshot` config field, colocated preflight, and aggregation/export/rollback are all explicitly deferred per the saved mktd plan (timestamp 20260427T002302).

## What landed

**`crates/csa-core/src/vcs.rs`** — `RevisionId` newtype, `JournalError` thiserror enum, `SnapshotJournal` trait with `snapshot()` and `session_start_revision()`. Doc comments make it explicit the trait is a sidecar contract, not a VcsBackend variant.

**`crates/csa-session/src/jj_journal.rs`** — `JjJournal` implementation:
- Fail-closed state path: `JjJournal::new` returns `Err(JournalError::Unavailable(...))` when `CSA_SESSION_DIR` is unset (no `temp_dir()` fallback — AGENTS.md Meta 037/041).
- Per-project_root flock guard via new `csa_lock::acquire_project_resource_lock` so two CSA sessions in the same colocated repo serialize on the SAME `.jj/` repo (different session_dirs no longer race).
- Atomic state writes (`.tmp` + rename), shell-safe `Command::new("jj").args(...)` (no shell), no git fallback when jj is missing.

**`crates/csa-lock/src/lib.rs`** — new `acquire_project_resource_lock(project_root, resource_kind, tool_name, reason)` helper. Lock path is `${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/<resource_kind>-locks/<sha256(canonical(project_root))>/<tool_name>.lock`. Cross-session coordination primitive for shared-resource scenarios.

**Tests added**:
- `new_fails_when_session_dir_missing` — fail-closed when CSA_SESSION_DIR absent.
- `new_succeeds_when_session_dir_set` — happy path.
- `concurrent_snapshot_rejected_by_lock` — two `JjJournal` instances on the same `project_root` (different state_paths) serialize on the per-project lock.
- `vcs_backend_and_journal_are_separate_traits` — trybuild compile-fail test asserting `JjJournal` does NOT impl `VcsBackend` (sidecar boundary).
- `csa-lock` regression tests for `acquire_project_resource_lock` (same-root conflicts, different-root non-conflicts).

## Explicitly deferred (NOT a Phase 1-A scope gap)

Per the saved mktd plan, the following are out-of-scope for Phase 1-A and tracked in subsequent phases of #1146:

- **Phase 1-B**: PostRun pipeline integration; colocated `.jj/`+`.git/` preflight gating.
- **Phase 1-C**: `csa-config::VcsConfig::auto_snapshot` field + opt-in default + the matching preflight that activates the journal only when both the config flag is on and the repo is colocated.
- **V2** (per user decision D2 — explicit-only): aggregation entrypoint, snapshot range verification, `jj git export` rollback path, `op_id` tracking for lineage proofs, `change_id` → `commit_id` migration for immutable snapshot identity.

These are not gaps in Phase 1-A — they are the next phases of the rollout. Local `csa review` rounds 2 and 3 re-flagged them as MVP-incomplete; per CLAUDE.md "iterative narrow fixes ≠ design ping-pong" rule, scope-expansion findings that don't name a new in-scope correctness bug are circuit-break signals, not iteration drivers.

## Local review history

- **Round 0** (2df8cf50): initial trait + stub landed.
- **Round 1** (review session 01KQ66DE78T → fix 5924df03): two HIGH findings — `derive_state_path` silently fell back to `temp_dir()`, and `snapshot()` had a non-atomic RMW. Both fixed: fail-closed Unavailable error + flock guard.
- **Round 2** (review session 01KQ680B0E → fixes 2e1e9b90 + 65158f08): one HIGH finding — flock was per-session-dir, two CSA sessions in the same repo could still race on `.jj/`. Fixed: introduced `csa_lock::acquire_project_resource_lock` keyed by canonical project_root.
- **Round 3** (review session 01KQ69Q1GX): no new in-scope correctness findings; only re-flagged the explicitly-deferred Phase 1-B/1-C/V2 items. Circuit-break per design-ping-pong rule.

## Test plan

- [ ] cloud bot review (gemini-code-assist) gives clean read on the Phase 1-A scope.
- [ ] CI green on Linux (macOS pre-existing red — see CLAUDE.md "ignore macOS CI failures" memory).
- [ ] No regression in `cargo test -p csa-core -p csa-session -p csa-lock`.
- [ ] `just pre-commit` exits 0 on the merge commit.

Related: #1146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)