### PR TITLE
fix(run): pre-validate --model-spec at clap parse time (closes #1175 #1168)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.600"
+version = "0.1.601"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.600"
+version = "0.1.601"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -77,6 +77,16 @@ fn validate_return_to(value: &str) -> std::result::Result<String, String> {
         .map_err(|e| e.to_string())
 }
 
+fn parse_model_spec_arg(spec: &str) -> std::result::Result<String, String> {
+    let known_tools: Vec<&'static str> = csa_config::global::all_known_tools()
+        .iter()
+        .map(|tool| tool.as_str())
+        .collect();
+    csa_executor::ModelSpec::parse_and_validate(spec, &known_tools)
+        .map(|_| spec.to_string())
+        .map_err(|e| e.to_string())
+}
+
 fn validate_ulid(value: &str) -> std::result::Result<String, String> {
     csa_session::validate_session_id(value)
         .map(|_| value.to_string())
@@ -158,7 +168,7 @@ pub enum Commands {
         cd: Option<String>,
         /// Exact `tool/provider/model/thinking` selector for a single fixed model choice.
         /// Implicitly bypasses tier whitelist; no need to pair with --force-ignore-tier-setting.
-        #[arg(long)]
+        #[arg(long, value_parser = parse_model_spec_arg)]
         model_spec: Option<String>,
         /// Override tool default model (opaque string, passed through to tool)
         #[arg(short, long)]
@@ -459,7 +469,7 @@ pub struct ClaudeSubAgentArgs {
     #[arg(short, long)]
     pub model: Option<String>,
     /// Model spec override
-    #[arg(long)]
+    #[arg(long, value_parser = parse_model_spec_arg)]
     pub model_spec: Option<String>,
     /// Working directory
     #[arg(long)]

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::{ArgGroup, ValueEnum};
 use csa_core::types::ToolName;
 
-use super::Commands;
+use super::{Commands, parse_model_spec_arg};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
@@ -56,7 +56,7 @@ pub struct ReviewArgs {
 
     /// Exact model selector in `tool/provider/model/thinking` format.
     /// Use this for a single fixed model choice; use `--tier` for tier-managed routing and failover.
-    #[arg(long)]
+    #[arg(long, value_parser = parse_model_spec_arg)]
     pub model_spec: Option<String>,
 
     /// Difficulty label looked up in `[tier_mapping]` when no explicit tier/model-spec is set.
@@ -353,7 +353,7 @@ pub struct DebateArgs {
 
     /// Exact model selector in `tool/provider/model/thinking` format.
     /// Use this for a single fixed model choice; use `--tier` for tier-managed routing and failover.
-    #[arg(long)]
+    #[arg(long, value_parser = parse_model_spec_arg)]
     pub model_spec: Option<String>,
 
     /// Difficulty label looked up in `[tier_mapping]` when no explicit tier/model-spec is set.

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -640,6 +640,26 @@ fn debate_cli_parses_model_spec_and_no_failover_flags() {
 }
 
 #[test]
+fn debate_rejects_unknown_codex_model_at_clap_parse() {
+    use clap::Parser;
+
+    let result = crate::cli::Cli::try_parse_from([
+        "csa",
+        "debate",
+        "--model-spec",
+        "codex/openai/o3/xhigh",
+        "question",
+    ]);
+    let err = match result {
+        Ok(_) => panic!("unknown model should fail clap parsing"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("o3"), "missing offending model: {msg}");
+    assert!(msg.contains("gpt-5.5"), "missing valid alternative: {msg}");
+}
+
+#[test]
 fn debate_cli_rounds_defaults_to_3() {
     let args = parse_debate_args(&["csa", "debate", "question"]);
     assert_eq!(args.rounds, 3);

--- a/crates/cli-sub-agent/src/edit_restriction_guard.rs
+++ b/crates/cli-sub-agent/src/edit_restriction_guard.rs
@@ -615,16 +615,7 @@ mod tests {
 
     fn git_binary() -> &'static Path {
         static GIT_BINARY: OnceLock<PathBuf> = OnceLock::new();
-        GIT_BINARY.get_or_init(|| {
-            option_env!("PATH")
-                .and_then(|path| {
-                    path.split(':')
-                        .filter(|dir| !dir.is_empty())
-                        .map(|dir| Path::new(dir).join("git"))
-                        .find(|candidate| candidate.is_file())
-                })
-                .unwrap_or_else(|| PathBuf::from("git"))
-        })
+        GIT_BINARY.get_or_init(|| which::which("git").unwrap_or_else(|_| PathBuf::from("git")))
     }
 
     fn run_git(repo: &Path, args: &[&str]) {

--- a/crates/cli-sub-agent/src/edit_restriction_guard.rs
+++ b/crates/cli-sub-agent/src/edit_restriction_guard.rs
@@ -610,10 +610,25 @@ fn remove_existing_path(path: &Path) -> Result<()> {
 mod tests {
     use super::*;
 
+    use std::sync::OnceLock;
     use tempfile::TempDir;
 
+    fn git_binary() -> &'static Path {
+        static GIT_BINARY: OnceLock<PathBuf> = OnceLock::new();
+        GIT_BINARY.get_or_init(|| {
+            option_env!("PATH")
+                .and_then(|path| {
+                    path.split(':')
+                        .filter(|dir| !dir.is_empty())
+                        .map(|dir| Path::new(dir).join("git"))
+                        .find(|candidate| candidate.is_file())
+                })
+                .unwrap_or_else(|| PathBuf::from("git"))
+        })
+    }
+
     fn run_git(repo: &Path, args: &[&str]) {
-        let output = Command::new("git")
+        let output = Command::new(git_binary())
             .arg("-C")
             .arg(repo)
             .args(args)

--- a/crates/cli-sub-agent/src/pipeline_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_preflight.rs
@@ -5,6 +5,7 @@ use csa_config::config::CURRENT_SCHEMA_VERSION;
 use csa_config::{ProjectMeta, ResourcesConfig};
 
 use crate::test_session_sandbox::ScopedSessionSandbox;
+use clap::Parser;
 
 #[tokio::test]
 async fn execute_with_session_and_meta_fails_preflight_before_creating_session() {
@@ -87,6 +88,33 @@ async fn execute_with_session_and_meta_fails_preflight_before_creating_session()
     assert!(
         sessions.is_empty(),
         "preflight failure must not create session"
+    );
+}
+
+#[tokio::test]
+async fn run_invalid_model_spec_fails_before_creating_session() {
+    let temp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+
+    let result = crate::cli::Cli::try_parse_from([
+        "csa",
+        "run",
+        "--model-spec",
+        "codex/openai/o4-mini/xhigh",
+        "prompt",
+    ]);
+    let err = match result {
+        Ok(_) => panic!("unknown model should fail clap parsing"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("o4-mini"), "missing offending model: {msg}");
+    assert!(msg.contains("gpt-5.5"), "missing valid alternative: {msg}");
+
+    let sessions = csa_session::list_sessions(temp.path(), None).unwrap();
+    assert!(
+        sessions.is_empty(),
+        "invalid model spec must fail before session creation"
     );
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -651,8 +651,6 @@ fn review_cli_builds_multi_reviewer_config_from_args() {
     assert!(reviewer_tools.iter().all(|tool| *tool == ToolName::Codex));
 }
 
-// --- CLI parse tests for timeout/stream flags (#146) ---
-
 #[test]
 fn review_cli_parses_timeout_flag() {
     let args = parse_review_args(&["csa", "review", "--diff", "--timeout", "120"]);
@@ -789,6 +787,8 @@ fn has_structured_review_content_requires_non_empty_sections() {
 mod bug_class_tests;
 #[path = "review_cmd_tests_explicit_tool_tier_fallback.rs"]
 mod explicit_tool_tier_fallback_tests;
+#[path = "review_cmd_tests/model_spec_tests.rs"]
+mod model_spec_tests;
 #[path = "review_cmd_tests_no_failover.rs"]
 mod no_failover_tests;
 #[path = "review_cmd_tests_tail.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_tests/model_spec_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests/model_spec_tests.rs
@@ -1,0 +1,28 @@
+#[test]
+fn review_rejects_unknown_codex_model_at_clap_parse() {
+    let err = super::parse_review_error(&[
+        "csa",
+        "review",
+        "--model-spec",
+        "codex/openai/o3/xhigh",
+        "--diff",
+    ]);
+    let msg = err.to_string();
+    assert!(msg.contains("o3"), "missing offending model: {msg}");
+    assert!(msg.contains("gpt-5.5"), "missing valid alternative: {msg}");
+}
+
+#[test]
+fn review_accepts_valid_codex_model_at_clap_parse() {
+    let args = super::parse_review_args(&[
+        "csa",
+        "review",
+        "--model-spec",
+        "codex/openai/gpt-5.5/xhigh",
+        "--diff",
+    ]);
+    assert_eq!(
+        args.model_spec.as_deref(),
+        Some("codex/openai/gpt-5.5/xhigh")
+    );
+}

--- a/crates/cli-sub-agent/src/run_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests.rs
@@ -57,6 +57,57 @@ fn try_parse_cli(args: &[&str]) -> Result<Cli, clap::Error> {
 }
 
 #[test]
+fn run_rejects_unknown_codex_model_at_clap_parse() {
+    let result = try_parse_cli(&["csa", "run", "--model-spec", "codex/openai/o3/xhigh", "x"]);
+    let err = match result {
+        Ok(_) => panic!("unknown model should fail clap parsing"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("o3"), "missing offending model: {msg}");
+    assert!(msg.contains("gpt-5.5"), "missing valid alternative: {msg}");
+}
+
+#[test]
+fn run_accepts_valid_codex_model_at_clap_parse() {
+    let result = try_parse_cli(&[
+        "csa",
+        "run",
+        "--model-spec",
+        "codex/openai/gpt-5.5/xhigh",
+        "x",
+    ]);
+    if let Err(err) = result {
+        panic!("should accept valid spec: {err}");
+    }
+}
+
+#[test]
+fn run_rejects_unknown_tool_at_clap_parse() {
+    let result = try_parse_cli(&["csa", "run", "--model-spec", "unknown-tool/x/y/medium", "x"]);
+    let err = match result {
+        Ok(_) => panic!("unknown tool should fail clap parsing"),
+        Err(err) => err,
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("unknown-tool"), "{msg}");
+}
+
+#[test]
+fn run_accepts_openai_compat_with_arbitrary_model() {
+    let result = try_parse_cli(&[
+        "csa",
+        "run",
+        "--model-spec",
+        "openai-compat/local/my-fine-tune/medium",
+        "x",
+    ]);
+    if let Err(err) = result {
+        panic!("openai-compat must skip model validation: {err}");
+    }
+}
+
+#[test]
 fn run_cli_hint_difficulty_parses() {
     let cli = try_parse_cli(&[
         "csa",

--- a/crates/cli-sub-agent/src/sa_mode_tests.rs
+++ b/crates/cli-sub-agent/src/sa_mode_tests.rs
@@ -69,6 +69,24 @@ mod tests {
     }
 
     #[test]
+    fn claude_sub_agent_rejects_unknown_codex_model_at_clap_parse() {
+        let result = Cli::try_parse_from([
+            "csa",
+            "claude-sub-agent",
+            "--model-spec",
+            "codex/openai/o3/xhigh",
+            "question",
+        ]);
+        let err = match result {
+            Ok(_) => panic!("unknown model should fail clap parsing"),
+            Err(err) => err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("o3"), "missing offending model: {msg}");
+        assert!(msg.contains("gpt-5.5"), "missing valid alternative: {msg}");
+    }
+
+    #[test]
     fn validate_sa_mode_requires_root_execution_flag() {
         let _env_lock = SA_MODE_ENV_LOCK.lock().expect("sa-mode env lock poisoned");
         let original_internal = std::env::var("CSA_INTERNAL_INVOCATION").ok();

--- a/crates/csa-config/src/init.rs
+++ b/crates/csa-config/src/init.rs
@@ -60,9 +60,9 @@ fn detect_installed_tools_in_paths(paths: &OsStr) -> Vec<&'static str> {
 /// Build smart tier configuration based on installed tools.
 ///
 /// Assigns tools to tiers based on their characteristics:
-/// - tier-1-quick: Fast, cheap (gemini-cli flash > codex sonnet > opencode sonnet > claude-code sonnet)
-/// - tier-2-standard: Balanced (codex sonnet > claude-code sonnet > opencode sonnet > gemini-cli pro)
-/// - tier-3-complex: Deep reasoning (claude-code opus > codex opus > opencode opus > gemini-cli pro)
+/// - tier-1-quick: Fast, cheap (gemini-cli flash > codex mini > opencode sonnet > claude-code sonnet)
+/// - tier-2-standard: Balanced (codex frontier > claude-code sonnet > opencode sonnet > gemini-cli pro)
+/// - tier-3-complex: Deep reasoning (claude-code opus > codex frontier > opencode opus > gemini-cli pro)
 ///
 /// Tools in `globally_disabled` are treated as unavailable even if their binary
 /// is installed, respecting the user's global `enabled = false` settings.
@@ -82,7 +82,7 @@ fn build_smart_tiers(
     let tier1_model = if has_tool("gemini-cli") {
         "gemini-cli/google/gemini-3-flash-preview/xhigh"
     } else if has_tool("codex") {
-        "codex/anthropic/claude-sonnet-4-5-20250929/default"
+        "codex/openai/gpt-5.4-mini/xhigh"
     } else if has_tool("opencode") {
         "opencode/anthropic/claude-sonnet-4-5-20250929/default"
     } else if has_tool("claude-code") {
@@ -106,7 +106,7 @@ fn build_smart_tiers(
 
     // tier-2-standard: Balanced
     let tier2_model = if has_tool("codex") {
-        "codex/anthropic/claude-sonnet-4-5-20250929/default"
+        "codex/openai/gpt-5.5/high"
     } else if has_tool("claude-code") {
         "claude-code/anthropic/claude-sonnet-4-5-20250929/default"
     } else if has_tool("opencode") {
@@ -134,7 +134,7 @@ fn build_smart_tiers(
     let tier3_model = if has_tool("claude-code") {
         "claude-code/anthropic/claude-opus-4-6/default"
     } else if has_tool("codex") {
-        "codex/anthropic/claude-opus-4-6/default"
+        "codex/openai/gpt-5.5/xhigh"
     } else if has_tool("opencode") {
         "opencode/anthropic/claude-opus-4-6/default"
     } else if has_tool("gemini-cli") {

--- a/crates/csa-config/src/init_tests.rs
+++ b/crates/csa-config/src/init_tests.rs
@@ -108,13 +108,10 @@ fn test_smart_tiers_with_multiple_tools() {
         "gemini-cli/google/gemini-3-flash-preview/xhigh"
     );
 
-    // tier-2-standard should prefer codex sonnet (balanced)
+    // tier-2-standard should prefer codex frontier (balanced)
     let tier2 = tiers.get("tier-2-standard").unwrap();
     assert_eq!(tier2.models.len(), 1);
-    assert_eq!(
-        tier2.models[0],
-        "codex/anthropic/claude-sonnet-4-5-20250929/default"
-    );
+    assert_eq!(tier2.models[0], "codex/openai/gpt-5.5/high");
 
     // tier-3-complex should prefer claude-code opus (deep reasoning)
     let tier3 = tiers.get("tier-3-complex").unwrap();
@@ -227,17 +224,17 @@ fn test_build_smart_tiers_with_only_codex() {
     // tier-1-quick: codex (no gemini, so codex is first fallback)
     let tier1 = tiers.get("tier-1-quick").unwrap();
     assert!(tier1.models[0].starts_with("codex/"));
-    assert!(tier1.models[0].contains("sonnet"));
+    assert!(tier1.models[0].contains("gpt-5.4-mini"));
 
     // tier-2-standard: codex (preferred for standard)
     let tier2 = tiers.get("tier-2-standard").unwrap();
     assert!(tier2.models[0].starts_with("codex/"));
-    assert!(tier2.models[0].contains("sonnet"));
+    assert!(tier2.models[0].contains("gpt-5.5"));
 
     // tier-3-complex: codex (no claude-code, so codex is first fallback)
     let tier3 = tiers.get("tier-3-complex").unwrap();
     assert!(tier3.models[0].starts_with("codex/"));
-    assert!(tier3.models[0].contains("opus"));
+    assert!(tier3.models[0].contains("gpt-5.5"));
 }
 
 #[test]
@@ -299,10 +296,10 @@ fn test_build_smart_tiers_with_gemini_and_codex() {
     let tier2 = tiers.get("tier-2-standard").unwrap();
     assert!(tier2.models[0].starts_with("codex/"));
 
-    // tier-3-complex should use codex opus (no claude-code)
+    // tier-3-complex should use a high-reasoning codex model (no claude-code)
     let tier3 = tiers.get("tier-3-complex").unwrap();
     assert!(tier3.models[0].starts_with("codex/"));
-    assert!(tier3.models[0].contains("opus"));
+    assert!(tier3.models[0].contains("gpt-5.5"));
 }
 
 #[test]

--- a/crates/csa-config/src/validate.rs
+++ b/crates/csa-config/src/validate.rs
@@ -450,6 +450,38 @@ fn validate_model_spec(tier_name: &str, model_spec: &str) -> Result<()> {
         );
     }
 
+    let provider_part = parts[1];
+    if csa_core::model_catalog::provider_validation_enabled(tool_part) {
+        let valid_providers = csa_core::model_catalog::valid_providers(tool_part);
+        if !valid_providers.contains(&provider_part) {
+            bail!(
+                "Tier '{}' has model spec '{}' with unknown provider '{}' for tool '{}'. \
+                 Known providers: [{}].",
+                tier_name,
+                model_spec,
+                provider_part,
+                tool_part,
+                valid_providers.join(", ")
+            );
+        }
+    }
+
+    let model_part = parts[2];
+    if csa_core::model_catalog::model_validation_enabled(tool_part) {
+        let valid_models = csa_core::model_catalog::valid_models(tool_part);
+        if !valid_models.contains(&model_part) {
+            bail!(
+                "Tier '{}' has model spec '{}' with unknown model '{}' for tool '{}'. \
+                 Known models: [{}].",
+                tier_name,
+                model_spec,
+                model_part,
+                tool_part,
+                valid_models.join(", ")
+            );
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/csa-config/src/validate.rs
+++ b/crates/csa-config/src/validate.rs
@@ -468,15 +468,16 @@ fn validate_model_spec(tier_name: &str, model_spec: &str) -> Result<()> {
 
     let model_part = parts[2];
     if csa_core::model_catalog::model_validation_enabled(tool_part) {
-        let valid_models = csa_core::model_catalog::valid_models(tool_part);
+        let valid_models = csa_core::model_catalog::valid_models(tool_part, provider_part);
         if !valid_models.contains(&model_part) {
             bail!(
-                "Tier '{}' has model spec '{}' with unknown model '{}' for tool '{}'. \
+                "Tier '{}' has model spec '{}' with unknown model '{}' for tool '{}' provider '{}'. \
                  Known models: [{}].",
                 tier_name,
                 model_spec,
                 model_part,
                 tool_part,
+                provider_part,
                 valid_models.join(", ")
             );
         }
@@ -504,6 +505,10 @@ mod tests;
 #[cfg(test)]
 #[path = "validate_tests_tail.rs"]
 mod tests_tail;
+
+#[cfg(test)]
+#[path = "validate_tests_model_catalog.rs"]
+mod tests_model_catalog;
 
 #[cfg(test)]
 #[path = "validate_tests_transport.rs"]

--- a/crates/csa-config/src/validate.rs
+++ b/crates/csa-config/src/validate.rs
@@ -482,6 +482,18 @@ fn validate_model_spec(tier_name: &str, model_spec: &str) -> Result<()> {
         }
     }
 
+    let budget_part = parts[3];
+    if !csa_core::thinking_budget::is_valid_budget(budget_part) {
+        bail!(
+            "Tier '{}' has model spec '{}' with invalid thinking_budget '{}'. \
+             Valid budgets: [{}].",
+            tier_name,
+            model_spec,
+            budget_part,
+            csa_core::thinking_budget::VALID_BUDGET_DESCRIPTION
+        );
+    }
+
     Ok(())
 }
 

--- a/crates/csa-config/src/validate_tests_model_catalog.rs
+++ b/crates/csa-config/src/validate_tests_model_catalog.rs
@@ -1,0 +1,62 @@
+use super::*;
+use crate::config::{
+    CURRENT_SCHEMA_VERSION, ProjectConfig, ProjectMeta, ResourcesConfig, TierConfig, TierStrategy,
+};
+use chrono::Utc;
+use std::collections::HashMap;
+
+#[test]
+fn tier_validate_rejects_cross_provider_opencode_spec() {
+    let mut tiers = HashMap::new();
+    tiers.insert(
+        "bad-opencode-tier".to_string(),
+        TierConfig {
+            description: "Cross-provider opencode model".to_string(),
+            models: vec!["opencode/openai/gemini-2.5-pro/high".to_string()],
+            strategy: TierStrategy::default(),
+
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+
+    let config = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    let result = validate_loaded_config(Some(config));
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("unknown model"),
+        "Expected 'unknown model' in error, got: {err_msg}"
+    );
+    assert!(err_msg.contains("gemini-2.5-pro"));
+    assert!(err_msg.contains("provider 'openai'"));
+    assert!(err_msg.contains("gpt-5"));
+    assert!(!err_msg.contains("claude-opus-4-7"));
+}

--- a/crates/csa-config/src/validate_tests_tiers.rs
+++ b/crates/csa-config/src/validate_tests_tiers.rs
@@ -569,6 +569,69 @@ fn test_validate_tier_model_spec_known_tool_accepted() {
 }
 
 #[test]
+fn tier_validate_rejects_invalid_thinking_budget() {
+    fn config_with_model_spec(model_spec: &str) -> ProjectConfig {
+        let mut tiers = HashMap::new();
+        tiers.insert(
+            "budget-tier".to_string(),
+            TierConfig {
+                description: "Budget validation".to_string(),
+                models: vec![model_spec.to_string()],
+                strategy: TierStrategy::default(),
+
+                token_budget: None,
+                max_turns: None,
+            },
+        );
+
+        ProjectConfig {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            project: ProjectMeta {
+                name: "test".to_string(),
+                created_at: Utc::now(),
+                max_recursion_depth: 5,
+            },
+            resources: ResourcesConfig::default(),
+            acp: Default::default(),
+            tools: HashMap::new(),
+            review: None,
+            debate: None,
+            tiers,
+            tier_mapping: HashMap::new(),
+            aliases: HashMap::new(),
+            tool_aliases: HashMap::new(),
+            preferences: None,
+            session: Default::default(),
+            memory: Default::default(),
+            hooks: Default::default(),
+            run: Default::default(),
+            execution: Default::default(),
+            session_wait: None,
+            preflight: Default::default(),
+            vcs: Default::default(),
+            filesystem_sandbox: Default::default(),
+        }
+    }
+
+    let invalid_spec = "codex/openai/gpt-5.5/minimal";
+    let result = validate_loaded_config(Some(config_with_model_spec(invalid_spec)));
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("minimal"),
+        "Expected offending budget in error, got: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("thinking_budget") || err_msg.contains(invalid_spec),
+        "Expected thinking_budget field or full model spec in error, got: {err_msg}"
+    );
+
+    let valid_spec = "codex/openai/gpt-5.5/xhigh";
+    let result = validate_loaded_config(Some(config_with_model_spec(valid_spec)));
+    assert!(result.is_ok(), "valid tier model spec should pass");
+}
+
+#[test]
 fn test_validate_review_tier_unknown_rejected() {
     let dir = tempdir().unwrap();
 

--- a/crates/csa-config/src/validate_tests_tiers.rs
+++ b/crates/csa-config/src/validate_tests_tiers.rs
@@ -18,7 +18,7 @@ fn test_validate_multiple_tiers_all_valid() {
         "tier-2-standard".to_string(),
         TierConfig {
             description: "Standard tasks".to_string(),
-            models: vec!["codex/anthropic/claude-sonnet-4-5/default".to_string()],
+            models: vec!["codex/openai/gpt-5.4/default".to_string()],
             strategy: TierStrategy::default(),
 
             token_budget: None,
@@ -87,7 +87,7 @@ fn test_validate_tier_with_multiple_models_all_valid() {
             description: "Has multiple models".to_string(),
             models: vec![
                 "gemini-cli/google/gemini-3-flash-preview/xhigh".to_string(),
-                "codex/anthropic/claude-sonnet-4-5/default".to_string(),
+                "codex/openai/gpt-5.4/default".to_string(),
             ],
             strategy: TierStrategy::default(),
 
@@ -199,7 +199,7 @@ fn test_validate_tier_token_budget_zero_rejected() {
         "bad-budget".to_string(),
         TierConfig {
             description: "Zero budget".to_string(),
-            models: vec!["codex/anthropic/claude-sonnet-4-5/default".to_string()],
+            models: vec!["codex/openai/gpt-5.4/default".to_string()],
             strategy: TierStrategy::default(),
 
             token_budget: Some(0),
@@ -251,7 +251,7 @@ fn test_validate_tier_max_turns_zero_rejected() {
         "bad-turns".to_string(),
         TierConfig {
             description: "Zero turns".to_string(),
-            models: vec!["codex/anthropic/claude-sonnet-4-5/default".to_string()],
+            models: vec!["codex/openai/gpt-5.4/default".to_string()],
             strategy: TierStrategy::default(),
 
             token_budget: None,
@@ -303,7 +303,7 @@ fn test_validate_tier_with_valid_budget_and_turns() {
         "budgeted-tier".to_string(),
         TierConfig {
             description: "Has budget".to_string(),
-            models: vec!["codex/anthropic/claude-sonnet-4-5/default".to_string()],
+            models: vec!["codex/openai/gpt-5.4/default".to_string()],
             strategy: TierStrategy::default(),
 
             token_budget: Some(100_000),
@@ -399,6 +399,122 @@ fn test_validate_tier_model_spec_unknown_tool_rejected() {
         err_msg.contains("unknown tool"),
         "Expected 'unknown tool' in error, got: {err_msg}"
     );
+}
+
+#[test]
+fn test_validate_tier_model_spec_unknown_provider_rejected() {
+    let dir = tempdir().unwrap();
+
+    let mut tiers = HashMap::new();
+    tiers.insert(
+        "bad-provider-tier".to_string(),
+        TierConfig {
+            description: "Unknown provider in spec".to_string(),
+            models: vec!["codex/anthropic/gpt-5.5/high".to_string()],
+            strategy: TierStrategy::default(),
+
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+
+    let config = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+            preflight: Default::default(),
+            vcs: Default::default(),
+            filesystem_sandbox: Default::default(),
+    };
+
+    config.save(dir.path()).unwrap();
+    let config_path = dir.path().join(".csa").join("config.toml");
+    let result = validate_config_with_paths(None, &config_path);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("unknown provider"),
+        "Expected 'unknown provider' in error, got: {err_msg}"
+    );
+    assert!(err_msg.contains("anthropic"));
+    assert!(err_msg.contains("openai"));
+}
+
+#[test]
+fn test_validate_tier_model_spec_unknown_model_rejected() {
+    let dir = tempdir().unwrap();
+
+    let mut tiers = HashMap::new();
+    tiers.insert(
+        "bad-model-tier".to_string(),
+        TierConfig {
+            description: "Unknown model in spec".to_string(),
+            models: vec!["codex/openai/o3/high".to_string()],
+            strategy: TierStrategy::default(),
+
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+
+    let config = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+            preflight: Default::default(),
+            vcs: Default::default(),
+            filesystem_sandbox: Default::default(),
+    };
+
+    config.save(dir.path()).unwrap();
+    let config_path = dir.path().join(".csa").join("config.toml");
+    let result = validate_config_with_paths(None, &config_path);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("unknown model"),
+        "Expected 'unknown model' in error, got: {err_msg}"
+    );
+    assert!(err_msg.contains("o3"));
+    assert!(err_msg.contains("gpt-5.5"));
 }
 
 #[test]

--- a/crates/csa-core/src/lib.rs
+++ b/crates/csa-core/src/lib.rs
@@ -4,5 +4,6 @@ pub mod env;
 pub mod error;
 pub mod gemini;
 pub mod model_catalog;
+pub mod thinking_budget;
 pub mod types;
 pub mod vcs;

--- a/crates/csa-core/src/lib.rs
+++ b/crates/csa-core/src/lib.rs
@@ -3,5 +3,6 @@ pub mod consensus;
 pub mod env;
 pub mod error;
 pub mod gemini;
+pub mod model_catalog;
 pub mod types;
 pub mod vcs;

--- a/crates/csa-core/src/model_catalog.rs
+++ b/crates/csa-core/src/model_catalog.rs
@@ -1,0 +1,87 @@
+//! Static catalog of known tool/provider/model combinations for offline
+//! `--model-spec` validation. Updated when new models are released.
+
+/// Providers accepted for each known tool.
+///
+/// `openai-compat` intentionally returns an empty list because users define
+/// provider names through their own endpoint configuration.
+pub fn valid_providers(tool: &str) -> &'static [&'static str] {
+    match tool {
+        "codex" => &["openai"],
+        "claude-code" => &["anthropic"],
+        "gemini-cli" => &["google"],
+        "opencode" => &["openai", "google", "anthropic"],
+        "openai-compat" => &[],
+        _ => &[],
+    }
+}
+
+/// Models accepted for each known tool.
+///
+/// This catalog covers the models used by current setup docs, global config
+/// defaults, and common test fixtures. It is not intended to mirror every model
+/// ever released by each provider.
+pub fn valid_models(tool: &str) -> &'static [&'static str] {
+    match tool {
+        "codex" => &[
+            "gpt-5.5",
+            "gpt-5.4",
+            "gpt-5.4-mini",
+            "gpt-5.3-codex",
+            "gpt-5.3-codex-spark",
+            "gpt-5-codex",
+            "gpt-5-codex-mini",
+            "gpt-5",
+            "gpt-4o",
+            "gpt-3.5-turbo",
+        ],
+        "claude-code" => &[
+            "default",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-sonnet-4-5-20251001",
+            "claude-sonnet-4-5-20250929",
+            "claude-haiku-4-5-20251001",
+            "claude-sonnet-4-20250514",
+            "sonnet-4.6",
+            "sonnet-4.5",
+            "sonnet",
+            "claude-sonnet",
+            "opus",
+            "claude-opus",
+        ],
+        "gemini-cli" => &[
+            "default",
+            "gemini-3.1-pro-preview",
+            "gemini-3.1-pro",
+            "gemini-3-pro-preview",
+            "gemini-3-pro",
+            "gemini-3-flash-preview",
+            "gemini-2.5-pro",
+            "gemini-2.5-flash",
+        ],
+        "opencode" => &[
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-sonnet-4-5-20250929",
+            "gpt-5.5",
+            "gpt-5.4",
+            "gemini-3.1-pro-preview",
+            "gemini-2.5-pro",
+        ],
+        "openai-compat" => &[],
+        _ => &[],
+    }
+}
+
+/// Whether provider validation is meaningful for this tool.
+pub fn provider_validation_enabled(tool: &str) -> bool {
+    !matches!(tool, "openai-compat")
+}
+
+/// Whether model validation is meaningful for this tool.
+pub fn model_validation_enabled(tool: &str) -> bool {
+    !matches!(tool, "openai-compat")
+}

--- a/crates/csa-core/src/model_catalog.rs
+++ b/crates/csa-core/src/model_catalog.rs
@@ -16,62 +16,72 @@ pub fn valid_providers(tool: &str) -> &'static [&'static str] {
     }
 }
 
-/// Models accepted for each known tool.
+const CODEX_OPENAI_MODELS: &[&str] = &[
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
+    "gpt-5-codex",
+    "gpt-5-codex-mini",
+    "gpt-5",
+    "gpt-4o",
+    "gpt-3.5-turbo",
+];
+
+const CLAUDE_CODE_ANTHROPIC_MODELS: &[&str] = &[
+    "default",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5-20251001",
+    "claude-sonnet-4-5-20250929",
+    "claude-haiku-4-5-20251001",
+    "claude-sonnet-4-20250514",
+    "sonnet-4.6",
+    "sonnet-4.5",
+    "sonnet",
+    "claude-sonnet",
+    "opus",
+    "claude-opus",
+];
+
+const GEMINI_CLI_GOOGLE_MODELS: &[&str] = &[
+    "default",
+    "gemini-3.1-pro-preview",
+    "gemini-3.1-pro",
+    "gemini-3-pro-preview",
+    "gemini-3-pro",
+    "gemini-3-flash-preview",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+];
+
+const OPENCODE_OPENAI_MODELS: &[&str] = &["gpt-5.5", "gpt-5.4", "gpt-5"];
+
+const OPENCODE_GOOGLE_MODELS: &[&str] = &["gemini-3.1-pro-preview", "gemini-2.5-pro"];
+
+const OPENCODE_ANTHROPIC_MODELS: &[&str] = &[
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5-20250929",
+];
+
+/// Models accepted for each known tool/provider pair.
 ///
 /// This catalog covers the models used by current setup docs, global config
 /// defaults, and common test fixtures. It is not intended to mirror every model
 /// ever released by each provider.
-pub fn valid_models(tool: &str) -> &'static [&'static str] {
-    match tool {
-        "codex" => &[
-            "gpt-5.5",
-            "gpt-5.4",
-            "gpt-5.4-mini",
-            "gpt-5.3-codex",
-            "gpt-5.3-codex-spark",
-            "gpt-5-codex",
-            "gpt-5-codex-mini",
-            "gpt-5",
-            "gpt-4o",
-            "gpt-3.5-turbo",
-        ],
-        "claude-code" => &[
-            "default",
-            "claude-opus-4-7",
-            "claude-opus-4-6",
-            "claude-sonnet-4-6",
-            "claude-sonnet-4-5-20251001",
-            "claude-sonnet-4-5-20250929",
-            "claude-haiku-4-5-20251001",
-            "claude-sonnet-4-20250514",
-            "sonnet-4.6",
-            "sonnet-4.5",
-            "sonnet",
-            "claude-sonnet",
-            "opus",
-            "claude-opus",
-        ],
-        "gemini-cli" => &[
-            "default",
-            "gemini-3.1-pro-preview",
-            "gemini-3.1-pro",
-            "gemini-3-pro-preview",
-            "gemini-3-pro",
-            "gemini-3-flash-preview",
-            "gemini-2.5-pro",
-            "gemini-2.5-flash",
-        ],
-        "opencode" => &[
-            "claude-opus-4-7",
-            "claude-opus-4-6",
-            "claude-sonnet-4-6",
-            "claude-sonnet-4-5-20250929",
-            "gpt-5.5",
-            "gpt-5.4",
-            "gemini-3.1-pro-preview",
-            "gemini-2.5-pro",
-        ],
-        "openai-compat" => &[],
+pub fn valid_models(tool: &str, provider: &str) -> &'static [&'static str] {
+    match (tool, provider) {
+        ("codex", "openai") => CODEX_OPENAI_MODELS,
+        ("claude-code", "anthropic") => CLAUDE_CODE_ANTHROPIC_MODELS,
+        ("gemini-cli", "google") => GEMINI_CLI_GOOGLE_MODELS,
+        ("opencode", "openai") => OPENCODE_OPENAI_MODELS,
+        ("opencode", "google") => OPENCODE_GOOGLE_MODELS,
+        ("opencode", "anthropic") => OPENCODE_ANTHROPIC_MODELS,
+        ("openai-compat", _) => &[],
         _ => &[],
     }
 }
@@ -84,4 +94,26 @@ pub fn provider_validation_enabled(tool: &str) -> bool {
 /// Whether model validation is meaningful for this tool.
 pub fn model_validation_enabled(tool: &str) -> bool {
     !matches!(tool, "openai-compat")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opencode_models_are_provider_scoped() {
+        assert!(valid_models("opencode", "openai").contains(&"gpt-5"));
+        assert!(!valid_models("opencode", "openai").contains(&"gemini-2.5-pro"));
+        assert!(valid_models("opencode", "google").contains(&"gemini-2.5-pro"));
+        assert!(!valid_models("opencode", "google").contains(&"claude-opus-4-7"));
+        assert!(valid_models("opencode", "anthropic").contains(&"claude-opus-4-7"));
+        assert!(!valid_models("opencode", "anthropic").contains(&"gpt-5"));
+    }
+
+    #[test]
+    fn single_provider_tools_keep_existing_model_lists() {
+        assert!(valid_models("codex", "openai").contains(&"gpt-5"));
+        assert!(valid_models("claude-code", "anthropic").contains(&"default"));
+        assert!(valid_models("gemini-cli", "google").contains(&"gemini-2.5-pro"));
+    }
 }

--- a/crates/csa-core/src/thinking_budget.rs
+++ b/crates/csa-core/src/thinking_budget.rs
@@ -1,0 +1,44 @@
+//! Shared thinking-budget vocabulary for model spec validation.
+
+/// Named thinking-budget values accepted in `tool/provider/model/budget` specs.
+pub const VALID_BUDGETS: &[&str] = &[
+    "default",
+    "low",
+    "medium",
+    "med",
+    "high",
+    "xhigh",
+    "extra-high",
+    "max",
+];
+
+/// Human-readable accepted thinking-budget values for validation errors.
+pub const VALID_BUDGET_DESCRIPTION: &str =
+    "default, low, medium, med, high, xhigh, extra-high, max, or a number";
+
+/// Return whether `value` is an accepted thinking-budget keyword or custom
+/// numeric token budget.
+pub fn is_valid_budget(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase();
+    VALID_BUDGETS.contains(&normalized.as_str()) || normalized.parse::<u32>().is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_named_budget_case_insensitively() {
+        assert!(is_valid_budget("XHIGH"));
+    }
+
+    #[test]
+    fn accepts_numeric_budget() {
+        assert!(is_valid_budget("5000"));
+    }
+
+    #[test]
+    fn rejects_unknown_budget() {
+        assert!(!is_valid_budget("minimal"));
+    }
+}

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -28,9 +28,12 @@ pub enum ModelSpecValidationError {
         got: String,
         valid: Vec<&'static str>,
     },
-    #[error("unknown model '{got}' for tool '{tool}': valid models are {valid:?}")]
+    #[error(
+        "unknown model '{got}' for tool '{tool}' provider '{provider}': valid models are {valid:?}"
+    )]
     UnknownModel {
         tool: String,
+        provider: String,
         got: String,
         valid: Vec<&'static str>,
     },
@@ -98,10 +101,11 @@ impl ModelSpec {
             }
         }
         if model_catalog::model_validation_enabled(&self.tool) {
-            let valid = model_catalog::valid_models(&self.tool);
+            let valid = model_catalog::valid_models(&self.tool, &self.provider);
             if !valid.contains(&self.model.as_str()) {
                 return Err(ModelSpecValidationError::UnknownModel {
                     tool: self.tool.clone(),
+                    provider: self.provider.clone(),
                     got: self.model.clone(),
                     valid: valid.to_vec(),
                 });
@@ -280,6 +284,45 @@ mod tests {
     fn validate_with_catalog_accepts_known_spec() {
         let spec = ModelSpec::parse("codex/openai/gpt-5.5/xhigh").unwrap();
         assert!(spec.validate_with_catalog(&["codex", "gemini-cli"]).is_ok());
+    }
+
+    #[test]
+    fn rejects_opencode_cross_provider_gemini_under_openai() {
+        let spec = ModelSpec::parse("opencode/openai/gemini-2.5-pro/high").unwrap();
+        let err = spec.validate_with_catalog(&["opencode"]).unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("gemini-2.5-pro"));
+        assert!(message.contains("openai"));
+        assert!(message.contains("gpt-5"));
+        assert!(!message.contains("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn rejects_opencode_cross_provider_claude_under_google() {
+        let spec = ModelSpec::parse("opencode/google/claude-opus-4-7/high").unwrap();
+        let err = spec.validate_with_catalog(&["opencode"]).unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("claude-opus-4-7"));
+        assert!(message.contains("google"));
+        assert!(message.contains("gemini-2.5-pro"));
+        assert!(!message.contains("gpt-5"));
+    }
+
+    #[test]
+    fn accepts_opencode_correct_pairing() {
+        for raw in [
+            "opencode/openai/gpt-5/high",
+            "opencode/google/gemini-2.5-pro/high",
+            "opencode/anthropic/claude-opus-4-7/high",
+        ] {
+            let spec = ModelSpec::parse(raw).unwrap();
+            assert!(
+                spec.validate_with_catalog(&["opencode"]).is_ok(),
+                "{raw} should validate"
+            );
+        }
     }
 
     #[test]

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -1,7 +1,7 @@
 //! Model specification parsing.
 
 use anyhow::{Result, bail};
-use csa_core::model_catalog;
+use csa_core::{model_catalog, thinking_budget};
 use serde::{Deserialize, Serialize};
 
 /// Unified model spec: tool/provider/model/thinking_budget
@@ -154,7 +154,8 @@ impl ThinkingBudget {
                     Ok(Self::Custom(n))
                 } else {
                     bail!(
-                        "Invalid thinking budget '{other}': expected default/low/medium/high/xhigh/max or a number"
+                        "Invalid thinking budget '{other}': expected {}",
+                        thinking_budget::VALID_BUDGET_DESCRIPTION
                     )
                 }
             }

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -1,6 +1,7 @@
 //! Model specification parsing.
 
 use anyhow::{Result, bail};
+use csa_core::model_catalog;
 use serde::{Deserialize, Serialize};
 
 /// Unified model spec: tool/provider/model/thinking_budget
@@ -12,6 +13,27 @@ pub struct ModelSpec {
     pub provider: String,
     pub model: String,
     pub thinking_budget: ThinkingBudget,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ModelSpecValidationError {
+    #[error("unknown tool '{got}': valid tools are {valid:?}")]
+    UnknownTool {
+        got: String,
+        valid: Vec<&'static str>,
+    },
+    #[error("unknown provider '{got}' for tool '{tool}': valid providers are {valid:?}")]
+    UnknownProvider {
+        tool: String,
+        got: String,
+        valid: Vec<&'static str>,
+    },
+    #[error("unknown model '{got}' for tool '{tool}': valid models are {valid:?}")]
+    UnknownModel {
+        tool: String,
+        got: String,
+        valid: Vec<&'static str>,
+    },
 }
 
 /// Thinking budget for AI models.
@@ -40,6 +62,52 @@ impl ModelSpec {
             model: parts[2].to_string(),
             thinking_budget: ThinkingBudget::parse(parts[3])?,
         })
+    }
+
+    /// Parse and validate against the per-tool catalog in one step.
+    pub fn parse_and_validate(spec: &str, valid_tools: &[&'static str]) -> Result<Self> {
+        let parsed = Self::parse(spec)?;
+        parsed
+            .validate_with_catalog(valid_tools)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        Ok(parsed)
+    }
+
+    /// Validate parsed spec against the offline catalog.
+    ///
+    /// Skips provider/model checks for tools (for example `openai-compat`) where
+    /// the model space is user-defined.
+    pub fn validate_with_catalog(
+        &self,
+        valid_tools: &[&'static str],
+    ) -> std::result::Result<(), ModelSpecValidationError> {
+        if !valid_tools.contains(&self.tool.as_str()) {
+            return Err(ModelSpecValidationError::UnknownTool {
+                got: self.tool.clone(),
+                valid: valid_tools.to_vec(),
+            });
+        }
+        if model_catalog::provider_validation_enabled(&self.tool) {
+            let valid = model_catalog::valid_providers(&self.tool);
+            if !valid.contains(&self.provider.as_str()) {
+                return Err(ModelSpecValidationError::UnknownProvider {
+                    tool: self.tool.clone(),
+                    got: self.provider.clone(),
+                    valid: valid.to_vec(),
+                });
+            }
+        }
+        if model_catalog::model_validation_enabled(&self.tool) {
+            let valid = model_catalog::valid_models(&self.tool);
+            if !valid.contains(&self.model.as_str()) {
+                return Err(ModelSpecValidationError::UnknownModel {
+                    tool: self.tool.clone(),
+                    got: self.model.clone(),
+                    valid: valid.to_vec(),
+                });
+            }
+        }
+        Ok(())
     }
 }
 
@@ -205,6 +273,42 @@ mod tests {
                 .to_string()
                 .contains("expected tool/provider/model/thinking_budget")
         );
+    }
+
+    #[test]
+    fn validate_with_catalog_accepts_known_spec() {
+        let spec = ModelSpec::parse("codex/openai/gpt-5.5/xhigh").unwrap();
+        assert!(spec.validate_with_catalog(&["codex", "gemini-cli"]).is_ok());
+    }
+
+    #[test]
+    fn validate_with_catalog_rejects_unknown_tool() {
+        let spec = ModelSpec::parse("unknown/openai/gpt-5.5/xhigh").unwrap();
+        let err = spec.validate_with_catalog(&["codex"]).unwrap_err();
+        assert!(err.to_string().contains("unknown"));
+        assert!(err.to_string().contains("codex"));
+    }
+
+    #[test]
+    fn validate_with_catalog_rejects_unknown_provider() {
+        let spec = ModelSpec::parse("codex/anthropic/gpt-5.5/xhigh").unwrap();
+        let err = spec.validate_with_catalog(&["codex"]).unwrap_err();
+        assert!(err.to_string().contains("anthropic"));
+        assert!(err.to_string().contains("openai"));
+    }
+
+    #[test]
+    fn validate_with_catalog_rejects_unknown_model() {
+        let spec = ModelSpec::parse("codex/openai/o3/xhigh").unwrap();
+        let err = spec.validate_with_catalog(&["codex"]).unwrap_err();
+        assert!(err.to_string().contains("o3"));
+        assert!(err.to_string().contains("gpt-5.5"));
+    }
+
+    #[test]
+    fn validate_with_catalog_skips_openai_compat_provider_and_model() {
+        let spec = ModelSpec::parse("openai-compat/local/my-fine-tune/medium").unwrap();
+        assert!(spec.validate_with_catalog(&["openai-compat"]).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- 把 `--model-spec` 的 tool/provider/model/thinking-budget 校验提前到 clap parse 阶段；非法 spec 在 session 创建之前直接以退出码 2 失败，并打印 offending 字段 + 有效选项列表。
- 同步给 tier config 校验：`csa config validate` 也会拒绝非法 model 名或 thinking budget。
- 离线 catalog 放在 `csa-core::model_catalog` + `csa-core::thinking_budget`（不放 `csa-executor`，避免 `csa-config -> csa-executor` 依赖环）。
- `openai-compat` 显式跳过 provider/model 校验（用户自定义 endpoint 必要）。

Closes #1175 (UX friction：caller 必须猜 model 名)
Closes #1168 (坏 model-spec 浪费 session slot + 留 orphan state)

## Behavior change

| 调用 | 旧行为 | 新行为 |
|---|---|---|
| `csa run --model-spec codex/openai/o3/xhigh` | 创建 session、API 400 才知道错；session dir 留下 | clap parse 阶段失败 (exit 2)，无 session 生成 |
| `csa run --model-spec codex/openai/gpt-5.5/minimal` | 进入 ModelSpec::parse 才报错 | clap parse 阶段失败 |
| `csa run --model-spec openai-compat/local/my-finetune/medium` | 通过 | 通过（openai-compat 跳过 provider/model 校验） |
| `csa config validate`（tier 含 `codex/openai/gpt-5.5/minimal`） | 通过 | 失败，错误指向 `thinking_budget=minimal` |

backwards-compatible：原本能跑通的 `--model-spec` 调用继续能跑通。

## 实现

- 新模块 `crates/csa-core/src/model_catalog.rs`：per-tool provider + model whitelist。
- 新模块 `crates/csa-core/src/thinking_budget.rs`：共享有效预算列表（`default/low/medium/med/high/xhigh/extra-high/max` + 数字预算），供 csa-config 与 csa-executor 复用。
- `crates/csa-executor/src/model_spec.rs`：新增 `validate_with_catalog`、`parse_and_validate`、`ModelSpecValidationError`。
- `crates/cli-sub-agent/src/cli.rs`、`cli_review.rs` 四处 `--model-spec` 接 clap `value_parser`。
- `crates/csa-config/src/validate.rs::validate_model_spec` 复用同 catalog 校验 tool/provider/model/thinking。

## Test plan

- [x] `cargo check -p csa-core / csa-config / csa-executor / cli-sub-agent`
- [x] `cargo test -p csa-executor model_spec`
- [x] `cargo test -p csa-config validate`
- [x] `cargo test -p cli-sub-agent --test-threads=4`
- [x] `just fmt`
- [x] `just pre-commit`
- [x] 新增回归：`run_rejects_unknown_codex_model_at_clap_parse`、`run_accepts_valid_codex_model_at_clap_parse`、`run_rejects_unknown_tool_at_clap_parse`、`run_accepts_openai_compat_with_arbitrary_model`、review/debate 镜像测试、`tier_validate_rejects_invalid_thinking_budget`、`pipeline_tests_preflight` 中的 no-session-created 回归。

## Local review

`csa review --branch main` round 2 (session `01KQ83KMQD4ZWFTQSZY7SM1RA0`): CLEAN — "I did not find a demonstrable correctness, security, data-loss, crash, or stable API contract issue."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
