### PR TITLE
feat(review): add checklist notebook — persistent review state + CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,6 +953,7 @@ dependencies = [
  "csa-process",
  "csa-resource",
  "data-encoding",
+ "fd-lock",
  "regex",
  "serde",
  "serde_json",
@@ -967,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.612"
+version = "0.1.613"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.612"
+version = "0.1.613"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/checklist_cmd.rs
+++ b/crates/cli-sub-agent/src/checklist_cmd.rs
@@ -1,0 +1,358 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use crate::cli::ChecklistCommands;
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use csa_core::checklist::{CheckStatus, ChecklistDocument, ChecklistItem, ChecklistMeta};
+use csa_session::ChecklistStore;
+
+pub(crate) fn handle_checklist_command(command: ChecklistCommands) -> Result<()> {
+    match command {
+        ChecklistCommands::Show { cd, branch } => handle_checklist_show(cd, branch),
+        ChecklistCommands::Check {
+            id,
+            evidence,
+            reviewer,
+            cd,
+            branch,
+        } => handle_checklist_check(id, evidence, reviewer, cd, branch),
+        ChecklistCommands::Reset { id, cd, branch } => handle_checklist_reset(id, cd, branch),
+        ChecklistCommands::Generate {
+            profile,
+            scope,
+            cd,
+            branch,
+        } => handle_checklist_generate(profile, scope, cd, branch),
+        ChecklistCommands::List { cd } => handle_checklist_list(cd),
+    }
+}
+
+pub(crate) fn handle_checklist_show(cd: Option<String>, branch: Option<String>) -> Result<()> {
+    let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+    let branch = resolve_branch(&project_root, branch)?;
+    let store = ChecklistStore::new()?;
+    let Some(doc) = store.load(&project_root, &branch)? else {
+        println!("No checklist for branch '{branch}'.");
+        println!(
+            "Run `csa checklist generate --branch {}` to create one.",
+            shell_words_safe(&branch)
+        );
+        return Ok(());
+    };
+
+    print_document(&doc);
+    Ok(())
+}
+
+pub(crate) fn handle_checklist_check(
+    id: String,
+    evidence: String,
+    reviewer: Option<String>,
+    cd: Option<String>,
+    branch: Option<String>,
+) -> Result<()> {
+    let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+    let branch = resolve_branch(&project_root, branch)?;
+    let reviewer = reviewer
+        .or_else(|| std::env::var("CSA_TOOL").ok())
+        .or_else(|| std::env::var("USER").ok())
+        .unwrap_or_else(|| "unknown".to_string());
+    ChecklistStore::new()?.check_item(&project_root, &branch, &id, &evidence, &reviewer)?;
+    println!("Checked {id}");
+    Ok(())
+}
+
+pub(crate) fn handle_checklist_reset(
+    id: String,
+    cd: Option<String>,
+    branch: Option<String>,
+) -> Result<()> {
+    let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+    let branch = resolve_branch(&project_root, branch)?;
+    ChecklistStore::new()?.reset_item(&project_root, &branch, &id)?;
+    println!("Reset {id}");
+    Ok(())
+}
+
+pub(crate) fn handle_checklist_generate(
+    profile: Option<String>,
+    scope: Option<String>,
+    cd: Option<String>,
+    branch: Option<String>,
+) -> Result<()> {
+    let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+    let branch = resolve_branch(&project_root, branch)?;
+    let profile = profile.unwrap_or_else(|| "rust".to_string());
+    let criteria = generate_criteria(&project_root, &profile)?;
+    let doc = ChecklistDocument {
+        meta: ChecklistMeta {
+            project_root: project_root.display().to_string(),
+            branch: branch.clone(),
+            created_at: Utc::now().to_rfc3339(),
+            scope: scope.unwrap_or_default(),
+            profile,
+        },
+        criteria,
+    };
+
+    let store = ChecklistStore::new()?;
+    store.save(&project_root, &branch, &doc)?;
+    println!(
+        "Generated {} checklist criteria at {}",
+        doc.criteria.len(),
+        store.checklist_path(&project_root, &branch).display()
+    );
+    Ok(())
+}
+
+pub(crate) fn handle_checklist_list(cd: Option<String>) -> Result<()> {
+    let store = ChecklistStore::new()?;
+    if let Some(cd) = cd {
+        let project_root = crate::pipeline::determine_project_root(Some(&cd))?;
+        let project_dir = store.project_dir(&project_root);
+        print_project_checklists(&project_dir)?;
+        return Ok(());
+    }
+
+    let project_dirs = store.list_projects()?;
+    if project_dirs.is_empty() {
+        println!("No active checklists.");
+        return Ok(());
+    }
+    for project_dir in project_dirs {
+        print_project_checklists(&project_dir)?;
+    }
+    Ok(())
+}
+
+fn print_project_checklists(project_dir: &Path) -> Result<()> {
+    for checklist_path in find_checklist_paths(project_dir)? {
+        print_checklist_summary(&checklist_path)?;
+    }
+    Ok(())
+}
+
+fn find_checklist_paths(project_dir: &Path) -> Result<Vec<std::path::PathBuf>> {
+    let mut stack = vec![project_dir.to_path_buf()];
+    let mut checklists = Vec::new();
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("Failed to read checklist project dir: {}", dir.display())
+                });
+            }
+        };
+        for entry in entries {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+            let path = entry.path();
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if entry.file_name() == "checklist.toml" {
+                checklists.push(path);
+            }
+        }
+    }
+    checklists.sort();
+    Ok(checklists)
+}
+
+fn print_checklist_summary(checklist_path: &Path) -> Result<()> {
+    let content = fs::read_to_string(checklist_path)
+        .with_context(|| format!("Failed to read checklist: {}", checklist_path.display()))?;
+    let doc: ChecklistDocument = toml::from_str(&content)
+        .with_context(|| format!("Failed to parse checklist: {}", checklist_path.display()))?;
+    let summary = doc.summary();
+    println!(
+        "{} {} checked={} unchecked={} failed={} na={}",
+        doc.meta.project_root,
+        doc.meta.branch,
+        summary.checked,
+        summary.unchecked,
+        summary.failed,
+        summary.not_applicable
+    );
+    Ok(())
+}
+
+fn print_document(doc: &ChecklistDocument) {
+    let summary = doc.summary();
+    println!("project: {}", doc.meta.project_root);
+    println!("branch: {}", doc.meta.branch);
+    println!("profile: {}", doc.meta.profile);
+    if !doc.meta.scope.is_empty() {
+        println!("scope: {}", doc.meta.scope);
+    }
+    println!(
+        "summary: checked={} unchecked={} failed={} na={} all_checked={}",
+        summary.checked,
+        summary.unchecked,
+        summary.failed,
+        summary.not_applicable,
+        doc.all_checked()
+    );
+    for item in &doc.criteria {
+        println!(
+            "- [{}] {} ({}) {}",
+            status_label(item.status),
+            item.id,
+            item.source,
+            item.description
+        );
+        if !item.evidence.is_empty() {
+            println!("  evidence: {}", item.evidence);
+        }
+        if !item.reviewer.is_empty() {
+            println!("  reviewer: {}", item.reviewer);
+        }
+    }
+}
+
+fn status_label(status: CheckStatus) -> &'static str {
+    match status {
+        CheckStatus::Unchecked => "unchecked",
+        CheckStatus::Checked => "checked",
+        CheckStatus::Failed => "failed",
+        CheckStatus::NotApplicable => "na",
+    }
+}
+
+fn resolve_branch(project_root: &Path, branch: Option<String>) -> Result<String> {
+    if let Some(branch) = branch {
+        if branch.trim().is_empty() {
+            bail!("branch cannot be empty");
+        }
+        return Ok(branch);
+    }
+    let output = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(project_root)
+        .output()
+        .with_context(|| format!("Failed to detect git branch in {}", project_root.display()))?;
+    if !output.status.success() {
+        bail!("Failed to detect git branch in {}", project_root.display());
+    }
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if branch.is_empty() {
+        bail!("Current checkout is detached; pass --branch explicitly");
+    }
+    Ok(branch)
+}
+
+fn generate_criteria(project_root: &Path, profile: &str) -> Result<Vec<ChecklistItem>> {
+    let agents_path = project_root.join("AGENTS.md");
+    let content = fs::read_to_string(&agents_path)
+        .with_context(|| format!("Failed to read {}", agents_path.display()))?;
+    let sections = sections_for_profile(profile);
+    let mut current_section = String::new();
+    let mut criteria = Vec::new();
+
+    for line in content.lines() {
+        if let Some(section) = line.strip_prefix("## ") {
+            current_section = section.trim().to_string();
+            continue;
+        }
+        if !sections.iter().any(|section| *section == current_section) {
+            continue;
+        }
+        let Some(item) = parse_rule_line(&current_section, line) else {
+            continue;
+        };
+        criteria.push(item);
+    }
+
+    if criteria.is_empty() {
+        bail!(
+            "No checklist criteria found in {} for profile '{}'",
+            agents_path.display(),
+            profile
+        );
+    }
+    Ok(criteria)
+}
+
+fn sections_for_profile(profile: &str) -> Vec<&'static str> {
+    let mut sections = vec!["Meta (Agent Behavior)", "Design", "Practice"];
+    match profile.to_ascii_lowercase().as_str() {
+        "rust" => sections.push("Rust"),
+        "python" => sections.push("Python"),
+        "go" => sections.push("Go"),
+        "node" | "typescript" | "ts" => sections.push("TypeScript"),
+        "mixed" | "all" => sections.extend(["Rust", "Go", "Python", "TypeScript", "gRPC / Proto"]),
+        _ => {}
+    }
+    sections
+}
+
+fn parse_rule_line(section: &str, line: &str) -> Option<ChecklistItem> {
+    let trimmed = line.trim();
+    let (id, rest) = trimmed.split_once('|')?;
+    let id = id.trim();
+    if id.len() != 3 || !id.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let (name, summary) = rest.split_once('|')?;
+    let section_slug = section
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    let rule_name = name.trim();
+    let item_id = format!("{section_slug}-{id}-{rule_name}");
+    Some(ChecklistItem {
+        id: item_id,
+        source: format!("{section} {id}|{rule_name}"),
+        description: summary.trim().to_string(),
+        status: CheckStatus::Unchecked,
+        evidence: String::new(),
+        reviewer: String::new(),
+        checked_at: String::new(),
+    })
+}
+
+fn shell_words_safe(value: &str) -> String {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '/' | '.'))
+    {
+        value.to_string()
+    } else {
+        format!("{value:?}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_rule_line, sections_for_profile};
+
+    #[test]
+    fn parse_rule_line_extracts_checklist_item() {
+        let item = parse_rule_line(
+            "Rust",
+            "002|error-handling|NEVER unwrap() in library, propagate with ?",
+        )
+        .expect("rule parsed");
+
+        assert_eq!(item.id, "rust-002-error-handling");
+        assert_eq!(item.source, "Rust 002|error-handling");
+        assert_eq!(
+            item.description,
+            "NEVER unwrap() in library, propagate with ?"
+        );
+    }
+
+    #[test]
+    fn rust_profile_includes_shared_and_rust_sections() {
+        let sections = sections_for_profile("rust");
+        assert!(sections.contains(&"Meta (Agent Behavior)"));
+        assert!(sections.contains(&"Design"));
+        assert!(sections.contains(&"Practice"));
+        assert!(sections.contains(&"Rust"));
+        assert!(!sections.contains(&"Python"));
+    }
+}

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -25,6 +25,9 @@ pub use cli_xurl::*;
 #[path = "cli_plan.rs"]
 mod cli_plan;
 pub use cli_plan::*;
+#[path = "cli_checklist.rs"]
+mod cli_checklist;
+pub use cli_checklist::*;
 
 /// Build version string combining Cargo.toml version and git describe.
 fn build_version() -> &'static str {
@@ -375,6 +378,12 @@ pub enum Commands {
     Todo {
         #[command(subcommand)]
         cmd: TodoCommands,
+    },
+
+    /// Review checklist management
+    Checklist {
+        #[command(subcommand)]
+        command: ChecklistCommands,
     },
 
     /// Execute weave workflow files

--- a/crates/cli-sub-agent/src/cli_checklist.rs
+++ b/crates/cli-sub-agent/src/cli_checklist.rs
@@ -1,0 +1,54 @@
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum ChecklistCommands {
+    /// Show current branch's review checklist
+    Show {
+        #[arg(long)]
+        cd: Option<String>,
+        #[arg(short, long)]
+        branch: Option<String>,
+    },
+    /// Check a criterion (mark as passed with evidence)
+    Check {
+        /// Criterion ID to check
+        id: String,
+        /// Evidence supporting the check
+        #[arg(long)]
+        evidence: String,
+        /// Reviewer name/model
+        #[arg(long)]
+        reviewer: Option<String>,
+        #[arg(long)]
+        cd: Option<String>,
+        #[arg(short, long)]
+        branch: Option<String>,
+    },
+    /// Reset a criterion back to unchecked
+    Reset {
+        /// Criterion ID to reset
+        id: String,
+        #[arg(long)]
+        cd: Option<String>,
+        #[arg(short, long)]
+        branch: Option<String>,
+    },
+    /// Generate a checklist from AGENTS.md rules for the current profile
+    Generate {
+        /// Project profile (rust, node, python, go, mixed)
+        #[arg(long)]
+        profile: Option<String>,
+        /// Diff scope (e.g., base:main)
+        #[arg(long)]
+        scope: Option<String>,
+        #[arg(long)]
+        cd: Option<String>,
+        #[arg(short, long)]
+        branch: Option<String>,
+    },
+    /// List all active checklists
+    List {
+        #[arg(long)]
+        cd: Option<String>,
+    },
+}

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -8,6 +8,7 @@ mod audit_cmds;
 mod batch;
 mod bug_class;
 mod caller_hints_tests;
+mod checklist_cmd;
 mod claude_sub_agent_cmd;
 mod cli;
 mod config_cmds;
@@ -755,6 +756,7 @@ async fn run() -> Result<()> {
                 }
             },
         },
+        Commands::Checklist { command } => checklist_cmd::handle_checklist_command(command)?,
         Commands::Plan { cmd } => {
             plan_cmd_daemon::dispatch(
                 cmd,

--- a/crates/csa-core/src/checklist.rs
+++ b/crates/csa-core/src/checklist.rs
@@ -1,0 +1,157 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckStatus {
+    #[default]
+    Unchecked,
+    Checked,
+    Failed,
+    #[serde(rename = "na")]
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChecklistItem {
+    pub id: String,
+    pub source: String,
+    pub description: String,
+    #[serde(default)]
+    pub status: CheckStatus,
+    #[serde(default)]
+    pub evidence: String,
+    #[serde(default)]
+    pub reviewer: String,
+    #[serde(default)]
+    pub checked_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChecklistMeta {
+    pub project_root: String,
+    pub branch: String,
+    pub created_at: String,
+    #[serde(default)]
+    pub scope: String,
+    #[serde(default)]
+    pub profile: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChecklistDocument {
+    pub meta: ChecklistMeta,
+    #[serde(default)]
+    pub criteria: Vec<ChecklistItem>,
+}
+
+impl ChecklistDocument {
+    pub fn all_checked(&self) -> bool {
+        self.criteria
+            .iter()
+            .all(|c| matches!(c.status, CheckStatus::Checked | CheckStatus::NotApplicable))
+    }
+
+    pub fn summary(&self) -> ChecklistSummary {
+        let mut s = ChecklistSummary::default();
+        for c in &self.criteria {
+            match c.status {
+                CheckStatus::Unchecked => s.unchecked += 1,
+                CheckStatus::Checked => s.checked += 1,
+                CheckStatus::Failed => s.failed += 1,
+                CheckStatus::NotApplicable => s.not_applicable += 1,
+            }
+        }
+        s
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ChecklistSummary {
+    pub unchecked: usize,
+    pub checked: usize,
+    pub failed: usize,
+    pub not_applicable: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CheckStatus, ChecklistDocument, ChecklistItem, ChecklistMeta, ChecklistSummary};
+
+    fn item(id: &str, status: CheckStatus) -> ChecklistItem {
+        ChecklistItem {
+            id: id.to_string(),
+            source: "Rust 002".to_string(),
+            description: "Propagate errors without unwrap".to_string(),
+            status,
+            evidence: String::new(),
+            reviewer: String::new(),
+            checked_at: String::new(),
+        }
+    }
+
+    fn doc(criteria: Vec<ChecklistItem>) -> ChecklistDocument {
+        ChecklistDocument {
+            meta: ChecklistMeta {
+                project_root: "/repo".to_string(),
+                branch: "feature".to_string(),
+                created_at: "2026-04-28T00:00:00Z".to_string(),
+                scope: "base:main".to_string(),
+                profile: "rust".to_string(),
+            },
+            criteria,
+        }
+    }
+
+    #[test]
+    fn all_checked_accepts_checked_and_not_applicable_only() {
+        assert!(
+            doc(vec![
+                item("a", CheckStatus::Checked),
+                item("b", CheckStatus::NotApplicable),
+            ])
+            .all_checked()
+        );
+
+        assert!(
+            !doc(vec![
+                item("a", CheckStatus::Checked),
+                item("b", CheckStatus::Unchecked),
+            ])
+            .all_checked()
+        );
+
+        assert!(!doc(vec![item("a", CheckStatus::Failed)]).all_checked());
+    }
+
+    #[test]
+    fn summary_counts_each_status() {
+        let summary = doc(vec![
+            item("a", CheckStatus::Unchecked),
+            item("b", CheckStatus::Checked),
+            item("c", CheckStatus::Failed),
+            item("d", CheckStatus::NotApplicable),
+            item("e", CheckStatus::Checked),
+        ])
+        .summary();
+
+        assert_eq!(
+            summary,
+            ChecklistSummary {
+                unchecked: 1,
+                checked: 2,
+                failed: 1,
+                not_applicable: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn toml_roundtrip_preserves_document() {
+        let original = doc(vec![item("rust-002", CheckStatus::Checked)]);
+        let encoded = toml::to_string_pretty(&original).expect("serialize checklist");
+        assert!(encoded.contains("status = \"checked\""));
+
+        let decoded: ChecklistDocument = toml::from_str(&encoded).expect("deserialize checklist");
+        assert_eq!(decoded, original);
+    }
+}

--- a/crates/csa-core/src/lib.rs
+++ b/crates/csa-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audit;
+pub mod checklist;
 pub mod consensus;
 pub mod env;
 pub mod error;

--- a/crates/csa-session/Cargo.toml
+++ b/crates/csa-session/Cargo.toml
@@ -12,6 +12,7 @@ csa-process.workspace = true
 csa-resource.workspace = true
 csa-lock.workspace = true
 csa-config.workspace = true
+fd-lock.workspace = true
 toml.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/csa-session/src/checklist_store.rs
+++ b/crates/csa-session/src/checklist_store.rs
@@ -1,0 +1,328 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use csa_core::checklist::{CheckStatus, ChecklistDocument};
+use fd_lock::RwLock;
+use sha2::{Digest, Sha256};
+
+pub struct ChecklistStore {
+    base_dir: PathBuf,
+}
+
+impl ChecklistStore {
+    pub fn new() -> Result<Self> {
+        let state_dir =
+            csa_config::paths::state_dir_write().context("Failed to determine state directory")?;
+        Ok(Self {
+            base_dir: state_dir.join("checklists"),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_base_dir(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+
+    pub fn project_dir(&self, project_root: &Path) -> PathBuf {
+        self.base_dir.join(project_hash(project_root))
+    }
+
+    pub fn branch_dir(&self, project_root: &Path, branch: &str) -> PathBuf {
+        self.project_dir(project_root)
+            .join(branch_storage_path(branch))
+    }
+
+    pub fn checklist_path(&self, project_root: &Path, branch: &str) -> PathBuf {
+        self.branch_dir(project_root, branch).join("checklist.toml")
+    }
+
+    pub fn load(&self, project_root: &Path, branch: &str) -> Result<Option<ChecklistDocument>> {
+        let branch_dir = self.branch_dir(project_root, branch);
+        let lock_path = branch_dir.join("checklist.lock");
+        let checklist_path = branch_dir.join("checklist.toml");
+        if !checklist_path.exists() {
+            return Ok(None);
+        }
+
+        fs::create_dir_all(&branch_dir)
+            .with_context(|| format!("Failed to create checklist dir: {}", branch_dir.display()))?;
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("Failed to open checklist lock: {}", lock_path.display()))?;
+        let mut lock = RwLock::new(lock_file);
+        let _guard = lock
+            .write()
+            .with_context(|| format!("Failed to lock checklist file: {}", lock_path.display()))?;
+
+        read_document(&checklist_path).map(Some)
+    }
+
+    pub fn save(&self, project_root: &Path, branch: &str, doc: &ChecklistDocument) -> Result<()> {
+        let branch_dir = self.branch_dir(project_root, branch);
+        fs::create_dir_all(&branch_dir)
+            .with_context(|| format!("Failed to create checklist dir: {}", branch_dir.display()))?;
+        let lock_path = branch_dir.join("checklist.lock");
+        let checklist_path = branch_dir.join("checklist.toml");
+
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("Failed to open checklist lock: {}", lock_path.display()))?;
+        let mut lock = RwLock::new(lock_file);
+        let _guard = lock
+            .write()
+            .with_context(|| format!("Failed to lock checklist file: {}", lock_path.display()))?;
+
+        write_document(&checklist_path, doc)
+    }
+
+    pub fn check_item(
+        &self,
+        project_root: &Path,
+        branch: &str,
+        item_id: &str,
+        evidence: &str,
+        reviewer: &str,
+    ) -> Result<()> {
+        self.update_item(project_root, branch, item_id, |item| {
+            item.status = CheckStatus::Checked;
+            item.evidence = evidence.to_string();
+            item.reviewer = reviewer.to_string();
+            item.checked_at = chrono::Utc::now().to_rfc3339();
+        })
+    }
+
+    pub fn reset_item(&self, project_root: &Path, branch: &str, item_id: &str) -> Result<()> {
+        self.update_item(project_root, branch, item_id, |item| {
+            item.status = CheckStatus::Unchecked;
+            item.evidence.clear();
+            item.reviewer.clear();
+            item.checked_at.clear();
+        })
+    }
+
+    pub fn list_projects(&self) -> Result<Vec<PathBuf>> {
+        let entries = match fs::read_dir(&self.base_dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("Failed to read checklist dir: {}", self.base_dir.display())
+                });
+            }
+        };
+
+        let mut projects = Vec::new();
+        for entry in entries {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                projects.push(entry.path());
+            }
+        }
+        projects.sort();
+        Ok(projects)
+    }
+
+    fn update_item<F>(
+        &self,
+        project_root: &Path,
+        branch: &str,
+        item_id: &str,
+        update: F,
+    ) -> Result<()>
+    where
+        F: FnOnce(&mut csa_core::checklist::ChecklistItem),
+    {
+        let branch_dir = self.branch_dir(project_root, branch);
+        fs::create_dir_all(&branch_dir)
+            .with_context(|| format!("Failed to create checklist dir: {}", branch_dir.display()))?;
+        let lock_path = branch_dir.join("checklist.lock");
+        let checklist_path = branch_dir.join("checklist.toml");
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("Failed to open checklist lock: {}", lock_path.display()))?;
+        let mut lock = RwLock::new(lock_file);
+        let _guard = lock
+            .write()
+            .with_context(|| format!("Failed to lock checklist file: {}", lock_path.display()))?;
+
+        let mut doc = read_document(&checklist_path)?;
+        let Some(item) = doc.criteria.iter_mut().find(|item| item.id == item_id) else {
+            bail!("Checklist criterion not found: {item_id}");
+        };
+        update(item);
+        write_document(&checklist_path, &doc)
+    }
+}
+
+fn project_hash(project_root: &Path) -> String {
+    let normalized = fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(normalized.to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    digest[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn branch_storage_path(branch: &str) -> PathBuf {
+    let mut path = PathBuf::new();
+    for segment in branch.replace('\\', "/").split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            path.push("_");
+        } else {
+            path.push(segment);
+        }
+    }
+    if path.as_os_str().is_empty() {
+        path.push("_");
+    }
+    path
+}
+
+fn read_document(path: &Path) -> Result<ChecklistDocument> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read checklist: {}", path.display()))?;
+    toml::from_str(&content)
+        .with_context(|| format!("Failed to parse checklist: {}", path.display()))
+}
+
+fn write_document(path: &Path, doc: &ChecklistDocument) -> Result<()> {
+    let content = toml::to_string_pretty(doc).context("Failed to serialize checklist")?;
+    let tmp_path = path.with_extension("toml.tmp");
+    {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp_path)
+            .with_context(|| {
+                format!("Failed to open checklist temp file: {}", tmp_path.display())
+            })?;
+        file.write_all(content.as_bytes()).with_context(|| {
+            format!(
+                "Failed to write checklist temp file: {}",
+                tmp_path.display()
+            )
+        })?;
+        file.sync_all().with_context(|| {
+            format!("Failed to sync checklist temp file: {}", tmp_path.display())
+        })?;
+    }
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "Failed to replace checklist {} with {}",
+            path.display(),
+            tmp_path.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChecklistStore;
+    use csa_core::checklist::{
+        CheckStatus, ChecklistDocument, ChecklistItem, ChecklistMeta, ChecklistSummary,
+    };
+    use tempfile::TempDir;
+
+    fn document(project_root: &str, branch: &str) -> ChecklistDocument {
+        ChecklistDocument {
+            meta: ChecklistMeta {
+                project_root: project_root.to_string(),
+                branch: branch.to_string(),
+                created_at: "2026-04-28T00:00:00Z".to_string(),
+                scope: "base:main".to_string(),
+                profile: "rust".to_string(),
+            },
+            criteria: vec![ChecklistItem {
+                id: "rust-002".to_string(),
+                source: "Rust 002".to_string(),
+                description: "Errors propagate without unwrap".to_string(),
+                status: CheckStatus::Unchecked,
+                evidence: String::new(),
+                reviewer: String::new(),
+                checked_at: String::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn save_load_roundtrip() {
+        let tmp = TempDir::new().expect("tempdir");
+        let store = ChecklistStore::with_base_dir(tmp.path().join("checklists"));
+        let doc = document(tmp.path().to_str().expect("utf8 path"), "feature");
+
+        store.save(tmp.path(), "feature", &doc).expect("save");
+        let loaded = store.load(tmp.path(), "feature").expect("load");
+
+        assert_eq!(loaded, Some(doc));
+    }
+
+    #[test]
+    fn check_and_reset_item_update_document() {
+        let tmp = TempDir::new().expect("tempdir");
+        let store = ChecklistStore::with_base_dir(tmp.path().join("checklists"));
+        let doc = document(tmp.path().to_str().expect("utf8 path"), "feature");
+        store.save(tmp.path(), "feature", &doc).expect("save");
+
+        store
+            .check_item(tmp.path(), "feature", "rust-002", "cargo test", "codex")
+            .expect("check item");
+        let checked = store
+            .load(tmp.path(), "feature")
+            .expect("load")
+            .expect("document exists");
+        assert_eq!(
+            checked.summary(),
+            ChecklistSummary {
+                unchecked: 0,
+                checked: 1,
+                failed: 0,
+                not_applicable: 0,
+            }
+        );
+        assert_eq!(checked.criteria[0].evidence, "cargo test");
+        assert_eq!(checked.criteria[0].reviewer, "codex");
+        assert!(!checked.criteria[0].checked_at.is_empty());
+
+        store
+            .reset_item(tmp.path(), "feature", "rust-002")
+            .expect("reset item");
+        let reset = store
+            .load(tmp.path(), "feature")
+            .expect("load")
+            .expect("document exists");
+        assert_eq!(reset.criteria[0].status, CheckStatus::Unchecked);
+        assert!(reset.criteria[0].evidence.is_empty());
+        assert!(reset.criteria[0].reviewer.is_empty());
+        assert!(reset.criteria[0].checked_at.is_empty());
+    }
+
+    #[test]
+    fn branch_dir_preserves_slash_branches_without_path_traversal() {
+        let tmp = TempDir::new().expect("tempdir");
+        let store = ChecklistStore::with_base_dir(tmp.path().join("checklists"));
+
+        let slash_branch = store.branch_dir(tmp.path(), "feat/1199-review-checklist-notebook");
+        assert!(slash_branch.ends_with("feat/1199-review-checklist-notebook"));
+
+        let traversal_branch = store.branch_dir(tmp.path(), "../outside");
+        assert!(traversal_branch.starts_with(store.project_dir(tmp.path())));
+        assert!(traversal_branch.ends_with("_/outside"));
+    }
+}

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -1,6 +1,7 @@
 //! Session management with ULID-based genealogy tracking.
 
 pub mod adjudication;
+pub mod checklist_store;
 pub mod checkpoint;
 pub mod cooldown;
 pub mod event_writer;
@@ -49,6 +50,7 @@ pub use cooldown::{
 
 // Re-export key types
 pub use adjudication::{AdjudicationRecord, AdjudicationSet, Verdict};
+pub use checklist_store::ChecklistStore;
 pub use state::{
     ContextStatus, Genealogy, MetaSessionState, PhaseEvent, ReviewSessionMeta, SandboxInfo,
     SessionPhase, TaskContext, TokenUsage, ToolState, write_review_meta,


### PR DESCRIPTION
## Summary
- **csa-core**: `ChecklistItem`, `ChecklistDocument`, `CheckStatus` (unchecked/checked/failed/na), `ChecklistSummary`, `all_checked()` gate
- **csa-session**: `ChecklistStore` with flock-based atomic reads/writes, project-hash isolation, auto-location from project root + branch
- **CLI**: `csa checklist show|check|reset|generate|list` subcommands for managing review checklists

The checklist persists at `~/.local/state/cli-sub-agent/checklists/<project_hash>/<branch>/checklist.toml` and tracks which review criteria were checked, by whom, with evidence.

Phase B (on-demand dimension loading, profile-specific dimension files) will follow as an incremental improvement.

Fixes #1199

## Test plan
- [x] `cargo test -p csa-core checklist` — 3 tests pass (TOML roundtrip, all_checked, summary)
- [x] `cargo test -p csa-session checklist` — 3 tests pass (store save/load/check_item)
- [x] `cargo clippy --workspace` clean
- [ ] `csa checklist generate` produces initial checklist
- [ ] `csa checklist check <id> --evidence "..."` atomically updates item under flock
- [ ] `csa checklist show` displays checklist with status

🤖 Generated with [Claude Code](https://claude.com/claude-code)