### PR TITLE
feat(prompt): add experimental prompt caching boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.651"
+version = "0.1.652"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.651"
+version = "0.1.652"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -371,7 +371,9 @@ struct LookupResolution {
 }
 
 fn is_global_only_key(key: &str) -> bool {
-    key.starts_with("kv_cache.") || key.starts_with("state_dir.")
+    key.starts_with("experimental.")
+        || key.starts_with("kv_cache.")
+        || key.starts_with("state_dir.")
 }
 
 #[derive(Debug, Clone)]
@@ -689,7 +691,10 @@ fn build_global_display_toml(config: &GlobalConfig) -> Result<toml::Value> {
 
 #[cfg(test)]
 fn resolve_effective_global_key(key: &str) -> Result<Option<toml::Value>> {
-    if !(key.starts_with("execution.") || key.starts_with("kv_cache.")) {
+    if !(key.starts_with("execution.")
+        || key.starts_with("experimental.")
+        || key.starts_with("kv_cache."))
+    {
         return Ok(None);
     }
 
@@ -734,6 +739,10 @@ pub(crate) fn handle_config_validate(cd: Option<String>) -> Result<()> {
 #[cfg(test)]
 #[path = "config_cmds_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "config_cmds_experimental_tests.rs"]
+mod experimental_tests;
 
 #[cfg(test)]
 #[path = "config_cmds_transport_display_tests.rs"]

--- a/crates/cli-sub-agent/src/config_cmds_experimental_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_experimental_tests.rs
@@ -1,0 +1,80 @@
+use super::*;
+use crate::test_env_lock::TEST_ENV_LOCK;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn write_global_config(contents: &str) {
+    let read_path =
+        csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
+    std::fs::create_dir_all(read_path.parent().expect("user config dir")).unwrap();
+    std::fs::write(&read_path, contents).unwrap();
+
+    let write_path = csa_config::GlobalConfig::config_path().expect("resolve global config path");
+    if write_path != read_path {
+        std::fs::create_dir_all(write_path.parent().expect("global config dir")).unwrap();
+        std::fs::write(&write_path, contents).unwrap();
+    }
+}
+
+#[test]
+fn resolve_effective_global_key_uses_experimental_defaults_when_global_config_missing() {
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let dir = tempfile::tempdir().unwrap();
+    let config_root = dir.path().join("xdg-config");
+    std::fs::create_dir_all(&config_root).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", dir.path());
+    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+
+    let value = resolve_effective_global_key("experimental.enable_prompt_caching")
+        .unwrap()
+        .expect("global prompt caching flag should resolve");
+
+    assert_eq!(value.as_bool(), Some(false));
+}
+
+#[test]
+fn resolve_effective_global_key_uses_configured_experimental_prompt_caching() {
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let dir = tempfile::tempdir().unwrap();
+    let config_root = dir.path().join("xdg-config");
+    std::fs::create_dir_all(&config_root).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", dir.path());
+    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+
+    write_global_config(
+        r#"
+[experimental]
+enable_prompt_caching = true
+"#,
+    );
+
+    let value = resolve_effective_global_key("experimental.enable_prompt_caching")
+        .unwrap()
+        .expect("configured prompt caching flag should resolve");
+
+    assert_eq!(value.as_bool(), Some(true));
+}

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -24,6 +24,9 @@ pub(crate) mod gate;
 #[path = "pipeline_prompt_guard.rs"]
 pub(crate) mod prompt_guard;
 
+#[path = "pipeline_prompt_cache.rs"]
+mod prompt_cache;
+
 #[path = "pipeline_changed_paths.rs"]
 pub(crate) mod changed_paths;
 

--- a/crates/cli-sub-agent/src/pipeline_design_context.rs
+++ b/crates/cli-sub-agent/src/pipeline_design_context.rs
@@ -10,36 +10,41 @@ use std::path::Path;
 
 use tracing::{debug, info};
 
-/// Inject project context and design context into the prompt on first turn.
-///
-/// Loads CLAUDE.md/AGENTS.md via [`csa_executor::load_project_context`] and
-/// prepends them to the prompt. Then checks for design context and appends it.
-pub(crate) fn inject_first_turn_context(
+#[derive(Debug, Default)]
+pub(crate) struct FirstTurnContext {
+    pub project_context: Option<String>,
+    pub design_context: Option<String>,
+}
+
+/// Load project context and design context for the first turn of a session.
+pub(crate) fn load_first_turn_context(
     session_project_path: &str,
     project_root: &Path,
     context_load_options: Option<&csa_executor::ContextLoadOptions>,
-    prompt: &mut String,
-) {
+) -> FirstTurnContext {
     // Project context (CLAUDE.md, AGENTS.md).
     let opts = context_load_options.cloned().unwrap_or_default();
     let files = csa_executor::load_project_context(Path::new(session_project_path), &opts);
-    if !files.is_empty() {
+    let project_context = if files.is_empty() {
+        None
+    } else {
         let ctx = csa_executor::format_context_for_prompt(&files);
         info!(
             files = files.len(),
             bytes = ctx.len(),
             "Injecting project context"
         );
-        *prompt = format!("{ctx}{prompt}");
-    }
+        Some(ctx)
+    };
 
     // Design context from TODO plan's design.md reference.
-    if let Some(dc) = load_design_context(project_root) {
+    let design_context = load_design_context(project_root).inspect(|dc| {
         info!(bytes = dc.len(), "Injecting design context into prompt");
-        if !prompt.ends_with('\n') {
-            prompt.push('\n');
-        }
-        prompt.push_str(&dc);
+    });
+
+    FirstTurnContext {
+        project_context,
+        design_context,
     }
 }
 

--- a/crates/cli-sub-agent/src/pipeline_prompt_cache.rs
+++ b/crates/cli-sub-agent/src/pipeline_prompt_cache.rs
@@ -1,0 +1,163 @@
+//! Prompt assembly helpers for experimental KV-cache-friendly ordering.
+
+use crate::pipeline::design_context::FirstTurnContext;
+
+pub(crate) const STATIC_START: &str = "<!-- CSA:CACHE_BOUNDARY:STATIC_START -->";
+pub(crate) const STATIC_END: &str = "<!-- CSA:CACHE_BOUNDARY:STATIC_END -->";
+
+#[derive(Debug)]
+pub(crate) struct PromptAssembly {
+    enable_prompt_caching: bool,
+    static_sections: Vec<String>,
+    dynamic_prompt: String,
+}
+
+impl PromptAssembly {
+    pub(crate) fn new(dynamic_prompt: String, enable_prompt_caching: bool) -> Self {
+        Self {
+            enable_prompt_caching,
+            static_sections: Vec::new(),
+            dynamic_prompt,
+        }
+    }
+
+    pub(crate) fn prepend_dynamic(&mut self, prefix: &str) {
+        self.dynamic_prompt = format!("{prefix}{}", self.dynamic_prompt);
+    }
+
+    pub(crate) fn add_first_turn_context(&mut self, context: FirstTurnContext) {
+        if let Some(project_context) = context.project_context {
+            if self.enable_prompt_caching {
+                self.static_sections.push(project_context);
+            } else {
+                self.dynamic_prompt = format!("{project_context}{}", self.dynamic_prompt);
+            }
+        }
+
+        if let Some(design_context) = context.design_context {
+            if !self.dynamic_prompt.ends_with('\n') {
+                self.dynamic_prompt.push('\n');
+            }
+            self.dynamic_prompt.push_str(&design_context);
+        }
+    }
+
+    pub(crate) fn dynamic_prompt_mut(&mut self) -> &mut String {
+        &mut self.dynamic_prompt
+    }
+
+    pub(crate) fn add_restriction_instructions(&mut self, instructions: Option<&str>) {
+        let Some(instructions) = instructions else {
+            return;
+        };
+        if self.enable_prompt_caching {
+            self.static_sections.push(instructions.to_string());
+        } else {
+            self.dynamic_prompt = format!("{instructions}\n\n{}", self.dynamic_prompt);
+        }
+    }
+
+    pub(crate) fn append_dynamic_block(&mut self, block: &str) {
+        self.dynamic_prompt = format!("{}\n\n{block}", self.dynamic_prompt);
+    }
+
+    pub(crate) fn add_static_or_append_dynamic(&mut self, section: &str) {
+        if self.enable_prompt_caching {
+            self.static_sections.push(section.to_string());
+        } else {
+            self.dynamic_prompt.push_str(section);
+        }
+    }
+
+    pub(crate) fn finish(self) -> String {
+        if !self.enable_prompt_caching || self.static_sections.is_empty() {
+            return self.dynamic_prompt;
+        }
+
+        let mut output = String::new();
+        output.push_str(STATIC_START);
+        output.push('\n');
+        for section in self.static_sections {
+            if section.is_empty() {
+                continue;
+            }
+            output.push_str(&section);
+            if !output.ends_with('\n') {
+                output.push('\n');
+            }
+            output.push('\n');
+        }
+        output.push_str(STATIC_END);
+        output.push('\n');
+        output.push_str(&self.dynamic_prompt);
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn first_turn_context() -> FirstTurnContext {
+        FirstTurnContext {
+            project_context: Some(
+                "<context-file path=\"CLAUDE.md\">\nstatic\n</context-file>\n\n".to_string(),
+            ),
+            design_context: Some("<design-context>\ndynamic design\n</design-context>".to_string()),
+        }
+    }
+
+    #[test]
+    fn disabled_preserves_legacy_order_without_markers() {
+        let mut assembly = PromptAssembly::new("user task".to_string(), false);
+        assembly.add_first_turn_context(first_turn_context());
+        assembly
+            .dynamic_prompt_mut()
+            .push_str("\n<memory>dynamic</memory>");
+        assembly.add_restriction_instructions(Some("STATIC RESTRICTION"));
+        assembly.add_static_or_append_dynamic("\n\n<csa-output-format>static</csa-output-format>");
+
+        let prompt = assembly.finish();
+
+        assert!(!prompt.contains(STATIC_START));
+        assert!(!prompt.contains(STATIC_END));
+        assert!(prompt.starts_with("STATIC RESTRICTION\n\n<context-file"));
+        assert!(prompt.contains("user task\n<design-context>"));
+        assert!(prompt.ends_with("<csa-output-format>static</csa-output-format>"));
+    }
+
+    #[test]
+    fn enabled_groups_static_block_before_dynamic_prompt() {
+        let mut assembly = PromptAssembly::new("user task".to_string(), true);
+        assembly.prepend_dynamic("dynamic warning\n");
+        assembly.add_first_turn_context(first_turn_context());
+        assembly
+            .dynamic_prompt_mut()
+            .push_str("\n<memory>dynamic</memory>");
+        assembly.add_restriction_instructions(Some("STATIC RESTRICTION"));
+        assembly.add_static_or_append_dynamic("\n\n<csa-output-format>static</csa-output-format>");
+        assembly.append_dynamic_block("<guard>dynamic guard</guard>");
+
+        let prompt = assembly.finish();
+
+        let static_start = prompt.find(STATIC_START).expect("static start marker");
+        let context = prompt.find("<context-file").expect("static context");
+        let restriction = prompt.find("STATIC RESTRICTION").expect("restriction");
+        let output_format = prompt.find("<csa-output-format>").expect("output format");
+        let static_end = prompt.find(STATIC_END).expect("static end marker");
+        let dynamic_warning = prompt.find("dynamic warning").expect("dynamic warning");
+        let user_task = prompt.find("user task").expect("user task");
+        let memory = prompt.find("<memory>dynamic</memory>").expect("memory");
+        let guard = prompt.find("<guard>dynamic guard</guard>").expect("guard");
+
+        assert_eq!(static_start, 0);
+        assert!(static_start < context);
+        assert!(context < restriction);
+        assert!(restriction < output_format);
+        assert!(output_format < static_end);
+        assert!(static_end < dynamic_warning);
+        assert!(dynamic_warning < user_task);
+        assert!(user_task < memory);
+        assert!(memory < guard);
+    }
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -1,3 +1,4 @@
+use super::prompt_cache::PromptAssembly;
 use super::prompt_guard::emit_prompt_guard_to_caller;
 use super::result_contract::{
     clear_expected_result_artifacts_for_prompt, enforce_result_toml_path_contract,
@@ -361,26 +362,28 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     let can_write_new = config.is_none_or(|cfg| cfg.can_tool_write_new(executor.tool_name()));
     debug!(tool = %executor.tool_name(), can_edit, can_write_new, "Restriction flags resolved");
     let raw_prompt = prompt.to_string();
-    let mut effective_prompt = raw_prompt.clone();
+    let prompt_caching_enabled =
+        global_config.is_some_and(|cfg| cfg.experimental.enable_prompt_caching);
+    let mut prompt_assembly = PromptAssembly::new(raw_prompt.clone(), prompt_caching_enabled);
     if let Err(err) = crate::preflight_state_dir::enforce_state_dir_cap(global_config) {
         return Err(persist_pre_exec_failure(err));
     }
     if (session_arg.is_none() || fresh_spawn_preflight_override)
         && let Some(w) = crate::preflight_state_dir::run_state_dir_preflight(global_config)
     {
-        effective_prompt = format!("{w}{effective_prompt}");
+        prompt_assembly.prepend_dynamic(&w);
     }
     let is_first_turn = session
         .tools
         .get(executor.tool_name())
         .is_none_or(|ts| ts.provider_session_id.is_none());
     if is_first_turn {
-        super::design_context::inject_first_turn_context(
+        let first_turn_context = super::design_context::load_first_turn_context(
             &session.project_path,
             project_root,
             context_load_options,
-            &mut effective_prompt,
         );
+        prompt_assembly.add_first_turn_context(first_turn_context);
     }
     let is_review_or_debate = matches!(task_type, Some("review" | "debate"));
     if !is_review_or_debate {
@@ -395,7 +398,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             memory_project_key.as_deref(),
             project_root,
             executor.tool_name(),
-            &mut effective_prompt,
+            prompt_assembly.dynamic_prompt_mut(),
         );
     }
     if !can_edit || !can_write_new {
@@ -405,7 +408,9 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             can_write_new,
             "Applying filesystem restrictions via prompt injection"
         );
-        effective_prompt = executor.apply_restrictions(&effective_prompt, can_edit, can_write_new);
+        prompt_assembly.add_restriction_instructions(
+            executor.restriction_instructions(can_edit, can_write_new),
+        );
     }
     let edit_guard = if !can_edit {
         crate::edit_restriction_guard::maybe_capture_tracked_file_guard(project_root)?
@@ -511,7 +516,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
                 "Injecting prompt guard output into effective prompt"
             );
             emit_prompt_guard_to_caller(&guard_block, guard_results.len());
-            effective_prompt = format!("{effective_prompt}\n\n{guard_block}");
+            prompt_assembly.append_dynamic_block(&guard_block);
         }
     }
     // Inject structured output section markers when enabled in config.
@@ -520,8 +525,9 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         csa_executor::structured_output_instructions(structured_output_enabled)
     {
         info!("Injecting structured output instructions into prompt");
-        effective_prompt.push_str(instructions);
+        prompt_assembly.add_static_or_append_dynamic(instructions);
     }
+    let effective_prompt = prompt_assembly.finish();
     // Resolve sandbox configuration from project config and enforcement mode.
     let liveness_dead_seconds = resolve_liveness_dead_seconds(config);
     let mut execute_options = match crate::pipeline_sandbox::resolve_sandbox_options(

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -71,6 +71,15 @@ pub struct GlobalConfig {
         skip_serializing_if = "crate::config_filesystem_sandbox::FilesystemSandboxConfig::is_default"
     )]
     pub filesystem_sandbox: crate::config_filesystem_sandbox::FilesystemSandboxConfig,
+    /// Experimental feature flags.
+    #[serde(default)]
+    pub experimental: ExperimentalConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExperimentalConfig {
+    #[serde(default)]
+    pub enable_prompt_caching: bool,
 }
 
 /// Configuration for `csa session wait`.

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -79,6 +79,10 @@ same_model_fallback = true
 [fallback]
 cloud_review_exhausted = "ask-user"
 
+# Experimental feature flags. Disabled by default.
+[experimental]
+enable_prompt_caching = false
+
 # KV cache-aware polling defaults.
 # `frequent_poll_seconds`: fast external state (GitHub API, bot responses).
 # `long_poll_seconds`: long waits that return control before the caller cache goes cold.

--- a/crates/csa-config/src/global_tests_heterogeneous.rs
+++ b/crates/csa-config/src/global_tests_heterogeneous.rs
@@ -69,6 +69,22 @@ max_concurrent = 3
 }
 
 #[test]
+fn test_experimental_prompt_caching_defaults_to_false() {
+    let config: GlobalConfig = toml::from_str("").unwrap();
+    assert!(!config.experimental.enable_prompt_caching);
+}
+
+#[test]
+fn test_experimental_prompt_caching_can_be_enabled() {
+    let toml_str = r#"
+[experimental]
+enable_prompt_caching = true
+"#;
+    let config: GlobalConfig = toml::from_str(toml_str).unwrap();
+    assert!(config.experimental.enable_prompt_caching);
+}
+
+#[test]
 fn test_all_known_tools() {
     let tools = all_known_tools();
     assert_eq!(tools.len(), 5);

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -39,10 +39,10 @@ pub use config_tool::{TransportKind, default_transport_for_tool};
 pub use gc::GcConfig;
 pub use global::{
     AiConfigSymlinkCheckConfig, DEFAULT_KV_CACHE_FREQUENT_POLL_SECS,
-    DEFAULT_KV_CACHE_LONG_POLL_SECS, ExecutionEnvOptions, GateMode, GateStep, GlobalConfig,
-    GlobalMcpConfig, KvCacheConfig, KvCacheValueSource, LEGACY_SESSION_WAIT_FALLBACK_SECS,
-    PreflightConfig, ResolvedKvCacheValue, ReviewConfig, SessionWaitConfig, StateDirConfig,
-    StateDirOnExceed, ToolSelection,
+    DEFAULT_KV_CACHE_LONG_POLL_SECS, ExecutionEnvOptions, ExperimentalConfig, GateMode, GateStep,
+    GlobalConfig, GlobalMcpConfig, KvCacheConfig, KvCacheValueSource,
+    LEGACY_SESSION_WAIT_FALLBACK_SECS, PreflightConfig, ResolvedKvCacheValue, ReviewConfig,
+    SessionWaitConfig, StateDirConfig, StateDirOnExceed, ToolSelection,
 };
 pub use init::{detect_installed_tools, init_project};
 pub use mcp::{McpFilter, McpRegistry, McpServerConfig, McpTransport};

--- a/crates/csa-executor/src/executor_restrictions.rs
+++ b/crates/csa-executor/src/executor_restrictions.rs
@@ -1,6 +1,33 @@
 use super::Executor;
 
 impl Executor {
+    pub fn restriction_instructions(
+        &self,
+        allow_edit: bool,
+        allow_write_new: bool,
+    ) -> Option<&'static str> {
+        if !allow_edit && !allow_write_new {
+            Some(
+                "IMPORTANT RESTRICTION: You are in READ-ONLY mode. \
+                 You MUST NOT edit existing files, create new files, or run commands \
+                 that modify the filesystem. You may ONLY perform read-only analysis, \
+                 search, and reporting.",
+            )
+        } else if !allow_edit {
+            Some(
+                "IMPORTANT RESTRICTION: You MUST NOT edit or modify any existing files. \
+                 You may only create new files or perform read-only analysis.",
+            )
+        } else if !allow_write_new {
+            Some(
+                "IMPORTANT RESTRICTION: You MUST NOT create new files. \
+                 You may only edit existing files or perform read-only analysis.",
+            )
+        } else {
+            None
+        }
+    }
+
     /// Apply restrictions by modifying the prompt to include restriction instructions.
     /// Returns the modified prompt.
     ///
@@ -12,23 +39,8 @@ impl Executor {
         allow_edit: bool,
         allow_write_new: bool,
     ) -> String {
-        if !allow_edit && !allow_write_new {
-            format!(
-                "IMPORTANT RESTRICTION: You are in READ-ONLY mode. \
-                 You MUST NOT edit existing files, create new files, or run commands \
-                 that modify the filesystem. You may ONLY perform read-only analysis, \
-                 search, and reporting.\n\n{prompt}"
-            )
-        } else if !allow_edit {
-            format!(
-                "IMPORTANT RESTRICTION: You MUST NOT edit or modify any existing files. \
-                 You may only create new files or perform read-only analysis.\n\n{prompt}"
-            )
-        } else if !allow_write_new {
-            format!(
-                "IMPORTANT RESTRICTION: You MUST NOT create new files. \
-                 You may only edit existing files or perform read-only analysis.\n\n{prompt}"
-            )
+        if let Some(instructions) = self.restriction_instructions(allow_edit, allow_write_new) {
+            format!("{instructions}\n\n{prompt}")
         } else {
             prompt.to_string()
         }

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -264,10 +264,37 @@ pub fn git_wrapper_script() -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use crate::test_support::ENV_LOCK;
+
     use super::{git_wrapper_script, inject_git_guard_env};
     use std::collections::HashMap;
     #[cfg(unix)]
+    use std::io::Write;
+    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    use std::path::Path;
+    #[cfg(unix)]
+    use std::time::Duration;
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path, contents: impl AsRef<[u8]>) {
+        let mut file = std::fs::File::create(path).unwrap();
+        file.write_all(contents.as_ref()).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        for attempt in 0..5 {
+            match std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)) {
+                Ok(()) => return,
+                Err(err) if err.raw_os_error() == Some(libc::ETXTBSY) && attempt < 4 => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(err) => panic!("failed to mark {} executable: {err}", path.display()),
+            }
+        }
+    }
 
     #[test]
     fn inject_git_guard_env_sets_real_git_and_path() {
@@ -285,22 +312,20 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn wrapper_blocks_no_verify_before_real_git() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
         let temp = tempfile::tempdir().unwrap();
         let wrapper = temp.path().join("git");
-        std::fs::write(&wrapper, git_wrapper_script()).unwrap();
-        std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+        write_executable(&wrapper, git_wrapper_script());
 
         let fake_git = temp.path().join("real-git");
         let marker = temp.path().join("called");
-        std::fs::write(
+        write_executable(
             &fake_git,
             format!(
                 "#!/usr/bin/env bash\necho called > '{}'\n",
                 marker.display()
             ),
-        )
-        .unwrap();
-        std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+        );
 
         let output = std::process::Command::new(&wrapper)
             .arg("commit")
@@ -317,22 +342,20 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn wrapper_blocks_lefthook_bypass_env_before_real_git() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
         let temp = tempfile::tempdir().unwrap();
         let wrapper = temp.path().join("git");
-        std::fs::write(&wrapper, git_wrapper_script()).unwrap();
-        std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+        write_executable(&wrapper, git_wrapper_script());
 
         let fake_git = temp.path().join("real-git");
         let marker = temp.path().join("called");
-        std::fs::write(
+        write_executable(
             &fake_git,
             format!(
                 "#!/usr/bin/env bash\necho called > '{}'\n",
                 marker.display()
             ),
-        )
-        .unwrap();
-        std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+        );
 
         let output = std::process::Command::new(&wrapper)
             .arg("commit")
@@ -351,14 +374,13 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn wrapper_allows_long_commit_options_containing_n() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
         let temp = tempfile::tempdir().unwrap();
         let wrapper = temp.path().join("git");
-        std::fs::write(&wrapper, git_wrapper_script()).unwrap();
-        std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+        write_executable(&wrapper, git_wrapper_script());
 
         let fake_git = temp.path().join("real-git");
-        std::fs::write(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n").unwrap();
-        std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+        write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
 
         let output = std::process::Command::new(&wrapper)
             .arg("commit")
@@ -377,14 +399,13 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn wrapper_forwards_non_commit_commands() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
         let temp = tempfile::tempdir().unwrap();
         let wrapper = temp.path().join("git");
-        std::fs::write(&wrapper, git_wrapper_script()).unwrap();
-        std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+        write_executable(&wrapper, git_wrapper_script());
 
         let fake_git = temp.path().join("real-git");
-        std::fs::write(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n").unwrap();
-        std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+        write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
 
         let output = std::process::Command::new(&wrapper)
             .arg("status")

--- a/crates/csa-hooks/src/guard_tests.rs
+++ b/crates/csa-hooks/src/guard_tests.rs
@@ -142,6 +142,8 @@ fn test_xml_escape_no_double_escape() {
 
 #[cfg(unix)]
 mod unix_tests {
+    use crate::test_support::ENV_LOCK;
+
     use super::*;
 
     fn test_context() -> GuardContext {
@@ -155,6 +157,27 @@ mod unix_tests {
         }
     }
 
+    fn run_test_prompt_guards(
+        guards: &[PromptGuardEntry],
+        context: &GuardContext,
+    ) -> Vec<PromptGuardResult> {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        run_prompt_guards(guards, context)
+    }
+
+    fn command_output(command: &mut std::process::Command) -> std::process::Output {
+        for attempt in 0..5 {
+            match command.output() {
+                Ok(output) => return output,
+                Err(err) if err.raw_os_error() == Some(libc::ETXTBSY) && attempt < 4 => {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(err) => panic!("failed to run command: {err}"),
+            }
+        }
+        unreachable!("bounded retry loop always returns or panics")
+    }
+
     #[test]
     fn test_run_guards_stdout_capture() {
         let guards = vec![PromptGuardEntry {
@@ -163,7 +186,7 @@ mod unix_tests {
             timeout_secs: 5,
         }];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "test-guard");
         assert_eq!(results[0].output, "Hello from guard");
@@ -177,7 +200,7 @@ mod unix_tests {
             timeout_secs: 5,
         }];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert!(results.is_empty(), "Empty stdout should be filtered out");
     }
 
@@ -189,7 +212,7 @@ mod unix_tests {
             timeout_secs: 5,
         }];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert!(results.is_empty(), "Non-zero exit guard should be skipped");
     }
 
@@ -201,7 +224,7 @@ mod unix_tests {
             timeout_secs: 1,
         }];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert!(results.is_empty(), "Timed-out guard should be skipped");
     }
 
@@ -220,7 +243,7 @@ mod unix_tests {
             },
         ];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].name, "first");
         assert_eq!(results[0].output, "Guard 1 output");
@@ -239,7 +262,7 @@ mod unix_tests {
         }];
 
         let ctx = test_context();
-        let results = run_prompt_guards(&guards, &ctx);
+        let results = run_test_prompt_guards(&guards, &ctx);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].output, "codex");
     }
@@ -252,14 +275,14 @@ mod unix_tests {
             timeout_secs: 5,
         }];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert!(results.is_empty(), "Missing script guard should be skipped");
     }
 
     #[test]
     fn test_run_guards_empty_list() {
         let guards: Vec<PromptGuardEntry> = vec![];
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert!(results.is_empty());
     }
 
@@ -283,7 +306,7 @@ mod unix_tests {
             },
         ];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].name, "good");
         assert_eq!(results[1].name, "good2");
@@ -297,7 +320,7 @@ mod unix_tests {
             timeout_secs: 5,
         }];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].output, "trimmed");
     }
@@ -312,7 +335,7 @@ mod unix_tests {
             timeout_secs: 5,
         }];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert_eq!(results.len(), 1);
         assert!(
             results[0].output.len() <= super::MAX_GUARD_OUTPUT_BYTES,
@@ -335,7 +358,7 @@ mod unix_tests {
         }];
 
         let start = std::time::Instant::now();
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert!(
             start.elapsed() < std::time::Duration::from_secs(3),
             "Must not hang waiting for background process, took {:?}",
@@ -357,7 +380,7 @@ mod unix_tests {
         }];
 
         let start = std::time::Instant::now();
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert!(
             start.elapsed() < std::time::Duration::from_secs(4),
             "Must not hang on setsid-detached process, took {:?}",
@@ -379,7 +402,7 @@ mod unix_tests {
         }];
 
         let start = std::time::Instant::now();
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         // Must complete well before timeout — proves no pipe deadlock.
         assert!(
             start.elapsed() < std::time::Duration::from_secs(3),
@@ -419,7 +442,7 @@ mod unix_tests {
             timeout_secs: 1,
         }];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert!(
             results.is_empty(),
             "Timed-out guard should produce no results"
@@ -464,7 +487,7 @@ mod unix_tests {
             timeout_secs: 10,
         }];
 
-        let results = run_prompt_guards(&guards, &test_context());
+        let results = run_test_prompt_guards(&guards, &test_context());
         assert_eq!(results.len(), 1);
         // Should have captured 1024 'a' characters (plus newlines, trimmed)
         let a_count = results[0].output.chars().filter(|&c| c == 'a').count();
@@ -494,7 +517,7 @@ mod unix_tests {
         // or non-git dirs it produces empty output. Both are valid.
         let guards = builtin_prompt_guards();
         let context_guard = &guards[0];
-        let results = run_prompt_guards(std::slice::from_ref(context_guard), &test_context());
+        let results = run_test_prompt_guards(std::slice::from_ref(context_guard), &test_context());
         assert!(
             results.len() <= 1,
             "branch-context should produce at most one result, got {}",
@@ -510,21 +533,21 @@ mod unix_tests {
         let tmp_path = tmp.path();
 
         // Initialize a git repo with a commit and create a feature branch.
-        std::process::Command::new("git")
-            .args(["init"])
-            .current_dir(tmp_path)
-            .output()
-            .unwrap();
-        std::process::Command::new("git")
-            .args(["commit", "--allow-empty", "-m", "init"])
-            .current_dir(tmp_path)
-            .output()
-            .unwrap();
-        std::process::Command::new("git")
-            .args(["checkout", "-b", "feat/test-branch"])
-            .current_dir(tmp_path)
-            .output()
-            .unwrap();
+        command_output(
+            std::process::Command::new("git")
+                .args(["init"])
+                .current_dir(tmp_path),
+        );
+        command_output(
+            std::process::Command::new("git")
+                .args(["commit", "--allow-empty", "-m", "init"])
+                .current_dir(tmp_path),
+        );
+        command_output(
+            std::process::Command::new("git")
+                .args(["checkout", "-b", "feat/test-branch"])
+                .current_dir(tmp_path),
+        );
 
         let guards = builtin_prompt_guards();
         let context_guard = &guards[0];
@@ -535,7 +558,7 @@ mod unix_tests {
             is_resume: false,
             cwd: tmp_path.to_string_lossy().to_string(),
         };
-        let results = run_prompt_guards(std::slice::from_ref(context_guard), &ctx);
+        let results = run_test_prompt_guards(std::slice::from_ref(context_guard), &ctx);
         assert_eq!(results.len(), 1, "Should produce output on feature branch");
         assert!(
             results[0].output.contains("BRANCH CONTEXT"),
@@ -560,16 +583,16 @@ mod unix_tests {
         let tmp = tempfile::tempdir().unwrap();
         let tmp_path = tmp.path();
 
-        std::process::Command::new("git")
-            .args(["init", "-b", "main"])
-            .current_dir(tmp_path)
-            .output()
-            .unwrap();
-        std::process::Command::new("git")
-            .args(["commit", "--allow-empty", "-m", "init"])
-            .current_dir(tmp_path)
-            .output()
-            .unwrap();
+        command_output(
+            std::process::Command::new("git")
+                .args(["init", "-b", "main"])
+                .current_dir(tmp_path),
+        );
+        command_output(
+            std::process::Command::new("git")
+                .args(["commit", "--allow-empty", "-m", "init"])
+                .current_dir(tmp_path),
+        );
 
         let guards = builtin_prompt_guards();
         let context_guard = &guards[0];
@@ -580,7 +603,7 @@ mod unix_tests {
             is_resume: false,
             cwd: tmp_path.to_string_lossy().to_string(),
         };
-        let results = run_prompt_guards(std::slice::from_ref(context_guard), &ctx);
+        let results = run_test_prompt_guards(std::slice::from_ref(context_guard), &ctx);
         assert!(
             results.is_empty(),
             "branch-context should be silent on main, got {} result(s)",
@@ -595,7 +618,7 @@ mod unix_tests {
         // branches it produces empty output. Both are valid outcomes.
         let guards = builtin_prompt_guards();
         let branch_guard = &guards[1];
-        let _results = run_prompt_guards(std::slice::from_ref(branch_guard), &test_context());
+        let _results = run_test_prompt_guards(std::slice::from_ref(branch_guard), &test_context());
         // No assertion on output content — just verify no panic/timeout.
     }
 
@@ -606,7 +629,7 @@ mod unix_tests {
         // reminder (1 result). Both are valid.
         let guards = builtin_prompt_guards();
         let dirty_guard = &guards[2];
-        let results = run_prompt_guards(std::slice::from_ref(dirty_guard), &test_context());
+        let results = run_test_prompt_guards(std::slice::from_ref(dirty_guard), &test_context());
         assert!(
             results.len() <= 1,
             "dirty-tree-reminder should produce at most one result, got {}",
@@ -621,7 +644,7 @@ mod unix_tests {
         // unpushed commits (0 or 1 result). Both are valid.
         let guards = builtin_prompt_guards();
         let workflow_guard = &guards[3];
-        let results = run_prompt_guards(std::slice::from_ref(workflow_guard), &test_context());
+        let results = run_test_prompt_guards(std::slice::from_ref(workflow_guard), &test_context());
         assert!(
             results.len() <= 1,
             "commit-workflow should produce at most one result, got {}",

--- a/crates/csa-hooks/src/mempal_capture.rs
+++ b/crates/csa-hooks/src/mempal_capture.rs
@@ -406,6 +406,7 @@ mod tests {
     fn executable_mempal_script(path: &Path, body: &str) {
         let mut script = fs::File::create(path).expect("create fake mempal");
         write!(script, "{body}").expect("write fake mempal");
+        script.sync_all().expect("sync fake mempal");
         drop(script);
 
         #[cfg(unix)]
@@ -413,7 +414,15 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             let mut perms = fs::metadata(path).expect("metadata").permissions();
             perms.set_mode(0o755);
-            fs::set_permissions(path, perms).expect("chmod");
+            for attempt in 0..5 {
+                match fs::set_permissions(path, perms.clone()) {
+                    Ok(()) => return,
+                    Err(err) if err.raw_os_error() == Some(libc::ETXTBSY) && attempt < 4 => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(err) => panic!("chmod fake mempal: {err}"),
+                }
+            }
         }
     }
 
@@ -520,23 +529,14 @@ mod tests {
         let log_path = temp.path().join("args.log");
         let stdin_path = temp.path().join("stdin.json");
         let script_path = temp.path().join("mempal-fake.sh");
-        let mut script = fs::File::create(&script_path).expect("create fake mempal");
-        writeln!(
-            script,
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\ncat > '{}'\n",
-            log_path.display(),
-            stdin_path.display()
-        )
-        .expect("write fake mempal");
-        drop(script);
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&script_path, perms).expect("chmod");
-        }
+        executable_mempal_script(
+            &script_path,
+            &format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\ncat > '{}'\n",
+                log_path.display(),
+                stdin_path.display()
+            ),
+        );
 
         let input_dir = temp.path().join("01ABCSESSION");
         fs::create_dir(&input_dir).expect("create input dir");
@@ -568,28 +568,19 @@ mod tests {
         let temp = tempfile::tempdir().expect("create tempdir");
         let log_path = temp.path().join("args.log");
         let script_path = temp.path().join("mempal-fake.sh");
-        let mut script = fs::File::create(&script_path).expect("create fake mempal");
-        writeln!(
-            script,
-            r#"#!/bin/sh
+        executable_mempal_script(
+            &script_path,
+            &format!(
+                r#"#!/bin/sh
 if [ "$2" = "--stdin" ]; then
   cat >/dev/null
   exit 2
 fi
 printf '%s\n' "$@" > '{}'
 "#,
-            log_path.display()
-        )
-        .expect("write fake mempal");
-        drop(script);
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&script_path, perms).expect("chmod");
-        }
+                log_path.display()
+            ),
+        );
 
         let input_dir = temp.path().join("session-output");
         fs::create_dir(&input_dir).expect("create input dir");

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.627"
-weave = "0.1.627"
+csa = "0.1.652"
+weave = "0.1.652"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Add `[experimental].enable_prompt_caching` config field (default: false)
- When enabled, prompt assembly wraps static content (rules, skills, tool configs) with `CSA:CACHE_BOUNDARY` markers, separating it from dynamic content (git state, session context)
- Static content is grouped contiguously at the top of injected prompts to maximize KV cache prefix hit rate
- No behavior change when disabled (the default)

Closes #1269

## Test plan

- [x] `just pre-commit` passes
- [x] Config parsing tests verify default=false and override=true
- [x] Review: PASS (verdict=CLEAN, 0 findings)

Co-Authored-By: codex <noreply@openai.com>