### PR TITLE
fix(review): prevent aggregate hang when reviewer times out (#1191)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.606"
+version = "0.1.607"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.606"
+version = "0.1.607"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -11,7 +11,7 @@ use crate::review_context::resolve_review_context;
 use crate::review_context::{ResolvedReviewContext, ResolvedReviewContextKind};
 #[cfg(test)]
 use crate::review_routing::ReviewRoutingMetadata;
-use anyhow::{Context, Result};
+use anyhow::Result;
 #[cfg(test)]
 use csa_config::GlobalConfig;
 #[cfg(test)]
@@ -39,6 +39,10 @@ mod findings_toml;
 mod fix;
 #[path = "review_cmd_flow.rs"]
 mod flow;
+#[path = "review_cmd_multi.rs"]
+mod multi;
+#[path = "review_cmd_parent_artifacts.rs"]
+mod parent_artifacts;
 #[path = "review_cmd_post_review.rs"]
 mod post_review;
 #[path = "review_cmd_prior_rounds.rs"]
@@ -74,7 +78,6 @@ use resolve::{
     resolve_review_effective_tier, resolve_review_model, resolve_review_selection,
     resolve_review_stream_mode, resolve_review_thinking, resolve_review_tier_name,
     review_scope_allows_auto_discovery, verify_review_skill_available,
-    write_multi_reviewer_consolidated_artifact,
 };
 use result_handling::{build_reviewer_outcome, resolve_single_review_result};
 #[rustfmt::skip]
@@ -581,6 +584,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         &global_config,
     )?;
     let reviewer_tools = reviewer_pool.reviewer_tools;
+    let reviewer_tool_plan = reviewer_tools.clone();
     let tier_reviewer_specs = reviewer_pool.tier_reviewer_specs;
 
     let mut join_set = JoinSet::new();
@@ -662,35 +666,8 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         });
     }
 
-    let mut outcomes = Vec::with_capacity(reviewers);
-    let collect_future = async {
-        while let Some(joined) = join_set.join_next().await {
-            let outcome = joined.context("reviewer task join failure")??;
-            outcomes.push(outcome);
-        }
-        Ok::<_, anyhow::Error>(())
-    };
-
-    if let Some(timeout_secs) = args.timeout {
-        match tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), collect_future)
-            .await
-        {
-            Ok(inner) => inner?,
-            Err(_) => {
-                error!(
-                    timeout_secs = timeout_secs,
-                    "Multi-reviewer review aborted: wall-clock timeout exceeded"
-                );
-                anyhow::bail!(
-                    "Review aborted: --timeout {timeout_secs}s exceeded. \
-                     Increase --timeout for longer runs, or use --idle-timeout to kill only when output stalls."
-                );
-            }
-        }
-    } else {
-        collect_future.await?;
-    }
-    outcomes.sort_by_key(|o| o.reviewer_index);
+    let outcomes =
+        multi::collect_reviewer_outcomes(&mut join_set, &reviewer_tool_plan, args.timeout).await?;
 
     let review_iterations = outcomes
         .first()
@@ -731,13 +708,6 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         persist_review_findings_toml(&project_root, &review_meta);
     }
 
-    if let Err(err) = write_multi_reviewer_consolidated_artifact(reviewers) {
-        warn!(
-            error = %err,
-            "Failed to write consolidated multi-reviewer artifact (shadow mode; continuing)"
-        );
-    }
-
     let responses: Vec<AgentResponse> = outcomes
         .iter()
         .map(|o| AgentResponse {
@@ -749,8 +719,28 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         .collect();
 
     let consensus_result = resolve_consensus(consensus_strategy, &responses);
-    let final_verdict = consensus_verdict(&consensus_result);
+    let all_reviewers_unavailable = !outcomes.is_empty()
+        && outcomes
+            .iter()
+            .all(|outcome| outcome.verdict == crate::review_consensus::UNAVAILABLE);
+    let final_verdict = if all_reviewers_unavailable {
+        crate::review_consensus::UNAVAILABLE
+    } else {
+        consensus_verdict(&consensus_result)
+    };
     let agreement = agreement_level(&consensus_result);
+
+    if let Err(err) = parent_artifacts::write_multi_reviewer_parent_artifacts(
+        reviewers,
+        &outcomes,
+        final_verdict,
+        all_reviewers_unavailable,
+    ) {
+        warn!(
+            error = %err,
+            "Failed to write parent multi-reviewer artifacts (continuing)"
+        );
+    }
 
     print_reviewer_outcomes(&outcomes);
 

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -1,0 +1,62 @@
+use anyhow::{Context, Result};
+use csa_core::types::ToolName;
+use tokio::task::JoinSet;
+use tracing::error;
+
+use super::output::ReviewerOutcome;
+use super::result_handling::build_unavailable_reviewer_outcome;
+
+pub(super) async fn collect_reviewer_outcomes(
+    join_set: &mut JoinSet<Result<ReviewerOutcome>>,
+    reviewer_tools: &[ToolName],
+    timeout_secs: Option<u64>,
+) -> Result<Vec<ReviewerOutcome>> {
+    let mut outcomes: Vec<ReviewerOutcome> = Vec::with_capacity(reviewer_tools.len());
+    let reviewer_timeout = timeout_secs.map(std::time::Duration::from_secs);
+    let deadline = reviewer_timeout.map(|timeout| tokio::time::Instant::now() + timeout);
+    while outcomes.len() < reviewer_tools.len() {
+        let joined = if let (Some(timeout), Some(dl)) = (reviewer_timeout, deadline) {
+            match tokio::time::timeout_at(dl, join_set.join_next()).await {
+                Ok(joined) => joined,
+                Err(_) => {
+                    error!(
+                        timeout_secs = timeout.as_secs(),
+                        completed_reviewers = outcomes.len(),
+                        total_reviewers = reviewer_tools.len(),
+                        "Reviewer timed out; marking incomplete reviewers UNAVAILABLE"
+                    );
+                    join_set.abort_all();
+                    synthesize_unavailable_outcomes(&mut outcomes, reviewer_tools, timeout);
+                    break;
+                }
+            }
+        } else {
+            join_set.join_next().await
+        };
+
+        let Some(joined) = joined else {
+            break;
+        };
+        let outcome = joined.context("reviewer task join failure")??;
+        outcomes.push(outcome);
+    }
+    outcomes.sort_by_key(|o| o.reviewer_index);
+    Ok(outcomes)
+}
+
+fn synthesize_unavailable_outcomes(
+    outcomes: &mut Vec<ReviewerOutcome>,
+    reviewer_tools: &[ToolName],
+    timeout: std::time::Duration,
+) {
+    for (reviewer_index, reviewer_tool) in reviewer_tools.iter().enumerate() {
+        if outcomes.iter().any(|o| o.reviewer_index == reviewer_index) {
+            continue;
+        }
+        outcomes.push(build_unavailable_reviewer_outcome(
+            reviewer_index,
+            *reviewer_tool,
+            format!("reviewer timed out after {}s", timeout.as_secs()),
+        ));
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -62,7 +62,7 @@ impl ToolReviewFailureKind {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct ReviewerOutcome {
+pub(in crate::review_cmd) struct ReviewerOutcome {
     pub reviewer_index: usize,
     pub tool: ToolName,
     pub session_id: String,

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -1,0 +1,307 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use anyhow::{Context, Result};
+use csa_core::env::CSA_SESSION_DIR_ENV_KEY;
+use csa_core::types::ReviewDecision;
+use csa_session::review_artifact::{Finding, ReviewArtifact};
+use csa_session::{
+    FindingsFile, ReviewFinding, ReviewFindingFileRange, ReviewVerdictArtifact,
+    write_findings_toml, write_review_verdict,
+};
+
+use crate::review_consensus::{build_consolidated_artifact, write_consolidated_artifact};
+
+use super::output::ReviewerOutcome;
+
+fn load_multi_reviewer_artifacts(
+    output_dir: &Path,
+    reviewers: usize,
+) -> Result<Vec<ReviewArtifact>> {
+    let mut reviewer_artifacts = Vec::new();
+    for reviewer_index in 1..=reviewers {
+        let artifact_path = output_dir
+            .join(format!("reviewer-{reviewer_index}"))
+            .join("review-findings.json");
+
+        if !artifact_path.exists() {
+            continue;
+        }
+
+        let content = fs::read_to_string(&artifact_path)
+            .with_context(|| format!("failed to read {}", artifact_path.display()))?;
+        let artifact: ReviewArtifact = serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse {}", artifact_path.display()))?;
+        reviewer_artifacts.push(artifact);
+    }
+    Ok(reviewer_artifacts)
+}
+
+pub(super) fn write_multi_reviewer_parent_artifacts(
+    reviewers: usize,
+    outcomes: &[ReviewerOutcome],
+    final_verdict: &str,
+    all_reviewers_unavailable: bool,
+) -> Result<()> {
+    let Some(session_dir) = std::env::var_os(CSA_SESSION_DIR_ENV_KEY) else {
+        return Ok(());
+    };
+    let session_dir = PathBuf::from(session_dir);
+    let session_id = std::env::var("CSA_SESSION_ID").unwrap_or_else(|_| "unknown".to_string());
+    let reviewer_artifacts = load_multi_reviewer_artifacts(&session_dir, reviewers)?;
+    let consolidated = build_consolidated_artifact(reviewer_artifacts, &session_id);
+    write_consolidated_artifact(&consolidated, &session_dir)?;
+    write_parent_findings_toml(&session_dir, &consolidated)?;
+    write_parent_review_verdict(
+        &session_dir,
+        &session_id,
+        &consolidated,
+        final_verdict,
+        all_reviewers_unavailable,
+    )?;
+    write_parent_review_summary(&session_dir, outcomes, final_verdict)?;
+    write_parent_review_details(&session_dir, outcomes)?;
+    Ok(())
+}
+
+fn write_parent_findings_toml(session_dir: &Path, artifact: &ReviewArtifact) -> Result<()> {
+    let findings = artifact
+        .findings
+        .iter()
+        .map(review_artifact_finding_to_findings_toml)
+        .collect();
+    write_findings_toml(session_dir, &FindingsFile { findings })
+        .context("failed to write parent output/findings.toml")
+}
+
+fn review_artifact_finding_to_findings_toml(finding: &Finding) -> ReviewFinding {
+    let file_ranges = finding
+        .line
+        .map(|line| {
+            vec![ReviewFindingFileRange {
+                path: finding.file.clone(),
+                start: line,
+                end: None,
+            }]
+        })
+        .unwrap_or_default();
+    ReviewFinding {
+        id: finding.fid.clone(),
+        severity: finding.severity.clone(),
+        file_ranges,
+        is_regression_of_commit: None,
+        suggested_test_scenario: None,
+        description: format!("{}: {}", finding.rule_id, finding.summary),
+    }
+}
+
+fn write_parent_review_verdict(
+    session_dir: &Path,
+    session_id: &str,
+    artifact: &ReviewArtifact,
+    final_verdict: &str,
+    all_reviewers_unavailable: bool,
+) -> Result<()> {
+    let decision = if all_reviewers_unavailable {
+        ReviewDecision::Unavailable
+    } else {
+        ReviewDecision::from_str(final_verdict).unwrap_or(ReviewDecision::Uncertain)
+    };
+    let verdict = ReviewVerdictArtifact::from_parts(
+        session_id.to_string(),
+        decision,
+        final_verdict.to_string(),
+        &artifact.findings,
+        Vec::new(),
+    );
+    write_review_verdict(session_dir, &verdict)
+        .context("failed to write parent output/review-verdict.json")
+}
+
+fn write_parent_review_summary(
+    session_dir: &Path,
+    outcomes: &[ReviewerOutcome],
+    final_verdict: &str,
+) -> Result<()> {
+    let output_dir = session_dir.join("output");
+    fs::create_dir_all(&output_dir)
+        .with_context(|| format!("failed to create {}", output_dir.display()))?;
+    let mut summary = format!("Final verdict: {final_verdict}\n\nReviewer outcomes:\n");
+    for outcome in outcomes {
+        summary.push_str(&format!(
+            "- reviewer {} ({}) => {}",
+            outcome.reviewer_index + 1,
+            outcome.tool,
+            outcome.verdict
+        ));
+        if let Some(diagnostic) = &outcome.diagnostic {
+            summary.push_str(&format!("; diagnostic: {diagnostic}"));
+        }
+        summary.push('\n');
+    }
+    fs::write(output_dir.join("summary.md"), summary)
+        .context("failed to write parent output/summary.md")
+}
+
+fn write_parent_review_details(session_dir: &Path, outcomes: &[ReviewerOutcome]) -> Result<()> {
+    let output_dir = session_dir.join("output");
+    fs::create_dir_all(&output_dir)
+        .with_context(|| format!("failed to create {}", output_dir.display()))?;
+    let mut details = String::new();
+    for outcome in outcomes {
+        details.push_str(&format!(
+            "## Reviewer {} ({})\n\nVerdict: {}\nExit code: {}\n",
+            outcome.reviewer_index + 1,
+            outcome.tool,
+            outcome.verdict,
+            outcome.exit_code
+        ));
+        if let Some(diagnostic) = &outcome.diagnostic {
+            details.push_str(&format!("Diagnostic: {diagnostic}\n"));
+        }
+        details.push('\n');
+        details.push_str(&outcome.output);
+        if !details.ends_with('\n') {
+            details.push('\n');
+        }
+        details.push('\n');
+    }
+    fs::write(output_dir.join("details.md"), details)
+        .context("failed to write parent output/details.md")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_multi_reviewer_parent_artifacts;
+    use crate::review_consensus::UNAVAILABLE;
+    use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+    use csa_core::env::CSA_SESSION_DIR_ENV_KEY;
+    use csa_core::types::{ReviewDecision, ToolName};
+    use csa_session::review_artifact::{
+        Finding, FindingsFile, ReviewArtifact, ReviewVerdictArtifact, Severity, SeveritySummary,
+    };
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn write_multi_reviewer_parent_artifacts_writes_output_sidecars() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let temp = tempdir().expect("tempdir should be created");
+        let session_dir = temp.path().display().to_string();
+        let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
+        let _session_id_guard =
+            ScopedEnvVarRestore::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
+
+        let reviewer_dir = temp.path().join("reviewer-1");
+        fs::create_dir_all(&reviewer_dir).expect("reviewer dir should be created");
+        let findings = vec![Finding {
+            severity: Severity::High,
+            fid: "FID-1".to_string(),
+            file: "src/lib.rs".to_string(),
+            line: Some(7),
+            rule_id: "rule.review.parent-sidecars".to_string(),
+            summary: "parent sidecar finding".to_string(),
+            engine: "reviewer".to_string(),
+        }];
+        let artifact = ReviewArtifact {
+            severity_summary: SeveritySummary::from_findings(&findings),
+            findings,
+            review_mode: Some("diff".to_string()),
+            schema_version: "1.0".to_string(),
+            session_id: "01CHILDSESSION0000000000000".to_string(),
+            timestamp: chrono::Utc::now(),
+        };
+        fs::write(
+            reviewer_dir.join("review-findings.json"),
+            serde_json::to_vec_pretty(&artifact).expect("artifact should serialize"),
+        )
+        .expect("review artifact should be written");
+
+        let outcomes = vec![
+            super::super::output::ReviewerOutcome {
+                reviewer_index: 0,
+                tool: ToolName::Codex,
+                session_id: "01CHILDSESSION0000000000000".to_string(),
+                output: "Reviewer details".to_string(),
+                exit_code: 1,
+                verdict: crate::review_consensus::HAS_ISSUES,
+                diagnostic: None,
+            },
+            super::super::output::ReviewerOutcome {
+                reviewer_index: 1,
+                tool: ToolName::GeminiCli,
+                session_id: "reviewer-2-unavailable".to_string(),
+                output: "Review unavailable: reviewer timed out after 1800s\n".to_string(),
+                exit_code: 1,
+                verdict: UNAVAILABLE,
+                diagnostic: Some("reviewer timed out after 1800s".to_string()),
+            },
+        ];
+
+        write_multi_reviewer_parent_artifacts(
+            2,
+            &outcomes,
+            crate::review_consensus::HAS_ISSUES,
+            false,
+        )
+        .expect("parent artifacts should be produced");
+
+        let output_dir = temp.path().join("output");
+        let findings_toml: FindingsFile = toml::from_str(
+            &fs::read_to_string(output_dir.join("findings.toml"))
+                .expect("findings.toml should exist"),
+        )
+        .expect("findings.toml should parse");
+        assert_eq!(findings_toml.findings.len(), 1);
+        assert_eq!(findings_toml.findings[0].id, "FID-1");
+
+        let verdict: ReviewVerdictArtifact = serde_json::from_str(
+            &fs::read_to_string(output_dir.join("review-verdict.json"))
+                .expect("review-verdict.json should exist"),
+        )
+        .expect("review verdict should parse");
+        assert_eq!(verdict.decision, ReviewDecision::Fail);
+        assert_eq!(verdict.severity_counts[&Severity::High], 1);
+        assert!(
+            fs::read_to_string(output_dir.join("summary.md"))
+                .expect("summary should exist")
+                .contains("reviewer 2 (gemini-cli) => UNAVAILABLE")
+        );
+        assert!(
+            fs::read_to_string(output_dir.join("details.md"))
+                .expect("details should exist")
+                .contains("Review unavailable: reviewer timed out")
+        );
+    }
+
+    #[test]
+    fn write_multi_reviewer_parent_artifacts_marks_all_unavailable() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let temp = tempdir().expect("tempdir should be created");
+        let session_dir = temp.path().display().to_string();
+        let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
+        let _session_id_guard =
+            ScopedEnvVarRestore::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
+        let outcomes = vec![super::super::output::ReviewerOutcome {
+            reviewer_index: 0,
+            tool: ToolName::Codex,
+            session_id: "reviewer-1-unavailable".to_string(),
+            output: "Review unavailable: reviewer timed out after 1800s\n".to_string(),
+            exit_code: 1,
+            verdict: UNAVAILABLE,
+            diagnostic: Some("reviewer timed out after 1800s".to_string()),
+        }];
+
+        write_multi_reviewer_parent_artifacts(1, &outcomes, UNAVAILABLE, true)
+            .expect("parent artifacts should be produced");
+
+        let verdict: ReviewVerdictArtifact = serde_json::from_str(
+            &fs::read_to_string(temp.path().join("output").join("review-verdict.json"))
+                .expect("review-verdict.json should exist"),
+        )
+        .expect("review verdict should parse");
+        assert_eq!(verdict.decision, ReviewDecision::Unavailable);
+        assert_eq!(verdict.verdict_legacy, UNAVAILABLE);
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -1,10 +1,9 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use tracing::{debug, warn};
 
 use crate::cli::{ReviewArgs, ReviewMode};
-use crate::review_consensus::{build_consolidated_artifact, write_consolidated_artifact};
 use crate::review_context::{
     ResolvedReviewContext, ResolvedReviewContextKind, discover_prior_round_assumptions,
     discover_review_checklist, render_spec_review_context,
@@ -15,7 +14,6 @@ use crate::tier_model_fallback::TierFilter;
 use csa_config::global::{heterogeneous_counterpart, select_heterogeneous_tool};
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::ToolName;
-use csa_session::review_artifact::ReviewArtifact;
 
 /// Verify the review pattern is installed before attempting execution.
 ///
@@ -516,34 +514,6 @@ Reason: CSA enforces heterogeneity in auto mode and will not fall back."
     )
 }
 
-pub(crate) fn write_multi_reviewer_consolidated_artifact(reviewers: usize) -> Result<()> {
-    let Some(session_dir) = std::env::var_os("CSA_SESSION_DIR") else {
-        return Ok(());
-    };
-    let output_dir = PathBuf::from(session_dir);
-    let session_id = std::env::var("CSA_SESSION_ID").unwrap_or_else(|_| "unknown".to_string());
-
-    let mut reviewer_artifacts = Vec::new();
-    for reviewer_index in 1..=reviewers {
-        let artifact_path = output_dir
-            .join(format!("reviewer-{reviewer_index}"))
-            .join("review-findings.json");
-
-        if !artifact_path.exists() {
-            continue;
-        }
-
-        let content = std::fs::read_to_string(&artifact_path)
-            .with_context(|| format!("failed to read {}", artifact_path.display()))?;
-        let artifact: ReviewArtifact = serde_json::from_str(&content)
-            .with_context(|| format!("failed to parse {}", artifact_path.display()))?;
-        reviewer_artifacts.push(artifact);
-    }
-
-    let consolidated = build_consolidated_artifact(reviewer_artifacts, &session_id);
-    write_consolidated_artifact(&consolidated, &output_dir)
-}
-
 /// Derive the review scope string from CLI arguments.
 ///
 /// Priority order (first match wins):
@@ -706,62 +676,4 @@ pub(crate) struct ReviewProjectPromptOptions<'a> {
     pub(crate) project_config: Option<&'a ProjectConfig>,
     pub(crate) prior_rounds_section: Option<&'a str>,
     pub(crate) full_consistency: bool,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::write_multi_reviewer_consolidated_artifact;
-    use crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE;
-    use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
-    use csa_core::env::CSA_SESSION_DIR_ENV_KEY;
-    use csa_session::review_artifact::{Finding, ReviewArtifact, Severity, SeveritySummary};
-    use std::fs;
-    use tempfile::tempdir;
-
-    #[test]
-    fn write_multi_reviewer_consolidated_artifact_reads_current_session_reviewer_dir() {
-        let _env_lock = TEST_ENV_LOCK.blocking_lock();
-        let temp = tempdir().expect("tempdir should be created");
-        let session_dir = temp.path().display().to_string();
-        let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
-        let _session_id_guard =
-            ScopedEnvVarRestore::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
-
-        let reviewer_dir = temp.path().join("reviewer-1");
-        fs::create_dir_all(&reviewer_dir).expect("reviewer dir should be created");
-        let findings = vec![Finding {
-            severity: Severity::High,
-            fid: "FID-1".to_string(),
-            file: "src/lib.rs".to_string(),
-            line: Some(7),
-            rule_id: "rule.review.parent-path".to_string(),
-            summary: "parent-path finding".to_string(),
-            engine: "reviewer".to_string(),
-        }];
-        let artifact = ReviewArtifact {
-            severity_summary: SeveritySummary::from_findings(&findings),
-            findings: findings.clone(),
-            review_mode: Some("diff".to_string()),
-            schema_version: "1.0".to_string(),
-            session_id: "01CHILDSESSION0000000000000".to_string(),
-            timestamp: chrono::Utc::now(),
-        };
-        fs::write(
-            reviewer_dir.join("review-findings.json"),
-            serde_json::to_vec_pretty(&artifact).expect("artifact should serialize"),
-        )
-        .expect("review artifact should be written");
-
-        write_multi_reviewer_consolidated_artifact(1)
-            .expect("consolidated artifact should be produced");
-
-        let consolidated_path = temp.path().join(CONSOLIDATED_REVIEW_ARTIFACT_FILE);
-        let consolidated: ReviewArtifact = serde_json::from_str(
-            &fs::read_to_string(&consolidated_path).expect("consolidated artifact should exist"),
-        )
-        .expect("consolidated artifact should parse");
-        assert_eq!(consolidated.findings.len(), 1);
-        assert_eq!(consolidated.findings[0].fid, "FID-1");
-        assert_eq!(consolidated.severity_summary.high, 1);
-    }
 }

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -173,6 +173,23 @@ pub(super) fn build_reviewer_outcome(
     })
 }
 
+pub(super) fn build_unavailable_reviewer_outcome(
+    reviewer_index: usize,
+    reviewer_tool: ToolName,
+    reason: impl Into<String>,
+) -> ReviewerOutcome {
+    let reason = reason.into();
+    ReviewerOutcome {
+        reviewer_index,
+        tool: reviewer_tool,
+        session_id: format!("reviewer-{}-unavailable", reviewer_index + 1),
+        output: format!("{REVIEW_UNAVAILABLE_PREFIX}{reason}\n"),
+        exit_code: 1,
+        verdict: UNAVAILABLE,
+        diagnostic: Some(reason),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Multi-reviewer aggregate now uses `tokio::time::timeout_at` with absolute deadline instead of per-iteration `timeout`, preventing wall-clock ceiling violation
- When a reviewer times out, synthesizes `UNAVAILABLE` outcome and proceeds to aggregate with completed reviewers instead of hanging indefinitely
- New parent-level aggregate artifact writer produces `output/findings.toml`, `output/review-verdict.json`, `output/details.md`, `output/summary.md`
- Single-reviewer mode is unaffected (no regression)

## Test plan

- [x] `cargo test -p cli-sub-agent write_multi_reviewer_parent_artifacts` passes
- [x] `cargo test -p cli-sub-agent auto_reviewer_selection_respects_explicit_reviewer_override` passes
- [x] `just pre-commit` passes (fmt, clippy, nextest, e2e)
- [x] Push-gate review CLEAN (session `01KQASCEHDMQM6SABBE66T8JJQ`)

Closes #1191

🤖 Generated with [Claude Code](https://claude.com/claude-code)