### PR TITLE
feat(cli): rename --allow-base-branch-commit to --allow-base-branch-working

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.650"
+version = "0.1.651"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.650"
+version = "0.1.651"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -173,9 +173,10 @@ pub enum Commands {
         /// Ephemeral session (no session persistence, auto-cleanup; tool runs in project dir)
         #[arg(long, conflicts_with = "session")]
         ephemeral: bool,
-        /// Allow csa run on protected base branches; prefer creating a feature branch first.
-        #[arg(long)]
-        allow_base_branch_commit: bool,
+        /// Allow working on the base branch (main/dev) without requiring a feature branch.
+        /// Use for read-only tasks or when you explicitly accept the risk.
+        #[arg(long, alias = "allow-base-branch-commit")]
+        allow_base_branch_working: bool,
         /// Working directory (defaults to CWD)
         #[arg(long)]
         cd: Option<String>,

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -355,7 +355,7 @@ async fn run() -> Result<()> {
             return_to,
             parent,
             ephemeral,
-            allow_base_branch_commit,
+            allow_base_branch_working,
             cd,
             model_spec,
             model,
@@ -387,7 +387,7 @@ async fn run() -> Result<()> {
                 && !daemon_child
                 && session_id.is_none()
                 && let Some(exit_code) = run_helpers_branch_guard::evaluate_run_refusal_for_cd(
-                    allow_base_branch_commit,
+                    allow_base_branch_working,
                     cd.as_deref(),
                 )?
             {
@@ -436,7 +436,7 @@ async fn run() -> Result<()> {
                 return_to,
                 parent,
                 ephemeral,
-                allow_base_branch_commit,
+                allow_base_branch_working,
                 cd,
                 model_spec,
                 model,

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -226,7 +226,7 @@ pub(crate) async fn handle_run(
     return_to: Option<String>,
     parent: Option<String>,
     ephemeral: bool,
-    allow_base_branch_commit: bool,
+    allow_base_branch_working: bool,
     cd: Option<String>,
     model_spec: Option<String>,
     model: Option<String>,
@@ -333,7 +333,7 @@ pub(crate) async fn handle_run(
         return Ok(1);
     };
     let branch_guard = crate::run_helpers_branch_guard::BranchGuardRuntime::for_run(
-        allow_base_branch_commit,
+        allow_base_branch_working,
         config.as_ref(),
         &global_config,
     );

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -29,7 +29,7 @@ fn project_config_with_gate(gate: PostExecGateConfig) -> ProjectConfig {
         preferences: None,
         hooks: Default::default(),
         run: RunConfig {
-            allow_base_branch_commit: false,
+            allow_base_branch_working: false,
             post_exec_gate: gate,
         },
         execution: Default::default(),

--- a/crates/cli-sub-agent/src/run_helpers_branch_guard.rs
+++ b/crates/cli-sub-agent/src/run_helpers_branch_guard.rs
@@ -71,7 +71,7 @@ impl BranchGuardRefusal {
              detected default branch: {}\n\
              reason: {}\n\
              recommend: git checkout -b feat/<your-feature> && csa run ...\n\
-             escape hatch: pass --allow-base-branch-commit to bypass (and accept risk)\n\
+             escape hatch: pass --allow-base-branch-working to bypass (and accept risk)\n\
              bypass source: {}",
             safe_display_option(self.current_branch.as_deref()),
             safe_display_option(self.detected_default.as_deref()),
@@ -104,9 +104,9 @@ impl BranchGuardRuntime {
         global_config: &GlobalConfig,
         read_only_mode: bool,
     ) -> Self {
-        let trusted_config_bypass = global_config.run.allow_base_branch_commit;
+        let trusted_config_bypass = global_config.run.allow_base_branch_working;
         let project_config_requested_bypass = project_config
-            .is_some_and(|config| config.run.allow_base_branch_commit)
+            .is_some_and(|config| config.run.allow_base_branch_working)
             && !trusted_config_bypass;
         Self {
             cli_bypass,
@@ -336,7 +336,7 @@ fn is_protected_branch(current: &str, detected_default: Option<&str>) -> bool {
 
 fn bypass_source_diagnostic(project_config_requested_bypass: bool) -> String {
     if project_config_requested_bypass {
-        "none (project-local allow_base_branch_commit is not trusted)".to_string()
+        "none (project-local allow_base_branch_working is not trusted)".to_string()
     } else {
         "none".to_string()
     }

--- a/crates/cli-sub-agent/tests/cli_run_branch_guard.rs
+++ b/crates/cli-sub-agent/tests/cli_run_branch_guard.rs
@@ -156,7 +156,7 @@ fn assert_branch_guard_refused(output: &Output) {
     assert!(stderr.contains("main"), "stderr: {stderr}");
     assert!(stderr.contains("git checkout -b"), "stderr: {stderr}");
     assert!(
-        stderr.contains("--allow-base-branch-commit"),
+        stderr.contains("--allow-base-branch-working"),
         "stderr: {stderr}"
     );
     assert!(
@@ -329,7 +329,7 @@ impl Drop for EnvGuard {
 }
 
 #[test]
-fn run_help_displays_allow_base_branch_commit_flag() {
+fn run_help_displays_allow_base_branch_working_flag() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let output = csa_cmd(tmp.path())
         .args(["run", "--help"])
@@ -338,11 +338,13 @@ fn run_help_displays_allow_base_branch_commit_flag() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("--allow-base-branch-commit"));
+    assert!(stdout.contains("--allow-base-branch-working"));
+    assert!(!stdout.contains("--allow-base-branch-commit"));
+    assert!(stdout.contains("Allow working on the base branch"));
 }
 
 #[test]
-fn config_show_displays_default_allow_base_branch_commit_false() {
+fn config_show_displays_default_allow_base_branch_working_false() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_csa_project(tmp.path());
 
@@ -356,7 +358,7 @@ fn config_show_displays_default_allow_base_branch_commit_false() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("[run]"), "stdout: {stdout}");
     assert!(
-        stdout.contains("allow_base_branch_commit = false"),
+        stdout.contains("allow_base_branch_working = false"),
         "stdout: {stdout}"
     );
 }
@@ -464,6 +466,17 @@ fn run_on_main_with_cli_bypass_allows_guard_to_later_tool_error() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_git_repo(tmp.path(), "main");
 
+    let output =
+        run_csa_with_missing_tool(tmp.path(), tmp.path(), &["--allow-base-branch-working"]);
+
+    assert_branch_guard_allowed_to_later_error(&output);
+}
+
+#[test]
+fn run_on_main_with_deprecated_cli_bypass_alias_allows_guard_to_later_tool_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_git_repo(tmp.path(), "main");
+
     let output = run_csa_with_missing_tool(tmp.path(), tmp.path(), &["--allow-base-branch-commit"]);
 
     assert_branch_guard_allowed_to_later_error(&output);
@@ -475,7 +488,7 @@ fn daemon_run_on_main_with_cli_bypass_spawns_before_later_tool_error() {
     init_git_repo(tmp.path(), "main");
 
     let output =
-        run_csa_daemon_with_missing_tool(tmp.path(), tmp.path(), &["--allow-base-branch-commit"]);
+        run_csa_daemon_with_missing_tool(tmp.path(), tmp.path(), &["--allow-base-branch-working"]);
 
     assert_daemon_spawned_and_cleanup(&output, tmp.path(), tmp.path());
 }
@@ -486,7 +499,7 @@ fn run_on_main_with_project_config_bypass_still_refuses() {
     init_git_repo(tmp.path(), "main");
     let config_path = tmp.path().join(".csa/config.toml");
     std::fs::create_dir_all(config_path.parent().expect("config dir")).expect("create config dir");
-    std::fs::write(config_path, "[run]\nallow_base_branch_commit = true\n")
+    std::fs::write(config_path, "[run]\nallow_base_branch_working = true\n")
         .expect("write project config");
 
     let output = run_csa_with_missing_tool(tmp.path(), tmp.path(), &[]);
@@ -498,6 +511,21 @@ fn run_on_main_with_project_config_bypass_still_refuses() {
 
 #[test]
 fn run_on_main_with_trusted_global_config_bypass_allows_guard_to_later_tool_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_git_repo(tmp.path(), "main");
+    let config_path = global_config_path(tmp.path());
+    std::fs::create_dir_all(config_path.parent().expect("global config dir"))
+        .expect("create global config dir");
+    std::fs::write(config_path, "[run]\nallow_base_branch_working = true\n")
+        .expect("write global config");
+
+    let output = run_csa_with_missing_tool(tmp.path(), tmp.path(), &[]);
+
+    assert_branch_guard_allowed_to_later_error(&output);
+}
+
+#[test]
+fn run_on_main_with_legacy_trusted_global_config_bypass_allows_guard_to_later_tool_error() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_git_repo(tmp.path(), "main");
     let config_path = global_config_path(tmp.path());

--- a/crates/cli-sub-agent/tests/daemon_stderr_e2e.rs
+++ b/crates/cli-sub-agent/tests/daemon_stderr_e2e.rs
@@ -181,7 +181,7 @@ fn daemon_child_err_path_captures_stderr_and_writes_completion() {
     // but fails during resolve_alias in handle_run → Err.
     // --force-ignore-tier-setting bypasses tier enforcement so the alias
     // resolution actually runs (not blocked by tier check).
-    // --allow-base-branch-commit keeps this non-repo daemon stderr test focused
+    // --allow-base-branch-working keeps this non-repo daemon stderr test focused
     // on the alias-resolution error path.
     let child = Command::new(env!("CARGO_BIN_EXE_csa"))
         .args([
@@ -194,7 +194,7 @@ fn daemon_child_err_path_captures_stderr_and_writes_completion() {
             "--force-ignore-tier-setting",
             "--tool",
             "bogus-tool-xyz",
-            "--allow-base-branch-commit",
+            "--allow-base-branch-working",
             "--no-idle-timeout",
             "--timeout",
             "1800",

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -690,7 +690,7 @@ fn run_direct_tool_tier_rejection_surfaces_cause_and_session_id() {
             "--no-daemon",
             "--tool",
             "codex",
-            "--allow-base-branch-commit",
+            "--allow-base-branch-working",
             "--no-idle-timeout",
             "--timeout",
             "1800",

--- a/crates/csa-config/src/config_session.rs
+++ b/crates/csa-config/src/config_session.rs
@@ -51,19 +51,19 @@ impl PostExecGateConfig {
 /// Run-command behavior (`[run]` in config).
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct RunConfig {
-    /// Allow `csa run` to execute on protected base branches.
+    /// Allow `csa run` to work on protected base branches.
     ///
     /// This is only honored from trusted user/global config or the explicit CLI
     /// flag; project-local config cannot disable the run branch guard.
-    #[serde(default)]
-    pub allow_base_branch_commit: bool,
+    #[serde(default, alias = "allow_base_branch_commit")]
+    pub allow_base_branch_working: bool,
     #[serde(default)]
     pub post_exec_gate: PostExecGateConfig,
 }
 
 impl RunConfig {
     pub fn is_default(&self) -> bool {
-        !self.allow_base_branch_commit && self.post_exec_gate.is_default()
+        !self.allow_base_branch_working && self.post_exec_gate.is_default()
     }
 }
 


### PR DESCRIPTION
## Summary

- Rename `--allow-base-branch-commit` to `--allow-base-branch-working` — the old name implied committing was required, but many valid use cases (research, review, exploration) are read-only
- Keep `--allow-base-branch-commit` as a hidden deprecated alias for backward compatibility
- Updated all internal field names and references

Closes #1268

## Test plan

- [x] `just pre-commit` passes
- [x] Review: PASS (verdict=CLEAN, 0 findings)

Co-Authored-By: codex <noreply@openai.com>