### PR TITLE
test(memory): add mempal integration tests and refactor injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.631"
+version = "0.1.632"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.631"
+version = "0.1.632"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/memory_capture.rs
+++ b/crates/cli-sub-agent/src/memory_capture.rs
@@ -128,9 +128,23 @@ pub fn build_memory_section_from_mempal(
     project_root: &Path,
     token_budget: u32,
 ) -> Option<String> {
-    let binary_path = csa_memory::detect_mempal()?.binary_path.clone();
+    build_memory_section_from_mempal_with_detector(query, project_root, token_budget, || {
+        csa_memory::detect_mempal().map(|info| PathBuf::from(&info.binary_path))
+    })
+}
+
+fn build_memory_section_from_mempal_with_detector<F>(
+    query: &str,
+    project_root: &Path,
+    token_budget: u32,
+    detect_binary: F,
+) -> Option<String>
+where
+    F: FnOnce() -> Option<PathBuf>,
+{
+    let binary_path = detect_binary()?;
     build_memory_section_from_mempal_binary(
-        Path::new(&binary_path),
+        &binary_path,
         query,
         project_root,
         token_budget,
@@ -727,65 +741,5 @@ mod tests {
         assert_eq!(bullet_count, 1, "token budget should limit to one memory");
     }
 
-    #[test]
-    fn test_build_memory_section_from_mempal_binary_wraps_context() {
-        let temp = tempdir().expect("create tempdir");
-        let script_path = temp.path().join("mempal-fake.sh");
-        let mut script = fs::File::create(&script_path).expect("create fake mempal");
-        writeln!(
-            script,
-            "#!/bin/sh\nprintf 'mempal remembered %s in %s\\n' \"$6\" \"$3\"\n"
-        )
-        .expect("write fake mempal");
-        drop(script);
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&script_path, perms).expect("chmod");
-        }
-
-        let section = build_memory_section_from_mempal_binary(
-            &script_path,
-            "review routing",
-            temp.path(),
-            200,
-            Duration::from_secs(5),
-        )
-        .expect("mempal section");
-
-        assert!(section.contains("<!-- CSA:MEMORY -->"));
-        assert!(section.contains("mempal remembered review routing"));
-        assert!(section.contains(temp.path().to_string_lossy().as_ref()));
-        assert!(section.contains("<!-- CSA:MEMORY:END -->"));
-    }
-
-    #[test]
-    fn test_build_memory_section_from_mempal_binary_returns_none_on_timeout() {
-        let temp = tempdir().expect("create tempdir");
-        let script_path = temp.path().join("mempal-sleep.sh");
-        let mut script = fs::File::create(&script_path).expect("create fake mempal");
-        writeln!(script, "#!/bin/sh\nsleep 2\n").expect("write fake mempal");
-        drop(script);
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&script_path, perms).expect("chmod");
-        }
-
-        let section = build_memory_section_from_mempal_binary(
-            &script_path,
-            "review routing",
-            temp.path(),
-            200,
-            Duration::from_millis(100),
-        );
-
-        assert!(section.is_none());
-    }
+    include!("memory_capture_mempal_tests.rs");
 }

--- a/crates/cli-sub-agent/src/memory_capture_mempal_tests.rs
+++ b/crates/cli-sub-agent/src/memory_capture_mempal_tests.rs
@@ -1,0 +1,94 @@
+#[test]
+fn test_build_memory_section_from_mempal_binary_wraps_context() {
+    let temp = tempdir().expect("create tempdir");
+    let script_path = temp.path().join("mempal-fake.sh");
+    let mut script = fs::File::create(&script_path).expect("create fake mempal");
+    writeln!(
+        script,
+        "#!/bin/sh\nprintf 'mempal remembered %s in %s\\n' \"$6\" \"$3\"\n"
+    )
+    .expect("write fake mempal");
+    drop(script);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).expect("chmod");
+    }
+
+    let section = build_memory_section_from_mempal_binary(
+        &script_path,
+        "review routing",
+        temp.path(),
+        200,
+        Duration::from_secs(5),
+    )
+    .expect("mempal section");
+
+    assert!(section.contains("<!-- CSA:MEMORY -->"));
+    assert!(section.contains("mempal remembered review routing"));
+    assert!(section.contains(temp.path().to_string_lossy().as_ref()));
+    assert!(section.contains("<!-- CSA:MEMORY:END -->"));
+}
+
+#[test]
+fn test_build_memory_section_from_mempal_uses_detected_binary() {
+    let temp = tempdir().expect("create tempdir");
+    let script_path = temp.path().join("mempal-fake.sh");
+    let mut script = fs::File::create(&script_path).expect("create fake mempal");
+    writeln!(
+        script,
+        "#!/bin/sh\nif [ \"$1\" = \"context\" ]; then\n  printf 'detected mempal context for %s\\n' \"$6\"\n  exit 0\nfi\nexit 64\n"
+    )
+    .expect("write fake mempal");
+    drop(script);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).expect("chmod");
+    }
+
+    let section = build_memory_section_from_mempal_with_detector(
+        "prompt routing",
+        temp.path(),
+        200,
+        || Some(script_path),
+    )
+    .expect("mempal section");
+
+    assert!(section.contains("detected mempal context for prompt routing"));
+    assert!(section.contains("<!-- CSA:MEMORY -->"));
+    assert!(section.contains("<!-- CSA:MEMORY:END -->"));
+}
+
+#[test]
+fn test_build_memory_section_from_mempal_binary_returns_none_on_timeout() {
+    let temp = tempdir().expect("create tempdir");
+    let script_path = temp.path().join("mempal-sleep.sh");
+    let mut script = fs::File::create(&script_path).expect("create fake mempal");
+    writeln!(script, "#!/bin/sh\nsleep 2\n").expect("write fake mempal");
+    drop(script);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).expect("chmod");
+    }
+
+    let section = build_memory_section_from_mempal_binary(
+        &script_path,
+        "review routing",
+        temp.path(),
+        200,
+        Duration::from_millis(100),
+    );
+
+    assert!(section.is_none());
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec_memory.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_memory.rs
@@ -52,7 +52,23 @@ fn build_memory_section_for_backend(
     memory_project_key: Option<&str>,
     project_root: &Path,
 ) -> Option<String> {
-    match csa_memory::resolve_backend(memory_cfg.backend) {
+    build_memory_section_for_resolved_backend(
+        csa_memory::resolve_backend(memory_cfg.backend),
+        memory_cfg,
+        memory_query,
+        memory_project_key,
+        project_root,
+    )
+}
+
+fn build_memory_section_for_resolved_backend(
+    backend: MemoryBackend,
+    memory_cfg: &MemoryConfig,
+    memory_query: &str,
+    memory_project_key: Option<&str>,
+    project_root: &Path,
+) -> Option<String> {
+    match backend {
         MemoryBackend::Mempal => memory_capture::build_memory_section_from_mempal(
             memory_query,
             project_root,
@@ -61,5 +77,62 @@ fn build_memory_section_for_backend(
         MemoryBackend::Legacy | MemoryBackend::Auto => {
             memory_capture::build_memory_section(memory_cfg, memory_query, memory_project_key)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env_lock::ScopedTestEnvVar;
+    use csa_memory::{MemoryEntry, MemorySource, MemoryStore};
+    use tempfile::tempdir;
+    use ulid::Ulid;
+
+    #[test]
+    fn auto_backend_fallback_injects_legacy_memory_when_resolved_legacy() {
+        let temp = tempdir().expect("create tempdir");
+        let _state = ScopedTestEnvVar::set("XDG_STATE_HOME", temp.path().join("state"));
+        let memory_dir = temp
+            .path()
+            .join("state")
+            .join("cli-sub-agent")
+            .join("memory");
+        let store = MemoryStore::new(memory_dir);
+        let now = chrono::Utc::now();
+        store
+            .append(&MemoryEntry {
+                id: Ulid::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid ulid"),
+                timestamp: now,
+                project: Some("test-project".to_string()),
+                tool: Some("codex".to_string()),
+                session_id: Some("01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string()),
+                tags: Vec::new(),
+                content: "legacy memory fallback preserves prompt context".to_string(),
+                facts: Vec::new(),
+                source: MemorySource::PostRun,
+                valid_from: Some(now),
+                valid_until: None,
+            })
+            .expect("append legacy memory");
+
+        let config = MemoryConfig {
+            backend: MemoryBackend::Auto,
+            inject: true,
+            inject_token_budget: 200,
+            ..MemoryConfig::default()
+        };
+
+        let section = build_memory_section_for_resolved_backend(
+            MemoryBackend::Legacy,
+            &config,
+            "legacy fallback context",
+            Some("test-project"),
+            temp.path(),
+        )
+        .expect("legacy memory section");
+
+        assert!(section.contains("previous sessions"));
+        assert!(section.contains("legacy memory fallback"));
+        assert!(section.contains("<!-- CSA:MEMORY:END -->"));
     }
 }

--- a/crates/csa-hooks/src/mempal_capture.rs
+++ b/crates/csa-hooks/src/mempal_capture.rs
@@ -45,6 +45,21 @@ pub fn spawn_mempal_ingest(
     input_path: &Path,
     tool_name: Option<&str>,
 ) {
+    let _ = spawn_mempal_ingest_with_resolver(config, room, input_path, tool_name, |config| {
+        resolve_mempal_binary(config)
+    });
+}
+
+fn spawn_mempal_ingest_with_resolver<F>(
+    config: &MemoryConfig,
+    room: &'static str,
+    input_path: &Path,
+    tool_name: Option<&str>,
+    resolve_binary: F,
+) -> Option<thread::JoinHandle<()>>
+where
+    F: FnOnce(&MemoryConfig) -> Option<PathBuf>,
+{
     if let Some(tool) = tool_name
         && tool_has_own_mempal(tool)
     {
@@ -53,19 +68,17 @@ pub fn spawn_mempal_ingest(
             room,
             "skipping mempal capture for {tool} (has own integration)"
         );
-        return;
+        return None;
     }
 
     if !config.auto_capture {
-        return;
+        return None;
     }
 
-    let Some(binary_path) = resolve_mempal_binary(config) else {
-        return;
-    };
+    let binary_path = resolve_binary(config)?;
 
     let input_path = input_path.to_path_buf();
-    thread::spawn(move || {
+    Some(thread::spawn(move || {
         if let Err(err) = run_mempal_ingest(&binary_path, room, &input_path, INGEST_TIMEOUT) {
             tracing::warn!(
                 room,
@@ -74,7 +87,7 @@ pub fn spawn_mempal_ingest(
                 "mempal ingest failed; continuing"
             );
         }
-    });
+    }))
 }
 
 /// Convenience wrapper for merge-guard capture, where only the current working
@@ -337,8 +350,169 @@ fn wait_for_mempal_child(mut child: std::process::Child, timeout: Duration) -> a
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::ENV_LOCK;
     use std::fs;
     use std::io::Write as _;
+    use std::path::PathBuf;
+
+    struct ScopedPath {
+        original: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl ScopedPath {
+        fn prepend(path: &Path) -> Self {
+            let lock = ENV_LOCK.lock().expect("env lock poisoned");
+            let original = std::env::var_os("PATH");
+            let mut paths = vec![path.to_path_buf()];
+            paths.extend(std::env::split_paths(
+                original
+                    .as_deref()
+                    .unwrap_or_else(|| std::ffi::OsStr::new("")),
+            ));
+            let joined = std::env::join_paths(paths).expect("join PATH");
+            // SAFETY: test-scoped env mutation protected by ENV_LOCK.
+            unsafe { std::env::set_var("PATH", joined) };
+            Self {
+                original,
+                _lock: lock,
+            }
+        }
+
+        fn set_only(path: &Path) -> Self {
+            let lock = ENV_LOCK.lock().expect("env lock poisoned");
+            let original = std::env::var_os("PATH");
+            // SAFETY: test-scoped env mutation protected by ENV_LOCK.
+            unsafe { std::env::set_var("PATH", path) };
+            Self {
+                original,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for ScopedPath {
+        fn drop(&mut self) {
+            // SAFETY: test-scoped env mutation protected by ENV_LOCK.
+            unsafe {
+                match self.original.take() {
+                    Some(path) => std::env::set_var("PATH", path),
+                    None => std::env::remove_var("PATH"),
+                }
+            }
+        }
+    }
+
+    fn executable_mempal_script(path: &Path, body: &str) {
+        let mut script = fs::File::create(path).expect("create fake mempal");
+        write!(script, "{body}").expect("write fake mempal");
+        drop(script);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(path).expect("metadata").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(path, perms).expect("chmod");
+        }
+    }
+
+    fn mempal_config() -> MemoryConfig {
+        MemoryConfig {
+            backend: MemoryBackend::Mempal,
+            auto_capture: true,
+            ..MemoryConfig::default()
+        }
+    }
+
+    fn which_mempal(_: &MemoryConfig) -> Option<PathBuf> {
+        which::which("mempal").ok()
+    }
+
+    #[test]
+    fn capture_with_mempal_available_sends_json_payload_to_stdin() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let fake_bin = temp.path().join("bin");
+        fs::create_dir(&fake_bin).expect("create fake bin");
+        let log_path = temp.path().join("stdin.json");
+        executable_mempal_script(
+            &fake_bin.join("mempal"),
+            &format!(
+                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'mempal mock 0.0.0\\n'\n  exit 0\nfi\nif [ \"$1\" = \"ingest\" ] && [ \"$2\" = \"--stdin\" ] && [ \"$3\" = \"--json\" ]; then\n  cat > '{}'\n  exit 0\nfi\nexit 64\n",
+                log_path.display()
+            ),
+        );
+        let _path = ScopedPath::prepend(&fake_bin);
+
+        let input_dir = temp.path().join("01KSESSION");
+        fs::create_dir(&input_dir).expect("create session dir");
+        let result_path = input_dir.join("result.toml");
+        fs::write(&result_path, "summary = \"captured via hook\"\n").expect("write result");
+
+        let handle = spawn_mempal_ingest_with_resolver(
+            &mempal_config(),
+            "csa-session",
+            &result_path,
+            Some("codex"),
+            which_mempal,
+        )
+        .expect("capture should spawn");
+        handle.join().expect("capture worker should not panic");
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(log_path).expect("read stdin log"))
+                .expect("stdin payload is json");
+        assert_eq!(payload["content"], "captured via hook");
+        assert_eq!(payload["wing"], "cli-sub-agent");
+        assert_eq!(payload["room"], "csa-session");
+        assert_eq!(payload["project"], "cli-sub-agent");
+        assert_eq!(payload["source"], "csa-session-01KSESSION");
+        assert_eq!(payload["source_file"], "stdin://csa-hook");
+    }
+
+    #[test]
+    fn capture_skips_when_mempal_unavailable() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let empty_bin = temp.path().join("empty-bin");
+        fs::create_dir(&empty_bin).expect("create empty bin");
+        let _path = ScopedPath::set_only(&empty_bin);
+
+        let result_path = temp.path().join("result.toml");
+        fs::write(&result_path, "summary = \"no mempal available\"\n").expect("write result");
+
+        let handle = spawn_mempal_ingest_with_resolver(
+            &mempal_config(),
+            "csa-session",
+            &result_path,
+            Some("codex"),
+            which_mempal,
+        );
+
+        assert!(
+            handle.is_none(),
+            "missing mempal should silently skip capture"
+        );
+    }
+
+    #[test]
+    fn capture_skips_for_claude_code_sessions() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let result_path = temp.path().join("result.toml");
+        fs::write(&result_path, "summary = \"claude-code owns mempal\"\n").expect("write result");
+
+        let handle = spawn_mempal_ingest_with_resolver(
+            &mempal_config(),
+            "csa-session",
+            &result_path,
+            Some("claude-code"),
+            |_| panic!("resolver must not run for claude-code sessions"),
+        );
+
+        assert!(
+            handle.is_none(),
+            "claude-code capture should be skipped before binary resolution"
+        );
+    }
 
     #[test]
     fn run_mempal_ingest_passes_expected_args() {


### PR DESCRIPTION
## Summary
- Add integration tests with mock mempal binary for capture and injection scenarios
- Test coverage: mempal available, unavailable, claude-code dedup skip
- Refactor memory injection pipeline for testability

Partially addresses #1181 (Phase 6)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` — all new tests pass
- [x] `csa review --range main...HEAD` — PASS/CLEAN
- [x] Mock mempal script validates stdin JSON payload format

🤖 Generated with [Claude Code](https://claude.com/claude-code)