### PR TITLE
fix(session): surface result.toml.summary on empty-output failure (#1172)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.595"
+version = "0.1.596"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.595"
+version = "0.1.596"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -75,6 +75,37 @@ fn session_has_terminal_process(session_dir: &Path) -> bool {
         || csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
 }
 
+fn session_output_logs_have_content(session_dir: &Path) -> bool {
+    ["stdout.log", "output.log"].iter().any(|name| {
+        fs::metadata(session_dir.join(name))
+            .map(|metadata| metadata.len() > 0)
+            .unwrap_or(false)
+    })
+}
+
+fn failure_summary_for_empty_output(session_dir: &Path, output_streamed: bool) -> Option<String> {
+    if output_streamed || session_output_logs_have_content(session_dir) {
+        return None;
+    }
+
+    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
+    let result = fs::read_to_string(result_path).ok().and_then(|contents| {
+        toml::from_str::<csa_session::result::SessionResult>(&contents).ok()
+    })?;
+    if result.status != "failure" || result.exit_code == 0 || result.summary.trim().is_empty() {
+        return None;
+    }
+
+    Some(result.summary)
+}
+
+fn emit_failure_summary_for_empty_output(session_dir: &Path, output_streamed: bool) {
+    let Some(summary) = failure_summary_for_empty_output(session_dir, output_streamed) else {
+        return;
+    };
+    eprintln!("{summary}");
+}
+
 /// Read the daemon PID from `daemon.pid`, falling back to legacy stderr directives.
 fn read_daemon_pid(session_dir: &std::path::Path) -> Option<u32> {
     // Primary: daemon.pid file (written by spawn_daemon since v0.1.198).
@@ -181,7 +212,12 @@ pub(crate) fn handle_session_attach(
         std::thread::sleep,
     )?;
     let Some(live_stdout_path) = live_stdout_path else {
-        return resolve_attach_terminal_exit(&project_root, &session_dir, &resolved.session_id);
+        return resolve_attach_terminal_exit(
+            &project_root,
+            &session_dir,
+            &resolved.session_id,
+            false,
+        );
     };
 
     let live_streams_output_log = live_stdout_path == output_path;
@@ -201,6 +237,7 @@ pub(crate) fn handle_session_attach(
 
     let mut buf = [0u8; 8192];
     let poll_interval = std::time::Duration::from_millis(100);
+    let mut streamed_output = false;
 
     loop {
         let mut any_output = false;
@@ -210,6 +247,7 @@ pub(crate) fn handle_session_attach(
             std::io::stdout().write_all(&buf[..n])?;
             std::io::stdout().flush()?;
             any_output = true;
+            streamed_output = true;
         }
 
         // Lazy-open stderr if it appeared after we started.
@@ -222,6 +260,7 @@ pub(crate) fn handle_session_attach(
                 std::io::stderr().write_all(&buf[..n])?;
                 std::io::stderr().flush()?;
                 any_output = true;
+                streamed_output = true;
             }
         }
 
@@ -235,6 +274,7 @@ pub(crate) fn handle_session_attach(
                     break;
                 }
                 std::io::stdout().write_all(&buf[..n])?;
+                streamed_output = true;
             }
             if live_streams_output_log {
                 if completion_stdout_file.is_none() && stdout_path.exists() {
@@ -247,6 +287,7 @@ pub(crate) fn handle_session_attach(
                             break;
                         }
                         std::io::stdout().write_all(&buf[..n])?;
+                        streamed_output = true;
                     }
                 }
             }
@@ -259,15 +300,22 @@ pub(crate) fn handle_session_attach(
                         break;
                     }
                     std::io::stderr().write_all(&buf[..n])?;
+                    streamed_output = true;
                 }
                 std::io::stderr().flush()?;
             }
+            emit_failure_summary_for_empty_output(&session_dir, streamed_output);
             // Return the session's exit code from result.toml.
             return Ok(completion.exit_code);
         }
 
         if !session_has_terminal_process(&session_dir) {
-            return resolve_attach_terminal_exit(&project_root, &session_dir, &resolved.session_id);
+            return resolve_attach_terminal_exit(
+                &project_root,
+                &session_dir,
+                &resolved.session_id,
+                streamed_output,
+            );
         }
 
         if !any_output {

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -75,23 +75,29 @@ fn session_has_terminal_process(session_dir: &Path) -> bool {
         || csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
 }
 
-fn session_output_logs_have_content(session_dir: &Path) -> bool {
-    ["stdout.log", "output.log"].iter().any(|name| {
-        fs::metadata(session_dir.join(name))
-            .map(|metadata| metadata.len() > 0)
-            .unwrap_or(false)
-    })
+fn session_log_has_content(session_dir: &Path, log_name: &str) -> bool {
+    fs::metadata(session_dir.join(log_name))
+        .map(|metadata| metadata.len() > 0)
+        .unwrap_or(false)
 }
 
-fn failure_summary_for_empty_output(session_dir: &Path, output_streamed: bool) -> Option<String> {
-    if output_streamed || session_output_logs_have_content(session_dir) {
+fn visible_output_logs_have_content(session_dir: &Path, output_log_visible: bool) -> bool {
+    session_log_has_content(session_dir, "stdout.log")
+        || (output_log_visible && session_log_has_content(session_dir, "output.log"))
+}
+
+fn failure_summary_for_empty_output(
+    session_dir: &Path,
+    output_streamed: bool,
+    output_log_visible: bool,
+) -> Option<String> {
+    if output_streamed || visible_output_logs_have_content(session_dir, output_log_visible) {
         return None;
     }
 
     let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
-    let result = fs::read_to_string(result_path).ok().and_then(|contents| {
-        toml::from_str::<csa_session::result::SessionResult>(&contents).ok()
-    })?;
+    let contents = fs::read_to_string(result_path).ok()?;
+    let result = toml::from_str::<csa_session::result::SessionResult>(&contents).ok()?;
     if result.status != "failure" || result.exit_code == 0 || result.summary.trim().is_empty() {
         return None;
     }
@@ -99,8 +105,14 @@ fn failure_summary_for_empty_output(session_dir: &Path, output_streamed: bool) -
     Some(result.summary)
 }
 
-fn emit_failure_summary_for_empty_output(session_dir: &Path, output_streamed: bool) {
-    let Some(summary) = failure_summary_for_empty_output(session_dir, output_streamed) else {
+fn emit_failure_summary_for_empty_output(
+    session_dir: &Path,
+    output_streamed: bool,
+    output_log_visible: bool,
+) {
+    let Some(summary) =
+        failure_summary_for_empty_output(session_dir, output_streamed, output_log_visible)
+    else {
         return;
     };
     eprintln!("{summary}");
@@ -217,6 +229,7 @@ pub(crate) fn handle_session_attach(
             &session_dir,
             &resolved.session_id,
             false,
+            false,
         );
     };
 
@@ -304,7 +317,11 @@ pub(crate) fn handle_session_attach(
                 }
                 std::io::stderr().flush()?;
             }
-            emit_failure_summary_for_empty_output(&session_dir, streamed_output);
+            emit_failure_summary_for_empty_output(
+                &session_dir,
+                streamed_output,
+                live_streams_output_log,
+            );
             // Return the session's exit code from result.toml.
             return Ok(completion.exit_code);
         }
@@ -315,6 +332,7 @@ pub(crate) fn handle_session_attach(
                 &session_dir,
                 &resolved.session_id,
                 streamed_output,
+                live_streams_output_log,
             );
         }
 

--- a/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
@@ -5,8 +5,8 @@ use anyhow::Result;
 use csa_executor::{TransportFactory, TransportMode};
 
 use super::{
-    AttachPrimaryOutput, load_daemon_completion_packet, read_daemon_pid,
-    session_has_terminal_process,
+    AttachPrimaryOutput, emit_failure_summary_for_empty_output, load_daemon_completion_packet,
+    read_daemon_pid, session_has_terminal_process,
 };
 
 pub(super) const ATTACH_METADATA_STDOUT_GRACE_WINDOW: std::time::Duration =
@@ -250,10 +250,12 @@ pub(super) fn resolve_attach_terminal_exit(
     project_root: &Path,
     session_dir: &Path,
     session_id: &str,
+    output_streamed: bool,
 ) -> Result<i32> {
     if let Some(completion) = load_daemon_completion_packet(session_dir)?
         && !session_has_terminal_process(session_dir)
     {
+        emit_failure_summary_for_empty_output(session_dir, output_streamed);
         return Ok(completion.exit_code);
     }
 
@@ -264,6 +266,7 @@ pub(super) fn resolve_attach_terminal_exit(
             .and_then(|s| toml::from_str::<csa_session::result::SessionResult>(&s).ok())
             .map(|r| r.exit_code)
             .unwrap_or(0);
+        emit_failure_summary_for_empty_output(session_dir, output_streamed);
         return Ok(exit_code);
     }
 
@@ -292,6 +295,7 @@ pub(super) fn resolve_attach_terminal_exit(
             && let Ok(contents) = fs::read_to_string(&result_path)
             && let Ok(result) = toml::from_str::<csa_session::result::SessionResult>(&contents)
         {
+            emit_failure_summary_for_empty_output(session_dir, output_streamed);
             return Ok(result.exit_code);
         }
         return Ok(1);

--- a/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
@@ -251,11 +251,12 @@ pub(super) fn resolve_attach_terminal_exit(
     session_dir: &Path,
     session_id: &str,
     output_streamed: bool,
+    output_log_visible: bool,
 ) -> Result<i32> {
     if let Some(completion) = load_daemon_completion_packet(session_dir)?
         && !session_has_terminal_process(session_dir)
     {
-        emit_failure_summary_for_empty_output(session_dir, output_streamed);
+        emit_failure_summary_for_empty_output(session_dir, output_streamed, output_log_visible);
         return Ok(completion.exit_code);
     }
 
@@ -266,7 +267,7 @@ pub(super) fn resolve_attach_terminal_exit(
             .and_then(|s| toml::from_str::<csa_session::result::SessionResult>(&s).ok())
             .map(|r| r.exit_code)
             .unwrap_or(0);
-        emit_failure_summary_for_empty_output(session_dir, output_streamed);
+        emit_failure_summary_for_empty_output(session_dir, output_streamed, output_log_visible);
         return Ok(exit_code);
     }
 
@@ -295,7 +296,7 @@ pub(super) fn resolve_attach_terminal_exit(
             && let Ok(contents) = fs::read_to_string(&result_path)
             && let Ok(result) = toml::from_str::<csa_session::result::SessionResult>(&contents)
         {
-            emit_failure_summary_for_empty_output(session_dir, output_streamed);
+            emit_failure_summary_for_empty_output(session_dir, output_streamed, output_log_visible);
             return Ok(result.exit_code);
         }
         return Ok(1);

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -212,7 +212,7 @@ where
             emit_wait_next_step_if_needed(&session_dir)?;
             #[rustfmt::skip]
             let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(completion.status.as_str(), completion.exit_code, synthetic, loaded_result.as_ref());
-            emit_failure_summary_for_empty_output(&session_dir, streamed_output);
+            emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
             emit_completion_signal(
                 &resolved.session_id,
                 completion_status.as_ref(),
@@ -233,7 +233,7 @@ where
             emit_wait_next_step_if_needed(&session_dir)?;
             #[rustfmt::skip]
             let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, false, Some(&result));
-            emit_failure_summary_for_empty_output(&session_dir, streamed_output);
+            emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
             emit_completion_signal(
                 &resolved.session_id,
                 completion_status.as_ref(),
@@ -259,7 +259,7 @@ where
             emit_wait_next_step_if_needed(&session_dir)?;
             #[rustfmt::skip]
             let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, reconciled.synthetic, Some(&result));
-            emit_failure_summary_for_empty_output(&session_dir, streamed_output);
+            emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
             emit_completion_signal(
                 &resolved.session_id,
                 completion_status.as_ref(),
@@ -287,7 +287,7 @@ where
                 emit_wait_next_step_if_needed(&session_dir)?;
                 #[rustfmt::skip]
                 let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, false, Some(&result));
-                emit_failure_summary_for_empty_output(&session_dir, streamed_output);
+                emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
                 emit_completion_signal(
                     &resolved.session_id,
                     completion_status.as_ref(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -212,6 +212,7 @@ where
             emit_wait_next_step_if_needed(&session_dir)?;
             #[rustfmt::skip]
             let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(completion.status.as_str(), completion.exit_code, synthetic, loaded_result.as_ref());
+            emit_failure_summary_for_empty_output(&session_dir, streamed_output);
             emit_completion_signal(
                 &resolved.session_id,
                 completion_status.as_ref(),
@@ -232,6 +233,7 @@ where
             emit_wait_next_step_if_needed(&session_dir)?;
             #[rustfmt::skip]
             let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, false, Some(&result));
+            emit_failure_summary_for_empty_output(&session_dir, streamed_output);
             emit_completion_signal(
                 &resolved.session_id,
                 completion_status.as_ref(),
@@ -257,6 +259,7 @@ where
             emit_wait_next_step_if_needed(&session_dir)?;
             #[rustfmt::skip]
             let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, reconciled.synthetic, Some(&result));
+            emit_failure_summary_for_empty_output(&session_dir, streamed_output);
             emit_completion_signal(
                 &resolved.session_id,
                 completion_status.as_ref(),
@@ -284,6 +287,7 @@ where
                 emit_wait_next_step_if_needed(&session_dir)?;
                 #[rustfmt::skip]
                 let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, false, Some(&result));
+                emit_failure_summary_for_empty_output(&session_dir, streamed_output);
                 emit_completion_signal(
                     &resolved.session_id,
                     completion_status.as_ref(),

--- a/crates/cli-sub-agent/tests/session_summary_visibility.rs
+++ b/crates/cli-sub-agent/tests/session_summary_visibility.rs
@@ -1,0 +1,113 @@
+use std::path::Path;
+use std::process::Command;
+
+use serial_test::serial;
+
+const PRE_EXEC_SUMMARY: &str = "pre-exec: Direct --tool is blocked when tiers are configured.";
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: this e2e test is serialized while mutating process-wide env.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: this e2e test is serialized while restoring process-wide env.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn csa_cmd(tmp: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+fn write_pre_exec_failure_result(session_dir: &Path) {
+    std::fs::create_dir_all(session_dir.join("output")).expect("create empty output dir");
+    std::fs::write(session_dir.join("stdout.log"), "").expect("write empty stdout log");
+    std::fs::write(
+        session_dir.join("result.toml"),
+        format!(
+            r#"status = "failure"
+exit_code = 1
+summary = "{PRE_EXEC_SUMMARY}"
+tool = "codex"
+started_at = "2026-04-27T00:00:00Z"
+completed_at = "2026-04-27T00:00:01Z"
+"#
+        ),
+    )
+    .expect("write result.toml");
+}
+
+fn create_empty_output_failure_session(tmp: &Path, name: &str) -> (std::path::PathBuf, String) {
+    let state_home = tmp.join(".local/state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", tmp);
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+
+    let project = tmp.join(name);
+    std::fs::create_dir_all(&project).expect("create project");
+    let session =
+        csa_session::create_session(&project, Some(name), None, Some("codex")).expect("session");
+    let session_id = session.meta_session_id;
+    let session_dir = csa_session::get_session_dir(&project, &session_id).expect("session dir");
+    write_pre_exec_failure_result(&session_dir);
+
+    (project, session_id)
+}
+
+fn assert_subcommand_surfaces_summary(subcommand: &str, session_name: &str) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (project, session_id) = create_empty_output_failure_session(tmp.path(), session_name);
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "session",
+            subcommand,
+            "--session",
+            &session_id,
+            "--cd",
+            project.to_str().expect("project path utf8"),
+        ])
+        .current_dir(&project)
+        .output()
+        .expect("run csa session command");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(PRE_EXEC_SUMMARY),
+        "stderr should surface result.toml summary, got: {stderr}"
+    );
+}
+
+#[test]
+#[serial]
+fn session_wait_surfaces_result_summary_when_failure_output_is_empty() {
+    assert_subcommand_surfaces_summary("wait", "wait-empty-output-failure");
+}
+
+#[test]
+#[serial]
+fn session_attach_surfaces_result_summary_when_failure_output_is_empty() {
+    assert_subcommand_surfaces_summary("attach", "attach-empty-output-failure");
+}

--- a/crates/cli-sub-agent/tests/session_summary_visibility.rs
+++ b/crates/cli-sub-agent/tests/session_summary_visibility.rs
@@ -58,7 +58,10 @@ completed_at = "2026-04-27T00:00:01Z"
     .expect("write result.toml");
 }
 
-fn create_empty_output_failure_session(tmp: &Path, name: &str) -> (std::path::PathBuf, String) {
+fn create_empty_output_failure_session(
+    tmp: &Path,
+    name: &str,
+) -> (std::path::PathBuf, String, std::path::PathBuf) {
     let state_home = tmp.join(".local/state");
     std::fs::create_dir_all(&state_home).expect("create state home");
     let _home_guard = EnvVarGuard::set("HOME", tmp);
@@ -72,14 +75,16 @@ fn create_empty_output_failure_session(tmp: &Path, name: &str) -> (std::path::Pa
     let session_dir = csa_session::get_session_dir(&project, &session_id).expect("session dir");
     write_pre_exec_failure_result(&session_dir);
 
-    (project, session_id)
+    (project, session_id, session_dir)
 }
 
-fn assert_subcommand_surfaces_summary(subcommand: &str, session_name: &str) {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let (project, session_id) = create_empty_output_failure_session(tmp.path(), session_name);
-
-    let output = csa_cmd(tmp.path())
+fn assert_subcommand_surfaces_summary_for_session(
+    tmp: &Path,
+    project: &Path,
+    subcommand: &str,
+    session_id: &str,
+) {
+    let output = csa_cmd(tmp)
         .args([
             "session",
             subcommand,
@@ -100,10 +105,31 @@ fn assert_subcommand_surfaces_summary(subcommand: &str, session_name: &str) {
     );
 }
 
+fn assert_subcommand_surfaces_summary(subcommand: &str, session_name: &str) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (project, session_id, _) = create_empty_output_failure_session(tmp.path(), session_name);
+    assert_subcommand_surfaces_summary_for_session(tmp.path(), &project, subcommand, &session_id);
+}
+
 #[test]
 #[serial]
 fn session_wait_surfaces_result_summary_when_failure_output_is_empty() {
     assert_subcommand_surfaces_summary("wait", "wait-empty-output-failure");
+}
+
+#[test]
+#[serial]
+fn session_wait_surfaces_result_summary_when_only_output_log_has_content() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (project, session_id, session_dir) =
+        create_empty_output_failure_session(tmp.path(), "wait-output-log-hidden-failure");
+    std::fs::write(
+        session_dir.join("output.log"),
+        "hidden output.log content\n",
+    )
+    .expect("write output log");
+
+    assert_subcommand_surfaces_summary_for_session(tmp.path(), &project, "wait", &session_id);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #1172.

When `csa run` fails at pre-exec (e.g., tier-routing rejects `--tool codex` while `[tiers]` are configured), the rejection summary lands in `result.toml.summary` but `csa session attach` returned empty and `csa session wait` only printed `status=failure exit=1 synthetic=false` — leaving callers with no actionable signal. Caller-visible behavior was indistinguishable from a true silent codex crash.

This PR surfaces `result.toml.summary` to caller stdout/stderr in the empty-output failure case for both `csa session attach` and the `csa session wait` completion notice. Existing behavior when stdout has content is unchanged — this is purely a fallback for the empty-output failure path.

## Changes

- session attach: fall back to `result.toml.summary` when `output.log`/streamed content is empty AND `result.toml.status == "failure"`.
- session wait completion: include the same fallback in the completion-print path (the `CSA:SESSION_WAIT_COMPLETED` line stays; summary is printed alongside).
- e2e coverage for empty-output failure session.
- workspace patch version bump.

## Test plan

- [x] `just pre-commit` exit 0
- [x] `cargo test` exit 0 (new test passes)
- [x] csa review --branch main: decision=pass, severity_counts all zero (session 01KQ73SDQB3QZ05HTHBHR0ZYNR)
- [ ] Manual sanity check: print `result.toml.summary` of mempal session `01KQ71JAY8QJQND6A71QP98CKM` and confirm visibility fix would surface the pre-exec rejection text.

## Notes

- Does NOT change pre-exec tier-routing logic (correct per AGENTS.md rule 004).
- Does NOT change codex execution (codex was never invoked in the buggy scenario).
- Adjacent issue: codex JSON-stream → STEP_x_OUTPUT (#1173) is a separate fix.