### PR TITLE
feat(vcs): jj sidecar Phase 2-B — session-level aggregation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "chrono",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "axum",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "chrono",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "chrono",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "chrono",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.619"
+version = "0.1.620"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.619"
+version = "0.1.620"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds_display.rs
+++ b/crates/cli-sub-agent/src/config_cmds_display.rs
@@ -32,6 +32,14 @@ fn build_vcs_toml(vcs: &csa_config::VcsConfig) -> Result<toml::Value> {
         toml::Value::Boolean(vcs.auto_snapshot),
     );
     table.insert(
+        "auto_aggregate".to_string(),
+        toml::Value::Boolean(vcs.resolved_auto_aggregate()),
+    );
+    table.insert(
+        "aggregate_message_template".to_string(),
+        toml::Value::String(vcs.aggregate_message_template.clone()),
+    );
+    table.insert(
         "snapshot_trigger".to_string(),
         toml::Value::String(snapshot_trigger_name(vcs.snapshot_trigger).to_string()),
     );
@@ -70,6 +78,8 @@ pub(super) fn build_project_display_json(config: &ProjectConfig) -> Result<serde
             "backend": config.vcs.backend,
             "colocated_default": config.vcs.colocated_default,
             "auto_snapshot": config.vcs.auto_snapshot,
+            "auto_aggregate": config.vcs.resolved_auto_aggregate(),
+            "aggregate_message_template": config.vcs.aggregate_message_template.clone(),
             "snapshot_trigger": snapshot_trigger_name(config.vcs.snapshot_trigger),
         }),
     );

--- a/crates/cli-sub-agent/src/config_cmds_vcs_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_vcs_tests.rs
@@ -13,6 +13,18 @@ fn build_project_display_toml_keeps_effective_vcs_snapshot_defaults_visible() {
     );
     assert_eq!(
         root.get("vcs")
+            .and_then(|value| value.get("auto_aggregate"))
+            .and_then(toml::Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        root.get("vcs")
+            .and_then(|value| value.get("aggregate_message_template"))
+            .and_then(toml::Value::as_str),
+        Some("csa: {session_id} ({count} snapshots)")
+    );
+    assert_eq!(
+        root.get("vcs")
             .and_then(|value| value.get("snapshot_trigger"))
             .and_then(toml::Value::as_str),
         Some("post-run")
@@ -27,6 +39,8 @@ schema_version = 1
 
 [vcs]
 auto_snapshot = true
+auto_aggregate = false
+aggregate_message_template = "custom {session_id} {count}"
 snapshot_trigger = "tool-completed"
 "#,
     )
@@ -38,6 +52,18 @@ snapshot_trigger = "tool-completed"
             .and_then(|value| value.get("auto_snapshot"))
             .and_then(toml::Value::as_bool),
         Some(true)
+    );
+    assert_eq!(
+        root.get("vcs")
+            .and_then(|value| value.get("auto_aggregate"))
+            .and_then(toml::Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        root.get("vcs")
+            .and_then(|value| value.get("aggregate_message_template"))
+            .and_then(toml::Value::as_str),
+        Some("custom {session_id} {count}")
     );
     assert_eq!(
         root.get("vcs")

--- a/crates/cli-sub-agent/src/pipeline_jj_journal.rs
+++ b/crates/cli-sub-agent/src/pipeline_jj_journal.rs
@@ -16,6 +16,37 @@ pub(crate) enum PostRunJjSnapshotOutcome {
     Failed { message: String },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SessionJjAggregateOutcome {
+    ConfigOff,
+    AggregateOff,
+    ChildSession,
+    NoJjDir,
+    NonColocated,
+    NoSnapshots,
+    Aggregated { snapshot_count: usize },
+    Failed { message: String },
+}
+
+pub(crate) async fn aggregate_session(
+    project_root: &Path,
+    session_dir: &Path,
+    session_id: &str,
+    snapshot_count: usize,
+    message_template: &str,
+) -> anyhow::Result<()> {
+    let project_root = project_root.to_path_buf();
+    let session_dir = session_dir.to_path_buf();
+    let session_id = session_id.to_string();
+    let message_template = message_template.to_string();
+    tokio::task::spawn_blocking(move || {
+        let journal = JjJournal::with_session_dir(project_root, session_dir)?;
+        journal.aggregate_session(&session_id, snapshot_count, &message_template)
+    })
+    .await?
+    .map_err(anyhow::Error::from)
+}
+
 pub(crate) fn maybe_record_post_run_snapshot(
     config: Option<&csa_config::VcsConfig>,
     project_root: &Path,
@@ -61,6 +92,114 @@ pub(crate) fn maybe_record_post_run_snapshot(
         }
     }
     outcome
+}
+
+pub(crate) async fn maybe_aggregate_session_snapshots(
+    config: Option<&csa_config::VcsConfig>,
+    project_root: &Path,
+    session_dir: &Path,
+    session_id: &str,
+    session_depth: u32,
+    result: &mut csa_process::ExecutionResult,
+) -> SessionJjAggregateOutcome {
+    let config = config.cloned().unwrap_or_default();
+    let outcome =
+        evaluate_session_aggregate(config, project_root, session_dir, session_id, session_depth)
+            .await;
+    match &outcome {
+        SessionJjAggregateOutcome::ConfigOff => {
+            info!("jj sidecar aggregation disabled because [vcs].auto_snapshot is false");
+        }
+        SessionJjAggregateOutcome::AggregateOff => {
+            info!("jj sidecar aggregation disabled by [vcs].auto_aggregate");
+        }
+        SessionJjAggregateOutcome::ChildSession => {
+            info!("Skipping jj sidecar aggregation for child session");
+        }
+        SessionJjAggregateOutcome::NoJjDir => append_snapshot_notice(
+            result,
+            "jj sidecar aggregation skipped: .jj/ not found; git fallback is intentionally disabled",
+        ),
+        SessionJjAggregateOutcome::NonColocated => append_snapshot_notice(
+            result,
+            "jj sidecar aggregation skipped: repository is not colocated (.git/ and .jj/ are both required); git fallback is intentionally disabled",
+        ),
+        SessionJjAggregateOutcome::NoSnapshots => {
+            info!("Skipping jj sidecar aggregation because no snapshots were recorded");
+        }
+        SessionJjAggregateOutcome::Aggregated { snapshot_count } => {
+            info!(snapshot_count, "Aggregated jj sidecar snapshots");
+        }
+        SessionJjAggregateOutcome::Failed { message } => {
+            append_snapshot_notice(
+                result,
+                &format!(
+                    "jj sidecar aggregation failed: {message}; git fallback is intentionally disabled"
+                ),
+            );
+        }
+    }
+    outcome
+}
+
+async fn evaluate_session_aggregate(
+    config: csa_config::VcsConfig,
+    project_root: &Path,
+    session_dir: &Path,
+    session_id: &str,
+    session_depth: u32,
+) -> SessionJjAggregateOutcome {
+    if !config.auto_snapshot {
+        return SessionJjAggregateOutcome::ConfigOff;
+    }
+    if !config.resolved_auto_aggregate() {
+        return SessionJjAggregateOutcome::AggregateOff;
+    }
+    if session_depth != 0 {
+        return SessionJjAggregateOutcome::ChildSession;
+    }
+    if !project_root.join(".jj").is_dir() {
+        return SessionJjAggregateOutcome::NoJjDir;
+    }
+    if !project_root.join(".git").exists() {
+        return SessionJjAggregateOutcome::NonColocated;
+    }
+
+    let journal = match JjJournal::with_session_dir(project_root, session_dir) {
+        Ok(journal) => journal,
+        Err(err) => {
+            return SessionJjAggregateOutcome::Failed {
+                message: render_journal_error(&err),
+            };
+        }
+    };
+    let snapshot_count = match journal.snapshot_revisions() {
+        Ok(revisions) => revisions.len(),
+        Err(err) => {
+            return SessionJjAggregateOutcome::Failed {
+                message: render_journal_error(&err),
+            };
+        }
+    };
+    if snapshot_count == 0 {
+        return SessionJjAggregateOutcome::NoSnapshots;
+    }
+
+    let message_template = config.aggregate_message_template.clone();
+    let aggregate = aggregate_session(
+        project_root,
+        session_dir,
+        session_id,
+        snapshot_count,
+        &message_template,
+    )
+    .await;
+    match aggregate {
+        Ok(()) => SessionJjAggregateOutcome::Aggregated { snapshot_count },
+        Err(err) => SessionJjAggregateOutcome::Failed {
+            message: err.to_string(),
+        },
+    }
 }
 
 fn evaluate_post_run_snapshot(
@@ -485,5 +624,38 @@ mod tests {
 
         assert!(message.contains("01SESSION;$(touch hacked)"));
         assert!(message.contains("codex`echo no`\nsecond"));
+    }
+
+    #[tokio::test]
+    async fn aggregate_skips_when_auto_aggregate_is_explicitly_off() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::create_dir(tmp.path().join(".git")).expect("create .git");
+        fs::create_dir(tmp.path().join(".jj")).expect("create .jj");
+        let config = csa_config::VcsConfig {
+            auto_snapshot: true,
+            auto_aggregate: Some(false),
+            ..Default::default()
+        };
+
+        let outcome =
+            evaluate_session_aggregate(config, tmp.path(), tmp.path(), "01SESSION", 0).await;
+
+        assert_eq!(outcome, SessionJjAggregateOutcome::AggregateOff);
+    }
+
+    #[tokio::test]
+    async fn aggregate_skips_child_sessions() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::create_dir(tmp.path().join(".git")).expect("create .git");
+        fs::create_dir(tmp.path().join(".jj")).expect("create .jj");
+        let config = csa_config::VcsConfig {
+            auto_snapshot: true,
+            ..Default::default()
+        };
+
+        let outcome =
+            evaluate_session_aggregate(config, tmp.path(), tmp.path(), "01SESSION", 1).await;
+
+        assert_eq!(outcome, SessionJjAggregateOutcome::ChildSession);
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -267,6 +267,16 @@ pub(crate) async fn process_execution_result(
         crate::pipeline::run_pipeline_hook(HookEvent::PostEdit, ctx.hooks_config, &hook_vars)?;
     }
 
+    crate::pipeline_jj_journal::maybe_aggregate_session_snapshots(
+        ctx.config.map(|config| &config.vcs),
+        ctx.project_root,
+        &ctx.session_dir,
+        &session.meta_session_id,
+        session.genealogy.depth,
+        result,
+    )
+    .await;
+
     // Memory capture
     let memory_config = ctx
         .config

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
@@ -320,10 +320,23 @@ async fn process_execution_result_respects_vcs_auto_snapshot_gate_for_colocated_
         .await
         .expect("process enabled post-exec");
     assert!(
-        jj_log_descriptions(&project_root).contains(&format!(
-            "CSA PostRun snapshot session={enabled_session_id}"
-        )),
-        "jj log should include enabled CSA session snapshot"
+        enabled_result.stderr_output.is_empty(),
+        "jj snapshot aggregation should not emit warnings: {}",
+        enabled_result.stderr_output
+    );
+    assert!(
+        jj_log_descriptions(&project_root).contains(&format!("csa: {enabled_session_id}")),
+        "jj log should include enabled CSA aggregate commit"
+    );
+    let journal_state = std::fs::read_to_string(
+        get_session_dir(&project_root, &enabled_session_id)
+            .expect("enabled session dir")
+            .join("jj-journal-state.json"),
+    )
+    .expect("read jj journal state");
+    assert!(
+        !journal_state.contains("snapshot_revisions"),
+        "successful aggregation should clear snapshot revisions: {journal_state}"
     );
 }
 

--- a/crates/csa-config/src/config_session.rs
+++ b/crates/csa-config/src/config_session.rs
@@ -365,6 +365,10 @@ pub enum SnapshotTrigger {
     ToolCompleted,
 }
 
+fn default_aggregate_message_template() -> String {
+    "csa: {session_id} ({count} snapshots)".to_string()
+}
+
 /// VCS backend configuration.
 ///
 /// Controls which VCS backend CSA uses for the project.
@@ -381,6 +385,13 @@ pub struct VcsConfig {
     /// Enable automatic sidecar snapshot journaling.
     #[serde(default)]
     pub auto_snapshot: bool,
+    /// Aggregate sidecar snapshots into one exported git commit at session completion.
+    /// `None` follows `auto_snapshot`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_aggregate: Option<bool>,
+    /// Commit message template for aggregated sidecar snapshots.
+    #[serde(default = "default_aggregate_message_template")]
+    pub aggregate_message_template: String,
     /// Event that triggers automatic snapshots.
     #[serde(default)]
     pub snapshot_trigger: SnapshotTrigger,
@@ -392,16 +403,24 @@ impl Default for VcsConfig {
             backend: None,
             colocated_default: None,
             auto_snapshot: false,
+            auto_aggregate: None,
+            aggregate_message_template: default_aggregate_message_template(),
             snapshot_trigger: SnapshotTrigger::PostRun,
         }
     }
 }
 
 impl VcsConfig {
+    pub fn resolved_auto_aggregate(&self) -> bool {
+        self.auto_aggregate.unwrap_or(self.auto_snapshot)
+    }
+
     pub fn is_default(&self) -> bool {
         self.backend.is_none()
             && self.colocated_default.is_none()
             && !self.auto_snapshot
+            && self.auto_aggregate.is_none()
+            && self.aggregate_message_template == default_aggregate_message_template()
             && self.snapshot_trigger == SnapshotTrigger::PostRun
     }
 }
@@ -415,6 +434,11 @@ mod vcs_config_tests {
         let config: VcsConfig = toml::from_str("").expect("parse defaults");
 
         assert!(!config.auto_snapshot);
+        assert!(!config.resolved_auto_aggregate());
+        assert_eq!(
+            config.aggregate_message_template,
+            "csa: {session_id} ({count} snapshots)"
+        );
         assert_eq!(config.snapshot_trigger, SnapshotTrigger::PostRun);
         assert!(config.is_default());
     }
@@ -424,13 +448,34 @@ mod vcs_config_tests {
         let config: VcsConfig = toml::from_str(
             r#"
 auto_snapshot = true
+auto_aggregate = false
+aggregate_message_template = "custom {session_id} {count}"
 snapshot_trigger = "tool-completed"
 "#,
         )
         .expect("parse explicit vcs config");
 
         assert!(config.auto_snapshot);
+        assert_eq!(config.auto_aggregate, Some(false));
+        assert!(!config.resolved_auto_aggregate());
+        assert_eq!(
+            config.aggregate_message_template,
+            "custom {session_id} {count}"
+        );
         assert_eq!(config.snapshot_trigger, SnapshotTrigger::ToolCompleted);
         assert!(!config.is_default());
+    }
+
+    #[test]
+    fn vcs_auto_aggregate_follows_auto_snapshot_when_unset() {
+        let config: VcsConfig = toml::from_str(
+            r#"
+auto_snapshot = true
+"#,
+        )
+        .expect("parse explicit auto snapshot");
+
+        assert_eq!(config.auto_aggregate, None);
+        assert!(config.resolved_auto_aggregate());
     }
 }

--- a/crates/csa-session/src/jj_journal.rs
+++ b/crates/csa-session/src/jj_journal.rs
@@ -41,6 +41,8 @@ struct JournalState {
     project_root: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     session_start_revision: Option<RevisionId>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    snapshot_revisions: Vec<RevisionId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     session_start_operation_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -141,6 +143,95 @@ impl JjJournal {
         Ok(op_id)
     }
 
+    pub fn snapshot_revisions(&self) -> Result<Vec<RevisionId>, JournalError> {
+        Ok(self
+            .read_state()?
+            .map(|state| state.snapshot_revisions)
+            .unwrap_or_default())
+    }
+
+    pub fn aggregate_session(
+        &self,
+        session_id: &str,
+        snapshot_count: usize,
+        message_template: &str,
+    ) -> Result<(), JournalError> {
+        let _lock = acquire_project_resource_lock(
+            &self.project_root,
+            "jj-journal",
+            "aggregate",
+            &format!("aggregate session {session_id}"),
+        )
+        .map_err(|err| JournalError::CommandFailed {
+            command: "acquire_project_resource_lock(jj-journal/aggregate)".to_string(),
+            message: err.to_string(),
+        })?;
+
+        let mut state = self.read_state()?.unwrap_or_default();
+        validate_state_project_root(&state, &self.project_root)?;
+        if snapshot_count == 0 || state.snapshot_revisions.is_empty() {
+            return Ok(());
+        }
+        if state.snapshot_revisions.len() != snapshot_count {
+            return Err(JournalError::InvalidState(format!(
+                "recorded {} jj snapshots for session {session_id}, expected {snapshot_count}",
+                state.snapshot_revisions.len()
+            )));
+        }
+
+        let pre_squash_op = self.current_operation_id()?;
+        let message = format_aggregate_message(message_template, session_id, snapshot_count)?;
+        self.combine_snapshot_revisions(&state.snapshot_revisions, &message)?;
+        match self.run_jj(["git", "export"]) {
+            Ok(_) => {
+                state.snapshot_revisions.clear();
+                state.session_start_revision = None;
+                state.session_start_operation_id = None;
+                state.last_operation_id = None;
+                self.write_state(&state)?;
+                Ok(())
+            }
+            Err(export_err) => {
+                let restore = self.run_jj(["op", "restore", pre_squash_op.as_str()]);
+                match restore {
+                    Ok(_) => Err(export_err),
+                    Err(restore_err) => Err(JournalError::CommandFailed {
+                        command: "jj op restore <pre-squash-op>".to_string(),
+                        message: format!(
+                            "jj git export failed ({export_err}); rollback also failed ({restore_err})"
+                        ),
+                    }),
+                }
+            }
+        }
+    }
+
+    fn combine_snapshot_revisions(
+        &self,
+        revisions: &[RevisionId],
+        message: &str,
+    ) -> Result<(), JournalError> {
+        let Some(first) = revisions.first() else {
+            return Ok(());
+        };
+        if revisions.len() == 1 {
+            self.run_jj(["describe", "-r", first.as_str(), "-m", message])?;
+            return Ok(());
+        }
+
+        let mut args = vec![OsString::from("squash")];
+        for revision in &revisions[1..] {
+            args.push(OsString::from("--from"));
+            args.push(OsString::from(revision.as_str()));
+        }
+        args.push(OsString::from("--into"));
+        args.push(OsString::from(first.as_str()));
+        args.push(OsString::from("-m"));
+        args.push(OsString::from(message));
+        self.run_jj(args)?;
+        Ok(())
+    }
+
     fn read_state(&self) -> Result<Option<JournalState>, JournalError> {
         match fs::read_to_string(&self.state_path) {
             Ok(raw) => {
@@ -198,6 +289,7 @@ impl JjJournal {
             current_state.session_start_revision = Some(revision.clone());
             current_state.session_start_operation_id = Some(operation_before_snapshot);
         }
+        current_state.snapshot_revisions.push(revision.clone());
         current_state.last_operation_id = Some(operation_after_snapshot);
         self.write_state(&current_state)?;
 
@@ -278,6 +370,28 @@ fn sanitize_snapshot_message(message: &str) -> Result<String, JournalError> {
         ));
     }
     Ok(bounded)
+}
+
+fn format_aggregate_message(
+    template: &str,
+    session_id: &str,
+    snapshot_count: usize,
+) -> Result<String, JournalError> {
+    let message = template
+        .replace("{session_id}", session_id)
+        .replace("{count}", &snapshot_count.to_string());
+    if message.contains('\0') {
+        return Err(JournalError::InvalidMessage(
+            "aggregate message contains null byte".to_string(),
+        ));
+    }
+    let trimmed = message.trim();
+    if trimmed.is_empty() {
+        return Err(JournalError::InvalidMessage(
+            "aggregate message empty after template expansion".to_string(),
+        ));
+    }
+    Ok(trimmed.to_string())
 }
 
 fn absolutize_project_root(project_root: &Path) -> Result<PathBuf, JournalError> {

--- a/crates/csa-session/src/jj_journal_tests.rs
+++ b/crates/csa-session/src/jj_journal_tests.rs
@@ -315,6 +315,111 @@ fn atomic_state_write() {
 }
 
 #[test]
+fn aggregate_session_squashes_later_snapshots_exports_and_clears_state() {
+    let _guard = TEST_ENV_LOCK.lock().expect("lock env");
+    let repo = tempdir().expect("repo tempdir");
+    let state_path = repo.path().join("state").join(STATE_FILE_NAME);
+    let bin_dir = tempdir().expect("bin tempdir");
+    let arg_log = repo.path().join("jj-aggregate-args.log");
+    let script = format!(
+        "#!/bin/sh\n\
+         printf '%s\\n' \"$*\" >> '{}'\n\
+         if [ \"$3\" = \"op\" ] && [ \"$4\" = \"log\" ]; then printf 'op-before\\n'; exit 0; fi\n\
+         exit 0\n",
+        arg_log.display()
+    );
+    make_fake_jj(bin_dir.path(), &script);
+    let _path_guard = PathGuard::prepend(bin_dir.path());
+    let journal = JjJournal::with_state_path(repo.path(), &state_path);
+    journal
+        .write_state(&JournalState {
+            project_root: Some(std::path::absolute(repo.path()).expect("absolute repo")),
+            session_start_revision: Some(RevisionId::from("rev-a")),
+            snapshot_revisions: vec![
+                RevisionId::from("rev-a"),
+                RevisionId::from("rev-b"),
+                RevisionId::from("rev-c"),
+            ],
+            session_start_operation_id: Some("op-start".to_string()),
+            last_operation_id: Some("op-latest".to_string()),
+        })
+        .expect("write state");
+
+    journal
+        .aggregate_session("01ABC", 3, "csa: {session_id} ({count} snapshots)")
+        .expect("aggregate session");
+
+    let command_log = fs::read_to_string(arg_log).expect("read arg log");
+    assert!(
+        command_log
+            .contains("squash --from rev-b --from rev-c --into rev-a -m csa: 01ABC (3 snapshots)"),
+        "aggregate should squash later snapshot revisions into the first revision: {command_log}"
+    );
+    assert!(
+        command_log.contains("git export"),
+        "aggregate must export jj state to git: {command_log}"
+    );
+    let state = journal
+        .read_state()
+        .expect("read state")
+        .expect("state remains");
+    assert!(
+        state.snapshot_revisions.is_empty(),
+        "successful aggregation should clear recorded snapshot revisions"
+    );
+    assert_eq!(state.session_start_revision, None);
+    assert_eq!(state.last_operation_id, None);
+}
+
+#[test]
+fn aggregate_session_rolls_back_when_git_export_fails() {
+    let _guard = TEST_ENV_LOCK.lock().expect("lock env");
+    let repo = tempdir().expect("repo tempdir");
+    let state_path = repo.path().join("state").join(STATE_FILE_NAME);
+    let bin_dir = tempdir().expect("bin tempdir");
+    let arg_log = repo.path().join("jj-aggregate-rollback-args.log");
+    let script = format!(
+        "#!/bin/sh\n\
+         printf '%s\\n' \"$*\" >> '{}'\n\
+         if [ \"$3\" = \"op\" ] && [ \"$4\" = \"log\" ]; then printf 'op-anchor\\n'; exit 0; fi\n\
+         if [ \"$3\" = \"git\" ] && [ \"$4\" = \"export\" ]; then printf 'export failed\\n' >&2; exit 42; fi\n\
+         exit 0\n",
+        arg_log.display()
+    );
+    make_fake_jj(bin_dir.path(), &script);
+    let _path_guard = PathGuard::prepend(bin_dir.path());
+    let journal = JjJournal::with_state_path(repo.path(), &state_path);
+    journal
+        .write_state(&JournalState {
+            project_root: Some(std::path::absolute(repo.path()).expect("absolute repo")),
+            session_start_revision: Some(RevisionId::from("rev-a")),
+            snapshot_revisions: vec![RevisionId::from("rev-a"), RevisionId::from("rev-b")],
+            session_start_operation_id: Some("op-start".to_string()),
+            last_operation_id: Some("op-latest".to_string()),
+        })
+        .expect("write state");
+
+    let error = journal
+        .aggregate_session("01ABC", 2, "csa: {session_id} ({count} snapshots)")
+        .expect_err("git export failure should fail aggregation");
+
+    assert!(error.to_string().contains("export failed"));
+    let command_log = fs::read_to_string(arg_log).expect("read arg log");
+    assert!(
+        command_log.contains("op restore op-anchor"),
+        "export failure must restore the pre-squash operation: {command_log}"
+    );
+    let state = journal
+        .read_state()
+        .expect("read state")
+        .expect("state remains");
+    assert_eq!(
+        state.snapshot_revisions,
+        vec![RevisionId::from("rev-a"), RevisionId::from("rev-b")]
+    );
+}
+
+#[test]
 fn concurrent_snapshot_rejected_by_lock() {
     let _guard = TEST_ENV_LOCK.lock().expect("lock env");
     let repo = tempdir().expect("repo tempdir");


### PR DESCRIPTION
## Summary
- **aggregate_session()**: After `csa run` completes, squash all per-snapshot jj changes into ONE atomic git commit via `jj squash` + `jj git export`
- **Rollback on failure**: If `jj git export` fails, `jj op restore` rolls back the squash to prevent jj/git desync
- **Config**: `[vcs] auto_aggregate` (defaults to follow `auto_snapshot`) + `aggregate_message_template`
- **Scope**: Only triggers at depth 0 (outermost session) when `auto_snapshot=true` and ≥1 snapshot exists

This is the "终结巨石 commit" feature — `csa run` in a colocated jj+git repo produces exactly ONE atomic commit in git log.

Fixes #1195

## Test plan
- [x] `cargo clippy --workspace` clean
- [x] Unit tests for aggregation + rollback
- [ ] `csa run` in colocated jj+git repo → `git log` shows 1 new commit
- [ ] `auto_snapshot=false` → aggregation is no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)