### PR TITLE
test(csa-session): retry checkpoint git init on ETXTBSY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.664"
+version = "0.1.665"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.664"
+version = "0.1.665"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-session/src/checkpoint.rs
+++ b/crates/csa-session/src/checkpoint.rs
@@ -205,7 +205,31 @@ pub fn note_from_session(session: &crate::MetaSessionState) -> CheckpointNote {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
     use tempfile::tempdir;
+
+    const ETXTBSY_RAW_OS_ERROR: i32 = 26;
+
+    fn ensure_git_init_with_etxtbsy_retry(sessions_dir: &Path) {
+        for attempt in 0..=3 {
+            match crate::git::ensure_git_init(sessions_dir) {
+                Ok(()) => return,
+                Err(err) if is_text_file_busy(&err) && attempt < 3 => {
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+                Err(err) => panic!("failed to initialize test git repository: {err:#}"),
+            }
+        }
+    }
+
+    fn is_text_file_busy(error: &anyhow::Error) -> bool {
+        error.chain().any(|cause| {
+            cause
+                .downcast_ref::<std::io::Error>()
+                .and_then(std::io::Error::raw_os_error)
+                == Some(ETXTBSY_RAW_OS_ERROR)
+        })
+    }
 
     fn make_note() -> CheckpointNote {
         CheckpointNote {
@@ -451,7 +475,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let sessions_dir = tmp.path().join("sessions");
         std::fs::create_dir_all(&sessions_dir).unwrap();
-        crate::git::ensure_git_init(&sessions_dir).unwrap();
+        ensure_git_init_with_etxtbsy_retry(&sessions_dir);
 
         // Create commit + checkpoint
         let session_id = ulid::Ulid::new().to_string();


### PR DESCRIPTION
## Summary
- Add retry with 100ms backoff for `git init` ETXTBSY errors in checkpoint test helper
- Fixes flaky test failures during parallel nextest execution where git binary is still being written

Closes #1289

## Test plan
- [x] `just pre-commit` passes
- [x] `cargo test -p csa-session` passes
- [x] CSA review verdict: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)