### PR TITLE
fix(executor): validate gemini-cli workspace directories exist before injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.657"
+version = "0.1.658"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/executor_arg_helpers.rs
+++ b/crates/csa-executor/src/executor_arg_helpers.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
@@ -181,6 +182,14 @@ fn trim_prompt_path_token(raw: &str) -> String {
 }
 
 fn push_unique_directory_string(directories: &mut Vec<String>, directory: &str) {
+    push_unique_directory_string_with_exists(directories, directory, |path| path.try_exists());
+}
+
+fn push_unique_directory_string_with_exists(
+    directories: &mut Vec<String>,
+    directory: &str,
+    try_exists: impl FnOnce(&Path) -> io::Result<bool>,
+) {
     let trimmed = directory.trim();
     if trimmed.is_empty() {
         return;
@@ -195,9 +204,139 @@ fn push_unique_directory_string(directories: &mut Vec<String>, directory: &str) 
     if directories.iter().any(|existing| existing == trimmed) {
         return;
     }
+
+    match try_exists(path) {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::warn!(
+                directory = %trimmed,
+                "Skipping Gemini include directory because it does not exist"
+            );
+            return;
+        }
+        Err(error) => {
+            tracing::warn!(
+                directory = %trimmed,
+                error = %error,
+                "Skipping Gemini include directory because existence could not be checked"
+            );
+            return;
+        }
+    }
+
     directories.push(trimmed.to_string());
 }
 
 fn is_filesystem_root(path: &Path) -> bool {
     path.is_absolute() && path.parent().is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct SharedBufferWriter {
+        buf: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl io::Write for SharedBufferWriter {
+        fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+            let mut guard = self.buf.lock().expect("buffer lock poisoned");
+            guard.extend_from_slice(data);
+            Ok(data.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct SharedMakeWriter {
+        buf: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl<'a> MakeWriter<'a> for SharedMakeWriter {
+        type Writer = SharedBufferWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            SharedBufferWriter {
+                buf: Arc::clone(&self.buf),
+            }
+        }
+    }
+
+    fn capture_warn_logs(action: impl FnOnce()) -> String {
+        let log_buf = Arc::new(Mutex::new(Vec::new()));
+        let make_writer = SharedMakeWriter {
+            buf: Arc::clone(&log_buf),
+        };
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .without_time()
+            .with_target(false)
+            .with_writer(make_writer)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, action);
+
+        String::from_utf8(log_buf.lock().expect("buffer lock poisoned").clone())
+            .expect("logs should be valid UTF-8")
+    }
+
+    #[test]
+    fn push_unique_directory_string_skips_nonexistent_path_with_warning() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let missing = temp.path().join("missing");
+        let missing = missing.to_string_lossy().to_string();
+        let mut directories = Vec::new();
+
+        let logs = capture_warn_logs(|| {
+            push_unique_directory_string(&mut directories, &missing);
+        });
+
+        assert!(directories.is_empty());
+        assert!(logs.contains("Skipping Gemini include directory because it does not exist"));
+        assert!(logs.contains(&missing));
+    }
+
+    #[test]
+    fn push_unique_directory_string_skips_permission_error_with_warning() {
+        let mut directories = Vec::new();
+
+        let logs = capture_warn_logs(|| {
+            push_unique_directory_string_with_exists(&mut directories, "/inaccessible", |_| {
+                Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "permission denied",
+                ))
+            });
+        });
+
+        assert!(directories.is_empty());
+        assert!(
+            logs.contains(
+                "Skipping Gemini include directory because existence could not be checked"
+            )
+        );
+        assert!(logs.contains("permission denied"));
+    }
+
+    #[test]
+    fn push_unique_directory_string_adds_existing_path_normally() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let existing = temp.path().to_string_lossy().to_string();
+        let mut directories = Vec::new();
+
+        let logs = capture_warn_logs(|| {
+            push_unique_directory_string(&mut directories, &existing);
+        });
+
+        assert_eq!(directories, vec![existing]);
+        assert!(!logs.contains("Skipping Gemini include directory"));
+    }
 }

--- a/crates/csa-executor/src/executor_build_cmd_tests.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests.rs
@@ -403,11 +403,22 @@ fn test_build_command_gemini_adds_include_directories_from_env() {
         model_override: None,
         thinking_budget: None,
     };
-    let session = make_test_session();
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let include_one = workspace.path().join("one");
+    let include_two = workspace.path().join("two");
+    std::fs::create_dir_all(&include_one).expect("create include one");
+    std::fs::create_dir_all(&include_two).expect("create include two");
+    let mut session = make_test_session();
+    session.project_path = workspace.path().to_string_lossy().to_string();
     let mut extra = HashMap::new();
     extra.insert(
         "CSA_GEMINI_INCLUDE_DIRECTORIES".to_string(),
-        " /tmp/one ,/tmp/two\n/tmp/one ".to_string(),
+        format!(
+            " {} ,{}\n{} ",
+            include_one.display(),
+            include_two.display(),
+            include_one.display()
+        ),
     );
 
     let (cmd, stdin_data) = exec.build_command("analyze code", None, &session, Some(&extra));
@@ -427,9 +438,9 @@ fn test_build_command_gemini_adds_include_directories_from_env() {
         include_flag_count, 3,
         "Expected execution dir + deduplicated include directories from env"
     );
-    assert!(args.contains(&"/tmp/test-project".to_string()));
-    assert!(args.contains(&"/tmp/one".to_string()));
-    assert!(args.contains(&"/tmp/two".to_string()));
+    assert!(args.contains(&workspace.path().to_string_lossy().to_string()));
+    assert!(args.contains(&include_one.to_string_lossy().to_string()));
+    assert!(args.contains(&include_two.to_string_lossy().to_string()));
 }
 
 #[test]
@@ -438,11 +449,15 @@ fn test_build_command_gemini_supports_fallback_include_directories_key() {
         model_override: None,
         thinking_budget: None,
     };
-    let session = make_test_session();
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let fallback = workspace.path().join("fallback");
+    std::fs::create_dir_all(&fallback).expect("create fallback include dir");
+    let mut session = make_test_session();
+    session.project_path = workspace.path().to_string_lossy().to_string();
     let mut extra = HashMap::new();
     extra.insert(
         "GEMINI_INCLUDE_DIRECTORIES".to_string(),
-        "/tmp/fallback".to_string(),
+        fallback.to_string_lossy().to_string(),
     );
 
     let (cmd, stdin_data) = exec.build_command("analyze code", None, &session, Some(&extra));
@@ -458,8 +473,8 @@ fn test_build_command_gemini_supports_fallback_include_directories_key() {
         args.contains(&"--include-directories".to_string()),
         "Expected --include-directories when fallback env key is set"
     );
-    assert!(args.contains(&"/tmp/test-project".to_string()));
-    assert!(args.contains(&"/tmp/fallback".to_string()));
+    assert!(args.contains(&workspace.path().to_string_lossy().to_string()));
+    assert!(args.contains(&fallback.to_string_lossy().to_string()));
 }
 
 #[cfg(unix)]
@@ -513,8 +528,11 @@ fn test_build_command_gemini_auto_includes_prompt_absolute_path_parent() {
         model_override: None,
         thinking_budget: None,
     };
-    let session = make_test_session();
     let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    let mut session = make_test_session();
+    session.project_path = workspace.to_string_lossy().to_string();
     let dir_with_space = temp.path().join("with space");
     std::fs::create_dir_all(&dir_with_space).expect("create spaced dir");
     let file_path = dir_with_space.join("sample.txt");
@@ -533,7 +551,7 @@ fn test_build_command_gemini_auto_includes_prompt_absolute_path_parent() {
         std::fs::canonicalize(&dir_with_space).unwrap_or_else(|_| dir_with_space.clone());
 
     assert!(args.contains(&"--include-directories".to_string()));
-    assert!(args.contains(&"/tmp/test-project".to_string()));
+    assert!(args.contains(&workspace.to_string_lossy().to_string()));
     assert!(args.contains(&expected_dir.to_string_lossy().to_string()));
 }
 
@@ -543,7 +561,9 @@ fn test_build_command_gemini_never_includes_filesystem_root_directory() {
         model_override: None,
         thinking_budget: None,
     };
-    let session = make_test_session();
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let mut session = make_test_session();
+    session.project_path = workspace.path().to_string_lossy().to_string();
     let mut extra = HashMap::new();
     extra.insert(
         "CSA_GEMINI_INCLUDE_DIRECTORIES".to_string(),
@@ -565,7 +585,7 @@ fn test_build_command_gemini_never_includes_filesystem_root_directory() {
         "Filesystem root must not be injected into --include-directories"
     );
     assert!(
-        args.contains(&"/tmp/test-project".to_string()),
+        args.contains(&workspace.path().to_string_lossy().to_string()),
         "Execution directory should still be included"
     );
 }

--- a/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
@@ -667,11 +667,16 @@ fn test_build_execute_in_command_gemini_adds_include_directories_from_env() {
         model_override: None,
         thinking_budget: None,
     };
-    let work_dir = std::path::Path::new("/tmp/test-project");
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let include_a = workspace.path().join("a");
+    let include_b = workspace.path().join("b");
+    std::fs::create_dir_all(&include_a).expect("create include a");
+    std::fs::create_dir_all(&include_b).expect("create include b");
+    let work_dir = workspace.path();
     let mut extra = HashMap::new();
     extra.insert(
         "CSA_GEMINI_INCLUDE_DIRECTORIES".to_string(),
-        "/tmp/a,/tmp/b".to_string(),
+        format!("{},{}", include_a.display(), include_b.display()),
     );
 
     let (cmd, _stdin_data) = exec.build_execute_in_command("test", work_dir, Some(&extra));
@@ -689,9 +694,9 @@ fn test_build_execute_in_command_gemini_adds_include_directories_from_env() {
         include_flag_count, 3,
         "Gemini execute_in should receive work_dir and both include directories"
     );
-    assert!(args.contains(&"/tmp/test-project".to_string()));
-    assert!(args.contains(&"/tmp/a".to_string()));
-    assert!(args.contains(&"/tmp/b".to_string()));
+    assert!(args.contains(&work_dir.to_string_lossy().to_string()));
+    assert!(args.contains(&include_a.to_string_lossy().to_string()));
+    assert!(args.contains(&include_b.to_string_lossy().to_string()));
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Add path existence validation in `push_unique_directory_string` before injecting workspace directories to gemini-cli
- `try_exists()` returning `Ok(false)` or `Err` both skip with `tracing::warn`
- Unit tests cover all three cases (non-existent, permission error, existing)

Closes #1286

## Test plan
- [x] `cargo test` passes
- [x] Non-existent paths skipped with warning
- [x] Existing paths injected normally

Generated with [Claude Code](https://claude.com/claude-code)