### PR TITLE
test(checkpoint): ensure files staged before roundtrip commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.669"
+version = "0.1.670"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.669"
+version = "0.1.670"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-session/src/checkpoint.rs
+++ b/crates/csa-session/src/checkpoint.rs
@@ -206,6 +206,7 @@ pub fn note_from_session(session: &crate::MetaSessionState) -> CheckpointNote {
 mod tests {
     use super::*;
     use crate::test_env::TEST_ENV_LOCK;
+    use std::process::Output;
     use std::time::Duration;
     use tempfile::tempdir;
 
@@ -230,6 +231,55 @@ mod tests {
                 .and_then(std::io::Error::raw_os_error)
                 == Some(ETXTBSY_RAW_OS_ERROR)
         })
+    }
+
+    fn run_git_output_with_etxtbsy_retry(sessions_dir: &Path, args: &[&str]) -> Output {
+        let max_attempts = 4;
+        for attempt in 0..max_attempts {
+            match Command::new("git")
+                .args(args)
+                .current_dir(sessions_dir)
+                .output()
+            {
+                Ok(output) => return output,
+                Err(err)
+                    if err.raw_os_error() == Some(ETXTBSY_RAW_OS_ERROR)
+                        && attempt + 1 < max_attempts =>
+                {
+                    std::thread::sleep(Duration::from_millis(25_u64 << attempt));
+                }
+                Err(err) => panic!("git {args:?} failed: {err}"),
+            }
+        }
+        unreachable!("retry loop should have returned or panicked")
+    }
+
+    fn stage_session_dir_for_commit(sessions_dir: &Path, session_id: &str) {
+        let session_path = format!("{session_id}/");
+        let output = run_git_output_with_etxtbsy_retry(sessions_dir, &["add", "--", &session_path]);
+        assert!(
+            output.status.success(),
+            "git add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn has_staged_session_changes(sessions_dir: &Path, session_id: &str) -> bool {
+        let session_path = format!("{session_id}/");
+        let output = run_git_output_with_etxtbsy_retry(
+            sessions_dir,
+            &["diff", "--cached", "--quiet", "--", &session_path],
+        );
+
+        match output.status.code() {
+            Some(0) => false,
+            Some(1) => true,
+            Some(code) => panic!(
+                "git diff --cached failed (exit {code}): {}",
+                String::from_utf8_lossy(&output.stderr)
+            ),
+            None => panic!("git diff --cached terminated by signal"),
+        }
     }
 
     fn make_note() -> CheckpointNote {
@@ -410,13 +460,26 @@ mod tests {
         let tmp = tempdir().unwrap();
         let sessions_dir = tmp.path().join("sessions");
         std::fs::create_dir_all(&sessions_dir).unwrap();
-        crate::git::ensure_git_init(&sessions_dir).unwrap();
+        ensure_git_init_with_etxtbsy_retry(&sessions_dir);
 
         // Create a commit to attach the note to
         let session_id = ulid::Ulid::new().to_string();
         let session_dir = sessions_dir.join(&session_id);
         std::fs::create_dir_all(&session_dir).unwrap();
         std::fs::write(session_dir.join("state.toml"), "test = true").unwrap();
+        stage_session_dir_for_commit(&sessions_dir, &session_id);
+        if !has_staged_session_changes(&sessions_dir, &session_id) {
+            std::fs::write(
+                session_dir.join("state.toml"),
+                "test = true\nroundtrip = true",
+            )
+            .unwrap();
+            stage_session_dir_for_commit(&sessions_dir, &session_id);
+        }
+        assert!(
+            has_staged_session_changes(&sessions_dir, &session_id),
+            "test fixture must have staged changes before commit_session"
+        );
         crate::git::commit_session(&sessions_dir, &session_id, "test session").unwrap();
 
         // Get the commit SHA for this session


### PR DESCRIPTION
## Summary
- Fix flaky `test_write_and_read_checkpoint_roundtrip` that fails with "No changes to commit"
- Add ETXTBSY retry helper and explicit staging verification before commit
- Assert staged changes exist before attempting checkpoint commit

Closes #1298

## Test plan
- [x] `just pre-commit` passes
- [x] `cargo test -p csa-session` passes
- [x] Defensive staging check prevents "No changes to commit" race

🤖 Generated with [Claude Code](https://claude.com/claude-code)