### PR TITLE
feat(mktd): enforce vertical-slice tracer-bullet task decomposition + TDD guidance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.658"
+version = "0.1.659"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -275,9 +275,24 @@ b) Each task item MUST include:
    - A descriptive title (not just "Implement X")
    - Context sub-bullet explaining WHY this task exists and HOW it relates to the design
    - Dependencies on other tasks with specific details (not just "depends on task 1")
+   - `Acceptance Criteria:` field listing behavior-level checks for this task
+   - `Blocked by:` field listing concrete prerequisite tasks, or `None` if independent
    - Each task description MUST be >= 20 words to provide sufficient context
 
-c) **"## Debate Findings" section** (left empty in draft, populated after Phase 3):
+c) Task decomposition MUST use thin vertical slices:
+   - Each task MUST cut through all integration layers needed for one behavior end-to-end, such as schema, API, business logic, and tests.
+   - Do NOT use horizontal slices that finish all models, then all handlers, then all tests.
+   - Prefer many thin vertical slices over a few thick tasks.
+   - Anti-pattern:
+     WRONG (horizontal): Task 1: write all models; Task 2: write all handlers; Task 3: write all tests.
+     RIGHT (vertical): Task 1: Feature A end-to-end (model + handler + test); Task 2: Feature B end-to-end.
+
+d) TDD guidance for implementation tasks:
+   - Prefer one-test-one-implementation cycles inside each vertical slice, not write-all-tests-then-all-implementation sequencing.
+   - Tests should verify behavior through public interfaces, not implementation details.
+   - This is guidance only, not a hard enforcement gate. Do not turn it into a `DONE WHEN:` clause or spec criterion unless the user explicitly requests TDD enforcement.
+
+e) **"## Debate Findings" section** (left empty in draft, populated after Phase 3):
    - Which debate points were adopted
    - Which were deferred and why
 

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -317,6 +317,42 @@ ${STEP_6_OUTPUT}
 
 CONSTRAINT VERIFICATION: Before drafting, check that RECON findings align with the user's original feature request (${FEATURE}). If the user specified a target crate, architecture, or key files, the plan MUST target those — not alternatives suggested by codebase pattern matching. If RECON findings contradict user constraints, note the conflict and follow the user's intent.
 
+#### TODO Structure Requirements
+
+The TODO plan MUST include the following sections for context recovery:
+
+a) **"## Design Overview" section** at the top with:
+   - Problem statement (1-2 sentences)
+   - Key design decisions with rationale
+   - Architecture constraints discovered during recon
+
+b) Each task item MUST include:
+   - A descriptive title (not just "Implement X")
+   - Context sub-bullet explaining WHY this task exists and HOW it relates to the design
+   - Dependencies on other tasks with specific details (not just "depends on task 1")
+   - `Acceptance Criteria:` field listing behavior-level checks for this task
+   - `Blocked by:` field listing concrete prerequisite tasks, or `None` if independent
+   - Each task description MUST be >= 20 words to provide sufficient context
+
+c) Task decomposition MUST use thin vertical slices:
+   - Each task MUST cut through all integration layers needed for one behavior end-to-end, such as schema, API, business logic, and tests.
+   - Do NOT use horizontal slices that finish all models, then all handlers, then all tests.
+   - Prefer many thin vertical slices over a few thick tasks.
+   - Anti-pattern:
+     WRONG (horizontal): Task 1: write all models; Task 2: write all handlers; Task 3: write all tests.
+     RIGHT (vertical): Task 1: Feature A end-to-end (model + handler + test); Task 2: Feature B end-to-end.
+
+d) TDD guidance for implementation tasks:
+   - Prefer one-test-one-implementation cycles inside each vertical slice, not write-all-tests-then-all-implementation sequencing.
+   - Tests should verify behavior through public interfaces, not implementation details.
+   - This is guidance only, not a hard enforcement gate. Do not turn it into a `DONE WHEN:` clause or spec criterion unless the user explicitly requests TDD enforcement.
+
+e) **"## Debate Findings" section** (left empty in draft, populated after Phase 3):
+   - Which debate points were adopted
+   - Which were deferred and why
+
+#### Formatting Rules
+
 Each item is a [ ] checkbox with executor tag.
 Write all TODO descriptions, section headers, and task names in `${STEP_2_OUTPUT}`.
 Technical terms, code snippets, commit scope strings, and executor tags remain in English.


### PR DESCRIPTION
## Summary
- Add vertical-slice (tracer bullet) decomposition guidance to mktd PATTERN.md Step 7
- Add TDD one-test-one-impl cycle guidance to prevent horizontal test-first anti-pattern
- Require acceptance criteria and blocked-by fields in generated tasks
- Sync PATTERN.md and workflow.toml per Rule 027

Closes #1281
Closes #1282

## Test plan
- [x] PATTERN.md and workflow.toml synchronized
- [x] `just pre-commit` passes
- [x] No changes to csa run global prompt

Generated with [Claude Code](https://claude.com/claude-code)