### PR TITLE
feat(jj-sidecar): Phase 1-B pipeline integration + PostRun hook (#1146)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.597"
+version = "0.1.598"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.597"
+version = "0.1.598"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -32,6 +32,7 @@ mod pipeline;
 mod pipeline_env;
 mod pipeline_execute;
 mod pipeline_handoff;
+mod pipeline_jj_journal;
 mod pipeline_post_exec;
 mod pipeline_project_key;
 mod pipeline_sandbox;

--- a/crates/cli-sub-agent/src/pipeline_jj_journal.rs
+++ b/crates/cli-sub-agent/src/pipeline_jj_journal.rs
@@ -1,0 +1,357 @@
+//! PostRun integration for the optional jj sidecar journal.
+
+use std::path::Path;
+
+use csa_core::vcs::{JournalError, RevisionId, SnapshotJournal};
+use csa_session::JjJournal;
+use tracing::{info, warn};
+
+pub(crate) const AUTO_SNAPSHOT_ENV: &str = "CSA_VCS_AUTO_SNAPSHOT";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PostRunJjSnapshotOutcome {
+    ConfigOff,
+    NoChangedPaths,
+    NoJjDir,
+    NonColocated,
+    Snapshot { revision: RevisionId },
+    Failed { message: String },
+}
+
+pub(crate) fn maybe_record_post_run_snapshot(
+    project_root: &Path,
+    session_dir: &Path,
+    session_id: &str,
+    tool_name: &str,
+    changed_paths: &[String],
+    result: &mut csa_process::ExecutionResult,
+) -> PostRunJjSnapshotOutcome {
+    let outcome = evaluate_post_run_snapshot(
+        project_root,
+        session_dir,
+        session_id,
+        tool_name,
+        changed_paths,
+    );
+    match &outcome {
+        PostRunJjSnapshotOutcome::ConfigOff => {
+            info!("jj sidecar snapshot disabled by CSA_VCS_AUTO_SNAPSHOT");
+        }
+        PostRunJjSnapshotOutcome::NoChangedPaths => {
+            info!("Skipping jj sidecar snapshot because PostRun changed_paths is empty");
+        }
+        PostRunJjSnapshotOutcome::NoJjDir => append_snapshot_notice(
+            result,
+            "jj sidecar snapshot skipped: .jj/ not found; git fallback is intentionally disabled",
+        ),
+        PostRunJjSnapshotOutcome::NonColocated => append_snapshot_notice(
+            result,
+            "jj sidecar snapshot skipped: repository is not colocated (.git/ and .jj/ are both required); git fallback is intentionally disabled",
+        ),
+        PostRunJjSnapshotOutcome::Snapshot { revision } => {
+            info!(revision = %revision, "Recorded jj sidecar snapshot");
+        }
+        PostRunJjSnapshotOutcome::Failed { message } => {
+            append_snapshot_notice(
+                result,
+                &format!(
+                    "jj sidecar snapshot failed: {message}; git fallback is intentionally disabled"
+                ),
+            );
+        }
+    }
+    outcome
+}
+
+fn evaluate_post_run_snapshot(
+    project_root: &Path,
+    session_dir: &Path,
+    session_id: &str,
+    tool_name: &str,
+    changed_paths: &[String],
+) -> PostRunJjSnapshotOutcome {
+    evaluate_post_run_snapshot_with(
+        auto_snapshot_enabled(),
+        project_root,
+        session_id,
+        tool_name,
+        changed_paths,
+        |message| {
+            JjJournal::with_session_dir(project_root, session_dir)
+                .and_then(|journal| journal.snapshot(message))
+        },
+    )
+}
+
+fn evaluate_post_run_snapshot_with<F>(
+    auto_snapshot_enabled: bool,
+    project_root: &Path,
+    session_id: &str,
+    tool_name: &str,
+    changed_paths: &[String],
+    snapshot: F,
+) -> PostRunJjSnapshotOutcome
+where
+    F: FnOnce(&str) -> Result<RevisionId, JournalError>,
+{
+    if !auto_snapshot_enabled {
+        return PostRunJjSnapshotOutcome::ConfigOff;
+    }
+    if changed_paths.is_empty() {
+        return PostRunJjSnapshotOutcome::NoChangedPaths;
+    }
+    if !project_root.join(".jj").is_dir() {
+        return PostRunJjSnapshotOutcome::NoJjDir;
+    }
+    if !project_root.join(".git").exists() {
+        return PostRunJjSnapshotOutcome::NonColocated;
+    }
+
+    let message = format_snapshot_message(session_id, tool_name, changed_paths);
+    match snapshot(&message) {
+        Ok(revision) => PostRunJjSnapshotOutcome::Snapshot { revision },
+        Err(err) => PostRunJjSnapshotOutcome::Failed {
+            message: render_journal_error(&err),
+        },
+    }
+}
+
+fn auto_snapshot_enabled() -> bool {
+    auto_snapshot_enabled_from_value(std::env::var_os(AUTO_SNAPSHOT_ENV).as_deref())
+}
+
+fn auto_snapshot_enabled_from_value(value: Option<&std::ffi::OsStr>) -> bool {
+    value
+        .and_then(std::ffi::OsStr::to_str)
+        .is_some_and(|value| value.trim() == "1")
+}
+
+fn format_snapshot_message(session_id: &str, tool_name: &str, changed_paths: &[String]) -> String {
+    let mut message = format!(
+        "CSA PostRun snapshot session={session_id} tool={tool_name} changed_paths={}",
+        changed_paths.len()
+    );
+    for path in changed_paths.iter().take(8) {
+        message.push_str(" path=");
+        message.push_str(path);
+    }
+    message
+}
+
+fn render_journal_error(error: &JournalError) -> String {
+    error.to_string()
+}
+
+fn append_snapshot_notice(result: &mut csa_process::ExecutionResult, message: &str) {
+    warn!("{message}");
+    if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+        result.stderr_output.push('\n');
+    }
+    result.stderr_output.push_str("CSA_VCS_AUTO_SNAPSHOT: ");
+    result.stderr_output.push_str(message);
+    result.stderr_output.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn result() -> csa_process::ExecutionResult {
+        csa_process::ExecutionResult {
+            output: String::new(),
+            stderr_output: String::new(),
+            summary: "ok".to_string(),
+            exit_code: 0,
+            peak_memory_mb: None,
+        }
+    }
+
+    #[test]
+    fn config_off_is_a_quiet_noop() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        let outcome = evaluate_post_run_snapshot_with(
+            false,
+            tmp.path(),
+            "01SESSION",
+            "codex",
+            &["src/lib.rs".to_string()],
+            |_| panic!("snapshot must not run when config is off"),
+        );
+
+        assert_eq!(outcome, PostRunJjSnapshotOutcome::ConfigOff);
+        let mut result = result();
+        match &outcome {
+            PostRunJjSnapshotOutcome::ConfigOff => {}
+            other => append_snapshot_notice(&mut result, &format!("{other:?}")),
+        }
+        assert!(result.stderr_output.is_empty());
+    }
+
+    #[test]
+    fn changed_paths_empty_skips_snapshot() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        let outcome =
+            evaluate_post_run_snapshot_with(true, tmp.path(), "01SESSION", "codex", &[], |_| {
+                panic!("snapshot must not run for empty changed paths")
+            });
+
+        assert_eq!(outcome, PostRunJjSnapshotOutcome::NoChangedPaths);
+        let mut result = result();
+        match &outcome {
+            PostRunJjSnapshotOutcome::NoChangedPaths => {}
+            other => append_snapshot_notice(&mut result, &format!("{other:?}")),
+        }
+        assert!(result.stderr_output.is_empty());
+    }
+
+    #[test]
+    fn no_jj_dir_degrades_without_git_fallback() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::create_dir(tmp.path().join(".git")).expect("create .git");
+
+        let outcome = evaluate_post_run_snapshot_with(
+            true,
+            tmp.path(),
+            "01SESSION",
+            "codex",
+            &["src/lib.rs".to_string()],
+            |_| panic!("snapshot must not run without .jj"),
+        );
+
+        assert_eq!(outcome, PostRunJjSnapshotOutcome::NoJjDir);
+        let mut result = result();
+        append_snapshot_notice(
+            &mut result,
+            "jj sidecar snapshot skipped: .jj/ not found; git fallback is intentionally disabled",
+        );
+        assert!(result.stderr_output.contains(".jj/ not found"));
+        assert!(
+            result
+                .stderr_output
+                .contains("git fallback is intentionally disabled")
+        );
+        assert!(!tmp.path().join(".git").join("index").exists());
+    }
+
+    #[test]
+    fn non_colocated_degrades_without_git_fallback() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::create_dir(tmp.path().join(".jj")).expect("create .jj");
+
+        let outcome = evaluate_post_run_snapshot_with(
+            true,
+            tmp.path(),
+            "01SESSION",
+            "codex",
+            &["src/lib.rs".to_string()],
+            |_| panic!("snapshot must not run in a non-colocated repo"),
+        );
+
+        assert_eq!(outcome, PostRunJjSnapshotOutcome::NonColocated);
+        let mut result = result();
+        append_snapshot_notice(
+            &mut result,
+            "jj sidecar snapshot skipped: repository is not colocated (.git/ and .jj/ are both required); git fallback is intentionally disabled",
+        );
+        assert!(result.stderr_output.contains("not colocated"));
+        assert!(
+            result
+                .stderr_output
+                .contains("git fallback is intentionally disabled")
+        );
+    }
+
+    #[test]
+    fn jj_missing_degrades_without_git_fallback() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::create_dir(tmp.path().join(".git")).expect("create .git");
+        fs::create_dir(tmp.path().join(".jj")).expect("create .jj");
+
+        let outcome = evaluate_post_run_snapshot_with(
+            true,
+            tmp.path(),
+            "01SESSION",
+            "codex",
+            &["src/lib.rs".to_string()],
+            |_| {
+                Err(JournalError::Unavailable(
+                    "jj binary not found; git fallback is intentionally disabled".to_string(),
+                ))
+            },
+        );
+
+        assert!(
+            matches!(outcome, PostRunJjSnapshotOutcome::Failed { ref message } if message.contains("jj binary not found"))
+        );
+        let mut result = result();
+        if let PostRunJjSnapshotOutcome::Failed { message } = &outcome {
+            append_snapshot_notice(
+                &mut result,
+                &format!(
+                    "jj sidecar snapshot failed: {message}; git fallback is intentionally disabled"
+                ),
+            );
+        }
+        assert!(result.stderr_output.contains("jj binary not found"));
+        assert!(
+            result
+                .stderr_output
+                .contains("git fallback is intentionally disabled")
+        );
+        assert!(!tmp.path().join(".git").join("index").exists());
+    }
+
+    #[test]
+    fn snapshot_success_returns_revision_without_notice() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::create_dir(tmp.path().join(".git")).expect("create .git");
+        fs::create_dir(tmp.path().join(".jj")).expect("create .jj");
+
+        let outcome = evaluate_post_run_snapshot_with(
+            true,
+            tmp.path(),
+            "01SESSION",
+            "codex",
+            &["src/lib.rs".to_string()],
+            |_| Ok(RevisionId::from("rev-from-journal")),
+        );
+
+        assert_eq!(
+            outcome,
+            PostRunJjSnapshotOutcome::Snapshot {
+                revision: RevisionId::from("rev-from-journal")
+            }
+        );
+        let result = result();
+        assert!(result.stderr_output.is_empty());
+    }
+
+    #[test]
+    fn auto_snapshot_env_accepts_only_one() {
+        assert!(auto_snapshot_enabled_from_value(Some(
+            std::ffi::OsStr::new("1")
+        )));
+        assert!(!auto_snapshot_enabled_from_value(None));
+        assert!(!auto_snapshot_enabled_from_value(Some(
+            std::ffi::OsStr::new("true",)
+        )));
+        assert!(!auto_snapshot_enabled_from_value(Some(
+            std::ffi::OsStr::new("0",)
+        )));
+    }
+
+    #[test]
+    fn snapshot_message_keeps_untrusted_fields_as_message_text() {
+        let message = format_snapshot_message(
+            "01SESSION;$(touch hacked)",
+            "codex`echo no`\nsecond",
+            &["src/lib.rs".to_string()],
+        );
+
+        assert!(message.contains("01SESSION;$(touch hacked)"));
+        assert!(message.contains("codex`echo no`\nsecond"));
+    }
+}

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -199,6 +199,14 @@ pub(crate) async fn process_execution_result(
             tool_state.last_action_summary = no_op_summary;
         }
     }
+    crate::pipeline_jj_journal::maybe_record_post_run_snapshot(
+        ctx.project_root,
+        &ctx.session_dir,
+        &session.meta_session_id,
+        ctx.executor.tool_name(),
+        &ctx.changed_paths,
+        result,
+    );
     audit::maybe_record_repo_write_audit(&ctx, session, &mut session_result);
     if let Err(e) = save_result(ctx.project_root, &session.meta_session_id, &session_result) {
         warn!("Failed to save session result: {}", e);

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -26,7 +26,13 @@ pub struct JjJournal {
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 struct JournalState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    project_root: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     session_start_revision: Option<RevisionId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    session_start_operation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_operation_id: Option<String>,
 }
 
 impl JjJournal {
@@ -36,6 +42,17 @@ impl JjJournal {
         Ok(Self {
             project_root,
             state_path,
+        })
+    }
+
+    pub fn with_session_dir(
+        project_root: impl AsRef<Path>,
+        session_dir: impl AsRef<Path>,
+    ) -> Result<Self, JournalError> {
+        let project_root = absolutize_project_root(project_root.as_ref())?;
+        Ok(Self {
+            project_root,
+            state_path: session_dir.as_ref().join(STATE_FILE_NAME),
         })
     }
 
@@ -108,6 +125,26 @@ impl JjJournal {
         Ok(output)
     }
 
+    fn current_operation_id(&self) -> Result<String, JournalError> {
+        let output = self.run_jj([
+            "op",
+            "log",
+            "--no-graph",
+            "-l",
+            "1",
+            "-T",
+            "self.id().short(12)",
+        ])?;
+        let op_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if op_id.is_empty() {
+            return Err(JournalError::CommandFailed {
+                command: "jj op log --no-graph -l 1 -T self.id().short(12)".to_string(),
+                message: "operation id was empty".to_string(),
+            });
+        }
+        Ok(op_id)
+    }
+
     fn read_state(&self) -> Result<Option<JournalState>, JournalError> {
         match fs::read_to_string(&self.state_path) {
             Ok(raw) => {
@@ -143,12 +180,30 @@ impl JjJournal {
                 })?;
 
         let mut current_state = self.read_state()?.unwrap_or_default();
+        validate_state_project_root(&current_state, &self.project_root)?;
+        let operation_before_snapshot = self.current_operation_id()?;
+        if let Some(expected_op_id) = current_state.last_operation_id.as_deref()
+            && expected_op_id != operation_before_snapshot
+        {
+            return Err(JournalError::InvalidState(format!(
+                "jj operation drift detected for {}: expected last operation {}, found {}; refusing sidecar snapshot",
+                self.project_root.display(),
+                expected_op_id,
+                operation_before_snapshot
+            )));
+        }
         let revision = revision_supplier(&sanitized)?;
+        let operation_after_snapshot = self.current_operation_id()?;
 
+        if current_state.project_root.is_none() {
+            current_state.project_root = Some(self.project_root.clone());
+        }
         if current_state.session_start_revision.is_none() {
             current_state.session_start_revision = Some(revision.clone());
-            self.write_state(&current_state)?;
+            current_state.session_start_operation_id = Some(operation_before_snapshot);
         }
+        current_state.last_operation_id = Some(operation_after_snapshot);
+        self.write_state(&current_state)?;
 
         Ok(revision)
     }
@@ -213,6 +268,22 @@ fn derive_state_path() -> Result<PathBuf, JournalError> {
                     .to_string(),
             )
         })
+}
+
+fn validate_state_project_root(
+    state: &JournalState,
+    project_root: &Path,
+) -> Result<(), JournalError> {
+    if let Some(recorded_root) = state.project_root.as_ref()
+        && recorded_root != project_root
+    {
+        return Err(JournalError::InvalidState(format!(
+            "journal state belongs to {}, not {}; refusing sidecar snapshot",
+            recorded_root.display(),
+            project_root.display()
+        )));
+    }
+    Ok(())
 }
 
 fn temp_state_path(path: &Path) -> Result<PathBuf, JournalError> {
@@ -387,7 +458,7 @@ mod tests {
         assert!(matches!(
             error,
             JournalError::CommandFailed { ref command, ref message }
-                if command == "jj --no-pager --color=never log --no-graph -r @ -T description"
+                if command == "jj --no-pager --color=never op log --no-graph -l 1 -T self.id().short(12)"
                     && message.contains("mock jj unavailable")
         ));
         assert!(
@@ -404,6 +475,10 @@ mod tests {
         let arg_log = repo.path().join("jj-args.bin");
         let script = format!(
             "#!/bin/sh\n\
+             if [ \"$3\" = \"op\" ]; then\n\
+               printf 'op-stable\\n'\n\
+               exit 0\n\
+             fi\n\
              if [ \"$3\" = \"log\" ]; then\n\
                printf 'rev-from-log\\n'\n\
                exit 0\n\
@@ -466,6 +541,7 @@ mod tests {
             .write_state_with_fault_injection(
                 &JournalState {
                     session_start_revision: Some(RevisionId::from("rev-123")),
+                    ..Default::default()
                 },
                 true,
             )
@@ -484,7 +560,12 @@ mod tests {
 
     #[test]
     fn concurrent_snapshot_rejected_by_lock() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock env");
         let repo = tempdir().expect("repo tempdir");
+        let bin_dir = tempdir().expect("bin tempdir");
+        let fake_jj = "#!/bin/sh\nif [ \"$3\" = \"op\" ]; then printf 'op-stable\\n'; exit 0; fi\nprintf 'ok\\n'\n";
+        make_fake_jj(bin_dir.path(), fake_jj);
+        let _path_guard = PathGuard::prepend(bin_dir.path());
         let session_dir_a = tempdir().expect("session A tempdir");
         let session_dir_b = tempdir().expect("session B tempdir");
         let first_journal = Arc::new(JjJournal::with_state_path(
@@ -531,6 +612,55 @@ mod tests {
                 .session_start_revision()
                 .expect("state read should succeed"),
             Some(RevisionId::from("rev-first"))
+        );
+    }
+
+    #[test]
+    fn operation_drift_rejected_before_snapshot() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock env");
+        let repo = tempdir().expect("repo tempdir");
+        let bin_dir = tempdir().expect("bin tempdir");
+        let op_file = repo.path().join("current-op");
+        fs::write(&op_file, "op-a").expect("write initial op");
+        let script = format!(
+            "#!/bin/sh\n\
+             if [ \"$3\" = \"op\" ]; then\n\
+               cat \"{}\"\n\
+               printf '\\n'\n\
+               exit 0\n\
+             fi\n\
+             printf 'ok\\n'\n",
+            op_file.display()
+        );
+        make_fake_jj(bin_dir.path(), &script);
+        let _path_guard = PathGuard::prepend(bin_dir.path());
+        let journal = JjJournal::with_state_path(
+            repo.path(),
+            repo.path().join("state").join(STATE_FILE_NAME),
+        );
+
+        let first = journal
+            .snapshot_with_revision_supplier("first", |_| Ok(RevisionId::from("rev-a")))
+            .expect("first snapshot should record lineage");
+        assert_eq!(first, RevisionId::from("rev-a"));
+
+        fs::write(&op_file, "op-b").expect("mutate op");
+        let error = journal
+            .snapshot_with_revision_supplier("second", |_| Ok(RevisionId::from("rev-b")))
+            .expect_err("operation drift must fail closed");
+
+        assert!(matches!(
+            error,
+            JournalError::InvalidState(ref message)
+                if message.contains("jj operation drift detected")
+                    && message.contains("op-a")
+                    && message.contains("op-b")
+        ));
+        assert_eq!(
+            journal
+                .session_start_revision()
+                .expect("state read should succeed"),
+            Some(RevisionId::from("rev-a"))
         );
     }
 }

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -132,7 +132,7 @@ impl JjJournal {
             "--ignore-working-copy",
             "--at-op=@",
             "--no-graph",
-            "-l",
+            "-n",
             "1",
             "-T",
             "self.id().short(12)",
@@ -140,7 +140,7 @@ impl JjJournal {
         let op_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if op_id.is_empty() {
             return Err(JournalError::CommandFailed {
-                command: "jj op log --ignore-working-copy --at-op=@ --no-graph -l 1 -T self.id().short(12)".to_string(),
+                command: "jj op log --ignore-working-copy --at-op=@ --no-graph -n 1 -T self.id().short(12)".to_string(),
                 message: "operation id was empty".to_string(),
             });
         }
@@ -460,12 +460,84 @@ mod tests {
         assert!(matches!(
             error,
             JournalError::CommandFailed { ref command, ref message }
-                if command == "jj --no-pager --color=never op log --ignore-working-copy --at-op=@ --no-graph -l 1 -T self.id().short(12)"
+                if command == "jj --no-pager --color=never op log --ignore-working-copy --at-op=@ --no-graph -n 1 -T self.id().short(12)"
                     && message.contains("mock jj unavailable")
         ));
         assert!(
             !state_path.exists(),
             "failed jj snapshot must not persist session state"
+        );
+    }
+
+    #[test]
+    fn current_operation_id_uses_jj_limit_n() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock env");
+        let repo = tempdir().expect("repo tempdir");
+        let bin_dir = tempdir().expect("bin tempdir");
+        let arg_log = repo.path().join("jj-current-op-args.bin");
+        let script = format!(
+            "#!/bin/sh\n\
+             if [ \"$3\" = \"op\" ] && [ \"$4\" = \"log\" ]; then\n\
+               printf 'CALL\\0' >> \"{}\"\n\
+               previous=''\n\
+               has_ignore=0\n\
+               has_at_op=0\n\
+               has_limit=0\n\
+               has_deprecated_limit=0\n\
+               for arg in \"$@\"; do\n\
+                 printf '%s\\0' \"$arg\" >> \"{}\"\n\
+                 if [ \"$arg\" = \"--ignore-working-copy\" ]; then\n\
+                   has_ignore=1\n\
+                 fi\n\
+                 if [ \"$arg\" = \"--at-op=@\" ]; then\n\
+                   has_at_op=1\n\
+                 fi\n\
+                 if [ \"$previous\" = \"-n\" ] && [ \"$arg\" = \"1\" ]; then\n\
+                   has_limit=1\n\
+                 fi\n\
+                 if [ \"$arg\" = \"-l\" ]; then\n\
+                   has_deprecated_limit=1\n\
+                 fi\n\
+                 previous=\"$arg\"\n\
+               done\n\
+               if [ \"$has_ignore\" != \"1\" ] || [ \"$has_at_op\" != \"1\" ] || [ \"$has_limit\" != \"1\" ] || [ \"$has_deprecated_limit\" = \"1\" ]; then\n\
+                 printf 'invalid op log args\\n' >&2\n\
+                 exit 64\n\
+               fi\n\
+               printf 'op-stable\\n'\n\
+               exit 0\n\
+             fi\n\
+             printf 'unexpected jj command\\n' >&2\n\
+             exit 65\n",
+            arg_log.display(),
+            arg_log.display()
+        );
+        make_fake_jj(bin_dir.path(), &script);
+        let _path_guard = PathGuard::prepend(bin_dir.path());
+        let journal = JjJournal::with_state_path(
+            repo.path(),
+            repo.path().join("state").join(STATE_FILE_NAME),
+        );
+
+        let operation_id = journal
+            .current_operation_id()
+            .expect("current operation id should use supported jj flags");
+
+        assert_eq!(operation_id, "op-stable");
+        let raw = fs::read(&arg_log).expect("read arg log");
+        let parts = raw
+            .split(|byte| *byte == 0)
+            .filter(|chunk| !chunk.is_empty())
+            .map(|chunk| String::from_utf8_lossy(chunk).to_string())
+            .collect::<Vec<_>>();
+        let command_line = parts.join(" ");
+        assert!(
+            command_line.contains("op log --ignore-working-copy --at-op=@ --no-graph -n 1"),
+            "op log must use jj's supported -n limit flag: {command_line}"
+        );
+        assert!(
+            !command_line.contains(&format!(" {} {}", "-l", "1")),
+            "op log must not use the deprecated jj limit flag: {command_line}"
         );
     }
 

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -129,6 +129,8 @@ impl JjJournal {
         let output = self.run_jj([
             "op",
             "log",
+            "--ignore-working-copy",
+            "--at-op=@",
             "--no-graph",
             "-l",
             "1",
@@ -138,7 +140,7 @@ impl JjJournal {
         let op_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if op_id.is_empty() {
             return Err(JournalError::CommandFailed {
-                command: "jj op log --no-graph -l 1 -T self.id().short(12)".to_string(),
+                command: "jj op log --ignore-working-copy --at-op=@ --no-graph -l 1 -T self.id().short(12)".to_string(),
                 message: "operation id was empty".to_string(),
             });
         }
@@ -458,7 +460,7 @@ mod tests {
         assert!(matches!(
             error,
             JournalError::CommandFailed { ref command, ref message }
-                if command == "jj --no-pager --color=never op log --no-graph -l 1 -T self.id().short(12)"
+                if command == "jj --no-pager --color=never op log --ignore-working-copy --at-op=@ --no-graph -l 1 -T self.id().short(12)"
                     && message.contains("mock jj unavailable")
         ));
         assert!(
@@ -661,6 +663,66 @@ mod tests {
                 .session_start_revision()
                 .expect("state read should succeed"),
             Some(RevisionId::from("rev-a"))
+        );
+    }
+
+    #[test]
+    fn read_only_operation_check_does_not_report_working_copy_snapshot_as_drift() {
+        let _guard = TEST_ENV_LOCK.lock().expect("lock env");
+        let repo = tempdir().expect("repo tempdir");
+        let bin_dir = tempdir().expect("bin tempdir");
+        let mutating_op_file = repo.path().join("mutating-op");
+        fs::write(&mutating_op_file, "op-a").expect("write initial op");
+        let script = format!(
+            "#!/bin/sh\n\
+             if [ \"$3\" = \"op\" ]; then\n\
+               has_ignore=0\n\
+               has_at_op=0\n\
+               for arg in \"$@\"; do\n\
+                 if [ \"$arg\" = \"--ignore-working-copy\" ]; then\n\
+                   has_ignore=1\n\
+                 fi\n\
+                 if [ \"$arg\" = \"--at-op=@\" ]; then\n\
+                   has_at_op=1\n\
+                 fi\n\
+               done\n\
+               if [ \"$has_ignore\" = \"1\" ] && [ \"$has_at_op\" = \"1\" ]; then\n\
+                 printf 'op-a\\n'\n\
+               else\n\
+                 cat \"{}\"\n\
+                 printf '\\n'\n\
+               fi\n\
+               exit 0\n\
+             fi\n\
+             printf 'ok\\n'\n",
+            mutating_op_file.display()
+        );
+        make_fake_jj(bin_dir.path(), &script);
+        let _path_guard = PathGuard::prepend(bin_dir.path());
+        let journal = JjJournal::with_state_path(
+            repo.path(),
+            repo.path().join("state").join(STATE_FILE_NAME),
+        );
+
+        let first = journal
+            .snapshot_with_revision_supplier("first", |_| Ok(RevisionId::from("rev-a")))
+            .expect("first snapshot should record lineage");
+        assert_eq!(first, RevisionId::from("rev-a"));
+
+        fs::write(&mutating_op_file, "op-b")
+            .expect("simulate jj auto-snapshot after working-copy edit");
+        let second = journal
+            .snapshot_with_revision_supplier("second", |_| Ok(RevisionId::from("rev-b")))
+            .expect("read-only op check must not report working-copy snapshot as drift");
+
+        assert_eq!(second, RevisionId::from("rev-b"));
+        assert_eq!(
+            journal
+                .read_state()
+                .expect("state read should succeed")
+                .expect("state should be persisted")
+                .last_operation_id,
+            Some("op-a".to_string())
         );
     }
 }


### PR DESCRIPTION
## Summary

Phase 1-B of #1146 jj sidecar journal — wires the `SnapshotJournal` trait + `JjJournal` impl from Phase 1-A (#1158) into the PostRun pipeline, gated behind `CSA_VCS_AUTO_SNAPSHOT=1` (Phase 1-C will add the `[vcs] auto_snapshot` config field).

- `crates/cli-sub-agent/src/pipeline_jj_journal.rs` (new, 357 lines): PostRun jj snapshot gate, changed-path eligibility, graceful-degrade for config off / no changes / missing `.jj` / non-colocated / jj failure
- `pipeline_post_exec.rs`: invokes the new gate in existing PostRun flow
- `csa-session::jj_journal`: records `project_root`, `session_start_revision`, `session_start_operation_id`, `last_operation_id`; fails closed on operation drift; all jj args go through `Command::arg` for shell-injection safety
- Tests: env gating, no-op skip, missing `.jj`, non-colocated, jj unavailable, shell-metacharacter handling, operation drift rejection, read-only op-check non-mutating

## Review-fix loop

- Round 1: implementation (commit 7e105f05)
- Round 1 review: HIGH — drift detection used `jj op log` without `--ignore-working-copy`, mutating working-copy snapshot during read
- Round 2 fix (66831659): `--ignore-working-copy --at-op=@` + regression test
- Round 2 review: HIGH — `-l 1` flag rejected by `jj 0.40.0` (limit is `-n`)
- Round 3 fix (daf38e1b): `-n 1` + builder regression test
- Round 3 review: CLEAN

## Constraints honored

- No git fallback (fail-closed per AGENTS.md 037/041)
- `require_commit_on_mutation` git semantics unchanged
- No new config fields (Phase 1-C scope)
- Env-var gate `CSA_VCS_AUTO_SNAPSHOT=1` for opt-in until Phase 1-C lands

## Test plan

- [x] `cargo test -p csa-session jj_journal` (8 passed)
- [x] `cargo test -p csa-session`
- [x] `cargo test -p cli-sub-agent`
- [x] `cargo test --workspace`
- [x] `just pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)