### PR TITLE
feat(cli): add mktsk subcommand for compact-resilient task decomposition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.672"
+version = "0.1.673"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.672"
+version = "0.1.673"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 use csa_core::types::{OutputFormat, ToolArg};
 
+#[path = "cli_common.rs"]
+mod cli_common;
+pub use cli_common::*;
 #[path = "cli_session.rs"]
 mod cli_session;
 pub use cli_session::*;
@@ -28,6 +30,9 @@ pub use cli_xurl::*;
 #[path = "cli_triage.rs"]
 mod cli_triage;
 pub use cli_triage::*;
+#[path = "cli_mktsk.rs"]
+mod cli_mktsk;
+pub use cli_mktsk::*;
 #[path = "cli_plan.rs"]
 mod cli_plan;
 pub use cli_plan::*;
@@ -37,20 +42,6 @@ pub use cli_checklist::*;
 #[path = "cli_memory.rs"]
 mod cli_memory;
 pub use cli_memory::*;
-
-/// Build version string combining Cargo.toml version and git describe.
-fn build_version() -> &'static str {
-    static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-    VERSION.get_or_init(|| {
-        let cargo_ver = env!("CARGO_PKG_VERSION");
-        let git_desc = env!("CSA_GIT_DESCRIBE");
-        if git_desc.is_empty() {
-            cargo_ver.to_string()
-        } else {
-            format!("{cargo_ver} ({git_desc})")
-        }
-    })
-}
 
 #[derive(Parser)]
 #[command(name = "csa", version = build_version())]
@@ -62,53 +53,6 @@ pub struct Cli {
     /// Output format (text or json)
     #[arg(long, global = true, default_value = "text")]
     pub format: OutputFormat,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ReturnTarget {
-    Last,
-    Auto,
-    SessionId(String),
-}
-
-pub fn parse_return_to(value: &str) -> Result<ReturnTarget> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        anyhow::bail!("return target cannot be empty");
-    }
-    match trimmed.to_ascii_lowercase().as_str() {
-        "last" => Ok(ReturnTarget::Last),
-        "auto" => Ok(ReturnTarget::Auto),
-        _ => Ok(ReturnTarget::SessionId(trimmed.to_string())),
-    }
-}
-
-fn validate_return_to(value: &str) -> std::result::Result<String, String> {
-    parse_return_to(value)
-        .map(|_| value.to_string())
-        .map_err(|e| e.to_string())
-}
-
-fn parse_model_spec_arg(spec: &str) -> std::result::Result<String, String> {
-    let known_tools: Vec<&'static str> = csa_config::global::all_known_tools()
-        .iter()
-        .map(|tool| tool.as_str())
-        .collect();
-    csa_executor::ModelSpec::parse_and_validate(spec, &known_tools)
-        .map(|_| spec.to_string())
-        .map_err(|e| e.to_string())
-}
-
-fn parse_spec_path_arg(spec: &str) -> std::result::Result<String, String> {
-    csa_core::spec_validate::validate_spec(std::path::Path::new(spec))
-        .map(|path| path.display().to_string())
-        .map_err(|err| err.to_string())
-}
-
-fn validate_ulid(value: &str) -> std::result::Result<String, String> {
-    csa_session::validate_session_id(value)
-        .map(|_| value.to_string())
-        .map_err(|e| e.to_string())
 }
 
 #[derive(Subcommand)]
@@ -299,6 +243,9 @@ pub enum Commands {
 
     /// Triage a GitHub issue into category and state roles
     Triage(TriageArgs),
+
+    /// Decompose a TODO plan into compact-resilient task entries
+    Mktsk(MktskArgs),
 
     /// Manage sessions
     Session {

--- a/crates/cli-sub-agent/src/cli_common.rs
+++ b/crates/cli-sub-agent/src/cli_common.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+
+/// Build version string combining Cargo.toml version and git describe.
+pub(crate) fn build_version() -> &'static str {
+    static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    VERSION.get_or_init(|| {
+        let cargo_ver = env!("CARGO_PKG_VERSION");
+        let git_desc = env!("CSA_GIT_DESCRIBE");
+        if git_desc.is_empty() {
+            cargo_ver.to_string()
+        } else {
+            format!("{cargo_ver} ({git_desc})")
+        }
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReturnTarget {
+    Last,
+    Auto,
+    SessionId(String),
+}
+
+pub fn parse_return_to(value: &str) -> Result<ReturnTarget> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("return target cannot be empty");
+    }
+    match trimmed.to_ascii_lowercase().as_str() {
+        "last" => Ok(ReturnTarget::Last),
+        "auto" => Ok(ReturnTarget::Auto),
+        _ => Ok(ReturnTarget::SessionId(trimmed.to_string())),
+    }
+}
+
+pub(crate) fn validate_return_to(value: &str) -> std::result::Result<String, String> {
+    parse_return_to(value)
+        .map(|_| value.to_string())
+        .map_err(|e| e.to_string())
+}
+
+pub(crate) fn parse_model_spec_arg(spec: &str) -> std::result::Result<String, String> {
+    let known_tools: Vec<&'static str> = csa_config::global::all_known_tools()
+        .iter()
+        .map(|tool| tool.as_str())
+        .collect();
+    csa_executor::ModelSpec::parse_and_validate(spec, &known_tools)
+        .map(|_| spec.to_string())
+        .map_err(|e| e.to_string())
+}
+
+pub(crate) fn parse_spec_path_arg(spec: &str) -> std::result::Result<String, String> {
+    csa_core::spec_validate::validate_spec(std::path::Path::new(spec))
+        .map(|path| path.display().to_string())
+        .map_err(|err| err.to_string())
+}
+
+pub(crate) fn validate_ulid(value: &str) -> std::result::Result<String, String> {
+    csa_session::validate_session_id(value)
+        .map(|_| value.to_string())
+        .map_err(|e| e.to_string())
+}

--- a/crates/cli-sub-agent/src/cli_mktsk.rs
+++ b/crates/cli-sub-agent/src/cli_mktsk.rs
@@ -1,0 +1,17 @@
+#[derive(clap::Args)]
+pub struct MktskArgs {
+    /// Task decomposition request
+    pub description: String,
+    /// TODO plan timestamp to read
+    #[arg(long)]
+    pub todo: Option<String>,
+    /// Tool to use
+    #[arg(long)]
+    pub tool: Option<String>,
+    /// Session timeout in seconds
+    #[arg(long, default_value = "7200")]
+    pub timeout: u64,
+    /// Allow working on base branch
+    #[arg(long, alias = "allow-base-branch-commit")]
+    pub allow_base_branch_working: bool,
+}

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -300,6 +300,9 @@ pub fn validate_command_args(
         Commands::Triage(args) => {
             validate_timeout(Some(args.timeout), min_timeout)?;
         }
+        Commands::Mktsk(args) => {
+            validate_timeout(Some(args.timeout), min_timeout)?;
+        }
         Commands::Review(args) => {
             validate_review_args(args)?;
             if !args.check_verdict {

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -28,6 +28,8 @@ mod gc;
 mod goal_loop;
 mod hooks_cmd;
 mod hunt_cmd;
+#[cfg(test)]
+mod main_auto_weave_tests;
 mod main_bootstrap;
 mod mcp_hub;
 mod mcp_server;
@@ -35,6 +37,7 @@ mod memory_capture;
 mod memory_cmd;
 mod memory_migrate;
 mod merge_cmd;
+mod mktsk_cmd;
 mod pattern_resolver;
 mod pipeline;
 mod pipeline_env;
@@ -68,6 +71,8 @@ mod run_cmd_post;
 mod run_cmd_tool_selection;
 mod run_helpers;
 mod run_helpers_branch_guard;
+#[cfg(test)]
+mod sa_mode_tests;
 mod self_update;
 mod session_cmds;
 mod session_cmds_daemon;
@@ -80,6 +85,10 @@ mod skill_cmds;
 mod skill_resolver;
 #[cfg(any(feature = "parallel-tasks", test))]
 pub mod task_lock;
+#[cfg(test)]
+mod test_env_lock;
+#[cfg(test)]
+mod test_session_sandbox;
 mod tier_model_fallback;
 mod tiers_cmd;
 mod todo_cmd;
@@ -87,17 +96,6 @@ mod todo_epic_cmd;
 mod todo_ref_cmd;
 mod tool_version;
 mod triage_cmd;
-
-#[cfg(test)]
-mod sa_mode_tests;
-
-#[cfg(test)]
-mod main_auto_weave_tests;
-
-#[cfg(test)]
-mod test_env_lock;
-#[cfg(test)]
-mod test_session_sandbox;
 #[cfg(test)]
 include!("review_cmd_exact_tests.rs");
 #[cfg(test)]
@@ -470,6 +468,11 @@ async fn run() -> Result<()> {
                 output_format,
             )
             .await?;
+            exit_current_process(exit_code);
+        }
+        Commands::Mktsk(args) => {
+            let exit_code =
+                mktsk_cmd::handle_mktsk_args(args, current_depth, output_format).await?;
             exit_current_process(exit_code);
         }
         Commands::Session { cmd } => session_dispatch::dispatch(cmd, output_format)?,

--- a/crates/cli-sub-agent/src/main_bootstrap.rs
+++ b/crates/cli-sub-agent/src/main_bootstrap.rs
@@ -31,7 +31,11 @@ pub(crate) fn should_attempt_auto_weave_upgrade(command: &Commands) -> bool {
     // Only execution commands need upgraded weave patterns.
     // All management/read-only commands stay available even when weave is unhealthy.
     match command {
-        Commands::Run { .. } | Commands::Hunt(_) | Commands::Arch(_) | Commands::Triage(_) => true,
+        Commands::Run { .. }
+        | Commands::Hunt(_)
+        | Commands::Arch(_)
+        | Commands::Triage(_)
+        | Commands::Mktsk(_) => true,
         Commands::Review(args) => !args.check_verdict,
         Commands::Debate(_) | Commands::Batch { .. } | Commands::Plan { .. } => true,
         Commands::ClaudeSubAgent(_) | Commands::McpServer => true,

--- a/crates/cli-sub-agent/src/mktsk_cmd.rs
+++ b/crates/cli-sub-agent/src/mktsk_cmd.rs
@@ -1,0 +1,132 @@
+use anyhow::{Result, anyhow};
+use csa_core::types::{OutputFormat, ToolArg};
+
+pub(crate) const MKTSK_PROMPT_PREFIX: &str = r#"TASK DECOMPOSITION MODE - COMPACT-RESILIENT TODO BREAKDOWN
+
+You are translating a CSA TODO plan into granular task entries that survive context
+compaction and session boundaries. Do not implement production code unless the caller
+explicitly asks for it. Your job is to read the current plan, decompose it into
+self-contained tasks, and capture the execution context each future agent needs.
+
+WORKFLOW
+1. Read the plan with `csa todo show`.
+2. Break the plan into individual task entries.
+3. For each task, write a compact-resilient description that can stand alone after
+   context compaction.
+4. Set dependency chains between tasks so execution order is explicit.
+
+PLAN READ REQUIREMENTS
+- If the caller provided a plan timestamp, read it with:
+  `csa todo show --timestamp <TIMESTAMP>`
+- Otherwise read the latest plan with:
+  `csa todo show`
+- Do not guess plan contents without reading the plan first.
+
+TASK ENTRY REQUIREMENTS
+For each task entry, include all of the following:
+- Title
+- Related issue numbers
+- Branch name
+- Files to modify or search paths
+- Fix/build approach
+- Dependencies on other tasks
+- DONE WHEN criteria with mechanically verifiable outcomes
+
+OUTPUT FORMAT
+- Start with `PLAN_SOURCE: <latest|timestamp>`
+- Then list the tasks in execution order.
+- Use one section per task with a stable identifier such as `TASK 1`, `TASK 2`, etc.
+- Make each task self-contained: a future agent should not need the original plan to
+  understand what to do.
+- End with `DEPENDENCY_GRAPH:` followed by a concise dependency summary."#;
+
+pub(crate) fn build_mktsk_prompt(description: &str, todo: Option<&str>) -> String {
+    let plan_source = match todo {
+        Some(timestamp) => format!(
+            "PLAN TO READ:\nUse `csa todo show --timestamp {timestamp}` before decomposing tasks."
+        ),
+        None => {
+            "PLAN TO READ:\nUse `csa todo show` to read the latest plan before decomposing tasks."
+                .to_string()
+        }
+    };
+
+    format!("{MKTSK_PROMPT_PREFIX}\n\n{plan_source}\n\nTASK DECOMPOSITION REQUEST:\n{description}")
+}
+
+pub(crate) async fn handle_mktsk(
+    description: String,
+    todo: Option<String>,
+    tool: Option<String>,
+    timeout: u64,
+    allow_base_branch_working: bool,
+    current_depth: u32,
+    output_format: OutputFormat,
+) -> Result<i32> {
+    let tool = tool
+        .map(|raw| {
+            raw.parse::<ToolArg>()
+                .map_err(|err| anyhow!("invalid mktsk tool `{raw}`: {err}"))
+        })
+        .transpose()?;
+    let prompt = build_mktsk_prompt(&description, todo.as_deref());
+
+    crate::run_cmd::SubagentRunConfig::new(prompt, output_format)
+        .tool(tool)
+        .timeout(timeout)
+        .allow_base_branch_working(allow_base_branch_working)
+        .current_depth(current_depth)
+        .run()
+        .await
+}
+
+pub(crate) async fn handle_mktsk_args(
+    args: crate::cli::MktskArgs,
+    current_depth: u32,
+    output_format: OutputFormat,
+) -> Result<i32> {
+    handle_mktsk(
+        args.description,
+        args.todo,
+        args.tool,
+        args.timeout,
+        args.allow_base_branch_working,
+        current_depth,
+        output_format,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MKTSK_PROMPT_PREFIX, build_mktsk_prompt};
+
+    #[test]
+    fn build_mktsk_prompt_targets_latest_plan_by_default() {
+        let prompt = build_mktsk_prompt("Decompose issue #1305 into tasks", None);
+
+        assert!(prompt.starts_with("TASK DECOMPOSITION MODE - COMPACT-RESILIENT TODO BREAKDOWN"));
+        assert!(MKTSK_PROMPT_PREFIX.contains("Read the plan with `csa todo show`."));
+        assert!(MKTSK_PROMPT_PREFIX.contains("Related issue numbers"));
+        assert!(MKTSK_PROMPT_PREFIX.contains("Branch name"));
+        assert!(MKTSK_PROMPT_PREFIX.contains("Files to modify or search paths"));
+        assert!(MKTSK_PROMPT_PREFIX.contains("Fix/build approach"));
+        assert!(MKTSK_PROMPT_PREFIX.contains("DONE WHEN criteria"));
+        assert!(MKTSK_PROMPT_PREFIX.contains("DEPENDENCY_GRAPH:"));
+        assert!(prompt.contains("Use `csa todo show` to read the latest plan"));
+        assert!(prompt.ends_with("Decompose issue #1305 into tasks"));
+    }
+
+    #[test]
+    fn build_mktsk_prompt_uses_explicit_timestamp_when_provided() {
+        let prompt =
+            build_mktsk_prompt("Decompose issue #1305 into tasks", Some("20260505-123456"));
+
+        assert!(
+            prompt.contains(
+                "Use `csa todo show --timestamp 20260505-123456` before decomposing tasks."
+            )
+        );
+        assert!(prompt.contains("TASK DECOMPOSITION REQUEST:"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `csa mktsk` CLI subcommand following the thin wrapper pattern (hunt/triage/arch)
- Reads TODO plans and decomposes them into self-contained TaskCreate entries
- Each task includes: issue numbers, files to modify, fix approach, branch name, DONE WHEN criteria
- Supports `--todo <timestamp>` flag to target specific TODO plans
- Extracts common CLI args into `cli_common.rs` to reduce duplication

Closes #1305

## Test plan
- [x] `just pre-commit` passes
- [x] `cargo check -p cli-sub-agent` compiles
- [x] Follows established thin wrapper pattern (SubagentRunConfig)
- [x] CLI args extracted to shared module for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)