### PR TITLE
feat(cli): add csa dev2merge CLI alias subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.663"
+version = "0.1.664"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.663"
+version = "0.1.664"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -425,6 +425,8 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: PlanCommands,
     },
+    #[command(name = "dev2merge", about = "Run the dev2merge workflow alias")]
+    Dev2merge(Dev2mergeArgs),
 
     /// Run pending config/state migrations
     Migrate {

--- a/crates/cli-sub-agent/src/cli_dev2merge.rs
+++ b/crates/cli-sub-agent/src/cli_dev2merge.rs
@@ -1,0 +1,22 @@
+//! CLI arguments for the `csa dev2merge` alias.
+
+use clap::Args;
+
+#[derive(Debug, Clone, Args)]
+pub struct Dev2mergeArgs {
+    /// GitHub issue number to fetch as FEATURE_INPUT
+    #[arg(long, value_name = "NUMBER", value_parser = clap::value_parser!(u64).range(1..))]
+    pub issue: Option<u64>,
+
+    /// Variable override passed through to the dev2merge workflow
+    #[arg(long = "var", value_name = "KEY=VALUE")]
+    pub vars: Vec<String>,
+
+    /// Autonomous mode flag (REQUIRED for root callers)
+    #[arg(long, value_name = "BOOL")]
+    pub sa_mode: Option<bool>,
+
+    /// Set MKTD_TIMEOUT_SECONDS for the dev2merge planning step
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+    pub timeout: Option<u64>,
+}

--- a/crates/cli-sub-agent/src/cli_plan.rs
+++ b/crates/cli-sub-agent/src/cli_plan.rs
@@ -3,6 +3,10 @@
 use clap::Subcommand;
 use csa_core::types::ToolName;
 
+#[path = "cli_dev2merge.rs"]
+mod cli_dev2merge;
+pub use cli_dev2merge::*;
+
 #[derive(Subcommand)]
 pub enum PlanCommands {
     /// Execute a weave workflow file

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -309,6 +309,9 @@ pub fn validate_command_args(
         Commands::Debate(args) => {
             validate_timeout(args.timeout, min_timeout)?;
         }
+        Commands::Dev2merge(args) => {
+            validate_timeout(args.timeout, min_timeout)?;
+        }
         _ => {}
     }
 

--- a/crates/cli-sub-agent/src/dev2merge_cmd.rs
+++ b/crates/cli-sub-agent/src/dev2merge_cmd.rs
@@ -1,0 +1,122 @@
+//! Thin CLI alias for running the dev2merge weave workflow.
+
+use anyhow::{Context, Result, bail};
+use tokio::process::Command;
+
+use crate::cli::Dev2mergeArgs;
+use crate::plan_cmd::{PlanRunArgs, PlanRunPipelineSource, handle_plan_run};
+
+const DEV2MERGE_PATTERN: &str = "dev2merge";
+const FEATURE_INPUT_VAR: &str = "FEATURE_INPUT";
+const MKTD_TIMEOUT_VAR: &str = "MKTD_TIMEOUT_SECONDS";
+
+pub(crate) async fn handle_dev2merge(args: Dev2mergeArgs, current_depth: u32) -> Result<()> {
+    let issue_body = match args.issue {
+        Some(issue) => Some(fetch_issue_body(issue).await?),
+        None => None,
+    };
+    let plan_args = build_plan_run_args(args, current_depth, issue_body);
+    handle_plan_run(plan_args).await
+}
+
+fn build_plan_run_args(
+    args: Dev2mergeArgs,
+    current_depth: u32,
+    issue_body: Option<String>,
+) -> PlanRunArgs {
+    let mut vars = Vec::new();
+    if let Some(body) = issue_body {
+        vars.push(format!("{FEATURE_INPUT_VAR}={body}"));
+    }
+    if let Some(timeout) = args.timeout {
+        vars.push(format!("{MKTD_TIMEOUT_VAR}={timeout}"));
+    }
+    vars.extend(args.vars);
+
+    PlanRunArgs {
+        file: None,
+        pattern: Some(DEV2MERGE_PATTERN.to_string()),
+        vars,
+        tool_override: None,
+        dry_run: false,
+        chunked: false,
+        resume: None,
+        cd: None,
+        current_depth,
+        pipeline_source: PlanRunPipelineSource::CliAlias,
+    }
+}
+
+async fn fetch_issue_body(issue: u64) -> Result<String> {
+    let issue_arg = issue.to_string();
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "view",
+            issue_arg.as_str(),
+            "--json",
+            "body",
+            "-q",
+            ".body",
+        ])
+        .output()
+        .await
+        .with_context(|| format!("Failed to run gh issue view {issue}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("gh issue view {issue} failed: {}", stderr.trim());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .trim_end_matches(['\r', '\n'])
+        .to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_dev2merge_plan_args_without_issue() {
+        let args = Dev2mergeArgs {
+            issue: None,
+            vars: vec!["EXTRA=value".to_string()],
+            sa_mode: Some(false),
+            timeout: None,
+        };
+
+        let plan_args = build_plan_run_args(args, 2, None);
+
+        assert_eq!(plan_args.file, None);
+        assert_eq!(plan_args.pattern.as_deref(), Some("dev2merge"));
+        assert_eq!(plan_args.vars, vec!["EXTRA=value"]);
+        assert_eq!(plan_args.current_depth, 2);
+        assert_eq!(plan_args.pipeline_source, PlanRunPipelineSource::CliAlias);
+    }
+
+    #[test]
+    fn issue_and_timeout_become_workflow_vars_before_passthrough_vars() {
+        let args = Dev2mergeArgs {
+            issue: Some(1287),
+            vars: vec![
+                "OTHER=value".to_string(),
+                "FEATURE_INPUT=explicit".to_string(),
+            ],
+            sa_mode: Some(true),
+            timeout: Some(1800),
+        };
+
+        let plan_args = build_plan_run_args(args, 0, Some("issue body".to_string()));
+
+        assert_eq!(
+            plan_args.vars,
+            vec![
+                "FEATURE_INPUT=issue body",
+                "MKTD_TIMEOUT_SECONDS=1800",
+                "OTHER=value",
+                "FEATURE_INPUT=explicit",
+            ]
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/dev2merge_cmd.rs
+++ b/crates/cli-sub-agent/src/dev2merge_cmd.rs
@@ -4,19 +4,38 @@ use anyhow::{Context, Result, bail};
 use tokio::process::Command;
 
 use crate::cli::Dev2mergeArgs;
-use crate::plan_cmd::{PlanRunArgs, PlanRunPipelineSource, handle_plan_run};
+use crate::plan_cmd::{PlanRunArgs, PlanRunPipelineSource};
+use crate::plan_cmd_daemon::{PlanRunDispatchInput, dispatch_plan_run};
 
 const DEV2MERGE_PATTERN: &str = "dev2merge";
 const FEATURE_INPUT_VAR: &str = "FEATURE_INPUT";
 const MKTD_TIMEOUT_VAR: &str = "MKTD_TIMEOUT_SECONDS";
 
-pub(crate) async fn handle_dev2merge(args: Dev2mergeArgs, current_depth: u32) -> Result<()> {
+pub(crate) async fn handle_dev2merge(
+    args: Dev2mergeArgs,
+    current_depth: u32,
+    sa_mode_active: bool,
+    text_output: bool,
+) -> Result<()> {
     let issue_body = match args.issue {
         Some(issue) => Some(fetch_issue_body(issue).await?),
         None => None,
     };
+    let sa_mode = args.sa_mode;
     let plan_args = build_plan_run_args(args, current_depth, issue_body);
-    handle_plan_run(plan_args).await
+    let forwarded_args = build_forwarded_plan_args(&plan_args, sa_mode);
+    dispatch_plan_run(
+        plan_args,
+        PlanRunDispatchInput {
+            foreground: false,
+            daemon_child: false,
+            session_id: None,
+            sa_mode_active,
+            text_output,
+            forwarded_args: Some(forwarded_args),
+        },
+    )
+    .await
 }
 
 fn build_plan_run_args(
@@ -45,6 +64,44 @@ fn build_plan_run_args(
         current_depth,
         pipeline_source: PlanRunPipelineSource::CliAlias,
     }
+}
+
+fn build_forwarded_plan_args(plan_args: &PlanRunArgs, sa_mode: Option<bool>) -> Vec<String> {
+    let mut forwarded = Vec::new();
+    if let Some(file) = &plan_args.file {
+        forwarded.push(file.clone());
+    }
+    if let Some(pattern) = &plan_args.pattern {
+        forwarded.push("--pattern".to_string());
+        forwarded.push(pattern.clone());
+    }
+    if let Some(sa_mode) = sa_mode {
+        forwarded.push("--sa-mode".to_string());
+        forwarded.push(sa_mode.to_string());
+    }
+    for var in &plan_args.vars {
+        forwarded.push("--var".to_string());
+        forwarded.push(var.clone());
+    }
+    if let Some(tool) = &plan_args.tool_override {
+        forwarded.push("--tool".to_string());
+        forwarded.push(tool.to_string());
+    }
+    if plan_args.dry_run {
+        forwarded.push("--dry-run".to_string());
+    }
+    if plan_args.chunked {
+        forwarded.push("--chunked".to_string());
+    }
+    if let Some(resume) = &plan_args.resume {
+        forwarded.push("--resume".to_string());
+        forwarded.push(resume.clone());
+    }
+    if let Some(cd) = &plan_args.cd {
+        forwarded.push("--cd".to_string());
+        forwarded.push(cd.clone());
+    }
+    forwarded
 }
 
 async fn fetch_issue_body(issue: u64) -> Result<String> {
@@ -123,6 +180,35 @@ mod tests {
                 "MKTD_TIMEOUT_SECONDS=1800",
                 "OTHER=value",
                 "FEATURE_INPUT=explicit",
+            ]
+        );
+    }
+
+    #[test]
+    fn forwarded_args_reexec_dev2merge_as_plan_run_with_alias_vars() {
+        let args = Dev2mergeArgs {
+            issue: Some(1287),
+            vars: vec!["OTHER=value".to_string()],
+            sa_mode: Some(true),
+            timeout: Some(1800),
+        };
+
+        let plan_args = build_plan_run_args(args, 0, Some("issue body".to_string()));
+        let forwarded = build_forwarded_plan_args(&plan_args, Some(true));
+
+        assert_eq!(
+            forwarded,
+            vec![
+                "--pattern",
+                "dev2merge",
+                "--sa-mode",
+                "true",
+                "--var",
+                "FEATURE_INPUT=issue body",
+                "--var",
+                "MKTD_TIMEOUT_SECONDS=1800",
+                "--var",
+                "OTHER=value",
             ]
         );
     }

--- a/crates/cli-sub-agent/src/dev2merge_cmd.rs
+++ b/crates/cli-sub-agent/src/dev2merge_cmd.rs
@@ -50,6 +50,13 @@ fn build_plan_run_args(
 async fn fetch_issue_body(issue: u64) -> Result<String> {
     let issue_arg = issue.to_string();
     let output = Command::new("gh")
+        .env(
+            "GH_CONFIG_DIR",
+            format!(
+                "{}/.config/gh-aider",
+                std::env::var("HOME").unwrap_or_default()
+            ),
+        )
         .args([
             "issue",
             "view",

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -17,6 +17,7 @@ mod debate_cmd;
 mod debate_cmd_output;
 mod debate_cmd_resolve;
 mod debate_errors;
+mod dev2merge_cmd;
 mod difficulty_routing;
 mod doctor;
 mod edit_restriction_guard;
@@ -766,6 +767,7 @@ async fn run() -> Result<()> {
             )
             .await?;
         }
+        Commands::Dev2merge(args) => dev2merge_cmd::handle_dev2merge(args, current_depth).await?,
         Commands::Migrate { dry_run, status } => {
             migrate_cmd::handle_migrate(dry_run, status)?;
         }

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -186,6 +186,7 @@ async fn run() -> Result<()> {
 
     let cli = Cli::parse_from(cli::normalize_epic_format_args(std::env::args_os()));
     let output_format = cli.format;
+    let text_output = matches!(output_format, OutputFormat::Text);
     let command = cli.command;
 
     // Resolve effective min_timeout_seconds from configs (project overrides global).
@@ -381,7 +382,7 @@ async fn run() -> Result<()> {
             // Daemon child path: continue with normal run logic and resolve stream mode.
             let stream_mode = if no_stream_stdout {
                 csa_process::StreamMode::BufferOnly
-            } else if stream_stdout || matches!(output_format, OutputFormat::Text) {
+            } else if stream_stdout || text_output {
                 csa_process::StreamMode::TeeToStderr
             } else {
                 csa_process::StreamMode::BufferOnly
@@ -438,7 +439,7 @@ async fn run() -> Result<()> {
             crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
                 sa_mode_active,
                 current_depth,
-                matches!(output_format, OutputFormat::Text),
+                text_output,
             );
             daemon_guard.finalize();
             exit_current_process(exit_code);
@@ -542,7 +543,7 @@ async fn run() -> Result<()> {
             crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
                 sa_mode_active,
                 current_depth,
-                matches!(output_format, OutputFormat::Text),
+                text_output,
             );
             daemon_guard.finalize();
             exit_current_process(exit_code);
@@ -561,7 +562,7 @@ async fn run() -> Result<()> {
             crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
                 sa_mode_active,
                 current_depth,
-                matches!(output_format, OutputFormat::Text),
+                text_output,
             );
             daemon_guard.finalize();
             exit_current_process(exit_code);
@@ -590,7 +591,7 @@ async fn run() -> Result<()> {
             crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
                 sa_mode_active,
                 current_depth,
-                matches!(output_format, OutputFormat::Text),
+                text_output,
             );
         }
         Commands::McpServer => {
@@ -759,15 +760,12 @@ async fn run() -> Result<()> {
         },
         Commands::Checklist { command } => checklist_cmd::handle_checklist_command(command)?,
         Commands::Plan { cmd } => {
-            plan_cmd_daemon::dispatch(
-                cmd,
-                current_depth,
-                sa_mode_active,
-                matches!(output_format, OutputFormat::Text),
-            )
-            .await?;
+            plan_cmd_daemon::dispatch(cmd, current_depth, sa_mode_active, text_output).await?;
         }
-        Commands::Dev2merge(args) => dev2merge_cmd::handle_dev2merge(args, current_depth).await?,
+        Commands::Dev2merge(args) => {
+            dev2merge_cmd::handle_dev2merge(args, current_depth, sa_mode_active, text_output)
+                .await?
+        }
         Commands::Migrate { dry_run, status } => {
             migrate_cmd::handle_migrate(dry_run, status)?;
         }
@@ -780,7 +778,7 @@ async fn run() -> Result<()> {
             crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
                 sa_mode_active,
                 current_depth,
-                matches!(output_format, OutputFormat::Text),
+                text_output,
             );
             exit_current_process(exit_code);
         }

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -66,6 +66,14 @@ impl PlanRunPipelineSource {
             Self::CliAlias => PLAN_PIPELINE_SOURCE_CLI_ALIAS,
         }
     }
+
+    pub(crate) fn from_str(value: &str) -> Option<Self> {
+        match value {
+            PLAN_PIPELINE_SOURCE_DIRECT => Some(Self::DirectPlanRun),
+            PLAN_PIPELINE_SOURCE_CLI_ALIAS => Some(Self::CliAlias),
+            _ => None,
+        }
+    }
 }
 
 fn default_plan_pipeline_source() -> String {
@@ -109,6 +117,7 @@ impl PlanRunJournal {
 struct PlanResumeContext {
     initial_vars: HashMap<String, String>,
     completed_steps: HashSet<usize>,
+    pipeline_source: Option<String>,
     resumed: bool,
 }
 
@@ -217,6 +226,7 @@ fn load_plan_resume_context(
         return Ok(PlanResumeContext {
             initial_vars,
             completed_steps: HashSet::new(),
+            pipeline_source: None,
             resumed: false,
         });
     }
@@ -236,6 +246,7 @@ fn load_plan_resume_context(
         return Ok(PlanResumeContext {
             initial_vars,
             completed_steps: HashSet::new(),
+            pipeline_source: None,
             resumed: false,
         });
     }
@@ -252,6 +263,7 @@ fn load_plan_resume_context(
         return Ok(PlanResumeContext {
             initial_vars,
             completed_steps: HashSet::new(),
+            pipeline_source: None,
             resumed: false,
         });
     }
@@ -276,6 +288,7 @@ fn load_plan_resume_context(
             return Ok(PlanResumeContext {
                 initial_vars,
                 completed_steps: HashSet::new(),
+                pipeline_source: None,
                 resumed: false,
             });
         }
@@ -286,6 +299,7 @@ fn load_plan_resume_context(
         );
     }
 
+    let pipeline_source = journal.pipeline_source.clone();
     for (key, value) in journal.vars {
         initial_vars.insert(key, value);
     }
@@ -297,6 +311,7 @@ fn load_plan_resume_context(
     Ok(PlanResumeContext {
         initial_vars,
         completed_steps: journal.completed_steps.into_iter().collect(),
+        pipeline_source: Some(pipeline_source),
         resumed: true,
     })
 }
@@ -548,7 +563,10 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
         &workflow_path,
         resume_context.initial_vars.clone(),
     );
-    journal.pipeline_source = pipeline_source.as_str().to_string();
+    journal.pipeline_source = resume_context
+        .pipeline_source
+        .clone()
+        .unwrap_or_else(|| pipeline_source.as_str().to_string());
     journal.completed_steps = resume_context.completed_steps.iter().copied().collect();
     apply_repo_fingerprint(&mut journal, &current_repo_fingerprint);
     persist_plan_journal(&journal_path, &journal)?;

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -50,12 +50,35 @@ pub(crate) use plan_cmd_steps::{
 };
 
 const PLAN_JOURNAL_SCHEMA_VERSION: u8 = 1;
+const PLAN_PIPELINE_SOURCE_DIRECT: &str = "direct-plan-run";
+const PLAN_PIPELINE_SOURCE_CLI_ALIAS: &str = "cli-alias";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlanRunPipelineSource {
+    DirectPlanRun,
+    CliAlias,
+}
+
+impl PlanRunPipelineSource {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::DirectPlanRun => PLAN_PIPELINE_SOURCE_DIRECT,
+            Self::CliAlias => PLAN_PIPELINE_SOURCE_CLI_ALIAS,
+        }
+    }
+}
+
+fn default_plan_pipeline_source() -> String {
+    PLAN_PIPELINE_SOURCE_DIRECT.to_string()
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PlanRunJournal {
     schema_version: u8,
     workflow_name: String,
     workflow_path: String,
+    #[serde(default = "default_plan_pipeline_source")]
+    pipeline_source: String,
     status: String,
     vars: HashMap<String, String>,
     completed_steps: Vec<usize>,
@@ -72,6 +95,7 @@ impl PlanRunJournal {
             schema_version: PLAN_JOURNAL_SCHEMA_VERSION,
             workflow_name: workflow_name.to_string(),
             workflow_path: normalize_path(workflow_path),
+            pipeline_source: default_plan_pipeline_source(),
             status: "running".to_string(),
             vars,
             completed_steps: Vec::new(),
@@ -368,6 +392,7 @@ pub(crate) struct PlanRunArgs {
     pub resume: Option<String>,
     pub cd: Option<String>,
     pub current_depth: u32,
+    pub pipeline_source: PlanRunPipelineSource,
 }
 
 /// Handle `csa plan run <file>` or `csa plan run --pattern <name>`.
@@ -388,6 +413,7 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
         resume,
         cd,
         current_depth,
+        pipeline_source,
     } = args;
 
     // 1. Determine project root
@@ -522,6 +548,7 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
         &workflow_path,
         resume_context.initial_vars.clone(),
     );
+    journal.pipeline_source = pipeline_source.as_str().to_string();
     journal.completed_steps = resume_context.completed_steps.iter().copied().collect();
     apply_repo_fingerprint(&mut journal, &current_repo_fingerprint);
     persist_plan_journal(&journal_path, &journal)?;

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -18,7 +18,7 @@ use tracing::warn;
 
 use crate::cli::PlanCommands;
 use crate::pipeline::determine_project_root;
-use crate::plan_cmd::{self, PlanRunArgs, handle_plan_run};
+use crate::plan_cmd::{self, PlanRunArgs, PlanRunPipelineSource, handle_plan_run};
 use crate::{error_hints, error_report, exit_current_process};
 
 const PLAN_TASK_TYPE: &str = "plan";
@@ -58,6 +58,7 @@ pub(crate) async fn dispatch(
         resume,
         cd,
         current_depth,
+        pipeline_source: PlanRunPipelineSource::DirectPlanRun,
     };
     if daemon_child {
         let sid = session_id.ok_or_else(|| {

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -22,6 +22,16 @@ use crate::plan_cmd::{self, PlanRunArgs, PlanRunPipelineSource, handle_plan_run}
 use crate::{error_hints, error_report, exit_current_process};
 
 const PLAN_TASK_TYPE: &str = "plan";
+const PLAN_PIPELINE_SOURCE_ENV: &str = "CSA_PLAN_PIPELINE_SOURCE";
+
+pub(crate) struct PlanRunDispatchInput {
+    pub foreground: bool,
+    pub daemon_child: bool,
+    pub session_id: Option<String>,
+    pub sa_mode_active: bool,
+    pub text_output: bool,
+    pub forwarded_args: Option<Vec<String>>,
+}
 
 /// Dispatch entry point for the `csa plan` subcommand group.
 ///
@@ -48,6 +58,14 @@ pub(crate) async fn dispatch(
         daemon_child,
         session_id,
     } = cmd;
+    let pipeline_source = if daemon_child {
+        std::env::var(PLAN_PIPELINE_SOURCE_ENV)
+            .ok()
+            .and_then(|value| PlanRunPipelineSource::from_str(&value))
+            .unwrap_or(PlanRunPipelineSource::DirectPlanRun)
+    } else {
+        PlanRunPipelineSource::DirectPlanRun
+    };
     let plan_args = PlanRunArgs {
         file,
         pattern,
@@ -58,10 +76,29 @@ pub(crate) async fn dispatch(
         resume,
         cd,
         current_depth,
-        pipeline_source: PlanRunPipelineSource::DirectPlanRun,
+        pipeline_source,
     };
-    if daemon_child {
-        let sid = session_id.ok_or_else(|| {
+    dispatch_plan_run(
+        plan_args,
+        PlanRunDispatchInput {
+            foreground,
+            daemon_child,
+            session_id,
+            sa_mode_active,
+            text_output,
+            forwarded_args: None,
+        },
+    )
+    .await
+}
+
+pub(crate) async fn dispatch_plan_run(
+    plan_args: PlanRunArgs,
+    input: PlanRunDispatchInput,
+) -> Result<()> {
+    let current_depth = plan_args.current_depth;
+    if input.daemon_child {
+        let sid = input.session_id.ok_or_else(|| {
             anyhow::anyhow!("--daemon-child requires --session-id (set by daemon parent)")
         })?;
         let exit_code = match handle_plan_run_daemon_child(plan_args, &sid).await {
@@ -76,19 +113,19 @@ pub(crate) async fn dispatch(
             }
         };
         crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
-            sa_mode_active,
+            input.sa_mode_active,
             current_depth,
-            text_output,
+            input.text_output,
         );
         exit_current_process(exit_code);
     }
 
-    if session_id.is_some() {
+    if input.session_id.is_some() {
         anyhow::bail!("--session-id is an internal flag and must not be used directly");
     }
 
     let needs_foreground = decide_needs_foreground(ForegroundDecisionInput {
-        foreground,
+        foreground: input.foreground,
         dry_run: plan_args.dry_run,
         chunked: plan_args.chunked,
         has_resume: plan_args.resume.is_some(),
@@ -97,15 +134,15 @@ pub(crate) async fn dispatch(
     });
 
     if !needs_foreground {
-        spawn_and_exit(&plan_args)?;
+        spawn_and_exit(&plan_args, input.forwarded_args)?;
         unreachable!("plan daemon spawn returned without exiting");
     }
 
     plan_cmd::handle_plan_run(plan_args).await?;
     crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
-        sa_mode_active,
+        input.sa_mode_active,
         current_depth,
-        text_output,
+        input.text_output,
     );
     Ok(())
 }
@@ -117,7 +154,10 @@ pub(crate) async fn dispatch(
 /// prints the ULID to stdout and an RPJ directive to stderr, then exits 0.
 ///
 /// On the daemon-child path, [`handle_plan_run_daemon_child`] takes over.
-pub(crate) fn spawn_and_exit(args: &PlanRunArgs) -> Result<()> {
+pub(crate) fn spawn_and_exit(
+    args: &PlanRunArgs,
+    forwarded_args: Option<Vec<String>>,
+) -> Result<()> {
     let session_id = csa_session::new_session_id();
     let project_root = determine_project_root(args.cd.as_deref())?;
     let session_root = csa_session::get_session_root(&project_root)?;
@@ -126,7 +166,8 @@ pub(crate) fn spawn_and_exit(args: &PlanRunArgs) -> Result<()> {
     let description = describe_plan_run(args);
     persist_placeholder_plan_session(&project_root, &session_dir, &session_id, &description)?;
 
-    let forwarded_args = build_forwarded_plan_args(&std::env::args().collect::<Vec<_>>());
+    let forwarded_args = forwarded_args
+        .unwrap_or_else(|| build_forwarded_plan_args(&std::env::args().collect::<Vec<_>>()));
 
     let csa_binary = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("csa"));
     let mut daemon_env = HashMap::new();
@@ -138,6 +179,10 @@ pub(crate) fn spawn_and_exit(args: &PlanRunArgs) -> Result<()> {
     daemon_env.insert(
         "CSA_DAEMON_PROJECT_ROOT".to_string(),
         project_root.display().to_string(),
+    );
+    daemon_env.insert(
+        PLAN_PIPELINE_SOURCE_ENV.to_string(),
+        args.pipeline_source.as_str().to_string(),
     );
 
     let config = csa_process::daemon::DaemonSpawnConfig {

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
@@ -14,6 +14,7 @@ fn make_args() -> PlanRunArgs {
         resume: None,
         cd: None,
         current_depth: 0,
+        pipeline_source: crate::plan_cmd::PlanRunPipelineSource::DirectPlanRun,
     }
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests.rs
@@ -85,6 +85,59 @@ fn load_plan_resume_context_reads_running_journal() {
         ctx.initial_vars.get("STEP_1_OUTPUT").map(String::as_str),
         Some("cached")
     );
+    assert_eq!(
+        ctx.pipeline_source.as_deref(),
+        Some(PLAN_PIPELINE_SOURCE_DIRECT)
+    );
+}
+
+#[test]
+fn load_plan_resume_context_preserves_cli_alias_pipeline_source() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workflow_path = tmp.path().join("workflow.toml");
+    std::fs::write(&workflow_path, "[workflow]\nname='dev2merge'\n").unwrap();
+
+    let plan = ExecutionPlan {
+        name: "dev2merge".into(),
+        description: String::new(),
+        variables: vec![],
+        steps: vec![],
+    };
+
+    let journal_path = tmp.path().join("dev2merge.journal.json");
+    let journal = PlanRunJournal {
+        schema_version: PLAN_JOURNAL_SCHEMA_VERSION,
+        workflow_name: "dev2merge".into(),
+        workflow_path: normalize_path(&workflow_path),
+        pipeline_source: PLAN_PIPELINE_SOURCE_CLI_ALIAS.to_string(),
+        status: "manual-handoff".into(),
+        vars: HashMap::new(),
+        completed_steps: vec![1],
+        last_error: Some("manual handoff required".to_string()),
+        repo_head: Some("abc123".to_string()),
+        repo_dirty: Some(false),
+    };
+    persist_plan_journal(&journal_path, &journal).unwrap();
+
+    let repo_fingerprint = RepoFingerprint {
+        head: Some("different-head".to_string()),
+        dirty: Some(true),
+    };
+    let ctx = load_plan_resume_context(
+        &plan,
+        &workflow_path,
+        &journal_path,
+        &HashMap::new(),
+        &repo_fingerprint,
+        true,
+    )
+    .unwrap();
+
+    assert!(ctx.resumed);
+    assert_eq!(
+        ctx.pipeline_source.as_deref(),
+        Some(PLAN_PIPELINE_SOURCE_CLI_ALIAS)
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/plan_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests.rs
@@ -9,6 +9,23 @@ fn safe_plan_name_normalizes_non_alphanumeric_characters() {
 }
 
 #[test]
+fn plan_journal_defaults_pipeline_source_for_legacy_json() {
+    let raw = r#"{
+        "schema_version": 1,
+        "workflow_name": "dev2merge",
+        "workflow_path": "/repo/patterns/dev2merge/workflow.toml",
+        "status": "running",
+        "vars": {},
+        "completed_steps": [],
+        "last_error": null
+    }"#;
+
+    let journal: PlanRunJournal = serde_json::from_str(raw).unwrap();
+
+    assert_eq!(journal.pipeline_source, PLAN_PIPELINE_SOURCE_DIRECT);
+}
+
+#[test]
 fn load_plan_resume_context_reads_running_journal() {
     let tmp = tempfile::tempdir().unwrap();
     let workflow_path = tmp.path().join("workflow.toml");
@@ -29,6 +46,7 @@ fn load_plan_resume_context_reads_running_journal() {
         schema_version: PLAN_JOURNAL_SCHEMA_VERSION,
         workflow_name: "test".into(),
         workflow_path: normalize_path(&workflow_path),
+        pipeline_source: default_plan_pipeline_source(),
         status: "running".into(),
         vars: HashMap::from([
             ("FEATURE".to_string(), "from-journal".to_string()),
@@ -87,6 +105,7 @@ fn load_plan_resume_context_rejects_journal_when_repo_fingerprint_changed() {
         schema_version: PLAN_JOURNAL_SCHEMA_VERSION,
         workflow_name: "test".into(),
         workflow_path: normalize_path(&workflow_path),
+        pipeline_source: default_plan_pipeline_source(),
         status: "running".into(),
         vars: HashMap::from([("STEP_1_OUTPUT".to_string(), "cached".to_string())]),
         completed_steps: vec![1],
@@ -134,6 +153,7 @@ fn load_plan_resume_context_requires_explicit_resume_for_manual_handoff() {
         schema_version: PLAN_JOURNAL_SCHEMA_VERSION,
         workflow_name: "test".into(),
         workflow_path: normalize_path(&workflow_path),
+        pipeline_source: default_plan_pipeline_source(),
         status: "manual-handoff".into(),
         vars: HashMap::from([("STEP_1_OUTPUT".to_string(), "cached".to_string())]),
         completed_steps: vec![1],
@@ -194,6 +214,7 @@ fn load_plan_resume_context_rejects_awaiting_user_journal_even_with_explicit_res
         schema_version: PLAN_JOURNAL_SCHEMA_VERSION,
         workflow_name: "test".into(),
         workflow_path: normalize_path(&workflow_path),
+        pipeline_source: default_plan_pipeline_source(),
         status: "awaiting-user".into(),
         vars: HashMap::from([("STEP_1_OUTPUT".to_string(), "cached".to_string())]),
         completed_steps: vec![1],

--- a/crates/cli-sub-agent/src/sa_mode.rs
+++ b/crates/cli-sub-agent/src/sa_mode.rs
@@ -14,6 +14,7 @@ fn command_name_for_sa_mode(command: &Commands) -> Option<&'static str> {
         Commands::Plan {
             cmd: PlanCommands::Run { .. },
         } => Some("plan run"),
+        Commands::Dev2merge(_) => Some("dev2merge"),
         Commands::ClaudeSubAgent(_) => Some("claude-sub-agent"),
         _ => None,
     }
@@ -29,6 +30,7 @@ pub(crate) fn command_sa_mode_arg(command: &Commands) -> Option<Option<bool>> {
         Commands::Plan {
             cmd: PlanCommands::Run { sa_mode, .. },
         } => Some(*sa_mode),
+        Commands::Dev2merge(args) => Some(args.sa_mode),
         Commands::ClaudeSubAgent(args) => Some(args.sa_mode),
         _ => None,
     }

--- a/crates/cli-sub-agent/src/sa_mode_tests.rs
+++ b/crates/cli-sub-agent/src/sa_mode_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::cli::{Cli, Commands, PlanCommands};
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
     use std::sync::{LazyLock, Mutex};
 
     static SA_MODE_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
@@ -41,7 +41,7 @@ mod tests {
     }
 
     #[test]
-    fn sa_mode_parses_for_batch_plan_and_claude_sub_agent() {
+    fn sa_mode_parses_for_batch_plan_dev2merge_and_claude_sub_agent() {
         let batch_cli = Cli::try_parse_from(["csa", "batch", "task.toml", "--sa-mode", "true"])
             .expect("batch cli should parse");
         match batch_cli.command {
@@ -59,6 +59,18 @@ mod tests {
             _ => panic!("expected plan command"),
         }
 
+        let dev2merge_cli =
+            Cli::try_parse_from(["csa", "dev2merge", "--sa-mode", "true", "--issue", "1287"])
+                .expect("dev2merge cli should parse");
+        match dev2merge_cli.command {
+            Commands::Dev2merge(args) => {
+                assert_eq!(args.sa_mode, Some(true));
+                assert_eq!(args.issue, Some(1287));
+                assert_eq!(args.timeout, None);
+            }
+            _ => panic!("expected dev2merge command"),
+        }
+
         let claude_cli =
             Cli::try_parse_from(["csa", "claude-sub-agent", "--sa-mode", "true", "question"])
                 .expect("claude-sub-agent cli should parse");
@@ -66,6 +78,15 @@ mod tests {
             Commands::ClaudeSubAgent(args) => assert_eq!(args.sa_mode, Some(true)),
             _ => panic!("expected claude-sub-agent command"),
         }
+    }
+
+    #[test]
+    fn top_level_help_lists_dev2merge_subcommand() {
+        let help = Cli::command().render_long_help().to_string();
+        assert!(
+            help.contains("dev2merge"),
+            "top-level help should list dev2merge subcommand:\n{help}"
+        );
     }
 
     #[test]
@@ -116,6 +137,7 @@ mod tests {
             &["csa", "debate", "question"],
             &["csa", "batch", "task.toml"],
             &["csa", "plan", "run", "flow.toml"],
+            &["csa", "dev2merge"],
             &["csa", "claude-sub-agent", "question"],
         ];
 


### PR DESCRIPTION
## Summary
- New `csa dev2merge` thin CLI alias wrapping `csa plan run patterns/dev2merge/workflow.toml`
- `--issue N` flag auto-fetches issue body via `gh issue view` (with Rule 029 GH_CONFIG_DIR)
- Routes through plan daemon for proper session management
- Preserves workflow.toml customizability (not a replacement)

Closes #1287

## Test plan
- [x] `cargo test` passes
- [x] `csa dev2merge --help` shows subcommand
- [x] GH_CONFIG_DIR set for `gh issue` calls (Rule 029)
- [x] SA mode propagation correct

Generated with [Claude Code](https://claude.com/claude-code)