### PR TITLE
fix(review): accept consensus parent sessions in review-check verdict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.667"
+version = "0.1.668"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.667"
+version = "0.1.668"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -226,11 +226,16 @@ fn session_matches_branch(session: &MetaSessionState, branch: &str) -> bool {
 }
 
 fn session_is_reviewer_sub_session(session: &MetaSessionState) -> bool {
-    session
-        .task_context
-        .task_type
-        .as_deref()
-        .is_some_and(|task_type| task_type == REVIEWER_SUB_SESSION_TASK_TYPE)
+    let has_marker =
+        session.task_context.task_type.as_deref() == Some(REVIEWER_SUB_SESSION_TASK_TYPE);
+    let legacy_child = session.genealogy.parent_session_id.is_some()
+        && session
+            .description
+            .as_deref()
+            .unwrap_or("")
+            .trim_start()
+            .starts_with("review[");
+    has_marker || legacy_child
 }
 
 fn read_review_meta(session_dir: &Path) -> Result<Option<ReviewSessionMeta>> {

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -9,6 +9,7 @@ use csa_session::state::{MetaSessionState, ReviewSessionMeta};
 use tracing::debug;
 
 const REQUIRED_FULL_DIFF_SCOPE: &str = "range:main...HEAD";
+const REVIEWER_SUB_SESSION_TASK_TYPE: &str = "reviewer_sub_session";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ReviewVerdictMatch {
@@ -226,9 +227,10 @@ fn session_matches_branch(session: &MetaSessionState, branch: &str) -> bool {
 
 fn session_is_reviewer_sub_session(session: &MetaSessionState) -> bool {
     session
-        .description
+        .task_context
+        .task_type
         .as_deref()
-        .is_some_and(|description| description.trim_start().starts_with("review["))
+        .is_some_and(|task_type| task_type == REVIEWER_SUB_SESSION_TASK_TYPE)
 }
 
 fn read_review_meta(session_dir: &Path) -> Result<Option<ReviewSessionMeta>> {
@@ -414,6 +416,13 @@ mod tests {
         .expect("write review verdict");
 
         session.meta_session_id
+    }
+
+    fn set_task_type(project_root: &Path, session_id: &str, task_type: &str) {
+        let mut session =
+            csa_session::load_session(project_root, session_id).expect("load session");
+        session.task_context.task_type = Some(task_type.to_string());
+        csa_session::save_session(&session).expect("save session");
     }
 
     fn set_review_diff_fingerprint(
@@ -607,7 +616,7 @@ mod tests {
         let project = temp.path().join("project");
         std::fs::create_dir_all(&project).unwrap();
 
-        write_review_session_with_description(
+        let sub_session_id = write_review_session_with_description(
             &project,
             "feature",
             "abcdef1234567890",
@@ -617,6 +626,7 @@ mod tests {
             None,
             "review[1]: range:main...HEAD",
         );
+        set_task_type(&project, &sub_session_id, REVIEWER_SUB_SESSION_TASK_TYPE);
         write_review_session(
             &project,
             "feature",
@@ -632,6 +642,32 @@ mod tests {
             found.is_none(),
             "unparented reviewer sub-session pass must not satisfy gate"
         );
+    }
+
+    #[test]
+    fn check_verdict_accepts_consensus_parent_named_like_reviewer() {
+        let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+        let temp = TempDir::new().unwrap();
+        let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", temp.path().join("state"));
+        let project = temp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+
+        let session_id = write_review_session_with_description(
+            &project,
+            "feature",
+            "abcdef1234567890",
+            REQUIRED_FULL_DIFF_SCOPE,
+            ReviewDecision::Pass,
+            "CLEAN",
+            None,
+            "review[2]: range:main...HEAD",
+        );
+        set_task_type(&project, &session_id, "review");
+
+        let found = check_review_verdict_for_target(&project, "feature", "abcdef1234567890", None)
+            .unwrap()
+            .expect("consensus parent session should satisfy gate");
+        assert_eq!(found.session_id, session_id);
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -48,6 +48,8 @@ use failures::{
     repair_completed_review_restriction_result,
 };
 
+const REVIEWER_SUB_SESSION_TASK_TYPE: &str = "reviewer_sub_session";
+
 pub(crate) struct ReviewExecutionOutcome {
     pub execution: crate::pipeline::SessionExecutionResult,
     pub persistable_session_id: Option<String>,
@@ -537,7 +539,7 @@ async fn execute_review_once(
         project_root,
         project_config,
         extra_env,
-        Some("review"),
+        Some(REVIEWER_SUB_SESSION_TASK_TYPE),
         tier_name,
         None,
         stream_mode,


### PR DESCRIPTION
## Summary
- Fix review-check pre-push hook misclassifying multi-reviewer parent consensus sessions as sub-sessions
- Use parent_session_id + description prefix (legacy) OR explicit task_type marker (new) to identify child reviewer sub-sessions
- Parent consensus sessions (no parent_session_id) are no longer skipped even with `review[N]:` description

Closes #1293, closes #1303

## Test plan
- [x] `just pre-commit` passes
- [x] `cargo check -p cli-sub-agent` compiles
- [x] Codex review: 1 finding (legacy compat gap) — fixed in second commit
- [x] Logic: parent sessions (no parent_id) pass through; legacy children (parent_id + review[ prefix) still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)