### PR TITLE
feat(workflow): checkout default branch after PR merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "chrono",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "axum",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "chrono",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "chrono",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.624"
+version = "0.1.625"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.624"
+version = "0.1.625"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-hooks/src/merge_guard/mod.rs
+++ b/crates/csa-hooks/src/merge_guard/mod.rs
@@ -112,7 +112,7 @@ _post_merge_sync() {
     DEFAULT_BRANCH="${DEFAULT_BRANCH#${PRIMARY_REMOTE}/}"
   fi
   if [ -z "${DEFAULT_BRANCH}" ]; then
-    printf 'NOTE: post-merge sync skipped — could not determine default branch (gh repo view failed, %s/HEAD not set)\n' "${PRIMARY_REMOTE}" >&2
+    printf 'NOTE: post-merge sync skipped: could not determine default branch (gh repo view failed, %s/HEAD not set)\n' "${PRIMARY_REMOTE}" >&2
     return 0
   fi
 
@@ -126,8 +126,10 @@ _post_merge_sync() {
     } >&2 || printf 'NOTE: in-place fast-forward failed, continuing\n' >&2
   else
     {
-      git fetch "${PRIMARY_REMOTE}" "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}"
-    } >&2 || printf 'NOTE: refspec update failed, continuing\n' >&2
+      git fetch "${PRIMARY_REMOTE}" "${DEFAULT_BRANCH}" &&
+      git checkout "${DEFAULT_BRANCH}" &&
+      git pull --ff-only "${PRIMARY_REMOTE}" "${DEFAULT_BRANCH}"
+    } >&2 || printf 'NOTE: post-merge checkout/pull failed, continuing\n' >&2
   fi
 }
 

--- a/crates/csa-hooks/src/merge_guard/tests_post_merge_sync.rs
+++ b/crates/csa-hooks/src/merge_guard/tests_post_merge_sync.rs
@@ -198,14 +198,15 @@ fn assert_in_place_sync_log_with_remote(git_log: &Path, remote: &str, branch: &s
     );
 }
 
-fn assert_refspec_sync_log(git_log: &Path, branch: &str) {
-    assert_refspec_sync_log_with_remote(git_log, "origin", branch);
+fn assert_checkout_sync_log(git_log: &Path, branch: &str) {
+    assert_checkout_sync_log_with_remote(git_log, "origin", branch);
 }
 
-fn assert_refspec_sync_log_with_remote(git_log: &Path, remote: &str, branch: &str) {
+fn assert_checkout_sync_log_with_remote(git_log: &Path, remote: &str, branch: &str) {
     let lines = git_log_lines(git_log);
-    assert_log_has_line(&lines, &format!("fetch {remote} {branch}:{branch}"));
-    assert_log_lacks_prefix(&lines, "checkout ");
+    assert_log_has_line(&lines, &format!("fetch {remote} {branch}"));
+    assert_log_has_line(&lines, &format!("checkout {branch}"));
+    assert_log_has_line(&lines, &format!("pull --ff-only {remote} {branch}"));
     assert_log_lacks_prefix(&lines, "merge ");
 }
 
@@ -311,7 +312,7 @@ fn post_merge_sync_ignores_local_branch_upstream_for_primary_remote() {
     create_test_marker(tmp.path());
     let (code, _, _) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
     assert_eq!(code, 0);
-    assert_refspec_sync_log_with_remote(&gl, "origin", "main");
+    assert_checkout_sync_log_with_remote(&gl, "origin", "main");
     let lines = git_log_lines(&gl);
     assert_log_lacks_prefix(&lines, "fetch main ");
     assert_log_lacks_prefix(&lines, "merge main/");
@@ -336,14 +337,14 @@ fn post_merge_sync_skips_when_all_default_detection_fails() {
 }
 
 #[test]
-fn post_merge_sync_uses_refspec_when_not_on_default() {
+fn post_merge_sync_checks_out_default_when_not_on_default() {
     let tmp = tempfile::tempdir().unwrap();
     let (gd, gh, mb, gl) =
         setup_post_merge_env_with_git(tmp.path(), 0, Some("main"), None, Some("feat/xyz"), 0);
     create_test_marker(tmp.path());
     let (code, _, _) = run_wrapper_with_mock_git(&gd, &gh, &mb, &["pr", "merge", "42"]);
     assert_eq!(code, 0);
-    assert_refspec_sync_log(&gl, "main");
+    assert_checkout_sync_log(&gl, "main");
 }
 
 #[test]

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -61,10 +61,10 @@ FORBIDDEN — all of these destroy per-commit audit trails:
 
 **Empty-diff structural guard**: Before any merge (or before delegating to
 pr-bot), verify `gh pr diff <PR>` is non-empty AND the branch has commits
-ahead of main with a non-empty cumulative diff. An empty-diff PR is the
+ahead of the default branch with a non-empty cumulative diff. An empty-diff PR is the
 structural fingerprint of the lefthook re-stage race documented in #1122 —
 when seen, surface `merge_blocked_empty_diff` instead of pushing through.
-Squash-merging an empty-diff PR produces an empty squash commit on main;
+Squash-merging an empty-diff PR produces an empty squash commit on the default branch;
 this is the exact corruption #1122 documents.
 
 dev2merge delegates merging to pr-bot (Step 15), which reads
@@ -368,7 +368,7 @@ Required actions:
 Tool: bash
 OnFail: abort
 
-Cumulative review covering all commits since main.
+Cumulative review covering all commits since the default branch.
 Sets REVIEW_COMPLETED=true as gate for push step.
 
 ```bash
@@ -381,7 +381,7 @@ echo '<!-- CSA:NEXT_STEP cmd="push to origin (Step 12)" required=true -->'
 
 When global config sets `[review].batch_commits >= 2`, intermediate cumulative
 reviews can be skipped until the branch accumulates enough new commits after
-the last passed `main...HEAD` review. Set `CSA_REVIEW_NOW=1` to bypass batching
+the last passed `${DEFAULT_BRANCH}...HEAD` review. Set `CSA_REVIEW_NOW=1` to bypass batching
 for the current run.
 
 ## ENDIF
@@ -397,7 +397,7 @@ Hard gates before any push:
 2. **Empty-diff structural guard (#1122)**: branch must have at least one
    commit ahead of base AND the cumulative diff vs base must be non-empty.
    An empty-diff branch is the lefthook-race fingerprint — it produces an
-   empty PR which can be silently squashed into an empty commit on main.
+   empty PR which can be silently squashed into an empty commit on the default branch.
    Aborting here surfaces `merge_blocked_empty_diff` to the orchestrator
    instead of letting it propagate to pr-bot.
 
@@ -432,7 +432,7 @@ Tool: bash
 OnFail: abort
 
 Hard gate before PR creation: the current branch HEAD must have a PASS/CLEAN
-review verdict for the full cumulative diff (`main...HEAD`).
+review verdict for the full cumulative diff (`${DEFAULT_BRANCH}...HEAD`).
 
 ```bash
 set -euo pipefail
@@ -487,7 +487,7 @@ done
 # Fallback: gh pr list --head
 if [ -z "${PR_NUMBER}" ]; then
   echo "INFO: gh pr view failed; falling back to gh pr list..."
-  PR_NUMBER="$(gh pr list --head "${BRANCH}" --base main --json number -q '.[0].number' 2>/dev/null || true)"
+  PR_NUMBER="$(gh pr list --head "${BRANCH}" --base "${DEFAULT_BRANCH}" --json number -q '.[0].number' 2>/dev/null || true)"
   if [ -n "${PR_NUMBER}" ] && printf '%s' "${PR_NUMBER}" | grep -Eq '^[0-9]+$'; then
     PR_URL="$(gh pr view "${PR_NUMBER}" --json url -q '.url' 2>/dev/null || true)"
   fi

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -457,7 +457,7 @@ COMMIT_SUBJECT="$(git log -1 --format=%s)"
 
 # --- Create or reuse PR ---
 set +e
-CREATE_OUTPUT="$(gh pr create --base main --title "${COMMIT_SUBJECT}" --body "Auto-created by dev2merge pipeline." 2>&1)"
+CREATE_OUTPUT="$(gh pr create --base "${DEFAULT_BRANCH}" --title "${COMMIT_SUBJECT}" --body "Auto-created by dev2merge pipeline." 2>&1)"
 CREATE_RC=$?
 set -e
 if [ "${CREATE_RC}" -ne 0 ]; then
@@ -620,14 +620,28 @@ if [ -n "${PR_NUMBER:-}" ]; then
   echo "PR #${PR_NUMBER} confirmed MERGED."
 fi
 FEATURE_BRANCH="$(git branch --show-current 2>/dev/null || true)"
-git fetch origin
-git checkout main
-git merge origin/main --ff-only
-LOCAL_SHA="$(git rev-parse HEAD)"
-REMOTE_SHA="$(git rev-parse origin/main)"
-if [ "${LOCAL_SHA}" != "${REMOTE_SHA}" ]; then
-  echo "ERROR: Local main does not match origin/main after sync." >&2
-  exit 1
+SYNC_REMOTE="origin"
+SYNC_DEFAULT_BRANCH="${DEFAULT_BRANCH:-}"
+if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
+  SYNC_DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
 fi
-echo "Local main synced to ${LOCAL_SHA}."
+if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
+  echo "WARNING: post-merge checkout skipped: could not determine default branch." >&2
+  exit 0
+fi
+if ! git checkout "${SYNC_DEFAULT_BRANCH}"; then
+  echo "WARNING: post-merge checkout of ${SYNC_DEFAULT_BRANCH} failed; leaving ${FEATURE_BRANCH:-current branch} checked out." >&2
+  exit 0
+fi
+if ! git pull --ff-only "${SYNC_REMOTE}" "${SYNC_DEFAULT_BRANCH}"; then
+  echo "WARNING: post-merge pull of ${SYNC_REMOTE}/${SYNC_DEFAULT_BRANCH} failed; merge already completed." >&2
+  exit 0
+fi
+LOCAL_SHA="$(git rev-parse HEAD)"
+REMOTE_SHA="$(git rev-parse "${SYNC_REMOTE}/${SYNC_DEFAULT_BRANCH}" 2>/dev/null || true)"
+if [ -n "${REMOTE_SHA}" ] && [ "${LOCAL_SHA}" != "${REMOTE_SHA}" ]; then
+  echo "WARNING: Local ${SYNC_DEFAULT_BRANCH} (${LOCAL_SHA}) does not match ${SYNC_REMOTE}/${SYNC_DEFAULT_BRANCH} (${REMOTE_SHA}) after sync." >&2
+  exit 0
+fi
+echo "Local ${SYNC_DEFAULT_BRANCH} synced to ${LOCAL_SHA}."
 ```

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -72,14 +72,14 @@ ABSOLUTE PROHIBITION (#1122): Squash-merge primitives are FORBIDDEN at every lev
 
 dev2merge delegates the actual merge to pr-bot (Step 15). pr-bot reads `pr_review.merge_strategy` from config (default `merge`). If a normal `gh pr merge --merge` fails (e.g. lefthook re-stage race producing an empty-diff PR, or upstream advancing during the wait), DO NOT escalate to `--squash`. Surface `merge_blocked` (or the structural variant `merge_blocked_empty_diff`) to the orchestrator.
 
-EMPTY-DIFF GUARD: Before any merge, verify `gh pr diff <PR>` is non-empty. An empty-diff PR is the structural fingerprint of the lefthook-race scenario in #1122 -- the branch tip drifted, the PR body still references the intended fix, but the actual diff vs main is empty. Aborting at the empty-diff signal is the correct behavior. Squash-merging an empty-diff PR produces an empty squash commit on main and corrupts the audit trail; this is the exact bug #1122 documents.
+EMPTY-DIFF GUARD: Before any merge, verify `gh pr diff <PR>` is non-empty. An empty-diff PR is the structural fingerprint of the lefthook-race scenario in #1122 -- the branch tip drifted, the PR body still references the intended fix, but the actual diff vs the default branch is empty. Aborting at the empty-diff signal is the correct behavior. Squash-merging an empty-diff PR produces an empty squash commit on the default branch and corrupts the audit trail; this is the exact bug #1122 documents.
 
-Once squashed, the original commits cannot be reconstructed from main. The audit cost is irreversible and silent.
+Once squashed, the original commits cannot be reconstructed from the default branch. The audit cost is irreversible and silent.
 </prompt-guard>
 
 ### Prerequisites
 
-- Must be on a feature branch (not `main` or `dev`)
+- Must be on a feature branch (not the default branch or `dev`)
 
 ### Quick Start
 
@@ -145,7 +145,7 @@ All steps use `on_fail = "abort"`. Variables propagate via `CSA_VAR:KEY=value`.
 
 | Step | Name | Gate | Tool |
 |------|------|------|------|
-| 1 | Validate Branch | Not main/dev | bash |
+| 1 | Validate Branch | Not default branch/dev | bash |
 | 2 | FAST_PATH Detection | Diff-stat heuristic | bash |
 | 3 | L1/L2 Quality Gates | `just fmt && just clippy` | bash |
 | **IF FAST_PATH** | | | |
@@ -157,13 +157,13 @@ All steps use `on_fail = "abort"`. Variables propagate via `CSA_VAR:KEY=value`.
 | 8 | Execute with mktsk | Follow mktsk PATTERN.md directly (TaskCreate/TaskUpdate) | main agent |
 | 9 | Version Bump | `just bump-patch` if needed | bash |
 | 10 | Self-Review Gate | Main agent checks and fixes the full branch diff before CSA review | main agent |
-| 11 | Pre-PR Cumulative Review Gate | `csa review --range main...HEAD` | bash |
+| 11 | Pre-PR Cumulative Review Gate | `csa review --range ${DEFAULT_BRANCH}...HEAD` | bash |
 | **ENDIF** | | | |
 | 12 | Push Gate | `REVIEW_COMPLETED=true` required | bash |
-| 13 | Pre-PR Review Verdict Check | `csa review --check-verdict` requires PASS/CLEAN for `main...HEAD` | bash |
+| 13 | Pre-PR Review Verdict Check | `csa review --check-verdict` requires PASS/CLEAN for `${DEFAULT_BRANCH}...HEAD` | bash |
 | 14 | Create or Reuse PR | `gh pr create` or reuse existing, outputs `PR_NUMBER`/`PR_URL` | bash |
 | 15 | pr-bot Hard Gate | **MANDATORY** — runs pr-bot (review + merge) | bash |
-| 16 | Post-Merge Sync | Verifies PR MERGED, then `git checkout main && git merge --ff-only` | bash |
+| 16 | Post-Merge Sync | Verifies PR MERGED, then checkout and fast-forward the default branch | bash |
 
 Steps 13-16 form the PR transaction. Step 13 verifies the pre-PR review verdict
 before any PR can be created. Step 14 creates the PR, Step 15 is a **hard gate**
@@ -204,7 +204,7 @@ ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
 
 ## Done Criteria
 
-1. Feature branch validated (not main/dev).
+1. Feature branch validated (not default branch/dev).
 2. FAST_PATH detection completed (heuristic applied).
 3. `just fmt` and `just clippy` exit 0 (L1/L2 gates).
 4. If full pipeline: mktd plan saved with `DONE WHEN` clauses, mktsk executed all tasks via main agent.
@@ -213,8 +213,8 @@ ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
 7. Pre-PR cumulative review passed (`REVIEW_COMPLETED=true`).
 8. Push completed via `--force-with-lease` (pre-push hook verified review HEAD).
 9. Pre-PR review verdict check passed (`csa review --check-verdict`).
-10. PR created or reused on GitHub targeting main, `PR_NUMBER` and `PR_URL` resolved.
+10. PR created or reused on GitHub targeting the default branch, `PR_NUMBER` and `PR_URL` resolved.
 11. pr-bot hard gate completed: either triggered `pr-bot` or detected an already-completed run for the same PR/HEAD.
 12. PR state verified as MERGED (defense in depth against skipped Step 15).
-13. Local main synced: `git fetch origin && git checkout main && git merge origin/main --ff-only`.
+13. Local default branch synced from its remote tracking branch.
 14. Feature branch cleaned up.

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -39,7 +39,13 @@ name = "DONE_MARKER"
 name = "FAST_PATH"
 
 [[workflow.variables]]
+name = "FEATURE_FILE_LINE_HITS"
+
+[[workflow.variables]]
 name = "FEATURE_INPUT"
+
+[[workflow.variables]]
+name = "FEATURE_INPUT_LEN"
 
 [[workflow.variables]]
 name = "HEAD_SHA"
@@ -118,6 +124,12 @@ name = "REMOTE_SHA"
 
 [[workflow.variables]]
 name = "REPO_SLUG"
+
+[[workflow.variables]]
+name = "SYNC_DEFAULT_BRANCH"
+
+[[workflow.variables]]
+name = "SYNC_REMOTE"
 
 [[workflow.variables]]
 name = "TODO_PATH"
@@ -279,17 +291,18 @@ id = 7
 title = "Plan with mktd"
 tool = "bash"
 prompt = '''
-Generate a TODO plan via mktd. Hard-capped at MKTD_TIMEOUT_SECONDS (default
-1800s, aligned with execution.min_timeout_seconds per #1137) to prevent
-runaway debate-loop sub-sessions (#1118). Auto-selects
-intensity based on:
+Generate a TODO plan via mktd. Hard-capped at `MKTD_TIMEOUT_SECONDS`
+(default `1800`s, aligned with `execution.min_timeout_seconds` per #1137) to
+prevent runaway debate-loop sub-sessions (#1118).
+Auto-selects intensity based on:
 
-- **Brief specificity** (#1118 part B): if `FEATURE_INPUT` is short (< 4096
-  chars) and already names ≥ 2 concrete `path/file.{rs,toml,md}:LINE`
-  references, default to `light` — the user already provided the change
-  shape and a debate-loop adds no value.
-- **Change size**: `light` when code_files ≤ 2 AND total_insertions < 50.
-- Otherwise: `full` (includes threat model + debate).
+- **Brief specificity** (#1118 part B): if `FEATURE_INPUT` is short
+  (< 4096 chars) and already names ≥ 2 concrete
+  `path/file.{rs,toml,md}:LINE` references, default to `light` — the user
+  already provided the change shape and a debate-loop adds no value.
+- **Change size**: `light` when code_files ≤ 2 AND total_insertions < 50
+  (small changes).
+- Otherwise: `full` (default, includes threat model + debate).
 
 ```bash
 set -euo pipefail
@@ -534,7 +547,7 @@ COMMIT_SUBJECT="$(git log -1 --format=%s)"
 
 # --- Create or reuse PR ---
 set +e
-CREATE_OUTPUT="$(gh pr create --base main --title "${COMMIT_SUBJECT}" --body "Auto-created by dev2merge pipeline." 2>&1)"
+CREATE_OUTPUT="$(gh pr create --base "${DEFAULT_BRANCH}" --title "${COMMIT_SUBJECT}" --body "Auto-created by dev2merge pipeline." 2>&1)"
 CREATE_RC=$?
 set -e
 if [ "${CREATE_RC}" -ne 0 ]; then
@@ -699,15 +712,29 @@ if [ -n "${PR_NUMBER:-}" ]; then
   echo "PR #${PR_NUMBER} confirmed MERGED."
 fi
 FEATURE_BRANCH="$(git branch --show-current 2>/dev/null || true)"
-git fetch origin
-git checkout main
-git merge origin/main --ff-only
-LOCAL_SHA="$(git rev-parse HEAD)"
-REMOTE_SHA="$(git rev-parse origin/main)"
-if [ "${LOCAL_SHA}" != "${REMOTE_SHA}" ]; then
-  echo "ERROR: Local main does not match origin/main after sync." >&2
-  exit 1
+SYNC_REMOTE="origin"
+SYNC_DEFAULT_BRANCH="${DEFAULT_BRANCH:-}"
+if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
+  SYNC_DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
 fi
-echo "Local main synced to ${LOCAL_SHA}."
+if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
+  echo "WARNING: post-merge checkout skipped: could not determine default branch." >&2
+  exit 0
+fi
+if ! git checkout "${SYNC_DEFAULT_BRANCH}"; then
+  echo "WARNING: post-merge checkout of ${SYNC_DEFAULT_BRANCH} failed; leaving ${FEATURE_BRANCH:-current branch} checked out." >&2
+  exit 0
+fi
+if ! git pull --ff-only "${SYNC_REMOTE}" "${SYNC_DEFAULT_BRANCH}"; then
+  echo "WARNING: post-merge pull of ${SYNC_REMOTE}/${SYNC_DEFAULT_BRANCH} failed; merge already completed." >&2
+  exit 0
+fi
+LOCAL_SHA="$(git rev-parse HEAD)"
+REMOTE_SHA="$(git rev-parse "${SYNC_REMOTE}/${SYNC_DEFAULT_BRANCH}" 2>/dev/null || true)"
+if [ -n "${REMOTE_SHA}" ] && [ "${LOCAL_SHA}" != "${REMOTE_SHA}" ]; then
+  echo "WARNING: Local ${SYNC_DEFAULT_BRANCH} (${LOCAL_SHA}) does not match ${SYNC_REMOTE}/${SYNC_DEFAULT_BRANCH} (${REMOTE_SHA}) after sync." >&2
+  exit 0
+fi
+echo "Local ${SYNC_DEFAULT_BRANCH} synced to ${LOCAL_SHA}."
 ```'''
 on_fail = "abort"

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -456,7 +456,7 @@ id = 11
 title = "Pre-PR Cumulative Review Gate"
 tool = "bash"
 prompt = '''
-Cumulative review covering all commits since main.
+Cumulative review covering all commits since the default branch.
 Sets REVIEW_COMPLETED=true as gate for push step.
 
 ```bash
@@ -469,7 +469,7 @@ echo '<!-- CSA:NEXT_STEP cmd="push to origin (Step 12)" required=true -->'
 
 When global config sets `[review].batch_commits >= 2`, intermediate cumulative
 reviews can be skipped until the branch accumulates enough new commits after
-the last passed `main...HEAD` review. Set `CSA_REVIEW_NOW=1` to bypass batching
+the last passed `${DEFAULT_BRANCH}...HEAD` review. Set `CSA_REVIEW_NOW=1` to bypass batching
 for the current run.'''
 on_fail = "abort"
 condition = "!(${FAST_PATH})"
@@ -485,7 +485,7 @@ Hard gates before any push:
 2. **Empty-diff structural guard (#1122)**: branch must have at least one
    commit ahead of base AND the cumulative diff vs base must be non-empty.
    An empty-diff branch is the lefthook-race fingerprint — it produces an
-   empty PR which can be silently squashed into an empty commit on main.
+   empty PR which can be silently squashed into an empty commit on the default branch.
    Aborting here surfaces `merge_blocked_empty_diff` to the orchestrator
    instead of letting it propagate to pr-bot.
 
@@ -521,7 +521,7 @@ title = "Pre-PR Review Verdict Check"
 tool = "bash"
 prompt = '''
 Hard gate before PR creation: the current branch HEAD must have a PASS/CLEAN
-review verdict for the full cumulative diff (`main...HEAD`).
+review verdict for the full cumulative diff (`${DEFAULT_BRANCH}...HEAD`).
 
 ```bash
 set -euo pipefail
@@ -577,7 +577,7 @@ done
 # Fallback: gh pr list --head
 if [ -z "${PR_NUMBER}" ]; then
   echo "INFO: gh pr view failed; falling back to gh pr list..."
-  PR_NUMBER="$(gh pr list --head "${BRANCH}" --base main --json number -q '.[0].number' 2>/dev/null || true)"
+  PR_NUMBER="$(gh pr list --head "${BRANCH}" --base "${DEFAULT_BRANCH}" --json number -q '.[0].number' 2>/dev/null || true)"
   if [ -n "${PR_NUMBER}" ] && printf '%s' "${PR_NUMBER}" | grep -Eq '^[0-9]+$'; then
     PR_URL="$(gh pr view "${PR_NUMBER}" --json url -q '.url' 2>/dev/null || true)"
   fi

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -1872,12 +1872,9 @@ MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG
 mkdir -p "${MARKER_DIR}"
 touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
-# Post-merge: sync local default branch with remote
-git fetch "${REMOTE_NAME}"
-git checkout "${DEFAULT_BRANCH}"
-git merge "${REMOTE_NAME}/${DEFAULT_BRANCH}" --ff-only
-git log --oneline -1  # verify local matches remote
-echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged without bot" required=false -->'
+MERGE_COMPLETED=true
+echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
+echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```
 
 ## ENDIF
@@ -1938,12 +1935,9 @@ MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG
 mkdir -p "${MARKER_DIR}"
 touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
-# Post-merge: sync local default branch with remote
-git fetch "${REMOTE_NAME}"
-git checkout "${DEFAULT_BRANCH}"
-git merge "${REMOTE_NAME}/${DEFAULT_BRANCH}" --ff-only
-git log --oneline -1  # verify local matches remote
-echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
+MERGE_COMPLETED=true
+echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
+echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```
 
 ## ELSE
@@ -1985,15 +1979,54 @@ MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG
 mkdir -p "${MARKER_DIR}"
 touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
-# Post-merge: sync local default branch with remote
-git fetch "${REMOTE_NAME}"
-git checkout "${DEFAULT_BRANCH}"
-git merge "${REMOTE_NAME}/${DEFAULT_BRANCH}" --ff-only
-git log --oneline -1  # verify local matches remote
-echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
+MERGE_COMPLETED=true
+echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
+echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```
 
 ## ENDIF
+
+## ENDIF
+
+## IF ${MERGE_COMPLETED}
+
+## Step 13: Post-Merge Default Branch Checkout
+
+> **Layer**: 0 (Orchestrator) -- best-effort checkout after successful merge.
+
+Tool: bash
+
+After `gh pr merge` succeeds, leave the working tree on the dynamically
+detected default branch and pull its latest remote state. This step is
+best-effort: checkout or pull failure warns but does not change the successful
+merge outcome.
+
+```bash
+set +e
+SYNC_REMOTE="${REMOTE_NAME:-origin}"
+SYNC_DEFAULT_BRANCH="${DEFAULT_BRANCH:-}"
+if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
+  SYNC_DEFAULT_BRANCH="$(git symbolic-ref "refs/remotes/${SYNC_REMOTE}/HEAD" 2>/dev/null | sed "s@^refs/remotes/${SYNC_REMOTE}/@@")"
+fi
+if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
+  SYNC_DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+  SYNC_REMOTE="origin"
+fi
+if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
+  echo "WARNING: post-merge checkout skipped: could not determine default branch." >&2
+  exit 0
+fi
+if ! git checkout "${SYNC_DEFAULT_BRANCH}"; then
+  echo "WARNING: post-merge checkout of ${SYNC_DEFAULT_BRANCH} failed; leaving current branch unchanged." >&2
+  exit 0
+fi
+if ! git pull --ff-only "${SYNC_REMOTE}" "${SYNC_DEFAULT_BRANCH}"; then
+  echo "WARNING: post-merge pull of ${SYNC_REMOTE}/${SYNC_DEFAULT_BRANCH} failed; merge already completed." >&2
+  exit 0
+fi
+git log --oneline -1
+echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
+```
 
 ## ENDIF
 

--- a/patterns/pr-bot/skills/pr-bot/SKILL.md
+++ b/patterns/pr-bot/skills/pr-bot/SKILL.md
@@ -29,7 +29,7 @@ triggers:
 
 ## Purpose
 
-Orchestrate the full PR review-and-merge lifecycle with two-layer review: local pre-PR cumulative audit (covering main...HEAD) plus configurable cloud bot review (default: gemini-code-assist; configurable via `pr_review.cloud_bot_name`). When bot times out, the workflow **aborts** (no silent fallback merge). The one explicit exception is a detected quota-exhaustion warning, which is cached and routed through the merge-without-bot audit path. Performs false-positive arbitration via adversarial debate, and manages fix-push-retrigger loops with user-prompted round limits (MAX_REVIEW_ROUNDS, default 10). Non-target bot comments (e.g., codex auto-review) are also detected and processed with a quota warning. Merges with `--merge` to preserve per-commit audit trail.
+Orchestrate the full PR review-and-merge lifecycle with two-layer review: local pre-PR cumulative audit (covering `${DEFAULT_BRANCH}...HEAD`) plus configurable cloud bot review (default: gemini-code-assist; configurable via `pr_review.cloud_bot_name`). When bot times out, the workflow **aborts** (no silent fallback merge). The one explicit exception is a detected quota-exhaustion warning, which is cached and routed through the merge-without-bot audit path. Performs false-positive arbitration via adversarial debate, and manages fix-push-retrigger loops with user-prompted round limits (MAX_REVIEW_ROUNDS, default 10). Non-target bot comments (e.g., codex auto-review) are also detected and processed with a quota warning. Merges with `--merge` to preserve per-commit audit trail.
 
 **MANDATORY AUDIT TRAIL**: When an agent determines a PR-page review finding
 (for example, a cloud bot finding) is NOT a real issue or is acceptable in
@@ -64,7 +64,7 @@ Layer 1 agents perform the actual work dispatched by Layer 0:
 
 | Step | Layer 1 Agent | Work Performed |
 |------|-------------|----------------|
-| Step 2 | `csa review --branch main` | Cumulative local review |
+| Step 2 | `csa review --branch ${DEFAULT_BRANCH}` | Cumulative local review |
 | Step 3 | `csa` (executor) | Fix local review issues |
 | Step 7 | claude-code (Task tool) | Classify bot comments |
 | Step 8 | `csa debate` | False-positive arbitration |
@@ -90,7 +90,7 @@ results.
 ```
 Layer 0 (Orchestrator)
   |
-  +-- dispatch --> Layer 1: csa review --branch main
+  +-- dispatch --> Layer 1: csa review --branch ${DEFAULT_BRANCH}
   |                  |
   |                  +-- spawn --> Layer 2: reviewer model(s)
   |
@@ -114,7 +114,7 @@ Layer 0 (Orchestrator)
 ### Prerequisites
 
 - All changes must be committed on a feature branch
-- Feature branch must be ahead of main
+- Feature branch must be ahead of the default branch
 - **FORBIDDEN**: Pushing the feature branch to remote BEFORE invoking this skill.
   Step 2 (local review) MUST complete before any push. If you push first,
   unreviewed code reaches the remote and CI/reviewers may act on it prematurely.
@@ -225,12 +225,12 @@ breaks prompt-guard propagation.
 ### Step-by-Step
 
 1. **Commit check**: Ensure all changes are committed. Record `WORKFLOW_BRANCH`.
-2. **Local pre-PR review** (SYNCHRONOUS -- MUST NOT background): use SHA-verified fast-path first (`CURRENT_HEAD` vs latest reviewed session HEAD SHA from `review_meta.json`). If matched, skip review; if mismatched/missing, run full `csa review --branch main --fix --max-rounds 3` (the `--fix` flag resumes the same reviewer session to fix issues, preserving full review context). This is the foundation -- without it, bot unavailability cannot safely merge. Sets `REVIEW_COMPLETED=true` on success.
-3. **Push and ensure PR** (PRECONDITION: `REVIEW_COMPLETED=true`): Detect if branch was already pushed (early-push warning). Resolve the push remote using the documented fork-convention guard; if `origin` looks canonical and no explicit push remote is configured, fail closed with a fix command instead of guessing. Then push with `--force-with-lease`, derive `source_owner` from `origin` remote URL, and resolve PR strictly by owner-aware lookup (`base=main + head=<source_owner>:${WORKFLOW_BRANCH}`). If none exists, create with `--head <source_owner>:<branch>` and re-resolve; handle create races where PR was created concurrently. FORBIDDEN: creating/reusing PR without Step 2 completion.
+2. **Local pre-PR review** (SYNCHRONOUS -- MUST NOT background): use SHA-verified fast-path first (`CURRENT_HEAD` vs latest reviewed session HEAD SHA from `review_meta.json`). If matched, skip review; if mismatched/missing, run full `csa review --branch "${DEFAULT_BRANCH}" --fix --max-rounds 3` (the `--fix` flag resumes the same reviewer session to fix issues, preserving full review context). This is the foundation -- without it, bot unavailability cannot safely merge. Sets `REVIEW_COMPLETED=true` on success.
+3. **Push and ensure PR** (PRECONDITION: `REVIEW_COMPLETED=true`): Detect if branch was already pushed (early-push warning). Resolve the push remote using the documented fork-convention guard; if `origin` looks canonical and no explicit push remote is configured, fail closed with a fix command instead of guessing. Then push with `--force-with-lease`, derive `source_owner` from `origin` remote URL, and resolve PR strictly by owner-aware lookup (`base=${DEFAULT_BRANCH} + head=<source_owner>:${WORKFLOW_BRANCH}`). If none exists, create with `--head <source_owner>:<branch>` and re-resolve; handle create races where PR was created concurrently. FORBIDDEN: creating/reusing PR without Step 2 completion.
 3a. **Check cloud bot config**: Run `csa config get pr_review.cloud_bot --default true`.
     If `false` → skip Steps 4-9. Apply the same SHA-verified fast-path before
     supplementary review. If SHA matches, skip review; if SHA mismatches/missing
-    (HEAD drift fallback), run full `csa review --branch main`. Then route through
+    (HEAD drift fallback), run full `csa review --branch "${DEFAULT_BRANCH}"`. Then route through
     the bot-unavailable merge path (Step 6a).
 4. **Trigger cloud bot and delegate waiting** (SELF-CONTAINED -- trigger + wait gate are atomic):
    - **Round 0** (initial PR): follows `cloud_bot_trigger` config (`"comment"` → @mention, `"auto"` → skip).
@@ -244,13 +244,13 @@ breaks prompt-guard propagation.
    - Category A (already fixed): react and acknowledge.
    - Category B (suspected false positive): queue for staleness filter, then arbitrate.
    - Category C (real issue): queue for staleness filter, then fix.
-6. **Staleness filter** (before arbitration/fix): For each comment classified as B or C, check if the referenced code has been modified since the comment was posted. Compare comment file paths and line ranges against `git diff main...HEAD` and `git log --since="${COMMENT_TIMESTAMP}"`. Comments referencing lines changed after the comment timestamp are reclassified as Category A (potentially stale, already addressed) and skipped. This prevents debates and fix cycles on already-resolved issues.
+6. **Staleness filter** (before arbitration/fix): For each comment classified as B or C, check if the referenced code has been modified since the comment was posted. Compare comment file paths and line ranges against `git diff "${DEFAULT_BRANCH}...HEAD"` and `git log --since="${COMMENT_TIMESTAMP}"`. Comments referencing lines changed after the comment timestamp are reclassified as Category A (potentially stale, already addressed) and skipped. This prevents debates and fix cycles on already-resolved issues.
 7. **Arbitrate non-stale false positives**: For surviving Category B comments, arbitrate via `csa debate` with independent model. Require structured debate output, then post the PR audit trail through an explicit `gh pr comment` step. If debate overturns the false-positive classification, reroute that comment into the real-issue fix step instead of posting a dismissal comment.
-8. **Fix non-stale real issues**: For surviving Category C comments, fix using `csa review --fix` to resume the reviewer session (preserves review context, avoids 50K+ token waste of spawning fresh). Commit fixes, then run `csa review --range main...HEAD` (review gate) BEFORE pushing — unreviewed fix code must not reach the remote.
+8. **Fix non-stale real issues**: For surviving Category C comments, fix using `csa review --fix` to resume the reviewer session (preserves review context, avoids 50K+ token waste of spawning fresh). Commit fixes, then run `csa review --range "${DEFAULT_BRANCH}...HEAD"` (review gate) BEFORE pushing — unreviewed fix code must not reach the remote.
 9. **Continue loop**: Push fixes and loop back (next trigger is issued in Step 4). Track iteration count via `REVIEW_ROUND`. When `REVIEW_ROUND` reaches `MAX_REVIEW_ROUNDS` (default: 10), STOP and present options to the user: (A) Merge now, (B) Continue for more rounds, (C) Abort and investigate manually. The workflow MUST NOT auto-merge or auto-abort at the round limit.
 10. **Clean resubmission** (if fixes accumulated): Create clean branch for final review.
 10.5. ~~**Rebase for clean history**~~: DISABLED. With merge commits (not squash), rebase destroys per-commit audit trail. Squash merges are forbidden for audit reasons.
-11. **Merge**: When `cloud_bot=false`, leave audit trail comment explaining merge rationale (bot disabled + local review CLEAN). When `cloud_bot=true`, either the bot must have confirmed no issues before reaching this step, or Step 4 must have explicitly routed through the quota-exhausted merge-without-bot path with an audit comment citing the cached window and local review session. Plain timeout still aborts and never falls through to merge. Read merge strategy from `csa config get pr_review.merge_strategy --default merge` and branch deletion from `csa config get pr_review.delete_branch --default false`. Then `gh pr merge --${MERGE_STRATEGY} [--delete-branch]`, then `git fetch origin && git checkout main && git merge origin/main --ff-only`.
+11. **Merge**: When `cloud_bot=false`, leave audit trail comment explaining merge rationale (bot disabled + local review CLEAN). When `cloud_bot=true`, either the bot must have confirmed no issues before reaching this step, or Step 4 must have explicitly routed through the quota-exhausted merge-without-bot path with an audit comment citing the cached window and local review session. Plain timeout still aborts and never falls through to merge. Read merge strategy from `csa config get pr_review.merge_strategy --default merge` and branch deletion from `csa config get pr_review.delete_branch --default false`. Then `gh pr merge --${MERGE_STRATEGY} [--delete-branch]`, then sync the local default branch from its remote tracking branch.
 
 ## Example Usage
 
@@ -268,7 +268,7 @@ breaks prompt-guard propagation.
 ## Done Criteria
 
 1. Step 2 completed synchronously (not backgrounded) via one of:
-   - full path: `csa review --branch main`, or
+   - full path: `csa review --branch "${DEFAULT_BRANCH}"`, or
    - fast-path: current HEAD SHA matches latest reviewed session HEAD SHA.
    - `REVIEW_COMPLETED=true` is set after successful completion.
 2. Any local review issues are fixed before PR creation.
@@ -277,14 +277,14 @@ breaks prompt-guard propagation.
 5. **If cloud_bot enabled (default)**: cloud bot triggered (round-aware: auto on round 0, explicit retrigger on round 1+), wait handled by the built-in `pr-bot-wait.sh` helper with hard timeout and positive review-event signal checks, and timeout path handled. If bot responds with environment/configuration setup message instead of actual review, workflow STOPS and reports to user (Step 5a).
 6. **If cloud_bot disabled**: supplementary check completed via one of:
    - fast-path: SHA match, review skipped, or
-   - fallback path: SHA mismatch/missing (HEAD drift) and full `csa review --branch main` executed.
+   - fallback path: SHA mismatch/missing (HEAD drift) and full `csa review --branch "${DEFAULT_BRANCH}"` executed.
 7. Every bot comment classified (A/B/C) and actioned appropriately (cloud_bot enabled only).
 8. Staleness filter applied (cloud_bot enabled only).
 9. Non-stale false positives arbitrated via `csa debate` (cloud_bot enabled only).
 10. Real issues fixed and re-reviewed (cloud_bot enabled only).
-10a. **Post-fix re-review gate** (HARD GATE): After fixing bot findings, bot is re-triggered on current HEAD via explicit retrigger command (NOT relying on auto-review), uses the same configurable wait policy as the initial gate (`cloud_bot_wait_seconds` quiet wait + `cloud_bot_poll_max_seconds` polling), and requires a **positive review event** (via `pulls/{pr}/reviews` API, filtered by `commit_id`) with zero actionable findings. If no review event or API failure, falls back to local `csa review --range main...HEAD`. If new findings appear, workflow aborts (user must re-run pr-bot).
+10a. **Post-fix re-review gate** (HARD GATE): After fixing bot findings, bot is re-triggered on current HEAD via explicit retrigger command (NOT relying on auto-review), uses the same configurable wait policy as the initial gate (`cloud_bot_wait_seconds` quiet wait + `cloud_bot_poll_max_seconds` polling), and requires a **positive review event** (via `pulls/{pr}/reviews` API, filtered by `commit_id`) with zero actionable findings. If no review event or API failure, falls back to local `csa review --range "${DEFAULT_BRANCH}...HEAD"`. If new findings appear, workflow aborts (user must re-run pr-bot).
 10b. **Round limit**: If `REVIEW_ROUND` reaches `MAX_REVIEW_ROUNDS` (default: 10), user was prompted with options (merge/continue/abort) and explicitly chose before proceeding.
 10c. ~~**Rebase for clean history**~~ (Step 10.5): DISABLED — merge commits preserve audit trail directly.
 11. **Audit trail**: Every dismissed PR-page finding (for example, a bot finding) has a corresponding explanatory PR comment posted by an explicit workflow step BEFORE proceeding or merging.
 12. PR merged via configured strategy (default: merge commit, full history preserved). Branch deletion controlled by `pr_review.delete_branch` config (default: false — branches preserved for audit).
-13. Local main updated: `git fetch origin && git checkout main && git merge origin/main --ff-only`.
+13. Local default branch updated from its remote tracking branch.

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -222,6 +222,9 @@ name = "MARKER_REPO_SLUG"
 name = "MAX_REVIEW_ROUNDS"
 
 [[workflow.variables]]
+name = "MERGE_COMPLETED"
+
+[[workflow.variables]]
 name = "MERGE_REASON"
 
 [[workflow.variables]]
@@ -354,6 +357,12 @@ name = "SOURCE_OWNER"
 name = "STEP_11_OUTPUT"
 
 [[workflow.variables]]
+name = "SYNC_DEFAULT_BRANCH"
+
+[[workflow.variables]]
+name = "SYNC_REMOTE"
+
+[[workflow.variables]]
 name = "TRIGGER_BODY"
 
 [[workflow.variables]]
@@ -402,9 +411,6 @@ name = "WORKFLOW_BRANCH"
 name = "attempt"
 
 [[workflow.variables]]
-name = "count"
-
-[[workflow.variables]]
 name = "field_name"
 
 [[workflow.variables]]
@@ -412,9 +418,6 @@ name = "latest_bot_comment_json"
 
 [[workflow.variables]]
 name = "latest_trigger_ts"
-
-[[workflow.variables]]
-name = "matches"
 
 [[workflow.variables]]
 name = "pr_num"
@@ -451,6 +454,9 @@ name = "reuse_existing_current_head_review"
 
 [[workflow.variables]]
 name = "setup_body"
+
+[[workflow.variables]]
+name = "status"
 
 [[workflow.variables]]
 name = "step"
@@ -2280,12 +2286,9 @@ MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG
 mkdir -p "${MARKER_DIR}"
 touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
-# Post-merge: sync local default branch with remote
-git fetch "${REMOTE_NAME}"
-git checkout "${DEFAULT_BRANCH}"
-git merge "${REMOTE_NAME}/${DEFAULT_BRANCH}" --ff-only
-git log --oneline -1  # verify local matches remote
-echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged without bot" required=false -->'
+MERGE_COMPLETED=true
+echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
+echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```'''
 on_fail = "abort"
 condition = "!(${CLOUD_BOT}) || ((${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && !(${FALLBACK_REVIEW_HAS_ISSUES}))"
@@ -2347,12 +2350,9 @@ MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG
 mkdir -p "${MARKER_DIR}"
 touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
-# Post-merge: sync local default branch with remote
-git fetch "${REMOTE_NAME}"
-git checkout "${DEFAULT_BRANCH}"
-git merge "${REMOTE_NAME}/${DEFAULT_BRANCH}" --ff-only
-git log --oneline -1  # verify local matches remote
-echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
+MERGE_COMPLETED=true
+echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
+echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```'''
 on_fail = "abort"
 condition = "(!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED}))"
@@ -2395,18 +2395,57 @@ MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG
 mkdir -p "${MARKER_DIR}"
 touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
-# Post-merge: sync local default branch with remote
-git fetch "${REMOTE_NAME}"
-git checkout "${DEFAULT_BRANCH}"
-git merge "${REMOTE_NAME}/${DEFAULT_BRANCH}" --ff-only
-git log --oneline -1  # verify local matches remote
-echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
+MERGE_COMPLETED=true
+echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
+echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```'''
 on_fail = "abort"
 condition = "(!(${BOT_UNAVAILABLE})) && (!(${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED})))"
 
 [[workflow.steps]]
 id = 24
+title = "Post-Merge Default Branch Checkout"
+tool = "bash"
+prompt = '''
+> **Layer**: 0 (Orchestrator) -- best-effort checkout after successful merge.
+
+
+After `gh pr merge` succeeds, leave the working tree on the dynamically
+detected default branch and pull its latest remote state. This step is
+best-effort: checkout or pull failure warns but does not change the successful
+merge outcome.
+
+```bash
+set +e
+SYNC_REMOTE="${REMOTE_NAME:-origin}"
+SYNC_DEFAULT_BRANCH="${DEFAULT_BRANCH:-}"
+if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
+  SYNC_DEFAULT_BRANCH="$(git symbolic-ref "refs/remotes/${SYNC_REMOTE}/HEAD" 2>/dev/null | sed "s@^refs/remotes/${SYNC_REMOTE}/@@")"
+fi
+if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
+  SYNC_DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+  SYNC_REMOTE="origin"
+fi
+if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
+  echo "WARNING: post-merge checkout skipped: could not determine default branch." >&2
+  exit 0
+fi
+if ! git checkout "${SYNC_DEFAULT_BRANCH}"; then
+  echo "WARNING: post-merge checkout of ${SYNC_DEFAULT_BRANCH} failed; leaving current branch unchanged." >&2
+  exit 0
+fi
+if ! git pull --ff-only "${SYNC_REMOTE}" "${SYNC_DEFAULT_BRANCH}"; then
+  echo "WARNING: post-merge pull of ${SYNC_REMOTE}/${SYNC_DEFAULT_BRANCH} failed; merge already completed." >&2
+  exit 0
+fi
+git log --oneline -1
+echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
+```'''
+on_fail = "abort"
+condition = "${MERGE_COMPLETED}"
+
+[[workflow.steps]]
+id = 25
 title = "Post-Merge Extensions"
 tool = "note"
 prompt = "> Post-merge rule-extractor pattern is available at `patterns/rule-extractor/` — integration pending separate PR. Invoke via `csa plan run patterns/rule-extractor/workflow.toml` after successful merge when HIGH/CRITICAL findings exist."


### PR DESCRIPTION
## Summary
- Add post-merge checkout step in dev2merge and pr-bot patterns/workflows
- Add `merge_completed` hook in `csa-hooks` merge guard that runs `git checkout <default> && git pull`
- Replace all hardcoded `--base main` with `${DEFAULT_BRANCH}` in pattern files
- Update skill files to stay in sync

Closes #1198

## Test plan
- [x] `cargo test` passes
- [x] `just pre-commit` clean
- [x] Pattern/workflow files synced (rule 027)
- [x] Review verdict PASS (round 2 after fixing hardcoded `--base main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)