### PR TITLE
refactor(cli): extract SubagentRunConfig from hunt_cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.660"
+version = "0.1.661"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.660"
+version = "0.1.661"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/hunt_cmd.rs
+++ b/crates/cli-sub-agent/src/hunt_cmd.rs
@@ -64,55 +64,14 @@ pub(crate) async fn handle_hunt(
         })
         .transpose()?;
     let prompt = build_hunt_prompt(&description);
-    let stream_mode = if matches!(output_format, OutputFormat::Text) {
-        csa_process::StreamMode::TeeToStderr
-    } else {
-        csa_process::StreamMode::BufferOnly
-    };
 
-    crate::run_cmd::handle_run(
-        tool,
-        None,
-        None,
-        None,
-        Some(prompt),
-        None,
-        None,
-        None,
-        None,
-        false,
-        None,
-        false,
-        None,
-        false,
-        None,
-        None,
-        false,
-        allow_base_branch_working,
-        None,
-        None,
-        None,
-        None,
-        false,
-        false,
-        false,
-        false,
-        None,
-        None,
-        Some(timeout),
-        false,
-        false,
-        None,
-        current_depth,
-        output_format,
-        stream_mode,
-        None,
-        false,
-        false,
-        Vec::new(),
-        Vec::new(),
-    )
-    .await
+    crate::run_cmd::SubagentRunConfig::new(prompt, output_format)
+        .tool(tool)
+        .timeout(timeout)
+        .allow_base_branch_working(allow_base_branch_working)
+        .current_depth(current_depth)
+        .run()
+        .await
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -2,6 +2,9 @@
 //!
 //! Extracted from main.rs to keep file sizes manageable.
 
+use anyhow::Result;
+use csa_core::types::{OutputFormat, ToolArg};
+
 #[path = "run_cmd_attempt.rs"]
 mod attempt;
 #[path = "run_cmd_attempt_exec.rs"]
@@ -44,6 +47,102 @@ pub(crate) use resume::{
     run_error_timeout_seconds, session_matches_interrupted_skill, signal_interruption_exit_code,
     skill_session_description, wall_timeout_seconds_from_error,
 };
+
+#[derive(Debug)]
+pub(crate) struct SubagentRunConfig {
+    tool: Option<ToolArg>,
+    prompt: String,
+    timeout: Option<u64>,
+    allow_base_branch_working: bool,
+    current_depth: u32,
+    output_format: OutputFormat,
+    stream_mode: csa_process::StreamMode,
+}
+
+impl SubagentRunConfig {
+    pub(crate) fn new(prompt: String, output_format: OutputFormat) -> Self {
+        let stream_mode = match output_format {
+            OutputFormat::Text => csa_process::StreamMode::TeeToStderr,
+            OutputFormat::Json => csa_process::StreamMode::BufferOnly,
+        };
+
+        Self {
+            tool: None,
+            prompt,
+            timeout: None,
+            allow_base_branch_working: false,
+            current_depth: 0,
+            output_format,
+            stream_mode,
+        }
+    }
+
+    pub(crate) fn tool(mut self, tool: Option<ToolArg>) -> Self {
+        self.tool = tool;
+        self
+    }
+
+    pub(crate) fn timeout(mut self, timeout: u64) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    pub(crate) fn allow_base_branch_working(mut self, allow_base_branch_working: bool) -> Self {
+        self.allow_base_branch_working = allow_base_branch_working;
+        self
+    }
+
+    pub(crate) fn current_depth(mut self, current_depth: u32) -> Self {
+        self.current_depth = current_depth;
+        self
+    }
+
+    pub(crate) async fn run(self) -> Result<i32> {
+        handle_run(
+            self.tool,
+            None,
+            None,
+            None,
+            Some(self.prompt),
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+            false,
+            None,
+            false,
+            None,
+            None,
+            false,
+            self.allow_base_branch_working,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+            false,
+            false,
+            None,
+            None,
+            self.timeout,
+            false,
+            false,
+            None,
+            self.current_depth,
+            self.output_format,
+            self.stream_mode,
+            None,
+            false,
+            false,
+            Vec::new(),
+            Vec::new(),
+        )
+        .await
+    }
+}
 
 #[cfg(test)]
 #[path = "run_cmd_tests.rs"]


### PR DESCRIPTION
## Summary
- Extract shared `SubagentRunConfig` builder in `run_cmd.rs` to reduce ~40-argument duplication at thin-wrapper call sites
- Refactor `hunt_cmd.rs` to use the new config struct
- Enables clean implementation of future triage/arch subcommands

## Test plan
- [x] `cargo test` passes
- [x] hunt_cmd behavior preserved (no regression)
- [x] SubagentRunConfig accessible from sibling modules

Generated with [Claude Code](https://claude.com/claude-code)