### PR TITLE
test(csa-process): stabilize flaky daemon_pid legacy session context test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "chrono",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "axum",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "chrono",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "chrono",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "chrono",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.625"
+version = "0.1.626"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.625"
+version = "0.1.626"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -531,11 +531,23 @@ fn is_process_alive(pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[cfg(target_os = "linux")]
     fn daemon_pid_record(pid: u32) -> String {
         let metadata = read_process_metadata(pid).expect("process metadata");
         format!("{pid} {}\n", metadata.start_time_ticks)
+    }
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn wait_for_process_command_line_contains(pid: u32, expected: &str) -> bool {
+        let deadline = std::time::Instant::now() + Duration::from_millis(100);
+        let mut delay = Duration::from_millis(1);
+        while std::time::Instant::now() < deadline {
+            if read_process_command_line(pid).is_some_and(|cmdline| cmdline.contains(expected)) {
+                return true;
+            }
+            std::thread::sleep(delay);
+            delay = delay.saturating_mul(2).min(Duration::from_millis(16));
+        }
+        read_process_command_line(pid).is_some_and(|cmdline| cmdline.contains(expected))
     }
 
     #[test]
@@ -563,7 +575,6 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let locks_dir = tmp.path().join("locks");
         fs::create_dir_all(&locks_dir).expect("create locks dir");
-        // Use a spawned process with 'codex' in cmdline to satisfy context check.
         let mut child = std::process::Command::new("sh")
             .arg("-c")
             .arg("sleep 60 # codex")
@@ -576,7 +587,6 @@ mod tests {
         )
         .expect("write lock");
 
-        // The process is running, so is_working should return true.
         let working = ToolLiveness::is_working(tmp.path());
         child.kill().ok();
         child.wait().ok();
@@ -591,7 +601,6 @@ mod tests {
 
     #[test]
     fn is_pid_working_returns_true_for_self() {
-        // Our own process should always be in R or S state.
         assert!(is_pid_working(std::process::id()));
     }
 
@@ -601,7 +610,6 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let locks_dir = tmp.path().join("locks");
         fs::create_dir_all(&locks_dir).expect("create locks dir");
-        // Use a spawned process with 'tool' in cmdline to satisfy context check.
         let mut child = std::process::Command::new("sh")
             .arg("-c")
             .arg("sleep 60 # tool")
@@ -648,28 +656,28 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn daemon_pid_is_alive_accepts_legacy_pid_with_session_id_context() {
+        const SESSION_ID: &str = "01TESTSESSIONCONTEXT0000000001";
+
         let tmp = tempfile::tempdir().expect("tempdir");
-        let session_dir = tmp.path().join("01TESTSESSIONCONTEXT0000000001");
+        let session_dir = tmp.path().join(SESSION_ID);
         fs::create_dir_all(&session_dir).expect("create session dir");
         let mut child = std::process::Command::new("sh")
-            .args([
-                "-c",
-                "sleep 60",
-                "csa-daemon",
-                "01TESTSESSIONCONTEXT0000000001",
-            ])
+            .args(["-c", "sleep 60", "csa-daemon", SESSION_ID])
             .spawn()
             .unwrap();
         let pid = child.id();
+        let cmdline_ready = wait_for_process_command_line_contains(pid, SESSION_ID);
         fs::write(session_dir.join(DAEMON_PID_FILE), format!("{pid}\n")).expect("write daemon pid");
-
-        assert!(
-            ToolLiveness::daemon_pid_is_alive(&session_dir),
-            "legacy bare daemon.pid should stay alive when the process command still carries the session context"
-        );
+        let daemon_pid_alive = ToolLiveness::daemon_pid_is_alive(&session_dir);
 
         child.kill().ok();
         child.wait().ok();
+
+        assert!(
+            cmdline_ready,
+            "spawned daemon command line should expose session context"
+        );
+        assert!(daemon_pid_alive, "legacy bare daemon.pid should stay alive");
     }
 
     #[cfg(target_os = "linux")]
@@ -756,11 +764,7 @@ mod tests {
     fn pid_matches_session_context_returns_true_for_recent_file_even_without_context_match() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let pid = std::process::id();
-        // Since we can't easily fake process_matches_session_context returning false on Linux
-        // (unless we use a pid that doesn't match), we use a pid that doesn't match.
-        // On Linux, process_matches_session_context(pid, "nonexistent", tmp.path()) should be false.
 
-        // This exercises Patch 1: (context || recent)
         assert!(pid_matches_session_context(
             pid,
             Some("nonexistent"),
@@ -776,11 +780,9 @@ mod tests {
         let locks_dir = tmp.path().join("locks");
         fs::create_dir_all(&locks_dir).expect("create locks dir");
 
-        // Put a fake reconcile lock in the PARENT session_dir
         let reconcile_lock = tmp.path().join(".reconcile.lock");
         fs::write(&reconcile_lock, "{\"pid\": 12345}").expect("write lock");
 
-        // Put a real tool lock in locks/
         let mut child = std::process::Command::new("sh")
             .arg("-c")
             .arg("sleep 60 # tool")
@@ -793,7 +795,6 @@ mod tests {
         child.kill().ok();
         child.wait().ok();
 
-        // Should find tool PID, not reconcile PID (12345)
         assert_eq!(found_pid, Some(pid));
     }
 }


### PR DESCRIPTION
## Summary
- Add `wait_for_process_command_line_contains()` helper with exponential backoff (1ms→16ms, 100ms cap)
- Replace immediate `/proc/<pid>/cmdline` reads with the retry helper in affected tests
- Eliminates race between process spawn and cmdline availability under high parallelism

Closes #1219

## Test plan
- [x] `cargo test` passes
- [x] `just pre-commit` clean
- [x] Review verdict PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)