### PR TITLE
chore(acp): gate csa-acp behind optional feature flag (default off)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "chrono",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "axum",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "chrono",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "chrono",
@@ -943,11 +943,10 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "chrono",
- "csa-acp",
  "csa-config",
  "csa-core",
  "csa-lock",
@@ -969,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.620"
+version = "0.1.621"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,26 @@
 [workspace]
 members = ["crates/*"]
+default-members = [
+    "crates/cli-sub-agent",
+    "crates/csa-config",
+    "crates/csa-core",
+    "crates/csa-eval",
+    "crates/csa-executor",
+    "crates/csa-hooks",
+    "crates/csa-lock",
+    "crates/csa-mcp-hub",
+    "crates/csa-memory",
+    "crates/csa-process",
+    "crates/csa-resource",
+    "crates/csa-scheduler",
+    "crates/csa-session",
+    "crates/csa-todo",
+    "crates/weave",
+]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.620"
+version = "0.1.621"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/Cargo.toml
+++ b/crates/cli-sub-agent/Cargo.toml
@@ -14,7 +14,7 @@ csa-core.workspace = true
 csa-eval.workspace = true
 csa-session.workspace = true
 csa-lock.workspace = true
-csa-acp = { path = "../csa-acp" }
+csa-acp = { path = "../csa-acp", optional = true }
 csa-executor.workspace = true
 csa-process.workspace = true
 csa-config.workspace = true
@@ -54,5 +54,6 @@ proptest = "1"
 serial_test = "3.4"
 
 [features]
+acp = ["dep:csa-acp", "csa-executor/acp"]
 codex-acp = ["csa-config/codex-acp", "csa-executor/codex-acp"]
 codex-pty-fork = ["csa-executor/codex-pty-fork"]

--- a/crates/cli-sub-agent/src/pipeline_transcript.rs
+++ b/crates/cli-sub-agent/src/pipeline_transcript.rs
@@ -53,9 +53,9 @@ pub(crate) fn persist_if_enabled(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use csa_acp::SessionEvent;
     use csa_config::config::CURRENT_SCHEMA_VERSION;
     use csa_config::{ProjectMeta, ResourcesConfig, SessionConfig};
+    use csa_core::transport_events::SessionEvent;
     use csa_process::ExecutionResult;
     use std::collections::HashMap;
 

--- a/crates/cli-sub-agent/src/run_cmd_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_policy.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from `run_cmd.rs` to keep module sizes manageable.
 
-use csa_acp::{SessionEvent, StreamingMetadata};
+use csa_core::transport_events::{SessionEvent, StreamingMetadata};
 use csa_core::types::OutputFormat;
 
 use super::git::PostRunCommitGuard;

--- a/crates/cli-sub-agent/src/run_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests.rs
@@ -7,7 +7,7 @@ use crate::run_cmd_tool_selection::{
 };
 use chrono::{TimeZone, Utc};
 use clap::Parser;
-use csa_acp::SessionEvent;
+use csa_core::transport_events::{SessionEvent, StreamingMetadata};
 use csa_core::types::{OutputFormat, ToolName};
 use csa_process::ExecutionResult;
 use csa_session::{Genealogy, MetaSessionState, SessionPhase, TaskContext};

--- a/crates/cli-sub-agent/src/run_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_tail.rs
@@ -624,7 +624,7 @@ fn extract_executed_shell_commands_from_events_returns_execute_titles() {
 
 #[test]
 fn extract_executed_shell_commands_prefers_incremental_metadata() {
-    let mut metadata = csa_acp::StreamingMetadata::default();
+    let mut metadata = StreamingMetadata::default();
     metadata.extracted_commands = vec!["git status".to_string(), "cargo test".to_string()];
     let events = vec![SessionEvent::ToolCallStarted {
         id: "call-1".to_string(),
@@ -658,7 +658,7 @@ fn events_contain_execute_tool_calls_detects_execute_entries() {
 
 #[test]
 fn execute_tool_calls_observed_uses_incremental_metadata() {
-    let mut metadata = csa_acp::StreamingMetadata::default();
+    let mut metadata = StreamingMetadata::default();
     metadata.has_execute_tool_calls = true;
     let events = vec![SessionEvent::ToolCallStarted {
         id: "call-1".to_string(),

--- a/crates/cli-sub-agent/src/run_helpers_transport_integration_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_transport_integration_tests.rs
@@ -106,7 +106,7 @@ transport = "acp"
 /// config must fail at executor/transport build time with a clear error
 /// citing the feature flag and #760/#1128.
 #[test]
-#[cfg(not(feature = "codex-acp"))]
+#[cfg(not(feature = "acp"))]
 fn codex_acp_project_config_is_rejected_without_feature() {
     let config = load_project_config(
         r#"
@@ -119,12 +119,12 @@ transport = "acp"
     let result = TransportFactory::create(&executor, Some(SessionConfig::default()));
 
     let err = match result {
-        Ok(_) => panic!("codex+ACP must fail without codex-acp feature"),
+        Ok(_) => panic!("codex+ACP must fail without acp feature"),
         Err(e) => e,
     };
     let message = format!("{err:#}");
     assert!(
-        message.contains("codex-acp") || message.contains("760") || message.contains("1128"),
+        message.contains("`acp` cargo feature") || message.contains("--features acp"),
         "error must cite the feature flag or issue number: {message}"
     );
 }

--- a/crates/csa-core/src/lib.rs
+++ b/crates/csa-core/src/lib.rs
@@ -7,5 +7,6 @@ pub mod gemini;
 pub mod model_catalog;
 pub mod spec_validate;
 pub mod thinking_budget;
+pub mod transport_events;
 pub mod types;
 pub mod vcs;

--- a/crates/csa-core/src/transport_events.rs
+++ b/crates/csa-core/src/transport_events.rs
@@ -1,0 +1,42 @@
+/// Incrementally accumulated metadata from streamed transport events.
+#[derive(Debug, Clone, Default)]
+pub struct StreamingMetadata {
+    /// Total number of events seen across the entire prompt turn, including dropped events.
+    pub total_events_count: usize,
+    /// Whether any `ToolCallStarted` event was observed.
+    pub has_tool_calls: bool,
+    /// Whether any execute `ToolCallStarted` event was observed.
+    pub has_execute_tool_calls: bool,
+    /// Whether a `--no-verify` or `-n` git commit command was observed.
+    pub has_no_verify_commit: bool,
+    /// Whether any `PlanUpdate` event was observed.
+    pub has_plan_updates: bool,
+    /// Tail of execute command titles observed during the prompt turn.
+    pub extracted_commands: Vec<String>,
+    /// Tail buffer of agent message/thought text.
+    pub tail_text: String,
+    /// Tail buffer of agent message text only.
+    pub message_text: String,
+    /// Tail buffer of agent thought text only.
+    pub thought_text: String,
+    /// Whether the output used thought text as fallback.
+    pub has_thought_fallback: bool,
+}
+
+/// Streaming session events collected from agent notifications.
+#[derive(Debug, Clone, serde::Serialize)]
+pub enum SessionEvent {
+    AgentMessage(String),
+    AgentThought(String),
+    ToolCallStarted {
+        id: String,
+        title: String,
+        kind: String,
+    },
+    ToolCallCompleted {
+        id: String,
+        status: String,
+    },
+    PlanUpdate(String),
+    Other(String),
+}

--- a/crates/csa-executor/Cargo.toml
+++ b/crates/csa-executor/Cargo.toml
@@ -10,7 +10,7 @@ csa-core.workspace = true
 csa-session.workspace = true
 csa-process.workspace = true
 csa-resource.workspace = true
-csa-acp = { path = "../csa-acp" }
+csa-acp = { path = "../csa-acp", optional = true }
 csa-hooks = { path = "../csa-hooks" }
 agent-teams.workspace = true
 tokio.workspace = true
@@ -28,17 +28,18 @@ reqwest.workspace = true
 
 [features]
 default = []
+acp = ["dep:csa-acp"]
 # Gate codex ACP transport behind this feature.
 # Disabled by default in favour of `codex exec resume <id>` CLI native resume
 # (codex-cli 0.125.0+), which is empirically equivalent to ACP loadSession on
 # server-side cache reuse (54%, 44,800/83,503 input tokens, #760 / #1128).
 # Enable with `--features codex-acp` when investigating the ACP path.
-codex-acp = []
+codex-acp = ["acp"]
 codex-pty-fork = ["csa-process/codex-pty-fork"]
 # Gate claude-code ACP transport behind this feature.
 # Disabled by default due to startup-crash bugs (#1115, #1117).
 # Enable with `--features claude-code-acp` when investigating the ACP path.
-claude-code-acp = []
+claude-code-acp = ["acp"]
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -1,7 +1,6 @@
 //! Executor enum for 4 AI tools.
 
 use anyhow::{Result, bail};
-use csa_acp::SessionConfig;
 use csa_core::types::{PromptTransport, ToolName};
 use csa_process::ExecutionResult;
 use csa_session::state::{MetaSessionState, ToolState};
@@ -20,6 +19,7 @@ use crate::install_hints::{
 };
 use crate::lefthook_guard::{sanitize_args_for_codex, sanitize_env_for_codex};
 use crate::model_spec::{ModelSpec, ThinkingBudget};
+use crate::session_config::SessionConfig;
 use crate::transport::{
     ResolvedTimeout, SandboxTransportConfig, Transport, TransportFactory, TransportOptions,
     TransportResult,

--- a/crates/csa-executor/src/lefthook_guard.rs
+++ b/crates/csa-executor/src/lefthook_guard.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "acp", test))]
 use std::collections::HashMap;
 
 use tokio::process::Command;
@@ -37,6 +38,7 @@ pub(crate) fn sanitize_env_for_codex(cmd: &mut Command) {
     }
 }
 
+#[cfg(any(feature = "acp", test))]
 pub(crate) fn sanitize_env_map_for_codex(env: &mut HashMap<String, String>) {
     env.retain(|key, _| !is_forbidden_env_key(key));
 }
@@ -45,6 +47,7 @@ pub(crate) fn sanitize_args_for_codex(args: &mut Vec<String>) {
     args.retain(|arg| !is_forbidden_arg(arg));
 }
 
+#[cfg(any(feature = "acp", test))]
 fn is_forbidden_env_key(key: &str) -> bool {
     FORBIDDEN_ENV_KEYS.contains(&key) || is_forbidden_env_key_prefix(key)
 }

--- a/crates/csa-executor/src/lib.rs
+++ b/crates/csa-executor/src/lib.rs
@@ -10,6 +10,7 @@ pub mod install_hints;
 mod lefthook_guard;
 pub mod logging;
 pub mod model_spec;
+pub mod session_config;
 pub mod session_id;
 pub mod transport;
 pub(crate) mod transport_gemini_retry;
@@ -31,9 +32,12 @@ pub use install_hints::{
 };
 pub use logging::create_session_log_writer;
 pub use model_spec::{ModelSpec, ThinkingBudget};
+pub use session_config::{McpServerConfig as AcpMcpServerConfig, SessionConfig};
 pub use session_id::{extract_session_id, extract_session_id_from_transport};
+#[cfg(feature = "acp")]
+pub use transport::AcpTransport;
 pub use transport::{
-    AcpTransport, CODEX_EXEC_INITIAL_STALL_REASON, ClaudeCodeCliTransport,
+    CODEX_EXEC_INITIAL_STALL_REASON, ClaudeCodeCliTransport,
     DEFAULT_CODEX_INITIAL_RESPONSE_TIMEOUT_SECONDS, LegacyTransport, PeakMemoryContext,
     ResolvedTimeout, SandboxTransportConfig, Transport, TransportCapabilities, TransportFactory,
     TransportFactoryError, TransportMode, TransportOptions, TransportResult,
@@ -41,6 +45,3 @@ pub use transport::{
     contains_gemini_oauth_prompt, normalize_gemini_prompt_text, resolve_initial_response_timeout,
     strip_ansi_escape_sequences,
 };
-
-// Re-export session config types from csa-acp for pipeline integration.
-pub use csa_acp::{McpServerConfig as AcpMcpServerConfig, SessionConfig};

--- a/crates/csa-executor/src/session_config.rs
+++ b/crates/csa-executor/src/session_config.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpServerConfig {
+    pub name: String,
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionConfig {
+    #[serde(default)]
+    pub no_load: Vec<String>,
+    #[serde(default)]
+    pub extra_load: Vec<String>,
+    pub tier: Option<String>,
+    #[serde(default)]
+    pub models: Vec<String>,
+    #[serde(default)]
+    pub mcp_servers: Vec<McpServerConfig>,
+    #[serde(default)]
+    pub mcp_proxy_socket: Option<String>,
+}

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -3,16 +3,22 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::executor::Executor;
+#[cfg(feature = "acp")]
 use crate::lefthook_guard::sanitize_args_for_codex;
+#[cfg(feature = "acp")]
+use crate::session_config::SessionConfig;
+#[cfg(feature = "acp")]
+use crate::transport_gemini_retry::is_gemini_rate_limited_error;
 use crate::transport_gemini_retry::{
     gemini_auth_mode, gemini_inject_api_key_fallback, gemini_max_attempts,
     gemini_rate_limit_backoff, gemini_retry_model, gemini_should_use_api_key,
-    is_gemini_rate_limited_error, is_gemini_rate_limited_result,
+    is_gemini_rate_limited_result,
 };
-use anyhow::{Result, anyhow};
+use anyhow::Result;
+#[cfg(feature = "acp")]
+use anyhow::anyhow;
 use async_trait::async_trait;
 use chrono::Utc;
-use csa_acp::SessionConfig;
 use csa_process::{
     ExecutionResult, SpawnOptions, StreamMode, spawn_tool_sandboxed, spawn_tool_with_options,
     wait_and_capture_with_idle_timeout,
@@ -25,21 +31,28 @@ use csa_session::{
 #[path = "transport_meta.rs"]
 mod transport_meta;
 pub use transport_meta::PeakMemoryContext;
-use transport_meta::{build_summary, run_acp_sandboxed};
+#[cfg(feature = "acp")]
+#[path = "transport_acp_sandbox.rs"]
+mod transport_acp_sandbox;
+#[cfg(feature = "acp")]
+use transport_acp_sandbox::{build_summary, run_acp_sandboxed};
 #[path = "transport_gemini_helpers.rs"]
 mod transport_gemini_helpers;
+#[cfg(feature = "acp")]
 use transport_gemini_helpers::{
     GeminiAcpInitFailureClassification, GeminiRetryPhase, annotate_gemini_retry_error,
     append_gemini_retry_report, apply_gemini_acp_initial_stall_summary,
-    apply_gemini_legacy_initial_stall_summary, apply_gemini_mcp_warning_summary,
-    apply_gemini_sandbox_runtime_contract, classify_gemini_acp_init_failure,
-    classify_gemini_acp_initial_stall, classify_gemini_legacy_initial_stall,
-    classify_gemini_oauth_prompt_result, classify_join_error, format_gemini_acp_init_failure,
-    gemini_acp_initial_response_timeout_seconds, gemini_phase_desc,
-    gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure, is_gemini_mcp_issue_result,
-    is_gemini_oauth_prompt_result, resolve_gemini_shared_npm_cache_source,
+    classify_gemini_acp_init_failure, classify_gemini_acp_initial_stall, classify_join_error,
+    format_gemini_acp_init_failure, gemini_acp_initial_response_timeout_seconds, gemini_phase_desc,
+    gemini_sandbox_runtime_env_overrides, is_gemini_acp_init_failure,
 };
-#[cfg(test)]
+use transport_gemini_helpers::{
+    apply_gemini_legacy_initial_stall_summary, apply_gemini_mcp_warning_summary,
+    apply_gemini_sandbox_runtime_contract, classify_gemini_legacy_initial_stall,
+    classify_gemini_oauth_prompt_result, is_gemini_mcp_issue_result, is_gemini_oauth_prompt_result,
+    resolve_gemini_shared_npm_cache_source,
+};
+#[cfg(all(test, feature = "acp"))]
 use transport_gemini_helpers::{
     apply_gemini_sandbox_runtime_env_overrides, ensure_gemini_runtime_home_writable_path,
     format_gemini_retry_report,
@@ -49,18 +62,23 @@ pub use transport_gemini_helpers::{
 };
 #[path = "transport_gemini_acp_runtime.rs"]
 mod transport_gemini_acp_runtime;
+#[cfg(feature = "acp")]
+use transport_gemini_acp_runtime::prepare_gemini_acp_runtime;
 use transport_gemini_acp_runtime::{
-    gemini_runtime_home_from_env, prepare_gemini_acp_runtime, prepare_gemini_runtime_env,
-    shared_npm_cache_dir,
+    gemini_runtime_home_from_env, prepare_gemini_runtime_env, shared_npm_cache_dir,
 };
 #[path = "transport_gemini_mcp_diagnostic.rs"]
 mod transport_gemini_mcp_diagnostic;
+#[cfg(feature = "acp")]
+use transport_gemini_mcp_diagnostic::McpInitDiagnostic;
 use transport_gemini_mcp_diagnostic::{
-    McpInitDiagnostic, diagnose_mcp_init_failure, disable_mcp_servers_in_runtime,
-    format_mcp_init_warning_summary, gemini_allow_degraded_mcp,
+    diagnose_mcp_init_failure, disable_mcp_servers_in_runtime, format_mcp_init_warning_summary,
+    gemini_allow_degraded_mcp,
 };
 #[path = "transport_acp_crash_retry.rs"]
+#[cfg(feature = "acp")]
 mod transport_acp_crash_retry;
+#[cfg(feature = "acp")]
 use transport_acp_crash_retry::execute_with_crash_retry;
 #[path = "transport_fork.rs"]
 mod transport_fork;
@@ -72,7 +90,9 @@ pub use transport_factory::{TransportFactory, TransportFactoryError, TransportMo
 mod transport_cli;
 pub use transport_cli::ClaudeCodeCliTransport;
 #[path = "transport_acp_payload_debug.rs"]
+#[cfg(feature = "acp")]
 mod transport_acp_payload_debug;
+#[cfg(feature = "acp")]
 use transport_acp_payload_debug::{AcpPayloadDebugRequest, maybe_write_acp_payload_debug};
 #[path = "transport_codex_exec_stall.rs"]
 mod transport_codex_exec_stall;
@@ -94,6 +114,7 @@ use transport_legacy_codex_exec_stall::{
 
 #[path = "transport_types.rs"]
 mod transport_types;
+#[cfg(feature = "acp")]
 use transport_types::should_stream_acp_stdout_to_stderr;
 pub use transport_types::{
     ResolvedTimeout, SandboxTransportConfig, TransportCapabilities, TransportOptions,
@@ -398,6 +419,7 @@ impl LegacyTransport {
 
 include!("transport_legacy_impl.rs");
 
+#[cfg(feature = "acp")]
 #[derive(Debug, Clone)]
 pub struct AcpTransport {
     pub(crate) tool_name: String,
@@ -406,6 +428,7 @@ pub struct AcpTransport {
     pub(crate) session_config: Option<SessionConfig>,
 }
 
+#[cfg(feature = "acp")]
 impl AcpTransport {
     pub fn new(tool_name: &str, session_config: Option<SessionConfig>) -> Self {
         let (cmd, args) = Self::acp_command_for_tool(tool_name);
@@ -429,8 +452,10 @@ impl AcpTransport {
     }
 }
 
+#[cfg(feature = "acp")]
 include!("transport_acp_spawn.rs");
 
+#[cfg(feature = "acp")]
 impl AcpTransport {
     /// Execute a single ACP attempt with the given args and env.
     ///
@@ -634,18 +659,59 @@ impl AcpTransport {
         Ok(TransportResult {
             execution,
             provider_session_id: Some(output.session_id),
-            events: output.events,
-            metadata: output.metadata,
+            events: output.events.into_iter().map(convert_acp_event).collect(),
+            metadata: convert_acp_metadata(output.metadata),
         })
     }
 }
 
+#[cfg(feature = "acp")]
+fn convert_acp_event(event: csa_acp::SessionEvent) -> csa_core::transport_events::SessionEvent {
+    match event {
+        csa_acp::SessionEvent::AgentMessage(text) => {
+            csa_core::transport_events::SessionEvent::AgentMessage(text)
+        }
+        csa_acp::SessionEvent::AgentThought(text) => {
+            csa_core::transport_events::SessionEvent::AgentThought(text)
+        }
+        csa_acp::SessionEvent::ToolCallStarted { id, title, kind } => {
+            csa_core::transport_events::SessionEvent::ToolCallStarted { id, title, kind }
+        }
+        csa_acp::SessionEvent::ToolCallCompleted { id, status } => {
+            csa_core::transport_events::SessionEvent::ToolCallCompleted { id, status }
+        }
+        csa_acp::SessionEvent::PlanUpdate(text) => {
+            csa_core::transport_events::SessionEvent::PlanUpdate(text)
+        }
+        csa_acp::SessionEvent::Other(text) => csa_core::transport_events::SessionEvent::Other(text),
+    }
+}
+
+#[cfg(feature = "acp")]
+fn convert_acp_metadata(
+    metadata: csa_acp::StreamingMetadata,
+) -> csa_core::transport_events::StreamingMetadata {
+    csa_core::transport_events::StreamingMetadata {
+        total_events_count: metadata.total_events_count,
+        has_tool_calls: metadata.has_tool_calls,
+        has_execute_tool_calls: metadata.has_execute_tool_calls,
+        has_no_verify_commit: metadata.has_no_verify_commit,
+        has_plan_updates: metadata.has_plan_updates,
+        extracted_commands: metadata.extracted_commands,
+        tail_text: metadata.tail_text,
+        message_text: metadata.message_text,
+        thought_text: metadata.thought_text,
+        has_thought_fallback: metadata.has_thought_fallback,
+    }
+}
+
+#[cfg(feature = "acp")]
 include!("transport_acp_impl.rs");
 
-#[cfg(test)]
+#[cfg(all(test, feature = "acp"))]
 #[path = "transport_tests_mod.rs"]
 mod tests;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "acp"))]
 #[path = "transport_lean_mode_tests.rs"]
 mod lean_mode_tests;

--- a/crates/csa-executor/src/transport_acp_crash_retry.rs
+++ b/crates/csa-executor/src/transport_acp_crash_retry.rs
@@ -9,7 +9,7 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
-use csa_acp::SessionEvent;
+use csa_core::transport_events::SessionEvent;
 use csa_session::state::{MetaSessionState, ToolState};
 use regex::Regex;
 

--- a/crates/csa-executor/src/transport_acp_sandbox.rs
+++ b/crates/csa-executor/src/transport_acp_sandbox.rs
@@ -1,0 +1,305 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Duration;
+
+use csa_resource::isolation_plan::IsolationPlan;
+
+use super::transport_meta::start_memory_monitor;
+
+const SUMMARY_MAX_CHARS: usize = 200;
+
+/// Result of [`run_acp_sandboxed`] that preserves peak memory even on failure.
+pub(super) struct AcpSandboxedResult {
+    pub result: csa_acp::AcpResult<csa_acp::transport::AcpOutput>,
+    /// Peak memory from cgroup `memory.peak`, available even when the ACP
+    /// session fails (OOM, timeout, init error).
+    pub peak_memory_mb: Option<u64>,
+    /// True only when `spawn_sandboxed()` itself failed (the process never
+    /// started).  False when the sandboxed process started but then failed
+    /// during execution (OOM, timeout, init error, prompt failure).
+    /// Callers should only fall back to unsandboxed execution when this is true.
+    pub sandbox_spawn_failed: bool,
+}
+
+/// Run an ACP prompt with sandbox isolation.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn run_acp_sandboxed(
+    command: &str,
+    args: &[String],
+    working_dir: &Path,
+    env: &HashMap<String, String>,
+    system_prompt: Option<&str>,
+    resume_session_id: Option<&str>,
+    meta: Option<serde_json::Map<String, serde_json::Value>>,
+    prompt: &str,
+    idle_timeout: Duration,
+    initial_response_timeout: Option<Duration>,
+    init_timeout: Duration,
+    termination_grace_period: Duration,
+    isolation_plan: &IsolationPlan,
+    tool_name: &str,
+    session_id: &str,
+    stream_stdout_to_stderr: bool,
+    output_spool: Option<&Path>,
+    output_spool_max_bytes: u64,
+    output_spool_keep_rotated: bool,
+) -> AcpSandboxedResult {
+    use csa_acp::AcpConnection;
+    use csa_acp::connection::{AcpConnectionOptions, AcpSandboxRequest, AcpSpawnRequest};
+
+    let (connection, sandbox_handle) = match AcpConnection::spawn_sandboxed(
+        AcpSpawnRequest {
+            command,
+            args,
+            working_dir,
+            env,
+            options: AcpConnectionOptions {
+                init_timeout,
+                termination_grace_period,
+            },
+        },
+        Some(AcpSandboxRequest {
+            isolation_plan,
+            tool_name,
+            session_id,
+            env_overrides: None,
+        }),
+    )
+    .await
+    {
+        Ok(pair) => pair,
+        Err(e) => {
+            // Spawn failed before we have a sandbox handle - no peak memory.
+            return AcpSandboxedResult {
+                result: Err(e),
+                peak_memory_mb: None,
+                sandbox_spawn_failed: true,
+            };
+        }
+    };
+
+    // Start memory monitor immediately after spawn, before initialize()/session
+    // setup, so cold-start memory usage is also tracked.
+    let memory_monitor = sandbox_handle
+        .scope_name()
+        .zip(connection.child_pid())
+        .and_then(|(scope, pid)| {
+            start_memory_monitor(scope, pid, isolation_plan, termination_grace_period)
+        });
+
+    // Inner block: all fallible operations after spawn. peak_memory_mb is
+    // captured regardless of success or failure.
+    let inner_result = run_acp_sandboxed_inner(
+        &connection,
+        memory_monitor,
+        system_prompt,
+        resume_session_id,
+        meta,
+        prompt,
+        idle_timeout,
+        initial_response_timeout,
+        stream_stdout_to_stderr,
+        output_spool,
+        output_spool_max_bytes,
+        output_spool_keep_rotated,
+        working_dir,
+    )
+    .await;
+
+    let exit_signal = match &inner_result {
+        Err(csa_acp::AcpError::ProcessExited { signal, .. }) => *signal,
+        _ => None,
+    };
+
+    // Capture peak memory and check for OOM BEFORE the sandbox handle is
+    // dropped (which stops the cgroup scope). Note: `run_acp_sandboxed` is
+    // called inside `spawn_blocking`, so synchronous systemctl queries are
+    // acceptable here.
+    let peak_memory_mb = sandbox_handle.memory_peak_mb();
+    let oom_diagnosis = sandbox_handle.oom_diagnosis_with_signal(exit_signal);
+    if let Some(ref hint) = oom_diagnosis {
+        tracing::error!(tool = tool_name, "{hint}");
+    }
+    if let Some(peak) = peak_memory_mb {
+        tracing::info!(
+            tool = tool_name,
+            peak_memory_mb = peak,
+            "cgroup peak memory recorded"
+        );
+    }
+
+    // Enrich error with OOM diagnosis if applicable.
+    let result = match inner_result {
+        Ok((prompt_result, acp_session_id)) => {
+            let mut exit_code = match connection.exit_code().await {
+                Ok(code) => code.unwrap_or(0),
+                Err(e) => {
+                    return AcpSandboxedResult {
+                        result: Err(e),
+                        peak_memory_mb,
+                        sandbox_spawn_failed: false,
+                    };
+                }
+            };
+            let mut stderr = connection.stderr();
+            if prompt_result.timed_out {
+                exit_code = 137;
+                if !stderr.is_empty() && !stderr.ends_with('\n') {
+                    stderr.push('\n');
+                }
+                let is_initial =
+                    prompt_result.exit_reason.as_deref() == Some("initial_response_timeout");
+                let timeout_secs = if is_initial {
+                    initial_response_timeout.unwrap_or(idle_timeout).as_secs()
+                } else {
+                    idle_timeout.as_secs()
+                };
+                let label = if is_initial {
+                    "initial response timeout"
+                } else {
+                    "idle timeout"
+                };
+                stderr.push_str(&format!(
+                    "{label}: no ACP events/stderr for {timeout_secs}s; process killed",
+                ));
+                stderr.push('\n');
+            }
+
+            Ok(csa_acp::transport::AcpOutput {
+                output: prompt_result.output,
+                stderr,
+                events: prompt_result.events,
+                session_id: acp_session_id,
+                exit_code,
+                metadata: prompt_result.metadata,
+                peak_memory_mb,
+            })
+        }
+        Err(e) => {
+            if let Some(hint) = &oom_diagnosis {
+                // Construct a typed ProcessExited error so callers retain
+                // programmatic access to exit code and signal fields.
+                let mut stderr = connection.stderr();
+                if !stderr.is_empty() && !stderr.ends_with('\n') {
+                    stderr.push('\n');
+                }
+                stderr.push_str(&format!("OOM detected: {hint}\n"));
+                stderr.push_str(&format!("original error: {e}\n"));
+                Err(csa_acp::AcpError::ProcessExited {
+                    code: 137,
+                    signal: Some(9),
+                    stderr,
+                })
+            } else {
+                Err(e)
+            }
+        }
+    };
+
+    // sandbox_handle dropped here, cleaning up cgroup scope if applicable.
+    AcpSandboxedResult {
+        result,
+        peak_memory_mb,
+        sandbox_spawn_failed: false,
+    }
+}
+
+/// Inner helper: session setup + prompt execution. Returns the prompt result
+/// and session ID so the caller can capture peak memory regardless of outcome.
+#[allow(clippy::too_many_arguments)]
+async fn run_acp_sandboxed_inner(
+    connection: &csa_acp::AcpConnection,
+    memory_monitor: Option<csa_resource::memory_monitor::MemoryMonitorHandle>,
+    system_prompt: Option<&str>,
+    resume_session_id: Option<&str>,
+    meta: Option<serde_json::Map<String, serde_json::Value>>,
+    prompt: &str,
+    idle_timeout: Duration,
+    initial_response_timeout: Option<Duration>,
+    stream_stdout_to_stderr: bool,
+    output_spool: Option<&Path>,
+    output_spool_max_bytes: u64,
+    output_spool_keep_rotated: bool,
+    working_dir: &Path,
+) -> csa_acp::AcpResult<(csa_acp::connection::PromptResult, String)> {
+    connection.initialize().await?;
+
+    let acp_session_id = if let Some(resume_id) = resume_session_id {
+        tracing::debug!(
+            resume_session_id = resume_id,
+            "loading ACP session (sandboxed)"
+        );
+        match connection.load_session(resume_id, Some(working_dir)).await {
+            Ok(id) => id,
+            Err(error) => {
+                tracing::warn!(
+                    resume_session_id = resume_id,
+                    error = %error,
+                    "Failed to resume sandboxed ACP session, creating new session"
+                );
+                connection
+                    .new_session(system_prompt, Some(working_dir), meta.clone())
+                    .await?
+            }
+        }
+    } else {
+        connection
+            .new_session(system_prompt, Some(working_dir), meta.clone())
+            .await?
+    };
+
+    let result = connection
+        .prompt_with_io(
+            &acp_session_id,
+            prompt,
+            idle_timeout,
+            initial_response_timeout,
+            csa_acp::connection::PromptIoOptions {
+                stream_stdout_to_stderr,
+                output_spool,
+                spool_max_bytes: output_spool_max_bytes,
+                keep_rotated_spool: output_spool_keep_rotated,
+            },
+        )
+        .await;
+
+    // Stop memory monitor before capturing peak memory (done by caller).
+    if let Some(monitor) = memory_monitor {
+        monitor.stop().await;
+    }
+
+    result.map(|r| (r, acp_session_id))
+}
+
+pub(super) fn build_summary(stdout: &str, stderr: &str, exit_code: i32) -> String {
+    if exit_code == 0 {
+        return truncate_line(last_non_empty_line(stdout), SUMMARY_MAX_CHARS);
+    }
+
+    let stdout_line = last_non_empty_line(stdout);
+    if !stdout_line.is_empty() {
+        return truncate_line(stdout_line, SUMMARY_MAX_CHARS);
+    }
+
+    let stderr_line = last_non_empty_line(stderr);
+    if !stderr_line.is_empty() {
+        return truncate_line(stderr_line, SUMMARY_MAX_CHARS);
+    }
+
+    format!("exit code {exit_code}")
+}
+
+fn last_non_empty_line(output: &str) -> &str {
+    output
+        .lines()
+        .rev()
+        .find(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !trimmed.starts_with("<!-- CSA:SECTION:")
+        })
+        .unwrap_or_default()
+}
+
+fn truncate_line(line: &str, max_chars: usize) -> String {
+    line.chars().take(max_chars).collect()
+}

--- a/crates/csa-executor/src/transport_acp_spawn.rs
+++ b/crates/csa-executor/src/transport_acp_spawn.rs
@@ -74,7 +74,7 @@ impl AcpTransport {
                         request.output_spool_keep_rotated,
                     ));
                     match sr {
-                        transport_meta::AcpSandboxedResult {
+                        transport_acp_sandbox::AcpSandboxedResult {
                             result: Ok(mut output),
                             peak_memory_mb,
                             ..
@@ -82,7 +82,7 @@ impl AcpTransport {
                             output.peak_memory_mb = output.peak_memory_mb.or(peak_memory_mb);
                             Ok(output)
                         }
-                        transport_meta::AcpSandboxedResult {
+                        transport_acp_sandbox::AcpSandboxedResult {
                             result: Err(e),
                             sandbox_spawn_failed: true,
                             ..
@@ -125,7 +125,7 @@ impl AcpTransport {
                             ))
                             .map_err(|e| anyhow!("ACP transport (unsandboxed fallback) failed: {e}"))
                         }
-                        transport_meta::AcpSandboxedResult {
+                        transport_acp_sandbox::AcpSandboxedResult {
                             result: Err(e),
                             peak_memory_mb,
                             ..

--- a/crates/csa-executor/src/transport_cli.rs
+++ b/crates/csa-executor/src/transport_cli.rs
@@ -48,7 +48,7 @@ use std::process::Stdio;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use csa_acp::{SessionEvent, StreamingMetadata};
+use csa_core::transport_events::{SessionEvent, StreamingMetadata};
 use csa_process::{
     SpawnOptions, StreamMode, spawn_tool_sandboxed, wait_and_capture_with_idle_timeout,
 };

--- a/crates/csa-executor/src/transport_cli_tests.rs
+++ b/crates/csa-executor/src/transport_cli_tests.rs
@@ -90,7 +90,7 @@ fn factory_returns_acp_for_claude_code_acp_metadata_with_feature() {
     assert_eq!(transport.mode(), TransportMode::Acp);
 }
 
-/// Without `claude-code-acp` feature, even an explicit ACP metadata request
+/// Without the ACP feature stack, even an explicit ACP metadata request
 /// must fail — the feature gate is the safety net for #1115/#1117.
 #[test]
 #[cfg(not(feature = "claude-code-acp"))]
@@ -107,7 +107,9 @@ fn factory_rejects_acp_for_claude_code_without_feature() {
     );
     let msg = format!("{:#}", result.err().unwrap());
     assert!(
-        msg.contains("claude-code-acp") || msg.contains("1115"),
+        msg.contains("`acp` cargo feature")
+            || msg.contains("claude-code-acp")
+            || msg.contains("1115"),
         "error should mention the feature flag or issue; got: {msg}"
     );
 }
@@ -151,7 +153,7 @@ fn factory_returns_acp_for_codex_acp_metadata_with_feature() {
     assert_eq!(transport.mode(), TransportMode::Acp);
 }
 
-/// Without `codex-acp` feature, even an explicit ACP metadata request must
+/// Without the ACP feature stack, even an explicit ACP metadata request must
 /// fail — the feature gate is the safety net for the #760 / #1128 transport
 /// flip. Mirrors `factory_rejects_acp_for_claude_code_without_feature`.
 #[test]
@@ -170,7 +172,10 @@ fn factory_rejects_acp_for_codex_without_feature() {
     );
     let msg = format!("{:#}", result.err().unwrap());
     assert!(
-        msg.contains("codex-acp") || msg.contains("760") || msg.contains("1128"),
+        msg.contains("`acp` cargo feature")
+            || msg.contains("codex-acp")
+            || msg.contains("760")
+            || msg.contains("1128"),
         "error should mention the feature flag or issue; got: {msg}"
     );
 }

--- a/crates/csa-executor/src/transport_factory.rs
+++ b/crates/csa-executor/src/transport_factory.rs
@@ -1,12 +1,11 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "acp")]
+use super::AcpTransport;
+use super::{ClaudeCodeCliTransport, LegacyTransport, Transport, TransportCapabilities};
 use crate::executor::Executor;
-use csa_acp::SessionConfig;
-
-use super::{
-    AcpTransport, ClaudeCodeCliTransport, LegacyTransport, Transport, TransportCapabilities,
-};
+use crate::session_config::SessionConfig;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -142,16 +141,21 @@ impl TransportFactory {
         };
 
         match (executor, mode) {
+            #[cfg(not(feature = "acp"))]
+            (_, TransportMode::Acp) => err(
+                "ACP transport requires the `acp` cargo feature; rebuild with `--features acp` to enable",
+            ),
+
             // ClaudeCode + ACP: gated behind the `claude-code-acp` cargo feature.
             // ACP for claude-code crashes at session startup (turn_count=0, #1115/#1117).
             // Build with `--features claude-code-acp` to re-enable this path.
-            #[cfg(not(feature = "claude-code-acp"))]
+            #[cfg(all(feature = "acp", not(feature = "claude-code-acp")))]
             (Executor::ClaudeCode { .. }, TransportMode::Acp) => err(
                 "claude-code ACP transport requires the `claude-code-acp` cargo feature \
                      (disabled by default due to startup-crash bugs #1115/#1117); \
                      rebuild with `--features claude-code-acp` to enable",
             ),
-            #[cfg(feature = "claude-code-acp")]
+            #[cfg(all(feature = "acp", feature = "claude-code-acp"))]
             (Executor::ClaudeCode { .. }, TransportMode::Acp) => Ok(()),
             (Executor::ClaudeCode { .. }, TransportMode::Legacy) => Ok(()),
             (Executor::ClaudeCode { .. }, TransportMode::OpenaiCompat) => {
@@ -164,13 +168,13 @@ impl TransportFactory {
             // on server-side cache reuse (#760 / #1128).
             // Build with `--features codex-acp` to re-enable this path.
             (Executor::Codex { .. }, TransportMode::Legacy) => Ok(()),
-            #[cfg(not(feature = "codex-acp"))]
+            #[cfg(all(feature = "acp", not(feature = "codex-acp")))]
             (Executor::Codex { .. }, TransportMode::Acp) => err(
                 "codex ACP transport requires the `codex-acp` cargo feature \
                      (disabled by default in favour of native `codex exec resume <id>`, \
                      #760/#1128); rebuild with `--features codex-acp` to enable",
             ),
-            #[cfg(feature = "codex-acp")]
+            #[cfg(all(feature = "acp", feature = "codex-acp"))]
             (Executor::Codex { .. }, TransportMode::Acp) => Ok(()),
             (Executor::Codex { .. }, TransportMode::OpenaiCompat) => {
                 err("codex only supports cli or acp transport")
@@ -178,6 +182,7 @@ impl TransportFactory {
 
             // GeminiCli: Legacy and ACP (native --acp mode)
             (Executor::GeminiCli { .. }, TransportMode::Legacy) => Ok(()),
+            #[cfg(feature = "acp")]
             (Executor::GeminiCli { .. }, TransportMode::Acp) => Ok(()),
             (Executor::GeminiCli { .. }, TransportMode::OpenaiCompat) => {
                 err("gemini-cli only supports cli or acp transport")
@@ -185,6 +190,7 @@ impl TransportFactory {
 
             // Opencode: Legacy only
             (Executor::Opencode { .. }, TransportMode::Legacy) => Ok(()),
+            #[cfg(feature = "acp")]
             (Executor::Opencode { .. }, TransportMode::Acp) => err("opencode has no acp transport"),
             (Executor::Opencode { .. }, TransportMode::OpenaiCompat) => {
                 err("opencode only supports cli transport")
@@ -195,6 +201,7 @@ impl TransportFactory {
             (Executor::OpenaiCompat { .. }, TransportMode::Legacy) => {
                 err("openai-compat has no cli binary")
             }
+            #[cfg(feature = "acp")]
             (Executor::OpenaiCompat { .. }, TransportMode::Acp) => {
                 err("openai-compat does not support acp transport")
             }
@@ -241,38 +248,50 @@ impl TransportFactory {
                 _ => Ok(Box::new(LegacyTransport::new(executor.clone()))),
             },
             TransportMode::Acp => {
-                // claude-code ACP transport is gated behind the `claude-code-acp` cargo
-                // feature (disabled by default, #1115/#1117). All other tools' ACP
-                // paths are always available.
-                #[cfg(not(feature = "claude-code-acp"))]
-                if matches!(executor, Executor::ClaudeCode { .. }) {
+                #[cfg(not(feature = "acp"))]
+                {
+                    let _ = executor;
+                    let _ = session_config;
                     anyhow::bail!(
-                        "claude-code ACP transport is disabled (cargo feature `claude-code-acp` \
+                        "ACP transport is disabled (cargo feature `acp` is not enabled). \
+                         Rebuild csa-executor with `--features acp` to enable ACP transport."
+                    );
+                }
+                #[cfg(feature = "acp")]
+                {
+                    // claude-code ACP transport is gated behind the `claude-code-acp` cargo
+                    // feature (disabled by default, #1115/#1117). All other tools' ACP
+                    // paths are always available.
+                    #[cfg(not(feature = "claude-code-acp"))]
+                    if matches!(executor, Executor::ClaudeCode { .. }) {
+                        anyhow::bail!(
+                            "claude-code ACP transport is disabled (cargo feature `claude-code-acp` \
                          is not enabled). This path was gated because ACP silently crashes at \
                          session startup (turn_count=0, output_log=0B, #1115/#1117). \
                          Rebuild csa-executor with `--features claude-code-acp` to enable \
                          this transport for investigation."
-                    );
-                }
-                // codex ACP transport is gated behind the `codex-acp` cargo feature
-                // (disabled by default, #760 / #1128) because native CLI resume
-                // (`codex exec resume <id>`, codex-cli 0.125.0+) is empirically
-                // equivalent on server-side cache reuse.
-                #[cfg(not(feature = "codex-acp"))]
-                if matches!(executor, Executor::Codex { .. }) {
-                    anyhow::bail!(
-                        "codex ACP transport is disabled (cargo feature `codex-acp` is not \
+                        );
+                    }
+                    // codex ACP transport is gated behind the `codex-acp` cargo feature
+                    // (disabled by default, #760 / #1128) because native CLI resume
+                    // (`codex exec resume <id>`, codex-cli 0.125.0+) is empirically
+                    // equivalent on server-side cache reuse.
+                    #[cfg(not(feature = "codex-acp"))]
+                    if matches!(executor, Executor::Codex { .. }) {
+                        anyhow::bail!(
+                            "codex ACP transport is disabled (cargo feature `codex-acp` is not \
                          enabled). This path was gated because native `codex exec resume <id>` \
                          (codex-cli 0.125.0+) is empirically equivalent to ACP loadSession on \
                          server-side cache reuse (54%, 44,800/83,503 input tokens, #760 / #1128). \
                          Rebuild csa-executor with `--features codex-acp` to enable this \
                          transport for investigation."
-                    );
+                        );
+                    }
+                    Ok(Box::new(AcpTransport::new(
+                        executor.tool_name(),
+                        session_config,
+                    )))
                 }
-                Ok(Box::new(AcpTransport::new(
-                    executor.tool_name(),
-                    session_config,
-                )))
             }
             TransportMode::OpenaiCompat => {
                 let default_model = if let Executor::OpenaiCompat { model_override, .. } = executor

--- a/crates/csa-executor/src/transport_factory_tests.rs
+++ b/crates/csa-executor/src/transport_factory_tests.rs
@@ -81,8 +81,8 @@ fn test_mode_for_executor_claude_code_default_is_legacy() {
 // Change 3: feature-gate — ACP without feature => error
 // ---------------------------------------------------------------------------
 
-/// When `claude-code-acp` feature is OFF, requesting ACP transport must fail with
-/// a clear error citing the feature flag and the issue numbers (#1115/#1117).
+/// When the ACP feature stack is OFF, requesting ACP transport must fail with
+/// a clear error citing the generic or tool-specific feature gate.
 #[test]
 #[cfg(not(feature = "claude-code-acp"))]
 fn test_validate_or_instantiate_claude_code_acp_errors_without_feature() {
@@ -96,7 +96,9 @@ fn test_validate_or_instantiate_claude_code_acp_errors_without_feature() {
     );
     let msg = format!("{}", result.unwrap_err());
     assert!(
-        msg.contains("claude-code-acp") || msg.contains("1115"),
+        msg.contains("`acp` cargo feature")
+            || msg.contains("claude-code-acp")
+            || msg.contains("1115"),
         "error should mention the feature flag or issue number; got: {msg}"
     );
 }
@@ -157,8 +159,8 @@ fn test_mode_for_executor_codex_default_is_legacy() {
 // Codex: feature-gate — ACP without feature => error
 // ---------------------------------------------------------------------------
 
-/// When `codex-acp` feature is OFF, requesting ACP transport must fail with a
-/// clear error citing the feature flag and the issue numbers (#760 / #1128).
+/// When the ACP feature stack is OFF, requesting ACP transport must fail with a
+/// clear error citing the generic or tool-specific feature gate.
 #[test]
 #[cfg(not(feature = "codex-acp"))]
 fn test_validate_or_instantiate_codex_acp_errors_without_feature() {
@@ -171,7 +173,10 @@ fn test_validate_or_instantiate_codex_acp_errors_without_feature() {
     );
     let msg = format!("{}", result.unwrap_err());
     assert!(
-        msg.contains("codex-acp") || msg.contains("760") || msg.contains("1128"),
+        msg.contains("`acp` cargo feature")
+            || msg.contains("codex-acp")
+            || msg.contains("760")
+            || msg.contains("1128"),
         "error should mention the feature flag or issue number; got: {msg}"
     );
 }
@@ -199,9 +204,9 @@ fn test_codex_acp_works_with_feature() {
 // (and vice versa). Both gates target their own tool only.
 // ---------------------------------------------------------------------------
 
-/// gemini-cli ACP path must remain available regardless of either feature gate.
-/// The feature gates are scoped to claude-code and codex only.
+/// gemini-cli ACP path is available when the generic ACP crate feature is enabled.
 #[test]
+#[cfg(feature = "acp")]
 fn test_gemini_cli_acp_unaffected_by_feature_gates() {
     let executor = Executor::GeminiCli {
         model_override: None,
@@ -211,5 +216,25 @@ fn test_gemini_cli_acp_unaffected_by_feature_gates() {
     assert!(
         result.is_ok(),
         "gemini-cli ACP must not be gated by either feature flag"
+    );
+}
+
+/// Without the generic ACP crate feature, every ACP transport mode is disabled.
+#[test]
+#[cfg(not(feature = "acp"))]
+fn test_gemini_cli_acp_requires_acp_feature() {
+    let executor = Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    };
+    let result = TransportFactory::validate_mode_for_executor_pub(&executor, TransportMode::Acp);
+    assert!(
+        result.is_err(),
+        "gemini-cli ACP must be gated by the generic acp feature"
+    );
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("`acp` cargo feature"),
+        "error should mention the generic acp feature; got: {msg}"
     );
 }

--- a/crates/csa-executor/src/transport_fork.rs
+++ b/crates/csa-executor/src/transport_fork.rs
@@ -53,7 +53,14 @@ impl TransportFactory {
     /// Determine which fork method applies for a given tool.
     pub fn fork_method_for_tool(tool_name: &str) -> ForkMethod {
         if tool_name == "claude-code" {
-            ForkMethod::Native
+            #[cfg(feature = "acp")]
+            {
+                ForkMethod::Native
+            }
+            #[cfg(not(feature = "acp"))]
+            {
+                ForkMethod::Soft
+            }
         } else if tool_name == "codex" {
             #[cfg(feature = "codex-pty-fork")]
             {
@@ -70,7 +77,7 @@ impl TransportFactory {
 
     /// Fork a session via the appropriate transport-level mechanism.
     ///
-    /// - `claude-code`: Native fork via `claude --fork-session` CLI.
+    /// - `claude-code`: Native fork via `claude --fork-session` CLI when ACP support is compiled in.
     /// - All others: Soft fork via context summary injection from parent session.
     pub async fn fork_session(request: &ForkRequest) -> ForkInfo {
         let method = request
@@ -87,36 +94,45 @@ impl TransportFactory {
             return Self::fork_codex_via_pty(request).await;
         }
 
-        let Some(provider_session_id) = &request.provider_session_id else {
-            return ForkInfo {
-                success: false,
-                method: ForkMethod::Native,
-                new_session_id: None,
-                notes: Some(
-                    "Native fork requires provider_session_id, but none was provided".to_string(),
-                ),
-            };
-        };
-
-        match csa_acp::fork_session_via_cli(
-            provider_session_id,
-            &request.working_dir,
-            request.timeout,
-        )
-        .await
+        #[cfg(not(feature = "acp"))]
         {
-            Ok(result) => ForkInfo {
-                success: true,
-                method: ForkMethod::Native,
-                new_session_id: Some(result.session_id),
-                notes: None,
-            },
-            Err(e) => ForkInfo {
-                success: false,
-                method: ForkMethod::Native,
-                new_session_id: None,
-                notes: Some(format!("Native fork failed: {e}")),
-            },
+            Self::fork_soft_with_reason(request, "ACP native fork support is not compiled in")
+        }
+
+        #[cfg(feature = "acp")]
+        {
+            let Some(provider_session_id) = &request.provider_session_id else {
+                return ForkInfo {
+                    success: false,
+                    method: ForkMethod::Native,
+                    new_session_id: None,
+                    notes: Some(
+                        "Native fork requires provider_session_id, but none was provided"
+                            .to_string(),
+                    ),
+                };
+            };
+
+            match csa_acp::fork_session_via_cli(
+                provider_session_id,
+                &request.working_dir,
+                request.timeout,
+            )
+            .await
+            {
+                Ok(result) => ForkInfo {
+                    success: true,
+                    method: ForkMethod::Native,
+                    new_session_id: Some(result.session_id),
+                    notes: None,
+                },
+                Err(e) => ForkInfo {
+                    success: false,
+                    method: ForkMethod::Native,
+                    new_session_id: None,
+                    notes: Some(format!("Native fork failed: {e}")),
+                },
+            }
         }
     }
 
@@ -220,10 +236,20 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "acp")]
     fn test_fork_method_for_tool_claude_code_is_native() {
         assert_eq!(
             TransportFactory::fork_method_for_tool("claude-code"),
             ForkMethod::Native
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "acp"))]
+    fn test_fork_method_for_tool_claude_code_is_soft_when_acp_feature_disabled() {
+        assert_eq!(
+            TransportFactory::fork_method_for_tool("claude-code"),
+            ForkMethod::Soft
         );
     }
 
@@ -351,11 +377,12 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "acp")]
     async fn test_fork_session_native_without_provider_id_fails() {
         let tmp = tempfile::tempdir().unwrap();
         let request = ForkRequest {
             tool_name: "claude-code".to_string(),
-            fork_method: None,
+            fork_method: Some(ForkMethod::Native),
             provider_session_id: None,
             codex_auto_trust: false,
             parent_csa_session_id: "01TEST_PARENT".to_string(),
@@ -374,6 +401,35 @@ mod tests {
                 .unwrap()
                 .contains("provider_session_id"),
             "Should explain missing provider ID: {:?}",
+            info.notes
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(not(feature = "acp"))]
+    async fn test_fork_session_native_without_acp_feature_degrades_to_soft() {
+        let tmp = tempfile::tempdir().unwrap();
+        let request = ForkRequest {
+            tool_name: "claude-code".to_string(),
+            fork_method: Some(ForkMethod::Native),
+            provider_session_id: None,
+            codex_auto_trust: false,
+            parent_csa_session_id: "01TEST_PARENT".to_string(),
+            parent_session_dir: tmp.path().to_path_buf(),
+            working_dir: tmp.path().to_path_buf(),
+            timeout: Duration::from_secs(10),
+        };
+
+        let info = TransportFactory::fork_session(&request).await;
+
+        assert!(info.success);
+        assert_eq!(info.method, ForkMethod::Soft);
+        assert!(
+            info.notes
+                .as_deref()
+                .unwrap()
+                .contains("ACP native fork support is not compiled in"),
+            "Should explain ACP feature-gated fork fallback: {:?}",
             info.notes
         );
     }

--- a/crates/csa-executor/src/transport_gemini_helpers.rs
+++ b/crates/csa-executor/src/transport_gemini_helpers.rs
@@ -6,19 +6,25 @@ use anyhow::{Result, anyhow};
 use csa_process::ExecutionResult;
 use csa_resource::isolation_plan::IsolationPlan;
 
+#[cfg(feature = "acp")]
 use super::transport_types::ResolvedTimeout;
 use crate::executor::Executor;
+#[cfg(feature = "acp")]
 use crate::transport_gemini_retry::{gemini_retry_model, gemini_should_use_api_key};
 
 pub(crate) const GEMINI_OAUTH_PROMPT_SUMMARY: &str =
     "gemini-cli auth failure: OAuth browser prompt detected; no tool output produced";
 pub(crate) const GEMINI_MCP_ISSUES_DETECTED_SUMMARY: &str =
     "MCP issues detected. Run /mcp list for status.";
+#[cfg(feature = "acp")]
 pub(crate) const GEMINI_ACP_INITIAL_STALL_REASON: &str = "gemini_acp_initial_stall";
 pub(crate) const GEMINI_LEGACY_INITIAL_STALL_REASON: &str = "gemini_legacy_initial_stall";
+#[cfg(feature = "acp")]
 const DEFAULT_GEMINI_ACP_INITIAL_RESPONSE_TIMEOUT_SECONDS: u64 = 180;
+#[cfg(feature = "acp")]
 const ACP_TIMEOUT_FOOTER_SUFFIX: &str = "s; process killed";
 
+#[cfg(feature = "acp")]
 #[derive(Debug, Clone)]
 pub(super) struct GeminiRetryPhase {
     pub(super) attempt: u8,
@@ -26,6 +32,7 @@ pub(super) struct GeminiRetryPhase {
     model: &'static str,
 }
 
+#[cfg(feature = "acp")]
 impl GeminiRetryPhase {
     pub(super) fn for_attempt(attempt: u8) -> Self {
         Self {
@@ -40,6 +47,7 @@ impl GeminiRetryPhase {
     }
 }
 
+#[cfg(feature = "acp")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct GeminiAcpInitialStallClassification {
     pub(super) code: &'static str,
@@ -94,6 +102,7 @@ pub(super) fn resolve_gemini_shared_npm_cache_source(
     }
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn gemini_acp_initial_response_timeout_seconds(
     tool_name: &str,
     resolved_timeout: ResolvedTimeout,
@@ -105,6 +114,7 @@ pub(super) fn gemini_acp_initial_response_timeout_seconds(
     resolved_timeout.as_option().filter(|seconds| *seconds > 0)
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn classify_gemini_acp_initial_stall(
     execution: &ExecutionResult,
     timeout_seconds: Option<u64>,
@@ -129,6 +139,7 @@ pub(super) fn classify_gemini_acp_initial_stall(
     })
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn apply_gemini_acp_initial_stall_summary(
     execution: &mut ExecutionResult,
     classification: &GeminiAcpInitialStallClassification,
@@ -147,6 +158,7 @@ pub(super) fn apply_gemini_acp_initial_stall_summary(
     execution.stderr_output.push('\n');
 }
 
+#[cfg(feature = "acp")]
 pub(crate) fn strip_acp_timeout_footer(stderr: &str) -> &str {
     let trimmed = stderr.strip_suffix('\n').unwrap_or(stderr);
     if let Some((prefix, last_line)) = trimmed.rsplit_once('\n') {
@@ -160,6 +172,7 @@ pub(crate) fn strip_acp_timeout_footer(stderr: &str) -> &str {
     stderr
 }
 
+#[cfg(feature = "acp")]
 fn is_acp_timeout_footer(line: &str) -> bool {
     [
         "initial response timeout: no ACP events/stderr for ",
@@ -243,6 +256,7 @@ pub(crate) fn apply_gemini_mcp_warning_summary(
     execution.stderr_output.push('\n');
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn gemini_phase_desc(attempt: u8) -> &'static str {
     match attempt {
         1 => "OAuth->APIKey(same model)",
@@ -252,6 +266,7 @@ pub(super) fn gemini_phase_desc(attempt: u8) -> &'static str {
     }
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn append_gemini_retry_report(
     execution: &mut ExecutionResult,
     phases: &[GeminiRetryPhase],
@@ -272,6 +287,7 @@ pub(super) fn append_gemini_retry_report(
     execution.stderr_output.push_str(&report);
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn annotate_gemini_retry_error(
     error: anyhow::Error,
     phases: &[GeminiRetryPhase],
@@ -619,6 +635,7 @@ pub fn strip_ansi_escape_sequences(text: &str) -> String {
 /// Broken-pipe panics (from `eprintln!` after the tool process closes stderr)
 /// are rewritten into a clean message that mentions the tool died, instead of
 /// surfacing the raw tokio panic trace.
+#[cfg(feature = "acp")]
 pub(super) fn classify_join_error(e: tokio::task::JoinError) -> anyhow::Error {
     if e.is_panic() {
         let msg = match e.into_panic().downcast::<String>() {
@@ -639,18 +656,21 @@ pub(super) fn classify_join_error(e: tokio::task::JoinError) -> anyhow::Error {
     }
 }
 
+#[cfg(feature = "acp")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct GeminiAcpInitFailureClassification {
     pub(super) code: &'static str,
     pub(super) missing_env_vars: Vec<&'static str>,
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn is_gemini_acp_init_failure(error: &str) -> bool {
     let error_lower = error.to_ascii_lowercase();
     error_lower.contains("acp initialization failed")
         || error_lower.contains("sandboxed acp: acp initialization failed")
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn classify_gemini_acp_init_failure(
     error: &str,
     execution_env: &HashMap<String, String>,
@@ -674,6 +694,7 @@ pub(super) fn classify_gemini_acp_init_failure(
     }
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn format_gemini_acp_init_failure(
     classification: &GeminiAcpInitFailureClassification,
     error: anyhow::Error,
@@ -707,6 +728,7 @@ pub(super) fn format_gemini_acp_init_failure(
     )
 }
 
+#[cfg(feature = "acp")]
 fn missing_gemini_auth_env_vars(execution_env: &HashMap<String, String>) -> Vec<&'static str> {
     [
         csa_core::gemini::API_KEY_ENV,
@@ -722,6 +744,7 @@ fn missing_gemini_auth_env_vars(execution_env: &HashMap<String, String>) -> Vec<
     .collect()
 }
 
+#[cfg(feature = "acp")]
 fn is_gemini_init_oom(error_lower: &str) -> bool {
     error_lower.contains("oom detected")
         || error_lower.contains("out of memory")
@@ -729,6 +752,7 @@ fn is_gemini_init_oom(error_lower: &str) -> bool {
         || error_lower.contains("memory limit")
 }
 
+#[cfg(feature = "acp")]
 fn is_gemini_init_auth_env(error_lower: &str) -> bool {
     [
         "auth",
@@ -746,6 +770,7 @@ fn is_gemini_init_auth_env(error_lower: &str) -> bool {
     .any(|pattern| error_lower.contains(pattern))
 }
 
+#[cfg(feature = "acp")]
 fn is_gemini_init_mcp_extension(error_lower: &str) -> bool {
     error_lower.contains("mcp-server")
         || error_lower.contains("gemini-cli-security")
@@ -756,6 +781,7 @@ fn is_gemini_init_mcp_extension(error_lower: &str) -> bool {
                 .any(|pattern| error_lower.contains(pattern)))
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn format_gemini_retry_report(phases: &[GeminiRetryPhase]) -> String {
     phases
         .iter()

--- a/crates/csa-executor/src/transport_gemini_retry.rs
+++ b/crates/csa-executor/src/transport_gemini_retry.rs
@@ -82,6 +82,7 @@ pub(crate) fn is_gemini_rate_limited_result(execution: &ExecutionResult) -> bool
     .is_some()
 }
 
+#[cfg(feature = "acp")]
 pub(crate) fn is_gemini_rate_limited_error(error_msg: &str) -> bool {
     detect_rate_limit_pattern(error_msg).is_some()
 }

--- a/crates/csa-executor/src/transport_lean_mode_tests.rs
+++ b/crates/csa-executor/src/transport_lean_mode_tests.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 
 use super::AcpTransport;
-use csa_acp::{McpServerConfig, SessionConfig};
+use crate::{AcpMcpServerConfig as McpServerConfig, SessionConfig};
 use std::collections::HashMap;
 
 #[test]

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -4,26 +4,43 @@
 //! This module handles meta/env construction and the sandboxed ACP run helper,
 //! while `transport.rs` retains trait definitions and Transport dispatch.
 
+#[cfg(feature = "acp")]
 use std::collections::HashMap;
+#[cfg(feature = "acp")]
 use std::path::Path;
 
-use csa_acp::SessionConfig;
+#[cfg(feature = "acp")]
 use csa_core::env::{CSA_PARENT_SESSION_DIR_ENV_KEY, CSA_SESSION_DIR_ENV_KEY};
 use csa_resource::isolation_plan::IsolationPlan;
+#[cfg(feature = "acp")]
 use csa_session::state::MetaSessionState;
+#[cfg(feature = "acp")]
+use serde_json::{Map, Value, json};
 
+#[cfg(feature = "acp")]
 use super::AcpTransport;
+#[cfg(feature = "acp")]
 use crate::lefthook_guard::sanitize_env_map_for_codex;
+#[cfg(feature = "acp")]
+use crate::session_config::SessionConfig;
 
-const SUMMARY_MAX_CHARS: usize = 200;
+#[cfg(feature = "acp")]
 const CSA_SESSION_ID_ENV: &str = "CSA_SESSION_ID";
+#[cfg(feature = "acp")]
 const CSA_DEPTH_ENV: &str = "CSA_DEPTH";
+#[cfg(feature = "acp")]
 const CSA_PROJECT_ROOT_ENV: &str = "CSA_PROJECT_ROOT";
+#[cfg(feature = "acp")]
 const CSA_TOOL_ENV: &str = "CSA_TOOL";
+#[cfg(feature = "acp")]
 const CSA_IS_SUBPROCESS_ENV: &str = "CSA_IS_SUBPROCESS";
+#[cfg(feature = "acp")]
 const CSA_PARENT_TOOL_ENV: &str = "CSA_PARENT_TOOL";
+#[cfg(feature = "acp")]
 const CSA_PARENT_SESSION_ENV: &str = "CSA_PARENT_SESSION";
+#[cfg(feature = "acp")]
 const CSA_FS_SANDBOXED_ENV: &str = "CSA_FS_SANDBOXED";
+#[cfg(feature = "acp")]
 const CSA_OWNED_ENV_KEYS: &[&str] = &[
     CSA_SESSION_ID_ENV,
     CSA_DEPTH_ENV,
@@ -46,6 +63,7 @@ const CSA_OWNED_ENV_KEYS: &[&str] = &[
 /// 8192MB hard cap, effectively negating the #555 increase.
 const DEFAULT_SOFT_LIMIT_PERCENT: u8 = 70;
 
+#[cfg(feature = "acp")]
 impl AcpTransport {
     pub(crate) fn build_system_prompt(session_config: Option<&SessionConfig>) -> Option<String> {
         let config = session_config?;
@@ -105,7 +123,7 @@ impl AcpTransport {
             );
         }
         if let Some(cfg) = session_config {
-            let mcp_servers = csa_acp::mcp_proxy_client::resolve_mcp_meta_servers(cfg);
+            let mcp_servers = resolve_mcp_meta_servers(cfg);
             let non_empty_servers = mcp_servers
                 .as_object()
                 .map(|servers| !servers.is_empty())
@@ -230,6 +248,40 @@ impl AcpTransport {
     }
 }
 
+#[cfg(feature = "acp")]
+fn resolve_mcp_meta_servers(config: &SessionConfig) -> Value {
+    if let Some(socket_path) = config
+        .mcp_proxy_socket
+        .as_deref()
+        .map(std::path::PathBuf::from)
+        && socket_path.exists()
+    {
+        let mut proxy_map = Map::new();
+        proxy_map.insert(
+            "csa-mcp-hub".to_string(),
+            json!({
+                "transport": "unix",
+                "socketPath": socket_path,
+            }),
+        );
+        return Value::Object(proxy_map);
+    }
+
+    let mut map = Map::new();
+    for server in &config.mcp_servers {
+        map.insert(
+            server.name.clone(),
+            json!({
+                "command": server.command,
+                "args": server.args,
+                "env": server.env,
+            }),
+        );
+    }
+    Value::Object(map)
+}
+
+#[cfg(feature = "acp")]
 fn is_csa_owned_env_key(key: &str) -> bool {
     CSA_OWNED_ENV_KEYS.contains(&key)
 }
@@ -255,302 +307,6 @@ impl PeakMemoryContext {
     pub fn into_anyhow(self, context: impl std::fmt::Display) -> anyhow::Error {
         anyhow::Error::new(self).context(context.to_string())
     }
-}
-
-/// Result of [`run_acp_sandboxed`] that preserves peak memory even on failure.
-pub(super) struct AcpSandboxedResult {
-    pub result: csa_acp::AcpResult<csa_acp::transport::AcpOutput>,
-    /// Peak memory from cgroup `memory.peak`, available even when the ACP
-    /// session fails (OOM, timeout, init error).
-    pub peak_memory_mb: Option<u64>,
-    /// True only when `spawn_sandboxed()` itself failed (the process never
-    /// started).  False when the sandboxed process started but then failed
-    /// during execution (OOM, timeout, init error, prompt failure).
-    /// Callers should only fall back to unsandboxed execution when this is true.
-    pub sandbox_spawn_failed: bool,
-}
-
-/// Run an ACP prompt with sandbox isolation.
-#[allow(clippy::too_many_arguments)]
-pub(super) async fn run_acp_sandboxed(
-    command: &str,
-    args: &[String],
-    working_dir: &Path,
-    env: &HashMap<String, String>,
-    system_prompt: Option<&str>,
-    resume_session_id: Option<&str>,
-    meta: Option<serde_json::Map<String, serde_json::Value>>,
-    prompt: &str,
-    idle_timeout: std::time::Duration,
-    initial_response_timeout: Option<std::time::Duration>,
-    init_timeout: std::time::Duration,
-    termination_grace_period: std::time::Duration,
-    isolation_plan: &IsolationPlan,
-    tool_name: &str,
-    session_id: &str,
-    stream_stdout_to_stderr: bool,
-    output_spool: Option<&Path>,
-    output_spool_max_bytes: u64,
-    output_spool_keep_rotated: bool,
-) -> AcpSandboxedResult {
-    use csa_acp::AcpConnection;
-    use csa_acp::connection::{AcpConnectionOptions, AcpSandboxRequest, AcpSpawnRequest};
-
-    let (connection, sandbox_handle) = match AcpConnection::spawn_sandboxed(
-        AcpSpawnRequest {
-            command,
-            args,
-            working_dir,
-            env,
-            options: AcpConnectionOptions {
-                init_timeout,
-                termination_grace_period,
-            },
-        },
-        Some(AcpSandboxRequest {
-            isolation_plan,
-            tool_name,
-            session_id,
-            env_overrides: None,
-        }),
-    )
-    .await
-    {
-        Ok(pair) => pair,
-        Err(e) => {
-            // Spawn failed before we have a sandbox handle — no peak memory.
-            return AcpSandboxedResult {
-                result: Err(e),
-                peak_memory_mb: None,
-                sandbox_spawn_failed: true,
-            };
-        }
-    };
-
-    // Start memory monitor immediately after spawn, before initialize()/session
-    // setup, so cold-start memory usage is also tracked.
-    let memory_monitor = sandbox_handle
-        .scope_name()
-        .zip(connection.child_pid())
-        .and_then(|(scope, pid)| {
-            start_memory_monitor(scope, pid, isolation_plan, termination_grace_period)
-        });
-
-    // Inner block: all fallible operations after spawn.  peak_memory_mb is
-    // captured regardless of success or failure.
-    let inner_result = run_acp_sandboxed_inner(
-        &connection,
-        memory_monitor,
-        system_prompt,
-        resume_session_id,
-        meta,
-        prompt,
-        idle_timeout,
-        initial_response_timeout,
-        stream_stdout_to_stderr,
-        output_spool,
-        output_spool_max_bytes,
-        output_spool_keep_rotated,
-        working_dir,
-    )
-    .await;
-
-    let exit_signal = match &inner_result {
-        Err(csa_acp::AcpError::ProcessExited { signal, .. }) => *signal,
-        _ => None,
-    };
-
-    // Capture peak memory and check for OOM BEFORE the sandbox handle is
-    // dropped (which stops the cgroup scope).  Note: `run_acp_sandboxed` is
-    // called inside `spawn_blocking`, so synchronous systemctl queries are
-    // acceptable here.
-    let peak_memory_mb = sandbox_handle.memory_peak_mb();
-    let oom_diagnosis = sandbox_handle.oom_diagnosis_with_signal(exit_signal);
-    if let Some(ref hint) = oom_diagnosis {
-        tracing::error!(tool = tool_name, "{hint}");
-    }
-    if let Some(peak) = peak_memory_mb {
-        tracing::info!(
-            tool = tool_name,
-            peak_memory_mb = peak,
-            "cgroup peak memory recorded"
-        );
-    }
-
-    // Enrich error with OOM diagnosis if applicable.
-    let result = match inner_result {
-        Ok((prompt_result, acp_session_id)) => {
-            let mut exit_code = match connection.exit_code().await {
-                Ok(code) => code.unwrap_or(0),
-                Err(e) => {
-                    return AcpSandboxedResult {
-                        result: Err(e),
-                        peak_memory_mb,
-                        sandbox_spawn_failed: false,
-                    };
-                }
-            };
-            let mut stderr = connection.stderr();
-            if prompt_result.timed_out {
-                exit_code = 137;
-                if !stderr.is_empty() && !stderr.ends_with('\n') {
-                    stderr.push('\n');
-                }
-                let is_initial =
-                    prompt_result.exit_reason.as_deref() == Some("initial_response_timeout");
-                let timeout_secs = if is_initial {
-                    initial_response_timeout.unwrap_or(idle_timeout).as_secs()
-                } else {
-                    idle_timeout.as_secs()
-                };
-                let label = if is_initial {
-                    "initial response timeout"
-                } else {
-                    "idle timeout"
-                };
-                stderr.push_str(&format!(
-                    "{label}: no ACP events/stderr for {timeout_secs}s; process killed",
-                ));
-                stderr.push('\n');
-            }
-
-            Ok(csa_acp::transport::AcpOutput {
-                output: prompt_result.output,
-                stderr,
-                events: prompt_result.events,
-                session_id: acp_session_id,
-                exit_code,
-                metadata: prompt_result.metadata,
-                peak_memory_mb,
-            })
-        }
-        Err(e) => {
-            if let Some(hint) = &oom_diagnosis {
-                // Construct a typed ProcessExited error so callers retain
-                // programmatic access to exit code and signal fields.
-                let mut stderr = connection.stderr();
-                if !stderr.is_empty() && !stderr.ends_with('\n') {
-                    stderr.push('\n');
-                }
-                stderr.push_str(&format!("OOM detected: {hint}\n"));
-                stderr.push_str(&format!("original error: {e}\n"));
-                Err(csa_acp::AcpError::ProcessExited {
-                    code: 137,
-                    signal: Some(9),
-                    stderr,
-                })
-            } else {
-                Err(e)
-            }
-        }
-    };
-
-    // sandbox_handle dropped here, cleaning up cgroup scope if applicable.
-    AcpSandboxedResult {
-        result,
-        peak_memory_mb,
-        sandbox_spawn_failed: false,
-    }
-}
-
-/// Inner helper: session setup + prompt execution.  Returns the prompt result
-/// and session ID so the caller can capture peak memory regardless of outcome.
-#[allow(clippy::too_many_arguments)]
-async fn run_acp_sandboxed_inner(
-    connection: &csa_acp::AcpConnection,
-    memory_monitor: Option<csa_resource::memory_monitor::MemoryMonitorHandle>,
-    system_prompt: Option<&str>,
-    resume_session_id: Option<&str>,
-    meta: Option<serde_json::Map<String, serde_json::Value>>,
-    prompt: &str,
-    idle_timeout: std::time::Duration,
-    initial_response_timeout: Option<std::time::Duration>,
-    stream_stdout_to_stderr: bool,
-    output_spool: Option<&Path>,
-    output_spool_max_bytes: u64,
-    output_spool_keep_rotated: bool,
-    working_dir: &Path,
-) -> csa_acp::AcpResult<(csa_acp::connection::PromptResult, String)> {
-    connection.initialize().await?;
-
-    let acp_session_id = if let Some(resume_id) = resume_session_id {
-        tracing::debug!(
-            resume_session_id = resume_id,
-            "loading ACP session (sandboxed)"
-        );
-        match connection.load_session(resume_id, Some(working_dir)).await {
-            Ok(id) => id,
-            Err(error) => {
-                tracing::warn!(
-                    resume_session_id = resume_id,
-                    error = %error,
-                    "Failed to resume sandboxed ACP session, creating new session"
-                );
-                connection
-                    .new_session(system_prompt, Some(working_dir), meta.clone())
-                    .await?
-            }
-        }
-    } else {
-        connection
-            .new_session(system_prompt, Some(working_dir), meta.clone())
-            .await?
-    };
-
-    let result = connection
-        .prompt_with_io(
-            &acp_session_id,
-            prompt,
-            idle_timeout,
-            initial_response_timeout,
-            csa_acp::connection::PromptIoOptions {
-                stream_stdout_to_stderr,
-                output_spool,
-                spool_max_bytes: output_spool_max_bytes,
-                keep_rotated_spool: output_spool_keep_rotated,
-            },
-        )
-        .await;
-
-    // Stop memory monitor before capturing peak memory (done by caller).
-    if let Some(monitor) = memory_monitor {
-        monitor.stop().await;
-    }
-
-    result.map(|r| (r, acp_session_id))
-}
-
-pub(super) fn build_summary(stdout: &str, stderr: &str, exit_code: i32) -> String {
-    if exit_code == 0 {
-        return truncate_line(last_non_empty_line(stdout), SUMMARY_MAX_CHARS);
-    }
-
-    let stdout_line = last_non_empty_line(stdout);
-    if !stdout_line.is_empty() {
-        return truncate_line(stdout_line, SUMMARY_MAX_CHARS);
-    }
-
-    let stderr_line = last_non_empty_line(stderr);
-    if !stderr_line.is_empty() {
-        return truncate_line(stderr_line, SUMMARY_MAX_CHARS);
-    }
-
-    format!("exit code {exit_code}")
-}
-
-fn last_non_empty_line(output: &str) -> &str {
-    output
-        .lines()
-        .rev()
-        .find(|line| {
-            let trimmed = line.trim();
-            !trimmed.is_empty() && !trimmed.starts_with("<!-- CSA:SECTION:")
-        })
-        .unwrap_or_default()
-}
-
-fn truncate_line(line: &str, max_chars: usize) -> String {
-    line.chars().take(max_chars).collect()
 }
 
 /// Start a memory monitor given cgroup scope details and isolation plan parameters.
@@ -581,7 +337,7 @@ pub(super) fn start_memory_monitor(
     })
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "acp"))]
 mod tests {
     use super::*;
     use std::sync::{LazyLock, Mutex};

--- a/crates/csa-executor/src/transport_tests_codex_acp_stall.rs
+++ b/crates/csa-executor/src/transport_tests_codex_acp_stall.rs
@@ -1,4 +1,4 @@
-use csa_acp::{SessionEvent, client::StreamingMetadata};
+use csa_core::transport_events::{SessionEvent, StreamingMetadata};
 use csa_process::ExecutionResult;
 
 fn codex_acp_stall_result(events: Vec<SessionEvent>) -> super::TransportResult {

--- a/crates/csa-executor/src/transport_tests_mod.rs
+++ b/crates/csa-executor/src/transport_tests_mod.rs
@@ -1,6 +1,6 @@
 use super::*;
+use crate::SessionConfig;
 use crate::transport_gemini_retry::*;
-use csa_acp::SessionConfig;
 use csa_resource::isolation_plan::IsolationPlan;
 
 include!("transport_tests_tail.rs");

--- a/crates/csa-executor/src/transport_types.rs
+++ b/crates/csa-executor/src/transport_types.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use csa_acp::SessionEvent;
+use csa_core::transport_events::{SessionEvent, StreamingMetadata};
 use csa_process::{ExecutionResult, StreamMode};
 use csa_resource::isolation_plan::IsolationPlan;
 use serde::{Deserialize, Serialize};
@@ -68,7 +68,7 @@ pub struct TransportResult {
     pub execution: ExecutionResult,
     pub provider_session_id: Option<String>,
     pub events: Vec<SessionEvent>,
-    pub metadata: csa_acp::StreamingMetadata,
+    pub metadata: StreamingMetadata,
 }
 
 /// Informational capability matrix for a Transport implementation.
@@ -85,6 +85,7 @@ pub struct TransportCapabilities {
     pub typed_events: bool,
 }
 
+#[cfg(feature = "acp")]
 pub(super) fn should_stream_acp_stdout_to_stderr(
     stream_mode: StreamMode,
     output_spool: Option<&Path>,

--- a/crates/csa-session/Cargo.toml
+++ b/crates/csa-session/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 
 [dependencies]
 csa-core.workspace = true
-csa-acp = { path = "../csa-acp" }
 csa-process.workspace = true
 csa-resource.workspace = true
 csa-lock.workspace = true

--- a/crates/csa-session/src/event_writer.rs
+++ b/crates/csa-session/src/event_writer.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 
 use crate::redact::redact_event;
 use chrono::SecondsFormat;
-use csa_acp::SessionEvent;
+use csa_core::transport_events::SessionEvent;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 


### PR DESCRIPTION
## Summary
- Put `csa-acp` crate behind `acp` feature flag, **default off**
- `cargo build` (default) no longer compiles ACP transport code
- `cargo build --features acp` re-enables full ACP support
- All ACP-dependent code wrapped in `#[cfg(feature = "acp")]`
- Extracted shared transport event types to `csa-core::transport_events` (needed by both ACP and non-ACP paths)
- 33 files changed, 791 insertions, 439 deletions

This retires ACP from default builds while preserving rollback capability. Users who need ACP can re-enable with `--features acp`.

Fixes #1156

## Test plan
- [x] `cargo build` (no features) succeeds without ACP
- [x] `cargo test` passes in default mode
- [x] `cargo clippy` clean
- [ ] `cargo build --features acp` still compiles with ACP

🤖 Generated with [Claude Code](https://claude.com/claude-code)