### PR TITLE
feat(memory): add csa memory status command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.632"
+version = "0.1.633"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.632"
+version = "0.1.633"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_memory.rs
+++ b/crates/cli-sub-agent/src/cli_memory.rs
@@ -73,6 +73,8 @@ pub enum MemoryCommands {
         #[arg(long)]
         cd: Option<String>,
     },
+    /// Show memory backend status (configured vs resolved, mempal detection)
+    Status,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]

--- a/crates/cli-sub-agent/src/memory_cmd.rs
+++ b/crates/cli-sub-agent/src/memory_cmd.rs
@@ -34,6 +34,7 @@ pub async fn handle_memory_command(command: MemoryCommands) -> Result<()> {
                 crate::memory_migrate::migrate_to_mempal(memory_store(), dry_run, cd)
             }
         },
+        MemoryCommands::Status => handle_status(),
     }
 }
 
@@ -344,6 +345,44 @@ async fn handle_consolidate(dry_run: bool) -> Result<()> {
     println!("  Entries before: {}", plan.total_before);
     println!("  Groups merged: {}", plan.groups_to_merge.len());
     println!("  Entries after (estimated): {}", plan.total_after_estimate);
+    Ok(())
+}
+
+fn handle_status() -> Result<()> {
+    let config = load_memory_config()?;
+    let resolved = csa_memory::resolve_backend(config.backend);
+    let mempal_info = csa_memory::detect_mempal();
+
+    println!("Memory Backend Status");
+    println!("  configured: {}", config.backend);
+    println!("  resolved:   {}", resolved);
+    println!("  auto_capture: {}", config.auto_capture);
+    println!("  inject:       {}", config.inject);
+    println!("  inject_token_budget: {}", config.inject_token_budget);
+    println!();
+
+    match mempal_info {
+        Some(info) => {
+            println!("Mempal Detection");
+            println!("  binary: {}", info.binary_path);
+            println!(
+                "  version: {}",
+                info.version.as_deref().unwrap_or("unknown")
+            );
+        }
+        None => {
+            println!("Mempal Detection");
+            println!("  not found on PATH");
+        }
+    }
+    println!();
+
+    let store = memory_store();
+    let legacy_count = store.load_all().map(|e| e.len()).unwrap_or(0);
+    println!("Legacy Store");
+    println!("  entries: {}", legacy_count);
+    println!("  path:    {}", store.base_dir().display());
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Add `csa memory status` subcommand showing configured vs resolved backend, mempal detection info, and legacy store stats
- Enable mempal backend in global config (`[memory]` section with `backend = "auto"`, `auto_capture = true`, `inject = true`)
- Closes #1181 — core write/read path integration is complete; CLI subcommand alignment (search/list/add routing through mempal) tracked separately

## Test plan
- [x] `cargo check` passes
- [x] `cargo test -- memory` (24 tests pass)
- [x] `just pre-commit` passes
- [x] `csa memory status` output verified: configured=auto, resolved=mempal, binary=/usr/local/bin/mempal
- [x] CSA review session 01KQE3VP9KZ verdict PASS (reviewer-2/review-findings.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)