### PR TITLE
feat(session): attach --prompt soft fork for all tools (#1325)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.676"
+version = "0.1.677"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.676"
+version = "0.1.677"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -385,13 +385,8 @@ fn reactivate_session_with_prompt(
         .ok_or_else(|| anyhow::anyhow!("session {session_id} is missing metadata.toml"))?;
     let session = csa_session::load_session(project_root, session_id)?;
     let actual_project_root = PathBuf::from(&session.project_path);
+    let use_native_resume = metadata.tool == "claude-code";
 
-    if metadata.tool != "claude-code" {
-        anyhow::bail!(
-            "session attach --prompt only supports claude-code sessions; session {session_id} uses {}",
-            metadata.tool
-        );
-    }
     if session.phase == csa_session::SessionPhase::Retired {
         anyhow::bail!("session {session_id} is retired and cannot be resumed");
     }
@@ -403,13 +398,15 @@ fn reactivate_session_with_prompt(
         );
     }
 
-    let provider_session_id =
-        csa_session::resolve_resume_session(project_root, session_id, "claude-code")?
-            .provider_session_id;
-    if provider_session_id.is_none() {
-        anyhow::bail!(
-            "session {session_id} has no claude-code provider session ID recorded; cannot resume it with --prompt"
-        );
+    if use_native_resume {
+        let provider_session_id =
+            csa_session::resolve_resume_session(project_root, session_id, "claude-code")?
+                .provider_session_id;
+        if provider_session_id.is_none() {
+            anyhow::bail!(
+                "session {session_id} has no claude-code provider session ID recorded; cannot resume it with --prompt"
+            );
+        }
     }
 
     // Clean old artifacts BEFORE spawn to avoid racing with the child process.
@@ -425,6 +422,7 @@ fn reactivate_session_with_prompt(
         &actual_project_root,
         &metadata.tool,
         &prompt_path,
+        use_native_resume,
     )
 }
 
@@ -500,6 +498,7 @@ fn spawn_attach_resume_daemon(
     project_root: &Path,
     tool: &str,
     prompt_path: &Path,
+    use_native_resume: bool,
 ) -> Result<()> {
     let csa_binary = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("csa"));
     let env = std::collections::HashMap::from([
@@ -513,19 +512,13 @@ fn spawn_attach_resume_daemon(
             project_root.display().to_string(),
         ),
     ]);
-    let args = vec![
-        "--sa-mode".to_string(),
-        "false".to_string(),
-        "--tool".to_string(),
-        tool.to_string(),
-        "--force".to_string(),
-        "--session".to_string(),
-        session_id.to_string(),
-        "--cd".to_string(),
-        project_root.display().to_string(),
-        "--prompt-file".to_string(),
-        prompt_path.display().to_string(),
-    ];
+    let args = build_attach_resume_args(
+        session_id,
+        project_root,
+        tool,
+        prompt_path,
+        use_native_resume,
+    );
 
     csa_process::daemon::spawn_daemon(csa_process::daemon::DaemonSpawnConfig {
         session_id: session_id.to_string(),
@@ -537,6 +530,33 @@ fn spawn_attach_resume_daemon(
     })
     .map(|_| ())
     .context("failed to spawn resumed daemon session")
+}
+
+fn build_attach_resume_args(
+    session_id: &str,
+    project_root: &Path,
+    tool: &str,
+    prompt_path: &Path,
+    use_native_resume: bool,
+) -> Vec<String> {
+    let resume_flag = if use_native_resume {
+        "--session"
+    } else {
+        "--fork-from"
+    };
+    vec![
+        "--sa-mode".to_string(),
+        "false".to_string(),
+        "--tool".to_string(),
+        tool.to_string(),
+        "--force".to_string(),
+        resume_flag.to_string(),
+        session_id.to_string(),
+        "--cd".to_string(),
+        project_root.display().to_string(),
+        "--prompt-file".to_string(),
+        prompt_path.display().to_string(),
+    ]
 }
 
 /// Kill a session with SIGTERM, then SIGKILL after a 5-second grace period if needed.

--- a/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
@@ -363,7 +363,7 @@ fn wait_for_attach_live_output_path_keeps_waiting_past_sixty_seconds_for_codex_o
 }
 
 #[test]
-fn handle_session_attach_with_prompt_rejects_non_claude_code_sessions() {
+fn handle_session_attach_with_prompt_accepts_non_claude_sessions_via_soft_fork() {
     let td = tempfile::tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -372,23 +372,52 @@ fn handle_session_attach_with_prompt_rejects_non_claude_code_sessions() {
     let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
     let project = td.path();
 
-    let session =
-        csa_session::create_session(project, Some("attach-non-claude"), None, Some("opencode"))
-            .expect("create session");
-    let err = handle_session_attach_with_prompt(
-        session.meta_session_id,
-        false,
-        Some(project.to_string_lossy().into_owned()),
-        Some("resume".to_string()),
-        None,
-        None,
-    )
-    .expect_err("non-claude attach resume must fail");
+    for tool in ["codex", "gemini-cli"] {
+        let session =
+            csa_session::create_session(project, Some("attach-non-claude"), None, Some(tool))
+                .expect("create session");
+        let session_id = session.meta_session_id.clone();
+        handle_session_attach_with_prompt(
+            session_id.clone(),
+            false,
+            Some(project.to_string_lossy().into_owned()),
+            Some("resume".to_string()),
+            None,
+            None,
+        )
+        .unwrap_or_else(|err| panic!("{tool} attach resume should use soft fork: {err:#}"));
 
-    assert!(
-        err.to_string().contains("only supports claude-code"),
-        "unexpected error: {err:#}"
-    );
+        let session_dir = csa_session::get_session_dir(project, &session_id).expect("session dir");
+        assert!(
+            session_dir.join("input").join("attach-prompt.txt").exists(),
+            "attach should persist the prompt before soft-fork spawn for {tool}"
+        );
+        assert!(
+            session_dir.join("daemon.pid").exists(),
+            "attach soft-fork spawn should write daemon.pid for {tool}"
+        );
+    }
+}
+
+#[test]
+fn build_attach_resume_args_selects_resume_flag_by_tool_mode() {
+    let project_root = std::path::Path::new("/tmp/project");
+    let prompt_path = std::path::Path::new("/tmp/session/input/attach-prompt.txt");
+    for (tool, use_native_resume, expected_flag, unexpected_flag) in [
+        ("claude-code", true, "--session", "--fork-from"),
+        ("codex", false, "--fork-from", "--session"),
+        ("gemini-cli", false, "--fork-from", "--session"),
+    ] {
+        let args = build_attach_resume_args(
+            "01KTEST1234567890ABCDEFGHJK",
+            project_root,
+            tool,
+            prompt_path,
+            use_native_resume,
+        );
+        assert!(args.iter().any(|arg| arg == expected_flag));
+        assert!(!args.iter().any(|arg| arg == unexpected_flag));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Non-claude-code sessions (codex, gemini-cli, opencode) now supported by `csa session attach --prompt`
- Uses `--fork-from` (soft fork: prior session output as context) instead of `--session` (ACP native reload)
- claude-code sessions retain native resume behavior unchanged

Closes #1325

## Test plan
- [x] New tests: `accepts_non_claude_sessions_via_soft_fork`, `selects_resume_flag_by_tool_mode`
- [x] `just pre-commit` clean (clippy, fmt, deny, nextest 32/32)
- [x] All existing session_cmds_daemon tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)