### PR TITLE
fix(csa-hooks): switch mempal capture to stdin JSON ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.629"
+version = "0.1.630"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.629"
+version = "0.1.630"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -320,7 +320,7 @@ pub(crate) async fn process_execution_result(
         csa_hooks::mempal_capture::spawn_mempal_ingest(
             memory_config,
             "csa-session",
-            &ctx.session_dir,
+            &ctx.session_dir.join("result.toml"),
             Some(ctx.executor.tool_name()),
         );
     }

--- a/crates/cli-sub-agent/src/review_cmd_mempal.rs
+++ b/crates/cli-sub-agent/src/review_cmd_mempal.rs
@@ -24,12 +24,15 @@ pub(crate) fn maybe_capture_review_mempal(
         return;
     };
     match csa_session::get_session_dir(project_root, session_id) {
-        Ok(session_dir) => csa_hooks::mempal_capture::spawn_mempal_ingest(
-            memory_config,
-            "csa-review",
-            &session_dir,
-            Some(tool_name),
-        ),
+        Ok(session_dir) => {
+            let result_path = session_dir.join("result.toml");
+            csa_hooks::mempal_capture::spawn_mempal_ingest(
+                memory_config,
+                "csa-review",
+                &result_path,
+                Some(tool_name),
+            );
+        }
         Err(err) => warn!(
             session_id,
             error = %err,

--- a/crates/csa-hooks/src/audit.rs
+++ b/crates/csa-hooks/src/audit.rs
@@ -86,7 +86,7 @@ fn emit_merge_completed_event_inner(
         crate::mempal_capture::spawn_mempal_ingest_for_project(
             &project_root,
             "csa-merge",
-            &events_dir,
+            &log_path,
             None,
         );
     }

--- a/crates/csa-hooks/src/mempal_capture.rs
+++ b/crates/csa-hooks/src/mempal_capture.rs
@@ -4,11 +4,16 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
+use std::{fs, io};
+
+use anyhow::{Context, anyhow};
 
 use csa_config::{GlobalConfig, MemoryBackend, MemoryConfig, ProjectConfig};
 
 const INGEST_TIMEOUT: Duration = Duration::from_secs(30);
 const WING: &str = "cli-sub-agent";
+const PROJECT: &str = "cli-sub-agent";
+const SOURCE_FILE: &str = "stdin://csa-hook";
 const CLAUDE_CODE_TOOL: &str = "claude-code";
 
 pub fn tool_has_own_mempal(tool: &str) -> bool {
@@ -100,6 +105,184 @@ fn run_mempal_ingest(
     input_path: &Path,
     timeout: Duration,
 ) -> anyhow::Result<()> {
+    let stdin_result = build_mempal_payload(room, input_path)
+        .and_then(|payload| run_mempal_ingest_stdin(binary_path, &payload, timeout));
+    match stdin_result {
+        Ok(()) => Ok(()),
+        Err(stdin_err) => {
+            tracing::debug!(
+                input = %input_path.display(),
+                error = %stdin_err,
+                "mempal stdin JSON ingest failed; falling back to path ingest"
+            );
+            let legacy_input_path = legacy_ingest_path(input_path);
+            run_mempal_ingest_path(binary_path, room, &legacy_input_path, timeout)
+                .with_context(|| format!("stdin JSON ingest failed: {stdin_err}"))?;
+            Ok(())
+        }
+    }
+}
+
+fn legacy_ingest_path(input_path: &Path) -> PathBuf {
+    if input_path.is_file()
+        && let Some(parent) = input_path.parent()
+        && parent.file_name().is_some()
+    {
+        return parent.to_path_buf();
+    }
+    input_path.to_path_buf()
+}
+
+fn build_mempal_payload(room: &str, input_path: &Path) -> anyhow::Result<Vec<u8>> {
+    let content = read_ingest_content(input_path)?;
+    let source = infer_source(input_path, room);
+    serde_json::to_vec(&serde_json::json!({
+        "content": content,
+        "wing": WING,
+        "room": room,
+        "project": PROJECT,
+        "source": source,
+        "source_file": SOURCE_FILE,
+    }))
+    .context("failed to serialize mempal ingest payload")
+}
+
+fn read_ingest_content(input_path: &Path) -> anyhow::Result<String> {
+    if input_path.is_dir() {
+        let result_path = input_path.join("result.toml");
+        if result_path.is_file() {
+            return read_result_summary(&result_path);
+        }
+
+        for relative_path in [
+            "output/summary.md",
+            "output/full.md",
+            "output.log",
+            "merge-guard.jsonl",
+        ] {
+            let candidate = input_path.join(relative_path);
+            if candidate.is_file() {
+                return read_text_file(&candidate);
+            }
+        }
+
+        anyhow::bail!(
+            "no summary source found in mempal input directory {}",
+            input_path.display()
+        );
+    }
+
+    if input_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "result.toml")
+    {
+        return read_result_summary(input_path);
+    }
+
+    read_text_file(input_path)
+}
+
+fn read_result_summary(result_path: &Path) -> anyhow::Result<String> {
+    let contents = read_text_file(result_path)?;
+    let parsed: toml::Value = toml::from_str(&contents).with_context(|| {
+        format!(
+            "failed to parse result summary from {}",
+            result_path.display()
+        )
+    })?;
+    parsed
+        .get("summary")
+        .and_then(toml::Value::as_str)
+        .map(str::trim)
+        .filter(|summary| !summary.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            anyhow!(
+                "result.toml has no non-empty summary: {}",
+                result_path.display()
+            )
+        })
+}
+
+fn read_text_file(path: &Path) -> anyhow::Result<String> {
+    let contents = fs::read_to_string(path).with_context(|| {
+        format!(
+            "failed to read mempal ingest content from {}",
+            path.display()
+        )
+    })?;
+    if path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "merge-guard.jsonl")
+    {
+        return contents
+            .lines()
+            .rev()
+            .find(|line| !line.trim().is_empty())
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| anyhow!("merge guard event log is empty: {}", path.display()));
+    }
+    Ok(contents)
+}
+
+fn infer_source(input_path: &Path, room: &str) -> String {
+    if room == "csa-merge" {
+        return "csa-merge".to_string();
+    }
+
+    let session_dir = if input_path.is_dir() {
+        input_path
+    } else {
+        input_path.parent().unwrap_or(input_path)
+    };
+
+    session_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(|name| format!("csa-session-{name}"))
+        .unwrap_or_else(|| format!("csa-session-{room}"))
+}
+
+fn run_mempal_ingest_stdin(
+    binary_path: &Path,
+    payload: &[u8],
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let mut command = Command::new(binary_path);
+    command
+        .arg("ingest")
+        .arg("--stdin")
+        .arg("--json")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let mut child = command.spawn()?;
+    if let Some(mut stdin) = child.stdin.take() {
+        match io::Write::write_all(&mut stdin, payload) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::BrokenPipe => {}
+            Err(err) => return Err(err).context("failed to write mempal ingest payload to stdin"),
+        }
+    }
+    wait_for_mempal_child(child, timeout)
+}
+
+fn run_mempal_ingest_path(
+    binary_path: &Path,
+    room: &str,
+    input_path: &Path,
+    timeout: Duration,
+) -> anyhow::Result<()> {
     let mut command = Command::new(binary_path);
     command
         .arg("ingest")
@@ -118,7 +301,11 @@ fn run_mempal_ingest(
         command.process_group(0);
     }
 
-    let mut child = command.spawn()?;
+    let child = command.spawn()?;
+    wait_for_mempal_child(child, timeout)
+}
+
+fn wait_for_mempal_child(mut child: std::process::Child, timeout: Duration) -> anyhow::Result<()> {
     let start = Instant::now();
     loop {
         match child.try_wait()? {
@@ -157,11 +344,66 @@ mod tests {
     fn run_mempal_ingest_passes_expected_args() {
         let temp = tempfile::tempdir().expect("create tempdir");
         let log_path = temp.path().join("args.log");
+        let stdin_path = temp.path().join("stdin.json");
         let script_path = temp.path().join("mempal-fake.sh");
         let mut script = fs::File::create(&script_path).expect("create fake mempal");
         writeln!(
             script,
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\ncat > '{}'\n",
+            log_path.display(),
+            stdin_path.display()
+        )
+        .expect("write fake mempal");
+        drop(script);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script_path, perms).expect("chmod");
+        }
+
+        let input_dir = temp.path().join("01ABCSESSION");
+        fs::create_dir(&input_dir).expect("create input dir");
+        let result_path = input_dir.join("result.toml");
+        fs::write(&result_path, "summary = \"captured summary\"\n").expect("write result");
+        run_mempal_ingest(
+            &script_path,
+            "csa-session",
+            &result_path,
+            Duration::from_secs(5),
+        )
+        .expect("run fake mempal");
+
+        let args = fs::read_to_string(log_path).expect("read args");
+        assert_eq!(args, "ingest\n--stdin\n--json\n");
+        let payload: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(stdin_path).expect("read stdin"))
+                .expect("stdin payload is json");
+        assert_eq!(payload["content"], "captured summary");
+        assert_eq!(payload["wing"], "cli-sub-agent");
+        assert_eq!(payload["room"], "csa-session");
+        assert_eq!(payload["project"], "cli-sub-agent");
+        assert_eq!(payload["source"], "csa-session-01ABCSESSION");
+        assert_eq!(payload["source_file"], "stdin://csa-hook");
+    }
+
+    #[test]
+    fn run_mempal_ingest_falls_back_to_path_args_when_stdin_is_unsupported() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let log_path = temp.path().join("args.log");
+        let script_path = temp.path().join("mempal-fake.sh");
+        let mut script = fs::File::create(&script_path).expect("create fake mempal");
+        writeln!(
+            script,
+            r#"#!/bin/sh
+if [ "$2" = "--stdin" ]; then
+  cat >/dev/null
+  exit 2
+fi
+printf '%s\n' "$@" > '{}'
+"#,
             log_path.display()
         )
         .expect("write fake mempal");
@@ -177,10 +419,12 @@ mod tests {
 
         let input_dir = temp.path().join("session-output");
         fs::create_dir(&input_dir).expect("create input dir");
+        let result_path = input_dir.join("result.toml");
+        fs::write(&result_path, "summary = \"fallback summary\"\n").expect("write result");
         run_mempal_ingest(
             &script_path,
             "csa-session",
-            &input_dir,
+            &result_path,
             Duration::from_secs(5),
         )
         .expect("run fake mempal");

--- a/crates/csa-hooks/src/merge_guard/mod.rs
+++ b/crates/csa-hooks/src/merge_guard/mod.rs
@@ -266,7 +266,13 @@ if [ -f "${MARKER_FILE}" ]; then
         *'"auto_capture":true'*|*'"auto_capture": true'*)
           case "${CSA_CONFIG_JSON}" in
             *'"backend":"mempal"'*|*'"backend": "mempal"'*|*'"backend":"auto"'*|*'"backend": "auto"'*)
-              ( timeout 30s mempal ingest --wing cli-sub-agent --room csa-merge "${EVENTS_DIR}" >/dev/null 2>&1 || true ) &
+              (
+                printf '{"content":"MergeCompleted PR #%s at HEAD %s","wing":"cli-sub-agent","room":"csa-merge","project":"cli-sub-agent","source":"csa-merge-%s-%s","source_file":"stdin://csa-hook"}\n' \
+                  "${PR_NUMBER}" "${HEAD_SHA}" "${PR_NUMBER}" "${HEAD_SHA}" |
+                  timeout 30s mempal ingest --stdin --json >/dev/null 2>&1 ||
+                  timeout 30s mempal ingest --wing cli-sub-agent --room csa-merge "${EVENTS_DIR}" >/dev/null 2>&1 ||
+                  true
+              ) &
               ;;
           esac
           ;;


### PR DESCRIPTION
## Summary
- Switch mempal hook capture from directory ingest to `mempal ingest --stdin --json`
- Builds structured JSON payload with content, wing, room, project, source fields
- More precise: sends only session summary, not all output files
- Falls back to directory ingest if stdin mode fails (older mempal versions)

Closes #1226

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` — all new tests pass (2 pre-existing VCS flakes unrelated)
- [x] `csa review --range main...HEAD` — PASS/CLEAN
- [x] Updated fake-mempal test verifies stdin JSON args

🤖 Generated with [Claude Code](https://claude.com/claude-code)