### PR TITLE
feat(review): add --diff --full-consistency flag for touched-file scan (closes #1161)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.590"
+version = "0.1.591"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.590"
+version = "0.1.591"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -78,6 +78,10 @@ pub struct ReviewArgs {
     #[arg(long)]
     pub diff: bool,
 
+    /// Extend review agent consistency scan to touched files; does not change diff scope
+    #[arg(long)]
+    pub full_consistency: bool,
+
     /// Compare against branch (default: main)
     #[arg(long, conflicts_with_all = ["diff", "commit", "range", "files"])]
     pub branch: Option<String>,

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -477,9 +477,9 @@ async fn handle_debate_marks_unavailable_when_all_tier_models_fail() {
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
 
-    for (binary, version, stderr_line) in
-        [("gemini", "gemini-cli 1.0.0", "reason: 'QUOTA_EXHAUSTED'")]
     {
+        let (binary, version, stderr_line) =
+            ("gemini", "gemini-cli 1.0.0", "reason: 'QUOTA_EXHAUSTED'");
         let path = bin_dir.join(binary);
         std::fs::write(
             &path,

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -1,4 +1,7 @@
 use crate::cli::ReviewArgs;
+use crate::pipeline::resolve_initial_response_timeout_for_tool;
+#[cfg(test)]
+use crate::pipeline::resolve_initial_response_timeout_for_tool as resolve_review_initial_response_timeout_seconds;
 use crate::review_consensus::{
     CLEAN, agreement_level, build_multi_reviewer_instruction, consensus_strategy_label,
     consensus_verdict, parse_consensus_strategy, resolve_consensus,
@@ -13,6 +16,7 @@ use crate::review_routing::ReviewRoutingMetadata;
 use anyhow::{Context, Result};
 #[cfg(test)]
 use csa_config::GlobalConfig;
+#[cfg(test)]
 use csa_config::ProjectConfig;
 use csa_core::consensus::AgentResponse;
 use csa_core::types::ReviewDecision;
@@ -331,7 +335,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
     let stream_mode = resolve_review_stream_mode(args.stream_stdout, args.no_stream_stdout);
     let idle_timeout_seconds =
         crate::pipeline::resolve_idle_timeout_seconds(config.as_ref(), args.idle_timeout);
-    let initial_response_timeout_seconds = resolve_review_initial_response_timeout_seconds(
+    let initial_response_timeout_seconds = resolve_initial_response_timeout_for_tool(
         config.as_ref(),
         args.initial_response_timeout,
         args.idle_timeout,
@@ -621,13 +625,12 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             });
         let reviewer_tier_name = resolved_tier_name.clone();
         let reviewer_thinking = review_thinking.clone();
-        let reviewer_initial_response_timeout_seconds =
-            resolve_review_initial_response_timeout_seconds(
-                reviewer_config.as_ref(),
-                args.initial_response_timeout,
-                args.idle_timeout,
-                reviewer_tool.as_str(),
-            );
+        let reviewer_initial_response_timeout_seconds = resolve_initial_response_timeout_for_tool(
+            reviewer_config.as_ref(),
+            args.initial_response_timeout,
+            args.idle_timeout,
+            reviewer_tool.as_str(),
+        );
         join_set.spawn(async move {
             let session_result = execute_review(
                 reviewer_tool,
@@ -779,19 +782,6 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
     Ok(if final_verdict == CLEAN { 0 } else { 1 })
 }
 
-fn resolve_review_initial_response_timeout_seconds(
-    config: Option<&ProjectConfig>,
-    cli_initial_response_timeout: Option<u64>,
-    cli_idle_timeout: Option<u64>,
-    tool_name: &str,
-) -> Option<u64> {
-    crate::pipeline::resolve_initial_response_timeout_for_tool(
-        config,
-        cli_initial_response_timeout,
-        cli_idle_timeout,
-        tool_name,
-    )
-}
 #[cfg(test)]
 #[path = "review_cmd_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -253,6 +253,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         ReviewProjectPromptOptions {
             project_config: config.as_ref(),
             prior_rounds_section: prior_rounds_section.as_deref(),
+            full_consistency: args.full_consistency,
         },
     );
 
@@ -785,6 +786,9 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
 #[cfg(test)]
 #[path = "review_cmd_tests.rs"]
 mod tests;
+#[cfg(test)]
+#[path = "review_cmd_tests_full_consistency.rs"]
+mod tests_full_consistency;
 #[cfg(test)]
 #[path = "review_cmd_timeout_tests.rs"]
 mod timeout_tests;

--- a/crates/cli-sub-agent/src/review_cmd_execute_guard_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_guard_tests.rs
@@ -20,7 +20,7 @@ async fn execute_review_fails_when_repo_root_output_artifact_is_created() {
     let fake_opencode = bin_dir.join("opencode");
     std::fs::write(
         &fake_opencode,
-        &format!(
+        format!(
             "#!/bin/sh\n\
 mkdir -p \"{}\"\n\
 printf 'repo-root leak\\n' > \"{}\"\n\
@@ -109,7 +109,7 @@ async fn execute_review_error_path_still_checks_artifact_contract() {
     let fake_opencode = bin_dir.join("opencode");
     std::fs::write(
         &fake_opencode,
-        &format!(
+        format!(
             "#!/bin/sh\n\
 mkdir -p \"{}\"\n\
 printf 'repo-root leak\\n' > \"{}\"\n\
@@ -289,7 +289,7 @@ async fn execute_review_fails_when_repo_root_findings_artifact_is_created() {
     let fake_opencode = bin_dir.join("opencode");
     std::fs::write(
         &fake_opencode,
-        &format!(
+        format!(
             "#!/bin/sh\n\
 printf '{{\"findings\":[]}}\\n' > \"{}\"\n\
 printf '%s\\n' \

--- a/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tests.rs
@@ -22,7 +22,7 @@ async fn execute_review_reclassifies_complete_review_after_edit_restriction() {
     let fake_opencode = bin_dir.join("opencode");
     std::fs::write(
         &fake_opencode,
-        &format!(
+        format!(
             "#!/bin/sh\n\
 printf '%s\\n' \
 '<!-- CSA:SECTION:summary -->' \

--- a/crates/cli-sub-agent/src/review_cmd_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix.rs
@@ -497,7 +497,7 @@ mod tests {
 
     /// Mixed staleness (#1045 round 4): stale findings.toml with a MEDIUM finding
     /// + stale review-findings.json with a HIGH finding. Converge clean → both
-    /// must be cleared, verdict must be pass.
+    ///   must be cleared, verdict must be pass.
     #[test]
     fn persist_fix_final_artifacts_clears_both_stale_artifacts_on_clean() {
         let project_root = temp_project_root("persist-fix-both-stale");

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -634,6 +634,12 @@ pub(crate) fn build_review_instruction_for_project(
     let review_routing = detect_review_routing_metadata(project_root, options.project_config);
     let mut instruction =
         build_review_instruction(scope, mode, security_mode, review_mode, context);
+    let consistency_scope = if options.full_consistency {
+        "touched-files"
+    } else {
+        "diff-only"
+    };
+    instruction.push_str(&format!("\nconsistency_scope={consistency_scope}"));
     instruction.push_str(&format!(
         "\n[project_profile: {}]",
         review_routing.project_profile
@@ -675,6 +681,7 @@ pub(crate) fn build_review_instruction_for_project(
 pub(crate) struct ReviewProjectPromptOptions<'a> {
     pub(crate) project_config: Option<&'a ProjectConfig>,
     pub(crate) prior_rounds_section: Option<&'a str>,
+    pub(crate) full_consistency: bool,
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -417,6 +417,7 @@ fn default_review_args() -> ReviewArgs {
         thinking: None,
         no_failover: false,
         diff: false,
+        full_consistency: false,
         branch: None,
         commit: None,
         range: None,

--- a/crates/cli-sub-agent/src/review_cmd_tests_checklist.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_checklist.rs
@@ -22,6 +22,7 @@ fn build_review_instruction_for_project_injects_review_checklist() {
         resolve::ReviewProjectPromptOptions {
             project_config: None,
             prior_rounds_section: None,
+            full_consistency: false,
         },
     );
 
@@ -50,6 +51,7 @@ fn build_review_instruction_for_project_omits_checklist_when_missing() {
         resolve::ReviewProjectPromptOptions {
             project_config: None,
             prior_rounds_section: None,
+            full_consistency: false,
         },
     );
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_full_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_full_consistency.rs
@@ -1,0 +1,67 @@
+use super::*;
+use crate::cli::{Cli, Commands, ReviewMode, validate_review_args};
+use clap::Parser;
+use tempfile::tempdir;
+
+fn parse_review_args(argv: &[&str]) -> ReviewArgs {
+    let cli = Cli::try_parse_from(argv).expect("review CLI args should parse");
+    match cli.command {
+        Commands::Review(args) => {
+            validate_review_args(&args).expect("review CLI args should validate");
+            args
+        }
+        _ => panic!("expected review subcommand"),
+    }
+}
+
+#[test]
+fn review_cli_parses_full_consistency_flag() {
+    let args = parse_review_args(&["csa", "review", "--diff", "--full-consistency"]);
+
+    assert!(args.diff);
+    assert!(args.full_consistency);
+}
+
+#[test]
+fn test_build_review_instruction_no_diff_content_default() {
+    let project_dir = tempdir().unwrap();
+    let (result, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: None,
+            full_consistency: false,
+        },
+    );
+
+    assert!(result.contains("scope=uncommitted"));
+    assert!(result.contains("consistency_scope=diff-only"));
+    assert!(!result.contains("git diff"));
+    assert!(!result.contains("Pass 1:"));
+}
+
+#[test]
+fn test_build_review_instruction_full_consistency() {
+    let project_dir = tempdir().unwrap();
+    let (result, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            prior_rounds_section: None,
+            full_consistency: true,
+        },
+    );
+
+    assert!(result.contains("scope=uncommitted"));
+    assert!(result.contains("consistency_scope=touched-files"));
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -118,6 +118,7 @@ fn build_review_instruction_for_project_contains_design_preference_anchor() {
         resolve::ReviewProjectPromptOptions {
             project_config: None,
             prior_rounds_section: None,
+            full_consistency: false,
         },
     );
 
@@ -159,6 +160,7 @@ fn count_prior_reviews_zero_omits_iteration_block() {
         resolve::ReviewProjectPromptOptions {
             project_config: None,
             prior_rounds_section: None,
+            full_consistency: false,
         },
     );
 
@@ -193,6 +195,7 @@ fn count_prior_reviews_one_injects_iteration_two() {
         resolve::ReviewProjectPromptOptions {
             project_config: None,
             prior_rounds_section: None,
+            full_consistency: false,
         },
     );
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
@@ -53,6 +53,7 @@ invariant = "lock-losing resume cannot mutate metadata of winning session"
         resolve::ReviewProjectPromptOptions {
             project_config: None,
             prior_rounds_section: Some(&prior_rounds),
+            full_consistency: false,
         },
     );
 
@@ -144,6 +145,7 @@ fn build_review_instruction_for_project_without_prior_rounds_flag_leaves_section
         resolve::ReviewProjectPromptOptions {
             project_config: None,
             prior_rounds_section: None,
+            full_consistency: false,
         },
     );
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -414,6 +414,7 @@ fn test_build_review_instruction_for_project_includes_rust_profile() {
         resolve::ReviewProjectPromptOptions {
             project_config: None,
             prior_rounds_section: None,
+            full_consistency: false,
         },
     );
 
@@ -435,6 +436,7 @@ fn test_build_review_instruction_for_project_includes_unknown_profile_for_empty_
         resolve::ReviewProjectPromptOptions {
             project_config: None,
             prior_rounds_section: None,
+            full_consistency: false,
         },
     );
 

--- a/crates/cli-sub-agent/src/run_cmd_attempt_exec.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_exec.rs
@@ -88,20 +88,6 @@ pub(super) async fn run_ephemeral_without_timeout(
     ))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn direct_entry_resolved_timeout_preserves_pipeline_resolved_semantics() {
-        assert_eq!(direct_entry_resolved_timeout(None), ResolvedTimeout(None));
-        assert_eq!(
-            direct_entry_resolved_timeout(Some(45)),
-            ResolvedTimeout(Some(45))
-        );
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn run_persistent_with_timeout(
     executor: &Executor,
@@ -335,4 +321,18 @@ async fn execute_persistent(
     };
 
     Ok(execution)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_entry_resolved_timeout_preserves_pipeline_resolved_semantics() {
+        assert_eq!(direct_entry_resolved_timeout(None), ResolvedTimeout(None));
+        assert_eq!(
+            direct_entry_resolved_timeout(Some(45)),
+            ResolvedTimeout(Some(45))
+        );
+    }
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics.rs
@@ -248,9 +248,7 @@ mod tests {
         // Write a file larger than DIAGNOSTIC_TAIL_BYTES (64 KiB).
         let line = "A".repeat(80) + "\n"; // 81 bytes per line
         let lines_needed = (DIAGNOSTIC_TAIL_BYTES as usize / line.len()) + 200;
-        let content: String = std::iter::repeat(line.as_str())
-            .take(lines_needed)
-            .collect();
+        let content: String = std::iter::repeat_n(line.as_str(), lines_needed).collect();
         assert!(content.len() as u64 > DIAGNOSTIC_TAIL_BYTES);
         fs::write(&path, &content).unwrap();
 

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -77,7 +77,7 @@ fn reconciler_does_not_clobber_runtime_liveness_snapshot() {
     let session_dir = td.path();
 
     fs::write(session_dir.join("output.log"), "fresh output bytes\n").expect("write output log");
-    write_liveness_snapshot(&session_dir, ["spool_bytes_written=19"]);
+    write_liveness_snapshot(session_dir, ["spool_bytes_written=19"]);
 
     let snapshot_path = session_dir.join(".liveness.snapshot");
     let before = fs::read(&snapshot_path).expect("read runtime snapshot before reconcile");
@@ -114,7 +114,7 @@ fn missing_current_sizes_do_not_count_as_reconcile_progress() {
     let session_dir = td.path();
 
     write_liveness_snapshot(
-        &session_dir,
+        session_dir,
         [
             "observed_spool_bytes_written=19",
             "acp_events_size=7",

--- a/patterns/csa-review/skills/csa-review/SKILL.md
+++ b/patterns/csa-review/skills/csa-review/SKILL.md
@@ -21,6 +21,7 @@ triggers:
 4. Your scope/mode/security_mode parameters are in your initial prompt. Parse them from there.
 5. **STRONG PREFERENCE — DIRECT REVIEW**: Perform the review DIRECTLY by running `git diff`, reading files, and analyzing code yourself. Avoid spawning `csa run`/`csa review`/`csa debate` sub-agents unless the scope genuinely requires delegation (e.g., a 50K-line changeset that won't fit). Fractal recursion is allowed up to the configured ceiling (`project.max_recursion_depth`, default 5) and `pipeline::load_and_validate` enforces it, but a reviewer that nests more reviewers rarely adds value and complicates artifact attribution. When in doubt, read and analyze in-process.
 6. **REVIEW-ONLY SAFETY**: Do NOT run `git add`, `git commit`, `git push`, `git merge`, `git rebase`, `git checkout`, `git reset`, `git stash`, or any `gh pr *` mutation command. Review mode must not mutate repo or PR state.
+7. If the initial prompt contains `consistency_scope=touched-files`, extend consistency checks to bounded full content for touched files as defined in [Review Protocol](references/review-protocol.md). If it contains `consistency_scope=diff-only` or omits the parameter, keep consistency checks limited to the collected diff.
 
 **Only if you are Claude Code and a human user typed `/csa-review` in the chat**:
 - You are the **orchestrator**. Follow the "Execution Protocol" steps below.
@@ -46,6 +47,7 @@ Run structured code reviews through CSA, ensuring:
 - `mode` (optional): `review-only` (default) or `review-and-fix`
 - `review_mode` (optional): `standard` (default) or `red-team`
 - `security_mode` (optional): `auto` (default) | `on` | `off`
+- `consistency_scope` (optional): `diff-only` (default) | `touched-files`
 - `tool` (optional): override review tool (default: auto-detect independent reviewer)
 - `context` (optional): path to `TODO.md` or `spec.toml` to check implementation alignment against the planned design
 

--- a/patterns/csa-review/skills/csa-review/references/review-protocol.md
+++ b/patterns/csa-review/skills/csa-review/references/review-protocol.md
@@ -86,6 +86,35 @@ git diff --no-color "{from}...{to}"
 git diff --no-color -- "{pathspec}"
 ```
 
+## Step 2.1: Touched-File Consistency Scan
+
+Consistency scope: {consistency_scope}
+
+Default behavior is `consistency_scope=diff-only`: use the collected diff as the
+review boundary and do not read full touched-file contents solely for consistency
+checking.
+
+When `consistency_scope=touched-files`, extend only the consistency scan:
+
+1. Collect touched paths for the selected scope before reading file contents:
+   - `uncommitted`: combine staged, unstaged, and untracked paths from
+     `git diff --name-status --staged`, `git diff --name-status`, and
+     `git ls-files --others --exclude-standard`.
+   - `base:<branch>`: use `git diff --name-status "$BASE_SHA"...HEAD`.
+   - `range:<from>...<to>`: use `git diff --name-status "{from}...{to}"`.
+   - `commit:<sha>`: use `git diff-tree --no-commit-id --name-status -r "{sha}"`.
+   - `files:<pathspec>`: use `git diff --name-status -- "{pathspec}"`.
+2. Read bounded full content only for touched paths that are non-binary,
+   undeleted, and still inside the repository.
+3. Skip and record any path that is deleted, binary, outside the repository, or
+   large (>200KB OR >5K lines).
+4. Use the bounded full-content set to check consistency issues that narrow diff
+   hunks often miss: field names, serialized wire names, section anchors, line
+   citations, and cross-file references.
+5. Do not expand to untouched files or the whole repository. If no touched files
+   are eligible, continue with the diff-only review.
+6. Report any unscanned touched paths in `open_questions` with the skip reason.
+
 ## Step 2.5: Plan / Spec Alignment (when context is provided)
 
 Context: {context}


### PR DESCRIPTION
## Summary

Adds an opt-in `--full-consistency` flag to `csa review --diff` that extends the review agent's consistency scan to a bounded full-text read of touched files (the files appearing in the diff), without changing the underlying diff scope or any of `--diff`/`--commit`/`--range`/`--files` semantics.

The previous strict-diff-only scope let cross-reference issues (wire-field renames, issuer attribution, cross-file section anchors, `§NN:LINE` citations, drifted line numbers) escape detection until they surfaced one-finding-per-round across 3-4 amend cycles. The opt-in flag converges the same correctness checks into a single bounded touched-file pass.

## What changed

- **CLI**: new `--full-consistency` flag on `csa review`, default `false`, no impact on existing scope flags.
- **Prompt**: emits `consistency_scope=touched-files` (vs `diff-only` default). Diff content itself remains out of the prompt — the existing test guard `test_build_review_instruction_no_diff_content` is preserved.
- **Protocol**: `patterns/csa-review/skills/csa-review/SKILL.md` and `references/review-protocol.md` updated to document the touched-file scan, the bounded full-text read with binary/deleted/oversized skip behavior, and open-question annotations for unscannable paths.
- **Boundary**: scope of the underlying diff command is unchanged. `derive_scope()`, scope metadata, and `diff_fingerprint` all preserved.

## Commits

1. `c52bc680` `refactor(review): inline timeout-resolver wrapper + autofix test warnings (#1161 prep)` — clears 800-line monolith headroom and fixes pre-existing clippy warnings that were blocking branch commits.
2. `21b8dc4f` `feat(review): add --diff --full-consistency flag for touched-file scan (closes #1161)` — the actual flag plumbing, prompt extension, protocol docs, and tests.

## Plan & RECON

- mktd plan: `~/.local/state/cli-sub-agent/.../todos/20260427T043652/TODO.md` — saved via `csa todo` with debate evidence and threat model.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p cli-sub-agent --all-targets -- -D warnings` clean
- [x] `cargo nextest run -p cli-sub-agent` (full suite) green, including new `review_cli_parses_full_consistency_flag` and prompt-extension tests in `review_cmd_tests_full_consistency.rs`
- [x] `just find-monolith-files` clean (all touched files ≤ 800 lines)
- [x] `just pre-commit` clean
- [x] `csa review --branch main` cumulative review on this branch: zero findings (HIGH/CRITICAL/MEDIUM/LOW)
- [ ] cloud-bot review on PR

## Threat model (Phase 2.5 from mktd plan)

- **Sensitive data**: full-text read limited to in-tree touched files; `.gitignore`d secrets/.env not in diff set.
- **Hostile input**: scanned content is source code; same prompt-injection risk as `--commit` mode (existing).
- **Token cost**: bounded by binary/oversized skip; reviewer reports unscanned paths as open questions.
- **Default behavior change**: opt-in flag, default unchanged — no backward-compat surface.