### PR TITLE
feat(memory): add mempal migration command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.630"
+version = "0.1.631"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.630"
+version = "0.1.631"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -28,6 +28,9 @@ pub use cli_plan::*;
 #[path = "cli_checklist.rs"]
 mod cli_checklist;
 pub use cli_checklist::*;
+#[path = "cli_memory.rs"]
+mod cli_memory;
+pub use cli_memory::*;
 
 /// Build version string combining Cargo.toml version and git describe.
 fn build_version() -> &'static str {
@@ -634,69 +637,6 @@ pub enum ConfigCommands {
         /// Working directory for --project (defaults to CWD)
         #[arg(long)]
         cd: Option<String>,
-    },
-}
-
-#[derive(Subcommand, Debug)]
-pub enum MemoryCommands {
-    /// Search memories using BM25 full-text search
-    Search {
-        /// Search query
-        query: String,
-        /// Maximum results
-        #[arg(short, long, default_value = "10")]
-        limit: usize,
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
-    },
-    /// List memory entries with optional filters
-    List {
-        /// Filter by project name
-        #[arg(long)]
-        project: Option<String>,
-        /// Filter by tool name
-        #[arg(long)]
-        tool: Option<String>,
-        /// Filter by tag
-        #[arg(long)]
-        tag: Option<String>,
-        /// Only show entries since this date (YYYY-MM-DD)
-        #[arg(long)]
-        since: Option<String>,
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
-    },
-    /// Manually add a memory entry
-    Add {
-        /// Memory content
-        content: String,
-        /// Comma-separated tags
-        #[arg(long)]
-        tags: Option<String>,
-    },
-    /// Show a specific memory entry by ID
-    Show {
-        /// Memory entry ULID (prefix match supported)
-        id: String,
-    },
-    /// Clean up old memory entries
-    Gc {
-        /// Remove entries older than N days
-        #[arg(long, default_value = "90")]
-        days: u32,
-        /// Preview what would be removed
-        #[arg(long)]
-        dry_run: bool,
-    },
-    /// Rebuild tantivy search index from JSONL
-    Reindex,
-    /// Consolidate memory entries via LLM semantic merge
-    Consolidate {
-        /// Preview consolidation plan without writing changes
-        #[arg(long)]
-        dry_run: bool,
     },
 }
 

--- a/crates/cli-sub-agent/src/cli_memory.rs
+++ b/crates/cli-sub-agent/src/cli_memory.rs
@@ -1,0 +1,81 @@
+use clap::{Subcommand, ValueEnum};
+
+#[derive(Subcommand, Debug)]
+pub enum MemoryCommands {
+    /// Search memories using BM25 full-text search
+    Search {
+        /// Search query
+        query: String,
+        /// Maximum results
+        #[arg(short, long, default_value = "10")]
+        limit: usize,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// List memory entries with optional filters
+    List {
+        /// Filter by project name
+        #[arg(long)]
+        project: Option<String>,
+        /// Filter by tool name
+        #[arg(long)]
+        tool: Option<String>,
+        /// Filter by tag
+        #[arg(long)]
+        tag: Option<String>,
+        /// Only show entries since this date (YYYY-MM-DD)
+        #[arg(long)]
+        since: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Manually add a memory entry
+    Add {
+        /// Memory content
+        content: String,
+        /// Comma-separated tags
+        #[arg(long)]
+        tags: Option<String>,
+    },
+    /// Show a specific memory entry by ID
+    Show {
+        /// Memory entry ULID (prefix match supported)
+        id: String,
+    },
+    /// Clean up old memory entries
+    Gc {
+        /// Remove entries older than N days
+        #[arg(long, default_value = "90")]
+        days: u32,
+        /// Preview what would be removed
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Rebuild tantivy search index from JSONL
+    Reindex,
+    /// Consolidate memory entries via LLM semantic merge
+    Consolidate {
+        /// Preview consolidation plan without writing changes
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Migrate legacy memory entries to another backend
+    Migrate {
+        /// Target memory backend
+        #[arg(long, value_enum)]
+        to: MemoryMigrationTarget,
+        /// Preview migration without invoking the target backend
+        #[arg(long)]
+        dry_run: bool,
+        /// Working directory for target backend ingestion
+        #[arg(long)]
+        cd: Option<String>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum MemoryMigrationTarget {
+    Mempal,
+}

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -28,6 +28,7 @@ mod mcp_hub;
 mod mcp_server;
 mod memory_capture;
 mod memory_cmd;
+mod memory_migrate;
 mod pattern_resolver;
 mod pipeline;
 mod pipeline_env;

--- a/crates/cli-sub-agent/src/memory_cmd.rs
+++ b/crates/cli-sub-agent/src/memory_cmd.rs
@@ -29,6 +29,11 @@ pub async fn handle_memory_command(command: MemoryCommands) -> Result<()> {
         MemoryCommands::Gc { days, dry_run } => handle_gc(days, dry_run),
         MemoryCommands::Reindex => handle_reindex(),
         MemoryCommands::Consolidate { dry_run } => handle_consolidate(dry_run).await,
+        MemoryCommands::Migrate { to, dry_run, cd } => match to {
+            crate::cli::MemoryMigrationTarget::Mempal => {
+                crate::memory_migrate::migrate_to_mempal(memory_store(), dry_run, cd)
+            }
+        },
     }
 }
 

--- a/crates/cli-sub-agent/src/memory_migrate.rs
+++ b/crates/cli-sub-agent/src/memory_migrate.rs
@@ -1,0 +1,244 @@
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, bail};
+use csa_memory::{MemoryEntry, MemoryStore};
+use serde_json::json;
+
+const WING: &str = "cli-sub-agent";
+const ROOM: &str = "csa-migration";
+const SOURCE_PREFIX: &str = "csa-memory-";
+const MEMORY_FILE_NAME: &str = "memories.jsonl";
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct MigrationStats {
+    pub migrated: usize,
+    pub skipped: usize,
+    pub failed: usize,
+}
+
+pub fn migrate_to_mempal(store: MemoryStore, dry_run: bool, cd: Option<String>) -> Result<()> {
+    let total_legacy_lines = count_legacy_memory_lines(&store)?;
+    let entries = store.load_all()?;
+    if entries.is_empty() {
+        println!(
+            "Memory migration complete: migrated=0 skipped={} failed=0",
+            total_legacy_lines
+        );
+        return Ok(());
+    }
+
+    let working_dir = resolve_working_dir(cd)?;
+    let mempal_binary = if dry_run {
+        None
+    } else {
+        Some(resolve_mempal_binary()?)
+    };
+
+    let stats = migrate_entries(
+        entries,
+        mempal_binary.as_deref(),
+        dry_run,
+        working_dir.as_deref(),
+        total_legacy_lines,
+    )?;
+    println!(
+        "Memory migration complete: migrated={} skipped={} failed={}",
+        stats.migrated, stats.skipped, stats.failed
+    );
+    Ok(())
+}
+
+fn migrate_entries(
+    entries: Vec<MemoryEntry>,
+    mempal_binary: Option<&Path>,
+    dry_run: bool,
+    working_dir: Option<&Path>,
+    total_legacy_lines: usize,
+) -> Result<MigrationStats> {
+    let mut stats = MigrationStats {
+        skipped: total_legacy_lines.saturating_sub(entries.len()),
+        ..MigrationStats::default()
+    };
+
+    for entry in entries {
+        if entry.content.trim().is_empty() {
+            stats.skipped += 1;
+            eprintln!("Warning: skipped empty memory entry {}", entry.id);
+            continue;
+        }
+
+        let payload = build_mempal_payload(&entry);
+        if dry_run {
+            stats.migrated += 1;
+            println!("{}", serde_json::to_string(&payload)?);
+            continue;
+        }
+
+        let binary_path = mempal_binary.context("mempal binary path missing")?;
+        match run_mempal_ingest(binary_path, &payload, working_dir) {
+            Ok(()) => stats.migrated += 1,
+            Err(error) => {
+                stats.failed += 1;
+                eprintln!(
+                    "Warning: failed to migrate memory entry {}: {error}",
+                    entry.id
+                );
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+fn count_legacy_memory_lines(store: &MemoryStore) -> Result<usize> {
+    let file_path = store.base_dir().join(MEMORY_FILE_NAME);
+    if !file_path.exists() {
+        return Ok(0);
+    }
+
+    let file = OpenOptions::new()
+        .read(true)
+        .open(&file_path)
+        .with_context(|| format!("failed to read memory file: {}", file_path.display()))?;
+    let reader = BufReader::new(file);
+    let mut count = 0usize;
+    for line in reader.lines() {
+        if !line
+            .with_context(|| format!("failed to read memory file: {}", file_path.display()))?
+            .trim()
+            .is_empty()
+        {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+fn build_mempal_payload(entry: &MemoryEntry) -> serde_json::Value {
+    json!({
+        "content": entry.content,
+        "wing": WING,
+        "room": ROOM,
+        "project": entry.project,
+        "source": format!("{SOURCE_PREFIX}{}", entry.id),
+        "metadata": {
+            "tool": entry.tool,
+            "session_id": entry.session_id,
+        },
+    })
+}
+
+fn resolve_mempal_binary() -> Result<PathBuf> {
+    let info = csa_memory::detect_mempal().ok_or_else(|| {
+        anyhow::anyhow!(
+            "mempal is not installed or not on PATH. Install mempal, then rerun `csa memory migrate --to mempal`."
+        )
+    })?;
+    Ok(PathBuf::from(&info.binary_path))
+}
+
+fn resolve_working_dir(cd: Option<String>) -> Result<Option<PathBuf>> {
+    let Some(raw) = cd else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(raw);
+    if !path.is_dir() {
+        bail!(
+            "--cd must point to an existing directory: {}",
+            path.display()
+        );
+    }
+    Ok(Some(path))
+}
+
+fn run_mempal_ingest(
+    binary_path: &Path,
+    payload: &serde_json::Value,
+    working_dir: Option<&Path>,
+) -> Result<()> {
+    let mut command = Command::new(binary_path);
+    command
+        .arg("ingest")
+        .arg("--stdin")
+        .arg("--json")
+        .arg("--no-gate")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    if let Some(dir) = working_dir {
+        command.current_dir(dir);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let mut child = command.spawn().with_context(|| {
+        format!(
+            "failed to spawn mempal ingest using {}",
+            binary_path.display()
+        )
+    })?;
+    if let Some(mut stdin) = child.stdin.take() {
+        serde_json::to_writer(&mut stdin, payload).context("failed to write mempal payload")?;
+        stdin
+            .write_all(b"\n")
+            .context("failed to terminate mempal payload")?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .context("failed to wait for mempal ingest")?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    bail!(
+        "mempal ingest exited with code {}: {}",
+        output.status.code().unwrap_or(-1),
+        stderr.trim()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use csa_memory::MemorySource;
+    use ulid::Ulid;
+
+    #[test]
+    fn build_mempal_payload_preserves_idempotency_source_and_metadata() {
+        let id = Ulid::new();
+        let entry = MemoryEntry {
+            id,
+            timestamp: Utc::now(),
+            project: Some("project-key".to_string()),
+            tool: Some("codex".to_string()),
+            session_id: Some("01SESSION".to_string()),
+            tags: vec!["one".to_string()],
+            content: "memory content".to_string(),
+            facts: Vec::new(),
+            source: MemorySource::PostRun,
+            valid_from: None,
+            valid_until: None,
+        };
+
+        let payload = build_mempal_payload(&entry);
+
+        assert_eq!(payload["content"], "memory content");
+        assert_eq!(payload["wing"], WING);
+        assert_eq!(payload["room"], ROOM);
+        assert_eq!(payload["project"], "project-key");
+        assert_eq!(payload["source"], format!("{SOURCE_PREFIX}{id}"));
+        assert_eq!(payload["metadata"]["tool"], "codex");
+        assert_eq!(payload["metadata"]["session_id"], "01SESSION");
+    }
+}

--- a/crates/cli-sub-agent/src/run_cmd_tests_core.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_core.rs
@@ -109,6 +109,32 @@ fn test_cli_fork_last_parses() {
 }
 
 #[test]
+fn test_cli_memory_migrate_mempal_parses() {
+    let cli = try_parse_cli(&[
+        "csa",
+        "memory",
+        "migrate",
+        "--to",
+        "mempal",
+        "--dry-run",
+        "--cd",
+        "/tmp/project",
+    ])
+    .unwrap();
+    match cli.command {
+        crate::cli::Commands::Memory { command } => match command {
+            crate::cli::MemoryCommands::Migrate { to, dry_run, cd } => {
+                assert_eq!(to, crate::cli::MemoryMigrationTarget::Mempal);
+                assert!(dry_run);
+                assert_eq!(cd.as_deref(), Some("/tmp/project"));
+            }
+            _ => panic!("expected memory migrate command"),
+        },
+        _ => panic!("expected Memory command"),
+    }
+}
+
+#[test]
 fn test_cli_fork_from_conflicts_with_session() {
     let result = try_parse_cli(&[
         "csa",


### PR DESCRIPTION
## Summary
- Add `csa memory migrate --to mempal` subcommand for legacy JSONL → mempal migration
- Reads `memories.jsonl`, converts to mempal format, pipes via `mempal ingest --stdin --json`
- Uses CSA ULID as idempotency key (source field) to prevent duplicates
- Supports `--dry-run` mode for preview
- Preserves original JSONL (rule 040)

Partially addresses #1181 (Phase 4)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` — all new tests pass
- [x] `csa review --range main...HEAD` — PASS/CLEAN
- [x] Dry-run mode prints migration preview without calling mempal

🤖 Generated with [Claude Code](https://claude.com/claude-code)