### PR TITLE
feat(cli): add csa merge subcommand for deterministic post-merge checkout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.648"
+version = "0.1.649"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.648"
+version = "0.1.649"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use csa_core::types::{OutputFormat, ToolArg};
 
 #[path = "cli_session.rs"]
@@ -287,6 +287,9 @@ pub enum Commands {
         cmd: SessionCommands,
     },
 
+    /// Merge a GitHub pull request and return to the default branch
+    Merge(MergeArgs),
+
     /// Manage audit manifest lifecycle
     Audit {
         #[command(subcommand)]
@@ -459,6 +462,21 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: HooksCommands,
     },
+}
+
+#[derive(Args)]
+pub struct MergeArgs {
+    /// Pull request number to merge
+    #[arg(value_name = "PR_NUMBER", value_parser = clap::value_parser!(u64).range(1..))]
+    pub pr_number: u64,
+
+    /// Use GitHub's rebase merge strategy instead of a merge commit
+    #[arg(long)]
+    pub rebase: bool,
+
+    /// Bypass pre-merge working tree checks
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(Subcommand)]

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -29,6 +29,7 @@ mod mcp_server;
 mod memory_capture;
 mod memory_cmd;
 mod memory_migrate;
+mod merge_cmd;
 mod pattern_resolver;
 mod pipeline;
 mod pipeline_env;
@@ -472,9 +473,8 @@ async fn run() -> Result<()> {
             daemon_guard.finalize();
             exit_current_process(exit_code);
         }
-        Commands::Session { cmd } => {
-            session_dispatch::dispatch(cmd, output_format)?;
-        }
+        Commands::Session { cmd } => session_dispatch::dispatch(cmd, output_format)?,
+        Commands::Merge(args) => merge_cmd::handle_merge(args)?,
         Commands::Audit { command } => {
             audit_cmds::handle_audit(command)?;
         }

--- a/crates/cli-sub-agent/src/merge_cmd.rs
+++ b/crates/cli-sub-agent/src/merge_cmd.rs
@@ -1,0 +1,201 @@
+use std::process::{Command, Output};
+
+use anyhow::{Context, Result};
+
+use crate::cli::MergeArgs;
+
+const DEFAULT_BRANCH_FALLBACK: &str = "main";
+
+pub(crate) fn handle_merge(args: MergeArgs) -> Result<()> {
+    if !args.force {
+        ensure_worktree_clean(
+            "pre-merge",
+            Some("pass --force to bypass this pre-merge check"),
+        )?;
+    }
+
+    let pr_number = args.pr_number.to_string();
+    let merge_flag = if args.rebase { "--rebase" } else { "--merge" };
+    run_checked(
+        "gh",
+        &["pr", "merge", &pr_number, merge_flag],
+        "merge pull request",
+    )?;
+
+    let default_branch = detect_default_branch();
+    run_checked(
+        "git",
+        &["checkout", &default_branch],
+        "checkout default branch",
+    )?;
+    run_checked(
+        "git",
+        &["pull", "origin", &default_branch],
+        "pull default branch",
+    )?;
+    ensure_worktree_clean("post-merge", None)?;
+
+    let current_branch = current_branch().unwrap_or(default_branch);
+    println!(
+        "Merged PR #{}; current branch: {current_branch}",
+        args.pr_number
+    );
+
+    Ok(())
+}
+
+fn detect_default_branch() -> String {
+    match Command::new("git")
+        .args(["remote", "show", "origin"])
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            parse_default_branch(&stdout).unwrap_or_else(|| {
+                eprintln!(
+                    "WARNING: could not parse origin default branch; falling back to `{DEFAULT_BRANCH_FALLBACK}`"
+                );
+                DEFAULT_BRANCH_FALLBACK.to_string()
+            })
+        }
+        Ok(output) => {
+            eprintln!(
+                "WARNING: `git remote show origin` failed; falling back to `{DEFAULT_BRANCH_FALLBACK}`\n{}",
+                command_output_text(&output)
+            );
+            DEFAULT_BRANCH_FALLBACK.to_string()
+        }
+        Err(err) => {
+            eprintln!(
+                "WARNING: failed to run `git remote show origin`: {err}; falling back to `{DEFAULT_BRANCH_FALLBACK}`"
+            );
+            DEFAULT_BRANCH_FALLBACK.to_string()
+        }
+    }
+}
+
+pub(crate) fn parse_default_branch(remote_show_output: &str) -> Option<String> {
+    remote_show_output.lines().find_map(|line| {
+        let branch = line.trim().strip_prefix("HEAD branch:")?.trim();
+        if branch.is_empty() || branch == "(unknown)" {
+            None
+        } else {
+            Some(branch.to_string())
+        }
+    })
+}
+
+fn ensure_worktree_clean(phase: &str, hint: Option<&str>) -> Result<()> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .with_context(|| "failed to run `git status --porcelain`")?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "`git status --porcelain` failed during {phase} check\n{}",
+            command_output_text(&output)
+        );
+    }
+
+    if !output.stdout.is_empty() {
+        let status = String::from_utf8_lossy(&output.stdout);
+        let hint_text = hint
+            .map(|value| format!("\nHint: {value}."))
+            .unwrap_or_default();
+        anyhow::bail!("working tree is not clean during {phase} check{hint_text}\n{status}");
+    }
+
+    Ok(())
+}
+
+fn current_branch() -> Result<String> {
+    let output = Command::new("git")
+        .args(["branch", "--show-current"])
+        .output()
+        .with_context(|| "failed to run `git branch --show-current`")?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "`git branch --show-current` failed\n{}",
+            command_output_text(&output)
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn run_checked(program: &str, args: &[&str], action: &str) -> Result<()> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run `{}`", shell_command(program, args)))?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "failed to {action} with `{}`\n{}",
+            shell_command(program, args),
+            command_output_text(&output)
+        );
+    }
+
+    Ok(())
+}
+
+fn shell_command(program: &str, args: &[&str]) -> String {
+    std::iter::once(program)
+        .chain(args.iter().copied())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn command_output_text(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    match (stdout.trim().is_empty(), stderr.trim().is_empty()) {
+        (true, true) => "(no output)".to_string(),
+        (false, true) => format!("stdout:\n{}", stdout.trim_end()),
+        (true, false) => format!("stderr:\n{}", stderr.trim_end()),
+        (false, false) => format!(
+            "stdout:\n{}\nstderr:\n{}",
+            stdout.trim_end(),
+            stderr.trim_end()
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_default_branch;
+
+    #[test]
+    fn parses_origin_head_branch() {
+        let output = r#"
+* remote origin
+  Fetch URL: git@github.com:owner/repo.git
+  Push  URL: git@github.com:owner/repo.git
+  HEAD branch: dev
+  Remote branches:
+    dev tracked
+"#;
+
+        assert_eq!(parse_default_branch(output).as_deref(), Some("dev"));
+    }
+
+    #[test]
+    fn parses_slash_branch_names() {
+        let output = "  HEAD branch: release/2026.05\n";
+
+        assert_eq!(
+            parse_default_branch(output).as_deref(),
+            Some("release/2026.05")
+        );
+    }
+
+    #[test]
+    fn ignores_missing_or_unknown_head_branch() {
+        assert_eq!(parse_default_branch("  Remote branches:\n"), None);
+        assert_eq!(parse_default_branch("  HEAD branch: (unknown)\n"), None);
+    }
+}

--- a/crates/cli-sub-agent/tests/merge_e2e.rs
+++ b/crates/cli-sub-agent/tests/merge_e2e.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+
+fn csa_cmd(tmp: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+#[test]
+fn merge_help_shows_post_merge_checkout_options() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = csa_cmd(tmp.path())
+        .args(["merge", "--help"])
+        .output()
+        .expect("failed to run csa merge --help");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("PR_NUMBER"));
+    assert!(stdout.contains("--rebase"));
+    assert!(stdout.contains("--force"));
+}


### PR DESCRIPTION
## Summary

- New `csa merge <PR#>` subcommand wrapping the full merge lifecycle: merge PR → checkout default branch → pull → verify clean tree
- Auto-detects repo's default branch via `git remote show origin` with fallback to `main`
- Supports `--rebase` flag and `--force` to bypass pre-merge worktree check
- Unit tests for default branch parsing + e2e test for CLI parsing

Closes #1264

## Test plan

- [x] `just pre-commit` passes (31/31 tests)
- [x] Unit tests cover branch name parsing edge cases
- [x] Review: findings=[], severity all 0

Co-Authored-By: codex <noreply@openai.com>