### PR TITLE
fix(cli): support --prompt-file - / /dev/stdin (closes #1162)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.602"
+version = "0.1.603"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.602"
+version = "0.1.603"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -120,7 +120,8 @@ pub enum Commands {
         /// Task prompt (flag form; same as the positional prompt)
         #[arg(long = "prompt", value_name = "PROMPT", conflicts_with_all = ["prompt", "prompt_file"])]
         prompt_flag: Option<String>,
-        /// Read prompt from a file (bypasses shell quoting issues with complex prompts)
+        /// Read prompt from a file (bypasses shell quoting issues with complex prompts).
+        /// Use `-` or `/dev/stdin` to read the prompt from stdin (heredoc or pipe).
         #[arg(long, value_name = "PATH", conflicts_with = "prompt")]
         prompt_file: Option<PathBuf>,
         /// Prepend summary/details/findings from a prior review session into the employee prompt

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -196,7 +196,8 @@ pub struct ReviewArgs {
     #[arg(long, value_delimiter = ',', value_name = "PATH")]
     pub extra_readable: Vec<PathBuf>,
 
-    /// Read supplementary prompt/context from a file (bypasses shell quoting issues)
+    /// Read supplementary prompt/context from a file path (bypasses shell quoting issues).
+    /// Review treats this as a path; stdin sentinels are not resolved.
     #[arg(long, value_name = "PATH")]
     pub prompt_file: Option<PathBuf>,
 
@@ -430,7 +431,8 @@ pub struct DebateArgs {
     #[arg(long, value_delimiter = ',', value_name = "PATH")]
     pub extra_readable: Vec<PathBuf>,
 
-    /// Read the debate question from a file (bypasses shell quoting issues)
+    /// Read the debate question from a file (bypasses shell quoting issues).
+    /// Use `-` or `/dev/stdin` to read the prompt from stdin (heredoc or pipe).
     #[arg(long, value_name = "PATH", conflicts_with_all = ["question", "topic"])]
     pub prompt_file: Option<PathBuf>,
 

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -554,7 +554,7 @@ async fn run() -> Result<()> {
                 args.daemon_child,
                 &args.session_id,
                 args.cd.as_deref(),
-                run_cmd_daemon::DaemonSpawnOptions::default(),
+                run_cmd_daemon::DaemonSpawnOptions::for_prompt_file(args.prompt_file.as_deref()),
             )?;
             let result = debate_cmd::handle_debate(args, current_depth, output_format).await;
             let exit_code = report_daemon_error_or_exit_code(result, &mut daemon_guard);

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -19,6 +19,7 @@ enum RunStdinPrompt {
     None,
     Omitted,
     PositionalSentinel,
+    PromptFileSentinel,
 }
 
 impl DaemonSpawnOptions {
@@ -28,15 +29,29 @@ impl DaemonSpawnOptions {
         prompt_flag: Option<&str>,
         prompt_file: Option<&Path>,
     ) -> Self {
-        let run_stdin_prompt = if prompt_file.is_some() || prompt_flag.is_some() {
-            RunStdinPrompt::None
-        } else if prompt == Some("-") {
-            RunStdinPrompt::PositionalSentinel
-        } else if prompt.is_none() && skill.is_none() {
-            RunStdinPrompt::Omitted
-        } else {
-            RunStdinPrompt::None
-        };
+        let run_stdin_prompt =
+            if prompt_file.is_some_and(crate::run_helpers::is_prompt_file_stdin_sentinel) {
+                RunStdinPrompt::PromptFileSentinel
+            } else if prompt_file.is_some() || prompt_flag.is_some() {
+                RunStdinPrompt::None
+            } else if prompt == Some("-") {
+                RunStdinPrompt::PositionalSentinel
+            } else if prompt.is_none() && skill.is_none() {
+                RunStdinPrompt::Omitted
+            } else {
+                RunStdinPrompt::None
+            };
+
+        Self { run_stdin_prompt }
+    }
+
+    pub(crate) fn for_prompt_file(prompt_file: Option<&Path>) -> Self {
+        let run_stdin_prompt =
+            if prompt_file.is_some_and(crate::run_helpers::is_prompt_file_stdin_sentinel) {
+                RunStdinPrompt::PromptFileSentinel
+            } else {
+                RunStdinPrompt::None
+            };
 
         Self { run_stdin_prompt }
     }
@@ -335,12 +350,36 @@ fn build_forwarded_args(
         }
     }
 
+    if spawn_options.run_stdin_prompt == RunStdinPrompt::PromptFileSentinel {
+        remove_prompt_file_sentinel_arg(&mut forwarded_args);
+    }
+
     if let Some(prompt_file) = stdin_prompt_file {
         forwarded_args.push("--prompt-file".to_string());
         forwarded_args.push(prompt_file.display().to_string());
     }
 
     forwarded_args
+}
+
+fn remove_prompt_file_sentinel_arg(args: &mut Vec<String>) {
+    let Some(pos) = args.iter().position(|arg| {
+        arg.strip_prefix("--prompt-file=").is_some_and(|value| {
+            crate::run_helpers::is_prompt_file_stdin_sentinel(Path::new(value))
+        }) || arg == "--prompt-file"
+    }) else {
+        return;
+    };
+
+    if args[pos] == "--prompt-file" {
+        if args.get(pos + 1).is_some_and(|value| {
+            crate::run_helpers::is_prompt_file_stdin_sentinel(Path::new(value))
+        }) {
+            args.drain(pos..=pos + 1);
+        }
+    } else {
+        args.remove(pos);
+    }
 }
 
 #[cfg(test)]
@@ -363,6 +402,18 @@ mod tests {
     fn run_daemon_options_detect_positional_stdin_sentinel() {
         let options = DaemonSpawnOptions::for_run(None, Some("-"), None, None);
         assert_eq!(options.run_stdin_prompt, RunStdinPrompt::PositionalSentinel);
+    }
+
+    #[test]
+    fn run_daemon_options_detect_prompt_file_stdin_sentinel() {
+        let options = DaemonSpawnOptions::for_run(None, None, None, Some(Path::new("-")));
+        assert_eq!(options.run_stdin_prompt, RunStdinPrompt::PromptFileSentinel);
+    }
+
+    #[test]
+    fn prompt_file_daemon_options_detect_dev_stdin() {
+        let options = DaemonSpawnOptions::for_prompt_file(Some(Path::new("/dev/stdin")));
+        assert_eq!(options.run_stdin_prompt, RunStdinPrompt::PromptFileSentinel);
     }
 
     #[test]
@@ -411,6 +462,69 @@ mod tests {
             "run",
             DaemonSpawnOptions {
                 run_stdin_prompt: RunStdinPrompt::PositionalSentinel,
+            },
+            Some(prompt_file),
+        );
+
+        assert_eq!(
+            forwarded,
+            vec![
+                "--sa-mode",
+                "true",
+                "--prompt-file",
+                "/state/session/input/stdin-prompt.txt"
+            ]
+        );
+    }
+
+    #[test]
+    fn forwarded_args_replace_prompt_file_stdin_sentinel_with_prompt_file() {
+        let all_args = vec![
+            "csa".to_string(),
+            "debate".to_string(),
+            "--sa-mode".to_string(),
+            "true".to_string(),
+            "--prompt-file".to_string(),
+            "/dev/stdin".to_string(),
+        ];
+        let prompt_file = Path::new("/state/session/input/stdin-prompt.txt");
+
+        let forwarded = build_forwarded_args(
+            &all_args,
+            "debate",
+            DaemonSpawnOptions {
+                run_stdin_prompt: RunStdinPrompt::PromptFileSentinel,
+            },
+            Some(prompt_file),
+        );
+
+        assert_eq!(
+            forwarded,
+            vec![
+                "--sa-mode",
+                "true",
+                "--prompt-file",
+                "/state/session/input/stdin-prompt.txt"
+            ]
+        );
+    }
+
+    #[test]
+    fn forwarded_args_replace_prompt_file_equals_stdin_sentinel_with_prompt_file() {
+        let all_args = vec![
+            "csa".to_string(),
+            "run".to_string(),
+            "--sa-mode".to_string(),
+            "true".to_string(),
+            "--prompt-file=-".to_string(),
+        ];
+        let prompt_file = Path::new("/state/session/input/stdin-prompt.txt");
+
+        let forwarded = build_forwarded_args(
+            &all_args,
+            "run",
+            DaemonSpawnOptions {
+                run_stdin_prompt: RunStdinPrompt::PromptFileSentinel,
             },
             Some(prompt_file),
         );

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -1,6 +1,6 @@
 //! Helper functions for `csa run`: tool resolution, executor building, token parsing.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::path::Path;
 
 use csa_config::{GlobalConfig, ProjectConfig};
@@ -26,7 +26,12 @@ pub(crate) use atomic_commit::atomic_commit_discipline_preamble;
 pub(crate) use atomic_commit::prepend_atomic_commit_discipline_to_prompt;
 pub(crate) use edit_requirement::{infer_task_edit_requirement, resolve_task_edit_requirement};
 pub(crate) use inline_review_context::prepend_review_context_to_prompt;
-pub(crate) use prompt::{read_prompt, resolve_positional_stdin_sentinel};
+#[cfg(test)]
+pub(crate) use prompt::resolve_prompt_with_file_from_reader;
+pub(crate) use prompt::{
+    is_prompt_file_stdin_sentinel, read_prompt, resolve_positional_stdin_sentinel,
+    resolve_prompt_with_file,
+};
 pub(crate) use routing_conflict::{is_routing_conflict, routing_conflict_error};
 pub(crate) use tool_availability::{
     ToolBinaryAvailability, is_tool_binary_available_for_config, resolved_claude_code_transport,
@@ -548,22 +553,6 @@ fn extract_cost(text: &str) -> Option<f64> {
         .collect();
 
     num_str.parse().ok()
-}
-
-/// Resolve prompt from `--prompt-file`, positional arg, or stdin (in priority order).
-pub(crate) fn resolve_prompt_with_file(
-    prompt: Option<String>,
-    prompt_file: Option<&std::path::Path>,
-) -> Result<String> {
-    if let Some(path) = prompt_file {
-        let content = std::fs::read_to_string(path)
-            .with_context(|| format!("--prompt-file: failed to read '{}'", path.display()))?;
-        if content.trim().is_empty() {
-            anyhow::bail!("--prompt-file '{}' is empty", path.display());
-        }
-        return Ok(content);
-    }
-    read_prompt(prompt)
 }
 
 /// Result of resolving a tool from a tier's models list.

--- a/crates/cli-sub-agent/src/run_helpers_prompt.rs
+++ b/crates/cli-sub-agent/src/run_helpers_prompt.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::io::{IsTerminal, Read};
+use std::path::Path;
 
 pub(crate) fn resolve_positional_stdin_sentinel(prompt: Option<String>) -> Result<Option<String>> {
     let mut stdin = std::io::stdin();
@@ -35,7 +36,56 @@ pub(crate) fn read_prompt(prompt: Option<String>) -> Result<String> {
     read_prompt_from_reader(prompt, stdin.is_terminal(), &mut stdin)
 }
 
-fn read_prompt_from_reader<R: Read>(
+/// Resolve prompt from `--prompt-file`, positional arg, or stdin (in priority order).
+pub(crate) fn resolve_prompt_with_file(
+    prompt: Option<String>,
+    prompt_file: Option<&Path>,
+) -> Result<String> {
+    if let Some(path) = prompt_file {
+        if is_prompt_file_stdin_sentinel(path) {
+            return read_prompt(None);
+        }
+
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("--prompt-file: failed to read '{}'", path.display()))?;
+        if content.trim().is_empty() {
+            anyhow::bail!("--prompt-file '{}' is empty", path.display());
+        }
+        return Ok(content);
+    }
+    read_prompt(prompt)
+}
+
+pub(crate) fn is_prompt_file_stdin_sentinel(path: &Path) -> bool {
+    matches!(
+        path.as_os_str().to_str(),
+        Some("-" | "/dev/stdin" | "/proc/self/fd/0")
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn resolve_prompt_with_file_from_reader<R: Read>(
+    prompt: Option<String>,
+    prompt_file: Option<&Path>,
+    stdin_is_terminal: bool,
+    reader: &mut R,
+) -> Result<String> {
+    if let Some(path) = prompt_file {
+        if is_prompt_file_stdin_sentinel(path) {
+            return read_prompt_from_reader(None, stdin_is_terminal, reader);
+        }
+
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("--prompt-file: failed to read '{}'", path.display()))?;
+        if content.trim().is_empty() {
+            anyhow::bail!("--prompt-file '{}' is empty", path.display());
+        }
+        return Ok(content);
+    }
+    read_prompt_from_reader(prompt, stdin_is_terminal, reader)
+}
+
+pub(crate) fn read_prompt_from_reader<R: Read>(
     prompt: Option<String>,
     stdin_is_terminal: bool,
     reader: &mut R,

--- a/crates/cli-sub-agent/src/run_helpers_tests_prompt.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tests_prompt.rs
@@ -9,6 +9,65 @@ fn resolve_prompt_with_file_reads_file_content() {
 }
 
 #[test]
+fn resolve_prompt_with_file_routes_dash_to_stdin() {
+    let mut stdin = std::io::Cursor::new("prompt from stdin");
+    let result = super::resolve_prompt_with_file_from_reader(
+        Some("positional".to_string()),
+        Some(std::path::Path::new("-")),
+        false,
+        &mut stdin,
+    )
+    .unwrap();
+    assert_eq!(result, "prompt from stdin");
+}
+
+#[test]
+fn resolve_prompt_with_file_routes_dev_stdin_to_stdin() {
+    let mut stdin = std::io::Cursor::new("prompt from dev stdin");
+    let result = super::resolve_prompt_with_file_from_reader(
+        Some("positional".to_string()),
+        Some(std::path::Path::new("/dev/stdin")),
+        false,
+        &mut stdin,
+    )
+    .unwrap();
+    assert_eq!(result, "prompt from dev stdin");
+}
+
+#[test]
+fn resolve_prompt_with_file_real_path_unchanged() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), "real file content").unwrap();
+    let mut stdin = std::io::Cursor::new("stdin should not win");
+    let result = super::resolve_prompt_with_file_from_reader(
+        Some("positional".to_string()),
+        Some(tmp.path()),
+        false,
+        &mut stdin,
+    )
+    .unwrap();
+    assert_eq!(result, "real file content");
+}
+
+#[test]
+fn resolve_prompt_with_file_empty_stdin_sentinel_bails() {
+    let mut stdin = std::io::Cursor::new("   ");
+    let result = super::resolve_prompt_with_file_from_reader(
+        None,
+        Some(std::path::Path::new("-")),
+        false,
+        &mut stdin,
+    );
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Empty prompt from stdin")
+    );
+}
+
+#[test]
 fn resolve_prompt_with_file_overrides_positional() {
     let tmp = tempfile::NamedTempFile::new().unwrap();
     std::fs::write(tmp.path(), "file wins").unwrap();


### PR DESCRIPTION
## Summary

Fixes #1162: `csa debate --prompt-file /dev/stdin <<HEREDOC` (and the same
flag on `csa run`) silently failed with `Error: --prompt-file '/dev/stdin'
is empty` because:

- `resolve_prompt_with_file` in `crates/cli-sub-agent/src/run_helpers.rs:554`
  read the path with `fs::read_to_string`. While `/dev/stdin` is a valid
  path in principle, the daemon spawn path detached the process before
  the `--prompt-file` consumer could see the stdin pipe — the heredoc
  content was lost between fork and re-read.
- The codebase already had a stdin sentinel (`-`) wired through positional
  prompts via `resolve_positional_stdin_sentinel` + `read_prompt`, but
  `--prompt-file` did NOT route through it.

This PR makes `--prompt-file -`, `--prompt-file /dev/stdin`, and
`--prompt-file /proc/self/fd/0` consume stdin in the parent (BEFORE daemon
spawn), persist to `${SESSION_DIR}/input/stdin-prompt.txt`, and forward
the daemon's effective `--prompt-file` argument to that path.

## Behavior change matrix

| Invocation | Before | After |
|------------|--------|-------|
| `csa run --prompt-file ./real.md` | reads file | reads file (unchanged) |
| `csa run --prompt-file - <<EOF...EOF` | empty / silent failure | reads heredoc into prompt |
| `csa debate --prompt-file /dev/stdin <<EOF...EOF` | "is empty" error | reads heredoc into prompt |
| `csa run --prompt-file -` (no piped stdin, terminal stdin) | (silent hang or empty) | clear error: "stdin is a terminal" with usage hint |
| `csa review --prompt-file ...` | path semantics for spec / context | path semantics preserved (sentinel NOT inline-read here; help text clarifies) |

## Implementation notes

- **Parent-side stdin consumption**: the daemon parent intercepts the
  sentinel in `DaemonSpawnOptions` BEFORE `spawn_and_exit` detaches, so
  the user's pipe/terminal is still attached when stdin is read. The
  daemon process is then started with `--prompt-file
  /path/to/session/input/stdin-prompt.txt` so the existing
  `fs::read_to_string` path picks it up.
- **CLI scope**: applies to `csa run` and `csa debate`. `csa review`
  treats `--prompt-file` as a path passed to the subagent (not inline
  content), so the sentinel is intentionally not parsed there; the help
  text clarifies this asymmetry.
- **Empty-stdin guard**: existing
  "Empty prompt from stdin. Provide a non-empty prompt." bail still
  triggers when the heredoc is empty.
- **TTY guard**: existing
  "No prompt provided and stdin is a terminal" bail triggers when
  `--prompt-file -` is given but stdin is a TTY.

## Test plan

- [x] `cargo check -p cli-sub-agent` — passes
- [x] `cargo test -p cli-sub-agent resolve_prompt_with_file` — 9 passed
- [x] `cargo test -p cli-sub-agent prompt` — 75 passed
- [x] `cargo test -p cli-sub-agent run_helpers_tests_prompt` — passes
- [x] `just fmt` — passes
- [x] `just pre-commit` — passes
- [x] `cargo build --release -p cli-sub-agent` — passes
- [x] heredoc smoke: `./target/release/csa debate ... --prompt-file -
      <<EOF...EOF` started a session with the heredoc as the prompt
      (verified session input file)
- [x] Push-gate `csa review --range main...HEAD` — CLEAN ("The
      implementation strategy is excellent"; one LOW advisory about
      `position()` vs `rposition()` for duplicate `--prompt-file` flags,
      explicitly non-blocking)

## Files touched

- `crates/cli-sub-agent/src/run_helpers.rs` — sentinel detection in
  `resolve_prompt_with_file`
- `crates/cli-sub-agent/src/run_helpers_prompt.rs` — reader-injection
  helpers (test ergonomics)
- `crates/cli-sub-agent/src/run_helpers_tests_prompt.rs` — sentinel
  routing tests + regression for real file paths
- `crates/cli-sub-agent/src/run_cmd_daemon.rs` — daemon-side stdin
  consumption + arg forwarding
- `Cargo.toml` / `Cargo.lock` — version bump 0.1.602 → 0.1.603 (release
  hook auto-bump)

## Notes

Cloud-bot review (gemini-code-assist) is still inside its 24h quota window
from the prior PR; merge will route through pr-bot's quota-exhaustion
path with the local push-gate as the merge gate.

Dogfooding observation while fixing this issue — minimal-input `csa debate`
has unexpectedly high token cost (17M+ input tokens for a heredoc-only
prompt). Filed as #1189 for separate investigation.

Closes #1162
