### PR TITLE
feat(cli): add csa arch deep module analysis subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.662"
+version = "0.1.663"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.662"
+version = "0.1.663"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/arch_cmd.rs
+++ b/crates/cli-sub-agent/src/arch_cmd.rs
@@ -1,0 +1,164 @@
+use anyhow::{Result, anyhow};
+use csa_core::types::{OutputFormat, ToolArg};
+
+pub(crate) const ARCH_PROMPT_PREFIX: &str = r#"ARCHITECTURE MODE - DEEP MODULE ANALYSIS
+
+You are running an Ousterhout-style deep module analysis. Do not implement
+production code changes unless the caller explicitly asks for implementation.
+Your job is to find places where interfaces are shallow, pass-through, or
+misplaced, then help the caller choose a design that increases depth.
+
+GLOSSARY
+- Module: anything with an interface and an implementation
+- Interface: everything a caller must know (types, invariants, error modes, ordering, config)
+- Implementation: the code inside
+- Depth: leverage at the interface. Deep = high leverage. Shallow = interface nearly as complex as implementation
+- Seam: where an interface lives; behavior can be altered without editing in place
+- Adapter: a concrete thing satisfying an interface at a seam
+- Leverage: what callers get from depth
+- Locality: what maintainers get from depth (change/bugs/knowledge concentrated in one place)
+
+KEY PRINCIPLES
+- Deletion test: imagine deleting the module. If complexity vanishes -> pass-through. If it reappears across N callers -> earning its keep
+- The interface is the test surface
+- One adapter = hypothetical seam. Two adapters = real seam
+
+PROCESS
+1. Explore: walk codebase noting friction (bouncing between modules, shallow modules, pure functions extracted just for testability)
+2. Present candidates: numbered list with files, problem, solution, benefits (in terms of locality and leverage)
+3. Grilling loop: design conversation for selected candidate
+
+EXPLORE GUIDANCE
+- Read from call sites inward. The caller-facing obligations define the real interface.
+- Track every detail callers must remember: ordering, setup, teardown, retries,
+  error interpretation, configuration defaults, mutation timing, and hidden invariants.
+- Prefer examples backed by file paths and current behavior over abstract critique.
+- Treat scattered tests as evidence about the interface: if every caller repeats the
+  same setup or assertion shape, the module may not be carrying enough complexity.
+- Do not count a wrapper as deep merely because it has a trait or a named type.
+
+CANDIDATE FORMAT
+For each candidate, include:
+1. Files:
+2. Problem:
+3. Current interface burden:
+4. Proposed module/interface:
+5. Expected locality benefit:
+6. Expected leverage benefit:
+7. Deletion test result:
+8. Adapter count:
+9. Risks or tradeoffs:
+
+GRILLING LOOP
+- Ask which candidate the caller wants to pursue.
+- For the selected candidate, challenge the design before implementation:
+  1. What exact caller knowledge disappears?
+  2. What invariant moves behind the interface?
+  3. What new interface would tests exercise?
+  4. Is the seam real now, or only justified by a second adapter soon?
+  5. What would make this candidate a pass-through abstraction?
+- Keep the loop concrete: propose a narrow next patch only after the interface is clear.
+
+SIDE EFFECTS
+- Update CONTEXT.md when naming new concepts that future agents must reuse.
+- Offer an ADR when rejecting a candidate for a load-bearing reason.
+
+OUTPUT REQUIREMENTS
+- Start with a short summary of the strongest candidate.
+- Include a numbered candidate list using the candidate format.
+- End with: RECOMMENDED_NEXT_STEP: <specific candidate or no-change rationale>"#;
+
+pub(crate) fn build_arch_prompt(description: &str) -> String {
+    format!("{ARCH_PROMPT_PREFIX}\n\nARCHITECTURE ANALYSIS REQUEST:\n{description}")
+}
+
+pub(crate) async fn handle_arch(
+    description: String,
+    tool: Option<String>,
+    timeout: u64,
+    allow_base_branch_working: bool,
+    current_depth: u32,
+    output_format: OutputFormat,
+) -> Result<i32> {
+    let tool = tool
+        .map(|raw| {
+            raw.parse::<ToolArg>()
+                .map_err(|err| anyhow!("invalid arch tool `{raw}`: {err}"))
+        })
+        .transpose()?;
+    let prompt = build_arch_prompt(&description);
+
+    crate::run_cmd::SubagentRunConfig::new(prompt, output_format)
+        .tool(tool)
+        .timeout(timeout)
+        .allow_base_branch_working(allow_base_branch_working)
+        .current_depth(current_depth)
+        .run()
+        .await
+}
+
+pub(crate) async fn handle_arch_args(
+    args: crate::cli::ArchArgs,
+    current_depth: u32,
+    output_format: OutputFormat,
+) -> Result<i32> {
+    handle_arch(
+        args.description,
+        args.tool,
+        args.timeout,
+        args.allow_base_branch_working,
+        current_depth,
+        output_format,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ARCH_PROMPT_PREFIX, build_arch_prompt};
+
+    #[test]
+    fn arch_prompt_contains_deep_module_vocabulary_and_process() {
+        let prompt = build_arch_prompt("Analyze command dispatch depth");
+
+        assert!(prompt.starts_with("ARCHITECTURE MODE - DEEP MODULE ANALYSIS"));
+        assert!(
+            ARCH_PROMPT_PREFIX
+                .contains("- Module: anything with an interface and an implementation")
+        );
+        assert!(ARCH_PROMPT_PREFIX.contains("- Interface: everything a caller must know (types, invariants, error modes, ordering, config)"));
+        assert!(ARCH_PROMPT_PREFIX.contains("- Implementation: the code inside"));
+        assert!(ARCH_PROMPT_PREFIX.contains("- Depth: leverage at the interface. Deep = high leverage. Shallow = interface nearly as complex as implementation"));
+        assert!(ARCH_PROMPT_PREFIX.contains(
+            "- Seam: where an interface lives; behavior can be altered without editing in place"
+        ));
+        assert!(
+            ARCH_PROMPT_PREFIX
+                .contains("- Adapter: a concrete thing satisfying an interface at a seam")
+        );
+        assert!(ARCH_PROMPT_PREFIX.contains("- Leverage: what callers get from depth"));
+        assert!(ARCH_PROMPT_PREFIX.contains("- Locality: what maintainers get from depth (change/bugs/knowledge concentrated in one place)"));
+        assert!(ARCH_PROMPT_PREFIX.contains("Deletion test: imagine deleting the module"));
+        assert!(ARCH_PROMPT_PREFIX.contains("The interface is the test surface"));
+        assert!(
+            ARCH_PROMPT_PREFIX
+                .contains("One adapter = hypothetical seam. Two adapters = real seam")
+        );
+        assert!(ARCH_PROMPT_PREFIX.contains("Explore: walk codebase noting friction"));
+        assert!(ARCH_PROMPT_PREFIX.contains("bouncing between modules"));
+        assert!(ARCH_PROMPT_PREFIX.contains("shallow modules"));
+        assert!(ARCH_PROMPT_PREFIX.contains("pure functions extracted just for testability"));
+        assert!(
+            ARCH_PROMPT_PREFIX.contains(
+                "Present candidates: numbered list with files, problem, solution, benefits"
+            )
+        );
+        assert!(
+            ARCH_PROMPT_PREFIX
+                .contains("Grilling loop: design conversation for selected candidate")
+        );
+        assert!(ARCH_PROMPT_PREFIX.contains("Update CONTEXT.md when naming new concepts"));
+        assert!(ARCH_PROMPT_PREFIX.contains("Offer an ADR when rejecting a candidate"));
+        assert!(prompt.ends_with("Analyze command dispatch depth"));
+    }
+}

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -7,6 +7,9 @@ use csa_core::types::{OutputFormat, ToolArg};
 #[path = "cli_session.rs"]
 mod cli_session;
 pub use cli_session::*;
+#[path = "cli_arch.rs"]
+mod cli_arch;
+pub use cli_arch::*;
 #[path = "cli_todo.rs"]
 mod cli_todo;
 pub use cli_todo::*;
@@ -290,6 +293,9 @@ pub enum Commands {
 
     /// Start a root-cause-first diagnostic debugging session
     Hunt(HuntArgs),
+
+    /// Run deep module architecture analysis
+    Arch(ArchArgs),
 
     /// Triage a GitHub issue into category and state roles
     Triage(TriageArgs),

--- a/crates/cli-sub-agent/src/cli_arch.rs
+++ b/crates/cli-sub-agent/src/cli_arch.rs
@@ -1,0 +1,14 @@
+#[derive(clap::Args)]
+pub struct ArchArgs {
+    /// Architecture analysis description
+    pub description: String,
+    /// Tool to use
+    #[arg(long)]
+    pub tool: Option<String>,
+    /// Session timeout in seconds
+    #[arg(long, default_value = "7200")]
+    pub timeout: u64,
+    /// Allow working on base branch
+    #[arg(long, alias = "allow-base-branch-commit")]
+    pub allow_base_branch_working: bool,
+}

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -294,6 +294,9 @@ pub fn validate_command_args(
         Commands::Hunt(args) => {
             validate_timeout(Some(args.timeout), min_timeout)?;
         }
+        Commands::Arch(args) => {
+            validate_timeout(Some(args.timeout), min_timeout)?;
+        }
         Commands::Triage(args) => {
             validate_timeout(Some(args.timeout), min_timeout)?;
         }

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use anyhow::Result;
 use clap::Parser;
 
+mod arch_cmd;
 mod audit;
 mod audit_cmds;
 mod batch;
@@ -451,6 +452,10 @@ async fn run() -> Result<()> {
                 output_format,
             )
             .await?;
+            exit_current_process(exit_code);
+        }
+        Commands::Arch(args) => {
+            let exit_code = arch_cmd::handle_arch_args(args, current_depth, output_format).await?;
             exit_current_process(exit_code);
         }
         Commands::Triage(args) => {

--- a/crates/cli-sub-agent/src/main_auto_weave_tests.rs
+++ b/crates/cli-sub-agent/src/main_auto_weave_tests.rs
@@ -44,6 +44,20 @@ fn triage_commands_still_attempt_auto_weave_upgrade() {
 }
 
 #[test]
+fn arch_commands_still_attempt_auto_weave_upgrade() {
+    let cli = Cli::parse_from(["csa", "arch", "module depth in command dispatch"]);
+    assert!(should_attempt_auto_weave_upgrade(&cli.command));
+}
+
+#[test]
+fn arch_command_is_listed_in_help() {
+    let help = Cli::command().render_long_help().to_string();
+
+    assert!(help.contains("arch"));
+    assert!(help.contains("Run deep module architecture analysis"));
+}
+
+#[test]
 fn triage_command_is_listed_in_help() {
     let help = Cli::command().render_long_help().to_string();
 

--- a/crates/cli-sub-agent/src/main_bootstrap.rs
+++ b/crates/cli-sub-agent/src/main_bootstrap.rs
@@ -31,7 +31,7 @@ pub(crate) fn should_attempt_auto_weave_upgrade(command: &Commands) -> bool {
     // Only execution commands need upgraded weave patterns.
     // All management/read-only commands stay available even when weave is unhealthy.
     match command {
-        Commands::Run { .. } | Commands::Hunt(_) | Commands::Triage(_) => true,
+        Commands::Run { .. } | Commands::Hunt(_) | Commands::Arch(_) | Commands::Triage(_) => true,
         Commands::Review(args) => !args.check_verdict,
         Commands::Debate(_) | Commands::Batch { .. } | Commands::Plan { .. } => true,
         Commands::ClaudeSubAgent(_) | Commands::McpServer => true,

--- a/crates/cli-sub-agent/tests/arch_e2e.rs
+++ b/crates/cli-sub-agent/tests/arch_e2e.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+fn csa_cmd(tmp: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+#[test]
+fn arch_help_shows_deep_module_options() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = csa_cmd(tmp.path())
+        .args(["arch", "--help"])
+        .output()
+        .expect("failed to run csa arch --help");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Architecture analysis description"));
+    assert!(stdout.contains("<DESCRIPTION>"));
+    assert!(stdout.contains("--tool"));
+    assert!(stdout.contains("--timeout"));
+    assert!(stdout.contains("--allow-base-branch-working"));
+}


### PR DESCRIPTION
## Summary
- New `csa arch` subcommand for Ousterhout-style deep module analysis
- Complete vocabulary: Module, Depth, Seam, Adapter, Leverage, Locality
- Deletion test, interface-as-test-surface principles
- 3-phase process: Explore → Present candidates → Grilling loop
- Uses SubagentRunConfig, includes e2e test

Closes #1285

## Test plan
- [x] `cargo test` passes
- [x] `csa arch --help` shows subcommand
- [x] e2e test validates CLI registration
- [x] Uses SubagentRunConfig pattern

Generated with [Claude Code](https://claude.com/claude-code)