### PR TITLE
feat(review): inject resume-session fix prompt on review failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.645"
+version = "0.1.646"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.645"
+version = "0.1.646"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -469,6 +469,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         let is_cumulative_review = review_scope_is_cumulative(&scope);
 
         if !should_run_fix_loop(args.fix, decision) {
+            post_review::suggest_review_failure_fix(&project_root, &review_meta, &sanitized);
             // Accumulate only on FINAL result to avoid double-counting when --fix resolves the same issues.
             if verdict != CLEAN && !empty_output && !auth_prompt_failure && !is_cumulative_review {
                 crate::review_findings::accumulate_findings(&project_root, &sanitized);

--- a/crates/cli-sub-agent/src/review_cmd_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix.rs
@@ -284,6 +284,7 @@ fn persist_fix_final_artifacts(
         }
     }
     persist_review_verdict(project_root, review_meta, &[], Vec::new());
+    super::post_review::persist_review_failure_suggestion(project_root, review_meta);
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_post_review.rs
+++ b/crates/cli-sub-agent/src/review_cmd_post_review.rs
@@ -1,6 +1,26 @@
+use std::fs;
+use std::path::Path;
+
 use csa_core::types::ReviewDecision;
+use csa_session::state::ReviewSessionMeta;
+use serde::Serialize;
+use tracing::{debug, warn};
 
 const POST_REVIEW_PR_BOT_CMD: &str = "csa plan run --sa-mode true --pattern pr-bot";
+const RESUME_TO_FIX_ACTION: &str = "resume_to_fix";
+const RESUME_TO_FIX_HINT: &str = "Resume this session to fix — reviewer KV cache is warm with full diff context. Use NEW session for next review round.";
+
+#[derive(Serialize)]
+struct ReviewSuggestionFile<'a> {
+    suggestion: ReviewFailureSuggestion<'a>,
+}
+
+#[derive(Serialize)]
+struct ReviewFailureSuggestion<'a> {
+    action: &'static str,
+    session_id: &'a str,
+    hint: &'static str,
+}
 
 pub(super) fn emit_post_review_output(output: &str) {
     let trimmed = output.trim_end();
@@ -15,6 +35,88 @@ pub(super) fn emit_post_review_output(output: &str) {
         println!("{trimmed}");
     }
     eprintln!("{trimmed}");
+}
+
+pub(super) fn build_review_failure_suggestion(
+    decision: ReviewDecision,
+    session_id: &str,
+) -> Option<String> {
+    if decision != ReviewDecision::Fail {
+        return None;
+    }
+
+    let suggestion = ReviewSuggestionFile {
+        suggestion: ReviewFailureSuggestion {
+            action: RESUME_TO_FIX_ACTION,
+            session_id,
+            hint: RESUME_TO_FIX_HINT,
+        },
+    };
+    match toml::to_string_pretty(&suggestion) {
+        Ok(rendered) => Some(rendered),
+        Err(error) => {
+            warn!(session_id, error = %error, "Failed to render review failure suggestion");
+            None
+        }
+    }
+}
+
+pub(super) fn emit_review_failure_suggestion(
+    decision: ReviewDecision,
+    session_id: &str,
+    preceding_output: &str,
+) {
+    let Some(suggestion) = build_review_failure_suggestion(decision, session_id) else {
+        return;
+    };
+    if !preceding_output.is_empty() && !preceding_output.ends_with('\n') {
+        println!();
+    }
+    print!("{suggestion}");
+}
+
+pub(super) fn persist_review_failure_suggestion(project_root: &Path, meta: &ReviewSessionMeta) {
+    let Some(suggestion) = build_review_failure_suggestion(
+        meta.decision
+            .parse::<ReviewDecision>()
+            .unwrap_or(ReviewDecision::Uncertain),
+        &meta.session_id,
+    ) else {
+        return;
+    };
+
+    match csa_session::get_session_dir(project_root, &meta.session_id) {
+        Ok(session_dir) => {
+            let output_dir = session_dir.join("output");
+            if let Err(error) = fs::create_dir_all(&output_dir) {
+                warn!(session_id = %meta.session_id, error = %error, "Failed to create review output dir");
+                return;
+            }
+            if let Err(error) = fs::write(output_dir.join("suggestion.toml"), suggestion) {
+                warn!(session_id = %meta.session_id, error = %error, "Failed to write output/suggestion.toml");
+            } else {
+                debug!(session_id = %meta.session_id, "Wrote output/suggestion.toml");
+            }
+        }
+        Err(error) => {
+            warn!(session_id = %meta.session_id, error = %error, "Cannot resolve session dir for review suggestion");
+        }
+    }
+}
+
+pub(super) fn suggest_review_failure_fix(
+    project_root: &Path,
+    meta: &ReviewSessionMeta,
+    preceding_output: &str,
+) {
+    emit_review_failure_suggestion(
+        meta.decision
+            .parse::<ReviewDecision>()
+            .unwrap_or(ReviewDecision::Uncertain),
+        &meta.session_id,
+        preceding_output,
+    );
+    persist_review_failure_suggestion(project_root, meta);
 }
 
 pub(super) fn build_post_review_output(
@@ -50,4 +152,84 @@ fn synthesize_post_review_next_step(decision: ReviewDecision, scope: &str) -> Op
 
 pub(crate) fn review_scope_is_cumulative(scope: &str) -> bool {
     scope.starts_with("base:") || scope.starts_with("range:")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_failure_suggestion_renders_resume_to_fix_block() {
+        let rendered =
+            build_review_failure_suggestion(ReviewDecision::Fail, "01HREVIEWSESSION0000000000")
+                .expect("fail decision should render suggestion");
+
+        assert_eq!(
+            rendered,
+            "[suggestion]\naction = \"resume_to_fix\"\nsession_id = \"01HREVIEWSESSION0000000000\"\nhint = \"Resume this session to fix — reviewer KV cache is warm with full diff context. Use NEW session for next review round.\"\n"
+        );
+    }
+
+    #[test]
+    fn review_failure_suggestion_only_renders_for_fail_decision() {
+        for decision in [
+            ReviewDecision::Pass,
+            ReviewDecision::Skip,
+            ReviewDecision::Uncertain,
+            ReviewDecision::Unavailable,
+        ] {
+            assert!(
+                build_review_failure_suggestion(decision, "01HREVIEWSESSION0000000000").is_none(),
+                "{decision:?} should not render suggestion"
+            );
+        }
+    }
+
+    #[test]
+    fn review_failure_suggestion_persists_to_session_output() {
+        let _env_lock = crate::test_env_lock::TEST_ENV_LOCK
+            .clone()
+            .blocking_lock_owned();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_root = temp.path().join("project");
+        let state_home = temp.path().join("state");
+        std::fs::create_dir_all(&project_root).expect("project dir");
+        std::fs::create_dir_all(&state_home).expect("state dir");
+        let _state_home =
+            crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+        let session =
+            csa_session::create_session(&project_root, Some("review"), None, Some("codex"))
+                .expect("create session");
+        let meta = ReviewSessionMeta {
+            session_id: session.meta_session_id.clone(),
+            head_sha: "HEAD".to_string(),
+            decision: ReviewDecision::Fail.as_str().to_string(),
+            verdict: "HAS_ISSUES".to_string(),
+            status_reason: None,
+            routed_to: None,
+            primary_failure: None,
+            failure_reason: None,
+            tool: "codex".to_string(),
+            scope: "range:main...HEAD".to_string(),
+            exit_code: 1,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 1,
+            timestamp: chrono::Utc::now(),
+            diff_fingerprint: None,
+        };
+
+        persist_review_failure_suggestion(&project_root, &meta);
+
+        let suggestion_path = csa_session::get_session_dir(&project_root, &session.meta_session_id)
+            .expect("session dir")
+            .join("output")
+            .join("suggestion.toml");
+        let rendered = std::fs::read_to_string(suggestion_path).expect("suggestion.toml");
+        assert_eq!(
+            rendered,
+            build_review_failure_suggestion(ReviewDecision::Fail, &session.meta_session_id)
+                .expect("expected rendered suggestion")
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- When `csa review` returns `decision: fail`, output now includes a structured `[suggestion]` block with session ID and hint to resume the reviewer session for fixes
- Writes `output/suggestion.toml` to session dir for programmatic access
- No behavioral change on `decision: pass`

Fixes #1254

## Test plan

- [x] `cargo test` passes with new tests
- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` — findings empty, summary positive (verdict=fail is false positive with 0 severity counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)