### PR TITLE
feat(memory): mempal integration — backend detection, capture hooks, prompt injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "chrono",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "axum",
@@ -872,11 +872,12 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "csa-config",
  "directories",
  "regex",
  "reqwest 0.13.2",
@@ -890,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "chrono",
@@ -909,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -925,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "chrono",
@@ -943,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "chrono",
@@ -968,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4516,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.626"
+version = "0.1.627"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "csa-config",
+ "csa-memory",
  "libc",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.626"
+version = "0.1.627"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/memory_capture.rs
+++ b/crates/cli-sub-agent/src/memory_capture.rs
@@ -1,6 +1,8 @@
 use std::fs::{self, File};
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use csa_config::memory::MemoryConfig;
@@ -17,6 +19,8 @@ const INJECT_MAX_RESULTS: usize = 5;
 const INJECT_QUERY_MAX_CHARS: usize = 200;
 const INJECT_FALLBACK_TERMS: usize = 10;
 const INJECT_SNIPPET_MAX_CHARS: usize = 200;
+const MEMPAL_CONTEXT_TIMEOUT: Duration = Duration::from_secs(50);
+const MEMPAL_CONTEXT_MAX_ITEMS: &str = "5";
 
 /// Capture memory from a completed session.
 pub async fn capture_session_memory(
@@ -117,6 +121,118 @@ pub(crate) fn build_memory_section(
     let store = MemoryStore::new(memory_dir.clone());
     let index_dir = memory_dir.join("index");
     build_memory_section_from_store(config, prompt, project_key, &store, &index_dir)
+}
+
+pub fn build_memory_section_from_mempal(
+    query: &str,
+    project_root: &Path,
+    token_budget: u32,
+) -> Option<String> {
+    let binary_path = csa_memory::detect_mempal()?.binary_path.clone();
+    build_memory_section_from_mempal_binary(
+        Path::new(&binary_path),
+        query,
+        project_root,
+        token_budget,
+        MEMPAL_CONTEXT_TIMEOUT,
+    )
+}
+
+fn build_memory_section_from_mempal_binary(
+    binary_path: &Path,
+    query: &str,
+    project_root: &Path,
+    token_budget: u32,
+    timeout: Duration,
+) -> Option<String> {
+    if query.trim().is_empty() || token_budget == 0 {
+        return None;
+    }
+
+    let output = run_mempal_context(binary_path, query, project_root, timeout)?;
+    if !output.status.success() {
+        tracing::warn!(
+            status = ?output.status.code(),
+            "mempal context failed; skipping memory injection"
+        );
+        return None;
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let body = raw.trim();
+    if body.is_empty() {
+        return None;
+    }
+
+    let max_chars = token_budget.saturating_mul(4) as usize;
+    if max_chars == 0 {
+        return None;
+    }
+    let body = body.chars().take(max_chars).collect::<String>();
+    if body.trim().is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "\n<!-- CSA:MEMORY -->\nThe following are relevant memories from mempal:\n\n{}\n<!-- CSA:MEMORY:END -->\n",
+        body.trim()
+    ))
+}
+
+fn run_mempal_context(
+    binary_path: &Path,
+    query: &str,
+    project_root: &Path,
+    timeout: Duration,
+) -> Option<std::process::Output> {
+    let mut command = Command::new(binary_path);
+    command
+        .arg("context")
+        .arg("--cwd")
+        .arg(project_root)
+        .arg("--max-items")
+        .arg(MEMPAL_CONTEXT_MAX_ITEMS)
+        .arg(query)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let mut child = command.spawn().ok()?;
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => return child.wait_with_output().ok(),
+            Ok(None) if start.elapsed() >= timeout => {
+                #[cfg(unix)]
+                {
+                    // SAFETY: negative PID targets the process group created above.
+                    unsafe {
+                        libc::kill(-(child.id() as i32), libc::SIGKILL);
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = child.kill();
+                }
+                let _ = child.wait();
+                tracing::warn!("mempal context timed out; skipping memory injection");
+                return None;
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(100)),
+            Err(err) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                tracing::warn!(error = %err, "mempal context failed; skipping memory injection");
+                return None;
+            }
+        }
+    }
 }
 
 fn build_memory_section_from_store(
@@ -338,6 +454,7 @@ mod tests {
     use super::*;
 
     use chrono::Utc;
+    use std::io::Write as _;
     use tempfile::tempdir;
     use ulid::Ulid;
 
@@ -608,5 +725,67 @@ mod tests {
             .filter(|line| line.starts_with("- ["))
             .count();
         assert_eq!(bullet_count, 1, "token budget should limit to one memory");
+    }
+
+    #[test]
+    fn test_build_memory_section_from_mempal_binary_wraps_context() {
+        let temp = tempdir().expect("create tempdir");
+        let script_path = temp.path().join("mempal-fake.sh");
+        let mut script = fs::File::create(&script_path).expect("create fake mempal");
+        writeln!(
+            script,
+            "#!/bin/sh\nprintf 'mempal remembered %s in %s\\n' \"$6\" \"$3\"\n"
+        )
+        .expect("write fake mempal");
+        drop(script);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script_path, perms).expect("chmod");
+        }
+
+        let section = build_memory_section_from_mempal_binary(
+            &script_path,
+            "review routing",
+            temp.path(),
+            200,
+            Duration::from_secs(5),
+        )
+        .expect("mempal section");
+
+        assert!(section.contains("<!-- CSA:MEMORY -->"));
+        assert!(section.contains("mempal remembered review routing"));
+        assert!(section.contains(temp.path().to_string_lossy().as_ref()));
+        assert!(section.contains("<!-- CSA:MEMORY:END -->"));
+    }
+
+    #[test]
+    fn test_build_memory_section_from_mempal_binary_returns_none_on_timeout() {
+        let temp = tempdir().expect("create tempdir");
+        let script_path = temp.path().join("mempal-sleep.sh");
+        let mut script = fs::File::create(&script_path).expect("create fake mempal");
+        writeln!(script, "#!/bin/sh\nsleep 2\n").expect("write fake mempal");
+        drop(script);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script_path, perms).expect("chmod");
+        }
+
+        let section = build_memory_section_from_mempal_binary(
+            &script_path,
+            "review routing",
+            temp.path(),
+            200,
+            Duration::from_millis(100),
+        );
+
+        assert!(section.is_none());
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use tracing::{info, warn};
 
-use csa_config::{GlobalConfig, ProjectConfig};
+use csa_config::{GlobalConfig, MemoryBackend, ProjectConfig};
 use csa_executor::{CODEX_EXEC_INITIAL_STALL_REASON, Executor};
 use csa_hooks::{HookEvent, run_hooks_for_event};
 use csa_session::{
@@ -277,28 +277,48 @@ pub(crate) async fn process_execution_result(
     )
     .await;
 
-    // Memory capture
+    // Legacy memory capture. Mempal capture is tied to SessionComplete below
+    // so it runs after the session result and hook artifacts are written.
     let memory_config = ctx
         .config
         .map(|cfg| &cfg.memory)
         .filter(|m| !m.is_default())
         .or_else(|| ctx.global_config.map(|cfg| &cfg.memory));
-    if let Some(memory_config) = memory_config
-        && let Err(e) = memory_capture::capture_session_memory(
-            memory_config,
-            &ctx.session_dir,
-            ctx.memory_project_key.as_deref(),
-            Some(ctx.executor.tool_name()),
-            Some(session.meta_session_id.as_str()),
-        )
-        .await
-    {
-        warn!("Memory capture failed: {}", e);
+    if let Some(memory_config) = memory_config {
+        match csa_memory::resolve_backend(memory_config.backend) {
+            MemoryBackend::Legacy => {
+                if let Err(e) = memory_capture::capture_session_memory(
+                    memory_config,
+                    &ctx.session_dir,
+                    ctx.memory_project_key.as_deref(),
+                    Some(ctx.executor.tool_name()),
+                    Some(session.meta_session_id.as_str()),
+                )
+                .await
+                {
+                    warn!("Memory capture failed: {}", e);
+                }
+            }
+            MemoryBackend::Mempal | MemoryBackend::Auto => {}
+        }
     }
 
     // SessionComplete hook: git-commits session artifacts
     if let Err(e) = run_hooks_for_event(HookEvent::SessionComplete, ctx.hooks_config, &hook_vars) {
         warn!("SessionComplete hook failed: {}", e);
+    }
+
+    if let Some(memory_config) = memory_config
+        && matches!(
+            csa_memory::resolve_backend(memory_config.backend),
+            MemoryBackend::Mempal
+        )
+    {
+        csa_hooks::mempal_capture::spawn_mempal_ingest(
+            memory_config,
+            "csa-session",
+            &ctx.session_dir,
+        );
     }
 
     // Tool output compression: runs last so parse_token_usage and hooks see

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -7,7 +7,6 @@ use super::{
     MemoryInjectionOptions, ParentSessionSource, SessionCreationMode, SessionExecutionResult,
     resolve_liveness_dead_seconds, resolve_mcp_servers, run_pipeline_hook,
 };
-use crate::memory_capture;
 use crate::pipeline_project_key::resolve_memory_project_key;
 use crate::run_helpers::truncate_prompt;
 use crate::session_guard::{SessionCleanupGuard, write_pre_exec_error_result};
@@ -30,6 +29,8 @@ use std::{
 use tracing::{debug, info, warn};
 #[path = "pipeline_session_exec_audit.rs"]
 mod session_exec_audit;
+#[path = "pipeline_session_exec_memory.rs"]
+mod session_exec_memory;
 #[path = "pipeline_session_exec_metadata.rs"]
 mod session_exec_metadata;
 #[path = "pipeline_session_exec_tool_state.rs"]
@@ -387,27 +388,14 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             .map(|cfg| &cfg.memory)
             .filter(|m| !m.is_default())
             .or_else(|| global_config.map(|cfg| &cfg.memory));
-        let memory_disabled =
-            memory_injection.is_none() || memory_injection.is_some_and(|opts| opts.disabled);
-        if let Some(memory_cfg) = memory_cfg
-            && memory_cfg.inject
-            && !memory_disabled
-        {
-            let memory_query = memory_injection
-                .and_then(|opts| opts.query_override.as_deref())
-                .unwrap_or(raw_prompt.as_str());
-            if let Some(memory_section) = memory_capture::build_memory_section(
-                memory_cfg,
-                memory_query,
-                memory_project_key.as_deref(),
-            ) {
-                info!(
-                    bytes = memory_section.len(),
-                    "Injecting memory context into prompt"
-                );
-                effective_prompt.push_str(&memory_section);
-            }
-        }
+        session_exec_memory::append_memory_section(
+            memory_cfg,
+            memory_injection,
+            raw_prompt.as_str(),
+            memory_project_key.as_deref(),
+            project_root,
+            &mut effective_prompt,
+        );
     }
     if !can_edit || !can_write_new {
         info!(

--- a/crates/cli-sub-agent/src/pipeline_session_exec_memory.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_memory.rs
@@ -1,0 +1,57 @@
+use std::path::Path;
+
+use csa_config::{MemoryBackend, MemoryConfig};
+use tracing::info;
+
+use crate::memory_capture;
+
+use super::MemoryInjectionOptions;
+
+pub(super) fn append_memory_section(
+    memory_cfg: Option<&MemoryConfig>,
+    memory_injection: Option<&MemoryInjectionOptions>,
+    raw_prompt: &str,
+    memory_project_key: Option<&str>,
+    project_root: &Path,
+    effective_prompt: &mut String,
+) {
+    let memory_disabled =
+        memory_injection.is_none() || memory_injection.is_some_and(|opts| opts.disabled);
+    let Some(memory_cfg) = memory_cfg else {
+        return;
+    };
+    if !memory_cfg.inject || memory_disabled {
+        return;
+    }
+
+    let memory_query = memory_injection
+        .and_then(|opts| opts.query_override.as_deref())
+        .unwrap_or(raw_prompt);
+    if let Some(memory_section) =
+        build_memory_section_for_backend(memory_cfg, memory_query, memory_project_key, project_root)
+    {
+        info!(
+            bytes = memory_section.len(),
+            "Injecting memory context into prompt"
+        );
+        effective_prompt.push_str(&memory_section);
+    }
+}
+
+fn build_memory_section_for_backend(
+    memory_cfg: &MemoryConfig,
+    memory_query: &str,
+    memory_project_key: Option<&str>,
+    project_root: &Path,
+) -> Option<String> {
+    match csa_memory::resolve_backend(memory_cfg.backend) {
+        MemoryBackend::Mempal => memory_capture::build_memory_section_from_mempal(
+            memory_query,
+            project_root,
+            memory_cfg.inject_token_budget,
+        ),
+        MemoryBackend::Legacy | MemoryBackend::Auto => {
+            memory_capture::build_memory_section(memory_cfg, memory_query, memory_project_key)
+        }
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -41,6 +41,8 @@ mod findings_toml;
 mod fix;
 #[path = "review_cmd_flow.rs"]
 mod flow;
+#[path = "review_cmd_mempal.rs"]
+mod mempal;
 #[path = "review_cmd_multi.rs"]
 mod multi;
 #[path = "review_cmd_parent_artifacts.rs"]
@@ -87,28 +89,24 @@ use reviewers::{ AutoReviewerRequest, resolve_effective_reviewer_count, resolve_
 #[cfg(test)]
 #[rustfmt::skip]
 pub(crate) use { fix::persist_fix_final_artifacts_for_tests, output::persist_review_verdict_for_tests };
+
 pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Result<i32> {
-    // 1. Determine project root
     let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
     if args.check_verdict {
         return check_verdict::handle_check_verdict(&project_root);
     }
     let project_root_for_hooks = project_root.display().to_string();
-    // 2. Load config and validate recursion depth
     let Some((config, global_config)) =
         crate::pipeline::load_and_validate(&project_root, current_depth)?
     else {
         return Ok(1);
     };
     let pre_session_hook = csa_hooks::load_global_pre_session_hook_invocation();
-    // 2b. Verify review skill is available (fail fast before any execution)
     verify_review_skill_available(&project_root, args.allow_fallback)?;
-    // Warn if running inside a worktree submodule (known limitation, see #487)
     if is_worktree_submodule(&project_root) {
         warn!(project_root = %project_root.display(),
             "Review inside git worktree submodule — may produce empty/unreliable output (issue #487)");
     }
-    // 2c. Run pre-review quality gate pipeline (after skill check, before tool execution)
     let gate_summary = {
         let gate_steps = global_config.review.effective_gate_steps();
         let gate_timeout = config
@@ -118,7 +116,6 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             .unwrap_or_else(csa_config::ReviewConfig::default_gate_timeout);
         let gate_mode = &global_config.review.gate_mode;
         if gate_steps.is_empty() {
-            // Legacy path: use single gate_command with auto-detection fallback
             let gate_command = config
                 .as_ref()
                 .and_then(|c| c.review.as_ref())
@@ -167,7 +164,6 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
                 None
             }
         } else {
-            // Multi-step pipeline: L1 → L2 → L3 sequential execution
             let pipeline_result = crate::pipeline::gate::evaluate_quality_gates(
                 &project_root,
                 &gate_steps,
@@ -212,7 +208,6 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         }
     };
 
-    // 3. Derive scope and mode from CLI args
     let scope = derive_scope(&args);
     let mode = if args.fix {
         "review-and-fix"
@@ -461,6 +456,12 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         persist_review_sidecars_if_session_exists(
             &project_root,
             &review_meta,
+            result.persistable_session_id.as_deref(),
+        );
+        mempal::maybe_capture_review_mempal(
+            config.as_ref(),
+            &global_config,
+            &project_root,
             result.persistable_session_id.as_deref(),
         );
 

--- a/crates/cli-sub-agent/src/review_cmd_mempal.rs
+++ b/crates/cli-sub-agent/src/review_cmd_mempal.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+
+use csa_config::{GlobalConfig, MemoryBackend, ProjectConfig};
+use tracing::warn;
+
+pub(crate) fn maybe_capture_review_mempal(
+    project_config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+    project_root: &Path,
+    session_id: Option<&str>,
+) {
+    let memory_config = project_config
+        .map(|config| &config.memory)
+        .filter(|memory| !memory.is_default())
+        .unwrap_or(&global_config.memory);
+    if !matches!(
+        csa_memory::resolve_backend(memory_config.backend),
+        MemoryBackend::Mempal
+    ) {
+        return;
+    }
+    let Some(session_id) = session_id else {
+        return;
+    };
+    match csa_session::get_session_dir(project_root, session_id) {
+        Ok(session_dir) => csa_hooks::mempal_capture::spawn_mempal_ingest(
+            memory_config,
+            "csa-review",
+            &session_dir,
+        ),
+        Err(err) => warn!(
+            session_id,
+            error = %err,
+            "Unable to resolve review session dir for mempal capture"
+        ),
+    }
+}

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -46,7 +46,7 @@ pub use global::{
 };
 pub use init::{detect_installed_tools, init_project};
 pub use mcp::{McpFilter, McpRegistry, McpServerConfig, McpTransport};
-pub use memory::{MemoryConfig, MemoryEphemeralConfig, MemoryLlmConfig};
+pub use memory::{MemoryBackend, MemoryConfig, MemoryEphemeralConfig, MemoryLlmConfig};
 pub use migrate::{Migration, MigrationRegistry, MigrationStep, Version, default_registry};
 pub use paths::{APP_NAME, LEGACY_APP_NAME};
 pub use project_profile::{ProjectProfile, detect_project_profile};

--- a/crates/csa-config/src/memory.rs
+++ b/crates/csa-config/src/memory.rs
@@ -1,9 +1,31 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryBackend {
+    #[default]
+    Legacy,
+    Mempal,
+    Auto,
+}
+
+impl fmt::Display for MemoryBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Legacy => write!(f, "legacy"),
+            Self::Mempal => write!(f, "mempal"),
+            Self::Auto => write!(f, "auto"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct MemoryConfig {
+    /// Memory backend implementation to use.
+    #[serde(default)]
+    pub backend: MemoryBackend,
     /// Enable automatic memory capture from PostRun hook.
     pub auto_capture: bool,
     /// Enable memory injection into csa run prompts.
@@ -21,6 +43,7 @@ pub struct MemoryConfig {
 impl Default for MemoryConfig {
     fn default() -> Self {
         Self {
+            backend: MemoryBackend::default(),
             auto_capture: false,
             inject: false,
             inject_token_budget: 2000,
@@ -33,7 +56,8 @@ impl Default for MemoryConfig {
 
 impl MemoryConfig {
     pub fn is_default(&self) -> bool {
-        !self.auto_capture
+        self.backend == MemoryBackend::default()
+            && !self.auto_capture
             && !self.inject
             && self.inject_token_budget == 2000
             && self.consolidation_threshold == 100
@@ -146,7 +170,7 @@ fn mask_api_key(api_key: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{MemoryConfig, MemoryLlmConfig};
+    use super::{MemoryBackend, MemoryConfig, MemoryLlmConfig};
     use crate::ProjectConfig;
 
     #[derive(Debug, serde::Deserialize)]
@@ -158,6 +182,7 @@ mod tests {
     #[test]
     fn test_memory_config_defaults() {
         let parsed: MemoryEnvelope = toml::from_str("[memory]\n").unwrap();
+        assert_eq!(parsed.memory.backend, MemoryBackend::Legacy);
         assert!(!parsed.memory.auto_capture);
         assert!(!parsed.memory.inject);
         assert_eq!(parsed.memory.inject_token_budget, 2000);
@@ -170,6 +195,7 @@ mod tests {
     fn test_memory_config_full() {
         let toml = r#"
 [memory]
+backend = "mempal"
 auto_capture = true
 inject = true
 inject_token_budget = 4096
@@ -186,6 +212,7 @@ enabled = true
 model_spec = "codex/openai/gpt-5.3-codex/low"
 "#;
         let parsed: MemoryEnvelope = toml::from_str(toml).unwrap();
+        assert_eq!(parsed.memory.backend, MemoryBackend::Mempal);
         assert!(parsed.memory.auto_capture);
         assert!(parsed.memory.inject);
         assert_eq!(parsed.memory.inject_token_budget, 4096);
@@ -216,6 +243,24 @@ models = "model-a,model-b,model-c"
     }
 
     #[test]
+    fn test_memory_backend_serde_roundtrip() {
+        for backend in [
+            MemoryBackend::Legacy,
+            MemoryBackend::Mempal,
+            MemoryBackend::Auto,
+        ] {
+            let config = MemoryConfig {
+                backend,
+                ..MemoryConfig::default()
+            };
+            let encoded = toml::to_string(&config).unwrap();
+            let decoded: MemoryConfig = toml::from_str(&encoded).unwrap();
+            assert_eq!(decoded.backend, backend);
+            assert_eq!(decoded.backend.to_string(), backend.to_string());
+        }
+    }
+
+    #[test]
     fn test_memory_config_backward_compat() {
         let parsed: ProjectConfig = toml::from_str(
             r#"
@@ -227,6 +272,7 @@ name = "compat-test"
         .unwrap();
         assert_eq!(parsed.memory.inject_token_budget, 2000);
         assert_eq!(parsed.memory.consolidation_threshold, 100);
+        assert_eq!(parsed.memory.backend, MemoryBackend::Legacy);
         assert!(!parsed.memory.auto_capture);
         assert!(!parsed.memory.inject);
         assert!(!parsed.memory.llm.enabled);

--- a/crates/csa-hooks/Cargo.toml
+++ b/crates/csa-hooks/Cargo.toml
@@ -12,6 +12,7 @@ async-hooks = []
 anyhow.workspace = true
 chrono.workspace = true
 csa-config.workspace = true
+csa-memory.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile.workspace = true

--- a/crates/csa-hooks/src/audit.rs
+++ b/crates/csa-hooks/src/audit.rs
@@ -81,6 +81,14 @@ fn emit_merge_completed_event_inner(
         log = %log_path.display(),
         "MergeCompleted audit event emitted"
     );
+
+    if let Ok(project_root) = std::env::current_dir() {
+        crate::mempal_capture::spawn_mempal_ingest_for_project(
+            &project_root,
+            "csa-merge",
+            &events_dir,
+        );
+    }
     Ok(())
 }
 

--- a/crates/csa-hooks/src/lib.rs
+++ b/crates/csa-hooks/src/lib.rs
@@ -53,6 +53,7 @@ pub mod directive;
 pub mod event;
 pub mod event_bus;
 pub mod guard;
+pub mod mempal_capture;
 pub mod merge_guard;
 pub mod policy;
 pub mod pre_session;

--- a/crates/csa-hooks/src/mempal_capture.rs
+++ b/crates/csa-hooks/src/mempal_capture.rs
@@ -1,0 +1,181 @@
+//! Best-effort mempal capture for lifecycle hook artifacts.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use csa_config::{GlobalConfig, MemoryBackend, MemoryConfig, ProjectConfig};
+
+const INGEST_TIMEOUT: Duration = Duration::from_secs(30);
+const WING: &str = "cli-sub-agent";
+
+/// Return the effective memory config using the same project-over-global
+/// precedence as the execution pipeline.
+pub fn load_effective_memory_config(project_root: &Path) -> Option<MemoryConfig> {
+    if let Ok(Some(config)) = ProjectConfig::load(project_root)
+        && !config.memory.is_default()
+    {
+        return Some(config.memory);
+    }
+
+    GlobalConfig::load()
+        .ok()
+        .map(|config| config.memory)
+        .filter(|memory| !memory.is_default())
+}
+
+/// Spawn a non-blocking mempal ingest for a hook artifact path.
+///
+/// Failures are logged and never propagated. The worker thread enforces its own
+/// timeout because hook capture must not delay the lifecycle action that fired it.
+pub fn spawn_mempal_ingest(config: &MemoryConfig, room: &'static str, input_path: &Path) {
+    if !config.auto_capture {
+        return;
+    }
+
+    let Some(binary_path) = resolve_mempal_binary(config) else {
+        return;
+    };
+
+    let input_path = input_path.to_path_buf();
+    thread::spawn(move || {
+        if let Err(err) = run_mempal_ingest(&binary_path, room, &input_path, INGEST_TIMEOUT) {
+            tracing::warn!(
+                room,
+                input = %input_path.display(),
+                error = %err,
+                "mempal ingest failed; continuing"
+            );
+        }
+    });
+}
+
+/// Convenience wrapper for merge-guard capture, where only the current working
+/// directory is available.
+pub fn spawn_mempal_ingest_for_project(project_root: &Path, room: &'static str, input_path: &Path) {
+    if let Some(config) = load_effective_memory_config(project_root) {
+        spawn_mempal_ingest(&config, room, input_path);
+    }
+}
+
+fn resolve_mempal_binary(config: &MemoryConfig) -> Option<PathBuf> {
+    match config.backend {
+        MemoryBackend::Legacy => None,
+        MemoryBackend::Mempal | MemoryBackend::Auto => {
+            csa_memory::detect_mempal().map(|info| PathBuf::from(&info.binary_path))
+        }
+    }
+}
+
+fn run_mempal_ingest(
+    binary_path: &Path,
+    room: &str,
+    input_path: &Path,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let mut command = Command::new(binary_path);
+    command
+        .arg("ingest")
+        .arg("--wing")
+        .arg(WING)
+        .arg("--room")
+        .arg(room)
+        .arg(input_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let mut child = command.spawn()?;
+    let start = Instant::now();
+    loop {
+        match child.try_wait()? {
+            Some(status) if status.success() => return Ok(()),
+            Some(status) => anyhow::bail!(
+                "mempal ingest exited with code {}",
+                status.code().unwrap_or(-1)
+            ),
+            None if start.elapsed() >= timeout => {
+                #[cfg(unix)]
+                {
+                    // SAFETY: negative PID targets the process group created above.
+                    unsafe {
+                        libc::kill(-(child.id() as i32), libc::SIGKILL);
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = child.kill();
+                }
+                let _ = child.wait();
+                anyhow::bail!("mempal ingest timed out after {}s", timeout.as_secs());
+            }
+            None => thread::sleep(Duration::from_millis(100)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write as _;
+
+    #[test]
+    fn run_mempal_ingest_passes_expected_args() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let log_path = temp.path().join("args.log");
+        let script_path = temp.path().join("mempal-fake.sh");
+        let mut script = fs::File::create(&script_path).expect("create fake mempal");
+        writeln!(
+            script,
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
+            log_path.display()
+        )
+        .expect("write fake mempal");
+        drop(script);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script_path, perms).expect("chmod");
+        }
+
+        let input_dir = temp.path().join("session-output");
+        fs::create_dir(&input_dir).expect("create input dir");
+        run_mempal_ingest(
+            &script_path,
+            "csa-session",
+            &input_dir,
+            Duration::from_secs(5),
+        )
+        .expect("run fake mempal");
+
+        let args = fs::read_to_string(log_path).expect("read args");
+        assert_eq!(
+            args,
+            format!(
+                "ingest\n--wing\ncli-sub-agent\n--room\ncsa-session\n{}\n",
+                input_dir.display()
+            )
+        );
+    }
+
+    #[test]
+    fn legacy_backend_disables_capture() {
+        let config = MemoryConfig {
+            backend: MemoryBackend::Legacy,
+            auto_capture: true,
+            ..MemoryConfig::default()
+        };
+        assert!(resolve_mempal_binary(&config).is_none());
+    }
+}

--- a/crates/csa-hooks/src/merge_guard/mod.rs
+++ b/crates/csa-hooks/src/merge_guard/mod.rs
@@ -257,6 +257,18 @@ if [ -f "${MARKER_FILE}" ]; then
     printf '{"event":"MergeCompleted","pr_number":%s,"head_sha":"%s","marker_path":"%s","timestamp":"%s"}\n' \
       "${PR_NUMBER}" "${HEAD_SHA}" "${MARKER_FILE}" "${AUDIT_TS}" \
       >> "${EVENTS_DIR}/merge-guard.jsonl" 2>/dev/null || true
+    if command -v csa >/dev/null 2>&1 && command -v mempal >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
+      CSA_CONFIG_JSON="$(csa config show --format json 2>/dev/null || true)"
+      case "${CSA_CONFIG_JSON}" in
+        *'"auto_capture":true'*|*'"auto_capture": true'*)
+          case "${CSA_CONFIG_JSON}" in
+            *'"backend":"mempal"'*|*'"backend": "mempal"'*|*'"backend":"auto"'*|*'"backend": "auto"'*)
+              ( timeout 30s mempal ingest --wing cli-sub-agent --room csa-merge "${EVENTS_DIR}" >/dev/null 2>&1 || true ) &
+              ;;
+          esac
+          ;;
+      esac
+    fi
     _post_merge_sync
   fi
   exit ${MERGE_EXIT}

--- a/crates/csa-memory/Cargo.toml
+++ b/crates/csa-memory/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+csa-config = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ulid = { workspace = true }

--- a/crates/csa-memory/src/lib.rs
+++ b/crates/csa-memory/src/lib.rs
@@ -3,7 +3,9 @@ mod entry;
 mod ephemeral_client;
 mod index;
 mod llm_client;
+mod mempal_detect;
 mod noop_client;
+mod resolve_backend;
 mod store;
 
 pub use consolidation::{ConsolidationPlan, MergeGroup, execute_consolidation, plan_consolidation};
@@ -11,5 +13,7 @@ pub use entry::{MemoryEntry, MemorySource};
 pub use ephemeral_client::EphemeralClient;
 pub use index::{MemoryIndex, SearchResult};
 pub use llm_client::{ApiClient, Fact, MemoryLlmClient, ModelRotator};
+pub use mempal_detect::{MempalInfo, detect_mempal};
 pub use noop_client::NoopClient;
+pub use resolve_backend::resolve_backend;
 pub use store::{MemoryFilter, MemoryStore, append_entry, list_entries, quick_search};

--- a/crates/csa-memory/src/mempal_detect.rs
+++ b/crates/csa-memory/src/mempal_detect.rs
@@ -1,0 +1,109 @@
+use std::process::{Command, Output, Stdio};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+const DETECTION_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MempalInfo {
+    pub binary_path: String,
+    pub version: Option<String>,
+}
+
+static DETECTION_RESULT: OnceLock<Option<MempalInfo>> = OnceLock::new();
+
+pub fn detect_mempal() -> Option<&'static MempalInfo> {
+    DETECTION_RESULT.get_or_init(detect_mempal_inner).as_ref()
+}
+
+fn detect_mempal_inner() -> Option<MempalInfo> {
+    detect_mempal_binary("mempal")
+}
+
+fn detect_mempal_binary(binary_name: &str) -> Option<MempalInfo> {
+    let which_output = run_command_with_timeout(
+        {
+            let mut command = Command::new("which");
+            command.arg(binary_name);
+            command
+        },
+        DETECTION_TIMEOUT,
+    )?;
+
+    if !which_output.status.success() {
+        return None;
+    }
+
+    let binary_path = String::from_utf8_lossy(&which_output.stdout)
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|path| !path.is_empty())?
+        .to_string();
+
+    let version = run_command_with_timeout(
+        {
+            let mut command = Command::new(&binary_path);
+            command.arg("--version");
+            command
+        },
+        DETECTION_TIMEOUT,
+    )
+    .filter(|output| output.status.success())
+    .and_then(|output| {
+        first_nonempty_line(&output.stdout).or_else(|| first_nonempty_line(&output.stderr))
+    });
+
+    Some(MempalInfo {
+        binary_path,
+        version,
+    })
+}
+
+fn first_nonempty_line(bytes: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
+}
+
+fn run_command_with_timeout(mut command: Command, timeout: Duration) -> Option<Output> {
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => return child.wait_with_output().ok(),
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detect_mempal_binary;
+
+    #[test]
+    fn detect_mempal_returns_none_when_binary_is_missing() {
+        let missing_binary = format!("csa-missing-mempal-{}", ulid::Ulid::new());
+        assert_eq!(detect_mempal_binary(&missing_binary), None);
+    }
+}

--- a/crates/csa-memory/src/resolve_backend.rs
+++ b/crates/csa-memory/src/resolve_backend.rs
@@ -1,0 +1,34 @@
+use csa_config::MemoryBackend;
+
+use crate::detect_mempal;
+
+pub fn resolve_backend(configured: MemoryBackend) -> MemoryBackend {
+    match configured {
+        MemoryBackend::Auto => {
+            if detect_mempal().is_some() {
+                MemoryBackend::Mempal
+            } else {
+                MemoryBackend::Legacy
+            }
+        }
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_backend;
+    use csa_config::MemoryBackend;
+
+    #[test]
+    fn resolve_backend_preserves_explicit_backend() {
+        assert_eq!(
+            resolve_backend(MemoryBackend::Legacy),
+            MemoryBackend::Legacy
+        );
+        assert_eq!(
+            resolve_backend(MemoryBackend::Mempal),
+            MemoryBackend::Mempal
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MemoryBackend` enum (`legacy`/`mempal`/`auto`) to `MemoryConfig` with serde support
- Add `MempalDetector` with `OnceLock`-cached `which mempal` + version detection (2s timeout)
- Add `resolve_backend()` for runtime auto-detection
- Add mempal capture in `csa-hooks`: session_complete, post_review, merge_completed hooks fire `mempal ingest` (30s timeout, fire-and-forget)
- Add `build_memory_section_from_mempal()` calling `mempal context` with 50s timeout for prompt injection
- Route memory injection through backend config in `pipeline_session_exec.rs`
- All mempal calls are optional — graceful degradation when mempal unavailable

Ref #1181 (Phase 1-3; Phase 4 migration + Phase 6 tests are follow-up)

## Non-breaking guarantees
- Default backend is `legacy` — no behavior change unless user opts in
- `--no-memory` disables both backends
- mempal unavailable → silent fallback to legacy
- No schema changes to mempal — uses existing CLI interface

## Test plan
- [x] `cargo test` passes
- [x] `just pre-commit` clean
- [x] Unit tests for MemoryBackend serde, MempalDetector, resolve_backend
- [x] Review verdict PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)