### PR TITLE
fix(review): correct verdict extraction from reviewer output (#1204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.609"
+version = "0.1.610"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.609"
+version = "0.1.610"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -416,7 +416,8 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             review_future.await?
         };
 
-        let resolved = resolve_single_review_result(&result, result.executed_tool, &scope);
+        let resolved =
+            resolve_single_review_result(&result, result.executed_tool, &scope, &project_root);
         let sanitized = resolved.sanitized;
         let empty_output = resolved.empty_output;
         let verdict = resolved.verdict;

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
 use csa_core::types::{ReviewDecision, ToolName};
+use std::fs;
+use std::path::Path;
 use tracing::warn;
 
 use crate::review_consensus::{
@@ -8,7 +10,7 @@ use crate::review_consensus::{
 
 use super::execute::ReviewExecutionOutcome;
 use super::output::{
-    GEMINI_AUTH_PROMPT_STATUS_REASON, ReviewerOutcome, detect_tool_diagnostic,
+    GEMINI_AUTH_PROMPT_STATUS_REASON, ReviewerOutcome, detect_tool_diagnostic, extract_review_text,
     is_review_output_empty, sanitize_review_output,
 };
 
@@ -50,6 +52,7 @@ pub(super) fn resolve_single_review_result(
     result: &ReviewExecutionOutcome,
     tool: ToolName,
     scope: &str,
+    project_root: &Path,
 ) -> SingleReviewResolution {
     let auth_prompt_failure =
         result.status_reason.as_deref() == Some(GEMINI_AUTH_PROMPT_STATUS_REASON);
@@ -93,9 +96,10 @@ pub(super) fn resolve_single_review_result(
     } else if auth_prompt_failure || empty_output {
         ReviewDecision::Uncertain
     } else {
-        parse_review_decision(
+        parse_review_decision_for_execution(
             &result.execution.execution.output,
             result.execution.execution.exit_code,
+            load_summary_fallback(project_root, &result.execution.meta_session_id).as_deref(),
         )
     };
     let verdict = verdict_from_decision(decision);
@@ -146,7 +150,11 @@ pub(super) fn build_reviewer_outcome(
         } else if auth_prompt_failure || empty {
             ReviewDecision::Uncertain
         } else {
-            parse_review_decision(&result.execution.output, result.execution.exit_code)
+            parse_review_decision_for_execution(
+                &result.execution.output,
+                result.execution.exit_code,
+                None,
+            )
         }),
         output: if auth_prompt_failure {
             AUTH_PROMPT_REVIEW_UNAVAILABLE.to_string()
@@ -166,11 +174,54 @@ pub(super) fn build_reviewer_outcome(
         } else if auth_prompt_failure || empty {
             ReviewDecision::Uncertain
         } else {
-            parse_review_decision(&result.execution.output, result.execution.exit_code)
+            parse_review_decision_for_execution(
+                &result.execution.output,
+                result.execution.exit_code,
+                None,
+            )
         }),
         diagnostic: diagnostic
             .or_else(|| auth_prompt_failure.then(|| AUTH_PROMPT_DIAGNOSTIC.to_string())),
     })
+}
+
+fn parse_review_decision_for_execution(
+    raw_output: &str,
+    exit_code: i32,
+    summary_fallback: Option<&str>,
+) -> ReviewDecision {
+    let review_text = extract_review_text(raw_output).unwrap_or_else(|| raw_output.to_string());
+    if !contains_explicit_verdict_token(&review_text)
+        && let Some(summary) = summary_fallback
+    {
+        return parse_review_decision(summary, 0);
+    }
+    parse_review_decision(&review_text, exit_code)
+}
+
+fn load_summary_fallback(project_root: &Path, session_id: &str) -> Option<String> {
+    let session_dir = csa_session::get_session_dir(project_root, session_id).ok()?;
+    fs::read_to_string(session_dir.join("output").join("summary.md")).ok()
+}
+
+fn contains_explicit_verdict_token(text: &str) -> bool {
+    [
+        "HAS_ISSUES",
+        "FAIL",
+        "UNAVAILABLE",
+        "UNCERTAIN",
+        "CLEAN",
+        "PASS",
+        "SKIP",
+    ]
+    .iter()
+    .any(|token| contains_token(text, token))
+}
+
+fn contains_token(haystack: &str, token: &str) -> bool {
+    haystack
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .any(|part| part.eq_ignore_ascii_case(token))
 }
 
 pub(super) fn build_unavailable_reviewer_outcome(
@@ -228,11 +279,100 @@ mod tests {
             ),
             ToolName::Codex,
             "uncommitted",
+            Path::new("."),
         );
 
         assert_eq!(resolved.decision, ReviewDecision::Uncertain);
         assert_eq!(resolved.verdict, UNCERTAIN);
         assert_eq!(resolved.effective_exit_code, 1);
+    }
+
+    #[test]
+    fn resolve_single_review_result_uses_last_reviewer_message_not_prompt_tokens() {
+        let raw = concat!(
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"Reviewer instructions mention HAS_ISSUES as a legacy alias.\"}}\n",
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"<!-- CSA:SECTION:summary -->\\nPASS\\n<!-- CSA:SECTION:summary:END -->\\n\\n<!-- CSA:SECTION:details -->\\nNo blocking correctness issues found.\\n<!-- CSA:SECTION:details:END -->\"}}\n",
+        );
+
+        let resolved = resolve_single_review_result(
+            &outcome(raw, 0),
+            ToolName::Codex,
+            "uncommitted",
+            Path::new("."),
+        );
+
+        assert_eq!(resolved.decision, ReviewDecision::Pass);
+        assert_eq!(resolved.verdict, CLEAN);
+        assert_eq!(resolved.effective_exit_code, 0);
+    }
+
+    #[test]
+    fn resolve_single_review_result_falls_back_to_summary_md_for_clear_verdict() {
+        let project_root = tempfile::tempdir().expect("temp project");
+        let session_dir = csa_session::get_session_root(project_root.path())
+            .expect("session root")
+            .join("sessions")
+            .join("01TESTRESULT");
+        fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+        fs::write(session_dir.join("output").join("summary.md"), "**PASS**\n")
+            .expect("write summary");
+
+        let resolved = resolve_single_review_result(
+            &outcome("review completed without a verdict token", 1),
+            ToolName::Codex,
+            "uncommitted",
+            project_root.path(),
+        );
+
+        assert_eq!(resolved.decision, ReviewDecision::Pass);
+        assert_eq!(resolved.verdict, CLEAN);
+    }
+
+    #[test]
+    fn mock_pass_review_persists_pass_review_meta() {
+        let project_root = tempfile::tempdir().expect("temp project");
+        let session_dir = csa_session::get_session_root(project_root.path())
+            .expect("session root")
+            .join("sessions")
+            .join("01TESTRESULT");
+        fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+        let raw = concat!(
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"Prompt context: legacy HAS_ISSUES maps to failure.\"}}\n",
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"<!-- CSA:SECTION:summary -->\\nPASS\\n<!-- CSA:SECTION:summary:END -->\\n\\n<!-- CSA:SECTION:details -->\\nNo blocking correctness issues found.\\n<!-- CSA:SECTION:details:END -->\"}}\n",
+        );
+        let resolved = resolve_single_review_result(
+            &outcome(raw, 0),
+            ToolName::Codex,
+            "uncommitted",
+            project_root.path(),
+        );
+        let meta = csa_session::state::ReviewSessionMeta {
+            session_id: "01TESTRESULT".to_string(),
+            head_sha: "HEAD".to_string(),
+            decision: resolved.decision.as_str().to_string(),
+            verdict: resolved.verdict.to_string(),
+            status_reason: None,
+            routed_to: None,
+            primary_failure: None,
+            failure_reason: None,
+            tool: ToolName::Codex.to_string(),
+            scope: "uncommitted".to_string(),
+            exit_code: resolved.effective_exit_code,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 0,
+            timestamp: chrono::Utc::now(),
+            diff_fingerprint: None,
+        };
+
+        csa_session::state::write_review_meta(&session_dir, &meta).expect("write review meta");
+        let persisted: csa_session::state::ReviewSessionMeta = serde_json::from_str(
+            &fs::read_to_string(session_dir.join("review_meta.json")).expect("read review meta"),
+        )
+        .expect("parse review meta");
+
+        assert_eq!(persisted.decision, ReviewDecision::Pass.as_str());
+        assert_eq!(persisted.verdict, CLEAN);
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -260,6 +260,20 @@ pub(crate) fn parse_review_decision(
 ) -> csa_core::types::ReviewDecision {
     use csa_core::types::ReviewDecision;
 
+    if let Some(decision) = parse_review_decision_token(output) {
+        return decision;
+    }
+
+    if exit_code == 0 && contains_clean_phrase(output) {
+        ReviewDecision::Pass
+    } else {
+        ReviewDecision::Fail
+    }
+}
+
+fn parse_review_decision_token(output: &str) -> Option<csa_core::types::ReviewDecision> {
+    use csa_core::types::ReviewDecision;
+
     let has_fail =
         contains_verdict_token(output, HAS_ISSUES) || contains_verdict_token(output, "FAIL");
     let has_unavailable = contains_verdict_token(output, UNAVAILABLE);
@@ -268,19 +282,17 @@ pub(crate) fn parse_review_decision(
     let has_skip = contains_verdict_token(output, SKIP);
 
     if has_fail {
-        ReviewDecision::Fail
+        Some(ReviewDecision::Fail)
     } else if has_unavailable {
-        ReviewDecision::Unavailable
+        Some(ReviewDecision::Unavailable)
     } else if has_uncertain {
-        ReviewDecision::Uncertain
+        Some(ReviewDecision::Uncertain)
     } else if has_pass {
-        ReviewDecision::Pass
+        Some(ReviewDecision::Pass)
     } else if has_skip {
-        ReviewDecision::Skip
-    } else if exit_code == 0 && contains_clean_phrase(output) {
-        ReviewDecision::Pass
+        Some(ReviewDecision::Skip)
     } else {
-        ReviewDecision::Fail
+        None
     }
 }
 
@@ -512,3 +524,7 @@ pub(crate) fn write_consolidated_artifact(
 #[cfg(test)]
 #[path = "review_consensus_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "review_consensus_parser_tests.rs"]
+mod parser_tests;

--- a/crates/cli-sub-agent/src/review_consensus_parser_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_parser_tests.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[test]
+fn parse_review_decision_accepts_clean_pass_section() {
+    use csa_core::types::ReviewDecision;
+
+    assert_eq!(
+        parse_review_decision(
+            "<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n\
+             <!-- CSA:SECTION:details -->\nNo blocking correctness issues found.\n<!-- CSA:SECTION:details:END -->",
+            0,
+        ),
+        ReviewDecision::Pass
+    );
+}
+
+#[test]
+fn parse_review_decision_accepts_markdown_pass_verdict() {
+    use csa_core::types::ReviewDecision;
+
+    assert_eq!(
+        parse_review_decision("## Verdict\n\n**PASS**\n\nNo findings.", 0),
+        ReviewDecision::Pass
+    );
+}
+
+#[test]
+fn parse_review_decision_fails_for_high_findings() {
+    use csa_core::types::ReviewDecision;
+
+    assert_eq!(
+        parse_review_decision(
+            "Verdict: FAIL\n\nFindings\n1. [High][correctness] incorrect cache key.",
+            1,
+        ),
+        ReviewDecision::Fail
+    );
+}
+
+#[test]
+fn parse_review_decision_no_issues_found_is_not_has_issues() {
+    use csa_core::types::ReviewDecision;
+
+    assert_eq!(
+        parse_review_decision("No issues found.", 0),
+        ReviewDecision::Pass
+    );
+}


### PR DESCRIPTION
## Summary

- Fixed the verdict token parser that extracts PASS/FAIL from reviewer output into `review_meta.json`
- Root cause: parser was misclassifying reviewer sessions with prose "PASS" as `decision=fail` due to incorrect token matching logic
- **Dogfood verified**: push-gate review on this very PR produced `decision: "pass"`, `verdict: "CLEAN"`, `review_iterations: 1` (previously always showed `decision: "fail"` with iterations=10+)

## Impact

Unblocks the `csa review --check-verdict` gate shipped in PR #1203 — without this fix, the push-gate would reject clean reviews due to parser misclassification.

## Test plan

- [x] `just pre-commit` passes
- [x] Push-gate review produces `decision: "pass"` (session `01KQB4XMYC5T5C6Z5V1QR3TJZM`)
- [x] New unit tests for verdict extraction covering PASS, FAIL, edge cases
- [x] Version bumped to 0.1.610

Closes #1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)