### PR TITLE
feat(triage): add csa triage subcommand with issue state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.661"
+version = "0.1.662"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.661"
+version = "0.1.662"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -22,6 +22,9 @@ pub use cli_tokuin::*;
 #[path = "cli_xurl.rs"]
 mod cli_xurl;
 pub use cli_xurl::*;
+#[path = "cli_triage.rs"]
+mod cli_triage;
+pub use cli_triage::*;
 #[path = "cli_plan.rs"]
 mod cli_plan;
 pub use cli_plan::*;
@@ -286,19 +289,10 @@ pub enum Commands {
     },
 
     /// Start a root-cause-first diagnostic debugging session
-    Hunt {
-        /// Bug description
-        description: String,
-        /// Tool to use
-        #[arg(long)]
-        tool: Option<String>,
-        /// Session timeout in seconds
-        #[arg(long, default_value = "7200")]
-        timeout: u64,
-        /// Allow working on base branch
-        #[arg(long, alias = "allow-base-branch-commit")]
-        allow_base_branch_working: bool,
-    },
+    Hunt(HuntArgs),
+
+    /// Triage a GitHub issue into category and state roles
+    Triage(TriageArgs),
 
     /// Manage sessions
     Session {

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -291,8 +291,11 @@ pub fn validate_command_args(
         Commands::Run { timeout, .. } => {
             validate_timeout(*timeout, min_timeout)?;
         }
-        Commands::Hunt { timeout, .. } => {
-            validate_timeout(Some(*timeout), min_timeout)?;
+        Commands::Hunt(args) => {
+            validate_timeout(Some(args.timeout), min_timeout)?;
+        }
+        Commands::Triage(args) => {
+            validate_timeout(Some(args.timeout), min_timeout)?;
         }
         Commands::Review(args) => {
             validate_review_args(args)?;

--- a/crates/cli-sub-agent/src/cli_triage.rs
+++ b/crates/cli-sub-agent/src/cli_triage.rs
@@ -1,0 +1,29 @@
+#[derive(clap::Args)]
+pub struct HuntArgs {
+    /// Bug description
+    pub description: String,
+    /// Tool to use
+    #[arg(long)]
+    pub tool: Option<String>,
+    /// Session timeout in seconds
+    #[arg(long, default_value = "7200")]
+    pub timeout: u64,
+    /// Allow working on base branch
+    #[arg(long, alias = "allow-base-branch-commit")]
+    pub allow_base_branch_working: bool,
+}
+
+#[derive(clap::Args)]
+pub struct TriageArgs {
+    /// Issue description
+    pub description: String,
+    /// Tool to use
+    #[arg(long)]
+    pub tool: Option<String>,
+    /// Session timeout in seconds
+    #[arg(long, default_value = "7200")]
+    pub timeout: u64,
+    /// Allow working on base branch
+    #[arg(long, alias = "allow-base-branch-commit")]
+    pub allow_base_branch_working: bool,
+}

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -84,6 +84,7 @@ mod todo_cmd;
 mod todo_epic_cmd;
 mod todo_ref_cmd;
 mod tool_version;
+mod triage_cmd;
 
 #[cfg(test)]
 mod sa_mode_tests;
@@ -440,17 +441,24 @@ async fn run() -> Result<()> {
             daemon_guard.finalize();
             exit_current_process(exit_code);
         }
-        Commands::Hunt {
-            description,
-            tool,
-            timeout,
-            allow_base_branch_working,
-        } => {
+        Commands::Hunt(args) => {
             let exit_code = hunt_cmd::handle_hunt(
-                description,
-                tool,
-                timeout,
-                allow_base_branch_working,
+                args.description,
+                args.tool,
+                args.timeout,
+                args.allow_base_branch_working,
+                current_depth,
+                output_format,
+            )
+            .await?;
+            exit_current_process(exit_code);
+        }
+        Commands::Triage(args) => {
+            let exit_code = triage_cmd::handle_triage(
+                args.description,
+                args.tool,
+                args.timeout,
+                args.allow_base_branch_working,
                 current_depth,
                 output_format,
             )

--- a/crates/cli-sub-agent/src/main_auto_weave_tests.rs
+++ b/crates/cli-sub-agent/src/main_auto_weave_tests.rs
@@ -1,5 +1,5 @@
 use super::{Cli, should_attempt_auto_weave_upgrade};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 
 #[test]
 fn todo_commands_skip_auto_weave_upgrade() {
@@ -35,6 +35,20 @@ fn gc_skips_auto_weave_upgrade() {
 fn run_commands_still_attempt_auto_weave_upgrade() {
     let cli = Cli::parse_from(["csa", "run", "--sa-mode", "false", "status"]);
     assert!(should_attempt_auto_weave_upgrade(&cli.command));
+}
+
+#[test]
+fn triage_commands_still_attempt_auto_weave_upgrade() {
+    let cli = Cli::parse_from(["csa", "triage", "issue description"]);
+    assert!(should_attempt_auto_weave_upgrade(&cli.command));
+}
+
+#[test]
+fn triage_command_is_listed_in_help() {
+    let help = Cli::command().render_long_help().to_string();
+
+    assert!(help.contains("triage"));
+    assert!(help.contains("Triage a GitHub issue into category and state roles"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/main_bootstrap.rs
+++ b/crates/cli-sub-agent/src/main_bootstrap.rs
@@ -31,7 +31,7 @@ pub(crate) fn should_attempt_auto_weave_upgrade(command: &Commands) -> bool {
     // Only execution commands need upgraded weave patterns.
     // All management/read-only commands stay available even when weave is unhealthy.
     match command {
-        Commands::Run { .. } | Commands::Hunt { .. } => true,
+        Commands::Run { .. } | Commands::Hunt(_) | Commands::Triage(_) => true,
         Commands::Review(args) => !args.check_verdict,
         Commands::Debate(_) | Commands::Batch { .. } | Commands::Plan { .. } => true,
         Commands::ClaudeSubAgent(_) | Commands::McpServer => true,

--- a/crates/cli-sub-agent/src/triage_cmd.rs
+++ b/crates/cli-sub-agent/src/triage_cmd.rs
@@ -1,0 +1,159 @@
+use anyhow::{Result, anyhow};
+use csa_core::types::{OutputFormat, ToolArg};
+
+pub(crate) const TRIAGE_PROMPT_PREFIX: &str = r#"ISSUE TRIAGE MODE - ROLE-BASED STATE MACHINE
+
+You are triaging a GitHub issue into exactly one category role and one state role.
+Do not implement code changes unless explicitly requested by the caller. Gather enough
+context for the next actor and leave the issue in a truthful state.
+
+CATEGORY ROLES
+- bug: A defect, regression, broken invariant, crash, incorrect behavior, data loss
+  risk, flaky failure, or documentation mismatch causing wrong use.
+- enhancement: New capability, workflow improvement, usability improvement, performance
+  improvement, refactor request, documentation expansion, or test/coverage improvement.
+
+STATE ROLES
+- needs-triage: Not enough investigation has been done to choose a truthful next
+  state. Use sparingly; prefer moving to needs-info, ready-for-agent, ready-for-human,
+  or wontfix after context gathering.
+- needs-info: More user or reporter input is required before work can proceed safely.
+- ready-for-agent: The issue can be handled by an autonomous coding agent with a
+  bounded brief, known files or search paths, acceptance criteria, and test strategy.
+- ready-for-human: Human judgment, product policy, credentials, production access,
+  security approval, legal decision, or maintainer prioritization is required before
+  implementation.
+- wontfix: The request is out of scope, already intentionally unsupported, invalid,
+  duplicate, superseded, or not worth carrying as open work. Explain the reason and
+  preserve useful context.
+
+WORKFLOW
+PHASE 1 - GATHER CONTEXT
+- Read the issue description and existing comments if available.
+- Inspect relevant code, tests, docs, workflows, configs, and recent history only as
+  needed.
+- Identify current labels, assignees, linked PRs/issues, and whether the report is
+  stale or already fixed.
+- For GitHub issue metadata/comment reads or issue comment writes, use:
+  GH_CONFIG_DIR=~/.config/gh-aider gh issue ...
+- For label operations, use default gh auth with no GH_CONFIG_DIR override, including:
+  gh issue edit ... --add-label ...
+  gh label list/create/edit ...
+- Do not mix auth modes: gh issue commands use GH_CONFIG_DIR=~/.config/gh-aider;
+  label ops use default auth.
+
+PHASE 2 - RECOMMEND CATEGORY AND STATE
+- Choose exactly one category role: bug or enhancement.
+- Choose exactly one state role: needs-triage, needs-info, ready-for-agent,
+  ready-for-human, or wontfix.
+- State the evidence and uncertainty.
+- Recommend concrete label changes, but do not perform label changes unless the caller
+  explicitly asks.
+
+PHASE 3 - REPRODUCE BUGS
+- For category=bug, attempt the smallest deterministic reproduction before recommending
+  ready-for-agent.
+- Prefer a failing test, existing command, fixture, or log-backed reproduction.
+- If reproduction is impossible, say what was tried and what data/access is missing.
+- If the bug cannot be reproduced but the report is plausible, use needs-info or
+  ready-for-human unless there is enough evidence for ready-for-agent.
+
+PHASE 4 - PRODUCE NEXT-ACTOR OUTPUT
+- If state=ready-for-agent, write an agent brief using the template below.
+- If state=needs-info, write a reporter-facing request using the needs-info template
+  below.
+- If state=ready-for-human, name the human decision or access needed.
+- If state=wontfix, state the closing rationale and any safer alternative.
+
+AGENT BRIEF TEMPLATE (for ready-for-agent)
+Category:
+State:
+Issue summary:
+What to build/fix:
+Files to touch:
+- <file or search path>
+Acceptance criteria:
+- <mechanically verifiable outcome>
+Test strategy:
+- <test/command to run>
+Constraints and risks:
+- <repo rules, auth split, migration/data/sandbox caveats>
+Suggested first command:
+- <single grep/test/read command>
+
+NEEDS-INFO TEMPLATE (for needs-info)
+Category:
+State:
+established so far:
+- <facts already verified>
+what we still need:
+- <specific missing detail, reproduction step, expected behavior, logs, version,
+  environment, screenshot, or access>
+Suggested question to reporter:
+<short direct question>
+
+OUTPUT REQUIREMENTS
+- End with: RECOMMENDED_CATEGORY: <bug|enhancement>
+- End with: RECOMMENDED_STATE: <needs-triage|needs-info|ready-for-agent|ready-for-human|wontfix>
+- Include exact GitHub commands only when they are safe and use the correct auth split."#;
+
+pub(crate) fn build_triage_prompt(description: &str) -> String {
+    format!("{TRIAGE_PROMPT_PREFIX}\n\nISSUE DESCRIPTION:\n{description}")
+}
+
+pub(crate) async fn handle_triage(
+    description: String,
+    tool: Option<String>,
+    timeout: u64,
+    allow_base_branch_working: bool,
+    current_depth: u32,
+    output_format: OutputFormat,
+) -> Result<i32> {
+    let tool = tool
+        .map(|raw| {
+            raw.parse::<ToolArg>()
+                .map_err(|err| anyhow!("invalid triage tool `{raw}`: {err}"))
+        })
+        .transpose()?;
+    let prompt = build_triage_prompt(&description);
+
+    crate::run_cmd::SubagentRunConfig::new(prompt, output_format)
+        .tool(tool)
+        .timeout(timeout)
+        .allow_base_branch_working(allow_base_branch_working)
+        .current_depth(current_depth)
+        .run()
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_triage_prompt;
+
+    #[test]
+    fn build_triage_prompt_prepends_state_machine_and_templates() {
+        let prompt = build_triage_prompt("Issue #1284 should get a triage command");
+
+        assert!(prompt.starts_with("ISSUE TRIAGE MODE - ROLE-BASED STATE MACHINE"));
+        assert!(prompt.contains("CATEGORY ROLES"));
+        assert!(prompt.contains("- bug:"));
+        assert!(prompt.contains("- enhancement:"));
+        assert!(prompt.contains("- needs-triage:"));
+        assert!(prompt.contains("- needs-info:"));
+        assert!(prompt.contains("- ready-for-agent:"));
+        assert!(prompt.contains("- ready-for-human:"));
+        assert!(prompt.contains("- wontfix:"));
+        assert!(prompt.contains("PHASE 1 - GATHER CONTEXT"));
+        assert!(prompt.contains("PHASE 3 - REPRODUCE BUGS"));
+        assert!(prompt.contains("AGENT BRIEF TEMPLATE"));
+        assert!(prompt.contains("What to build/fix:"));
+        assert!(prompt.contains("Files to touch:"));
+        assert!(prompt.contains("Acceptance criteria:"));
+        assert!(prompt.contains("Test strategy:"));
+        assert!(prompt.contains("GH_CONFIG_DIR=~/.config/gh-aider gh issue"));
+        assert!(prompt.contains("label ops use default auth"));
+        assert!(prompt.contains("established so far:"));
+        assert!(prompt.contains("what we still need:"));
+        assert!(prompt.ends_with("Issue #1284 should get a triage command"));
+    }
+}


### PR DESCRIPTION
## Summary
- New `csa triage` subcommand with role-based issue state machine
- 5 state roles: needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix
- Agent brief template for ready-for-agent issues
- GH_CONFIG_DIR auth split rule embedded in prompt
- Uses SubagentRunConfig (clean call site)

Closes #1284

## Test plan
- [x] `cargo test` passes
- [x] `csa triage --help` shows subcommand
- [x] Uses SubagentRunConfig pattern
- [x] GH auth rules in prompt

Generated with [Claude Code](https://claude.com/claude-code)