### PR TITLE
fix(run): cache VCS probes in run loop + robust JJ trunk parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "chrono",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "chrono",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "axum",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "chrono",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "chrono",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.613"
+version = "0.1.614"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.613"
+version = "0.1.614"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -145,6 +145,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
     let mut is_auto_seed_fork = request.is_auto_seed_fork;
     let mut session_arg = request.session_arg;
     let mut effective_session_arg = request.effective_session_arg;
+    let mut vcs_probe_cache = crate::run_helpers_branch_guard::VcsProbeCache::default();
     let enforce_tier =
         !request.force && !request.force_ignore_tier_setting && !request.user_model_spec_explicit;
     let result = loop {
@@ -313,9 +314,10 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             }
         }
 
-        let branch_state = crate::run_helpers_branch_guard::observe_branch_state(
+        let branch_state = crate::run_helpers_branch_guard::observe_branch_state_with_cache(
             request.project_root,
             request.config,
+            Some(&mut vcs_probe_cache),
         );
         if let Some(exit_code) = crate::run_helpers_branch_guard::evaluate_and_emit_refusal(
             &request.branch_guard,

--- a/crates/cli-sub-agent/src/run_helpers_branch_guard.rs
+++ b/crates/cli-sub-agent/src/run_helpers_branch_guard.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use csa_config::{GlobalConfig, ProjectConfig};
+use csa_core::vcs::VcsKind;
 
 pub(crate) const BRANCH_GUARD_EXIT_CODE: i32 = 2;
 
@@ -26,6 +27,16 @@ pub(crate) enum VcsBranchState {
         detected_default: Option<String>,
         reason: String,
     },
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct VcsProbeCache {
+    vcs_kind: Option<VcsKind>,
+    vcs_kind_observed: bool,
+    vcs_kind_error: Option<String>,
+    default_branch: Option<String>,
+    default_branch_observed: bool,
+    default_branch_error: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -190,12 +201,16 @@ pub(crate) fn observe_branch_state(
     project_root: &Path,
     project_config: Option<&ProjectConfig>,
 ) -> VcsBranchState {
+    observe_branch_state_with_cache(project_root, project_config, None)
+}
+
+pub(crate) fn observe_branch_state_with_cache(
+    project_root: &Path,
+    project_config: Option<&ProjectConfig>,
+    mut cache: Option<&mut VcsProbeCache>,
+) -> VcsBranchState {
     let vcs_config = project_config.map(|config| &config.vcs);
-    let kind = match csa_session::vcs_backends::detect_vcs_kind_with_config(
-        project_root,
-        vcs_config.and_then(|config| config.backend),
-        vcs_config.and_then(|config| config.colocated_default),
-    ) {
+    let kind = match cached_vcs_kind(project_root, vcs_config, cache.as_deref_mut()) {
         Ok(Some(kind)) => kind,
         Ok(None) => return VcsBranchState::NoRepository,
         Err(err) => {
@@ -221,7 +236,7 @@ pub(crate) fn observe_branch_state(
             };
         }
     };
-    let detected_default = match backend.default_branch(project_root) {
+    let detected_default = match cached_default_branch(project_root, backend.as_ref(), cache) {
         Ok(default_branch) => default_branch,
         Err(err) => {
             return VcsBranchState::Indeterminate {
@@ -242,6 +257,72 @@ pub(crate) fn observe_branch_state(
             detected_default,
             reason: "current branch is unknown or detached".to_string(),
         },
+    }
+}
+
+fn cached_vcs_kind(
+    project_root: &Path,
+    vcs_config: Option<&csa_config::VcsConfig>,
+    cache: Option<&mut VcsProbeCache>,
+) -> Result<Option<VcsKind>, String> {
+    let Some(cache) = cache else {
+        return csa_session::vcs_backends::detect_vcs_kind_with_config(
+            project_root,
+            vcs_config.and_then(|config| config.backend),
+            vcs_config.and_then(|config| config.colocated_default),
+        );
+    };
+
+    if !cache.vcs_kind_observed {
+        match csa_session::vcs_backends::detect_vcs_kind_with_config(
+            project_root,
+            vcs_config.and_then(|config| config.backend),
+            vcs_config.and_then(|config| config.colocated_default),
+        ) {
+            Ok(kind) => {
+                cache.vcs_kind = kind;
+                cache.vcs_kind_error = None;
+            }
+            Err(err) => {
+                cache.vcs_kind = None;
+                cache.vcs_kind_error = Some(err);
+            }
+        }
+        cache.vcs_kind_observed = true;
+    }
+
+    match &cache.vcs_kind_error {
+        Some(err) => Err(err.clone()),
+        None => Ok(cache.vcs_kind),
+    }
+}
+
+fn cached_default_branch(
+    project_root: &Path,
+    backend: &dyn csa_core::vcs::VcsBackend,
+    cache: Option<&mut VcsProbeCache>,
+) -> Result<Option<String>, String> {
+    let Some(cache) = cache else {
+        return backend.default_branch(project_root);
+    };
+
+    if !cache.default_branch_observed {
+        match backend.default_branch(project_root) {
+            Ok(default_branch) => {
+                cache.default_branch = default_branch;
+                cache.default_branch_error = None;
+            }
+            Err(err) => {
+                cache.default_branch = None;
+                cache.default_branch_error = Some(err);
+            }
+        }
+        cache.default_branch_observed = true;
+    }
+
+    match &cache.default_branch_error {
+        Some(err) => Err(err.clone()),
+        None => Ok(cache.default_branch.clone()),
     }
 }
 

--- a/crates/csa-session/src/vcs_backends.rs
+++ b/crates/csa-session/src/vcs_backends.rs
@@ -375,6 +375,14 @@ fn parse_jj_current_bookmark(bookmarks: &str) -> Option<String> {
     })
 }
 
+fn parse_jj_trunk_bookmark(bookmarks: &str) -> Option<String> {
+    bookmarks
+        .lines()
+        .flat_map(str::split_whitespace)
+        .find(|bookmark| !bookmark.is_empty())
+        .map(str::to_string)
+}
+
 fn git_output(project_root: &Path, args: &[&str]) -> Result<Output, String> {
     Command::new("git")
         .args(args)
@@ -436,7 +444,16 @@ fn git_default_from_local_heads(project_root: &Path) -> Result<Option<String>, S
 
 fn jj_default_from_trunk_config(project_root: &Path) -> Result<Option<String>, String> {
     let output = match Command::new("jj")
-        .args(["config", "get", "revset-aliases.trunk()"])
+        .args([
+            "log",
+            "-r",
+            "trunk()",
+            "--no-graph",
+            "-T",
+            "bookmarks ++ \"\\n\"",
+            "--limit",
+            "1",
+        ])
         .current_dir(project_root)
         .output()
     {
@@ -446,14 +463,8 @@ fn jj_default_from_trunk_config(project_root: &Path) -> Result<Option<String>, S
     if !output.status.success() {
         return Ok(None);
     }
-    let raw = parse_utf8_stdout(output.stdout, "jj config get revset-aliases.trunk()")?;
-    let candidate = raw
-        .trim()
-        .trim_matches('"')
-        .strip_prefix("bookmarks(")
-        .and_then(|value| value.strip_suffix(')'))
-        .map(|value| value.trim_matches('"').trim_matches('\'').to_string());
-    Ok(candidate.filter(|value| !value.is_empty()))
+    let raw = parse_utf8_stdout(output.stdout, "jj log trunk() bookmarks")?;
+    Ok(parse_jj_trunk_bookmark(&raw))
 }
 
 /// Maximum commit message length (bytes). Prevents accidental or malicious oversized messages.
@@ -627,6 +638,20 @@ mod tests {
         let bookmark = parse_jj_current_bookmark("main: abc123def\n");
 
         assert_eq!(bookmark.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn jj_trunk_bookmark_uses_first_resolved_bookmark() {
+        let bookmark = parse_jj_trunk_bookmark("release main\n");
+
+        assert_eq!(bookmark.as_deref(), Some("release"));
+    }
+
+    #[test]
+    fn jj_trunk_bookmark_returns_none_without_bookmarks() {
+        let bookmark = parse_jj_trunk_bookmark("\n  \n");
+
+        assert_eq!(bookmark, None);
     }
 
     #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.612"
-weave = "0.1.612"
+csa = "0.1.613"
+weave = "0.1.613"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- **F2 — VCS probe cache**: VCS kind and default branch are now cached across `execute_run_loop` iterations via `VcsProbeCache`. Only current branch is recomputed per iteration (it may change between rounds). Eliminates repeated subprocess spawns for `jj root` / `git rev-parse --show-toplevel` / default branch detection.
- **F3 — JJ trunk alias parser**: Replaced fragile `bookmarks("name")` text pattern matching with `jj log -r 'trunk()' --no-graph -T 'bookmarks'` — lets jj resolve the revset natively. Falls back to None if trunk() is not configured.

Fixes #1184

## Test plan
- [x] `cargo clippy --workspace` clean
- [ ] `csa run` on git repo — VCS probe runs once, not per iteration
- [ ] `csa run` on jj repo — trunk alias resolved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)