### PR TITLE
fix(hooks): require explicit review-check bypass instead of auto CSA_DEPTH skip

### DIFF
--- a/.claude/rules/csa-architecture-ref.md
+++ b/.claude/rules/csa-architecture-ref.md
@@ -55,6 +55,11 @@ Per-tool transport: `[tools.<name>].transport = "auto" | "acp" | "cli"`; current
 
 **tier-routing** — When `[tiers]` are configured, direct `--tool`/`--model`/`--thinking` is blocked by default across `csa run`, `csa review`, and `csa debate`. Callers must use `--tier <name>` to select a tier by name, which resolves tool/model/thinking from the tier definition. Override with `--force-ignore-tier-setting` (alias: `--force-tier`) to bypass. The existing `--force` flag also bypasses tier enforcement. When no tiers are configured (empty `[tiers]`), all existing behavior is preserved. Priority chain: CLI `--tier` > config tier > CLI `--tool` (with force) > config tool > auto-select.
 
+## Weave Execution Model
+
+Deterministic workflow compiler. `tool = "bash"` steps run via `spawn_bash()` — LLM not involved, exit code checked programmatically. `tool = "manual"` steps are non-enforceable handoffs. `on_fail = "abort"` forms hard gates. `csa review --check-verdict` reads `review_meta.json` + `output/review-verdict.json` from session dir (`~/.local/state/`). Pre-push hook (`scripts/hooks/review-check.sh`) is last-resort defense for pushes bypassing weave pipeline.
+→ `.agents/project-rules-ref/weave-execution-model.md`
+
 ## Patterns & Skills
 
 Patterns in `patterns/` (weave packages). Skills in `.claude/skills/` (SKILL.md + .skill.toml). **MANDATORY**: every pattern needs companion skill symlink; pattern changes MUST pass `weave compile`; workflow variables MUST sync between PATTERN.md and workflow.toml (PR #257: 17 review rounds from orphaned variable). **dev2merge** is the primary deterministic pipeline (`csa plan run patterns/dev2merge/workflow.toml`): branch validation → FAST_PATH detection → L1/L2 gates → mktd → mktsk → cumulative review → push gate → PR → pr-bot → merge. All steps enforced via `on_fail = "abort"` and git pre-push hook (`scripts/hooks/pre-push`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.634"
+version = "0.1.635"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.634"
+version = "0.1.635"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -514,7 +514,9 @@ fi
 # Resolve branch name (BRANCH may be unset in standalone /commit)
 BRANCH="${BRANCH:-$(git branch --show-current)}"
 
-git push -u origin "${BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="commit workflow push after commit step" \
+  git push -u origin "${BRANCH}"
 set +e
 CREATE_OUTPUT="$(gh pr create --base main --title "${COMMIT_SUBJECT}" --body "${PR_BODY}" 2>&1)"
 CREATE_RC=$?

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -576,7 +576,9 @@ if [ -z "${BRANCH}" ] || [ "${BRANCH}" = "HEAD" ]; then
   exit 1
 fi
 
-git push -u origin "${BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="commit workflow push after commit step" \
+  git push -u origin "${BRANCH}"
 set +e
 CREATE_OUTPUT="$(gh pr create --base main --title "${COMMIT_SUBJECT}" --body "${PR_BODY}" 2>&1)"
 CREATE_RC=$?

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -421,7 +421,9 @@ if [ "${DIFF_LINES}" -eq 0 ]; then
   echo "Investigate the working tree and the failed commit's intended files; do NOT escalate to squash merge."
   exit 1
 fi
-git push -u origin "${BRANCH}" --force-with-lease
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="dev2merge Step 12 push after Step 11 review verification" \
+  git push -u origin "${BRANCH}" --force-with-lease
 echo "CSA_VAR:PUSHED=true"
 echo '<!-- CSA:NEXT_STEP cmd="verify review verdict (Step 13)" required=true -->'
 ```

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -509,7 +509,9 @@ if [ "${DIFF_LINES}" -eq 0 ]; then
   echo "Investigate the working tree and the failed commit's intended files; do NOT escalate to squash merge."
   exit 1
 fi
-git push -u origin "${BRANCH}" --force-with-lease
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="dev2merge Step 12 push after Step 11 review verification" \
+  git push -u origin "${BRANCH}" --force-with-lease
 echo "CSA_VAR:PUSHED=true"
 echo '<!-- CSA:NEXT_STEP cmd="verify review verdict (Step 13)" required=true -->'
 ```'''

--- a/patterns/mktsk/workflow.toml
+++ b/patterns/mktsk/workflow.toml
@@ -146,7 +146,9 @@ fi
 
 # Push
 BRANCH="$(git branch --show-current)"
-git push -u origin "${BRANCH}" --force-with-lease
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="mktsk workflow push after implementation" \
+  git push -u origin "${BRANCH}" --force-with-lease
 
 # Create or reuse PR
 COMMIT_SUBJECT="$(git log -1 --format=%s)"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -235,7 +235,9 @@ if git ls-remote --heads "${REMOTE_NAME}" "${WORKFLOW_BRANCH}" 2>/dev/null | gre
   echo "Unreviewed code may have been visible to CI/reviewers. Continuing with force-push of reviewed code."
 fi
 
-git push --force-with-lease -u "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot initial branch push for CI/review" \
+  git push --force-with-lease -u "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
 ORIGIN_URL="$(git remote get-url --push "${REMOTE_NAME}")"
 SOURCE_OWNER="$(
   printf '%s\n' "${ORIGIN_URL}" | sed -nE \
@@ -1403,7 +1405,9 @@ if [ -n "${ROUND_LIMIT_ACTION}" ]; then
       ROUND_LIMIT_REACHED=false  # Clear so Steps 10.5/11/12 are unblocked
       # Push any Category C fixes from Step 9 so remote HEAD includes them.
       # Without this, gh pr merge merges the stale remote head.
-      git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+      CSA_SKIP_REVIEW_CHECK=1 \
+      CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push after round-limit merge decision" \
+        git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
       echo "CSA_VAR:ROUND_LIMIT_REACHED=$ROUND_LIMIT_REACHED"
       echo "CSA_VAR:ROUND_LIMIT_ACTION="
       echo "ROUND_LIMIT_MERGE: Routing to merge step."
@@ -1458,7 +1462,9 @@ if [ "${REVIEW_ROUND}" -ge "${MAX_REVIEW_ROUNDS}" ]; then
 fi
 
 # --- Push fixes only (next trigger happens in Step 5) ---
-git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push fixes between review rounds" \
+  git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
 ROUND_LIMIT_REACHED=false
 echo "CSA_VAR:ROUND_LIMIT_REACHED=$ROUND_LIMIT_REACHED"
 echo "CSA_VAR:REVIEW_ROUND=$REVIEW_ROUND"
@@ -1826,7 +1832,9 @@ fi
 
 # Push fallback fix commits so the remote PR head includes them.
 # Without this, gh pr merge uses the stale remote HEAD and omits fixes.
-git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push fallback fixes before merge" \
+  git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
 
 # Audit trail: explain why merging without bot review.
 DIFF_SUMMARY="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" | sed -n '1,20p')"
@@ -1894,7 +1902,9 @@ If fixes accumulated, create clean branch for final review.
 ```bash
 CLEAN_BRANCH="${WORKFLOW_BRANCH}-clean"
 git checkout -b "${CLEAN_BRANCH}"
-git push -u "${REMOTE_NAME}" "${CLEAN_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push clean branch for PR" \
+  git push -u "${REMOTE_NAME}" "${CLEAN_BRANCH}"
 gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${CLEAN_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}"
 ```
 
@@ -1920,7 +1930,9 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
   exit 1
 fi
 
-git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12 pre-merge push" \
+  git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
 MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
 DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
@@ -1964,7 +1976,9 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
   exit 1
 fi
 
-git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12b pre-merge push" \
+  git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
 MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
 DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -666,7 +666,9 @@ if git ls-remote --heads "${REMOTE_NAME}" "${WORKFLOW_BRANCH}" 2>/dev/null | gre
   echo "Unreviewed code may have been visible to CI/reviewers. Continuing with force-push of reviewed code."
 fi
 
-git push --force-with-lease -u "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot initial branch push for CI/review" \
+  git push --force-with-lease -u "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
 ORIGIN_URL="$(git remote get-url --push "${REMOTE_NAME}")"
 SOURCE_OWNER="$(
   printf '%s\n' "${ORIGIN_URL}" | sed -nE \
@@ -1816,7 +1818,9 @@ if [ -n "${ROUND_LIMIT_ACTION}" ]; then
       ROUND_LIMIT_REACHED=false  # Clear so Steps 10.5/11/12 are unblocked
       # Push any Category C fixes from Step 9 so remote HEAD includes them.
       # Without this, gh pr merge merges the stale remote head.
-      git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+      CSA_SKIP_REVIEW_CHECK=1 \
+      CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push after round-limit merge decision" \
+        git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
       echo "CSA_VAR:ROUND_LIMIT_REACHED=$ROUND_LIMIT_REACHED"
       echo "CSA_VAR:ROUND_LIMIT_ACTION="
       echo "ROUND_LIMIT_MERGE: Routing to merge step."
@@ -1871,7 +1875,9 @@ if [ "${REVIEW_ROUND}" -ge "${MAX_REVIEW_ROUNDS}" ]; then
 fi
 
 # --- Push fixes only (next trigger happens in Step 5) ---
-git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push fixes between review rounds" \
+  git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
 ROUND_LIMIT_REACHED=false
 echo "CSA_VAR:ROUND_LIMIT_REACHED=$ROUND_LIMIT_REACHED"
 echo "CSA_VAR:REVIEW_ROUND=$REVIEW_ROUND"
@@ -2240,7 +2246,9 @@ fi
 
 # Push fallback fix commits so the remote PR head includes them.
 # Without this, gh pr merge uses the stale remote HEAD and omits fixes.
-git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push fallback fixes before merge" \
+  git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
 
 # Audit trail: explain why merging without bot review.
 DIFF_SUMMARY="$(git diff --stat "${DEFAULT_BRANCH}...HEAD" | sed -n '1,20p')"
@@ -2306,7 +2314,9 @@ If fixes accumulated, create clean branch for final review.
 ```bash
 CLEAN_BRANCH="${WORKFLOW_BRANCH}-clean"
 git checkout -b "${CLEAN_BRANCH}"
-git push -u "${REMOTE_NAME}" "${CLEAN_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push clean branch for PR" \
+  git push -u "${REMOTE_NAME}" "${CLEAN_BRANCH}"
 gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${CLEAN_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}"
 ```'''
 on_fail = "abort"
@@ -2335,7 +2345,9 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
   exit 1
 fi
 
-git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12 pre-merge push" \
+  git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
 MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
 DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
@@ -2380,7 +2392,9 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
   exit 1
 fi
 
-git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12b pre-merge push" \
+  git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
 MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
 DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then

--- a/patterns/rule-extractor/PATTERN.md
+++ b/patterns/rule-extractor/PATTERN.md
@@ -423,7 +423,9 @@ Extracted from HIGH/CRITICAL finding in PR #${PR_NUM}.
 Bug class: ${BUG_CLASS_NAME}
 Source: pr-bot-finding auto-extraction (issue #661)"
 
-git push -u origin "${PROPOSAL_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="rule-extractor workflow push for proposal PR" \
+  git push -u origin "${PROPOSAL_BRANCH}"
 gh pr create \
   --title "chore(rules): propose ${LANG}/${RULE_FILE} — ${BUG_CLASS_NAME}" \
   --body "## Rule Proposal (auto-extracted)

--- a/patterns/rule-extractor/workflow.toml
+++ b/patterns/rule-extractor/workflow.toml
@@ -465,7 +465,9 @@ Extracted from HIGH/CRITICAL finding in PR #${PR_NUM}.
 Bug class: ${BUG_CLASS_NAME}
 Source: pr-bot-finding auto-extraction (issue #661)"
 
-git push -u origin "${PROPOSAL_BRANCH}"
+CSA_SKIP_REVIEW_CHECK=1 \
+CSA_SKIP_REVIEW_CHECK_REASON="rule-extractor workflow push for proposal PR" \
+  git push -u origin "${PROPOSAL_BRANCH}"
 gh pr create \
   --title "chore(rules): propose ${LANG}/${RULE_FILE} — ${BUG_CLASS_NAME}" \
   --body "## Rule Proposal (auto-extracted)

--- a/scripts/hooks/review-check.sh
+++ b/scripts/hooks/review-check.sh
@@ -9,18 +9,6 @@
 
 set -euo pipefail
 
-# Auto-bypass when running inside a nested CSA session (depth > 0).
-# Rationale: parent orchestrator reviews the final SHA before the user push
-# (pr-bot Step 2 cumulative local review + Step 8 fix re-review). Employee
-# push attempts should NOT trigger a nested csa review — that duplicates the
-# audit the parent already runs, burning ~1M tokens per duplicate session
-# (issue #890). The bypass is logged below with a distinguishable reason
-# starting with "nested CSA session" so audit trail is preserved.
-if [ -z "${CSA_SKIP_REVIEW_CHECK:-}" ] && [ "${CSA_DEPTH:-0}" -gt 0 ]; then
-  CSA_SKIP_REVIEW_CHECK=1
-  CSA_SKIP_REVIEW_CHECK_REASON="nested CSA session (depth=${CSA_DEPTH}, sid=${CSA_SESSION_ID:-<unknown>}); parent will review final SHA"
-fi
-
 if [ "${CSA_SKIP_REVIEW_CHECK:-0}" = "1" ]; then
   timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   head_sha="$(git rev-parse HEAD 2>/dev/null || echo "<unknown-head>")"


### PR DESCRIPTION
## Summary

- Removes the automatic `CSA_DEPTH > 0` bypass in `scripts/hooks/review-check.sh` that allowed any nested CSA session to push without review
- Adds explicit `CSA_SKIP_REVIEW_CHECK=1` with per-step reason to every `git push` in all workflow files (dev2merge, pr-bot, commit, mktsk, rule-extractor) — both `workflow.toml` and `PATTERN.md` paths
- Maintains the existing explicit `CSA_SKIP_REVIEW_CHECK=1` escape hatch for legitimate bypass scenarios

The old behavior silently skipped the pre-push review gate for ALL nested CSA sessions (depth > 0), which meant any employee session could push unreviewed code. The new behavior requires each push site to explicitly opt in with a documented reason, logged to `.csa/review-bypass.log`.

**Coverage**: 11 workflow.toml push sites + 10 PATTERN.md push sites across 5 patterns, all with per-step reason strings.

Closes #1235

## Test plan

- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` verdict: PASS (session 01KQEBW5TP8)
- [x] Push succeeds with explicit bypass
- [ ] Verify pr-bot workflow push works in a real PR review cycle
- [ ] Verify commit workflow push works in `/commit` skill invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)