### PR TITLE
feat(cli): add csa hunt subcommand for root-cause-first debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.652"
+version = "0.1.653"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.652"
+version = "0.1.653"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -282,6 +282,21 @@ pub enum Commands {
         session_id: Option<String>,
     },
 
+    /// Start a root-cause-first diagnostic debugging session
+    Hunt {
+        /// Bug description
+        description: String,
+        /// Tool to use
+        #[arg(long)]
+        tool: Option<String>,
+        /// Session timeout in seconds
+        #[arg(long, default_value = "7200")]
+        timeout: u64,
+        /// Allow working on base branch
+        #[arg(long, alias = "allow-base-branch-commit")]
+        allow_base_branch_working: bool,
+    },
+
     /// Manage sessions
     Session {
         #[command(subcommand)]

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -291,6 +291,9 @@ pub fn validate_command_args(
         Commands::Run { timeout, .. } => {
             validate_timeout(*timeout, min_timeout)?;
         }
+        Commands::Hunt { timeout, .. } => {
+            validate_timeout(Some(*timeout), min_timeout)?;
+        }
         Commands::Review(args) => {
             validate_review_args(args)?;
             if !args.check_verdict {

--- a/crates/cli-sub-agent/src/hunt_cmd.rs
+++ b/crates/cli-sub-agent/src/hunt_cmd.rs
@@ -1,0 +1,116 @@
+use anyhow::{Result, anyhow};
+use csa_core::types::{OutputFormat, ToolArg};
+
+const DIAGNOSTIC_PROMPT_PREFIX: &str = r#"DIAGNOSTIC MODE — ROOT-CAUSE-FIRST DEBUGGING
+
+You are in diagnostic hunt mode. You MUST follow this strict sequence:
+
+PHASE 1 — INVESTIGATE (read-only)
+- Read code, logs, error messages
+- Grep for patterns, inspect git history
+- You MUST NOT modify any files in this phase
+
+PHASE 2 — REPRODUCE
+- Write a minimal failing test or reproduction script
+- Run it to confirm the bug exists
+- The test MUST fail demonstrating the bug
+
+PHASE 3 — DIAGNOSE
+- State the root cause in ONE sentence
+- Format: ROOT_CAUSE: <your one-sentence diagnosis>
+- Explain WHY this causes the observed behavior
+
+PHASE 4 — FIX
+- Only NOW may you modify production code
+- The fix must be minimal and targeted
+- Run the reproduction test to verify the fix works
+
+SELF-DECEPTION CHECKLIST (before Phase 4):
+- [ ] Have I actually reproduced the bug, or am I guessing?
+- [ ] Is my root cause specific (names a file and line), not vague?
+- [ ] Could there be a different root cause I haven't considered?"#;
+
+pub(crate) fn build_hunt_prompt(description: &str) -> String {
+    format!("{DIAGNOSTIC_PROMPT_PREFIX}\n\nBUG DESCRIPTION:\n{description}")
+}
+
+pub(crate) async fn handle_hunt(
+    description: String,
+    tool: Option<String>,
+    timeout: u64,
+    allow_base_branch_working: bool,
+    current_depth: u32,
+    output_format: OutputFormat,
+) -> Result<i32> {
+    let tool = tool
+        .map(|raw| {
+            raw.parse::<ToolArg>()
+                .map_err(|err| anyhow!("invalid hunt tool `{raw}`: {err}"))
+        })
+        .transpose()?;
+    let prompt = build_hunt_prompt(&description);
+    let stream_mode = if matches!(output_format, OutputFormat::Text) {
+        csa_process::StreamMode::TeeToStderr
+    } else {
+        csa_process::StreamMode::BufferOnly
+    };
+
+    crate::run_cmd::handle_run(
+        tool,
+        None,
+        None,
+        None,
+        Some(prompt),
+        None,
+        None,
+        None,
+        None,
+        false,
+        None,
+        false,
+        None,
+        false,
+        None,
+        None,
+        false,
+        allow_base_branch_working,
+        None,
+        None,
+        None,
+        None,
+        false,
+        false,
+        false,
+        false,
+        None,
+        None,
+        Some(timeout),
+        false,
+        false,
+        None,
+        current_depth,
+        output_format,
+        stream_mode,
+        None,
+        false,
+        false,
+        Vec::new(),
+        Vec::new(),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_hunt_prompt;
+
+    #[test]
+    fn build_hunt_prompt_prepends_diagnostic_state_machine() {
+        let prompt = build_hunt_prompt("the command exits before writing the result");
+
+        assert!(prompt.starts_with("DIAGNOSTIC MODE — ROOT-CAUSE-FIRST DEBUGGING"));
+        assert!(prompt.contains("PHASE 1 — INVESTIGATE (read-only)"));
+        assert!(prompt.contains("ROOT_CAUSE: <your one-sentence diagnosis>"));
+        assert!(prompt.ends_with("the command exits before writing the result"));
+    }
+}

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -24,6 +24,8 @@ mod error_report;
 mod eval_cmd;
 mod gc;
 mod hooks_cmd;
+mod hunt_cmd;
+mod main_bootstrap;
 mod mcp_hub;
 mod mcp_server;
 mod memory_capture;
@@ -103,6 +105,9 @@ use cli::{
     validate_command_args,
 };
 use csa_core::types::OutputFormat;
+use main_bootstrap::{
+    link_bug_class_pipeline, resolve_effective_min_timeout, should_attempt_auto_weave_upgrade,
+};
 use sa_mode::apply_sa_mode_prompt_guard;
 
 mod migrate_cmd;
@@ -143,50 +148,6 @@ fn exit_current_process(exit_code: i32) -> ! {
     let _ = std::io::stderr().flush();
     crate::session_cmds_daemon::persist_daemon_completion_from_env(exit_code);
     std::process::exit(exit_code);
-}
-
-/// Resolve the effective minimum timeout from project and global configs.
-///
-/// Priority: project `[execution].min_timeout_seconds` > global > compile-time default.
-/// Config loading errors are silently ignored (fall back to compile-time default).
-fn resolve_effective_min_timeout() -> u64 {
-    let compile_default = csa_config::ExecutionConfig::default_min_timeout();
-
-    // Try to load project config (merged with user-level).
-    // This is the same merged config that pipeline uses, so project overrides global
-    // via the standard TOML deep-merge path.
-    if let Ok(cwd) = std::env::current_dir()
-        && let Ok(Some(config)) = csa_config::ProjectConfig::load(&cwd)
-        && !config.execution.is_default()
-    {
-        return config.execution.min_timeout_seconds;
-    }
-
-    // Fall back to global config.
-    if let Ok(global) = csa_config::GlobalConfig::load()
-        && !global.execution.is_default()
-    {
-        return global.execution.min_timeout_seconds;
-    }
-
-    compile_default
-}
-
-fn should_attempt_auto_weave_upgrade(command: &Commands) -> bool {
-    // Only execution commands need upgraded weave patterns.
-    // All management/read-only commands stay available even when weave is unhealthy.
-    match command {
-        Commands::Run { .. } => true,
-        Commands::Review(args) => !args.check_verdict,
-        Commands::Debate(_) | Commands::Batch { .. } | Commands::Plan { .. } => true,
-        Commands::ClaudeSubAgent(_) | Commands::McpServer => true,
-        _ => false,
-    }
-}
-
-fn link_bug_class_pipeline() {
-    let _ = bug_class::BugClassCandidate::aggregate_from_review_artifacts(&[]);
-    bug_class::link_bug_class_pipeline_symbols();
 }
 
 #[tokio::main]
@@ -471,6 +432,23 @@ async fn run() -> Result<()> {
                 matches!(output_format, OutputFormat::Text),
             );
             daemon_guard.finalize();
+            exit_current_process(exit_code);
+        }
+        Commands::Hunt {
+            description,
+            tool,
+            timeout,
+            allow_base_branch_working,
+        } => {
+            let exit_code = hunt_cmd::handle_hunt(
+                description,
+                tool,
+                timeout,
+                allow_base_branch_working,
+                current_depth,
+                output_format,
+            )
+            .await?;
             exit_current_process(exit_code);
         }
         Commands::Session { cmd } => session_dispatch::dispatch(cmd, output_format)?,

--- a/crates/cli-sub-agent/src/main_bootstrap.rs
+++ b/crates/cli-sub-agent/src/main_bootstrap.rs
@@ -1,0 +1,45 @@
+use crate::cli::Commands;
+
+/// Resolve the effective minimum timeout from project and global configs.
+///
+/// Priority: project `[execution].min_timeout_seconds` > global > compile-time default.
+/// Config loading errors are silently ignored (fall back to compile-time default).
+pub(crate) fn resolve_effective_min_timeout() -> u64 {
+    let compile_default = csa_config::ExecutionConfig::default_min_timeout();
+
+    // Try to load project config (merged with user-level).
+    // This is the same merged config that pipeline uses, so project overrides global
+    // via the standard TOML deep-merge path.
+    if let Ok(cwd) = std::env::current_dir()
+        && let Ok(Some(config)) = csa_config::ProjectConfig::load(&cwd)
+        && !config.execution.is_default()
+    {
+        return config.execution.min_timeout_seconds;
+    }
+
+    // Fall back to global config.
+    if let Ok(global) = csa_config::GlobalConfig::load()
+        && !global.execution.is_default()
+    {
+        return global.execution.min_timeout_seconds;
+    }
+
+    compile_default
+}
+
+pub(crate) fn should_attempt_auto_weave_upgrade(command: &Commands) -> bool {
+    // Only execution commands need upgraded weave patterns.
+    // All management/read-only commands stay available even when weave is unhealthy.
+    match command {
+        Commands::Run { .. } | Commands::Hunt { .. } => true,
+        Commands::Review(args) => !args.check_verdict,
+        Commands::Debate(_) | Commands::Batch { .. } | Commands::Plan { .. } => true,
+        Commands::ClaudeSubAgent(_) | Commands::McpServer => true,
+        _ => false,
+    }
+}
+
+pub(crate) fn link_bug_class_pipeline() {
+    let _ = crate::bug_class::BugClassCandidate::aggregate_from_review_artifacts(&[]);
+    crate::bug_class::link_bug_class_pipeline_symbols();
+}

--- a/crates/cli-sub-agent/tests/hunt_e2e.rs
+++ b/crates/cli-sub-agent/tests/hunt_e2e.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+fn csa_cmd(tmp: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+#[test]
+fn hunt_help_shows_diagnostic_options() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = csa_cmd(tmp.path())
+        .args(["hunt", "--help"])
+        .output()
+        .expect("failed to run csa hunt --help");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("root-cause-first"));
+    assert!(stdout.contains("<DESCRIPTION>"));
+    assert!(stdout.contains("--tool"));
+    assert!(stdout.contains("--timeout"));
+    assert!(stdout.contains("--allow-base-branch-working"));
+}


### PR DESCRIPTION
## Summary

- New `csa hunt` subcommand enforcing a strict diagnostic state machine: Investigate → Reproduce → Diagnose → Fix
- Agent is structurally forbidden from modifying code until root cause is stated in one sentence
- Includes self-deception checklist to prevent premature fixes
- Thin wrapper around `csa run` with specialized diagnostic prompt prefix
- Naturally feature-gated by explicit invocation (no impact on default `csa run`)

Closes #1270

## Test plan

- [x] `just pre-commit` passes (32/32 tests)
- [x] E2E test for CLI parsing
- [x] Review: findings=[], severity all 0

Co-Authored-By: codex <noreply@openai.com>