### PR TITLE
fix(mempal): skip duplicate capture/injection for claude-code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.628"
+version = "0.1.629"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.628"
+version = "0.1.629"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -321,6 +321,7 @@ pub(crate) async fn process_execution_result(
             memory_config,
             "csa-session",
             &ctx.session_dir,
+            Some(ctx.executor.tool_name()),
         );
     }
 

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -394,6 +394,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             raw_prompt.as_str(),
             memory_project_key.as_deref(),
             project_root,
+            executor.tool_name(),
             &mut effective_prompt,
         );
     }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_memory.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_memory.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use csa_config::{MemoryBackend, MemoryConfig};
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::memory_capture;
 
@@ -13,6 +13,7 @@ pub(super) fn append_memory_section(
     raw_prompt: &str,
     memory_project_key: Option<&str>,
     project_root: &Path,
+    tool_name: &str,
     effective_prompt: &mut String,
 ) {
     let memory_disabled =
@@ -21,6 +22,13 @@ pub(super) fn append_memory_section(
         return;
     };
     if !memory_cfg.inject || memory_disabled {
+        return;
+    }
+    if csa_hooks::mempal_capture::tool_has_own_mempal(tool_name) {
+        debug!(
+            tool = tool_name,
+            "skipping mempal prompt injection for {tool_name} (has own integration)"
+        );
         return;
     }
 

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -463,6 +463,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             &global_config,
             &project_root,
             result.persistable_session_id.as_deref(),
+            result.executed_tool.as_str(),
         );
 
         let is_cumulative_review = review_scope_is_cumulative(&scope);

--- a/crates/cli-sub-agent/src/review_cmd_mempal.rs
+++ b/crates/cli-sub-agent/src/review_cmd_mempal.rs
@@ -8,6 +8,7 @@ pub(crate) fn maybe_capture_review_mempal(
     global_config: &GlobalConfig,
     project_root: &Path,
     session_id: Option<&str>,
+    tool_name: &str,
 ) {
     let memory_config = project_config
         .map(|config| &config.memory)
@@ -27,6 +28,7 @@ pub(crate) fn maybe_capture_review_mempal(
             memory_config,
             "csa-review",
             &session_dir,
+            Some(tool_name),
         ),
         Err(err) => warn!(
             session_id,

--- a/crates/csa-hooks/src/audit.rs
+++ b/crates/csa-hooks/src/audit.rs
@@ -87,6 +87,7 @@ fn emit_merge_completed_event_inner(
             &project_root,
             "csa-merge",
             &events_dir,
+            None,
         );
     }
     Ok(())

--- a/crates/csa-hooks/src/mempal_capture.rs
+++ b/crates/csa-hooks/src/mempal_capture.rs
@@ -9,6 +9,11 @@ use csa_config::{GlobalConfig, MemoryBackend, MemoryConfig, ProjectConfig};
 
 const INGEST_TIMEOUT: Duration = Duration::from_secs(30);
 const WING: &str = "cli-sub-agent";
+const CLAUDE_CODE_TOOL: &str = "claude-code";
+
+pub fn tool_has_own_mempal(tool: &str) -> bool {
+    tool == CLAUDE_CODE_TOOL
+}
 
 /// Return the effective memory config using the same project-over-global
 /// precedence as the execution pipeline.
@@ -29,7 +34,23 @@ pub fn load_effective_memory_config(project_root: &Path) -> Option<MemoryConfig>
 ///
 /// Failures are logged and never propagated. The worker thread enforces its own
 /// timeout because hook capture must not delay the lifecycle action that fired it.
-pub fn spawn_mempal_ingest(config: &MemoryConfig, room: &'static str, input_path: &Path) {
+pub fn spawn_mempal_ingest(
+    config: &MemoryConfig,
+    room: &'static str,
+    input_path: &Path,
+    tool_name: Option<&str>,
+) {
+    if let Some(tool) = tool_name
+        && tool_has_own_mempal(tool)
+    {
+        tracing::debug!(
+            tool,
+            room,
+            "skipping mempal capture for {tool} (has own integration)"
+        );
+        return;
+    }
+
     if !config.auto_capture {
         return;
     }
@@ -53,9 +74,14 @@ pub fn spawn_mempal_ingest(config: &MemoryConfig, room: &'static str, input_path
 
 /// Convenience wrapper for merge-guard capture, where only the current working
 /// directory is available.
-pub fn spawn_mempal_ingest_for_project(project_root: &Path, room: &'static str, input_path: &Path) {
+pub fn spawn_mempal_ingest_for_project(
+    project_root: &Path,
+    room: &'static str,
+    input_path: &Path,
+    tool_name: Option<&str>,
+) {
     if let Some(config) = load_effective_memory_config(project_root) {
-        spawn_mempal_ingest(&config, room, input_path);
+        spawn_mempal_ingest(&config, room, input_path, tool_name);
     }
 }
 
@@ -177,5 +203,13 @@ mod tests {
             ..MemoryConfig::default()
         };
         assert!(resolve_mempal_binary(&config).is_none());
+    }
+
+    #[test]
+    fn tool_has_own_mempal_only_matches_claude_code() {
+        assert!(tool_has_own_mempal("claude-code"));
+        assert!(!tool_has_own_mempal("codex"));
+        assert!(!tool_has_own_mempal("gemini-cli"));
+        assert!(!tool_has_own_mempal("opencode"));
     }
 }

--- a/crates/csa-hooks/src/merge_guard/mod.rs
+++ b/crates/csa-hooks/src/merge_guard/mod.rs
@@ -257,7 +257,10 @@ if [ -f "${MARKER_FILE}" ]; then
     printf '{"event":"MergeCompleted","pr_number":%s,"head_sha":"%s","marker_path":"%s","timestamp":"%s"}\n' \
       "${PR_NUMBER}" "${HEAD_SHA}" "${MARKER_FILE}" "${AUDIT_TS}" \
       >> "${EVENTS_DIR}/merge-guard.jsonl" 2>/dev/null || true
-    if command -v csa >/dev/null 2>&1 && command -v mempal >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
+    MEM_CAP_TOOL="${CSA_TOOL_NAME:-${CSA_TOOL:-}}"
+    if [ "${MEM_CAP_TOOL}" = "claude-code" ]; then
+      :
+    elif command -v csa >/dev/null 2>&1 && command -v mempal >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
       CSA_CONFIG_JSON="$(csa config show --format json 2>/dev/null || true)"
       case "${CSA_CONFIG_JSON}" in
         *'"auto_capture":true'*|*'"auto_capture": true'*)


### PR DESCRIPTION
## Summary
- Skip mempal capture for claude-code sessions (CC already writes to mempal via MCP)
- Skip mempal prompt injection for claude-code sessions (CC's SessionStart hook already loads context)
- Non-CC tools (codex, gemini-cli, opencode) unaffected — CSA remains their sole mempal path

Closes #1227

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` — 4191 passed (1 pre-existing flaky unrelated to this change)
- [x] `csa review --range main...HEAD` — PASS/CLEAN
- [x] Unit test for `tool_has_own_mempal_integration()` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)