### PR TITLE
feat(vcs): gate jj snapshots from config (jj sidecar Phase 1-C, #1146)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.605"
+version = "0.1.606"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.605"
+version = "0.1.606"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -13,7 +13,7 @@ mod helpers;
 use helpers::{format_missing_key_message, format_toml_value, resolve_key, suggest_key_paths};
 #[path = "config_cmds_display.rs"]
 mod display;
-use display::{inject_resolved_tool_transports_json, inject_resolved_tool_transports_toml};
+use display::{build_execution_toml, build_project_display_json, build_project_display_toml};
 #[path = "config_cmds_set.rs"]
 mod set;
 pub(crate) use set::handle_config_set;
@@ -676,48 +676,6 @@ fn load_and_resolve(path: &std::path::Path, key: &str) -> Result<Option<toml::Va
     Ok(load_toml_root(path)?.and_then(|root| resolve_key(&root, key)))
 }
 
-fn build_execution_toml(execution: &csa_config::ExecutionConfig) -> toml::Value {
-    let mut table = toml::map::Map::new();
-    table.insert(
-        "min_timeout_seconds".to_string(),
-        toml::Value::Integer(execution.min_timeout_seconds as i64),
-    );
-    table.insert(
-        "auto_weave_upgrade".to_string(),
-        toml::Value::Boolean(execution.auto_weave_upgrade),
-    );
-    toml::Value::Table(table)
-}
-
-fn build_project_display_toml(config: &ProjectConfig) -> Result<toml::Value> {
-    let mut root = toml::Value::try_from(config.clone())?;
-    let root_table = root
-        .as_table_mut()
-        .expect("serialized project config should be a TOML table");
-    root_table.insert(
-        "execution".to_string(),
-        build_execution_toml(&config.execution),
-    );
-    inject_resolved_tool_transports_toml(root_table, config);
-    Ok(root)
-}
-
-fn build_project_display_json(config: &ProjectConfig) -> Result<serde_json::Value> {
-    let mut root = serde_json::to_value(config)?;
-    let root_object = root
-        .as_object_mut()
-        .expect("serialized project config should be a JSON object");
-    root_object.insert(
-        "execution".to_string(),
-        serde_json::json!({
-            "min_timeout_seconds": config.execution.min_timeout_seconds,
-            "auto_weave_upgrade": config.execution.auto_weave_upgrade,
-        }),
-    );
-    inject_resolved_tool_transports_json(root_object, config);
-    Ok(root)
-}
-
 fn build_global_display_toml(config: &GlobalConfig) -> Result<toml::Value> {
     let mut root = toml::Value::try_from(config.clone())?;
     root.as_table_mut()
@@ -780,6 +738,10 @@ mod tests;
 #[cfg(test)]
 #[path = "config_cmds_transport_display_tests.rs"]
 mod transport_display_tests;
+
+#[cfg(test)]
+#[path = "config_cmds_vcs_tests.rs"]
+mod vcs_tests;
 
 #[cfg(test)]
 #[path = "config_cmds_lookup_tests.rs"]

--- a/crates/cli-sub-agent/src/config_cmds_display.rs
+++ b/crates/cli-sub-agent/src/config_cmds_display.rs
@@ -1,4 +1,81 @@
+use anyhow::Result;
 use csa_config::ProjectConfig;
+
+pub(super) fn build_execution_toml(execution: &csa_config::ExecutionConfig) -> toml::Value {
+    let mut table = toml::map::Map::new();
+    table.insert(
+        "min_timeout_seconds".to_string(),
+        toml::Value::Integer(execution.min_timeout_seconds as i64),
+    );
+    table.insert(
+        "auto_weave_upgrade".to_string(),
+        toml::Value::Boolean(execution.auto_weave_upgrade),
+    );
+    toml::Value::Table(table)
+}
+
+fn snapshot_trigger_name(trigger: csa_config::SnapshotTrigger) -> &'static str {
+    match trigger {
+        csa_config::SnapshotTrigger::PostRun => "post-run",
+        csa_config::SnapshotTrigger::ToolCompleted => "tool-completed",
+    }
+}
+
+fn build_vcs_toml(vcs: &csa_config::VcsConfig) -> Result<toml::Value> {
+    let serialized = toml::Value::try_from(vcs.clone())?;
+    let mut table = serialized
+        .as_table()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("serialized vcs config was not a TOML table"))?;
+    table.insert(
+        "auto_snapshot".to_string(),
+        toml::Value::Boolean(vcs.auto_snapshot),
+    );
+    table.insert(
+        "snapshot_trigger".to_string(),
+        toml::Value::String(snapshot_trigger_name(vcs.snapshot_trigger).to_string()),
+    );
+    Ok(toml::Value::Table(table))
+}
+
+pub(super) fn build_project_display_toml(config: &ProjectConfig) -> Result<toml::Value> {
+    let mut root = toml::Value::try_from(config.clone())?;
+    let root_table = root
+        .as_table_mut()
+        .expect("serialized project config should be a TOML table");
+    root_table.insert(
+        "execution".to_string(),
+        build_execution_toml(&config.execution),
+    );
+    root_table.insert("vcs".to_string(), build_vcs_toml(&config.vcs)?);
+    inject_resolved_tool_transports_toml(root_table, config);
+    Ok(root)
+}
+
+pub(super) fn build_project_display_json(config: &ProjectConfig) -> Result<serde_json::Value> {
+    let mut root = serde_json::to_value(config)?;
+    let root_object = root
+        .as_object_mut()
+        .expect("serialized project config should be a JSON object");
+    root_object.insert(
+        "execution".to_string(),
+        serde_json::json!({
+            "min_timeout_seconds": config.execution.min_timeout_seconds,
+            "auto_weave_upgrade": config.execution.auto_weave_upgrade,
+        }),
+    );
+    root_object.insert(
+        "vcs".to_string(),
+        serde_json::json!({
+            "backend": config.vcs.backend,
+            "colocated_default": config.vcs.colocated_default,
+            "auto_snapshot": config.vcs.auto_snapshot,
+            "snapshot_trigger": snapshot_trigger_name(config.vcs.snapshot_trigger),
+        }),
+    );
+    inject_resolved_tool_transports_json(root_object, config);
+    Ok(root)
+}
 
 pub(super) fn inject_resolved_tool_transports_toml(
     root: &mut toml::map::Map<String, toml::Value>,

--- a/crates/cli-sub-agent/src/config_cmds_vcs_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_vcs_tests.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[test]
+fn build_project_display_toml_keeps_effective_vcs_snapshot_defaults_visible() {
+    let config: ProjectConfig = toml::from_str("schema_version = 1\n").unwrap();
+    let root = build_project_display_toml(&config).unwrap();
+
+    assert_eq!(
+        root.get("vcs")
+            .and_then(|value| value.get("auto_snapshot"))
+            .and_then(toml::Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        root.get("vcs")
+            .and_then(|value| value.get("snapshot_trigger"))
+            .and_then(toml::Value::as_str),
+        Some("post-run")
+    );
+}
+
+#[test]
+fn build_project_display_toml_keeps_explicit_vcs_snapshot_values_visible() {
+    let config: ProjectConfig = toml::from_str(
+        r#"
+schema_version = 1
+
+[vcs]
+auto_snapshot = true
+snapshot_trigger = "tool-completed"
+"#,
+    )
+    .unwrap();
+    let root = build_project_display_toml(&config).unwrap();
+
+    assert_eq!(
+        root.get("vcs")
+            .and_then(|value| value.get("auto_snapshot"))
+            .and_then(toml::Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        root.get("vcs")
+            .and_then(|value| value.get("snapshot_trigger"))
+            .and_then(toml::Value::as_str),
+        Some("tool-completed")
+    );
+}

--- a/crates/cli-sub-agent/src/pipeline_jj_journal.rs
+++ b/crates/cli-sub-agent/src/pipeline_jj_journal.rs
@@ -6,8 +6,6 @@ use csa_core::vcs::{JournalError, RevisionId, SnapshotJournal};
 use csa_session::JjJournal;
 use tracing::{info, warn};
 
-pub(crate) const AUTO_SNAPSHOT_ENV: &str = "CSA_VCS_AUTO_SNAPSHOT";
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PostRunJjSnapshotOutcome {
     ConfigOff,
@@ -19,6 +17,7 @@ pub(crate) enum PostRunJjSnapshotOutcome {
 }
 
 pub(crate) fn maybe_record_post_run_snapshot(
+    config: Option<&csa_config::VcsConfig>,
     project_root: &Path,
     session_dir: &Path,
     session_id: &str,
@@ -27,6 +26,7 @@ pub(crate) fn maybe_record_post_run_snapshot(
     result: &mut csa_process::ExecutionResult,
 ) -> PostRunJjSnapshotOutcome {
     let outcome = evaluate_post_run_snapshot(
+        config,
         project_root,
         session_dir,
         session_id,
@@ -35,7 +35,7 @@ pub(crate) fn maybe_record_post_run_snapshot(
     );
     match &outcome {
         PostRunJjSnapshotOutcome::ConfigOff => {
-            info!("jj sidecar snapshot disabled by CSA_VCS_AUTO_SNAPSHOT");
+            info!("jj sidecar snapshot disabled by [vcs].auto_snapshot");
         }
         PostRunJjSnapshotOutcome::NoChangedPaths => {
             info!("Skipping jj sidecar snapshot because PostRun changed_paths is empty");
@@ -64,6 +64,7 @@ pub(crate) fn maybe_record_post_run_snapshot(
 }
 
 fn evaluate_post_run_snapshot(
+    config: Option<&csa_config::VcsConfig>,
     project_root: &Path,
     session_dir: &Path,
     session_id: &str,
@@ -71,7 +72,7 @@ fn evaluate_post_run_snapshot(
     changed_paths: &[String],
 ) -> PostRunJjSnapshotOutcome {
     evaluate_post_run_snapshot_with(
-        auto_snapshot_enabled(),
+        config.cloned().unwrap_or_default(),
         project_root,
         session_id,
         tool_name,
@@ -84,7 +85,7 @@ fn evaluate_post_run_snapshot(
 }
 
 fn evaluate_post_run_snapshot_with<F>(
-    auto_snapshot_enabled: bool,
+    config: csa_config::VcsConfig,
     project_root: &Path,
     session_id: &str,
     tool_name: &str,
@@ -94,8 +95,13 @@ fn evaluate_post_run_snapshot_with<F>(
 where
     F: FnOnce(&str) -> Result<RevisionId, JournalError>,
 {
-    if !auto_snapshot_enabled {
+    if !config.auto_snapshot {
         return PostRunJjSnapshotOutcome::ConfigOff;
+    }
+    if config.snapshot_trigger == csa_config::SnapshotTrigger::ToolCompleted {
+        warn!(
+            "[vcs].snapshot_trigger=\"tool-completed\" is reserved for V2; falling back to post-run snapshot"
+        );
     }
     if changed_paths.is_empty() {
         return PostRunJjSnapshotOutcome::NoChangedPaths;
@@ -114,16 +120,6 @@ where
             message: render_journal_error(&err),
         },
     }
-}
-
-fn auto_snapshot_enabled() -> bool {
-    auto_snapshot_enabled_from_value(std::env::var_os(AUTO_SNAPSHOT_ENV).as_deref())
-}
-
-fn auto_snapshot_enabled_from_value(value: Option<&std::ffi::OsStr>) -> bool {
-    value
-        .and_then(std::ffi::OsStr::to_str)
-        .is_some_and(|value| value.trim() == "1")
 }
 
 fn format_snapshot_message(session_id: &str, tool_name: &str, changed_paths: &[String]) -> String {
@@ -147,7 +143,7 @@ fn append_snapshot_notice(result: &mut csa_process::ExecutionResult, message: &s
     if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
         result.stderr_output.push('\n');
     }
-    result.stderr_output.push_str("CSA_VCS_AUTO_SNAPSHOT: ");
+    result.stderr_output.push_str("[vcs].auto_snapshot: ");
     result.stderr_output.push_str(message);
     result.stderr_output.push('\n');
 }
@@ -155,7 +151,16 @@ fn append_snapshot_notice(result: &mut csa_process::ExecutionResult, message: &s
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
     use std::fs;
+    use std::process::Command;
+
+    fn vcs_config(auto_snapshot: bool) -> csa_config::VcsConfig {
+        csa_config::VcsConfig {
+            auto_snapshot,
+            ..Default::default()
+        }
+    }
 
     fn result() -> csa_process::ExecutionResult {
         csa_process::ExecutionResult {
@@ -167,12 +172,70 @@ mod tests {
         }
     }
 
+    fn run_command(repo: &Path, program: &str, args: &[&str]) {
+        let output = Command::new(program)
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .unwrap_or_else(|err| panic!("spawn {program}: {err}"));
+        assert!(
+            output.status.success(),
+            "{program} {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn jj_log_descriptions(repo: &Path) -> String {
+        let output = Command::new("jj")
+            .args(["log", "--no-graph", "-T", "description ++ \"\\n\""])
+            .current_dir(repo)
+            .output()
+            .expect("run jj log");
+        assert!(
+            output.status.success(),
+            "jj log failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).to_string()
+    }
+
+    fn setup_colocated_jj_git_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        run_command(repo.path(), "git", &["init"]);
+        run_command(
+            repo.path(),
+            "git",
+            &["config", "user.email", "csa-test@example.com"],
+        );
+        run_command(repo.path(), "git", &["config", "user.name", "CSA Test"]);
+        run_command(repo.path(), "jj", &["git", "init", "--colocate"]);
+        run_command(
+            repo.path(),
+            "jj",
+            &[
+                "config",
+                "set",
+                "--repo",
+                "user.email",
+                "csa-test@example.com",
+            ],
+        );
+        run_command(
+            repo.path(),
+            "jj",
+            &["config", "set", "--repo", "user.name", "CSA Test"],
+        );
+        repo
+    }
+
     #[test]
     fn config_off_is_a_quiet_noop() {
         let tmp = tempfile::tempdir().expect("tempdir");
 
         let outcome = evaluate_post_run_snapshot_with(
-            false,
+            vcs_config(false),
             tmp.path(),
             "01SESSION",
             "codex",
@@ -193,10 +256,14 @@ mod tests {
     fn changed_paths_empty_skips_snapshot() {
         let tmp = tempfile::tempdir().expect("tempdir");
 
-        let outcome =
-            evaluate_post_run_snapshot_with(true, tmp.path(), "01SESSION", "codex", &[], |_| {
-                panic!("snapshot must not run for empty changed paths")
-            });
+        let outcome = evaluate_post_run_snapshot_with(
+            vcs_config(true),
+            tmp.path(),
+            "01SESSION",
+            "codex",
+            &[],
+            |_| panic!("snapshot must not run for empty changed paths"),
+        );
 
         assert_eq!(outcome, PostRunJjSnapshotOutcome::NoChangedPaths);
         let mut result = result();
@@ -213,7 +280,7 @@ mod tests {
         fs::create_dir(tmp.path().join(".git")).expect("create .git");
 
         let outcome = evaluate_post_run_snapshot_with(
-            true,
+            vcs_config(true),
             tmp.path(),
             "01SESSION",
             "codex",
@@ -242,7 +309,7 @@ mod tests {
         fs::create_dir(tmp.path().join(".jj")).expect("create .jj");
 
         let outcome = evaluate_post_run_snapshot_with(
-            true,
+            vcs_config(true),
             tmp.path(),
             "01SESSION",
             "codex",
@@ -271,7 +338,7 @@ mod tests {
         fs::create_dir(tmp.path().join(".jj")).expect("create .jj");
 
         let outcome = evaluate_post_run_snapshot_with(
-            true,
+            vcs_config(true),
             tmp.path(),
             "01SESSION",
             "codex",
@@ -311,7 +378,7 @@ mod tests {
         fs::create_dir(tmp.path().join(".jj")).expect("create .jj");
 
         let outcome = evaluate_post_run_snapshot_with(
-            true,
+            vcs_config(true),
             tmp.path(),
             "01SESSION",
             "codex",
@@ -330,17 +397,82 @@ mod tests {
     }
 
     #[test]
-    fn auto_snapshot_env_accepts_only_one() {
-        assert!(auto_snapshot_enabled_from_value(Some(
-            std::ffi::OsStr::new("1")
-        )));
-        assert!(!auto_snapshot_enabled_from_value(None));
-        assert!(!auto_snapshot_enabled_from_value(Some(
-            std::ffi::OsStr::new("true",)
-        )));
-        assert!(!auto_snapshot_enabled_from_value(Some(
-            std::ffi::OsStr::new("0",)
-        )));
+    fn real_colocated_jj_repo_snapshots_only_when_vcs_config_enables_it() {
+        if which::which("jj").is_err() {
+            eprintln!("skipping real jj snapshot test because jj is not installed");
+            return;
+        }
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let env_home = tempfile::tempdir().expect("env home tempdir");
+        let jj_config_home = env_home.path().join("jj-config-home");
+        fs::create_dir_all(&jj_config_home).expect("create jj config home");
+        let _home_guard = ScopedEnvVarRestore::set("HOME", &jj_config_home);
+        let _config_guard = ScopedEnvVarRestore::set("XDG_CONFIG_HOME", &jj_config_home);
+        let repo = setup_colocated_jj_git_repo();
+        let session_dir = tempfile::tempdir().expect("session tempdir");
+        fs::write(repo.path().join("tracked.txt"), "first\n").expect("write tracked file");
+        let changed_paths = vec!["tracked.txt".to_string()];
+
+        let mut disabled_result = result();
+        let disabled_outcome = maybe_record_post_run_snapshot(
+            Some(&vcs_config(false)),
+            repo.path(),
+            session_dir.path(),
+            "01DISABLED",
+            "codex",
+            &changed_paths,
+            &mut disabled_result,
+        );
+        assert_eq!(disabled_outcome, PostRunJjSnapshotOutcome::ConfigOff);
+        assert!(!jj_log_descriptions(repo.path()).contains("01DISABLED"));
+
+        let mut enabled_result = result();
+        let enabled_outcome = maybe_record_post_run_snapshot(
+            Some(&vcs_config(true)),
+            repo.path(),
+            session_dir.path(),
+            "01ENABLED",
+            "codex",
+            &changed_paths,
+            &mut enabled_result,
+        );
+        assert!(matches!(
+            enabled_outcome,
+            PostRunJjSnapshotOutcome::Snapshot { .. }
+        ));
+        assert!(enabled_result.stderr_output.is_empty());
+        assert!(
+            jj_log_descriptions(repo.path()).contains("CSA PostRun snapshot session=01ENABLED"),
+            "jj log should include the CSA snapshot description"
+        );
+    }
+
+    #[test]
+    fn tool_completed_trigger_falls_back_to_post_run_snapshot() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::create_dir(tmp.path().join(".git")).expect("create .git");
+        fs::create_dir(tmp.path().join(".jj")).expect("create .jj");
+        let config = csa_config::VcsConfig {
+            auto_snapshot: true,
+            snapshot_trigger: csa_config::SnapshotTrigger::ToolCompleted,
+            ..Default::default()
+        };
+
+        let outcome = evaluate_post_run_snapshot_with(
+            config,
+            tmp.path(),
+            "01SESSION",
+            "codex",
+            &["src/lib.rs".to_string()],
+            |_| Ok(RevisionId::from("rev-from-fallback")),
+        );
+
+        assert_eq!(
+            outcome,
+            PostRunJjSnapshotOutcome::Snapshot {
+                revision: RevisionId::from("rev-from-fallback")
+            }
+        );
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -200,6 +200,7 @@ pub(crate) async fn process_execution_result(
         }
     }
     crate::pipeline_jj_journal::maybe_record_post_run_snapshot(
+        ctx.config.map(|config| &config.vcs),
         ctx.project_root,
         &ctx.session_dir,
         &session.meta_session_id,

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_session::{create_session, get_session_dir, load_session};
+use std::path::Path;
+use std::process::Command;
 
 #[test]
 fn ensure_terminal_result_on_post_exec_error_writes_missing_result() {
@@ -137,6 +139,191 @@ fn ensure_terminal_result_for_session_on_post_exec_error_persists_output_tail_fo
     assert_eq!(
         reloaded.termination_reason.as_deref(),
         Some("post_exec_error")
+    );
+}
+
+fn run_command(repo: &Path, program: &str, args: &[&str]) {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap_or_else(|err| panic!("spawn {program}: {err}"));
+    assert!(
+        output.status.success(),
+        "{program} {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn setup_colocated_jj_git_repo(repo: &Path) {
+    std::fs::create_dir_all(repo).expect("create repo dir");
+    run_command(repo, "git", &["init"]);
+    run_command(
+        repo,
+        "git",
+        &["config", "user.email", "csa-test@example.com"],
+    );
+    run_command(repo, "git", &["config", "user.name", "CSA Test"]);
+    run_command(repo, "jj", &["git", "init", "--colocate"]);
+    run_command(
+        repo,
+        "jj",
+        &[
+            "config",
+            "set",
+            "--repo",
+            "user.email",
+            "csa-test@example.com",
+        ],
+    );
+    run_command(
+        repo,
+        "jj",
+        &["config", "set", "--repo", "user.name", "CSA Test"],
+    );
+}
+
+fn jj_log_descriptions(repo: &Path) -> String {
+    let output = Command::new("jj")
+        .args(["log", "--no-graph", "-T", "description ++ \"\\n\""])
+        .current_dir(repo)
+        .output()
+        .expect("run jj log");
+    assert!(
+        output.status.success(),
+        "jj log failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn post_exec_jj_config(auto_snapshot: bool) -> csa_config::ProjectConfig {
+    toml::from_str(&format!(
+        r#"
+schema_version = 1
+
+[vcs]
+auto_snapshot = {auto_snapshot}
+snapshot_trigger = "post-run"
+"#
+    ))
+    .expect("parse project config")
+}
+
+#[tokio::test]
+async fn process_execution_result_respects_vcs_auto_snapshot_gate_for_colocated_jj_repo() {
+    if which::which("jj").is_err() {
+        eprintln!("skipping real jj post-exec snapshot test because jj is not installed");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut sandbox = ScopedSessionSandbox::new(&tmp).await;
+    sandbox.track_env("XDG_CONFIG_HOME");
+    let config_home = tmp.path().join("config-home");
+    std::fs::create_dir_all(&config_home).expect("create config home");
+    // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for this test.
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", &config_home) };
+
+    let project_root = tmp.path().join("repo");
+    setup_colocated_jj_git_repo(&project_root);
+    std::fs::write(project_root.join("tracked.txt"), "first\n").expect("write tracked file");
+    let changed_paths = vec!["tracked.txt".to_string()];
+    let executor = csa_executor::Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: csa_executor::ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+
+    let disabled_config = post_exec_jj_config(false);
+    let mut disabled_session =
+        create_session(&project_root, Some("disabled"), None, Some("claude-code"))
+            .expect("create disabled session");
+    let disabled_session_dir = get_session_dir(&project_root, &disabled_session.meta_session_id)
+        .expect("disabled session dir");
+    let disabled_ctx = PostExecContext {
+        executor: &executor,
+        prompt: "test prompt",
+        effective_prompt: "test prompt",
+        task_type: Some("run"),
+        readonly_project_root: false,
+        project_root: &project_root,
+        config: Some(&disabled_config),
+        global_config: None,
+        session_dir: disabled_session_dir,
+        sessions_root: "test-root".to_string(),
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(2),
+        hooks_config: &hooks_config,
+        memory_project_key: None,
+        provider_session_id: None,
+        events_count: 1,
+        transcript_artifacts: vec![],
+        changed_paths: changed_paths.clone(),
+        pre_exec_snapshot: None,
+        has_tool_calls: true,
+        sa_mode: false,
+    };
+    let mut disabled_result = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: "ok".to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+    };
+
+    process_execution_result(disabled_ctx, &mut disabled_session, &mut disabled_result)
+        .await
+        .expect("process disabled post-exec");
+    assert!(!jj_log_descriptions(&project_root).contains("disabled"));
+
+    let enabled_config = post_exec_jj_config(true);
+    let mut enabled_session =
+        create_session(&project_root, Some("enabled"), None, Some("claude-code"))
+            .expect("create enabled session");
+    let enabled_session_dir = get_session_dir(&project_root, &enabled_session.meta_session_id)
+        .expect("enabled session dir");
+    let enabled_session_id = enabled_session.meta_session_id.clone();
+    let enabled_ctx = PostExecContext {
+        executor: &executor,
+        prompt: "test prompt",
+        effective_prompt: "test prompt",
+        task_type: Some("run"),
+        readonly_project_root: false,
+        project_root: &project_root,
+        config: Some(&enabled_config),
+        global_config: None,
+        session_dir: enabled_session_dir,
+        sessions_root: "test-root".to_string(),
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(2),
+        hooks_config: &hooks_config,
+        memory_project_key: None,
+        provider_session_id: None,
+        events_count: 1,
+        transcript_artifacts: vec![],
+        changed_paths,
+        pre_exec_snapshot: None,
+        has_tool_calls: true,
+        sa_mode: false,
+    };
+    let mut enabled_result = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: "ok".to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+    };
+
+    process_execution_result(enabled_ctx, &mut enabled_session, &mut enabled_result)
+        .await
+        .expect("process enabled post-exec");
+    assert!(
+        jj_log_descriptions(&project_root).contains(&format!(
+            "CSA PostRun snapshot session={enabled_session_id}"
+        )),
+        "jj log should include enabled CSA session snapshot"
     );
 }
 

--- a/crates/cli-sub-agent/tests/config_get_vcs_e2e.rs
+++ b/crates/cli-sub-agent/tests/config_get_vcs_e2e.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+use std::process::Command;
+
+fn csa_cmd(tmp: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+#[test]
+fn config_get_resolves_vcs_snapshot_defaults_and_explicit_values() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = csa_config::ProjectConfig::config_path(tmp.path());
+    std::fs::create_dir_all(config_path.parent().expect("config dir")).expect("create config dir");
+    std::fs::write(&config_path, "schema_version = 1\n").expect("write default config");
+
+    let default_auto_snapshot = csa_cmd(tmp.path())
+        .args(["config", "get", "vcs.auto_snapshot"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa config get vcs.auto_snapshot");
+    assert!(
+        default_auto_snapshot.status.success(),
+        "config get vcs.auto_snapshot should exit 0"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&default_auto_snapshot.stdout).trim(),
+        "false"
+    );
+
+    let default_trigger = csa_cmd(tmp.path())
+        .args(["config", "get", "vcs.snapshot_trigger"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa config get vcs.snapshot_trigger");
+    assert!(
+        default_trigger.status.success(),
+        "config get vcs.snapshot_trigger should exit 0"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&default_trigger.stdout).trim(),
+        "post-run"
+    );
+
+    std::fs::write(
+        &config_path,
+        r#"
+schema_version = 1
+
+[vcs]
+auto_snapshot = true
+snapshot_trigger = "tool-completed"
+"#,
+    )
+    .expect("write explicit vcs config");
+
+    let explicit_auto_snapshot = csa_cmd(tmp.path())
+        .args(["config", "get", "vcs.auto_snapshot"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa config get explicit vcs.auto_snapshot");
+    assert!(
+        explicit_auto_snapshot.status.success(),
+        "config get explicit vcs.auto_snapshot should exit 0"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&explicit_auto_snapshot.stdout).trim(),
+        "true"
+    );
+
+    let explicit_trigger = csa_cmd(tmp.path())
+        .args(["config", "get", "vcs.snapshot_trigger"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa config get explicit vcs.snapshot_trigger");
+    assert!(
+        explicit_trigger.status.success(),
+        "config get explicit vcs.snapshot_trigger should exit 0"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&explicit_trigger.stdout).trim(),
+        "tool-completed"
+    );
+}

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -197,7 +197,7 @@ fn default_recursion_depth() -> u32 {
 
 pub use super::config_session::{
     DEFAULT_COOLDOWN_SECS, ExecutionConfig, HooksSection, PostExecGateConfig, RunConfig,
-    SessionConfig, VcsConfig,
+    SessionConfig, SnapshotTrigger, VcsConfig,
 };
 pub use super::config_tool::{
     ToolConfig, ToolFilesystemSandboxConfig, ToolRestrictions, TransportKind,

--- a/crates/csa-config/src/config_session.rs
+++ b/crates/csa-config/src/config_session.rs
@@ -354,11 +354,22 @@ impl ExecutionConfig {
     }
 }
 
+/// Hook event used for automatic sidecar VCS snapshots.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SnapshotTrigger {
+    /// Snapshot after a run finishes.
+    #[default]
+    PostRun,
+    /// Reserved for V2 tool-completed wiring.
+    ToolCompleted,
+}
+
 /// VCS backend configuration.
 ///
 /// Controls which VCS backend CSA uses for the project.
 /// When `backend` is `None`, auto-detection is used (`.jj/` → Jj, `.git` → Git).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VcsConfig {
     /// Explicit VCS backend override. `None` means auto-detect.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -367,10 +378,59 @@ pub struct VcsConfig {
     /// Defaults to Git when not set, overriding auto-detect's jj preference.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub colocated_default: Option<VcsKind>,
+    /// Enable automatic sidecar snapshot journaling.
+    #[serde(default)]
+    pub auto_snapshot: bool,
+    /// Event that triggers automatic snapshots.
+    #[serde(default)]
+    pub snapshot_trigger: SnapshotTrigger,
+}
+
+impl Default for VcsConfig {
+    fn default() -> Self {
+        Self {
+            backend: None,
+            colocated_default: None,
+            auto_snapshot: false,
+            snapshot_trigger: SnapshotTrigger::PostRun,
+        }
+    }
 }
 
 impl VcsConfig {
     pub fn is_default(&self) -> bool {
-        self.backend.is_none() && self.colocated_default.is_none()
+        self.backend.is_none()
+            && self.colocated_default.is_none()
+            && !self.auto_snapshot
+            && self.snapshot_trigger == SnapshotTrigger::PostRun
+    }
+}
+
+#[cfg(test)]
+mod vcs_config_tests {
+    use super::*;
+
+    #[test]
+    fn vcs_config_defaults_to_auto_snapshot_off_post_run_trigger() {
+        let config: VcsConfig = toml::from_str("").expect("parse defaults");
+
+        assert!(!config.auto_snapshot);
+        assert_eq!(config.snapshot_trigger, SnapshotTrigger::PostRun);
+        assert!(config.is_default());
+    }
+
+    #[test]
+    fn vcs_config_parses_explicit_snapshot_values() {
+        let config: VcsConfig = toml::from_str(
+            r#"
+auto_snapshot = true
+snapshot_trigger = "tool-completed"
+"#,
+        )
+        .expect("parse explicit vcs config");
+
+        assert!(config.auto_snapshot);
+        assert_eq!(config.snapshot_trigger, SnapshotTrigger::ToolCompleted);
+        assert!(!config.is_default());
     }
 }

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -28,8 +28,9 @@ pub mod weave_lock;
 pub use acp::AcpConfig;
 pub use config::{
     DEFAULT_COOLDOWN_SECS, EnforcementMode, ExecutionConfig, HooksSection, PostExecGateConfig,
-    ProjectConfig, ProjectMeta, RunConfig, SessionConfig, TierConfig, TierStrategy, ToolConfig,
-    ToolFilesystemSandboxConfig, ToolResourceProfile, ToolRestrictions,
+    ProjectConfig, ProjectMeta, RunConfig, SessionConfig, SnapshotTrigger, TierConfig,
+    TierStrategy, ToolConfig, ToolFilesystemSandboxConfig, ToolResourceProfile, ToolRestrictions,
+    VcsConfig,
 };
 pub use config_filesystem_sandbox::FilesystemSandboxConfig;
 pub use config_resources::ResourcesConfig;


### PR DESCRIPTION
## Summary

Implements jj sidecar MVP Phase 1-C from RFC #1146: gate the existing PostRun
jj snapshot path on a new `[vcs]` config section, with both fields default-off
to preserve current behavior for users who haven't opted in.

Phase 1-A (SnapshotJournal trait + JjJournal impl with CRITICAL-1 / CRITICAL-2
mitigations) and Phase 1-B (PostRun hook wiring) already landed in main. This
PR adds the config gate that Phase 1-B's commit message reserved.

## Config schema

```toml
[vcs]
auto_snapshot = false              # default — PostRun snapshot is no-op
snapshot_trigger = "post-run"      # default — V2 will switch to "tool-completed"
```

| Field | Type | Default | Behavior |
|-------|------|---------|----------|
| `auto_snapshot` | `bool` | `false` | When `false`, PostRun snapshot is a no-op (zero overhead). |
| `snapshot_trigger` | `enum { "post-run", "tool-completed" }` | `"post-run"` | When `"tool-completed"` (V2 not landed), logs a one-line warning and falls back to `"post-run"` rather than silently disabling — user explicitly opted in. |

## Behavior matrix

| `auto_snapshot` | `snapshot_trigger` | PostRun behavior |
|-----------------|-------------------|------------------|
| `false` (default) | any | no-op |
| `true` | `"post-run"` (default) | snapshot via `JjJournal::snapshot` |
| `true` | `"tool-completed"` | warn + fall back to post-run snapshot |

## Migration note

`CSA_VCS_AUTO_SNAPSHOT` env var (Phase 1-B's temporary toggle) is removed in
favor of config-backed gating. Per the gate's default-off semantics, users who
haven't enabled it see no behavior change.

## Implementation

- `crates/csa-config/src/config_session.rs` — `[vcs]` section parsing + defaults
- `crates/cli-sub-agent/src/pipeline_jj_journal.rs` — gate + fallback warning
- `crates/cli-sub-agent/src/config_cmds_display.rs` — surface raw/effective values for `csa config get vcs.*`
- `crates/cli-sub-agent/src/config_cmds_vcs_tests.rs` — focused unit tests (split out for monolith check)
- `crates/cli-sub-agent/src/pipeline_tests_post_exec.rs` — gate behavior unit tests
- `crates/cli-sub-agent/tests/config_get_vcs_e2e.rs` — `csa config get` e2e for vcs keys

## Test plan

- [x] `cargo test -p csa-config vcs_config_tests` — passes
- [x] `cargo test -p cli-sub-agent pipeline_jj_journal::tests` — passes
- [x] `cargo test -p cli-sub-agent process_execution_result_respects_vcs_auto_snapshot_gate_for_colocated_jj_repo` — passes (real colocated jj+git repo)
- [x] `cargo test -p cli-sub-agent build_project_display` — passes
- [x] `cargo test -p cli-sub-agent --test config_get_vcs_e2e` — passes
- [x] `just test` — passes
- [x] `just pre-commit` — passes
- [x] Push-gate `csa review --range main...HEAD` — CLEAN
      (severity_counts all 0; details.md "No blocking findings";
       decision=fail field is the known #820 docs-only mismarking)

## Files touched

- `crates/csa-config/src/config.rs` / `config_session.rs` / `lib.rs` — config schema
- `crates/cli-sub-agent/src/config_cmds_display.rs` — `csa config get` exposure
- `crates/cli-sub-agent/src/pipeline_jj_journal.rs` — gate
- `crates/cli-sub-agent/src/pipeline_post_exec.rs` — wiring
- `crates/cli-sub-agent/src/pipeline_tests_post_exec.rs` — tests
- `crates/cli-sub-agent/src/config_cmds_vcs_tests.rs` — tests
- `crates/cli-sub-agent/tests/config_get_vcs_e2e.rs` — e2e
- `Cargo.toml` / `Cargo.lock` — version bump 0.1.605 → 0.1.606

## Phase progression

- [x] Phase 1-A — SnapshotJournal trait + JjJournal impl with CRITICAL mitigations
- [x] Phase 1-B — PostRun hook wired to JjJournal::snapshot
- [x] Phase 1-C — `[vcs]` config gate (this PR)
- [ ] V2 — per-event callback wiring for `snapshot_trigger = "tool-completed"`

## Notes

Cloud-bot (gemini-code-assist) 24h quota cache still active until
2026-04-28T21:18:49Z; pr-bot will route through merge-without-bot path with
local push-gate as the merge gate.

Closes #1146 (Phase 1-C only; V2 phases tracked separately)
