### PR TITLE
fix(scheduler): enable tier failover on gemini retry chain exhaustion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.674"
+version = "0.1.675"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.674"
+version = "0.1.675"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-scheduler/src/rate_limit.rs
+++ b/crates/csa-scheduler/src/rate_limit.rs
@@ -31,12 +31,12 @@ const GEMINI_RETRY_CHAIN_FAILOVER_PATTERNS: &[FailoverPattern] = &[
     FailoverPattern {
         pattern: GEMINI_RETRY_CHAIN_EXHAUSTION_PATTERNS[0],
         reason: "gemini_retry_chain_exhausted",
-        advance_to_next_model: false,
+        advance_to_next_model: true,
     },
     FailoverPattern {
         pattern: GEMINI_RETRY_CHAIN_EXHAUSTION_PATTERNS[1],
         reason: "gemini_retry_chain_exhausted",
-        advance_to_next_model: false,
+        advance_to_next_model: true,
     },
 ];
 
@@ -647,6 +647,33 @@ mod tests {
             None,
         );
         assert!(result.is_some());
-        assert_eq!(result.unwrap().matched_pattern, "retry chain exhausted");
+        let detected = result.unwrap();
+        assert_eq!(detected.matched_pattern, "retry chain exhausted");
+        assert!(
+            detected.advance_to_next_model,
+            "gemini retry chain exhaustion must trigger tier-level failover to next tool"
+        );
+    }
+
+    #[test]
+    fn test_gemini_retry_chain_exhausted_triggers_tier_failover() {
+        let result = detect_rate_limit(
+            "gemini-cli",
+            "gemini acp retry chain exhausted after all fallback phases failed",
+            "",
+            1,
+            Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        );
+        assert!(result.is_some());
+        let detected = result.unwrap();
+        assert!(
+            detected.advance_to_next_model,
+            "tier failover must activate when gemini retry chain is exhausted (#1320)"
+        );
+        assert_eq!(detected.reason, "gemini_retry_chain_exhausted");
+        assert_eq!(
+            detected.model_spec.as_deref(),
+            Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix `GEMINI_RETRY_CHAIN_FAILOVER_PATTERNS` to set `advance_to_next_model: true`
- When gemini-cli's internal 3-phase retry chain exhausts (OAuth → API key → flash), tier-level failover to the next tool (codex/claude-code) now triggers correctly
- Add test asserting the failover flag is set

Closes #1320

## Root cause

`advance_to_next_model: false` on the retry-chain-exhausted patterns caused `classify_next_model_failure()` to filter them out (tier_model_fallback.rs:136), preventing the tier fallback loop in `review_cmd_execute.rs:433` from advancing to the next candidate.

## Test plan

- [x] `cargo test -p csa-scheduler -- rate_limit` — 30 tests pass
- [x] New test `test_gemini_retry_chain_exhausted_triggers_tier_failover` asserts `advance_to_next_model: true`
- [x] Existing test updated to also assert the flag
- [x] `just fmt && just clippy` clean
- [x] Review verdict: PASS (session 01KQY3DBHGVPQZ6NXX5KR7HA4K)

🤖 Generated with [Claude Code](https://claude.com/claude-code)