### PR TITLE
fix(pr-bot): step 5 owner-aware PR lookup + create-race detection (closes #1171)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.601"
+version = "0.1.602"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.601"
+version = "0.1.602"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -252,7 +252,7 @@ fn pr_bot_step5_pr_lookup_is_owner_strict_and_idempotent() {
         .find("find_branch_pr() {")
         .expect("Step 5 must define find_branch_pr");
     let find_branch_pr_end = step5[find_branch_pr_start..]
-        .find("\n}\n\nset +e")
+        .find("\n}\n\nfind_branch_pr_with_retry()")
         .map(|offset| find_branch_pr_start + offset)
         .expect("Step 5 must close find_branch_pr before invoking it");
     let find_branch_pr = &step5[find_branch_pr_start..find_branch_pr_end];
@@ -298,6 +298,17 @@ fn pr_bot_step5_pr_lookup_is_owner_strict_and_idempotent() {
     assert!(
         step5.contains("a pull request for branch .* already exists"),
         "Step 5 must recover from gh pr create reporting that the PR already exists"
+    );
+    assert!(
+        step5.contains("find_branch_pr_with_retry() {"),
+        "Step 5 must define one shared retry helper for stale gh pr list results"
+    );
+    assert!(
+        step5
+            .matches(r#"PR_NUM="$(find_branch_pr_with_retry)""#)
+            .count()
+            == 2,
+        "Step 5 must use the shared retry helper in both create-race and create-success paths"
     );
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -203,21 +203,42 @@ fn pr_bot_archive_includes_helper_scripts() {
 fn pr_bot_step5_pr_lookup_is_owner_strict_and_idempotent() {
     let workflow = pr_bot_artifact_text("patterns/pr-bot/workflow.toml");
     let step5 = extract_pr_bot_step_prompt(&workflow, 5, "patterns/pr-bot/workflow.toml");
+    let find_branch_pr_start = step5
+        .find("find_branch_pr() {")
+        .expect("Step 5 must define find_branch_pr");
+    let find_branch_pr_end = step5[find_branch_pr_start..]
+        .find("\n}\n\nset +e")
+        .map(|offset| find_branch_pr_start + offset)
+        .expect("Step 5 must close find_branch_pr before invoking it");
+    let find_branch_pr = &step5[find_branch_pr_start..find_branch_pr_end];
 
     assert!(
         step5.contains("--json number,headRefName,headRepositoryOwner"),
         "Step 5 must request head owner metadata for client-side PR owner verification"
     );
     assert!(
+        find_branch_pr.contains(r#"--head "${WORKFLOW_BRANCH}""#),
+        "Step 5 must query gh pr list with branch-only --head"
+    );
+    assert!(
+        !find_branch_pr.contains(r#"--head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}""#),
+        "Step 5 must not pass owner-qualified syntax to gh pr list --head"
+    );
+    assert!(
+        find_branch_pr.contains(r#".headRefName == \"${WORKFLOW_BRANCH}\""#)
+            && find_branch_pr.contains(r#".headRepositoryOwner.login == \"${SOURCE_OWNER}\""#),
+        "Step 5 jq filter must strictly match both head branch and head owner"
+    );
+    assert!(
         step5.contains("headRepositoryOwner.login == "),
         "Step 5 must strictly filter PR lookup results by head owner"
     );
     assert!(
-        step5.lines().all(
-            |line| !line.trim().starts_with(r#"--head "${WORKFLOW_BRANCH}""#)
-                && !line.contains(r#" --head "${WORKFLOW_BRANCH}""#)
-        ),
-        "Step 5 must not use an unqualified --head \"${{WORKFLOW_BRANCH}}\" fallback"
+        find_branch_pr
+            .matches(r#"--head "${WORKFLOW_BRANCH}""#)
+            .count()
+            == 1,
+        "Step 5 must have exactly one branch-only gh pr list --head lookup, not a fallback chain"
     );
     assert!(
         step5.contains("a pull request for branch .* already exists"),

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -188,6 +188,7 @@ fn pr_bot_workflow_resolves_helpers_from_pattern_dir() {
 #[test]
 fn pr_bot_workflow_advisory_steps_have_tool_note() {
     let workflow = pr_bot_artifact_text("patterns/pr-bot/workflow.toml");
+    let pattern = pr_bot_artifact_text("patterns/pr-bot/PATTERN.md");
     let plan = plan_from_toml(&workflow).unwrap();
 
     let non_note_advisory_steps: Vec<usize> = plan
@@ -211,6 +212,21 @@ fn pr_bot_workflow_advisory_steps_have_tool_note() {
     assert!(
         non_note_advisory_steps.is_empty(),
         "pr-bot advisory steps must use tool = \"note\"; offenders: {non_note_advisory_steps:?}"
+    );
+
+    let post_merge_extensions = pattern
+        .find("## Post-Merge Extensions")
+        .expect("PATTERN.md must contain Post-Merge Extensions section");
+    let post_merge_hint_window = pattern[post_merge_extensions..]
+        .lines()
+        .take(5)
+        .collect::<Vec<_>>();
+
+    assert!(
+        post_merge_hint_window
+            .iter()
+            .any(|line| line.trim() == "Tool: note"),
+        "Post-Merge Extensions in PATTERN.md must include Tool: note near the heading"
     );
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -225,9 +225,19 @@ fn pr_bot_step5_pr_lookup_is_owner_strict_and_idempotent() {
         "Step 5 must not pass owner-qualified syntax to gh pr list --head"
     );
     assert!(
-        find_branch_pr.contains(r#".headRefName == \"${WORKFLOW_BRANCH}\""#)
-            && find_branch_pr.contains(r#".headRepositoryOwner.login == \"${SOURCE_OWNER}\""#),
-        "Step 5 jq filter must strictly match both head branch and head owner"
+        find_branch_pr.contains("jq -r")
+            && find_branch_pr.contains(r#"--arg branch "${WORKFLOW_BRANCH}""#)
+            && find_branch_pr.contains(r#"--arg owner "${SOURCE_OWNER}""#),
+        "Step 5 jq filter must bind head branch and owner as jq data"
+    );
+    assert!(
+        find_branch_pr.contains(".headRefName == $branch")
+            && find_branch_pr.contains(".headRepositoryOwner.login == $owner"),
+        "Step 5 jq filter must strictly match both bound head branch and head owner"
+    );
+    assert!(
+        !find_branch_pr.contains(r#"--jq ".[] | select(.headRefName == \"${WORKFLOW_BRANCH}\""#),
+        "Step 5 must not interpolate WORKFLOW_BRANCH into jq source"
     );
     assert!(
         step5.contains("headRepositoryOwner.login == "),

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -61,6 +61,16 @@ fn pr_bot_artifact_text(path: &str) -> String {
     std::fs::read_to_string(workspace_root().join(path)).unwrap()
 }
 
+fn extract_pr_bot_step_prompt(text: &str, step_id: usize, artifact: &str) -> String {
+    let step_marker = format!("id = {step_id}");
+    let start = text
+        .find(&step_marker)
+        .unwrap_or_else(|| panic!("{artifact} must contain workflow step id {step_id}"));
+    let body = &text[start..];
+    let next_step = body.find("\n[[workflow.steps]]").unwrap_or(body.len());
+    body[..next_step].to_string()
+}
+
 fn assert_marker_order(text: &str, first: &str, second: &str, artifact: &str) {
     let first_idx = text
         .find(first)
@@ -186,6 +196,32 @@ fn pr_bot_archive_includes_helper_scripts() {
     assert!(
         entries.contains(&"patterns/pr-bot/scripts/csa/session-wait-until-done.sh".to_string()),
         "git archive for patterns/pr-bot must include session-wait-until-done.sh"
+    );
+}
+
+#[test]
+fn pr_bot_step5_pr_lookup_is_owner_strict_and_idempotent() {
+    let workflow = pr_bot_artifact_text("patterns/pr-bot/workflow.toml");
+    let step5 = extract_pr_bot_step_prompt(&workflow, 5, "patterns/pr-bot/workflow.toml");
+
+    assert!(
+        step5.contains("--json number,headRefName,headRepositoryOwner"),
+        "Step 5 must request head owner metadata for client-side PR owner verification"
+    );
+    assert!(
+        step5.contains("headRepositoryOwner.login == "),
+        "Step 5 must strictly filter PR lookup results by head owner"
+    );
+    assert!(
+        step5.lines().all(
+            |line| !line.trim().starts_with(r#"--head "${WORKFLOW_BRANCH}""#)
+                && !line.contains(r#" --head "${WORKFLOW_BRANCH}""#)
+        ),
+        "Step 5 must not use an unqualified --head \"${{WORKFLOW_BRANCH}}\" fallback"
+    );
+    assert!(
+        step5.contains("a pull request for branch .* already exists"),
+        "Step 5 must recover from gh pr create reporting that the PR already exists"
     );
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -186,6 +186,35 @@ fn pr_bot_workflow_resolves_helpers_from_pattern_dir() {
 }
 
 #[test]
+fn pr_bot_workflow_advisory_steps_have_tool_note() {
+    let workflow = pr_bot_artifact_text("patterns/pr-bot/workflow.toml");
+    let plan = plan_from_toml(&workflow).unwrap();
+
+    let non_note_advisory_steps: Vec<usize> = plan
+        .steps
+        .iter()
+        .filter(|step| {
+            let title = step.title.to_ascii_lowercase();
+            let advisory_title = ["note", "advisory", "extensions"]
+                .iter()
+                .any(|marker| title.contains(marker));
+            let advisory_prompt = step
+                .prompt
+                .trim_start()
+                .starts_with("> Post-merge rule-extractor pattern");
+
+            (advisory_title || advisory_prompt) && step.tool.as_deref() != Some("note")
+        })
+        .map(|step| step.id)
+        .collect();
+
+    assert!(
+        non_note_advisory_steps.is_empty(),
+        "pr-bot advisory steps must use tool = \"note\"; offenders: {non_note_advisory_steps:?}"
+    );
+}
+
+#[test]
 fn pr_bot_archive_includes_helper_scripts() {
     let entries = git_archive_entries(&workspace_root(), "patterns/pr-bot");
 

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -275,6 +275,28 @@ find_branch_pr() {
   fi
 }
 
+find_branch_pr_with_retry() {
+  local attempt pr_num rc
+  rc=2
+  for attempt in 1 2 3 4 5; do
+    set +e
+    pr_num="$(find_branch_pr)"
+    rc=$?
+    set -e
+    if [ "${rc}" = "0" ] && [ -n "${pr_num}" ]; then
+      printf '%s\n' "${pr_num}"
+      return 0
+    fi
+    if [ "${rc}" = "1" ]; then
+      return 1
+    fi
+    if [ "${attempt}" != "5" ]; then
+      sleep 2
+    fi
+  done
+  return "${rc}"
+}
+
 set +e
 PR_NUM="$(find_branch_pr)"
 FIND_RC=$?
@@ -292,7 +314,7 @@ else
     if printf '%s' "${CREATE_OUTPUT}" | grep -qiE "a pull request for branch .* already exists"; then
       echo "INFO: PR already exists for ${SOURCE_OWNER}:${WORKFLOW_BRANCH}; re-resolving." >&2
       set +e
-      PR_NUM="$(find_branch_pr)"
+      PR_NUM="$(find_branch_pr_with_retry)"
       FIND_RC=$?
       set -e
       if [ "${FIND_RC}" = "0" ] && [ -n "${PR_NUM}" ]; then
@@ -307,21 +329,10 @@ else
     fi
   fi
   if [ "${CREATE_RC}" = "0" ]; then
-    FIND_RC=2
-    PR_NUM=""
-    for attempt in 1 2 3 4 5; do
-      set +e
-      PR_NUM="$(find_branch_pr)"
-      FIND_RC=$?
-      set -e
-      if [ "${FIND_RC}" = "0" ] && [ -n "${PR_NUM}" ]; then
-        break
-      fi
-      if [ "${FIND_RC}" = "1" ]; then
-        break
-      fi
-      sleep 2
-    done
+    set +e
+    PR_NUM="$(find_branch_pr_with_retry)"
+    FIND_RC=$?
+    set -e
     if [ "${FIND_RC}" != "0" ] || [ -z "${PR_NUM}" ]; then
       echo "ERROR: Failed to resolve a unique PR for branch ${WORKFLOW_BRANCH} targeting \"${DEFAULT_BRANCH}\"." >&2
       exit 1

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -1983,4 +1983,6 @@ echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false --
 
 ## Post-Merge Extensions
 
+Tool: note
+
 > Post-merge rule-extractor pattern is available at `patterns/rule-extractor/` — integration pending separate PR. Invoke via `csa plan run patterns/rule-extractor/workflow.toml` after successful merge when HIGH/CRITICAL findings exist.

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -255,8 +255,13 @@ find_branch_pr() {
       --state open \
       --head "${WORKFLOW_BRANCH}" \
       --json number,headRefName,headRepositoryOwner \
-      --jq ".[] | select(.headRefName == \"${WORKFLOW_BRANCH}\" and .headRepositoryOwner.login == \"${SOURCE_OWNER}\") | .number" \
-      2>/dev/null || true
+      2>/dev/null \
+    | jq -r \
+        --arg branch "${WORKFLOW_BRANCH}" \
+        --arg owner "${SOURCE_OWNER}" \
+        '.[] | select(.headRefName == $branch and .headRepositoryOwner.login == $owner) | .number' \
+      2>/dev/null \
+      || true
   )"
   count="$(printf '%s\n' "${matches}" | sed '/^$/d' | wc -l | tr -d ' ')"
   if [ "${count}" = "1" ]; then

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -211,9 +211,10 @@ OnFail: abort
   `ERROR: Local review found unresolved issues. Fix them before PR creation.`
 - FORBIDDEN: Creating a PR without completing Step 2. This violates the two-layer review guarantee.
 
-PR lookup is strictly owner-aware: query only `${SOURCE_OWNER}:${WORKFLOW_BRANCH}`,
-verify returned rows by `headRepositoryOwner.login` and `headRefName`, and never
-fall back to unqualified `--head "${WORKFLOW_BRANCH}"`. If `gh pr create`
+PR lookup is strictly owner-aware: query `--head "${WORKFLOW_BRANCH}"`,
+then verify returned rows by `headRepositoryOwner.login` and `headRefName`.
+Never rely on `--head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}"`; `gh pr list --head`
+accepts a branch name only. If `gh pr create`
 reports `a pull request for branch ... already exists`, re-resolve via the same
 owner-aware lookup and reuse the existing PR.
 
@@ -252,7 +253,7 @@ find_branch_pr() {
       --repo "${REPO_SLUG}" \
       --base "${DEFAULT_BRANCH}" \
       --state open \
-      --head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}" \
+      --head "${WORKFLOW_BRANCH}" \
       --json number,headRefName,headRepositoryOwner \
       --jq ".[] | select(.headRefName == \"${WORKFLOW_BRANCH}\" and .headRepositoryOwner.login == \"${SOURCE_OWNER}\") | .number" \
       2>/dev/null || true

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -42,7 +42,7 @@ This pattern follows a 3-layer dispatcher architecture:
 
 Each step below is annotated with its execution layer.
 
-## Workflow Step 1: Assumed Fork Convention
+## Assumed Fork Convention
 
 Tool: note
 
@@ -211,6 +211,12 @@ OnFail: abort
   `ERROR: Local review found unresolved issues. Fix them before PR creation.`
 - FORBIDDEN: Creating a PR without completing Step 2. This violates the two-layer review guarantee.
 
+PR lookup is strictly owner-aware: query only `${SOURCE_OWNER}:${WORKFLOW_BRANCH}`,
+verify returned rows by `headRepositoryOwner.login` and `headRefName`, and never
+fall back to unqualified `--head "${WORKFLOW_BRANCH}"`. If `gh pr create`
+reports `a pull request for branch ... already exists`, re-resolve via the same
+owner-aware lookup and reuse the existing PR.
+
 ```bash
 # --- Precondition gate: review must be complete ---
 if [ "${REVIEW_COMPLETED:-}" != "true" ]; then
@@ -240,35 +246,27 @@ if [ -z "${SOURCE_OWNER}" ]; then
   SOURCE_OWNER="$(gh repo view "${REPO_SLUG}" --json owner -q '.owner.login')"
 fi
 find_branch_pr() {
-  local owner_matches owner_count branch_matches branch_count
-  owner_matches="$(
-    gh pr list --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --state open --head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}" --json number \
-      --jq '.[].number' 2>/dev/null || true
+  local matches count
+  matches="$(
+    gh pr list \
+      --repo "${REPO_SLUG}" \
+      --base "${DEFAULT_BRANCH}" \
+      --state open \
+      --head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}" \
+      --json number,headRefName,headRepositoryOwner \
+      --jq ".[] | select(.headRefName == \"${WORKFLOW_BRANCH}\" and .headRepositoryOwner.login == \"${SOURCE_OWNER}\") | .number" \
+      2>/dev/null || true
   )"
-  owner_count="$(printf '%s\n' "${owner_matches}" | sed '/^$/d' | wc -l | tr -d ' ')"
-  if [ "${owner_count}" = "1" ]; then
-    printf '%s\n' "${owner_matches}" | sed '/^$/d' | head -n 1
+  count="$(printf '%s\n' "${matches}" | sed '/^$/d' | wc -l | tr -d ' ')"
+  if [ "${count}" = "1" ]; then
+    printf '%s\n' "${matches}" | sed '/^$/d' | head -n 1
     return 0
-  fi
-  if [ "${owner_count}" -gt 1 ]; then
+  elif [ "${count}" = "0" ]; then
+    return 2
+  else
     echo "ERROR: Multiple open PRs found for ${SOURCE_OWNER}:${WORKFLOW_BRANCH}. Resolve ambiguity manually." >&2
     return 1
   fi
-
-  branch_matches="$(
-    gh pr list --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --state open --head "${WORKFLOW_BRANCH}" --json number \
-      --jq '.[].number' 2>/dev/null || true
-  )"
-  branch_count="$(printf '%s\n' "${branch_matches}" | sed '/^$/d' | wc -l | tr -d ' ')"
-  if [ "${branch_count}" = "1" ]; then
-    printf '%s\n' "${branch_matches}" | sed '/^$/d' | head -n 1
-    return 0
-  fi
-  if [ "${branch_count}" -gt 1 ]; then
-    echo "ERROR: Multiple open PRs found for branch ${WORKFLOW_BRANCH}. Resolve ambiguity manually." >&2
-    return 1
-  fi
-  return 2
 }
 
 set +e
@@ -285,30 +283,43 @@ else
   CREATE_RC=$?
   set -e
   if [ "${CREATE_RC}" != "0" ]; then
-    if ! printf '%s\n' "${CREATE_OUTPUT}" | grep -Eiq 'already exists|a pull request already exists'; then
+    if printf '%s' "${CREATE_OUTPUT}" | grep -qiE "a pull request for branch .* already exists"; then
+      echo "INFO: PR already exists for ${SOURCE_OWNER}:${WORKFLOW_BRANCH}; re-resolving." >&2
+      set +e
+      PR_NUM="$(find_branch_pr)"
+      FIND_RC=$?
+      set -e
+      if [ "${FIND_RC}" = "0" ] && [ -n "${PR_NUM}" ]; then
+        echo "Using existing PR #${PR_NUM} for branch ${WORKFLOW_BRANCH}"
+      else
+        echo "ERROR: gh pr create reports PR exists but find_branch_pr could not resolve it (rc=${FIND_RC}). Check fork ownership and branch ${WORKFLOW_BRANCH}." >&2
+        exit 1
+      fi
+    else
       echo "ERROR: gh pr create failed: ${CREATE_OUTPUT}" >&2
       exit 1
     fi
-    echo "Detected existing PR during create race; resolving PR number by owner+branch."
   fi
-  FIND_RC=2
-  PR_NUM=""
-  for attempt in 1 2 3 4 5; do
-    set +e
-    PR_NUM="$(find_branch_pr)"
-    FIND_RC=$?
-    set -e
-    if [ "${FIND_RC}" = "0" ] && [ -n "${PR_NUM}" ]; then
-      break
+  if [ "${CREATE_RC}" = "0" ]; then
+    FIND_RC=2
+    PR_NUM=""
+    for attempt in 1 2 3 4 5; do
+      set +e
+      PR_NUM="$(find_branch_pr)"
+      FIND_RC=$?
+      set -e
+      if [ "${FIND_RC}" = "0" ] && [ -n "${PR_NUM}" ]; then
+        break
+      fi
+      if [ "${FIND_RC}" = "1" ]; then
+        break
+      fi
+      sleep 2
+    done
+    if [ "${FIND_RC}" != "0" ] || [ -z "${PR_NUM}" ]; then
+      echo "ERROR: Failed to resolve a unique PR for branch ${WORKFLOW_BRANCH} targeting \"${DEFAULT_BRANCH}\"." >&2
+      exit 1
     fi
-    if [ "${FIND_RC}" = "1" ]; then
-      break
-    fi
-    sleep 2
-  done
-  if [ "${FIND_RC}" != "0" ] || [ -z "${PR_NUM}" ]; then
-    echo "ERROR: Failed to resolve a unique PR for branch ${WORKFLOW_BRANCH} targeting \"${DEFAULT_BRANCH}\"." >&2
-    exit 1
   fi
 fi
 if [ -z "${PR_NUM:-}" ] || ! printf '%s' "${PR_NUM}" | grep -Eq '^[0-9]+$'; then

--- a/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
+++ b/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 state_dir="${GH_STUB_STATE_DIR:?}"
 scenario="${GH_STUB_SCENARIO:?}"
-expected_head="${GH_STUB_EXPECTED_HEAD:?}"
+expected_list_head="${GH_STUB_EXPECTED_LIST_HEAD:?}"
+expected_create_head="${GH_STUB_EXPECTED_CREATE_HEAD:?}"
 expected_base="${GH_STUB_EXPECTED_BASE:?}"
 
 count_call() {
@@ -37,7 +38,8 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
   head_arg="$(arg_value "--head" "$@")"
   base_arg="$(arg_value "--base" "$@")"
   json_arg="$(arg_value "--json" "$@")"
-  if [ "${head_arg}" != "${expected_head}" ]; then
+  jq_arg="$(arg_value "--jq" "$@")"
+  if [ "${head_arg}" != "${expected_list_head}" ]; then
     echo "unexpected --head: ${head_arg}" >&2
     exit 1
   fi
@@ -49,37 +51,52 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
     echo "unexpected --json: ${json_arg}" >&2
     exit 1
   fi
+  if [ -z "${jq_arg}" ]; then
+    echo "missing --jq" >&2
+    exit 1
+  fi
 
   list_call="$(count_call pr-list)"
   case "${scenario}" in
     create-success)
       if [ "${list_call}" -ge 2 ]; then
-        printf '101\n'
+        printf '[{"number":101,"headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"}}]\n'
+      else
+        printf '[]\n'
       fi
       ;;
     preexisting)
-      printf '202\n'
+      printf '[{"number":202,"headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"}}]\n'
       ;;
     missed-already-exists)
       if [ "${list_call}" -ge 2 ]; then
-        printf '303\n'
+        printf '[{"number":303,"headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"}}]\n'
+      else
+        printf '[]\n'
       fi
       ;;
     ambiguous)
-      printf '404\n405\n'
+      printf '[{"number":404,"headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"}},{"number":405,"headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"}}]\n'
+      ;;
+    cross-owner)
+      if [ "${list_call}" -ge 2 ]; then
+        printf '[{"number":101,"headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"}}]\n'
+      else
+        printf '[{"number":606,"headRefName":"fix/1171","headRepositoryOwner":{"login":"other-owner"}}]\n'
+      fi
       ;;
     *)
       echo "unknown GH_STUB_SCENARIO: ${scenario}" >&2
       exit 1
       ;;
-  esac
+  esac | jq -r "${jq_arg}"
   exit 0
 fi
 
 if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ]; then
   head_arg="$(arg_value "--head" "$@")"
   base_arg="$(arg_value "--base" "$@")"
-  if [ "${head_arg}" != "${expected_head}" ]; then
+  if [ "${head_arg}" != "${expected_create_head}" ]; then
     echo "unexpected create --head: ${head_arg}" >&2
     exit 1
   fi
@@ -89,7 +106,7 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ]; then
   fi
   count_call pr-create >/dev/null
   case "${scenario}" in
-    create-success)
+    create-success|cross-owner)
       printf 'https://github.com/test-owner/test-repo/pull/101\n'
       ;;
     missed-already-exists)

--- a/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
+++ b/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
@@ -70,6 +70,13 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
         printf '[]\n'
       fi
       ;;
+    stale-already-exists)
+      if [ "${list_call}" -ge 3 ]; then
+        printf '[{"number":808,"headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"}}]\n'
+      else
+        printf '[]\n'
+      fi
+      ;;
     ambiguous)
       printf '[{"number":404,"headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"}},{"number":405,"headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"}}]\n'
       ;;
@@ -107,7 +114,7 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ]; then
     create-success|cross-owner)
       printf 'https://github.com/test-owner/test-repo/pull/101\n'
       ;;
-    missed-already-exists)
+    missed-already-exists|stale-already-exists)
       echo "a pull request for branch \"test-owner:fix/1171\" into branch \"main\" already exists" >&2
       exit 1
       ;;

--- a/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
+++ b/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+state_dir="${GH_STUB_STATE_DIR:?}"
+scenario="${GH_STUB_SCENARIO:?}"
+expected_head="${GH_STUB_EXPECTED_HEAD:?}"
+expected_base="${GH_STUB_EXPECTED_BASE:?}"
+
+count_call() {
+  local name="$1"
+  local file="${state_dir}/${name}-count"
+  local count=0
+  if [ -f "${file}" ]; then
+    count="$(<"${file}")"
+  fi
+  count=$((count + 1))
+  printf '%s\n' "${count}" >"${file}"
+  printf '%s\n' "${count}"
+}
+
+arg_value() {
+  local flag="$1"
+  shift
+  while [ "$#" -gt 0 ]; do
+    if [ "${1}" = "${flag}" ]; then
+      shift
+      printf '%s\n' "${1:-}"
+      return 0
+    fi
+    shift
+  done
+  return 1
+}
+
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
+  head_arg="$(arg_value "--head" "$@")"
+  base_arg="$(arg_value "--base" "$@")"
+  json_arg="$(arg_value "--json" "$@")"
+  if [ "${head_arg}" != "${expected_head}" ]; then
+    echo "unexpected --head: ${head_arg}" >&2
+    exit 1
+  fi
+  if [ "${base_arg}" != "${expected_base}" ]; then
+    echo "unexpected --base: ${base_arg}" >&2
+    exit 1
+  fi
+  if [ "${json_arg}" != "number,headRefName,headRepositoryOwner" ]; then
+    echo "unexpected --json: ${json_arg}" >&2
+    exit 1
+  fi
+
+  list_call="$(count_call pr-list)"
+  case "${scenario}" in
+    create-success)
+      if [ "${list_call}" -ge 2 ]; then
+        printf '101\n'
+      fi
+      ;;
+    preexisting)
+      printf '202\n'
+      ;;
+    missed-already-exists)
+      if [ "${list_call}" -ge 2 ]; then
+        printf '303\n'
+      fi
+      ;;
+    ambiguous)
+      printf '404\n405\n'
+      ;;
+    *)
+      echo "unknown GH_STUB_SCENARIO: ${scenario}" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ]; then
+  head_arg="$(arg_value "--head" "$@")"
+  base_arg="$(arg_value "--base" "$@")"
+  if [ "${head_arg}" != "${expected_head}" ]; then
+    echo "unexpected create --head: ${head_arg}" >&2
+    exit 1
+  fi
+  if [ "${base_arg}" != "${expected_base}" ]; then
+    echo "unexpected create --base: ${base_arg}" >&2
+    exit 1
+  fi
+  count_call pr-create >/dev/null
+  case "${scenario}" in
+    create-success)
+      printf 'https://github.com/test-owner/test-repo/pull/101\n'
+      ;;
+    missed-already-exists)
+      echo "a pull request for branch \"test-owner:fix/1171\" into branch \"main\" already exists" >&2
+      exit 1
+      ;;
+    preexisting|ambiguous)
+      echo "gh pr create should not be called for scenario ${scenario}" >&2
+      exit 1
+      ;;
+    *)
+      echo "unknown GH_STUB_SCENARIO: ${scenario}" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+if [ "${1:-}" = "repo" ] && [ "${2:-}" = "view" ]; then
+  printf 'test-owner\n'
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1

--- a/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
+++ b/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
@@ -38,7 +38,6 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
   head_arg="$(arg_value "--head" "$@")"
   base_arg="$(arg_value "--base" "$@")"
   json_arg="$(arg_value "--json" "$@")"
-  jq_arg="$(arg_value "--jq" "$@")"
   if [ "${head_arg}" != "${expected_list_head}" ]; then
     echo "unexpected --head: ${head_arg}" >&2
     exit 1
@@ -49,10 +48,6 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
   fi
   if [ "${json_arg}" != "number,headRefName,headRepositoryOwner" ]; then
     echo "unexpected --json: ${json_arg}" >&2
-    exit 1
-  fi
-  if [ -z "${jq_arg}" ]; then
-    echo "missing --jq" >&2
     exit 1
   fi
 
@@ -85,11 +80,14 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
         printf '[{"number":606,"headRefName":"fix/1171","headRepositoryOwner":{"login":"other-owner"}}]\n'
       fi
       ;;
+    quoted-branch)
+      printf '[{"number":707,"headRefName":"feat/has\\"quote","headRepositoryOwner":{"login":"test-owner"}}]\n'
+      ;;
     *)
       echo "unknown GH_STUB_SCENARIO: ${scenario}" >&2
       exit 1
       ;;
-  esac | jq -r "${jq_arg}"
+  esac
   exit 0
 fi
 
@@ -113,7 +111,7 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ]; then
       echo "a pull request for branch \"test-owner:fix/1171\" into branch \"main\" already exists" >&2
       exit 1
       ;;
-    preexisting|ambiguous)
+    preexisting|ambiguous|quoted-branch)
       echo "gh pr create should not be called for scenario ${scenario}" >&2
       exit 1
       ;;

--- a/patterns/pr-bot/scripts/tests/_stubs/git-stub.sh
+++ b/patterns/pr-bot/scripts/tests/_stubs/git-stub.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+state_dir="${GIT_STUB_STATE_DIR:?}"
+source_owner="${GIT_STUB_SOURCE_OWNER:-test-owner}"
+
+if [ "${1:-}" = "ls-remote" ] && [ "${2:-}" = "--heads" ]; then
+  if [ "${GIT_STUB_BRANCH_PUSHED:-false}" = "true" ]; then
+    printf '0000000000000000000000000000000000000000\trefs/heads/%s\n' "${4:-}"
+  fi
+  exit 0
+fi
+
+if [ "${1:-}" = "push" ]; then
+  count_file="${state_dir}/push-count"
+  count=0
+  if [ -f "${count_file}" ]; then
+    count="$(<"${count_file}")"
+  fi
+  count=$((count + 1))
+  printf '%s\n' "${count}" >"${count_file}"
+  exit 0
+fi
+
+if [ "${1:-}" = "remote" ] && [ "${2:-}" = "get-url" ] && [ "${3:-}" = "--push" ]; then
+  printf 'git@github.com:%s/test-repo.git\n' "${source_owner}"
+  exit 0
+fi
+
+echo "unexpected git invocation: $*" >&2
+exit 1

--- a/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
+++ b/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
@@ -108,6 +108,7 @@ run_case "branch-pushed-create" "true" "create-success" "0" "101" "1"
 run_case "lookup-hits-reuse" "true" "preexisting" "0" "202" "0"
 run_case "cross-owner-create" "true" "cross-owner" "0" "101" "1"
 run_case "create-already-exists-reresolve" "true" "missed-already-exists" "0" "303" "1" "PR already exists for test-owner:fix/1171; re-resolving"
+run_case "stale-list-create-race-recovery" "true" "stale-already-exists" "0" "808" "1" "PR already exists for test-owner:fix/1171; re-resolving"
 run_case "ambiguous-fail-closed" "true" "ambiguous" "1" "" "0" "Multiple open PRs found for test-owner:fix/1171"
 run_case "quoted-branch-reuse" "true" "quoted-branch" "0" "707" "0" "" 'feat/has"quote'
 

--- a/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
+++ b/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+WORKFLOW_PATH="${ROOT_DIR}/patterns/pr-bot/workflow.toml"
+STUB_DIR="${ROOT_DIR}/patterns/pr-bot/scripts/tests/_stubs"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+extract_step5_script() {
+  local output_path="$1"
+  awk '
+    $0 == "id = 5" { in_step = 1 }
+    in_step && $0 == "```bash" { in_code = 1; next }
+    in_code && $0 ~ /^```/ { exit }
+    in_code { print }
+  ' "${WORKFLOW_PATH}" >"${output_path}"
+  chmod +x "${output_path}"
+}
+
+assert_file_value() {
+  local file="$1"
+  local expected="$2"
+  local actual="0"
+  if [ -f "${file}" ]; then
+    actual="$(<"${file}")"
+  fi
+  if [ "${actual}" != "${expected}" ]; then
+    echo "expected ${file} to contain ${expected}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+run_case() {
+  local case_name="$1"
+  local branch_pushed="$2"
+  local scenario="$3"
+  local expected_rc="$4"
+  local expected_pr="$5"
+  local expected_creates="$6"
+  local expected_error="${7:-}"
+  local case_dir="${TMP_ROOT}/${case_name}"
+  local bin_dir="${case_dir}/bin"
+  local stdout_file="${case_dir}/stdout.txt"
+  local stderr_file="${case_dir}/stderr.txt"
+  local script_path="${case_dir}/step5.sh"
+  local rc
+
+  mkdir -p "${bin_dir}"
+  ln -s "${STUB_DIR}/git-stub.sh" "${bin_dir}/git"
+  ln -s "${STUB_DIR}/gh-stub.sh" "${bin_dir}/gh"
+  extract_step5_script "${script_path}"
+
+  set +e
+  (
+    PATH="${bin_dir}:${PATH}" \
+    GIT_STUB_STATE_DIR="${case_dir}" \
+    GIT_STUB_BRANCH_PUSHED="${branch_pushed}" \
+    GIT_STUB_SOURCE_OWNER="test-owner" \
+    GH_STUB_STATE_DIR="${case_dir}" \
+    GH_STUB_SCENARIO="${scenario}" \
+    GH_STUB_EXPECTED_HEAD="test-owner:fix/1171" \
+    GH_STUB_EXPECTED_BASE="main" \
+    REVIEW_COMPLETED="true" \
+    REMOTE_NAME="origin" \
+    WORKFLOW_BRANCH="fix/1171" \
+    REPO_SLUG="test-owner/test-repo" \
+    DEFAULT_BRANCH="main" \
+    PR_TITLE="Fix 1171" \
+    PR_BODY="Body" \
+    "${script_path}" >"${stdout_file}" 2>"${stderr_file}"
+  )
+  rc=$?
+  set -e
+
+  if [ "${rc}" != "${expected_rc}" ]; then
+    echo "${case_name}: expected rc ${expected_rc}, got ${rc}" >&2
+    echo "--- stdout ---" >&2
+    sed -n '1,120p' "${stdout_file}" >&2
+    echo "--- stderr ---" >&2
+    sed -n '1,120p' "${stderr_file}" >&2
+    exit 1
+  fi
+
+  assert_file_value "${case_dir}/push-count" "1"
+  assert_file_value "${case_dir}/pr-create-count" "${expected_creates}"
+
+  if [ "${expected_rc}" = "0" ]; then
+    grep -q "CSA_VAR:PR_NUM=${expected_pr}" "${stdout_file}"
+  fi
+  if [ -n "${expected_error}" ]; then
+    grep -q "${expected_error}" "${stderr_file}"
+  fi
+}
+
+run_case "branch-unpushed-create" "false" "create-success" "0" "101" "1"
+run_case "branch-pushed-create" "true" "create-success" "0" "101" "1"
+run_case "lookup-hits-reuse" "true" "preexisting" "0" "202" "0"
+run_case "create-already-exists-reresolve" "true" "missed-already-exists" "0" "303" "1" "PR already exists for test-owner:fix/1171; re-resolving"
+run_case "ambiguous-fail-closed" "true" "ambiguous" "1" "" "0" "Multiple open PRs found for test-owner:fix/1171"
+
+echo "ensure-pr Step 5 tests: PASS"

--- a/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
+++ b/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
@@ -60,7 +60,8 @@ run_case() {
     GIT_STUB_SOURCE_OWNER="test-owner" \
     GH_STUB_STATE_DIR="${case_dir}" \
     GH_STUB_SCENARIO="${scenario}" \
-    GH_STUB_EXPECTED_HEAD="test-owner:fix/1171" \
+    GH_STUB_EXPECTED_LIST_HEAD="fix/1171" \
+    GH_STUB_EXPECTED_CREATE_HEAD="test-owner:fix/1171" \
     GH_STUB_EXPECTED_BASE="main" \
     REVIEW_COMPLETED="true" \
     REMOTE_NAME="origin" \
@@ -97,6 +98,7 @@ run_case() {
 run_case "branch-unpushed-create" "false" "create-success" "0" "101" "1"
 run_case "branch-pushed-create" "true" "create-success" "0" "101" "1"
 run_case "lookup-hits-reuse" "true" "preexisting" "0" "202" "0"
+run_case "cross-owner-create" "true" "cross-owner" "0" "101" "1"
 run_case "create-already-exists-reresolve" "true" "missed-already-exists" "0" "303" "1" "PR already exists for test-owner:fix/1171; re-resolving"
 run_case "ambiguous-fail-closed" "true" "ambiguous" "1" "" "0" "Multiple open PRs found for test-owner:fix/1171"
 

--- a/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
+++ b/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
@@ -8,6 +8,11 @@ STUB_DIR="${ROOT_DIR}/patterns/pr-bot/scripts/tests/_stubs"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "${TMP_ROOT}"' EXIT
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ensure-pr Step 5 tests: SKIP (jq is required for client-side PR lookup filtering)" >&2
+  exit 0
+fi
+
 extract_step5_script() {
   local output_path="$1"
   awk '
@@ -40,6 +45,9 @@ run_case() {
   local expected_pr="$5"
   local expected_creates="$6"
   local expected_error="${7:-}"
+  local workflow_branch="${8:-fix/1171}"
+  local expected_list_head="${9:-${workflow_branch}}"
+  local expected_create_head="${10:-test-owner:${workflow_branch}}"
   local case_dir="${TMP_ROOT}/${case_name}"
   local bin_dir="${case_dir}/bin"
   local stdout_file="${case_dir}/stdout.txt"
@@ -60,12 +68,12 @@ run_case() {
     GIT_STUB_SOURCE_OWNER="test-owner" \
     GH_STUB_STATE_DIR="${case_dir}" \
     GH_STUB_SCENARIO="${scenario}" \
-    GH_STUB_EXPECTED_LIST_HEAD="fix/1171" \
-    GH_STUB_EXPECTED_CREATE_HEAD="test-owner:fix/1171" \
+    GH_STUB_EXPECTED_LIST_HEAD="${expected_list_head}" \
+    GH_STUB_EXPECTED_CREATE_HEAD="${expected_create_head}" \
     GH_STUB_EXPECTED_BASE="main" \
     REVIEW_COMPLETED="true" \
     REMOTE_NAME="origin" \
-    WORKFLOW_BRANCH="fix/1171" \
+    WORKFLOW_BRANCH="${workflow_branch}" \
     REPO_SLUG="test-owner/test-repo" \
     DEFAULT_BRANCH="main" \
     PR_TITLE="Fix 1171" \
@@ -101,5 +109,6 @@ run_case "lookup-hits-reuse" "true" "preexisting" "0" "202" "0"
 run_case "cross-owner-create" "true" "cross-owner" "0" "101" "1"
 run_case "create-already-exists-reresolve" "true" "missed-already-exists" "0" "303" "1" "PR already exists for test-owner:fix/1171; re-resolving"
 run_case "ambiguous-fail-closed" "true" "ambiguous" "1" "" "0" "Multiple open PRs found for test-owner:fix/1171"
+run_case "quoted-branch-reuse" "true" "quoted-branch" "0" "707" "0" "" 'feat/has"quote'
 
 echo "ensure-pr Step 5 tests: PASS"

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -627,9 +627,10 @@ prompt = '''
   `ERROR: Local review found unresolved issues. Fix them before PR creation.`
 - FORBIDDEN: Creating a PR without completing Step 2. This violates the two-layer review guarantee.
 
-PR lookup is strictly owner-aware: query only `${SOURCE_OWNER}:${WORKFLOW_BRANCH}`,
-verify returned rows by `headRepositoryOwner.login` and `headRefName`, and never
-fall back to unqualified `--head "${WORKFLOW_BRANCH}"`. If `gh pr create`
+PR lookup is strictly owner-aware: query `--head "${WORKFLOW_BRANCH}"`,
+then verify returned rows by `headRepositoryOwner.login` and `headRefName`.
+Never rely on `--head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}"`; `gh pr list --head`
+accepts a branch name only. If `gh pr create`
 reports `a pull request for branch ... already exists`, re-resolve via the same
 owner-aware lookup and reuse the existing PR.
 
@@ -668,7 +669,7 @@ find_branch_pr() {
       --repo "${REPO_SLUG}" \
       --base "${DEFAULT_BRANCH}" \
       --state open \
-      --head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}" \
+      --head "${WORKFLOW_BRANCH}" \
       --json number,headRefName,headRepositoryOwner \
       --jq ".[] | select(.headRefName == \"${WORKFLOW_BRANCH}\" and .headRepositoryOwner.login == \"${SOURCE_OWNER}\") | .number" \
       2>/dev/null || true

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -2383,5 +2383,6 @@ condition = "(!(${BOT_UNAVAILABLE})) && (!(${FIXES_ACCUMULATED} && !(${REBASE_CL
 [[workflow.steps]]
 id = 24
 title = "Post-Merge Extensions"
+tool = "note"
 prompt = "> Post-merge rule-extractor pattern is available at `patterns/rule-extractor/` — integration pending separate PR. Invoke via `csa plan run patterns/rule-extractor/workflow.toml` after successful merge when HIGH/CRITICAL findings exist."
 on_fail = "abort"

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -399,6 +399,9 @@ name = "WAIT_SLEEP_PID"
 name = "WORKFLOW_BRANCH"
 
 [[workflow.variables]]
+name = "attempt"
+
+[[workflow.variables]]
 name = "count"
 
 [[workflow.variables]]
@@ -414,6 +417,9 @@ name = "latest_trigger_ts"
 name = "matches"
 
 [[workflow.variables]]
+name = "pr_num"
+
+[[workflow.variables]]
 name = "quota_body"
 
 [[workflow.variables]]
@@ -424,6 +430,9 @@ name = "quota_now_utc"
 
 [[workflow.variables]]
 name = "quota_section_header"
+
+[[workflow.variables]]
+name = "rc"
 
 [[workflow.variables]]
 name = "remaining"
@@ -691,6 +700,28 @@ find_branch_pr() {
   fi
 }
 
+find_branch_pr_with_retry() {
+  local attempt pr_num rc
+  rc=2
+  for attempt in 1 2 3 4 5; do
+    set +e
+    pr_num="$(find_branch_pr)"
+    rc=$?
+    set -e
+    if [ "${rc}" = "0" ] && [ -n "${pr_num}" ]; then
+      printf '%s\n' "${pr_num}"
+      return 0
+    fi
+    if [ "${rc}" = "1" ]; then
+      return 1
+    fi
+    if [ "${attempt}" != "5" ]; then
+      sleep 2
+    fi
+  done
+  return "${rc}"
+}
+
 set +e
 PR_NUM="$(find_branch_pr)"
 FIND_RC=$?
@@ -708,7 +739,7 @@ else
     if printf '%s' "${CREATE_OUTPUT}" | grep -qiE "a pull request for branch .* already exists"; then
       echo "INFO: PR already exists for ${SOURCE_OWNER}:${WORKFLOW_BRANCH}; re-resolving." >&2
       set +e
-      PR_NUM="$(find_branch_pr)"
+      PR_NUM="$(find_branch_pr_with_retry)"
       FIND_RC=$?
       set -e
       if [ "${FIND_RC}" = "0" ] && [ -n "${PR_NUM}" ]; then
@@ -723,21 +754,10 @@ else
     fi
   fi
   if [ "${CREATE_RC}" = "0" ]; then
-    FIND_RC=2
-    PR_NUM=""
-    for attempt in 1 2 3 4 5; do
-      set +e
-      PR_NUM="$(find_branch_pr)"
-      FIND_RC=$?
-      set -e
-      if [ "${FIND_RC}" = "0" ] && [ -n "${PR_NUM}" ]; then
-        break
-      fi
-      if [ "${FIND_RC}" = "1" ]; then
-        break
-      fi
-      sleep 2
-    done
+    set +e
+    PR_NUM="$(find_branch_pr_with_retry)"
+    FIND_RC=$?
+    set -e
     if [ "${FIND_RC}" != "0" ] || [ -z "${PR_NUM}" ]; then
       echo "ERROR: Failed to resolve a unique PR for branch ${WORKFLOW_BRANCH} targeting \"${DEFAULT_BRANCH}\"." >&2
       exit 1

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -123,9 +123,6 @@ name = "COMMENT_START_LINE"
 name = "COMMENT_TIMESTAMP"
 
 [[workflow.variables]]
-name = "COMMIT_COUNT"
-
-[[workflow.variables]]
 name = "CREATE_OUTPUT"
 
 [[workflow.variables]]
@@ -192,31 +189,22 @@ name = "FIX_RESULT"
 name = "FIX_SID"
 
 [[workflow.variables]]
-name = "GATE_MARKER"
-
-[[workflow.variables]]
-name = "GATE_RC"
-
-[[workflow.variables]]
-name = "GATE_RESULT"
-
-[[workflow.variables]]
-name = "GATE_SID"
-
-[[workflow.variables]]
 name = "HOME"
 
 [[workflow.variables]]
 name = "INTERVAL"
 
 [[workflow.variables]]
+name = "LATEST_BOT_COMMENT_BODY"
+
+[[workflow.variables]]
+name = "LATEST_BOT_COMMENT_JSON"
+
+[[workflow.variables]]
+name = "LATEST_BOT_COMMENT_RC"
+
+[[workflow.variables]]
 name = "LATEST_CURRENT_HEAD_TRIGGER_TS"
-
-[[workflow.variables]]
-name = "LATE_ACTIONABLE_COUNT"
-
-[[workflow.variables]]
-name = "LATE_ACTIONABLE_RC"
 
 [[workflow.variables]]
 name = "LOCAL_REVIEW_HAS_ISSUES"
@@ -234,9 +222,6 @@ name = "MARKER_REPO_SLUG"
 name = "MAX_REVIEW_ROUNDS"
 
 [[workflow.variables]]
-name = "MERGE_BASE"
-
-[[workflow.variables]]
 name = "MERGE_REASON"
 
 [[workflow.variables]]
@@ -244,9 +229,6 @@ name = "MERGE_STRATEGY"
 
 [[workflow.variables]]
 name = "MERGE_WITHOUT_BOT_REASON_KIND"
-
-[[workflow.variables]]
-name = "NEW_COMMIT_COUNT"
 
 [[workflow.variables]]
 name = "NOW_UTC"
@@ -279,9 +261,6 @@ name = "POST_FIX_REUSED_REVIEW_ID"
 name = "POST_FIX_REVIEW_WINDOW_START"
 
 [[workflow.variables]]
-name = "POST_REBASE_TIMEOUT"
-
-[[workflow.variables]]
 name = "PR_BODY"
 
 [[workflow.variables]]
@@ -297,19 +276,19 @@ name = "PR_NUM"
 name = "PR_TITLE"
 
 [[workflow.variables]]
-name = "REBASE_CURRENT_SHA"
+name = "QUOTA_EXPECTED_RESET_AT"
 
 [[workflow.variables]]
-name = "REBASE_REVIEW_HAS_ISSUES"
+name = "QUOTA_NOW_UTC"
 
 [[workflow.variables]]
 name = "REBASE_CLEAN_HISTORY_APPLIED"
 
 [[workflow.variables]]
-name = "REBASE_TRIGGER_BODY"
+name = "REBASE_REVIEW_HAS_ISSUES"
 
 [[workflow.variables]]
-name = "REBASE_TRIGGER_TS"
+name = "REBASE_SCRIPT"
 
 [[workflow.variables]]
 name = "REMOTE_NAME"
@@ -420,22 +399,19 @@ name = "WAIT_SLEEP_PID"
 name = "WORKFLOW_BRANCH"
 
 [[workflow.variables]]
-name = "branch_count"
-
-[[workflow.variables]]
-name = "branch_matches"
+name = "count"
 
 [[workflow.variables]]
 name = "field_name"
 
 [[workflow.variables]]
+name = "latest_bot_comment_json"
+
+[[workflow.variables]]
 name = "latest_trigger_ts"
 
 [[workflow.variables]]
-name = "owner_count"
-
-[[workflow.variables]]
-name = "owner_matches"
+name = "matches"
 
 [[workflow.variables]]
 name = "quota_body"
@@ -478,6 +454,8 @@ id = 1
 title = "Assumed Fork Convention"
 tool = "note"
 prompt = """
+> **Layer**: 0 (Orchestrator) -- advisory text only.
+
 pr-bot assumes the GitHub-common fork convention:
 
 - `origin` = your personal fork (push target and PR source)
@@ -504,8 +482,7 @@ git config remote.pushDefault <fork-remote-name>
 When multiple remotes exist, `origin` does not reference the authenticated
 GitHub login, and no explicit push remote is configured, pr-bot fails closed
 with an actionable error instead of guessing and risking a push to the
-canonical repository.
-"""
+canonical repository."""
 on_fail = "abort"
 
 [[workflow.steps]]
@@ -650,6 +627,12 @@ prompt = '''
   `ERROR: Local review found unresolved issues. Fix them before PR creation.`
 - FORBIDDEN: Creating a PR without completing Step 2. This violates the two-layer review guarantee.
 
+PR lookup is strictly owner-aware: query only `${SOURCE_OWNER}:${WORKFLOW_BRANCH}`,
+verify returned rows by `headRepositoryOwner.login` and `headRefName`, and never
+fall back to unqualified `--head "${WORKFLOW_BRANCH}"`. If `gh pr create`
+reports `a pull request for branch ... already exists`, re-resolve via the same
+owner-aware lookup and reuse the existing PR.
+
 ```bash
 # --- Precondition gate: review must be complete ---
 if [ "${REVIEW_COMPLETED:-}" != "true" ]; then
@@ -679,35 +662,27 @@ if [ -z "${SOURCE_OWNER}" ]; then
   SOURCE_OWNER="$(gh repo view "${REPO_SLUG}" --json owner -q '.owner.login')"
 fi
 find_branch_pr() {
-  local owner_matches owner_count branch_matches branch_count
-  owner_matches="$(
-    gh pr list --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --state open --head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}" --json number \
-      --jq '.[].number' 2>/dev/null || true
+  local matches count
+  matches="$(
+    gh pr list \
+      --repo "${REPO_SLUG}" \
+      --base "${DEFAULT_BRANCH}" \
+      --state open \
+      --head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}" \
+      --json number,headRefName,headRepositoryOwner \
+      --jq ".[] | select(.headRefName == \"${WORKFLOW_BRANCH}\" and .headRepositoryOwner.login == \"${SOURCE_OWNER}\") | .number" \
+      2>/dev/null || true
   )"
-  owner_count="$(printf '%s\n' "${owner_matches}" | sed '/^$/d' | wc -l | tr -d ' ')"
-  if [ "${owner_count}" = "1" ]; then
-    printf '%s\n' "${owner_matches}" | sed '/^$/d' | head -n 1
+  count="$(printf '%s\n' "${matches}" | sed '/^$/d' | wc -l | tr -d ' ')"
+  if [ "${count}" = "1" ]; then
+    printf '%s\n' "${matches}" | sed '/^$/d' | head -n 1
     return 0
-  fi
-  if [ "${owner_count}" -gt 1 ]; then
+  elif [ "${count}" = "0" ]; then
+    return 2
+  else
     echo "ERROR: Multiple open PRs found for ${SOURCE_OWNER}:${WORKFLOW_BRANCH}. Resolve ambiguity manually." >&2
     return 1
   fi
-
-  branch_matches="$(
-    gh pr list --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --state open --head "${WORKFLOW_BRANCH}" --json number \
-      --jq '.[].number' 2>/dev/null || true
-  )"
-  branch_count="$(printf '%s\n' "${branch_matches}" | sed '/^$/d' | wc -l | tr -d ' ')"
-  if [ "${branch_count}" = "1" ]; then
-    printf '%s\n' "${branch_matches}" | sed '/^$/d' | head -n 1
-    return 0
-  fi
-  if [ "${branch_count}" -gt 1 ]; then
-    echo "ERROR: Multiple open PRs found for branch ${WORKFLOW_BRANCH}. Resolve ambiguity manually." >&2
-    return 1
-  fi
-  return 2
 }
 
 set +e
@@ -724,30 +699,43 @@ else
   CREATE_RC=$?
   set -e
   if [ "${CREATE_RC}" != "0" ]; then
-    if ! printf '%s\n' "${CREATE_OUTPUT}" | grep -Eiq 'already exists|a pull request already exists'; then
+    if printf '%s' "${CREATE_OUTPUT}" | grep -qiE "a pull request for branch .* already exists"; then
+      echo "INFO: PR already exists for ${SOURCE_OWNER}:${WORKFLOW_BRANCH}; re-resolving." >&2
+      set +e
+      PR_NUM="$(find_branch_pr)"
+      FIND_RC=$?
+      set -e
+      if [ "${FIND_RC}" = "0" ] && [ -n "${PR_NUM}" ]; then
+        echo "Using existing PR #${PR_NUM} for branch ${WORKFLOW_BRANCH}"
+      else
+        echo "ERROR: gh pr create reports PR exists but find_branch_pr could not resolve it (rc=${FIND_RC}). Check fork ownership and branch ${WORKFLOW_BRANCH}." >&2
+        exit 1
+      fi
+    else
       echo "ERROR: gh pr create failed: ${CREATE_OUTPUT}" >&2
       exit 1
     fi
-    echo "Detected existing PR during create race; resolving PR number by owner+branch."
   fi
-  FIND_RC=2
-  PR_NUM=""
-  for attempt in 1 2 3 4 5; do
-    set +e
-    PR_NUM="$(find_branch_pr)"
-    FIND_RC=$?
-    set -e
-    if [ "${FIND_RC}" = "0" ] && [ -n "${PR_NUM}" ]; then
-      break
+  if [ "${CREATE_RC}" = "0" ]; then
+    FIND_RC=2
+    PR_NUM=""
+    for attempt in 1 2 3 4 5; do
+      set +e
+      PR_NUM="$(find_branch_pr)"
+      FIND_RC=$?
+      set -e
+      if [ "${FIND_RC}" = "0" ] && [ -n "${PR_NUM}" ]; then
+        break
+      fi
+      if [ "${FIND_RC}" = "1" ]; then
+        break
+      fi
+      sleep 2
+    done
+    if [ "${FIND_RC}" != "0" ] || [ -z "${PR_NUM}" ]; then
+      echo "ERROR: Failed to resolve a unique PR for branch ${WORKFLOW_BRANCH} targeting \"${DEFAULT_BRANCH}\"." >&2
+      exit 1
     fi
-    if [ "${FIND_RC}" = "1" ]; then
-      break
-    fi
-    sleep 2
-  done
-  if [ "${FIND_RC}" != "0" ] || [ -z "${PR_NUM}" ]; then
-    echo "ERROR: Failed to resolve a unique PR for branch ${WORKFLOW_BRANCH} targeting \"${DEFAULT_BRANCH}\"." >&2
-    exit 1
   fi
 fi
 if [ -z "${PR_NUM:-}" ] || ! printf '%s' "${PR_NUM}" | grep -Eq '^[0-9]+$'; then
@@ -2140,6 +2128,8 @@ title = "Step 10.5: Rebase for Clean History"
 tool = "bash"
 prompt = '''
 > **Layer**: 0 (Orchestrator) -- git history cleanup before merge.
+
+
 Reorganize accumulated fix commits into logical groups (source, patterns, other)
 before merging, but only when the branch meets the audit guard:
 - branch has 3+ commits since `${DEFAULT_BRANCH}`
@@ -2286,7 +2276,7 @@ git push -u "${REMOTE_NAME}" "${CLEAN_BRANCH}"
 gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${CLEAN_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}"
 ```'''
 on_fail = "abort"
-condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED}) && !(${REBASE_CLEAN_HISTORY_APPLIED})"
+condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED}))"
 
 [[workflow.steps]]
 id = 22
@@ -2334,7 +2324,7 @@ git log --oneline -1  # verify local matches remote
 echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
 ```'''
 on_fail = "abort"
-condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED}) && !(${REBASE_CLEAN_HISTORY_APPLIED})"
+condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED}))"
 
 [[workflow.steps]]
 id = 23
@@ -2382,4 +2372,10 @@ git log --oneline -1  # verify local matches remote
 echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
 ```'''
 on_fail = "abort"
-condition = "(!(${BOT_UNAVAILABLE})) && ((!(${FIXES_ACCUMULATED})) || (${REBASE_CLEAN_HISTORY_APPLIED}))"
+condition = "(!(${BOT_UNAVAILABLE})) && (!(${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED})))"
+
+[[workflow.steps]]
+id = 24
+title = "Post-Merge Extensions"
+prompt = "> Post-merge rule-extractor pattern is available at `patterns/rule-extractor/` — integration pending separate PR. Invoke via `csa plan run patterns/rule-extractor/workflow.toml` after successful merge when HIGH/CRITICAL findings exist."
+on_fail = "abort"

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -671,8 +671,13 @@ find_branch_pr() {
       --state open \
       --head "${WORKFLOW_BRANCH}" \
       --json number,headRefName,headRepositoryOwner \
-      --jq ".[] | select(.headRefName == \"${WORKFLOW_BRANCH}\" and .headRepositoryOwner.login == \"${SOURCE_OWNER}\") | .number" \
-      2>/dev/null || true
+      2>/dev/null \
+    | jq -r \
+        --arg branch "${WORKFLOW_BRANCH}" \
+        --arg owner "${SOURCE_OWNER}" \
+        '.[] | select(.headRefName == $branch and .headRepositoryOwner.login == $owner) | .number' \
+      2>/dev/null \
+      || true
   )"
   count="$(printf '%s\n' "${matches}" | sed '/^$/d' | wc -l | tr -d ' ')"
   if [ "${count}" = "1" ]; then


### PR DESCRIPTION
## Summary

Fixes #1171: pr-bot Step 5 (`find_branch_pr` / "Push and ensure PR") was not
idempotent across the GitHub fork convention assumed by the skill, leading to
two failure surfaces:

1. **Cross-owner false-match**: an upstream PR with the same branch name from
   a *different* fork could be picked up as "this branch's PR" and force-pushed
   into.
2. **Create race**: when a concurrent agent already opened the PR for this
   branch, `gh pr create` exits non-zero with `pull request for branch ...
   already exists`, which the skill treated as a hard error instead of
   recovering.

This PR makes Step 5 strictly owner-aware and idempotent against the create
race.

## Behavior change matrix

| Scenario | Before | After |
|----------|--------|-------|
| PR exists for `<source_owner>:<branch>` | reuse | reuse (unchanged) |
| PR exists for *different* `owner:<branch>` (cross-fork same name) | could false-match → push to wrong PR | filtered out, treated as "no PR yet", create attempted |
| Concurrent create race (PR opened by another agent between check and create) | hard error, abort | detect "already exists", re-resolve via owner-aware lookup, reuse |
| Multiple PRs match `<source_owner>:<branch>` (ambiguity) | undefined | fail-closed with explicit error |
| Branch name contains `"` (e.g. `feat/has"quote`) | jq source-string interpolation could break | safe via `jq --arg` data binding |

## Iteration trail (5 rounds)

Each round identified a NEW concrete correctness bug — iterative quality work,
not design ping-pong (per CLAUDE.md "iterative narrow fixes ≠ design ping-pong"
guidance). Round-5 push-gate review came back CLEAN.

- **R1** `b92e71f8` — strict owner-aware lookup + create-race detection.
- **R2** `6d0768bf` — `gh pr list --head` does not accept `<owner>:<branch>`
  syntax (branch only). Switched to branch-only `--head` plus client-side
  filtering.
- **R3** `58dbf288` — jq source-string interpolation of `${WORKFLOW_BRANCH}`
  was unsafe (git accepts `"` in branch names). Switched to `jq --arg branch
  --arg owner` data binding. Added Case G test for quoted branch.
- **R4** `da81b56b` — Step 24 "Post-Merge Extensions" added without
  `tool = "note"`; would otherwise spawn an extra AI session post-merge and
  fail-after-merge on quota. Added regression test
  `pr_bot_workflow_advisory_steps_have_tool_note`.
- **R5** `60359988` — `PATTERN.md` lacked the `Tool: note` hint that
  `workflow.toml` had. Sync gap (rule 027): if `weave compile` regenerated
  `workflow.toml`, the explicit `tool = "note"` would NOT carry over and the
  step could revert to default-AI-tool execution. Added the hint to PATTERN.md
  and extended the regression test to cover both files.

## Final fix shape (Step 5 lookup)

```bash
SOURCE_OWNER="$(git remote get-url origin | ...)"

PR_NUMBER="$(gh pr list \
  --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --state open \
  --head "${WORKFLOW_BRANCH}" \
  --json number,headRefName,headRepositoryOwner \
  | jq -r --arg branch "${WORKFLOW_BRANCH}" --arg owner "${SOURCE_OWNER}" \
    '[.[] | select(.headRefName == $branch and .headRepositoryOwner.login == $owner) | .number]
     | if length == 1 then .[0]
       elif length == 0 then empty
       else error("ambiguous: multiple PRs match \($owner):\($branch)")
       end')"
```

`gh pr create` failure with `already exists` is detected and re-resolved through
the same owner-aware lookup.

## Test plan

- [x] `cargo test -p cli-sub-agent pr_bot_step5_pr_lookup_is_owner_strict_and_idempotent` — passes
- [x] `cargo test -p cli-sub-agent pr_bot_workflow_advisory_steps_have_tool_note` — passes (covers both `workflow.toml` and `PATTERN.md`)
- [x] `patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh` — passes (Cases A-G: A=happy reuse, B=create when missing, C=cross-owner same-name rejection, D=create-race recovery, E=ambiguity fail-closed, F=branch-only `--head`, G=quoted branch via `jq --arg`)
- [x] `weave compile patterns/pr-bot/PATTERN.md -o patterns/pr-bot/workflow.toml` — regenerates byte-identical workflow.toml (sync invariant verified)
- [x] `just pre-commit` — passes
- [x] R5 push-gate `csa review` — CLEAN, no blocking findings

## Files touched

- `patterns/pr-bot/PATTERN.md` — Step 5 owner-aware lookup, Post-Merge Extensions Tool: note hint
- `patterns/pr-bot/workflow.toml` — Step 5 + Step 24 (synced via weave)
- `patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh` — mirror real gh `--head` semantics (branch-only)
- `patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh` — Cases A-G
- `crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs` — contract tests

Closes #1171
