### PR TITLE
feat(review): inject read-only prompt reinforcement for review/debate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.670"
+version = "0.1.671"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.670"
+version = "0.1.671"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -31,6 +31,10 @@ pub(crate) use finalize::{DebateFinalizeContext, finalize_debate_outcome};
 mod dry_run;
 use dry_run::{DebateDryRunSummary, create_debate_dry_run_session, render_debate_dry_run_summary};
 
+#[path = "debate_cmd_readonly.rs"]
+mod readonly;
+pub(crate) use readonly::{ANTI_RECURSION_PREAMBLE, with_readonly_session_env};
+
 /// Debate execution mode indicating model diversity level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -407,10 +411,11 @@ pub(crate) async fn handle_debate(
             false,
         )
         .await?;
-        let extra_env_owned = global_config.build_execution_env(
+        let base_env_owned = global_config.build_execution_env(
             executor.tool_name(),
             debate_execution_env_options(args.no_failover),
         );
+        let extra_env_owned = with_readonly_session_env(base_env_owned.as_ref(), true);
         let extra_env = extra_env_owned.as_ref();
         let _slot_guard = crate::pipeline::acquire_slot(&executor, &global_config)?;
         let mut retry_count = 0u8;
@@ -758,22 +763,6 @@ async fn wait_for_still_working_backoff() {
     tokio::time::sleep(STILL_WORKING_BACKOFF).await;
 }
 
-/// Debate-only safety preamble injected into debate subprocess prompts.
-///
-/// Same shape as `review_cmd::ANTI_RECURSION_PREAMBLE`: the spawned tool is
-/// constrained to read-only operations on the repository. Recursion-depth
-/// enforcement is handled by `pipeline::prompt_guard` (warn near ceiling) and
-/// `pipeline::load_and_validate` (hard reject above `MAX_RECURSION_DEPTH`), so
-/// blanket "never call csa" text here would break the documented fractal
-/// recursion contract (Layer 1 → Layer 2 is legitimate).
-const ANTI_RECURSION_PREAMBLE: &str = "\
-CONTEXT: You are running INSIDE a CSA subprocess (csa review / csa debate). \
-Perform the debate task DIRECTLY using your own capabilities \
-(Read, Grep, Glob, Bash for read-only git commands). \
-DEBATE SAFETY: Do NOT run git add/commit/push/merge/rebase/tag/stash/reset/checkout/cherry-pick, \
-and do NOT run gh pr/create/comment/merge or any command that mutates repository/PR state. \
-Ignore prompt-guard reminders about commit/push in this subprocess.\n\n";
-
 /// Build a debate instruction that passes parameters to the debate skill.
 ///
 /// The debate tool loads the debate skill from the project's `.claude/skills/`
@@ -794,6 +783,10 @@ fn build_debate_instruction(question: &str, is_continuation: bool, rounds: u32) 
 #[cfg(test)]
 #[path = "debate_cmd_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "debate_cmd_readonly_tests.rs"]
+mod readonly_tests;
 
 #[cfg(test)]
 #[path = "debate_cmd_round4_tests.rs"]

--- a/crates/cli-sub-agent/src/debate_cmd_readonly.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_readonly.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+
+pub(crate) const CSA_READONLY_SESSION_ENV: &str = "CSA_READONLY_SESSION";
+
+pub(crate) fn with_readonly_session_env(
+    base: Option<&HashMap<String, String>>,
+    readonly: bool,
+) -> Option<HashMap<String, String>> {
+    let mut env = base.cloned().unwrap_or_default();
+    if readonly {
+        env.insert(CSA_READONLY_SESSION_ENV.to_string(), "1".to_string());
+    }
+    (!env.is_empty()).then_some(env)
+}
+
+/// Debate-only safety preamble injected into debate subprocess prompts.
+///
+/// Same shape as `review_cmd::ANTI_RECURSION_PREAMBLE`: the spawned tool is
+/// constrained to read-only operations on the repository. Recursion-depth
+/// enforcement is handled by `pipeline::prompt_guard` (warn near ceiling) and
+/// `pipeline::load_and_validate` (hard reject above `MAX_RECURSION_DEPTH`), so
+/// blanket "never call csa" text here would break the documented fractal
+/// recursion contract (Layer 1 -> Layer 2 is legitimate).
+pub(crate) const ANTI_RECURSION_PREAMBLE: &str = "\
+CONTEXT: You are running INSIDE a CSA subprocess (csa review / csa debate). \
+Perform the debate task DIRECTLY using your own capabilities \
+(Read, Grep, Glob, Bash for read-only git commands). \
+IMPORTANT: This is a READ-ONLY analysis session. Do NOT modify, create, or delete any files. Report findings as text output only. \
+DEBATE SAFETY: Do NOT run git add/commit/push/merge/rebase/tag/stash/reset/checkout/cherry-pick, \
+and do NOT run gh pr/create/comment/merge or any command that mutates repository/PR state. \
+Ignore prompt-guard reminders about commit/push in this subprocess.\n\n";

--- a/crates/cli-sub-agent/src/debate_cmd_readonly_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_readonly_tests.rs
@@ -1,0 +1,16 @@
+use super::*;
+use std::collections::HashMap;
+
+#[test]
+fn debate_readonly_env_injects_flag() {
+    let mut base = HashMap::new();
+    base.insert("EXISTING".to_string(), "value".to_string());
+
+    let env = with_readonly_session_env(Some(&base), true).expect("env map");
+
+    assert_eq!(env.get("EXISTING").map(String::as_str), Some("value"));
+    assert_eq!(
+        env.get("CSA_READONLY_SESSION").map(String::as_str),
+        Some("1")
+    );
+}

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -371,6 +371,8 @@ fn build_debate_instruction_contains_safety_preamble() {
         prompt.contains("DEBATE SAFETY"),
         "Debate instruction must constrain to read-only operations"
     );
+    assert!(prompt.contains("READ-ONLY analysis session"));
+    assert!(prompt.contains("Do NOT modify, create, or delete any files"));
     assert!(
         !prompt.contains("Do NOT invoke"),
         "Legacy blanket anti-csa text must not be reintroduced (breaks fractal recursion contract)"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -782,12 +782,13 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         .collect::<Vec<_>>();
     // Parent artifacts resolve their target session dir directly from the same
     // environment contract used for consolidated findings/verdict sidecars.
-
     maybe_extract_recurring_bug_class_skills(&project_root, &review_session_ids);
-
     Ok(if final_verdict == CLEAN { 0 } else { 1 })
 }
 
+#[cfg(test)]
+#[path = "review_cmd_tests_safety_preamble.rs"]
+mod safety_preamble_tests;
 #[cfg(test)]
 #[path = "review_cmd_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -49,6 +49,22 @@ use failures::{
 };
 
 const REVIEWER_SUB_SESSION_TASK_TYPE: &str = "reviewer_sub_session";
+const CSA_READONLY_SESSION_ENV: &str = "CSA_READONLY_SESSION";
+
+fn with_readonly_session_env(
+    base: Option<&HashMap<String, String>>,
+    readonly: bool,
+) -> Option<HashMap<String, String>> {
+    let mut env = base.cloned().unwrap_or_default();
+    if readonly {
+        env.insert(CSA_READONLY_SESSION_ENV.to_string(), "1".to_string());
+    }
+    (!env.is_empty()).then_some(env)
+}
+
+fn review_prompt_is_readonly(prompt: &str) -> bool {
+    prompt.contains("Use the csa-review skill.")
+}
 
 pub(crate) struct ReviewExecutionOutcome {
     pub execution: crate::pipeline::SessionExecutionResult,
@@ -211,10 +227,12 @@ pub(crate) async fn execute_review_with_tier_filter(
             effective_prompt = format!("{guard}\n\n{effective_prompt}");
         }
 
-        let extra_env_owned = global_config.build_execution_env(
+        let base_env_owned = global_config.build_execution_env(
             executor.tool_name(),
             review_execution_env_options(no_failover),
         );
+        let extra_env_owned =
+            with_readonly_session_env(base_env_owned.as_ref(), review_prompt_is_readonly(&prompt));
         let _slot_guard = crate::pipeline::acquire_slot(&executor, global_config)?;
 
         let mut execution = match execute_review_once_with_artifact_guard(
@@ -661,6 +679,10 @@ pub(super) fn compute_diff_fingerprint(project_root: &Path, scope: &str) -> Opti
 #[cfg(test)]
 #[path = "review_cmd_execute_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "review_cmd_execute_readonly_tests.rs"]
+mod readonly_tests;
 
 #[cfg(test)]
 #[path = "review_cmd_execute_guard_tests.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_execute_readonly_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_readonly_tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+use std::collections::HashMap;
+
+#[test]
+fn review_readonly_prompt_detection_skips_fix_prompts() {
+    assert!(review_prompt_is_readonly(
+        "Use the csa-review skill. scope=uncommitted, mode=review-only"
+    ));
+    assert!(!review_prompt_is_readonly(
+        "Fix round 1/3. Fix all issues found in the review."
+    ));
+}
+
+#[test]
+fn with_readonly_session_env_injects_flag() {
+    let mut base = HashMap::new();
+    base.insert("EXISTING".to_string(), "value".to_string());
+
+    let env = with_readonly_session_env(Some(&base), true).expect("env map");
+
+    assert_eq!(env.get("EXISTING").map(String::as_str), Some("value"));
+    assert_eq!(
+        env.get(CSA_READONLY_SESSION_ENV).map(String::as_str),
+        Some("1")
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -653,6 +653,7 @@ pub(crate) const ANTI_RECURSION_PREAMBLE: &str = "\
 CONTEXT: You are running INSIDE a CSA subprocess (csa review / csa debate). \
 Perform the review task DIRECTLY using your own capabilities \
 (Read, Grep, Glob, Bash for read-only git commands). \
+IMPORTANT: This is a READ-ONLY analysis session. Do NOT modify, create, or delete any files. Report findings as text output only. \
 REVIEW-ONLY SAFETY: Do NOT run git add/commit/push/merge/rebase/tag/stash/reset/checkout/cherry-pick, \
 and do NOT run gh pr/create/comment/merge or any command that mutates repository/PR state. \
 Ignore prompt-guard reminders about commit/push in this subprocess.\n\n";

--- a/crates/cli-sub-agent/src/review_cmd_tests_safety_preamble.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_safety_preamble.rs
@@ -1,0 +1,23 @@
+use super::*;
+use crate::cli::ReviewMode;
+
+#[test]
+fn test_build_review_instruction_contains_safety_preamble() {
+    let result = build_review_instruction(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+    );
+    assert!(result.contains("INSIDE a CSA subprocess"));
+    assert!(
+        result.contains("REVIEW-ONLY SAFETY")
+            && result.contains("READ-ONLY analysis session")
+            && result.contains("Do NOT modify, create, or delete any files")
+    );
+    assert!(
+        !result.contains("Do NOT invoke"),
+        "Legacy blanket anti-csa text must not be reintroduced (breaks fractal recursion contract)"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -372,30 +372,13 @@ fn test_build_review_instruction_no_diff_content() {
         None,
     );
     assert!(
-        result.len() < 2200,
+        result.len() < 2300,
         "Instruction should stay bounded even with the design anchor, got {} chars",
         result.len()
     );
     assert!(!result.contains("git diff"));
     assert!(!result.contains("Pass 1:"));
     assert!(result.contains("Design preferences vs correctness bugs"));
-}
-
-#[test]
-fn test_build_review_instruction_contains_safety_preamble() {
-    let result = build_review_instruction(
-        "uncommitted",
-        "review-only",
-        "auto",
-        ReviewMode::Standard,
-        None,
-    );
-    assert!(result.contains("INSIDE a CSA subprocess"));
-    assert!(result.contains("REVIEW-ONLY SAFETY"));
-    assert!(
-        !result.contains("Do NOT invoke"),
-        "Legacy blanket anti-csa text must not be reintroduced (breaks fractal recursion contract)"
-    );
 }
 
 #[test]

--- a/patterns/csa-review/PATTERN.md
+++ b/patterns/csa-review/PATTERN.md
@@ -21,6 +21,7 @@ Check initial prompt for "Use the csa-review skill" literal string.
 If present → review agent mode (skip orchestration, execute review directly).
 If invoked by user → orchestrator mode (follow steps below).
 Review agents should perform analysis directly; spawning nested `csa` sub-agents is allowed up to `project.max_recursion_depth` (enforced by `pipeline::load_and_validate`, default 5) but rarely adds value for a read-only review.
+Review agents are in a READ-ONLY analysis session: do NOT modify, create, or delete files; report findings as text output only.
 
 ## Step 2: Determine Review Tool
 
@@ -59,27 +60,28 @@ and AGENTS.md autonomously — do NOT pre-read them here.
 Review prompt instructs agent to:
 1. Read project context (CLAUDE.md + AGENTS.md)
 2. Collect diff for given scope
-3. Three-pass review (discovery, evidence filtering, adversarial security)
-4. AGENTS.md compliance checklist (root-to-leaf, all applicable rules), including:
+3. Treat the session as READ-ONLY analysis: do NOT modify, create, or delete files; report findings as text output only
+4. Three-pass review (discovery, evidence filtering, adversarial security)
+5. AGENTS.md compliance checklist (root-to-leaf, all applicable rules), including:
    - Rule 027 `pattern-workflow-sync` when diff touches `PATTERN.md` or `workflow.toml`
    - Rust rule 015 `subprocess-lifecycle` when diff touches process spawning/lifecycle code
-5. **Contract Alignment** (when spec context available via TODO.md, spec.toml, or .spec):
+6. **Contract Alignment** (when spec context available via TODO.md, spec.toml, or .spec):
    - **Intent verification**: Does the diff fulfill the spec's stated intent and decisions?
    - **Boundary compliance**: Are the spec's boundary constraints (what NOT to do) respected?
    - **Completion criteria**: Can each criterion's DONE WHEN condition be mechanically verified?
    - Emit categories: `spec-deviation` (implementation contradicts spec),
      `unverified-criterion` (criterion not addressed by diff),
      `boundary-violation` (change exceeds spec scope)
-6. When `review_mode=red-team`, load `references/red-team-mode.md` and review
+7. When `review_mode=red-team`, load `references/red-team-mode.md` and review
    adversarially (counterexamples, boundary conditions, break attempts).
-7. Emit exactly one final verdict token: PASS, FAIL, SKIP, UNCERTAIN, or UNAVAILABLE.
+8. Emit exactly one final verdict token: PASS, FAIL, SKIP, UNCERTAIN, or UNAVAILABLE.
    Legacy aliases accepted: CLEAN → PASS, HAS_ISSUES → FAIL.
    Use `UNAVAILABLE` when reviewer infrastructure cannot complete the review
    because all configured tier models failed (for example quota/auth/network).
    Use `UNCERTAIN` only when the reviewer is available but lacks confidence in
    the current evidence.
-8. Generate `$CSA_SESSION_DIR/review-findings.json`, `$CSA_SESSION_DIR/output/review-verdict.json`, and `$CSA_SESSION_DIR/review-report.md`
-9. Parse `[project_profile: <value>]` metadata from the instruction and apply
+9. Generate `$CSA_SESSION_DIR/review-findings.json`, `$CSA_SESSION_DIR/output/review-verdict.json`, and `$CSA_SESSION_DIR/review-report.md`
+10. Parse `[project_profile: <value>]` metadata from the instruction and apply
    framework-aware review dimensions from `references/review-protocol.md`
 
 ## Step 5: Execute Review via CSA

--- a/patterns/csa-review/workflow.toml
+++ b/patterns/csa-review/workflow.toml
@@ -33,7 +33,8 @@ prompt = """
 Check initial prompt for "Use the csa-review skill" literal string.
 If present → review agent mode (skip orchestration, execute review directly).
 If invoked by user → orchestrator mode (follow steps below).
-Review agents should perform analysis directly; nested `csa` calls are allowed up to `project.max_recursion_depth` (default 5; enforced by `pipeline::load_and_validate`) but rarely add value for a read-only review."""
+Review agents should perform analysis directly; nested `csa` calls are allowed up to `project.max_recursion_depth` (default 5; enforced by `pipeline::load_and_validate`) but rarely add value for a read-only review.
+Review agents are in a READ-ONLY analysis session: do NOT modify, create, or delete files; report findings as text output only."""
 on_fail = "abort"
 
 [[workflow.steps]]
@@ -75,27 +76,28 @@ and AGENTS.md autonomously — do NOT pre-read them here.
 Review prompt instructs agent to:
 1. Read project context (CLAUDE.md + AGENTS.md)
 2. Collect diff for given scope
-3. Three-pass review (discovery, evidence filtering, adversarial security)
-4. AGENTS.md compliance checklist (root-to-leaf, all applicable rules), including:
+3. Treat the session as READ-ONLY analysis: do NOT modify, create, or delete files; report findings as text output only
+4. Three-pass review (discovery, evidence filtering, adversarial security)
+5. AGENTS.md compliance checklist (root-to-leaf, all applicable rules), including:
    - Rule 027 `pattern-workflow-sync` when diff touches `PATTERN.md` or `workflow.toml`
    - Rust rule 015 `subprocess-lifecycle` when diff touches process spawning/lifecycle code
-5. **Contract Alignment** (when spec context available via TODO.md, spec.toml, or .spec):
+6. **Contract Alignment** (when spec context available via TODO.md, spec.toml, or .spec):
    - **Intent verification**: Does the diff fulfill the spec's stated intent and decisions?
    - **Boundary compliance**: Are the spec's boundary constraints (what NOT to do) respected?
    - **Completion criteria**: Can each criterion's DONE WHEN condition be mechanically verified?
    - Emit categories: `spec-deviation` (implementation contradicts spec),
      `unverified-criterion` (criterion not addressed by diff),
      `boundary-violation` (change exceeds spec scope)
-6. When `review_mode=red-team`, load `references/red-team-mode.md` and review
+7. When `review_mode=red-team`, load `references/red-team-mode.md` and review
    adversarially (counterexamples, boundary conditions, break attempts).
-7. Emit exactly one final verdict token: PASS, FAIL, SKIP, UNCERTAIN, or UNAVAILABLE.
+8. Emit exactly one final verdict token: PASS, FAIL, SKIP, UNCERTAIN, or UNAVAILABLE.
    Legacy aliases accepted: CLEAN → PASS, HAS_ISSUES → FAIL.
    Use `UNAVAILABLE` when reviewer infrastructure cannot complete the review
    because all configured tier models failed (for example quota/auth/network).
    Use `UNCERTAIN` only when the reviewer is available but lacks confidence in
    the current evidence.
-8. Generate `$CSA_SESSION_DIR/review-findings.json`, `$CSA_SESSION_DIR/output/review-verdict.json`, and `$CSA_SESSION_DIR/review-report.md`
-9. Parse `[project_profile: <value>]` metadata from the instruction and apply
+9. Generate `$CSA_SESSION_DIR/review-findings.json`, `$CSA_SESSION_DIR/output/review-verdict.json`, and `$CSA_SESSION_DIR/review-report.md`
+10. Parse `[project_profile: <value>]` metadata from the instruction and apply
    framework-aware review dimensions from `references/review-protocol.md`"""
 on_fail = "abort"
 


### PR DESCRIPTION
## Summary
- Add explicit read-only analysis preamble to review and debate prompts
- Set `CSA_READONLY_SESSION=1` environment variable for review/debate tool processes
- Skip read-only enforcement for `--fix` mode which legitimately needs write access
- Sync pattern/workflow files per Rule 027

Closes #1307

## Test plan
- [x] `just pre-commit` passes
- [x] `cargo check -p cli-sub-agent` compiles
- [x] New test files verify preamble injection and env var propagation
- [x] `--fix` mode excluded from read-only enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)