### PR TITLE
feat(cli): add --goal autonomous loop mode with budget guardrails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "chrono",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "axum",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "chrono",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "chrono",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.653"
+version = "0.1.654"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.653"
+version = "0.1.654"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -129,6 +129,9 @@ pub enum Commands {
         sa_mode: Option<bool>,
         /// Task prompt; reads from stdin if omitted
         prompt: Option<String>,
+        /// Autonomous goal mode: loop until success criteria met or budget exhausted
+        #[arg(long)]
+        goal: Option<String>,
         /// Task prompt (flag form; same as the positional prompt)
         #[arg(long = "prompt", value_name = "PROMPT", conflicts_with_all = ["prompt", "prompt_file"])]
         prompt_flag: Option<String>,

--- a/crates/cli-sub-agent/src/config_cmds_experimental_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_experimental_tests.rs
@@ -52,8 +52,16 @@ fn resolve_effective_global_key_uses_experimental_defaults_when_global_config_mi
     let value = resolve_effective_global_key("experimental.enable_prompt_caching")
         .unwrap()
         .expect("global prompt caching flag should resolve");
+    let max_loops = resolve_effective_global_key("experimental.max_goal_loops")
+        .unwrap()
+        .expect("global goal loop limit should resolve");
+    let max_tokens = resolve_effective_global_key("experimental.max_goal_tokens")
+        .unwrap()
+        .expect("global goal token limit should resolve");
 
     assert_eq!(value.as_bool(), Some(false));
+    assert_eq!(max_loops.as_integer(), Some(3));
+    assert_eq!(max_tokens.as_integer(), Some(500_000));
 }
 
 #[test]
@@ -69,12 +77,22 @@ fn resolve_effective_global_key_uses_configured_experimental_prompt_caching() {
         r#"
 [experimental]
 enable_prompt_caching = true
+max_goal_loops = 7
+max_goal_tokens = 42
 "#,
     );
 
     let value = resolve_effective_global_key("experimental.enable_prompt_caching")
         .unwrap()
         .expect("configured prompt caching flag should resolve");
+    let max_loops = resolve_effective_global_key("experimental.max_goal_loops")
+        .unwrap()
+        .expect("configured goal loop limit should resolve");
+    let max_tokens = resolve_effective_global_key("experimental.max_goal_tokens")
+        .unwrap()
+        .expect("configured goal token limit should resolve");
 
     assert_eq!(value.as_bool(), Some(true));
+    assert_eq!(max_loops.as_integer(), Some(7));
+    assert_eq!(max_tokens.as_integer(), Some(42));
 }

--- a/crates/cli-sub-agent/src/goal_loop.rs
+++ b/crates/cli-sub-agent/src/goal_loop.rs
@@ -1,0 +1,425 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use csa_core::types::{OutputFormat, ToolArg};
+
+pub(crate) struct GoalLoop {
+    goal_criteria: String,
+    max_loops: u32,
+    max_tokens: u64,
+    current_loop: u32,
+    tokens_used: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GoalDecision {
+    Continue,
+    BudgetExhausted(&'static str),
+}
+
+impl GoalLoop {
+    pub(crate) fn new(goal_criteria: String, max_loops: u32, max_tokens: u64) -> Self {
+        Self {
+            goal_criteria,
+            max_loops,
+            max_tokens,
+            current_loop: 0,
+            tokens_used: 0,
+        }
+    }
+
+    pub(crate) fn should_continue(&self) -> GoalDecision {
+        if self.current_loop >= self.max_loops {
+            return GoalDecision::BudgetExhausted("max loops");
+        }
+        if self.tokens_used >= self.max_tokens {
+            return GoalDecision::BudgetExhausted("max tokens");
+        }
+        GoalDecision::Continue
+    }
+
+    fn record_iteration(&mut self, tokens_used: u64) {
+        self.current_loop = self.current_loop.saturating_add(1);
+        self.tokens_used = self.tokens_used.saturating_add(tokens_used);
+    }
+
+    fn next_iteration(&self) -> u32 {
+        self.current_loop.saturating_add(1)
+    }
+
+    fn goal_criteria(&self) -> &str {
+        &self.goal_criteria
+    }
+
+    fn loops_used(&self) -> u32 {
+        self.current_loop
+    }
+
+    fn tokens_used(&self) -> u64 {
+        self.tokens_used
+    }
+}
+
+pub(crate) struct GoalRunRequest {
+    pub(crate) goal_criteria: Option<String>,
+    pub(crate) tool: Option<ToolArg>,
+    pub(crate) auto_route: Option<String>,
+    pub(crate) hint_difficulty: Option<String>,
+    pub(crate) skill: Option<String>,
+    pub(crate) prompt: Option<String>,
+    pub(crate) prompt_flag: Option<String>,
+    pub(crate) prompt_file: Option<PathBuf>,
+    pub(crate) inline_context_from_review_session: Option<String>,
+    pub(crate) session: Option<String>,
+    pub(crate) last: bool,
+    pub(crate) fork_from: Option<String>,
+    pub(crate) fork_last: bool,
+    pub(crate) description: Option<String>,
+    pub(crate) fork_call: bool,
+    pub(crate) return_to: Option<String>,
+    pub(crate) parent: Option<String>,
+    pub(crate) ephemeral: bool,
+    pub(crate) allow_base_branch_working: bool,
+    pub(crate) cd: Option<String>,
+    pub(crate) model_spec: Option<String>,
+    pub(crate) model: Option<String>,
+    pub(crate) thinking: Option<String>,
+    pub(crate) force: bool,
+    pub(crate) force_override_user_config: bool,
+    pub(crate) no_failover: bool,
+    pub(crate) wait: bool,
+    pub(crate) idle_timeout: Option<u64>,
+    pub(crate) initial_response_timeout: Option<u64>,
+    pub(crate) timeout: Option<u64>,
+    pub(crate) no_idle_timeout: bool,
+    pub(crate) no_memory: bool,
+    pub(crate) memory_query: Option<String>,
+    pub(crate) current_depth: u32,
+    pub(crate) output_format: OutputFormat,
+    pub(crate) stream_mode: csa_process::StreamMode,
+    pub(crate) tier: Option<String>,
+    pub(crate) force_ignore_tier_setting: bool,
+    pub(crate) no_fs_sandbox: bool,
+    pub(crate) extra_writable: Vec<PathBuf>,
+    pub(crate) extra_readable: Vec<PathBuf>,
+}
+
+struct FailureContext {
+    iteration: u32,
+    exit_code: i32,
+    session_id: Option<String>,
+    summary: String,
+}
+
+struct IterationResult {
+    exit_code: i32,
+    session_id: Option<String>,
+    summary: String,
+    tokens_used: u64,
+}
+
+pub(crate) async fn handle_run_or_goal(request: GoalRunRequest) -> Result<i32> {
+    if request.goal_criteria.is_some() {
+        return handle_goal_run(request).await;
+    }
+
+    crate::run_cmd::handle_run(
+        request.tool,
+        request.auto_route,
+        request.hint_difficulty,
+        request.skill,
+        request.prompt,
+        request.prompt_flag,
+        request.prompt_file,
+        request.inline_context_from_review_session,
+        request.session,
+        request.last,
+        request.fork_from,
+        request.fork_last,
+        request.description,
+        request.fork_call,
+        request.return_to,
+        request.parent,
+        request.ephemeral,
+        request.allow_base_branch_working,
+        request.cd,
+        request.model_spec,
+        request.model,
+        request.thinking,
+        request.force,
+        request.force_override_user_config,
+        request.no_failover,
+        request.wait,
+        request.idle_timeout,
+        request.initial_response_timeout,
+        request.timeout,
+        request.no_idle_timeout,
+        request.no_memory,
+        request.memory_query,
+        request.current_depth,
+        request.output_format,
+        request.stream_mode,
+        request.tier,
+        request.force_ignore_tier_setting,
+        request.no_fs_sandbox,
+        request.extra_writable,
+        request.extra_readable,
+    )
+    .await
+}
+
+async fn handle_goal_run(request: GoalRunRequest) -> Result<i32> {
+    let project_root = crate::pipeline::determine_project_root(request.cd.as_deref())?;
+    let global_config = csa_config::GlobalConfig::load()?;
+    let goal_criteria = request
+        .goal_criteria
+        .clone()
+        .expect("goal criteria should be present in goal mode");
+    let mut goal_loop = GoalLoop::new(
+        goal_criteria,
+        global_config.experimental.max_goal_loops,
+        global_config.experimental.max_goal_tokens,
+    );
+    let user_prompt = resolve_goal_user_prompt(&request)?;
+    let mut previous_failure = None;
+
+    loop {
+        if let GoalDecision::BudgetExhausted(reason) = goal_loop.should_continue() {
+            eprintln!(
+                "goal loop stopped before dispatch: budget exhausted ({reason}); loops={} tokens={}",
+                goal_loop.loops_used(),
+                goal_loop.tokens_used()
+            );
+            return Ok(1);
+        }
+
+        let iteration = goal_loop.next_iteration();
+        let prompt = build_goal_prompt(goal_loop.goal_criteria(), &user_prompt, &previous_failure);
+        let result = run_goal_iteration(&request, &project_root, prompt, iteration == 1).await?;
+        goal_loop.record_iteration(result.tokens_used);
+
+        if result.exit_code == 0 {
+            eprintln!(
+                "goal loop complete: status=success loops={} tokens={} final_session={}",
+                goal_loop.loops_used(),
+                goal_loop.tokens_used(),
+                result.session_id.as_deref().unwrap_or("(none)")
+            );
+            return Ok(0);
+        }
+
+        previous_failure = Some(FailureContext {
+            iteration,
+            exit_code: result.exit_code,
+            session_id: result.session_id,
+            summary: result.summary,
+        });
+
+        if let GoalDecision::BudgetExhausted(reason) = goal_loop.should_continue() {
+            eprintln!(
+                "goal loop stopped: budget exhausted ({reason}); loops={} tokens={} final_status=failure",
+                goal_loop.loops_used(),
+                goal_loop.tokens_used()
+            );
+            return Ok(result.exit_code);
+        }
+    }
+}
+
+fn resolve_goal_user_prompt(request: &GoalRunRequest) -> Result<String> {
+    let prompt = crate::run_helpers::resolve_positional_stdin_sentinel(request.prompt.clone())?
+        .or_else(|| request.prompt_flag.clone());
+
+    if request.prompt_file.is_some() {
+        return crate::run_helpers::resolve_prompt_with_file(
+            prompt,
+            request.prompt_file.as_deref(),
+        );
+    }
+
+    if prompt.is_some() {
+        return crate::run_helpers::read_prompt(prompt);
+    }
+
+    if request.skill.is_some() {
+        return Ok(String::new());
+    }
+
+    crate::run_helpers::read_prompt(None)
+}
+
+fn build_goal_prompt(
+    goal_criteria: &str,
+    user_prompt: &str,
+    previous_failure: &Option<FailureContext>,
+) -> String {
+    let mut prompt = format!(
+        "<goal-mode>\nGoal criteria:\n{goal_criteria}\n\nSuccess detection for this CSA version is deterministic: exit code 0 means success; non-zero means retry while budget remains.\n</goal-mode>\n\nUser task:\n{user_prompt}"
+    );
+
+    if let Some(failure) = previous_failure {
+        prompt.push_str(&format!(
+            "\n\n<goal-loop-feedback iteration=\"{}\" exit_code=\"{}\" session=\"{}\">\nPrevious attempt did not meet the goal. Use this failure context to correct the next attempt.\n\nSummary:\n{}\n</goal-loop-feedback>",
+            failure.iteration,
+            failure.exit_code,
+            failure.session_id.as_deref().unwrap_or("(none)"),
+            failure.summary
+        ));
+    }
+
+    prompt
+}
+
+async fn run_goal_iteration(
+    request: &GoalRunRequest,
+    project_root: &Path,
+    prompt: String,
+    first_iteration: bool,
+) -> Result<IterationResult> {
+    let before_sessions = snapshot_session_ids(project_root)?;
+    let exit_code = crate::run_cmd::handle_run(
+        request.tool.clone(),
+        request.auto_route.clone(),
+        request.hint_difficulty.clone(),
+        request.skill.clone(),
+        Some(prompt),
+        None,
+        None,
+        request.inline_context_from_review_session.clone(),
+        first_iteration.then(|| request.session.clone()).flatten(),
+        first_iteration && request.last,
+        first_iteration.then(|| request.fork_from.clone()).flatten(),
+        first_iteration && request.fork_last,
+        request.description.clone(),
+        request.fork_call,
+        request.return_to.clone(),
+        request.parent.clone(),
+        request.ephemeral,
+        request.allow_base_branch_working,
+        request.cd.clone(),
+        request.model_spec.clone(),
+        request.model.clone(),
+        request.thinking.clone(),
+        request.force,
+        request.force_override_user_config,
+        request.no_failover,
+        request.wait,
+        request.idle_timeout,
+        request.initial_response_timeout,
+        request.timeout,
+        request.no_idle_timeout,
+        request.no_memory,
+        request.memory_query.clone(),
+        request.current_depth,
+        request.output_format,
+        request.stream_mode,
+        request.tier.clone(),
+        request.force_ignore_tier_setting,
+        request.no_fs_sandbox,
+        request.extra_writable.clone(),
+        request.extra_readable.clone(),
+    )
+    .await?;
+
+    let session_id = newest_created_session_id(project_root, &before_sessions)?;
+    let summary = session_id
+        .as_deref()
+        .and_then(|sid| load_result_summary(project_root, sid).ok().flatten())
+        .unwrap_or_else(|| format!("run exited with code {exit_code}; session result unavailable"));
+    let tokens_used = session_id
+        .as_deref()
+        .and_then(|sid| load_session_token_usage(project_root, sid).ok())
+        .unwrap_or(0);
+
+    Ok(IterationResult {
+        exit_code,
+        session_id,
+        summary,
+        tokens_used,
+    })
+}
+
+fn snapshot_session_ids(project_root: &Path) -> Result<HashSet<String>> {
+    Ok(csa_session::list_sessions(project_root, None)?
+        .into_iter()
+        .map(|session| session.meta_session_id)
+        .collect())
+}
+
+fn newest_created_session_id(
+    project_root: &Path,
+    before_sessions: &HashSet<String>,
+) -> Result<Option<String>> {
+    Ok(csa_session::list_sessions(project_root, None)?
+        .into_iter()
+        .filter(|session| !before_sessions.contains(&session.meta_session_id))
+        .max_by_key(|session| session.created_at)
+        .map(|session| session.meta_session_id))
+}
+
+fn load_result_summary(project_root: &Path, session_id: &str) -> Result<Option<String>> {
+    Ok(csa_session::load_result(project_root, session_id)?
+        .map(|result| result.summary)
+        .filter(|summary| !summary.trim().is_empty()))
+}
+
+fn load_session_token_usage(project_root: &Path, session_id: &str) -> Result<u64> {
+    let session = csa_session::load_session(project_root, session_id)?;
+    if let Some(usage) = session.total_token_usage.as_ref() {
+        return Ok(token_usage_total(usage));
+    }
+
+    Ok(session
+        .tools
+        .values()
+        .filter_map(|tool| tool.token_usage.as_ref())
+        .map(token_usage_total)
+        .sum())
+}
+
+fn token_usage_total(usage: &csa_session::TokenUsage) -> u64 {
+    usage
+        .total_tokens
+        .or_else(|| match (usage.input_tokens, usage.output_tokens) {
+            (Some(input), Some(output)) => Some(input.saturating_add(output)),
+            (Some(input), None) => Some(input),
+            (None, Some(output)) => Some(output),
+            (None, None) => None,
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn goal_loop_continues_within_budget() {
+        let goal_loop = GoalLoop::new("pass tests".to_string(), 3, 500_000);
+
+        assert_eq!(goal_loop.should_continue(), GoalDecision::Continue);
+    }
+
+    #[test]
+    fn goal_loop_stops_when_loops_exhausted() {
+        let mut goal_loop = GoalLoop::new("pass tests".to_string(), 1, 500_000);
+        goal_loop.record_iteration(10);
+
+        assert_eq!(
+            goal_loop.should_continue(),
+            GoalDecision::BudgetExhausted("max loops")
+        );
+    }
+
+    #[test]
+    fn goal_loop_stops_when_tokens_exhausted() {
+        let mut goal_loop = GoalLoop::new("pass tests".to_string(), 3, 10);
+        goal_loop.record_iteration(10);
+
+        assert_eq!(
+            goal_loop.should_continue(),
+            GoalDecision::BudgetExhausted("max tokens")
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -23,6 +23,7 @@ mod error_hints;
 mod error_report;
 mod eval_cmd;
 mod gc;
+mod goal_loop;
 mod hooks_cmd;
 mod hunt_cmd;
 mod main_bootstrap;
@@ -304,6 +305,7 @@ async fn run() -> Result<()> {
             skill,
             sa_mode: _,
             prompt,
+            goal,
             prompt_flag,
             prompt_file,
             inline_context_from_review_session,
@@ -354,9 +356,10 @@ async fn run() -> Result<()> {
             {
                 exit_current_process(exit_code);
             }
+            let effective_no_daemon = no_daemon || goal.is_some();
             let mut daemon_guard = run_cmd_daemon::check_daemon_flags(
                 "run",
-                no_daemon,
+                effective_no_daemon,
                 daemon_child,
                 &session_id,
                 cd.as_deref(),
@@ -379,7 +382,8 @@ async fn run() -> Result<()> {
                 csa_process::StreamMode::BufferOnly
             };
 
-            let result = run_cmd::handle_run(
+            let result = goal_loop::handle_run_or_goal(goal_loop::GoalRunRequest {
+                goal_criteria: goal,
                 tool,
                 auto_route,
                 hint_difficulty,
@@ -420,7 +424,7 @@ async fn run() -> Result<()> {
                 no_fs_sandbox,
                 extra_writable,
                 extra_readable,
-            )
+            })
             .await;
             // Report errors while fd 2 is still open (guard holds stderr rotation).
             // Dropping the guard closes fd 2, so eprintln! must happen first.

--- a/crates/cli-sub-agent/src/run_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests.rs
@@ -108,6 +108,18 @@ fn run_accepts_openai_compat_with_arbitrary_model() {
 }
 
 #[test]
+fn run_accepts_goal_at_clap_parse() {
+    let cli = try_parse_cli(&["csa", "run", "--goal", "tests pass", "fix it"]).unwrap();
+
+    match cli.command {
+        crate::cli::Commands::Run { goal, .. } => {
+            assert_eq!(goal.as_deref(), Some("tests pass"));
+        }
+        _ => panic!("expected run command"),
+    }
+}
+
+#[test]
 fn run_cli_hint_difficulty_parses() {
     let cli = try_parse_cli(&[
         "csa",

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -125,13 +125,14 @@ fn cli_help_displays_correctly() {
 fn run_help_shows_tool_options() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let output = csa_cmd(tmp.path())
-        .args(["run", "--help"])
+        .args(["run", "--goal", "test", "--help"])
         .output()
-        .expect("failed to run csa run --help");
+        .expect("failed to run csa run --goal test --help");
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--tool"));
+    assert!(stdout.contains("--goal"));
     assert!(stdout.contains("--session"));
     assert!(stdout.contains("--ephemeral"));
     assert!(stdout.contains("--model"));

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -76,10 +76,32 @@ pub struct GlobalConfig {
     pub experimental: ExperimentalConfig,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub fn default_max_goal_loops() -> u32 {
+    3
+}
+
+pub fn default_max_goal_tokens() -> u64 {
+    500_000
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExperimentalConfig {
     #[serde(default)]
     pub enable_prompt_caching: bool,
+    #[serde(default = "default_max_goal_loops")]
+    pub max_goal_loops: u32,
+    #[serde(default = "default_max_goal_tokens")]
+    pub max_goal_tokens: u64,
+}
+
+impl Default for ExperimentalConfig {
+    fn default() -> Self {
+        Self {
+            enable_prompt_caching: false,
+            max_goal_loops: default_max_goal_loops(),
+            max_goal_tokens: default_max_goal_tokens(),
+        }
+    }
 }
 
 /// Configuration for `csa session wait`.

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -82,6 +82,8 @@ cloud_review_exhausted = "ask-user"
 # Experimental feature flags. Disabled by default.
 [experimental]
 enable_prompt_caching = false
+max_goal_loops = 3
+max_goal_tokens = 500000
 
 # KV cache-aware polling defaults.
 # `frequent_poll_seconds`: fast external state (GitHub API, bot responses).

--- a/crates/csa-config/src/global_tests_heterogeneous.rs
+++ b/crates/csa-config/src/global_tests_heterogeneous.rs
@@ -75,6 +75,13 @@ fn test_experimental_prompt_caching_defaults_to_false() {
 }
 
 #[test]
+fn test_experimental_goal_defaults() {
+    let config: GlobalConfig = toml::from_str("").unwrap();
+    assert_eq!(config.experimental.max_goal_loops, 3);
+    assert_eq!(config.experimental.max_goal_tokens, 500_000);
+}
+
+#[test]
 fn test_experimental_prompt_caching_can_be_enabled() {
     let toml_str = r#"
 [experimental]
@@ -82,6 +89,18 @@ enable_prompt_caching = true
 "#;
     let config: GlobalConfig = toml::from_str(toml_str).unwrap();
     assert!(config.experimental.enable_prompt_caching);
+}
+
+#[test]
+fn test_experimental_goal_limits_can_be_configured() {
+    let toml_str = r#"
+[experimental]
+max_goal_loops = 5
+max_goal_tokens = 123456
+"#;
+    let config: GlobalConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.experimental.max_goal_loops, 5);
+    assert_eq!(config.experimental.max_goal_tokens, 123_456);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- New `--goal` flag on `csa run` implementing autonomous self-correcting loop
- Budget caps enforced deterministically in Rust: `max_goal_loops` (default 3) + `max_goal_tokens` (default 500K)
- On failure, feeds error context back into next iteration automatically
- Config: `[experimental].max_goal_loops` / `max_goal_tokens`
- Feature-gated by explicit `--goal` flag — no impact on normal `csa run`

Closes #1271

## Test plan

- [x] `just pre-commit` passes (32/32 tests)
- [x] GoalLoop budget enforcement unit tests
- [x] Config default value tests
- [x] Review: findings=[], severity all 0

Co-Authored-By: codex <noreply@openai.com>