### PR TITLE
fix(review): polish review prompt parameters (closes #1164)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.604"
+version = "0.1.605"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.604"
+version = "0.1.605"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -1,7 +1,5 @@
 use crate::cli::ReviewArgs;
 use crate::pipeline::resolve_initial_response_timeout_for_tool;
-#[cfg(test)]
-use crate::pipeline::resolve_initial_response_timeout_for_tool as resolve_review_initial_response_timeout_seconds;
 use crate::review_consensus::{
     CLEAN, agreement_level, build_multi_reviewer_instruction, consensus_strategy_label,
     consensus_verdict, parse_consensus_strategy, resolve_consensus,

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -596,7 +596,26 @@ Ignore prompt-guard reminders about commit/push in this subprocess.\n\n";
 /// CSA only passes scope, mode, and optional parameters — no diff content.
 /// An anti-recursion preamble is prepended to prevent the spawned tool from
 /// re-invoking CSA commands (see GitHub issue #272).
+#[cfg(test)]
 pub(crate) fn build_review_instruction(
+    scope: &str,
+    mode: &str,
+    security_mode: &str,
+    review_mode: ReviewMode,
+    context: Option<&ResolvedReviewContext>,
+) -> String {
+    let mut instruction = build_review_instruction_without_design_anchor(
+        scope,
+        mode,
+        security_mode,
+        review_mode,
+        context,
+    );
+    crate::review_design_anchor::append_design_anchor(&mut instruction);
+    instruction
+}
+
+fn build_review_instruction_without_design_anchor(
     scope: &str,
     mode: &str,
     security_mode: &str,
@@ -618,7 +637,6 @@ pub(crate) fn build_review_instruction(
             instruction.push_str(&render_spec_review_context(spec));
         }
     }
-    crate::review_design_anchor::append_design_anchor(&mut instruction);
     instruction
 }
 
@@ -632,14 +650,20 @@ pub(crate) fn build_review_instruction_for_project(
     options: ReviewProjectPromptOptions<'_>,
 ) -> (String, ReviewRoutingMetadata) {
     let review_routing = detect_review_routing_metadata(project_root, options.project_config);
-    let mut instruction =
-        build_review_instruction(scope, mode, security_mode, review_mode, context);
+    let mut instruction = build_review_instruction_without_design_anchor(
+        scope,
+        mode,
+        security_mode,
+        review_mode,
+        context,
+    );
     let consistency_scope = if options.full_consistency {
         "touched-files"
     } else {
         "diff-only"
     };
     instruction.push_str(&format!("\nconsistency_scope={consistency_scope}"));
+    crate::review_design_anchor::append_design_anchor(&mut instruction);
     instruction.push_str(&format!(
         "\n[project_profile: {}]",
         review_routing.project_profile

--- a/crates/cli-sub-agent/src/review_cmd_tests_full_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_full_consistency.rs
@@ -41,6 +41,14 @@ fn test_build_review_instruction_no_diff_content_default() {
 
     assert!(result.contains("scope=uncommitted"));
     assert!(result.contains("consistency_scope=diff-only"));
+    assert!(
+        result
+            .find("consistency_scope=diff-only")
+            .expect("consistency scope marker")
+            < result
+                .find("Design preferences vs correctness bugs")
+                .expect("design anchor")
+    );
     assert!(!result.contains("git diff"));
     assert!(!result.contains("Pass 1:"));
 }

--- a/crates/cli-sub-agent/src/review_cmd_timeout_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_timeout_tests.rs
@@ -14,9 +14,8 @@ fn review_initial_response_timeout_is_resolved_per_reviewer_tool() {
     cfg.resources.initial_response_timeout_seconds = None;
 
     let gemini_timeout =
-        resolve_review_initial_response_timeout_seconds(Some(&cfg), None, None, "gemini-cli");
-    let codex_timeout =
-        resolve_review_initial_response_timeout_seconds(Some(&cfg), None, None, "codex");
+        resolve_initial_response_timeout_for_tool(Some(&cfg), None, None, "gemini-cli");
+    let codex_timeout = resolve_initial_response_timeout_for_tool(Some(&cfg), None, None, "codex");
 
     assert_eq!(
         gemini_timeout,


### PR DESCRIPTION
## Summary

Closes #1164. Two cosmetic-polish followup MEDIUMs from PR #1163's gemini review.
No behavior change.

## Changes

1. **`consistency_scope=` placement** (`crates/cli-sub-agent/src/review_cmd_resolve.rs`).
   Previously appended after the design-preference anchor; bot suggested moving
   alongside `scope=` / `mode=` (skill-parameter group) before the anchor. Did
   so by extracting a private helper for the prompt-header build path so the
   ordering is explicit and tested.

2. **Drop test-only timeout-resolver alias** (`crates/cli-sub-agent/src/review_cmd.rs`).
   The original function was already removed in favor of a direct call to
   `resolve_initial_response_timeout_for_tool`; the `#[cfg(test)] use ... as ...`
   alias kept stale naming alive. Test files updated to import the production
   name directly.

## Test plan

- [x] Targeted prompt-shape test for `consistency_scope=diff-only` ordering vs design anchor — passes
- [x] `cargo test -p cli-sub-agent` (1774 unit + e2e + compat) — passes
- [x] `just pre-commit` (workspace nextest 4375 passed, --all-features nextest, fmt, deny, clippy) — passes
- [x] Push-gate `csa review --range main...HEAD --tier tier-4-critical` — CLEAN
      (decision=fail field is the known #820 docs-only mismarking;
       severity_counts all 0; details.md "No blocking findings")

## Files touched

- `crates/cli-sub-agent/src/review_cmd_resolve.rs` — prompt-header helper + placement
- `crates/cli-sub-agent/src/review_cmd.rs` — drop test-only alias
- `crates/cli-sub-agent/src/review_cmd_tests_full_consistency.rs` — ordering assertion
- `crates/cli-sub-agent/src/review_cmd_timeout_tests.rs` — direct import
- `Cargo.toml` / `Cargo.lock` — version bump 0.1.604 → 0.1.605 (release hook)

## Notes

Cloud-bot (gemini-code-assist) 24h quota cache still active until
2026-04-28T21:18:49Z; pr-bot will route through merge-without-bot path.

Closes #1164
