### PR TITLE
fix(migrate): keep --dry-run read-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "axum",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.621"
+version = "0.1.622"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.621"
+version = "0.1.622"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/migrate_cmd.rs
+++ b/crates/cli-sub-agent/src/migrate_cmd.rs
@@ -67,8 +67,20 @@ fn run_migrations(
     registry: &csa_config::MigrationRegistry,
     dry_run: bool,
 ) -> Result<()> {
-    let mut lock = csa_config::WeaveLock::load_or_init(project_dir, csa_version, weave_version)?;
-    let had_versions_before = lock.versions().is_some();
+    let existing_lock = csa_config::WeaveLock::load(project_dir)?;
+    let had_versions_before = existing_lock
+        .as_ref()
+        .and_then(csa_config::WeaveLock::versions)
+        .is_some();
+    let mut lock = match existing_lock {
+        Some(lock) => lock,
+        None if dry_run => csa_config::WeaveLock::new(csa_version, weave_version),
+        None => {
+            let lock = csa_config::WeaveLock::new(csa_version, weave_version);
+            lock.save(project_dir)?;
+            lock
+        }
+    };
 
     let lock_version = lock
         .versions_or_init(csa_version, weave_version)
@@ -86,10 +98,16 @@ fn run_migrations(
     if pending.is_empty() {
         eprintln!("No pending migrations. Lock is up to date.");
         if sync_version_stamp(&mut lock, had_versions_before, csa_version, weave_version) {
-            lock.save(project_dir)?;
-            eprintln!(
-                "Updated weave.lock version stamp(s) to csa {csa_version}, weave {weave_version}."
-            );
+            if dry_run {
+                eprintln!(
+                    "(dry-run: would update weave.lock version stamp(s) to csa {csa_version}, weave {weave_version})"
+                );
+            } else {
+                lock.save(project_dir)?;
+                eprintln!(
+                    "Updated weave.lock version stamp(s) to csa {csa_version}, weave {weave_version}."
+                );
+            }
         }
         return Ok(());
     }
@@ -168,5 +186,20 @@ mod tests {
         let versions = lock.versions().unwrap();
         assert_eq!(versions.csa, "0.1.1");
         assert_eq!(versions.weave, "0.1.1");
+    }
+
+    #[test]
+    fn dry_run_does_not_save_version_stamp_drift() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock = csa_config::WeaveLock::new("0.1.1", "0.1.0");
+        lock.save(dir.path()).expect("save stale lock");
+        let lock_path = dir.path().join("weave.lock");
+        let before = std::fs::read_to_string(&lock_path).expect("read stale lock");
+        let registry = csa_config::MigrationRegistry::new();
+
+        run_migrations(dir.path(), "0.1.1", "0.1.1", &registry, true).expect("dry-run migrate");
+
+        let after = std::fs::read_to_string(&lock_path).expect("read lock after dry-run");
+        assert_eq!(after, before);
     }
 }


### PR DESCRIPTION
## Summary
- Gate `lock.save()` behind `!dry_run` in the version stamp sync path
- In dry-run mode, print `(dry-run: would update ...)` instead of writing
- Add regression test `dry_run_does_not_save_version_stamp_drift`

Closes #1201

## Test plan
- [x] `cargo test` passes
- [x] `just pre-commit` clean
- [x] Regression test verifies weave.lock unchanged after dry-run migrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)