### PR TITLE
fix(sandbox): resolve symlinks and relative paths in extra-writable validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.643"
+version = "0.1.644"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.643"
+version = "0.1.644"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -132,16 +132,19 @@ pub(crate) fn resolve_sandbox_options(
             }
             // CLI --extra-writable / --expose-readable (no-config path).
             if !extra_writable.is_empty() {
-                if let Err(e) = csa_resource::isolation_plan::validate_writable_paths(
+                let resolved = match csa_resource::isolation_plan::resolve_writable_paths(
                     extra_writable,
                     project_root,
                 ) {
-                    return SandboxResolution::RequiredButUnavailable(format!(
-                        "--extra-writable validation failed: {e}"
-                    ));
-                }
-                for path in extra_writable {
-                    builder = builder.with_writable_path(path.clone());
+                    Ok(paths) => paths,
+                    Err(e) => {
+                        return SandboxResolution::RequiredButUnavailable(format!(
+                            "--extra-writable validation failed: {e}"
+                        ));
+                    }
+                };
+                for path in resolved {
+                    builder = builder.with_writable_path(path);
                 }
             }
             if !extra_readable.is_empty() {
@@ -297,21 +300,36 @@ pub(crate) fn resolve_sandbox_options(
     if !no_fs_sandbox {
         if let Some(ref paths) = per_tool_writable {
             // Validate user-provided writable paths before applying.
-            if let Err(e) =
-                csa_resource::isolation_plan::validate_writable_paths(paths, project_root)
-            {
-                return SandboxResolution::RequiredButUnavailable(format!(
-                    "Per-tool writable_paths validation failed for '{tool_name}': {e}"
-                ));
-            }
-            for path in paths {
-                builder = builder.with_writable_path(path.clone());
+            let resolved =
+                match csa_resource::isolation_plan::resolve_writable_paths(paths, project_root) {
+                    Ok(paths) => paths,
+                    Err(e) => {
+                        return SandboxResolution::RequiredButUnavailable(format!(
+                            "Per-tool writable_paths validation failed for '{tool_name}': {e}"
+                        ));
+                    }
+                };
+            for path in resolved {
+                builder = builder.with_writable_path(path);
             }
         } else {
             // No per-tool override — apply global extra_writable paths.
             let fs_config = &cfg.filesystem_sandbox;
-            for path in &fs_config.extra_writable {
-                builder = builder.with_writable_path(path.clone());
+            if !fs_config.extra_writable.is_empty() {
+                let resolved = match csa_resource::isolation_plan::resolve_writable_paths(
+                    &fs_config.extra_writable,
+                    project_root,
+                ) {
+                    Ok(paths) => paths,
+                    Err(e) => {
+                        return SandboxResolution::RequiredButUnavailable(format!(
+                            "filesystem_sandbox.extra_writable validation failed: {e}"
+                        ));
+                    }
+                };
+                for path in resolved {
+                    builder = builder.with_writable_path(path);
+                }
             }
         }
 
@@ -331,15 +349,19 @@ pub(crate) fn resolve_sandbox_options(
 
     // CLI --extra-writable paths: always appended (APPEND semantics, not REPLACE).
     if !no_fs_sandbox && !extra_writable.is_empty() {
-        if let Err(e) =
-            csa_resource::isolation_plan::validate_writable_paths(extra_writable, project_root)
-        {
-            return SandboxResolution::RequiredButUnavailable(format!(
-                "--extra-writable validation failed: {e}"
-            ));
-        }
-        for path in extra_writable {
-            builder = builder.with_writable_path(path.clone());
+        let resolved = match csa_resource::isolation_plan::resolve_writable_paths(
+            extra_writable,
+            project_root,
+        ) {
+            Ok(paths) => paths,
+            Err(e) => {
+                return SandboxResolution::RequiredButUnavailable(format!(
+                    "--extra-writable validation failed: {e}"
+                ));
+            }
+        };
+        for path in resolved {
+            builder = builder.with_writable_path(path);
         }
     }
 

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -545,6 +545,9 @@ writable_paths = ["/tmp/restricted-only"]
 /// CLI --extra-writable paths are appended to writable_paths (APPEND semantics).
 #[test]
 fn test_extra_writable_appended_to_isolation_plan() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let extra_dir = project_root.path().join("extra-dir");
+    std::fs::create_dir_all(&extra_dir).expect("create extra dir");
     let cfg = parse_project_config(
         r#"
 [resources]
@@ -553,12 +556,12 @@ enforcement_mode = "best-effort"
 "#,
     );
 
-    let extra = vec![PathBuf::from("/tmp/extra-dir")];
+    let extra = vec![PathBuf::from("./extra-dir")];
     let result = resolve_sandbox_options(
         Some(&cfg),
         "claude-code",
         "test-session",
-        &current_project_root(),
+        project_root.path(),
         StreamMode::BufferOnly,
         120,
         600,
@@ -581,7 +584,7 @@ enforcement_mode = "best-effort"
         sandbox
             .isolation_plan
             .writable_paths
-            .contains(&PathBuf::from("/tmp/extra-dir")),
+            .contains(&extra_dir.canonicalize().unwrap()),
         "extra_writable path should be in writable_paths, got: {:?}",
         sandbox.isolation_plan.writable_paths
     );
@@ -589,6 +592,52 @@ enforcement_mode = "best-effort"
     assert!(
         !sandbox.isolation_plan.readonly_project_root,
         "extra_writable uses APPEND semantics — project root stays writable"
+    );
+}
+
+#[test]
+fn test_global_extra_writable_resolves_relative_path() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let drafts = project_root.path().join("drafts");
+    std::fs::create_dir_all(&drafts).expect("create drafts dir");
+    let cfg = parse_project_config(
+        r#"
+[resources]
+memory_max_mb = 2048
+enforcement_mode = "best-effort"
+
+[filesystem_sandbox]
+extra_writable = ["drafts"]
+"#,
+    );
+
+    let result = resolve_sandbox_options(
+        Some(&cfg),
+        "claude-code",
+        "test-session",
+        project_root.path(),
+        StreamMode::BufferOnly,
+        120,
+        600,
+        Some(120),
+        false,
+        false,
+        &[],
+        &[],
+    );
+
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("Expected SandboxResolution::Ok");
+    };
+
+    let sandbox = opts.sandbox.expect("expected sandbox context");
+    assert!(
+        sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&drafts.canonicalize().unwrap()),
+        "global extra_writable path should be resolved into writable_paths, got: {:?}",
+        sandbox.isolation_plan.writable_paths
     );
 }
 

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -2,7 +2,7 @@
 //! single, builder-configured plan that executors can apply uniformly.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use anyhow::Context;
 
@@ -435,6 +435,23 @@ fn sandbox_tmpdir_for_capability(filesystem: FilesystemCapability, session_dir: 
 /// Returns an error listing any rejected paths that are not under an allowed
 /// parent directory.
 pub fn validate_writable_paths(paths: &[PathBuf], project_root: &Path) -> anyhow::Result<()> {
+    resolve_writable_paths(paths, project_root).map(|_| ())
+}
+
+/// Resolve and validate writable sandbox paths.
+///
+/// Relative paths are resolved against `project_root`. Existing symlinks are
+/// resolved through their target before the path is returned, so the sandbox can
+/// bind-mount the actual host location.
+///
+/// # Errors
+///
+/// Returns an error listing any rejected paths that are not under an allowed
+/// parent directory.
+pub fn resolve_writable_paths(
+    paths: &[PathBuf],
+    project_root: &Path,
+) -> anyhow::Result<Vec<PathBuf>> {
     validate_sandbox_paths(
         paths,
         project_root,
@@ -443,7 +460,8 @@ pub fn validate_writable_paths(paths: &[PathBuf], project_root: &Path) -> anyhow
             require_absolute: false,
             require_exists: false,
             reject_tmp_root: false,
-            canonicalize_for_allowlist: false,
+            canonicalize_for_allowlist: true,
+            allow_requested_path_for_allowlist: true,
         },
     )
 }
@@ -464,8 +482,10 @@ pub fn validate_readable_paths(paths: &[PathBuf], project_root: &Path) -> anyhow
             require_exists: true,
             reject_tmp_root: true,
             canonicalize_for_allowlist: true,
+            allow_requested_path_for_allowlist: false,
         },
     )
+    .map(|_| ())
 }
 
 /// Canonicalize `path` by resolving its deepest existing ancestor, then
@@ -538,22 +558,26 @@ struct PathValidationOptions<'a> {
     require_exists: bool,
     reject_tmp_root: bool,
     canonicalize_for_allowlist: bool,
+    allow_requested_path_for_allowlist: bool,
 }
 
 fn validate_sandbox_paths(
     paths: &[PathBuf],
     project_root: &Path,
     options: PathValidationOptions<'_>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Vec<PathBuf>> {
     let home = home_dir().unwrap_or_else(|| PathBuf::from("/nonexistent"));
-    let project_root = project_root.to_path_buf();
+    let project_root = canonicalize_or_fallback(project_root);
+    let project_root_for_join = project_root.clone();
     let home = canonicalize_or_fallback(home.as_path());
     let tmp_root = canonicalize_or_fallback(Path::new("/tmp"));
     let allowed_parents = [project_root, home, tmp_root];
     let mut rejected = Vec::new();
+    let mut resolved_paths = Vec::with_capacity(paths.len());
 
     for path in paths {
-        let path_for_allowlist = match validate_single_path(path, &allowed_parents, &options) {
+        let validated = match validate_single_path(path, &options, project_root_for_join.as_path())
+        {
             Ok(candidate) => candidate,
             Err(reason) => {
                 rejected.push(format!("{} ({reason})", path.display()));
@@ -563,17 +587,24 @@ fn validate_sandbox_paths(
 
         let is_allowed = allowed_parents
             .iter()
-            .any(|parent| path_for_allowlist.starts_with(parent));
+            .any(|parent| validated.resolved.starts_with(parent))
+            || (options.allow_requested_path_for_allowlist
+                && allowed_parents
+                    .iter()
+                    .any(|parent| validated.requested.starts_with(parent)));
         if !is_allowed {
             rejected.push(format!(
-                "{} (outside allowed roots: home, /tmp, project root)",
-                path.display()
+                "{} (resolved {}; outside allowed roots: home, /tmp, project root)",
+                path.display(),
+                validated.resolved.display()
             ));
+            continue;
         }
+        resolved_paths.push(validated.resolved);
     }
 
     if rejected.is_empty() {
-        return Ok(());
+        return Ok(resolved_paths);
     }
 
     anyhow::bail!(
@@ -583,11 +614,16 @@ fn validate_sandbox_paths(
     );
 }
 
+struct ValidatedPath {
+    requested: PathBuf,
+    resolved: PathBuf,
+}
+
 fn validate_single_path(
     path: &Path,
-    allowed_parents: &[PathBuf],
     options: &PathValidationOptions<'_>,
-) -> anyhow::Result<PathBuf> {
+    project_root: &Path,
+) -> anyhow::Result<ValidatedPath> {
     if path == Path::new("/") {
         anyhow::bail!("root path is forbidden");
     }
@@ -601,25 +637,56 @@ fn validate_single_path(
         anyhow::bail!("path must exist");
     }
 
-    if !options.canonicalize_for_allowlist {
-        return Ok(path.to_path_buf());
+    let requested = normalize_path_components(if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        project_root.join(path)
+    });
+    if requested == Path::new("/") {
+        anyhow::bail!("root path is forbidden");
+    }
+    if options.reject_tmp_root && requested == Path::new("/tmp") {
+        anyhow::bail!("/tmp itself is forbidden; expose a specific sub-path instead");
     }
 
-    let canonical = path.canonicalize()?;
-    let canonical_allowed = allowed_parents
-        .iter()
-        .any(|parent| canonical.starts_with(parent));
-    if !canonical_allowed {
-        anyhow::bail!(
-            "resolved path {} escapes allowed roots",
-            canonical.display()
-        );
+    if !options.canonicalize_for_allowlist {
+        return Ok(ValidatedPath {
+            requested: requested.clone(),
+            resolved: requested,
+        });
     }
-    Ok(canonical)
+
+    let resolved = canonicalize_through_existing_ancestors(&requested)?;
+    if is_sensitive_system_path(&resolved) {
+        anyhow::bail!("resolved path {} is forbidden", resolved.display());
+    }
+    Ok(ValidatedPath {
+        requested,
+        resolved,
+    })
 }
 
 fn canonicalize_or_fallback(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn normalize_path_components(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if normalized.as_os_str().is_empty() || normalized == Path::new("/") {
+                    continue;
+                }
+                normalized.pop();
+            }
+        }
+    }
+    normalized
 }
 
 /// Add `dir` to `paths` if it exists, otherwise pre-create it when a
@@ -723,3 +790,7 @@ fn detect_superproject_root(project_root: &Path) -> Option<PathBuf> {
 #[cfg(test)]
 #[path = "isolation_plan_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "isolation_plan_path_tests.rs"]
+mod path_tests;

--- a/crates/csa-resource/src/isolation_plan_path_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_path_tests.rs
@@ -1,0 +1,70 @@
+use super::*;
+
+#[test]
+fn test_resolve_writable_relative_path_against_project_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    let drafts = project.join("drafts");
+    std::fs::create_dir_all(&drafts).expect("create drafts dir");
+
+    let resolved =
+        resolve_writable_paths(&[PathBuf::from("./drafts")], &project).expect("valid path");
+
+    assert_eq!(resolved, vec![drafts.canonicalize().unwrap()]);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_resolve_writable_symlink_inside_project_to_external_target() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    let external = tmp.path().join("external-drafts");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    std::fs::create_dir_all(&external).expect("create external dir");
+    symlink(&external, project.join("drafts")).expect("create symlink");
+
+    let resolved = resolve_writable_paths(&[PathBuf::from("drafts")], &project)
+        .expect("project-local symlink should be accepted");
+
+    let canonical_project = project.canonicalize().unwrap();
+    let canonical_external = external.canonicalize().unwrap();
+    assert_eq!(resolved, vec![canonical_external.clone()]);
+    assert!(!canonical_external.starts_with(canonical_project));
+}
+
+#[test]
+fn test_resolve_writable_nonexistent_path_uses_existing_parent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+
+    let resolved =
+        resolve_writable_paths(&[PathBuf::from("drafts/new")], &project).expect("valid path");
+
+    let expected = project.canonicalize().unwrap().join("drafts/new");
+    assert_eq!(resolved, vec![expected.clone()]);
+    assert!(!expected.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn test_writable_validation_error_includes_original_and_resolved_path() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    symlink("/etc", project.join("etc-link")).expect("create symlink");
+
+    let err = resolve_writable_paths(&[PathBuf::from("etc-link")], &project)
+        .expect_err("sensitive symlink target should be rejected")
+        .to_string();
+
+    assert!(err.contains("etc-link"), "missing original path: {err}");
+    assert!(
+        err.contains("resolved path /etc is forbidden"),
+        "missing resolved path: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

- Resolve symlinks via `canonicalize()` before validating `--extra-writable` paths against allowed roots
- Resolve relative paths against project root so `--extra-writable ./drafts` works
- Improved error messages showing both original and resolved paths

Fixes #1255

## Test plan

- [x] `cargo test -p csa-resource` — new path resolution tests
- [x] `cargo test -p cli-sub-agent` — pipeline sandbox tests
- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)