### PR TITLE
feat(mktd): epic decomposition — scale detection + story DAG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "chrono",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.611"
+version = "0.1.612"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.611"
+version = "0.1.612"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_todo.rs
+++ b/crates/cli-sub-agent/src/cli_todo.rs
@@ -1,5 +1,7 @@
 //! CLI subcommands for the `csa todo` command group.
 
+use std::ffi::OsString;
+
 use clap::{Subcommand, ValueEnum};
 
 #[derive(Subcommand)]
@@ -177,6 +179,12 @@ pub enum TodoCommands {
         cd: Option<String>,
     },
 
+    /// Epic plan management
+    Epic {
+        #[command(subcommand)]
+        command: EpicCommands,
+    },
+
     /// Manage reference files attached to TODO plans
     Ref {
         #[command(subcommand)]
@@ -189,6 +197,54 @@ pub enum TodoDagFormat {
     Mermaid,
     Terminal,
     Dot,
+}
+
+#[derive(Subcommand)]
+pub enum EpicCommands {
+    /// Show the epic plan for current TODO
+    Show {
+        /// Timestamp of the TODO plan (default: latest)
+        #[arg(short, long)]
+        timestamp: Option<String>,
+
+        /// Output format (also accepts --format)
+        #[arg(long = "epic-format", value_enum, default_value_t = EpicFormat::Terminal)]
+        epic_format: EpicFormat,
+
+        /// Working directory
+        #[arg(long)]
+        cd: Option<String>,
+    },
+
+    /// Validate epic plan (check DAG, no cycles, all deps valid)
+    Validate {
+        /// Timestamp of the TODO plan (default: latest)
+        #[arg(short, long)]
+        timestamp: Option<String>,
+
+        /// Working directory
+        #[arg(long)]
+        cd: Option<String>,
+    },
+
+    /// Show next actionable stories (pending with all deps merged)
+    Next {
+        /// Timestamp of the TODO plan (default: latest)
+        #[arg(short, long)]
+        timestamp: Option<String>,
+
+        /// Working directory
+        #[arg(long)]
+        cd: Option<String>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum EpicFormat {
+    Terminal,
+    Mermaid,
+    Dot,
+    Json,
 }
 
 #[derive(Subcommand)]
@@ -274,4 +330,104 @@ pub enum TodoRefCommands {
         #[arg(long)]
         cd: Option<String>,
     },
+}
+
+pub(crate) fn normalize_epic_format_args(
+    args: impl IntoIterator<Item = OsString>,
+) -> Vec<OsString> {
+    let mut in_todo = false;
+    let mut in_epic = false;
+    let mut in_epic_show = false;
+
+    args.into_iter()
+        .map(|arg| {
+            if in_epic_show {
+                // The root command owns global --format, so clap cannot also define a
+                // subcommand-local --format. Keep the epic user-facing syntax stable by
+                // rewriting it to the internal flag before clap parses the command.
+                if arg == "--format" {
+                    return OsString::from("--epic-format");
+                }
+                if let Some(value) = arg.to_str().and_then(|s| s.strip_prefix("--format=")) {
+                    return OsString::from(format!("--epic-format={value}"));
+                }
+                return arg;
+            }
+
+            if arg == "todo" {
+                in_todo = true;
+            } else if in_todo && arg == "epic" {
+                in_epic = true;
+            } else if in_epic && arg == "show" {
+                in_epic_show = true;
+            }
+
+            arg
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod epic_arg_normalization_tests {
+    use super::normalize_epic_format_args;
+    use std::ffi::OsString;
+
+    fn normalize(args: &[&str]) -> Vec<String> {
+        normalize_epic_format_args(args.iter().map(OsString::from))
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn rewrites_epic_show_format_flag() {
+        let args = normalize(&[
+            "csa", "todo", "epic", "show", "--format", "mermaid", "--cd", ".",
+        ]);
+
+        assert_eq!(
+            args,
+            vec![
+                "csa",
+                "todo",
+                "epic",
+                "show",
+                "--epic-format",
+                "mermaid",
+                "--cd",
+                "."
+            ]
+        );
+    }
+
+    #[test]
+    fn rewrites_epic_show_format_equals() {
+        let args = normalize(&["csa", "todo", "epic", "show", "--format=json"]);
+
+        assert_eq!(
+            args,
+            vec!["csa", "todo", "epic", "show", "--epic-format=json"]
+        );
+    }
+
+    #[test]
+    fn preserves_global_format_before_command() {
+        let args = normalize(&[
+            "csa", "--format", "json", "todo", "epic", "show", "--format", "dot",
+        ]);
+
+        assert_eq!(
+            args,
+            vec![
+                "csa",
+                "--format",
+                "json",
+                "todo",
+                "epic",
+                "show",
+                "--epic-format",
+                "dot"
+            ]
+        );
+    }
 }

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -72,6 +72,7 @@ mod skill_resolver;
 mod tier_model_fallback;
 mod tiers_cmd;
 mod todo_cmd;
+mod todo_epic_cmd;
 mod todo_ref_cmd;
 mod tool_version;
 
@@ -213,7 +214,7 @@ async fn run() -> Result<()> {
         .try_init()
         .ok();
 
-    let cli = Cli::parse();
+    let cli = Cli::parse_from(cli::normalize_epic_format_args(std::env::args_os()));
     let output_format = cli.format;
     let command = cli.command;
 
@@ -713,6 +714,9 @@ async fn run() -> Result<()> {
                 cd,
             } => {
                 todo_cmd::handle_dag(timestamp, format, cd)?;
+            }
+            TodoCommands::Epic { command } => {
+                todo_epic_cmd::handle_epic_command(command)?;
             }
             TodoCommands::Ref { cmd } => match cmd {
                 TodoRefCommands::List {

--- a/crates/cli-sub-agent/src/todo_epic_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_epic_cmd.rs
@@ -1,0 +1,141 @@
+use crate::cli::{EpicCommands, EpicFormat};
+use anyhow::Result;
+use csa_todo::{EpicPlan, Story, StoryStatus, TodoManager};
+
+pub(crate) fn handle_epic_command(command: EpicCommands) -> Result<()> {
+    match command {
+        EpicCommands::Show {
+            timestamp,
+            epic_format,
+            cd,
+        } => handle_epic_show(timestamp, epic_format, cd),
+        EpicCommands::Validate { timestamp, cd } => handle_epic_validate(timestamp, cd),
+        EpicCommands::Next { timestamp, cd } => handle_epic_next(timestamp, cd),
+    }
+}
+
+fn handle_epic_show(
+    timestamp: Option<String>,
+    format: EpicFormat,
+    cd: Option<String>,
+) -> Result<()> {
+    let (_ts, epic_plan) = load_required_epic_plan(timestamp, cd)?;
+    epic_plan.validate()?;
+
+    let rendered = match format {
+        EpicFormat::Terminal => render_epic_plan_terminal(&epic_plan)?,
+        EpicFormat::Mermaid => epic_plan.to_dependency_graph().to_mermaid(),
+        EpicFormat::Dot => epic_plan.to_dependency_graph().to_dot(),
+        EpicFormat::Json => serde_json::to_string_pretty(&epic_plan)?,
+    };
+
+    println!("{rendered}");
+    Ok(())
+}
+
+fn handle_epic_validate(timestamp: Option<String>, cd: Option<String>) -> Result<()> {
+    let (ts, epic_plan) = load_required_epic_plan(timestamp, cd)?;
+
+    epic_plan.validate()?;
+    println!("Epic plan '{ts}' is valid.");
+    Ok(())
+}
+
+fn handle_epic_next(timestamp: Option<String>, cd: Option<String>) -> Result<()> {
+    let (_ts, epic_plan) = load_required_epic_plan(timestamp, cd)?;
+
+    epic_plan.validate()?;
+    let actionable = epic_plan.next_actionable();
+    if actionable.is_empty() {
+        println!("No actionable stories.");
+        return Ok(());
+    }
+
+    println!("{:<20}  {:<10}  {:<40}  SUMMARY", "ID", "STATUS", "BRANCH");
+    for story in actionable {
+        println!(
+            "{:<20}  {:<10}  {:<40}  {}",
+            story.id,
+            story_status_label(story.status),
+            truncate_branch(&story.branch, 40),
+            story.summary
+        );
+    }
+
+    Ok(())
+}
+
+fn load_required_epic_plan(
+    timestamp: Option<String>,
+    cd: Option<String>,
+) -> Result<(String, EpicPlan)> {
+    let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+    let manager = TodoManager::new(&project_root)?;
+    let ts = crate::todo_cmd::resolve_timestamp(&manager, timestamp.as_deref())?;
+    manager.load(&ts)?;
+
+    let Some(epic_plan) = manager.load_epic_plan(&ts)? else {
+        anyhow::bail!("No epic plan found for plan '{ts}'");
+    };
+
+    Ok((ts, epic_plan))
+}
+
+fn render_epic_plan_terminal(epic_plan: &EpicPlan) -> Result<String> {
+    let mut rendered = String::new();
+    rendered.push_str(&format!("Epic: {}\n", epic_plan.epic.name));
+    rendered.push_str(&format!("Branch prefix: {}\n", epic_plan.epic.prefix));
+    if !epic_plan.epic.summary.is_empty() {
+        rendered.push_str(&format!("Summary: {}\n", epic_plan.epic.summary));
+    }
+
+    rendered.push_str("\nStories:\n");
+    for story in epic_plan.execution_order()? {
+        rendered.push_str(&render_story_line(story));
+    }
+
+    let graph = epic_plan.to_dependency_graph();
+    if graph.node_count() > 0 {
+        rendered.push_str("\nDependency DAG:\n");
+        rendered.push_str(&graph.to_terminal());
+        rendered.push('\n');
+    }
+
+    Ok(rendered)
+}
+
+fn render_story_line(story: &Story) -> String {
+    let dependencies = if story.depends_on.is_empty() {
+        "-".to_string()
+    } else {
+        story.depends_on.join(", ")
+    };
+
+    format!(
+        "- [{}] {}: {}\n  branch: {}\n  depends_on: {}\n",
+        story_status_label(story.status),
+        story.id,
+        story.summary,
+        story.branch,
+        dependencies
+    )
+}
+
+fn story_status_label(status: StoryStatus) -> &'static str {
+    match status {
+        StoryStatus::Pending => "pending",
+        StoryStatus::InProgress => "inprogress",
+        StoryStatus::Merged => "merged",
+        StoryStatus::Skipped => "skipped",
+    }
+}
+
+fn truncate_branch(value: &str, max_len: usize) -> String {
+    let char_count = value.chars().count();
+    if char_count <= max_len {
+        value.to_string()
+    } else {
+        let truncated: String = value.chars().take(max_len - 1).collect();
+        format!("{truncated}\u{2026}")
+    }
+}

--- a/crates/csa-todo/src/dag.rs
+++ b/crates/csa-todo/src/dag.rs
@@ -15,6 +15,52 @@ pub struct DependencyGraph {
 }
 
 impl DependencyGraph {
+    pub fn from_nodes_and_edges(
+        nodes: Vec<DependencyNode>,
+        edge_pairs: impl IntoIterator<Item = (usize, usize)>,
+    ) -> Result<Self> {
+        Self::try_from_nodes_and_edges(nodes, edge_pairs)
+    }
+
+    pub(crate) fn from_trusted_nodes_and_edges(
+        nodes: Vec<DependencyNode>,
+        edge_pairs: impl IntoIterator<Item = (usize, usize)>,
+    ) -> Self {
+        match Self::try_from_nodes_and_edges(nodes, edge_pairs) {
+            Ok(graph) => graph,
+            Err(error) => panic!("trusted dependency graph edge indexes are invalid: {error}"),
+        }
+    }
+
+    fn try_from_nodes_and_edges(
+        nodes: Vec<DependencyNode>,
+        edge_pairs: impl IntoIterator<Item = (usize, usize)>,
+    ) -> Result<Self> {
+        let mut edge_set: BTreeSet<(usize, usize)> = BTreeSet::new();
+        for (from, to) in edge_pairs {
+            if from >= nodes.len() || to >= nodes.len() {
+                bail!(
+                    "Dependency edge index out of bounds: {from} -> {to} for {} nodes",
+                    nodes.len()
+                );
+            }
+            edge_set.insert((from, to));
+        }
+
+        let mut edges = vec![Vec::new(); nodes.len()];
+        let mut incoming = vec![Vec::new(); nodes.len()];
+        for (from, to) in edge_set {
+            edges[from].push(to);
+            incoming[to].push(from);
+        }
+
+        Ok(Self {
+            nodes,
+            edges,
+            incoming,
+        })
+    }
+
     /// Build a dependency graph from TODO markdown content.
     ///
     /// Supported dependency formats:

--- a/crates/csa-todo/src/epic_plan.rs
+++ b/crates/csa-todo/src/epic_plan.rs
@@ -1,0 +1,302 @@
+use crate::dag::{DependencyGraph, DependencyNode};
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+fn default_schema_version() -> u32 {
+    1
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EpicPlan {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    pub epic: EpicMeta,
+    #[serde(default)]
+    pub stories: Vec<Story>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EpicMeta {
+    pub name: String,
+    pub prefix: String,
+    #[serde(default)]
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Story {
+    pub id: String,
+    pub branch: String,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    pub summary: String,
+    #[serde(default)]
+    pub status: StoryStatus,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StoryStatus {
+    #[default]
+    Pending,
+    InProgress,
+    Merged,
+    Skipped,
+}
+
+impl std::fmt::Display for StoryStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(f, "pending"),
+            Self::InProgress => write!(f, "inprogress"),
+            Self::Merged => write!(f, "merged"),
+            Self::Skipped => write!(f, "skipped"),
+        }
+    }
+}
+
+impl EpicPlan {
+    pub fn validate(&self) -> Result<()> {
+        let mut ids = BTreeSet::new();
+        for story in &self.stories {
+            if !ids.insert(story.id.as_str()) {
+                bail!("Duplicate story id: {}", story.id);
+            }
+        }
+
+        for story in &self.stories {
+            for dependency in &story.depends_on {
+                if !ids.contains(dependency.as_str()) {
+                    bail!(
+                        "Story '{}' depends on unknown story id '{}'",
+                        story.id,
+                        dependency
+                    );
+                }
+            }
+        }
+
+        let graph = self.to_dependency_graph();
+        let _ = graph.topological_sort()?;
+        Ok(())
+    }
+
+    pub fn to_dependency_graph(&self) -> DependencyGraph {
+        let nodes: Vec<DependencyNode> = self
+            .stories
+            .iter()
+            .map(|story| DependencyNode {
+                title: story.id.clone(),
+                is_done: story.status == StoryStatus::Merged,
+            })
+            .collect();
+
+        let id_to_index: BTreeMap<&str, usize> = self
+            .stories
+            .iter()
+            .enumerate()
+            .map(|(index, story)| (story.id.as_str(), index))
+            .collect();
+
+        let edges = self
+            .stories
+            .iter()
+            .enumerate()
+            .flat_map(|(to_index, story)| {
+                let id_to_index = &id_to_index;
+                story
+                    .depends_on
+                    .iter()
+                    .filter_map(move |dependency| id_to_index.get(dependency.as_str()))
+                    .map(move |from_index| (*from_index, to_index))
+            });
+
+        DependencyGraph::from_trusted_nodes_and_edges(nodes, edges)
+    }
+
+    pub fn execution_order(&self) -> Result<Vec<&Story>> {
+        self.validate()?;
+        self.to_dependency_graph()
+            .topological_sort()?
+            .into_iter()
+            .map(|index| {
+                self.stories
+                    .get(index)
+                    .with_context(|| format!("Story index {index} missing from epic plan"))
+            })
+            .collect()
+    }
+
+    pub fn next_actionable(&self) -> Vec<&Story> {
+        let status_by_id: BTreeMap<&str, StoryStatus> = self
+            .stories
+            .iter()
+            .map(|story| (story.id.as_str(), story.status))
+            .collect();
+
+        self.stories
+            .iter()
+            .filter(|story| story.status == StoryStatus::Pending)
+            .filter(|story| {
+                story.depends_on.iter().all(|dependency| {
+                    status_by_id.get(dependency.as_str()) == Some(&StoryStatus::Merged)
+                })
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScaleSignals {
+    pub new_modules: u32,
+    pub new_pub_apis: u32,
+    pub new_config_sections: u32,
+    pub new_cli_subcommands: u32,
+    pub cross_crate_deps: u32,
+    pub design_doc_pages: u32,
+}
+
+impl ScaleSignals {
+    pub fn signals_fired(&self) -> u32 {
+        u32::from(self.new_modules > 2)
+            + u32::from(self.new_pub_apis > 5)
+            + u32::from(self.new_config_sections > 2)
+            + u32::from(self.new_cli_subcommands > 1)
+            + u32::from(self.cross_crate_deps > 3)
+            + u32::from(self.design_doc_pages > 5)
+    }
+
+    pub fn is_epic(&self) -> bool {
+        self.signals_fired() >= 3
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EpicMeta, EpicPlan, ScaleSignals, Story, StoryStatus};
+
+    fn sample_plan() -> EpicPlan {
+        EpicPlan {
+            schema_version: 1,
+            epic: EpicMeta {
+                name: "JJ sidecar".to_string(),
+                prefix: "feat/jj-sidecar".to_string(),
+                summary: "Split sidecar support into independent stories.".to_string(),
+            },
+            stories: vec![
+                Story {
+                    id: "phase-1a".to_string(),
+                    branch: "feat/jj-sidecar/phase-1a-core-trait".to_string(),
+                    depends_on: Vec::new(),
+                    summary: "Add core trait.".to_string(),
+                    status: StoryStatus::Merged,
+                },
+                Story {
+                    id: "phase-1b".to_string(),
+                    branch: "feat/jj-sidecar/phase-1b-cli".to_string(),
+                    depends_on: vec!["phase-1a".to_string()],
+                    summary: "Add CLI wiring.".to_string(),
+                    status: StoryStatus::Pending,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn epic_plan_toml_roundtrip() {
+        let plan = sample_plan();
+
+        let toml = toml::to_string_pretty(&plan).expect("epic plan should serialize to TOML");
+        let decoded: EpicPlan =
+            toml::from_str(&toml).expect("epic plan should deserialize from TOML");
+
+        assert_eq!(decoded, plan);
+    }
+
+    #[test]
+    fn story_status_defaults_to_pending() {
+        let toml = r#"
+id = "phase-1a"
+branch = "feat/example/phase-1a"
+summary = "Missing status should default to pending."
+"#;
+
+        let decoded: Story =
+            toml::from_str(toml).expect("story should deserialize with default status");
+
+        assert_eq!(decoded.status, StoryStatus::Pending);
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_story_ids() {
+        let mut plan = sample_plan();
+        plan.stories[1].id = "phase-1a".to_string();
+
+        let err = plan.validate().expect_err("duplicate ids should fail");
+
+        assert!(err.to_string().contains("Duplicate story id: phase-1a"));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_dependencies() {
+        let mut plan = sample_plan();
+        plan.stories[1].depends_on = vec!["missing".to_string()];
+
+        let err = plan
+            .validate()
+            .expect_err("unknown dependencies should fail");
+
+        assert!(
+            err.to_string()
+                .contains("Story 'phase-1b' depends on unknown story id 'missing'")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_cycles() {
+        let mut plan = sample_plan();
+        plan.stories[0].depends_on = vec!["phase-1b".to_string()];
+
+        let err = plan.validate().expect_err("cycles should fail");
+
+        assert!(err.to_string().contains("Dependency cycle detected"));
+    }
+
+    #[test]
+    fn execution_order_returns_dependencies_first() {
+        let plan = sample_plan();
+
+        let order = plan
+            .execution_order()
+            .expect("valid plan should have execution order");
+
+        assert_eq!(order[0].id, "phase-1a");
+        assert_eq!(order[1].id, "phase-1b");
+    }
+
+    #[test]
+    fn next_actionable_returns_pending_stories_with_merged_dependencies() {
+        let plan = sample_plan();
+
+        let actionable = plan.next_actionable();
+
+        assert_eq!(actionable.len(), 1);
+        assert_eq!(actionable[0].id, "phase-1b");
+    }
+
+    #[test]
+    fn scale_signals_require_three_thresholds() {
+        let signals = ScaleSignals {
+            new_modules: 3,
+            new_pub_apis: 6,
+            new_config_sections: 2,
+            new_cli_subcommands: 1,
+            cross_crate_deps: 4,
+            design_doc_pages: 5,
+        };
+
+        assert_eq!(signals.signals_fired(), 3);
+        assert!(signals.is_epic());
+    }
+}

--- a/crates/csa-todo/src/lib.rs
+++ b/crates/csa-todo/src/lib.rs
@@ -25,11 +25,14 @@ use std::path::{Path, PathBuf};
 const METADATA_FILE: &str = "metadata.toml";
 const TODO_MD_FILE: &str = "TODO.md";
 const SPEC_FILE: &str = "spec.toml";
+const EPIC_PLAN_FILE: &str = "epic-plan.toml";
 const LOCK_FILE: &str = ".lock";
 
+pub use epic_plan::{EpicMeta, EpicPlan, ScaleSignals, Story, StoryStatus};
 pub use reference::{ReferenceFile, ReferenceIndex, ReferenceSource};
 pub use spec::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument};
 
+pub mod epic_plan;
 pub mod reference;
 mod spec;
 
@@ -276,6 +279,11 @@ impl TodoManager {
         self.todos_dir.join(timestamp).join(SPEC_FILE)
     }
 
+    /// Return the path to epic-plan.toml for the given plan timestamp.
+    pub fn epic_plan_path(&self, timestamp: &str) -> PathBuf {
+        self.todos_dir.join(timestamp).join(EPIC_PLAN_FILE)
+    }
+
     /// Load spec.toml for a plan when it exists.
     pub fn load_spec(&self, timestamp: &str) -> Result<Option<SpecDocument>> {
         validate_timestamp(timestamp)?;
@@ -290,6 +298,22 @@ impl TodoManager {
         let spec: SpecDocument = toml::from_str(&content)
             .with_context(|| format!("Failed to parse spec: {}", spec_path.display()))?;
         Ok(Some(spec))
+    }
+
+    /// Load epic-plan.toml for a plan when it exists.
+    pub fn load_epic_plan(&self, timestamp: &str) -> Result<Option<EpicPlan>> {
+        validate_timestamp(timestamp)?;
+
+        let epic_plan_path = self.epic_plan_path(timestamp);
+        if !epic_plan_path.exists() {
+            return Ok(None);
+        }
+
+        let content = std::fs::read_to_string(&epic_plan_path)
+            .with_context(|| format!("Failed to read epic plan: {}", epic_plan_path.display()))?;
+        let epic_plan: EpicPlan = toml::from_str(&content)
+            .with_context(|| format!("Failed to parse epic plan: {}", epic_plan_path.display()))?;
+        Ok(Some(epic_plan))
     }
 
     /// Save spec.toml for an existing TODO plan.

--- a/crates/csa-todo/src/lib_ext_tests.rs
+++ b/crates/csa-todo/src/lib_ext_tests.rs
@@ -287,3 +287,60 @@ fn test_save_spec_requires_existing_plan() {
 
     assert!(result.is_err());
 }
+
+// -- epic-plan.toml support ----------------------------------------------
+
+fn sample_epic_plan() -> EpicPlan {
+    EpicPlan {
+        schema_version: 1,
+        epic: EpicMeta {
+            name: "Epic decomposition".to_string(),
+            prefix: "feat/epic".to_string(),
+            summary: "Validate epic-plan persistence.".to_string(),
+        },
+        stories: vec![Story {
+            id: "phase-1a".to_string(),
+            branch: "feat/epic/phase-1a".to_string(),
+            depends_on: Vec::new(),
+            summary: "First story.".to_string(),
+            status: StoryStatus::Pending,
+        }],
+    }
+}
+
+#[test]
+fn test_epic_plan_path_points_to_epic_plan_toml() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+    let path = manager.epic_plan_path("20260211T023000");
+    assert_eq!(
+        path,
+        dir.path().join("20260211T023000").join("epic-plan.toml")
+    );
+}
+
+#[test]
+fn test_load_epic_plan_returns_none_when_missing() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+    let plan = manager.create("Epic Missing", None).unwrap();
+
+    let epic_plan = manager.load_epic_plan(&plan.timestamp).unwrap();
+
+    assert!(epic_plan.is_none());
+}
+
+#[test]
+fn test_load_epic_plan_roundtrip() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+    let plan = manager.create("Epic Roundtrip", None).unwrap();
+    let epic_plan = sample_epic_plan();
+    let content = toml::to_string_pretty(&epic_plan).unwrap();
+
+    std::fs::write(manager.epic_plan_path(&plan.timestamp), content).unwrap();
+    let loaded = manager.load_epic_plan(&plan.timestamp).unwrap();
+
+    assert_eq!(loaded, Some(epic_plan));
+}

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -27,6 +27,21 @@ Light mode flow: Phase 1 (RECON) → Phase 1.5 (LANGUAGE) → Phase 2 (DRAFT) �
 Phase 2.25 (SPEC) → Phase 4 (SAVE) → Phase 4.5 (APPROVE).
 The SAVE step uses the draft TODO directly instead of the revised version.
 
+### Epic Mode
+
+When RECON findings indicate an epic-scale task (>= 3 scale signals),
+the DRAFT phase produces BOTH a summary TODO.md and an `epic-plan.toml`
+with a story dependency graph. Each story is an independent unit of work
+with its own branch (`feat/<epic>/<story>`), own TODO, and own dev2merge run.
+
+Scale signals: new modules (>2), new public APIs (>5), new config sections (>2),
+new CLI subcommands (>1), cross-crate deps (>3), design doc pages (>5).
+
+After mktd completes, use `csa todo epic show` to view the story DAG and
+`csa todo epic next` to see which stories are ready to start.
+
+Each story follows: branch from main -> mktd (story-specific) -> dev2merge -> merge to main.
+
 ## Step 0: Phase 0.5 — Auto Session Discovery
 
 Tool: bash
@@ -273,6 +288,51 @@ Write all TODO descriptions, section headers, and task names in `${STEP_2_OUTPUT
 Technical terms, code snippets, commit scope strings, and executor tags remain in English.
 Pre-assign executors: [Main], [Sub:developer], [Skill:commit], [CSA:tool].
 Every checkbox item MUST include a mechanically verifiable `DONE WHEN:` line.
+
+### Epic Scale Detection
+
+Before drafting, assess whether this task is epic-scale. Count how many of these signals appear in the RECON findings:
+
+1. New crate/module count > 2
+2. New public API surface > 5 new pub fn/trait
+3. New config schema sections > 2
+4. New CLI subcommands > 1
+5. Cross-crate dependency edges > 3
+6. Whitepaper/RFC/design-doc exceeds 5 logical pages
+
+If >= 3 signals fire, this is an EPIC. Produce BOTH:
+(A) A summary TODO.md that lists the epic's stories as checkbox items
+(B) An epic-plan.toml section enclosed in a fenced code block tagged ```epic-plan.toml
+
+The epic-plan.toml MUST follow this schema:
+```toml
+[epic]
+name = "feature-name"
+prefix = "feat/feature-name"
+summary = "One-line description"
+
+[[stories]]
+id = "phase-1"
+branch = "feat/feature-name/phase-1-description"
+depends_on = []
+summary = "What this story delivers"
+
+[[stories]]
+id = "phase-2"
+branch = "feat/feature-name/phase-2-description"
+depends_on = ["phase-1"]
+summary = "What this story delivers"
+```
+
+Each story MUST have:
+- Unique id (short kebab-case, e.g. "phase-1a", "core-types")
+- Branch name under the epic prefix
+- Explicit depends_on (empty array if independent)
+- Summary describing what the story delivers
+
+The summary TODO.md should reference `epic-plan.toml` and list each story as a checkbox item with its branch and dependencies.
+
+If < 3 signals fire, produce a regular TODO.md as before (no epic plan).
 
 ### Output
 
@@ -569,6 +629,16 @@ TODO_TS=$(csa todo create --branch "${CURRENT_BRANCH}" "${LANG_ARGS[@]}" -- "${F
 TODO_PATH=$(csa todo show -t "${TODO_TS}" --path | head -n1) || { echo "csa todo show failed" >&2; exit 1; }
 SPEC_PATH="$(dirname "${TODO_PATH}")/spec.toml"
 printf '%s\n' "${FINAL_TODO}" > "${TODO_PATH}" || { echo "write TODO failed" >&2; exit 1; }
+# Extract and save epic-plan.toml if present in FINAL_TODO
+EPIC_PLAN=$(printf '%s\n' "${FINAL_TODO}" | sed -n '/^```epic-plan.toml$/,/^```$/p' | sed '1d;$d')
+if [[ -n "${EPIC_PLAN:-}" ]]; then
+  EPIC_PATH="$(dirname "${TODO_PATH}")/epic-plan.toml"
+  printf '%s\n' "${EPIC_PLAN}" > "${EPIC_PATH}" || { echo "write epic-plan.toml failed" >&2; exit 1; }
+  [[ -s "${EPIC_PATH}" ]] || { echo "saved epic-plan.toml is empty" >&2; exit 1; }
+  # Validate via csa todo epic validate
+  csa todo epic validate -t "${TODO_TS}" 2>&1 || { echo "epic-plan.toml validation failed" >&2; exit 1; }
+  echo "Epic plan saved and validated" >&2
+fi
 SPEC_CONTENT="${STEP_8_OUTPUT//__PLAN_ID__/${TODO_TS}}"
 printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_PATH}" || { echo "write spec failed" >&2; exit 1; }
 [[ -s "${TODO_PATH}" ]] || { echo "saved TODO is empty" >&2; exit 1; }

--- a/patterns/mktd/skills/mktd/SKILL.md
+++ b/patterns/mktd/skills/mktd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mktd
-description: "Use when: creating TODO plan with debate-enhanced CSA reconnaissance"
+description: "Use when: creating TODO plan with debate-enhanced CSA reconnaissance, including epic decomposition for large tasks"
 allowed-tools: Bash, Read, Grep, Glob, Write, Edit
 triggers:
   - "mktd"
@@ -30,7 +30,7 @@ Treat the run as executor ONLY when initial prompt contains:
 
 ## Purpose
 
-Generate a structured TODO plan for a feature through five phases: parallel CSA reconnaissance (structure, patterns, constraints, semantic invariants), draft synthesis, security threat model, mandatory adversarial debate review, and user approval gate. The main agent performs zero file reads during exploration -- CSA sub-agents gather all context. Plans are saved via `csa todo` for git-tracked lifecycle management.
+Generate a structured TODO plan for a feature through five phases: parallel CSA reconnaissance (structure, patterns, constraints, semantic invariants), draft synthesis, security threat model, mandatory adversarial debate review, and user approval gate. The main agent performs zero file reads during exploration -- CSA sub-agents gather all context. Plans are saved via `csa todo` for git-tracked lifecycle management. Epic-scale tasks are decomposed into summary TODO stories plus an `epic-plan.toml` dependency graph.
 
 ## Intensity Modes
 

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -21,6 +21,9 @@ name = "DEBATE_PROMPT"
 name = "FINAL_TODO"
 
 [[workflow.variables]]
+name = "EPIC_PLAN"
+
+[[workflow.variables]]
 name = "FEATURE"
 
 [[workflow.variables]]
@@ -320,6 +323,51 @@ Technical terms, code snippets, commit scope strings, and executor tags remain i
 Pre-assign executors: [Main], [Sub:developer], [Skill:commit], [CSA:tool].
 Every checkbox item MUST include a mechanically verifiable `DONE WHEN:` line.
 
+### Epic Scale Detection
+
+Before drafting, assess whether this task is epic-scale. Count how many of these signals appear in the RECON findings:
+
+1. New crate/module count > 2
+2. New public API surface > 5 new pub fn/trait
+3. New config schema sections > 2
+4. New CLI subcommands > 1
+5. Cross-crate dependency edges > 3
+6. Whitepaper/RFC/design-doc exceeds 5 logical pages
+
+If >= 3 signals fire, this is an EPIC. Produce BOTH:
+(A) A summary TODO.md that lists the epic's stories as checkbox items
+(B) An epic-plan.toml section enclosed in a fenced code block tagged ```epic-plan.toml
+
+The epic-plan.toml MUST follow this schema:
+```toml
+[epic]
+name = "feature-name"
+prefix = "feat/feature-name"
+summary = "One-line description"
+
+[[stories]]
+id = "phase-1"
+branch = "feat/feature-name/phase-1-description"
+depends_on = []
+summary = "What this story delivers"
+
+[[stories]]
+id = "phase-2"
+branch = "feat/feature-name/phase-2-description"
+depends_on = ["phase-1"]
+summary = "What this story delivers"
+```
+
+Each story MUST have:
+- Unique id (short kebab-case, e.g. "phase-1a", "core-types")
+- Branch name under the epic prefix
+- Explicit depends_on (empty array if independent)
+- Summary describing what the story delivers
+
+The summary TODO.md should reference `epic-plan.toml` and list each story as a checkbox item with its branch and dependencies.
+
+If < 3 signals fire, produce a regular TODO.md as before (no epic plan).
+
 ### Output
 
 Output the COMPLETE TODO plan as text to stdout.
@@ -611,6 +659,16 @@ TODO_TS=$(csa todo create --branch "${CURRENT_BRANCH}" "${LANG_ARGS[@]}" -- "${F
 TODO_PATH=$(csa todo show -t "${TODO_TS}" --path | head -n1) || { echo "csa todo show failed" >&2; exit 1; }
 SPEC_PATH="$(dirname "${TODO_PATH}")/spec.toml"
 printf '%s\n' "${FINAL_TODO}" > "${TODO_PATH}" || { echo "write TODO failed" >&2; exit 1; }
+# Extract and save epic-plan.toml if present in FINAL_TODO
+EPIC_PLAN=$(printf '%s\n' "${FINAL_TODO}" | sed -n '/^```epic-plan.toml$/,/^```$/p' | sed '1d;$d')
+if [[ -n "${EPIC_PLAN:-}" ]]; then
+  EPIC_PATH="$(dirname "${TODO_PATH}")/epic-plan.toml"
+  printf '%s\n' "${EPIC_PLAN}" > "${EPIC_PATH}" || { echo "write epic-plan.toml failed" >&2; exit 1; }
+  [[ -s "${EPIC_PATH}" ]] || { echo "saved epic-plan.toml is empty" >&2; exit 1; }
+  # Validate via csa todo epic validate
+  csa todo epic validate -t "${TODO_TS}" 2>&1 || { echo "epic-plan.toml validation failed" >&2; exit 1; }
+  echo "Epic plan saved and validated" >&2
+fi
 SPEC_CONTENT="${STEP_8_OUTPUT//__PLAN_ID__/${TODO_TS}}"
 printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_PATH}" || { echo "write spec failed" >&2; exit 1; }
 [[ -s "${TODO_PATH}" ]] || { echo "saved TODO is empty" >&2; exit 1; }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.608"
-weave = "0.1.608"
+csa = "0.1.612"
+weave = "0.1.612"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- **Phase A** (`epic_plan.rs`): `EpicPlan`/`Story`/`StoryStatus` types with TOML serde, DAG validation via existing `DependencyGraph`, topological sort, `next_actionable()` for ready stories, `ScaleSignals` heuristic (≥3 signals → epic)
- **Phase A** (CLI): `csa todo epic show|validate|next` subcommands with terminal/mermaid/dot/json output
- **Phase B** (mktd pattern): Scale detection instructions in DRAFT step, `epic-plan.toml` extraction + validation in Save step, epic mode documentation

Fixes #1197

## Test plan
- [x] `cargo test -p csa-todo` — all 167 tests pass (TOML roundtrip, DAG validation, cycle detection, scale signals)
- [x] `cargo clippy --workspace` clean
- [x] `just pre-commit` — 31/31 tests pass
- [ ] `csa todo epic show` displays epic plan with DAG
- [ ] `csa todo epic validate` rejects cycles + unknown deps
- [ ] `csa todo epic next` shows actionable stories
- [ ] mktd on large task produces `epic-plan.toml`
- [ ] mktd on small task produces only `TODO.md` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)