### PR TITLE
fix(review): fall back to branch diff when --diff finds clean tree (#1238)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.636"
+version = "0.1.637"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.636"
+version = "0.1.637"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -78,7 +78,7 @@ use resolve::build_review_instruction;
 #[cfg(test)]
 pub(crate) use resolve::resolve_review_tool;
 use resolve::{
-    ReviewProjectPromptOptions, build_review_instruction_for_project, derive_scope,
+    ReviewProjectPromptOptions, build_review_instruction_for_project, derive_scope_for_project,
     resolve_review_effective_tier, resolve_review_model, resolve_review_selection,
     resolve_review_stream_mode, resolve_review_thinking, resolve_review_tier_name,
     review_scope_allows_auto_discovery, verify_review_skill_available,
@@ -208,7 +208,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         }
     };
 
-    let scope = derive_scope(&args);
+    let scope = derive_scope_for_project(&args, &project_root);
     let mode = if args.fix {
         "review-and-fix"
     } else {

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::cli::{ReviewArgs, ReviewMode};
 use crate::review_context::{
@@ -536,6 +536,101 @@ pub(crate) fn derive_scope(args: &ReviewArgs) -> String {
         return "uncommitted".to_string();
     }
     format!("base:{}", args.branch.as_deref().unwrap_or("main"))
+}
+
+/// Derive the review scope string from CLI arguments and repository state.
+///
+/// `--diff` primarily means uncommitted changes. If that diff is empty on a
+/// feature branch with commits ahead of the default branch, review the branch
+/// diff instead so clean committed feature branches are not skipped.
+pub(crate) fn derive_scope_for_project(args: &ReviewArgs, project_root: &Path) -> String {
+    let scope = derive_scope(args);
+    if scope != "uncommitted" {
+        return scope;
+    }
+
+    derive_diff_scope_for_project(project_root)
+}
+
+fn derive_diff_scope_for_project(project_root: &Path) -> String {
+    if git_diff_has_output(project_root, &["diff", "HEAD"]).unwrap_or(true) {
+        return "uncommitted".to_string();
+    }
+
+    if git_has_untracked_files(project_root).unwrap_or(false) {
+        return "uncommitted".to_string();
+    }
+
+    let Some((current_branch, default_branch)) = detect_current_and_default_branch(project_root)
+    else {
+        return "uncommitted".to_string();
+    };
+
+    if is_protected_review_branch(&current_branch, &default_branch) {
+        return "uncommitted".to_string();
+    }
+
+    let ahead_range = format!("{default_branch}..HEAD");
+    if !git_rev_list_has_commits(project_root, &ahead_range).unwrap_or(false) {
+        return "uncommitted".to_string();
+    }
+
+    info!("No uncommitted changes; falling back to branch diff (base:{default_branch})");
+    format!("base:{default_branch}")
+}
+
+fn detect_current_and_default_branch(project_root: &Path) -> Option<(String, String)> {
+    let vcs_kind = csa_session::vcs_backends::detect_vcs_kind_with_config(project_root, None, None)
+        .ok()
+        .flatten()?;
+    let backend = csa_session::vcs_backends::create_vcs_backend_with_config(
+        project_root,
+        Some(vcs_kind),
+        None,
+    );
+    let current_branch = backend.current_branch(project_root).ok().flatten()?;
+    let default_branch = backend.default_branch(project_root).ok().flatten()?;
+    Some((current_branch, default_branch))
+}
+
+fn is_protected_review_branch(current_branch: &str, default_branch: &str) -> bool {
+    matches!(current_branch, "main" | "master" | "dev" | "develop")
+        || current_branch == default_branch
+}
+
+fn git_diff_has_output(project_root: &Path, args: &[&str]) -> Option<bool> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+
+    output.status.success().then_some(!output.stdout.is_empty())
+}
+
+fn git_has_untracked_files(project_root: &Path) -> Option<bool> {
+    let output = std::process::Command::new("git")
+        .args(["ls-files", "--others", "--exclude-standard"])
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+
+    output.status.success().then_some(!output.stdout.is_empty())
+}
+
+fn git_rev_list_has_commits(project_root: &Path, range: &str) -> Option<bool> {
+    let output = std::process::Command::new("git")
+        .args(["rev-list", "--count", range])
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let count = stdout.trim().parse::<u64>().ok()?;
+    Some(count > 0)
 }
 
 pub(crate) fn review_scope_allows_auto_discovery(args: &ReviewArgs) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -461,7 +461,7 @@ fn derive_scope_uncommitted() {
         diff: true,
         ..default_review_args()
     };
-    assert_eq!(derive_scope(&args), "uncommitted");
+    assert_eq!(super::resolve::derive_scope(&args), "uncommitted");
 }
 
 #[test]
@@ -470,7 +470,7 @@ fn derive_scope_commit() {
         commit: Some("abc123".to_string()),
         ..default_review_args()
     };
-    assert_eq!(derive_scope(&args), "commit:abc123");
+    assert_eq!(super::resolve::derive_scope(&args), "commit:abc123");
 }
 
 #[test]
@@ -479,7 +479,7 @@ fn derive_scope_range() {
         range: Some("main...HEAD".to_string()),
         ..default_review_args()
     };
-    assert_eq!(derive_scope(&args), "range:main...HEAD");
+    assert_eq!(super::resolve::derive_scope(&args), "range:main...HEAD");
 }
 
 #[test]
@@ -488,7 +488,7 @@ fn derive_scope_files() {
         files: Some("src/**/*.rs".to_string()),
         ..default_review_args()
     };
-    assert_eq!(derive_scope(&args), "files:src/**/*.rs");
+    assert_eq!(super::resolve::derive_scope(&args), "files:src/**/*.rs");
 }
 
 #[test]
@@ -497,7 +497,7 @@ fn derive_scope_default_branch() {
         branch: Some("develop".to_string()),
         ..default_review_args()
     };
-    assert_eq!(derive_scope(&args), "base:develop");
+    assert_eq!(super::resolve::derive_scope(&args), "base:develop");
 }
 
 #[test]
@@ -582,19 +582,19 @@ fn review_cli_rejects_branch_with_diff() {
 #[test]
 fn review_cli_accepts_single_scope_flags() {
     let diff = parse_review_args(&["csa", "review", "--diff"]);
-    assert_eq!(derive_scope(&diff), "uncommitted");
+    assert_eq!(super::resolve::derive_scope(&diff), "uncommitted");
 
     let commit = parse_review_args(&["csa", "review", "--commit", "abc123"]);
-    assert_eq!(derive_scope(&commit), "commit:abc123");
+    assert_eq!(super::resolve::derive_scope(&commit), "commit:abc123");
 
     let range = parse_review_args(&["csa", "review", "--range", "main...HEAD"]);
-    assert_eq!(derive_scope(&range), "range:main...HEAD");
+    assert_eq!(super::resolve::derive_scope(&range), "range:main...HEAD");
 
     let files = parse_review_args(&["csa", "review", "--files", "src/"]);
-    assert_eq!(derive_scope(&files), "files:src/");
+    assert_eq!(super::resolve::derive_scope(&files), "files:src/");
 
     let branch = parse_review_args(&["csa", "review", "--branch", "develop"]);
-    assert_eq!(derive_scope(&branch), "base:develop");
+    assert_eq!(super::resolve::derive_scope(&branch), "base:develop");
 }
 
 #[test]
@@ -609,7 +609,7 @@ fn review_cli_parses_range_scope_with_multiple_reviewers() {
     ]);
 
     assert_eq!(args.reviewers, Some(3));
-    assert_eq!(derive_scope(&args), "range:main...HEAD");
+    assert_eq!(super::resolve::derive_scope(&args), "range:main...HEAD");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_tests_scope_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_scope_tail.rs
@@ -1,0 +1,67 @@
+use super::super::super::resolve::derive_scope_for_project;
+use super::super::*;
+
+fn setup_git_repo_on_main() -> tempfile::TempDir {
+    let temp = setup_git_repo();
+    run_git(temp.path(), &["branch", "-M", "main"]);
+    temp
+}
+
+fn diff_review_args() -> ReviewArgs {
+    ReviewArgs {
+        diff: true,
+        ..default_review_args()
+    }
+}
+
+#[test]
+fn derive_scope_for_project_falls_back_to_branch_diff_for_clean_feature_branch() {
+    let temp = setup_git_repo_on_main();
+    run_git(temp.path(), &["checkout", "-b", "fix/review-diff"]);
+    std::fs::write(temp.path().join("feature.txt"), "feature\n").expect("write feature file");
+    run_git(temp.path(), &["add", "feature.txt"]);
+    run_git(temp.path(), &["commit", "-m", "feature change"]);
+
+    assert_eq!(
+        derive_scope_for_project(&diff_review_args(), temp.path()),
+        "base:main"
+    );
+}
+
+#[test]
+fn derive_scope_for_project_keeps_uncommitted_scope_when_worktree_has_changes() {
+    let temp = setup_git_repo_on_main();
+    run_git(temp.path(), &["checkout", "-b", "fix/review-diff"]);
+    std::fs::write(temp.path().join("tracked.txt"), "baseline\npending\n")
+        .expect("write pending tracked change");
+
+    assert_eq!(
+        derive_scope_for_project(&diff_review_args(), temp.path()),
+        "uncommitted"
+    );
+}
+
+#[test]
+fn derive_scope_for_project_keeps_uncommitted_scope_when_untracked_files_exist() {
+    let temp = setup_git_repo_on_main();
+    run_git(temp.path(), &["checkout", "-b", "fix/review-diff"]);
+    std::fs::write(temp.path().join("feature.txt"), "feature\n").expect("write feature file");
+    run_git(temp.path(), &["add", "feature.txt"]);
+    run_git(temp.path(), &["commit", "-m", "feature change"]);
+    std::fs::write(temp.path().join("untracked.txt"), "pending\n").expect("write untracked file");
+
+    assert_eq!(
+        derive_scope_for_project(&diff_review_args(), temp.path()),
+        "uncommitted"
+    );
+}
+
+#[test]
+fn derive_scope_for_project_keeps_uncommitted_scope_on_clean_main() {
+    let temp = setup_git_repo_on_main();
+
+    assert_eq!(
+        derive_scope_for_project(&diff_review_args(), temp.path()),
+        "uncommitted"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -5,6 +5,9 @@ use csa_config::{ProjectProfile, ToolRestrictions};
 use std::path::Path;
 use tempfile::tempdir;
 
+#[path = "review_cmd_tests_scope_tail.rs"]
+mod scope_tail_tests;
+
 // --- is_worktree_submodule tests ---
 
 #[test]


### PR DESCRIPTION
## Summary
- When `csa review --diff` runs on a feature branch with all changes committed, fall back to `base:{default_branch}` scope instead of reporting empty diff
- Checks for tracked changes (`git diff HEAD`), untracked files (`git ls-files --others`), and protected branches before fallback
- Preserves original behavior: uncommitted changes reviewed as "uncommitted" scope, main branch stays "uncommitted"

## Context
`csa review --diff` always resolved to "uncommitted" scope (`git diff HEAD`). When codex commits all changes during implementation, the working tree is clean and the review silently passes with 0 findings — a false-negative that allowed unreviewed code through.

Closes #1238

## Test plan
- [x] `derive_scope_for_project_falls_back_to_branch_diff_for_clean_feature_branch` — new test
- [x] `derive_scope_for_project_keeps_uncommitted_scope_when_worktree_has_changes` — new test
- [x] `derive_scope_for_project_keeps_uncommitted_scope_on_clean_main` — new test
- [x] `derive_scope_for_project_keeps_uncommitted_scope_when_untracked_files_exist` — new test
- [ ] Manual: run `csa review --diff` on a real feature branch with committed-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)