### PR TITLE
fix(sandbox): add claude session-env to review writable paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.666"
+version = "0.1.667"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.666"
+version = "0.1.667"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -301,17 +301,11 @@ impl IsolationPlanBuilder {
                 add_dir_or_creatable_parent(&mut self.writable_paths, &default_rustup);
             }
 
-            // NOTE: mise-managed Rust toolchain paths are intentionally NOT added
-            // as writable. Making the entire install dir writable (rustc, stdlib)
-            // is an isolation regression. The cargo registry/git cache dirs are
-            // already covered by the CARGO_HOME logic above — when mise sets
-            // CARGO_HOME into the toolchain dir, those subdirs get write access.
+            // Do not make mise-managed toolchain install dirs writable; only the
+            // registry/git cache subdirs above need write access.
 
-            // Codex writes rollout JSONL and arg0 PATH shim files under
-            // CODEX_HOME (default: ~/.codex).  Expose an existing Codex home
-            // for every sandboxed parent because CSA sessions can recursively
-            // spawn Codex ACP children; an inner bwrap cannot make a source
-            // path writable if the parent bwrap mounted it read-only.
+            // Expose existing CODEX_HOME for every sandboxed parent so nested
+            // Codex CSA children inherit a writable source path.
             codex_paths::add_codex_home_for_tool(
                 tool_name,
                 &home,
@@ -319,19 +313,25 @@ impl IsolationPlanBuilder {
                 &mut self.required_writable_dirs,
             );
 
-            // Tool-specific config/data directories (only if they exist).
-            let tool_dirs: &[&str] = match tool_name {
-                "claude-code" => &[".claude"],
-                "codex" => &[],
-                "gemini-cli" => &[".gemini", ".config/gemini-cli"],
-                "opencode" => &[".config/opencode"],
-                _ => &[],
-            };
-            for rel in tool_dirs {
-                let p = home.join(rel);
-                if p.exists() {
-                    self.writable_paths.push(p);
+            // claude-code may cold-start by creating ~/.claude/session-env/<uuid>
+            // during review; pre-create ~/.claude so HOME does not stay read-only.
+            match tool_name {
+                "claude-code" => {
+                    let claude_dir = home.join(".claude");
+                    add_dir_or_creatable_parent(&mut self.writable_paths, &claude_dir);
                 }
+                "gemini-cli" => [".gemini", ".config/gemini-cli"]
+                    .into_iter()
+                    .map(|rel| home.join(rel))
+                    .filter(|path| path.exists())
+                    .for_each(|path| self.writable_paths.push(path)),
+                "opencode" => {
+                    let p = home.join(".config/opencode");
+                    if p.exists() {
+                        self.writable_paths.push(p);
+                    }
+                }
+                _ => {}
             }
         }
         self

--- a/crates/csa-resource/src/isolation_plan_path_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_path_tests.rs
@@ -1,4 +1,35 @@
 use super::*;
+use std::ffi::OsString;
+use std::sync::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: tests that mutate process environment hold ENV_LOCK.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: tests that mutate process environment hold ENV_LOCK.
+        unsafe {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+}
 
 #[test]
 fn test_resolve_writable_relative_path_against_project_root() {
@@ -79,4 +110,27 @@ fn test_writable_validation_error_includes_original_and_resolved_path() {
         err.contains("resolved path /etc is forbidden"),
         "missing resolved path: {err}"
     );
+}
+
+#[test]
+fn test_claude_tool_defaults_precreate_claude_dir_for_session_env() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+    let _home_env = ScopedEnvVar::set("HOME", &home);
+
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_tool_defaults(
+            "claude-code",
+            std::path::Path::new("/tmp/project"),
+            std::path::Path::new("/tmp/session"),
+        )
+        .build()
+        .expect("should succeed");
+
+    let claude_dir = home.join(".claude");
+    assert!(claude_dir.is_dir());
+    assert!(plan.writable_paths.contains(&claude_dir));
 }


### PR DESCRIPTION
## Summary
- Fix claude-code reviewer EROFS failure when creating `~/.claude/session-env/<uuid>` under bwrap sandbox
- Pre-create `~/.claude` directory and add it to writable bind mounts for review sessions
- Add test coverage for path provisioning logic

Closes #1292

## Test plan
- [x] `just pre-commit` passes
- [x] `cargo test -p csa-resource` passes
- [x] Codex review: findings=[] (PASS equivalent)
- [x] Gemini-cli unavailable (OAuth rate limit crash × 3 attempts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)