### PR TITLE
chore(dev2merge): drop --tool codex default so per-step tiers decide (closes #1169)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.594"
+version = "0.1.595"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.594"
+version = "0.1.595"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -229,7 +229,7 @@ set -euo pipefail
 CURRENT_BRANCH="$(git branch --show-current)"
 FEATURE_INPUT="${FEATURE_INPUT:-${SCOPE:-current branch changes pending merge}}"
 USER_LANGUAGE_OVERRIDE="${CSA_USER_LANGUAGE:-}"
-MKTD_TOOL_EFFECTIVE="${MKTD_TOOL:-${CSA_MKTD_TOOL:-codex}}" # Default codex; gemini-cli ACP blocked by #778/#755
+MKTD_TOOL_EFFECTIVE="${MKTD_TOOL:-${CSA_MKTD_TOOL:-}}" # Default empty so mktd's per-step tier annotations decide; override via env (closes #1169)
 MKTD_TIMEOUT_SECONDS="${MKTD_TIMEOUT_SECONDS:-1800}" # #1118 part A + #1137: hard cap on mktd wall-clock, aligned with csa CLI execution.min_timeout_seconds (1800s)
 if [ -n "${MKTD_TOOL_EFFECTIVE}" ]; then
   MKTD_TOOL_ARGS=(--tool "${MKTD_TOOL_EFFECTIVE}")

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -296,7 +296,7 @@ set -euo pipefail
 CURRENT_BRANCH="$(git branch --show-current)"
 FEATURE_INPUT="${FEATURE_INPUT:-${SCOPE:-current branch changes pending merge}}"
 USER_LANGUAGE_OVERRIDE="${CSA_USER_LANGUAGE:-}"
-MKTD_TOOL_EFFECTIVE="${MKTD_TOOL:-${CSA_MKTD_TOOL:-codex}}" # Default codex; gemini-cli ACP blocked by #778/#755
+MKTD_TOOL_EFFECTIVE="${MKTD_TOOL:-${CSA_MKTD_TOOL:-}}" # Default empty so mktd's per-step tier annotations decide; override via env (closes #1169)
 MKTD_TIMEOUT_SECONDS="${MKTD_TIMEOUT_SECONDS:-1800}" # #1118 part A + #1137: hard cap on mktd wall-clock, aligned with csa CLI execution.min_timeout_seconds (1800s)
 if [ -n "${MKTD_TOOL_EFFECTIVE}" ]; then
   MKTD_TOOL_ARGS=(--tool "${MKTD_TOOL_EFFECTIVE}")

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,7 @@
-package = []
-
 [versions]
-csa = "0.1.300"
+csa = "0.1.594"
+weave = "0.1.594"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.300"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary

PR #1167 added `tier-3-complex` annotations to `patterns/mktd/workflow.toml`
Steps 7/8/12 to escape the codex 1MB-input limit on dense DRAFT TODO synthesis.
But the fix did not take effect: dev2merge step 7 was forcing `--tool codex`
on the outer `csa plan run`, which silently overrode every per-step tier
annotation in the spawned mktd plan.

#1169 reproduces #1166's failure mode after #1167 thought it was fixed:
4 RECON sessions complete normally (~9M tokens), then DRAFT TODO concatenation
exceeds 1,048,576 chars and `codex turn/start` aborts the whole pipeline.

This PR changes the default from `codex` to empty so each mktd step honours
its own tier annotation:

- `tier-1-quick` (RECON dims): gemini-cli first, codex fallback.
- `tier-3-complex` (DRAFT/Spec/Revise): claude-code first (1M ctx).

Users who explicitly want codex can still set `CSA_MKTD_TOOL=codex` or
`MKTD_TOOL=codex` in env.

`PATTERN.md` ↔ `workflow.toml` synced per AGENTS.md rule 027.

## Test plan

- [x] Pre-commit (`just pre-commit`) green
- [x] `csa review --range main...HEAD --tier tier-review` → PASS via gemini-cli
- [ ] Post-merge: re-dispatch dev2merge for #38 (jj sidecar Phase 1-B) and
      verify Step 7 DRAFT TODO no longer hits codex 1MB limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)