### PR TITLE
fix(plan): extract codex JSON event stream into clean STEP_x_OUTPUT (#1173)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.596"
+version = "0.1.597"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.596"
+version = "0.1.597"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
+use serde::Deserialize;
 use tracing::{info, warn};
 
 use csa_config::ProjectConfig;
@@ -15,6 +16,37 @@ use crate::pipeline::{
 use crate::run_helpers::build_executor;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Deserialize)]
+struct CodexTranscriptEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    agent_message: Option<AgentMessageText>,
+    #[serde(default)]
+    item: Option<CodexTranscriptItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexTranscriptItem {
+    #[serde(default)]
+    text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum AgentMessageText {
+    Text(String),
+    Object { text: String },
+}
+
+impl AgentMessageText {
+    fn into_text(self) -> String {
+        match self {
+            Self::Text(text) | Self::Object { text } => text,
+        }
+    }
+}
 
 pub(super) struct StepExecutionOutcome {
     pub(super) exit_code: i32,
@@ -269,18 +301,78 @@ pub(super) async fn execute_csa_step(
         Err(error) => return Err(error),
     };
 
-    let captured = if !result.execution.output.is_empty() {
+    let raw_captured = if !result.execution.output.is_empty() {
         result.execution.output
     } else if !result.execution.summary.is_empty() {
         result.execution.summary
     } else {
         String::new()
     };
+    let captured = clean_step_output_for_env(&raw_captured, tool_name, OutputFormat::Json);
     Ok(StepExecutionOutcome {
         exit_code: result.execution.exit_code,
         output: captured,
         session_id: Some(result.meta_session_id),
     })
+}
+
+fn clean_step_output_for_env(
+    raw_output: &str,
+    tool_name: &ToolName,
+    output_format: OutputFormat,
+) -> String {
+    if !should_extract_codex_json_events(raw_output, tool_name, output_format) {
+        return raw_output.to_string();
+    }
+
+    extract_codex_json_event_text(raw_output).unwrap_or_else(|| raw_output.to_string())
+}
+
+fn should_extract_codex_json_events(
+    raw_output: &str,
+    tool_name: &ToolName,
+    output_format: OutputFormat,
+) -> bool {
+    (matches!(tool_name, ToolName::Codex) && matches!(output_format, OutputFormat::Json))
+        || first_non_empty_line_is_thread_started(raw_output)
+}
+
+fn first_non_empty_line_is_thread_started(raw_output: &str) -> bool {
+    let Some(line) = raw_output.lines().find(|line| !line.trim().is_empty()) else {
+        return false;
+    };
+
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .is_some_and(|value| {
+            value
+                .as_object()
+                .and_then(|object| object.get("type"))
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|event_type| event_type == "thread.started")
+        })
+}
+
+fn extract_codex_json_event_text(raw_output: &str) -> Option<String> {
+    let pieces: Vec<String> = raw_output
+        .lines()
+        .filter_map(|line| serde_json::from_str::<CodexTranscriptEvent>(line).ok())
+        .filter_map(|event| {
+            if let Some(agent_message) = event.agent_message {
+                return Some(agent_message.into_text());
+            }
+            if event.event_type == "item.completed" {
+                return event.item.and_then(|item| item.text);
+            }
+            None
+        })
+        .collect();
+
+    if pieces.is_empty() {
+        None
+    } else {
+        Some(pieces.join("\n"))
+    }
 }
 
 pub(super) fn is_stale_session_error(error: &anyhow::Error) -> bool {
@@ -381,6 +473,60 @@ mod tests {
             Some("sid")
         );
         assert_eq!(reduced.get("SCOPE").map(String::as_str), Some("demo"));
+    }
+
+    #[test]
+    fn clean_step_output_extracts_codex_json_event_stream_text() {
+        let output = [
+            r#"{"type":"thread.started","thread_id":"thread_1"}"#,
+            r#"{"type":"item.completed","item":{"id":"item_1","text":"- [ ] write test"}}"#,
+            r#"{"type":"item.completed","item":{"id":"item_2","text":"schema_version = 1"}}"#,
+        ]
+        .join("\n");
+
+        assert_eq!(
+            clean_step_output_for_env(&output, &ToolName::Codex, OutputFormat::Json),
+            "- [ ] write test\nschema_version = 1"
+        );
+    }
+
+    #[test]
+    fn clean_step_output_falls_back_for_codex_json_without_text() {
+        let output = "not json\n{\"type\":\"thread.started\"}";
+
+        assert_eq!(
+            clean_step_output_for_env(output, &ToolName::Codex, OutputFormat::Json),
+            output
+        );
+    }
+
+    #[test]
+    fn clean_step_output_leaves_clean_prose_for_non_codex_tools() {
+        let output = "plain summary\n- [ ] already clean";
+
+        assert_eq!(
+            clean_step_output_for_env(output, &ToolName::GeminiCli, OutputFormat::Json),
+            output
+        );
+        assert_eq!(
+            clean_step_output_for_env(output, &ToolName::ClaudeCode, OutputFormat::Json),
+            output
+        );
+    }
+
+    #[test]
+    fn clean_step_output_extracts_mixed_json_stream_and_ignores_trailing_prose() {
+        let output = [
+            r#"{"type":"thread.started","thread_id":"thread_1"}"#,
+            r#"{"type":"item.completed","item":{"id":"item_1","text":"natural text"}}"#,
+            "trailing progress note",
+        ]
+        .join("\n");
+
+        assert_eq!(
+            clean_step_output_for_env(&output, &ToolName::GeminiCli, OutputFormat::Text),
+            "natural text"
+        );
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -29,6 +29,8 @@ struct CodexTranscriptEvent {
 
 #[derive(Debug, Deserialize)]
 struct CodexTranscriptItem {
+    #[serde(default, rename = "type")]
+    item_type: String,
     #[serde(default)]
     text: Option<String>,
 }
@@ -354,22 +356,34 @@ fn first_non_empty_line_is_thread_started(raw_output: &str) -> bool {
 }
 
 fn extract_codex_json_event_text(raw_output: &str) -> Option<String> {
+    let mut first_non_empty_was_json = None;
     let pieces: Vec<String> = raw_output
         .lines()
-        .filter_map(|line| serde_json::from_str::<CodexTranscriptEvent>(line).ok())
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| {
+            let event = serde_json::from_str::<CodexTranscriptEvent>(line).ok();
+            if first_non_empty_was_json.is_none() {
+                first_non_empty_was_json = Some(event.is_some());
+            }
+            event
+        })
         .filter_map(|event| {
             if let Some(agent_message) = event.agent_message {
                 return Some(agent_message.into_text());
             }
             if event.event_type == "item.completed" {
-                return event.item.and_then(|item| item.text);
+                return event.item.and_then(|item| {
+                    (item.item_type == "agent_message")
+                        .then_some(item.text)
+                        .flatten()
+                });
             }
             None
         })
         .collect();
 
     if pieces.is_empty() {
-        None
+        first_non_empty_was_json.unwrap_or(false).then(String::new)
     } else {
         Some(pieces.join("\n"))
     }
@@ -479,14 +493,43 @@ mod tests {
     fn clean_step_output_extracts_codex_json_event_stream_text() {
         let output = [
             r#"{"type":"thread.started","thread_id":"thread_1"}"#,
-            r#"{"type":"item.completed","item":{"id":"item_1","text":"- [ ] write test"}}"#,
-            r#"{"type":"item.completed","item":{"id":"item_2","text":"schema_version = 1"}}"#,
+            r#"{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"- [ ] write test"}}"#,
+            r#"{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"schema_version = 1"}}"#,
         ]
         .join("\n");
 
         assert_eq!(
             clean_step_output_for_env(&output, &ToolName::Codex, OutputFormat::Json),
             "- [ ] write test\nschema_version = 1"
+        );
+    }
+
+    #[test]
+    fn clean_step_output_ignores_codex_tool_result_items() {
+        let output = [
+            r#"{"type":"thread.started","thread_id":"thread_1"}"#,
+            r#"{"type":"item.completed","item":{"id":"item_1","type":"tool_result","text":"secret shell output"}}"#,
+            r#"{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"agent summary"}}"#,
+        ]
+        .join("\n");
+
+        assert_eq!(
+            clean_step_output_for_env(&output, &ToolName::Codex, OutputFormat::Json),
+            "agent summary"
+        );
+    }
+
+    #[test]
+    fn clean_step_output_drops_codex_stream_without_agent_messages() {
+        let output = [
+            r#"{"type":"thread.started","thread_id":"thread_1"}"#,
+            r#"{"type":"item.completed","item":{"id":"item_1","type":"tool_result","text":"secret shell output"}}"#,
+        ]
+        .join("\n");
+
+        assert_eq!(
+            clean_step_output_for_env(&output, &ToolName::Codex, OutputFormat::Json),
+            ""
         );
     }
 
@@ -518,7 +561,7 @@ mod tests {
     fn clean_step_output_extracts_mixed_json_stream_and_ignores_trailing_prose() {
         let output = [
             r#"{"type":"thread.started","thread_id":"thread_1"}"#,
-            r#"{"type":"item.completed","item":{"id":"item_1","text":"natural text"}}"#,
+            r#"{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"natural text"}}"#,
             "trailing progress note",
         ]
         .join("\n");


### PR DESCRIPTION
## Summary

Closes #1173.

`plan_cmd_exec::execute_csa_step` now normalises codex's JSON event stream into clean natural-language text before storing it as `STEP_x_OUTPUT`. This unblocks mktd Step 13 (and any other grep-based plan-step validation) when codex handles a step that was previously gemini/claude-code-only.

Two commits, audit-trail preserved (no squash):

1. `364fe17b fix(plan): extract codex ACP JSON event stream into clean STEP_x_OUTPUT (closes #1173)` — initial extractor + 4 unit tests + version bump 0.1.596 → 0.1.597.
2. `afe547a5 fix(plan): filter codex item.completed by item.type=agent_message (#1173 round 2)` — round-1 review caught that `item.completed` events with `item.type == "tool_result"` would also leak into `STEP_x_OUTPUT`. Added `item.type == "agent_message"` filter matching adjacent ACP parsers + regression test.

## Why

Symptom: dev2merge / mktd silently aborts at Step 13 with no useful stderr when codex handles Steps 7/8/12 (tier-3-complex). Root cause: codex JSON event stream stored verbatim as `STEP_x_OUTPUT` → grep validations (`grep -qE '^- \[ \] .+'`, `grep -q '^schema_version = 1'`) fail because real content is wrapped inside `{"type":"item.completed","item":{"text":"..."}}`. Other tools (gemini-cli, claude-code) produce clean prose, so the bug only triggered on codex paths.

## Scope

- Single file: `crates/cli-sub-agent/src/plan_cmd_exec.rs`
- Plus required `Cargo.toml` / `Cargo.lock` patch-version bump
- No transport-layer changes; the fix is post-capture, transport-agnostic (survives any future ACP→CLI migration)

## Test plan

- [x] `cargo test -p cli-sub-agent plan_cmd_exec` — all unit tests pass (codex JSON extraction, fallback on garbage stdout, non-codex prose unchanged, mixed JSON+prose, tool_result rejection)
- [x] `just pre-commit` exit 0 (both rounds)
- [x] Local pre-PR review (codex, session 01KQ79N1D3ABWZ4J9NBP9BWBT4) — CLEAN, no blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)