### PR TITLE
feat(caller-hint): recommend run_in_background for csa session wait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.638"
+version = "0.1.639"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.638"
+version = "0.1.639"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -7,6 +7,8 @@
 #![cfg(test)]
 
 const NO_STACK_WAKEUP_WARNING: &str = "do NOT stack ScheduleWakeup, /loop, or sleep loops on top";
+const BACKGROUND_WAIT_RECOMMENDATION: &str = "with run_in_background: true";
+const TASK_NOTIFICATION_WAKE_SIGNAL: &str = "The task-notification IS your wake signal";
 
 const RUN_CMD_DAEMON_SRC: &str = include_str!("run_cmd_daemon.rs");
 const PLAN_CMD_DAEMON_SRC: &str = include_str!("plan_cmd_daemon.rs");
@@ -27,6 +29,29 @@ fn caller_hint_blocks(src: &str) -> Vec<&str> {
             &tail[..end]
         })
         .collect()
+}
+
+fn assert_wait_hint_contract(block: &str, site: &str) {
+    assert!(
+        block.contains("action=\\\"wait\\\""),
+        "{site} emits action=\"wait\""
+    );
+    assert!(
+        block.contains(BACKGROUND_WAIT_RECOMMENDATION),
+        "{site} CALLER_HINT must recommend backgrounding session wait with run_in_background: true"
+    );
+    assert!(
+        block.contains(TASK_NOTIFICATION_WAKE_SIGNAL),
+        "{site} CALLER_HINT must state that task-notification is the wake signal"
+    );
+    assert!(
+        block.contains(NO_STACK_WAKEUP_WARNING),
+        "{site} CALLER_HINT must warn against ScheduleWakeup/loop stacking; missing warning: {NO_STACK_WAKEUP_WARNING}"
+    );
+    assert!(
+        !block.contains("in a SEPARATE Bash call"),
+        "{site} CALLER_HINT must not lead with the old foreground-wait phrasing"
+    );
 }
 
 #[test]
@@ -59,28 +84,14 @@ fn caller_hint_blocks_ignores_unrelated_mentions_in_comments() {
 fn run_cmd_daemon_wait_hint_warns_no_stack_wakeup() {
     let blocks = caller_hint_blocks(RUN_CMD_DAEMON_SRC);
     assert_eq!(blocks.len(), 1, "run_cmd_daemon emits one CALLER_HINT");
-    assert!(
-        blocks[0].contains("action=\\\"wait\\\""),
-        "run_cmd_daemon emits action=\"wait\""
-    );
-    assert!(
-        blocks[0].contains(NO_STACK_WAKEUP_WARNING),
-        "run_cmd_daemon CALLER_HINT must warn against ScheduleWakeup/loop stacking; missing warning: {NO_STACK_WAKEUP_WARNING}"
-    );
+    assert_wait_hint_contract(blocks[0], "run_cmd_daemon");
 }
 
 #[test]
 fn plan_cmd_daemon_wait_hint_warns_no_stack_wakeup() {
     let blocks = caller_hint_blocks(PLAN_CMD_DAEMON_SRC);
     assert_eq!(blocks.len(), 1, "plan_cmd_daemon emits one CALLER_HINT");
-    assert!(
-        blocks[0].contains("action=\\\"wait\\\""),
-        "plan_cmd_daemon emits action=\"wait\""
-    );
-    assert!(
-        blocks[0].contains(NO_STACK_WAKEUP_WARNING),
-        "plan_cmd_daemon CALLER_HINT must warn against ScheduleWakeup/loop stacking"
-    );
+    assert_wait_hint_contract(blocks[0], "plan_cmd_daemon");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -165,10 +165,9 @@ pub(crate) fn spawn_and_exit(args: &PlanRunArgs) -> Result<()> {
     );
     eprintln!(
         "<!-- CSA:CALLER_HINT action=\"wait\" \
-         rule=\"Call 'csa session wait --session {id}{cd}' in a SEPARATE Bash call. \
-         NEVER batch multiple waits in a for/while loop. \
-         Each wait returns periodically so you can generate tokens and keep your KV cache warm. \
-         If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens.\" -->",
+         rule=\"Call 'csa session wait --session {id}{cd}' with run_in_background: true. \
+         The task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top. \
+         NEVER batch multiple waits in a for/while loop; use one backgrounded Bash tool call per session.\" -->",
         id = result.session_id,
         cd = cd_hint,
     );

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -232,10 +232,9 @@ pub(crate) fn spawn_and_exit(
     );
     eprintln!(
         "<!-- CSA:CALLER_HINT action=\"wait\" \
-         rule=\"Call 'csa session wait --session {id}{cd}' in a SEPARATE Bash call. \
-         NEVER batch multiple waits in a for/while loop. \
-         Each wait returns periodically so you can generate tokens and keep your KV cache warm. \
-         If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens.\" -->",
+         rule=\"Call 'csa session wait --session {id}{cd}' with run_in_background: true. \
+         The task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top. \
+         NEVER batch multiple waits in a for/while loop; use one backgrounded Bash tool call per session.\" -->",
         id = result.session_id,
         cd = cd_hint,
     );


### PR DESCRIPTION
## Summary
- Updated CSA:CALLER_HINT template to explicitly recommend `run_in_background: true` for `csa session wait`
- The hint now tells callers that the task-notification IS the wake signal, and warns against stacking ScheduleWakeup/sleep loops
- Updated tests to verify the new hint text

Closes #1244

## Test plan
- [x] `just pre-commit` passes
- [x] Existing caller_hints_tests updated and pass
- [x] Review verdict: PASS/CLEAN (0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)