### PR TITLE
fix(review): rebuild nested session env to prevent artifact path leakage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "chrono",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "axum",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "chrono",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "chrono",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.623"
+version = "0.1.624"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.623"
+version = "0.1.624"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/audit_cmds.rs
+++ b/crates/cli-sub-agent/src/audit_cmds.rs
@@ -288,6 +288,13 @@ mod tests {
     use super::*;
     use crate::audit::helpers::canonical_root;
     use std::fs;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn current_dir_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn test_audit_init_stores_mirror_dir_in_manifest() {
@@ -469,21 +476,31 @@ mod tests {
 
     /// RAII guard for temporarily changing the working directory in tests.
     ///
-    /// Restores to a known-good stable directory on drop, not the previous cwd,
-    /// to avoid failures when parallel tests remove each other's temp directories.
-    struct TempCwd;
+    /// Restores to the previous working directory on drop.
+    struct TempCwd {
+        original: PathBuf,
+        _lock: MutexGuard<'static, ()>,
+    }
 
     impl TempCwd {
         fn set(new_dir: &Path) -> Self {
+            let lock = current_dir_lock().lock().expect("cwd lock");
+            let original = std::env::current_dir().expect("read cwd");
             std::env::set_current_dir(new_dir).expect("set cwd");
-            Self
+            Self {
+                original,
+                _lock: lock,
+            }
         }
     }
 
     impl Drop for TempCwd {
         fn drop(&mut self) {
-            // Restore to a stable directory that always exists.
-            let _ = std::env::set_current_dir("/tmp");
+            if std::env::set_current_dir(&self.original).is_err() {
+                // Last-resort stable directory when another test removed the
+                // previous cwd before this guard dropped.
+                let _ = std::env::set_current_dir("/tmp");
+            }
         }
     }
 }

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -196,19 +196,7 @@ Reviewer tool hint: {}.",
 
 fn reviewer_output_dir(reviewer_index: usize) -> String {
     let reviewer_dir = format!("reviewer-{reviewer_index}");
-    std::env::var(CSA_SESSION_DIR_ENV_KEY)
-        .or_else(|_| std::env::var(CSA_PARENT_SESSION_DIR_ENV_KEY))
-        .map(|session_dir| {
-            Path::new(&session_dir)
-                .join(&reviewer_dir)
-                .display()
-                .to_string()
-        })
-        .unwrap_or_else(|_| {
-            format!(
-                "${{{CSA_SESSION_DIR_ENV_KEY}:-${CSA_PARENT_SESSION_DIR_ENV_KEY}}}/{reviewer_dir}"
-            )
-        })
+    format!("${{{CSA_SESSION_DIR_ENV_KEY}:-${CSA_PARENT_SESSION_DIR_ENV_KEY}}}/{reviewer_dir}")
 }
 
 pub(crate) fn parse_consensus_strategy(raw: &str) -> Result<ConsensusStrategy> {

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -271,7 +271,7 @@ fn parse_review_verdict_accepts_clean_phrase_without_explicit_token() {
 }
 
 #[test]
-fn build_multi_reviewer_instruction_prefers_current_session_dir_env_when_both_exist() {
+fn build_multi_reviewer_instruction_keeps_session_dir_deferred_when_env_exists() {
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _parent_guard =
         ScopedEnvVarRestore::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
@@ -286,15 +286,20 @@ fn build_multi_reviewer_instruction_prefers_current_session_dir_env_when_both_ex
         None,
     );
 
-    assert!(prompt.contains("/tmp/child-session/reviewer-2/review-findings.json"));
     assert!(
-        !prompt.contains("/tmp/parent-session/reviewer-2/review-findings.json"),
-        "current session dir should override parent session dir when both exist"
+        prompt.contains(
+            "${CSA_SESSION_DIR:-$CSA_PARENT_SESSION_DIR}/reviewer-2/review-findings.json"
+        ),
+        "review prompt should defer session dir resolution to the reviewer process"
+    );
+    assert!(
+        !prompt.contains("/tmp/child-session") && !prompt.contains("/tmp/parent-session"),
+        "review prompt must not capture the parent process session dirs"
     );
 }
 
 #[test]
-fn build_multi_reviewer_instruction_falls_back_to_parent_session_dir_env() {
+fn build_multi_reviewer_instruction_does_not_capture_parent_session_dir_env() {
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let _parent_guard =
         ScopedEnvVarRestore::set(CSA_PARENT_SESSION_DIR_ENV_KEY, "/tmp/parent-session");
@@ -309,7 +314,15 @@ fn build_multi_reviewer_instruction_falls_back_to_parent_session_dir_env() {
         None,
     );
 
-    assert!(prompt.contains("/tmp/parent-session/reviewer-3/review-findings.json"));
+    assert!(
+        prompt.contains(
+            "${CSA_SESSION_DIR:-$CSA_PARENT_SESSION_DIR}/reviewer-3/review-findings.json"
+        )
+    );
+    assert!(
+        !prompt.contains("/tmp/parent-session"),
+        "review prompt must not inherit the outer CSA session dir"
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/tool_version.rs
+++ b/crates/cli-sub-agent/src/tool_version.rs
@@ -126,10 +126,7 @@ fn parse_first_numeric_version_token(text: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        detect_tool_version, parse_first_numeric_version_token, probe_binary_version_with_timeout,
-    };
-    use csa_executor::Executor;
+    use super::{parse_first_numeric_version_token, probe_binary_version_with_timeout};
     use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
     use std::time::Duration;
@@ -152,12 +149,14 @@ mod tests {
 
     #[tokio::test]
     async fn tool_version_probe_returns_none_on_missing_binary() {
-        let executor = Executor::ClaudeCode {
-            model_override: None,
-            thinking_budget: None,
-            runtime_metadata: csa_executor::claude_runtime_metadata(),
-        };
-        assert!(detect_tool_version(&executor).await.is_none());
+        assert!(
+            probe_binary_version_with_timeout(
+                "/definitely/missing/csa-tool-version-probe",
+                Duration::from_millis(50),
+            )
+            .await
+            .is_none()
+        );
     }
 
     #[cfg(unix)]

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -31,6 +31,8 @@ use arg_helpers::{
     effective_gemini_model_override, gemini_include_directories,
 };
 
+#[path = "executor_env.rs"]
+mod executor_env;
 #[path = "executor_pre_session.rs"]
 mod pre_session;
 #[path = "executor_prompt_helpers.rs"]
@@ -276,7 +278,9 @@ impl Executor {
     /// Inject environment variables from global config into a Command.
     pub fn inject_env(cmd: &mut Command, env_vars: &HashMap<String, String>) {
         for (key, value) in env_vars {
-            cmd.env(key, value);
+            if !Self::STRIPPED_ENV_VARS.contains(&key.as_str()) {
+                cmd.env(key, value);
+            }
         }
     }
 
@@ -295,7 +299,7 @@ impl Executor {
         if let Some(env) = extra_env {
             Self::inject_env(&mut cmd, env);
         }
-        Self::inject_session_path_env(&mut cmd, session);
+        self.inject_csa_owned_env(&mut cmd, session);
         let gemini_include_directories =
             gemini_include_directories(extra_env, prompt, Some(Path::new(&session.project_path)));
         let (prompt_transport, stdin_data) = self.select_prompt_transport(prompt);
@@ -513,17 +517,7 @@ impl Executor {
     }
 
     /// Environment variables to strip from child processes.
-    ///
-    /// These prevent recursive-invocation guards in CLI tools from blocking
-    /// legitimate CSA sub-agent launches, and ensure hook-bypass env vars
-    /// never leak into child tool processes.  Mirrors the same list in
-    /// `csa-acp::AcpConnection::STRIPPED_ENV_VARS`.
-    const STRIPPED_ENV_VARS: &[&str] = &[
-        "CLAUDECODE",
-        "CLAUDE_CODE_ENTRYPOINT",
-        "LEFTHOOK",
-        "LEFTHOOK_SKIP",
-    ];
+    const STRIPPED_ENV_VARS: &[&str] = executor_env::STRIPPED_ENV_VARS;
 
     /// Strip process-inherited gemini auth/routing env vars so that CSA's
     /// extra_env controls auth mode exclusively (OAuth-first, API key fallback
@@ -547,11 +541,16 @@ impl Executor {
             cmd.env_remove(var);
         }
 
-        // Set CSA environment variables
+        self.inject_csa_owned_env(&mut cmd, session);
+
+        cmd
+    }
+
+    fn inject_csa_owned_env(&self, cmd: &mut Command, session: &MetaSessionState) {
         cmd.env("CSA_SESSION_ID", &session.meta_session_id);
         cmd.env("CSA_DEPTH", (session.genealogy.depth + 1).to_string());
         cmd.env("CSA_PROJECT_ROOT", &session.project_path);
-        Self::inject_session_path_env(&mut cmd, session);
+        Self::inject_session_path_env(cmd, session);
 
         // CSA_TOOL: tells the child process which tool it is running as
         cmd.env("CSA_TOOL", self.tool_name());
@@ -564,8 +563,6 @@ impl Executor {
         if let Some(ref parent) = session.genealogy.parent_session_id {
             cmd.env("CSA_PARENT_SESSION", parent);
         }
-
-        cmd
     }
 
     fn inject_session_path_env(cmd: &mut Command, session: &MetaSessionState) {

--- a/crates/csa-executor/src/executor_build_cmd_tests.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests.rs
@@ -193,8 +193,11 @@ fn test_build_command_no_parent_session_env_when_root() {
     let env_map: HashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> = envs.into_iter().collect();
 
     assert!(
-        !env_map.contains_key(std::ffi::OsStr::new("CSA_PARENT_SESSION")),
-        "Root session should not set CSA_PARENT_SESSION"
+        !matches!(
+            env_map.get(std::ffi::OsStr::new("CSA_PARENT_SESSION")),
+            Some(Some(_))
+        ),
+        "Root session should not set a CSA_PARENT_SESSION value"
     );
 }
 
@@ -275,6 +278,54 @@ fn test_build_command_reserved_session_paths_override_extra_env() {
     assert!(
         result_contract_path.contains("01HTEST000000000000000000"),
         "reserved result contract path should include the session ID, got: {result_contract_path}"
+    );
+}
+
+#[test]
+fn test_build_command_rebuilds_session_env_after_extra_env_merge() {
+    let exec = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
+    };
+    let session = make_test_session();
+    let extra = HashMap::from([
+        (
+            "CSA_SESSION_ID".to_string(),
+            "01HOUTER00000000000000000".to_string(),
+        ),
+        (
+            "CSA_SESSION_DIR".to_string(),
+            "/tmp/outer-session".to_string(),
+        ),
+        (
+            "CSA_DAEMON_SESSION_DIR".to_string(),
+            "/tmp/outer-daemon-session".to_string(),
+        ),
+    ]);
+
+    let (cmd, _stdin_data) = exec.build_command("test", None, &session, Some(&extra));
+    let envs: Vec<_> = cmd.as_std().get_envs().collect();
+    let env_map: HashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> = envs.into_iter().collect();
+
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("CSA_SESSION_ID")),
+        Some(&Some(std::ffi::OsStr::new("01HTEST000000000000000000"))),
+        "CSA_SESSION_ID must be rebuilt from the new session"
+    );
+    let session_dir = env_map
+        .get(std::ffi::OsStr::new("CSA_SESSION_DIR"))
+        .expect("CSA_SESSION_DIR should be present")
+        .expect("CSA_SESSION_DIR should have a value")
+        .to_string_lossy();
+    assert!(
+        session_dir.contains("01HTEST000000000000000000"),
+        "CSA_SESSION_DIR must point at the new session, got: {session_dir}"
+    );
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("CSA_DAEMON_SESSION_DIR")),
+        Some(&None),
+        "CSA_DAEMON_SESSION_DIR must not be inherited by child tool processes"
     );
 }
 

--- a/crates/csa-executor/src/executor_env.rs
+++ b/crates/csa-executor/src/executor_env.rs
@@ -1,0 +1,18 @@
+//! Environment ownership for child tool processes.
+
+/// Variables scrubbed before tool spawn.
+///
+/// The list removes recursive-invocation guards, hook bypass switches, and
+/// session-scoped CSA values that must be rebuilt for each fresh session.
+pub(crate) const STRIPPED_ENV_VARS: &[&str] = &[
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "LEFTHOOK",
+    "LEFTHOOK_SKIP",
+    "CSA_SESSION_ID",
+    "CSA_SESSION_DIR",
+    "CSA_PARENT_SESSION",
+    "CSA_PARENT_SESSION_DIR",
+    "CSA_DAEMON_SESSION_DIR",
+    csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
+];

--- a/crates/csa-executor/src/transport_cli.rs
+++ b/crates/csa-executor/src/transport_cli.rs
@@ -128,6 +128,7 @@ impl ClaudeCodeCliTransport {
         &self,
         prompt: &str,
         work_dir: &Path,
+        session: Option<&MetaSessionState>,
         resume_session_id: Option<&str>,
         extra_env: Option<&HashMap<String, String>>,
     ) -> Command {
@@ -141,8 +142,13 @@ impl ClaudeCodeCliTransport {
         }
         if let Some(env) = extra_env {
             for (key, value) in env {
-                cmd.env(key, value);
+                if !CLI_TRANSPORT_CSA_OWNED_ENV_VARS.contains(&key.as_str()) {
+                    cmd.env(key, value);
+                }
             }
+        }
+        if let Some(session) = session {
+            inject_cli_session_env(&mut cmd, session);
         }
         for arg in Self::build_argv(&self.executor, prompt, resume_session_id) {
             cmd.arg(arg);
@@ -157,6 +163,7 @@ impl ClaudeCodeCliTransport {
         let cmd = self.build_command(
             request.prompt,
             request.work_dir,
+            request.session,
             request.resume_session_id,
             request.extra_env,
         );
@@ -214,6 +221,7 @@ impl ClaudeCodeCliTransport {
 struct ExecuteOnceRequest<'a> {
     prompt: &'a str,
     work_dir: &'a Path,
+    session: Option<&'a MetaSessionState>,
     resume_session_id: Option<&'a str>,
     extra_env: Option<&'a HashMap<String, String>>,
     stream_mode: StreamMode,
@@ -270,6 +278,7 @@ impl Transport for ClaudeCodeCliTransport {
         self.execute_once(ExecuteOnceRequest {
             prompt,
             work_dir: &work_dir,
+            session: Some(session),
             resume_session_id,
             extra_env,
             stream_mode: options.stream_mode,
@@ -294,6 +303,7 @@ impl Transport for ClaudeCodeCliTransport {
         self.execute_once(ExecuteOnceRequest {
             prompt,
             work_dir,
+            session: None,
             resume_session_id: None,
             extra_env,
             stream_mode,
@@ -392,7 +402,65 @@ const CLI_TRANSPORT_STRIPPED_ENV_VARS: &[&str] = &[
     "CLAUDE_CODE_ENTRYPOINT",
     "LEFTHOOK",
     "LEFTHOOK_SKIP",
+    "CSA_SESSION_ID",
+    "CSA_SESSION_DIR",
+    "CSA_PARENT_SESSION",
+    "CSA_PARENT_SESSION_DIR",
+    "CSA_DAEMON_SESSION_DIR",
+    csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
 ];
+
+const CLI_TRANSPORT_CSA_OWNED_ENV_VARS: &[&str] = &[
+    "CSA_SESSION_ID",
+    "CSA_DEPTH",
+    "CSA_PROJECT_ROOT",
+    "CSA_TOOL",
+    "CSA_PARENT_TOOL",
+    "CSA_PARENT_SESSION",
+    "CSA_SESSION_DIR",
+    "CSA_PARENT_SESSION_DIR",
+    "CSA_DAEMON_SESSION_DIR",
+    csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
+];
+
+fn inject_cli_session_env(cmd: &mut Command, session: &MetaSessionState) {
+    cmd.env("CSA_SESSION_ID", &session.meta_session_id);
+    cmd.env("CSA_DEPTH", (session.genealogy.depth + 1).to_string());
+    cmd.env("CSA_PROJECT_ROOT", &session.project_path);
+    cmd.env("CSA_TOOL", "claude-code");
+    if let Ok(current_tool) = std::env::var("CSA_TOOL") {
+        cmd.env("CSA_PARENT_TOOL", current_tool);
+    }
+    if let Some(parent_session_id) = session.genealogy.parent_session_id.as_deref() {
+        cmd.env("CSA_PARENT_SESSION", parent_session_id);
+    }
+    if let Ok(session_dir) = csa_session::manager::get_session_dir(
+        Path::new(&session.project_path),
+        &session.meta_session_id,
+    ) {
+        cmd.env(
+            "CSA_SESSION_DIR",
+            session_dir.to_string_lossy().into_owned(),
+        );
+        cmd.env(
+            csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
+            csa_session::contract_result_path(&session_dir)
+                .to_string_lossy()
+                .into_owned(),
+        );
+    }
+    if let Some(parent_session_id) = session.genealogy.parent_session_id.as_deref()
+        && let Ok(parent_dir) = csa_session::manager::get_session_dir(
+            Path::new(&session.project_path),
+            parent_session_id,
+        )
+    {
+        cmd.env(
+            "CSA_PARENT_SESSION_DIR",
+            parent_dir.to_string_lossy().into_owned(),
+        );
+    }
+}
 
 /// Result of parsing a `claude --output-format stream-json` byte stream.
 #[derive(Debug, Default)]

--- a/crates/csa-executor/src/transport_cli_tests.rs
+++ b/crates/csa-executor/src/transport_cli_tests.rs
@@ -18,6 +18,7 @@ use crate::{LegacyTransport, TransportFactory};
 use csa_resource::filesystem_sandbox::FilesystemCapability;
 use csa_resource::isolation_plan::IsolationPlan;
 use csa_resource::sandbox::ResourceCapability;
+use csa_session::state::{ContextStatus, Genealogy, MetaSessionState, SessionPhase, TaskContext};
 use std::collections::HashMap as StdHashMap;
 
 fn make_executor() -> Executor {
@@ -51,6 +52,38 @@ fn make_test_isolation_plan() -> IsolationPlan {
         project_root: None,
         soft_limit_percent: None,
         memory_monitor_interval_seconds: None,
+    }
+}
+
+fn make_test_session() -> MetaSessionState {
+    let now = chrono::Utc::now();
+    MetaSessionState {
+        meta_session_id: "01HCLITEST000000000000000".to_string(),
+        description: Some("cli transport test".to_string()),
+        project_path: "/tmp/test-project".to_string(),
+        branch: None,
+        created_at: now,
+        last_accessed: now,
+        csa_version: None,
+        genealogy: Genealogy::default(),
+        tools: StdHashMap::new(),
+        context_status: ContextStatus::default(),
+        total_token_usage: None,
+        phase: SessionPhase::Active,
+        task_context: TaskContext::default(),
+        turn_count: 0,
+        token_budget: None,
+        sandbox_info: None,
+        termination_reason: None,
+        is_seed_candidate: false,
+        git_head_at_creation: None,
+        pre_session_porcelain: None,
+        last_return_packet: None,
+        change_id: None,
+        spec_id: None,
+        fork_call_timestamps: Vec::new(),
+        vcs_identity: None,
+        identity_version: 1,
     }
 }
 
@@ -188,6 +221,57 @@ fn capabilities_advertise_resume_fork_streaming() {
     assert!(caps.session_fork, "claude --fork-session works");
     assert!(caps.streaming, "claude --output-format stream-json works");
     assert!(caps.typed_events, "stream-json yields typed events");
+}
+
+#[test]
+fn build_command_rebuilds_session_env_for_cli_transport() {
+    let transport = ClaudeCodeCliTransport::new(make_executor());
+    let session = make_test_session();
+    let extra_env = StdHashMap::from([
+        (
+            "CSA_SESSION_ID".to_string(),
+            "01HOUTER00000000000000000".to_string(),
+        ),
+        (
+            "CSA_SESSION_DIR".to_string(),
+            "/tmp/outer-session".to_string(),
+        ),
+        (
+            "CSA_DAEMON_SESSION_DIR".to_string(),
+            "/tmp/outer-daemon-session".to_string(),
+        ),
+    ]);
+
+    let cmd = transport.build_command(
+        "hello",
+        std::path::Path::new("/tmp/test-project"),
+        Some(&session),
+        None,
+        Some(&extra_env),
+    );
+    let envs: Vec<_> = cmd.as_std().get_envs().collect();
+    let env_map: StdHashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> =
+        envs.into_iter().collect();
+
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("CSA_SESSION_ID")),
+        Some(&Some(std::ffi::OsStr::new("01HCLITEST000000000000000"))),
+        "CLI transport must rebuild CSA_SESSION_ID from the new session"
+    );
+    let session_dir = env_map
+        .get(std::ffi::OsStr::new("CSA_SESSION_DIR"))
+        .expect("CSA_SESSION_DIR should be set")
+        .expect("CSA_SESSION_DIR should have a value")
+        .to_string_lossy();
+    assert!(
+        session_dir.contains("01HCLITEST000000000000000"),
+        "CLI transport must rebuild CSA_SESSION_DIR from the new session, got: {session_dir}"
+    );
+    assert_eq!(
+        env_map.get(std::ffi::OsStr::new("CSA_DAEMON_SESSION_DIR")),
+        Some(&None),
+        "CLI transport must scrub inherited daemon session dir"
+    );
 }
 
 // ---- Resume-id propagation ----

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -39,6 +39,8 @@ const CSA_PARENT_TOOL_ENV: &str = "CSA_PARENT_TOOL";
 #[cfg(feature = "acp")]
 const CSA_PARENT_SESSION_ENV: &str = "CSA_PARENT_SESSION";
 #[cfg(feature = "acp")]
+const CSA_DAEMON_SESSION_DIR_ENV: &str = "CSA_DAEMON_SESSION_DIR";
+#[cfg(feature = "acp")]
 const CSA_FS_SANDBOXED_ENV: &str = "CSA_FS_SANDBOXED";
 #[cfg(feature = "acp")]
 const CSA_OWNED_ENV_KEYS: &[&str] = &[
@@ -49,6 +51,7 @@ const CSA_OWNED_ENV_KEYS: &[&str] = &[
     CSA_IS_SUBPROCESS_ENV,
     CSA_PARENT_TOOL_ENV,
     CSA_PARENT_SESSION_ENV,
+    CSA_DAEMON_SESSION_DIR_ENV,
     CSA_FS_SANDBOXED_ENV,
     CSA_SESSION_DIR_ENV_KEY,
     CSA_PARENT_SESSION_DIR_ENV_KEY,
@@ -479,6 +482,10 @@ mod tests {
                 CSA_PARENT_SESSION_ENV.to_string(),
                 "spoofed-parent-session".to_string(),
             ),
+            (
+                CSA_DAEMON_SESSION_DIR_ENV.to_string(),
+                "/tmp/spoofed-daemon-session-dir".to_string(),
+            ),
             (CSA_FS_SANDBOXED_ENV.to_string(), "0".to_string()),
             (
                 CSA_SESSION_DIR_ENV_KEY.to_string(),
@@ -521,6 +528,10 @@ mod tests {
         assert_eq!(
             env.get(CSA_PARENT_SESSION_ENV).map(String::as_str),
             Some("01HPARENT000000000000000000")
+        );
+        assert!(
+            !env.contains_key(CSA_DAEMON_SESSION_DIR_ENV),
+            "CSA_DAEMON_SESSION_DIR must not flow into fresh ACP subprocess env"
         );
         assert_eq!(env.get(CSA_FS_SANDBOXED_ENV).map(String::as_str), Some("1"));
         assert_eq!(


### PR DESCRIPTION
## Summary
- Add `SCRUBBED_CSA_ENV_KEYS` list in `executor_env.rs` defining session-specific env vars that must NOT be inherited by child processes
- Rebuild `CSA_SESSION_DIR`, `CSA_SESSION_ID`, `CSA_DAEMON_SESSION_DIR` from the new session context in CLI transport and meta transport
- Scrub inherited env in executor command construction
- Add regression tests verifying nested session env is rebuilt, not inherited

Closes #1202

## Test plan
- [x] `cargo test` passes
- [x] `just pre-commit` clean
- [x] New tests in `executor_build_cmd_tests.rs` and `transport_cli_tests.rs` verify env scrubbing
- [x] Review verdict PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)