### PR TITLE
fix(hooks): use target project cwd for mempal capture (#1327)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.678"
+version = "0.1.679"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.678"
+version = "0.1.679"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -321,6 +321,7 @@ pub(crate) async fn process_execution_result(
             memory_config,
             "csa-session",
             &ctx.session_dir.join("result.toml"),
+            ctx.project_root,
             Some(ctx.executor.tool_name()),
         );
     }

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_session::{create_session, get_session_dir, load_session};
+use std::fs;
+use std::io::Write as _;
 use std::path::Path;
 use std::process::Command;
 
@@ -403,5 +405,143 @@ fn read_output_log_tail_reads_from_file_end_window() {
     assert!(
         !tail.contains("line-0000"),
         "tail reader should not depend on loading the full file"
+    );
+}
+
+struct CurrentDirGuard {
+    original: std::path::PathBuf,
+}
+
+impl CurrentDirGuard {
+    fn enter(path: &Path) -> Self {
+        let original = std::env::current_dir().expect("current dir");
+        std::env::set_current_dir(path).expect("set current dir");
+        Self { original }
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.original).expect("restore current dir");
+    }
+}
+
+fn write_executable_script(path: &Path, body: &str) {
+    let mut script = fs::File::create(path).expect("create script");
+    write!(script, "{body}").expect("write script");
+    script.sync_all().expect("sync script");
+    drop(script);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod script");
+    }
+}
+
+#[tokio::test]
+async fn process_execution_result_mempal_payload_uses_target_project_cwd() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut sandbox = ScopedSessionSandbox::new(&temp).await;
+    sandbox.track_env("PATH");
+
+    let invocation_cwd = temp.path().join("cli-sub-agent-install");
+    let project_root = temp.path().join("warifu-ce");
+    fs::create_dir_all(&invocation_cwd).expect("create invocation cwd");
+    fs::create_dir_all(&project_root).expect("create project root");
+    let _cwd = CurrentDirGuard::enter(&invocation_cwd);
+
+    let fake_bin = temp.path().join("bin");
+    fs::create_dir_all(&fake_bin).expect("create fake bin");
+    let payload_path = temp.path().join("mempal-payload.json");
+    write_executable_script(
+        &fake_bin.join("mempal"),
+        &format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'mempal mock 0.0.0\\n'\n  exit 0\nfi\nif [ \"$1\" = \"ingest\" ] && [ \"$2\" = \"--stdin\" ] && [ \"$3\" = \"--json\" ]; then\n  cat > '{}'\n  exit 0\nfi\nexit 64\n",
+            payload_path.display()
+        ),
+    );
+    let original_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut path_entries = vec![fake_bin.clone()];
+    path_entries.extend(std::env::split_paths(&original_path));
+    let joined_path = std::env::join_paths(path_entries).expect("join PATH");
+    // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for this test.
+    unsafe { std::env::set_var("PATH", joined_path) };
+
+    let executor = csa_executor::Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: csa_executor::codex_runtime::codex_runtime_metadata(),
+    };
+    let config: csa_config::ProjectConfig = toml::from_str(
+        r#"
+schema_version = 1
+
+[memory]
+backend = "mempal"
+auto_capture = true
+"#,
+    )
+    .expect("project config");
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let mut session =
+        create_session(&project_root, Some("target cwd"), None, Some("codex")).expect("session");
+    let session_dir =
+        get_session_dir(&project_root, &session.meta_session_id).expect("resolve session dir");
+
+    let ctx = PostExecContext {
+        executor: &executor,
+        prompt: "test prompt",
+        effective_prompt: "test prompt",
+        task_type: Some("run"),
+        readonly_project_root: false,
+        project_root: &project_root,
+        config: Some(&config),
+        global_config: None,
+        session_dir,
+        sessions_root: "test-root".to_string(),
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+        hooks_config: &hooks_config,
+        memory_project_key: None,
+        provider_session_id: None,
+        events_count: 1,
+        transcript_artifacts: vec![],
+        changed_paths: vec![],
+        pre_exec_snapshot: None,
+        has_tool_calls: true,
+        sa_mode: false,
+    };
+    let mut result = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: "captured via session complete".to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+    };
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process result");
+
+    for _ in 0..50 {
+        if payload_path.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(payload_path.exists(), "mempal payload should be written");
+
+    let payload: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&payload_path).expect("read payload"))
+            .expect("parse payload");
+    assert_eq!(payload["project"], "warifu-ce");
+    assert_eq!(payload["cwd"], project_root.display().to_string());
+    assert_eq!(payload["claude_cwd"], project_root.display().to_string());
+    assert_ne!(
+        payload["cwd"],
+        invocation_cwd.display().to_string(),
+        "session mempal payload must use target project root, not process cwd"
     );
 }

--- a/crates/cli-sub-agent/src/review_cmd_mempal.rs
+++ b/crates/cli-sub-agent/src/review_cmd_mempal.rs
@@ -30,6 +30,7 @@ pub(crate) fn maybe_capture_review_mempal(
                 memory_config,
                 "csa-review",
                 &result_path,
+                project_root,
                 Some(tool_name),
             );
         }

--- a/crates/csa-hooks/src/mempal_capture.rs
+++ b/crates/csa-hooks/src/mempal_capture.rs
@@ -12,7 +12,6 @@ use csa_config::{GlobalConfig, MemoryBackend, MemoryConfig, ProjectConfig};
 
 const INGEST_TIMEOUT: Duration = Duration::from_secs(30);
 const WING: &str = "cli-sub-agent";
-const PROJECT: &str = "cli-sub-agent";
 const SOURCE_FILE: &str = "stdin://csa-hook";
 const CLAUDE_CODE_TOOL: &str = "claude-code";
 
@@ -43,17 +42,24 @@ pub fn spawn_mempal_ingest(
     config: &MemoryConfig,
     room: &'static str,
     input_path: &Path,
+    project_root: &Path,
     tool_name: Option<&str>,
 ) {
-    let _ = spawn_mempal_ingest_with_resolver(config, room, input_path, tool_name, |config| {
-        resolve_mempal_binary(config)
-    });
+    let _ = spawn_mempal_ingest_with_resolver(
+        config,
+        room,
+        input_path,
+        project_root,
+        tool_name,
+        resolve_mempal_binary,
+    );
 }
 
 fn spawn_mempal_ingest_with_resolver<F>(
     config: &MemoryConfig,
     room: &'static str,
     input_path: &Path,
+    project_root: &Path,
     tool_name: Option<&str>,
     resolve_binary: F,
 ) -> Option<thread::JoinHandle<()>>
@@ -78,8 +84,15 @@ where
     let binary_path = resolve_binary(config)?;
 
     let input_path = input_path.to_path_buf();
+    let project_root = project_root.to_path_buf();
     Some(thread::spawn(move || {
-        if let Err(err) = run_mempal_ingest(&binary_path, room, &input_path, INGEST_TIMEOUT) {
+        if let Err(err) = run_mempal_ingest(
+            &binary_path,
+            room,
+            &input_path,
+            &project_root,
+            INGEST_TIMEOUT,
+        ) {
             tracing::warn!(
                 room,
                 input = %input_path.display(),
@@ -99,7 +112,7 @@ pub fn spawn_mempal_ingest_for_project(
     tool_name: Option<&str>,
 ) {
     if let Some(config) = load_effective_memory_config(project_root) {
-        spawn_mempal_ingest(&config, room, input_path, tool_name);
+        spawn_mempal_ingest(&config, room, input_path, project_root, tool_name);
     }
 }
 
@@ -116,9 +129,10 @@ fn run_mempal_ingest(
     binary_path: &Path,
     room: &str,
     input_path: &Path,
+    project_root: &Path,
     timeout: Duration,
 ) -> anyhow::Result<()> {
-    let stdin_result = build_mempal_payload(room, input_path)
+    let stdin_result = build_mempal_payload(room, input_path, project_root)
         .and_then(|payload| run_mempal_ingest_stdin(binary_path, &payload, timeout));
     match stdin_result {
         Ok(()) => Ok(()),
@@ -146,14 +160,22 @@ fn legacy_ingest_path(input_path: &Path) -> PathBuf {
     input_path.to_path_buf()
 }
 
-fn build_mempal_payload(room: &str, input_path: &Path) -> anyhow::Result<Vec<u8>> {
+fn build_mempal_payload(
+    room: &str,
+    input_path: &Path,
+    project_root: &Path,
+) -> anyhow::Result<Vec<u8>> {
     let content = read_ingest_content(input_path)?;
     let source = infer_source(input_path, room);
+    let project_name = infer_project_name(project_root);
+    let cwd = project_root.display().to_string();
     serde_json::to_vec(&serde_json::json!({
         "content": content,
         "wing": WING,
         "room": room,
-        "project": PROJECT,
+        "project": project_name,
+        "cwd": cwd,
+        "claude_cwd": cwd,
         "source": source,
         "source_file": SOURCE_FILE,
     }))
@@ -257,6 +279,15 @@ fn infer_source(input_path: &Path, room: &str) -> String {
         .filter(|name| !name.is_empty())
         .map(|name| format!("csa-session-{name}"))
         .unwrap_or_else(|| format!("csa-session-{room}"))
+}
+
+fn infer_project_name(project_root: &Path) -> String {
+    project_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| project_root.display().to_string())
 }
 
 fn run_mempal_ingest_stdin(
@@ -438,9 +469,16 @@ mod tests {
         which::which("mempal").ok()
     }
 
+    fn temp_project_root(temp: &tempfile::TempDir) -> PathBuf {
+        let project_root = temp.path().join("warifu-ce");
+        fs::create_dir(&project_root).expect("create project root");
+        project_root
+    }
+
     #[test]
     fn capture_with_mempal_available_sends_json_payload_to_stdin() {
         let temp = tempfile::tempdir().expect("create tempdir");
+        let project_root = temp_project_root(&temp);
         let fake_bin = temp.path().join("bin");
         fs::create_dir(&fake_bin).expect("create fake bin");
         let log_path = temp.path().join("stdin.json");
@@ -462,6 +500,7 @@ mod tests {
             &mempal_config(),
             "csa-session",
             &result_path,
+            &project_root,
             Some("codex"),
             which_mempal,
         )
@@ -474,7 +513,9 @@ mod tests {
         assert_eq!(payload["content"], "captured via hook");
         assert_eq!(payload["wing"], "cli-sub-agent");
         assert_eq!(payload["room"], "csa-session");
-        assert_eq!(payload["project"], "cli-sub-agent");
+        assert_eq!(payload["project"], "warifu-ce");
+        assert_eq!(payload["cwd"], project_root.display().to_string());
+        assert_eq!(payload["claude_cwd"], project_root.display().to_string());
         assert_eq!(payload["source"], "csa-session-01KSESSION");
         assert_eq!(payload["source_file"], "stdin://csa-hook");
     }
@@ -482,6 +523,7 @@ mod tests {
     #[test]
     fn capture_skips_when_mempal_unavailable() {
         let temp = tempfile::tempdir().expect("create tempdir");
+        let project_root = temp_project_root(&temp);
         let empty_bin = temp.path().join("empty-bin");
         fs::create_dir(&empty_bin).expect("create empty bin");
         let _path = ScopedPath::set_only(&empty_bin);
@@ -493,6 +535,7 @@ mod tests {
             &mempal_config(),
             "csa-session",
             &result_path,
+            &project_root,
             Some("codex"),
             which_mempal,
         );
@@ -506,6 +549,7 @@ mod tests {
     #[test]
     fn capture_skips_for_claude_code_sessions() {
         let temp = tempfile::tempdir().expect("create tempdir");
+        let project_root = temp_project_root(&temp);
         let result_path = temp.path().join("result.toml");
         fs::write(&result_path, "summary = \"claude-code owns mempal\"\n").expect("write result");
 
@@ -513,6 +557,7 @@ mod tests {
             &mempal_config(),
             "csa-session",
             &result_path,
+            &project_root,
             Some("claude-code"),
             |_| panic!("resolver must not run for claude-code sessions"),
         );
@@ -526,6 +571,7 @@ mod tests {
     #[test]
     fn run_mempal_ingest_passes_expected_args() {
         let temp = tempfile::tempdir().expect("create tempdir");
+        let project_root = temp_project_root(&temp);
         let log_path = temp.path().join("args.log");
         let stdin_path = temp.path().join("stdin.json");
         let script_path = temp.path().join("mempal-fake.sh");
@@ -546,6 +592,7 @@ mod tests {
             &script_path,
             "csa-session",
             &result_path,
+            &project_root,
             Duration::from_secs(5),
         )
         .expect("run fake mempal");
@@ -558,7 +605,9 @@ mod tests {
         assert_eq!(payload["content"], "captured summary");
         assert_eq!(payload["wing"], "cli-sub-agent");
         assert_eq!(payload["room"], "csa-session");
-        assert_eq!(payload["project"], "cli-sub-agent");
+        assert_eq!(payload["project"], "warifu-ce");
+        assert_eq!(payload["cwd"], project_root.display().to_string());
+        assert_eq!(payload["claude_cwd"], project_root.display().to_string());
         assert_eq!(payload["source"], "csa-session-01ABCSESSION");
         assert_eq!(payload["source_file"], "stdin://csa-hook");
     }
@@ -566,6 +615,7 @@ mod tests {
     #[test]
     fn run_mempal_ingest_falls_back_to_path_args_when_stdin_is_unsupported() {
         let temp = tempfile::tempdir().expect("create tempdir");
+        let project_root = temp_project_root(&temp);
         let log_path = temp.path().join("args.log");
         let script_path = temp.path().join("mempal-fake.sh");
         executable_mempal_script(
@@ -590,6 +640,7 @@ printf '%s\n' "$@" > '{}'
             &script_path,
             "csa-session",
             &result_path,
+            &project_root,
             Duration::from_secs(5),
         )
         .expect("run fake mempal");
@@ -620,5 +671,11 @@ printf '%s\n' "$@" > '{}'
         assert!(!tool_has_own_mempal("codex"));
         assert!(!tool_has_own_mempal("gemini-cli"));
         assert!(!tool_has_own_mempal("opencode"));
+    }
+
+    #[test]
+    fn infer_project_name_falls_back_to_full_path_when_basename_missing() {
+        let root = Path::new("/");
+        assert_eq!(infer_project_name(root), root.display().to_string());
     }
 }


### PR DESCRIPTION
## Summary

- Fixed session and review mempal hook captures to use the target project root for project/cwd attribution
- Previously, when csa ran codex targeting project B from cli-sub-agent's install dir, all session output was attributed to cli-sub-agent instead of the target project
- Now populates both `cwd` and `claude_cwd` fields from the resolved session project root
- Added unit and post-exec integration tests for cwd attribution

Closes #1327

## Test plan

- [x] `just pre-commit` passes
- [x] New tests verify cwd field uses target project, not csa install dir
- [x] All existing tests pass
- [ ] Manual: run `csa run --cd /path/to/other-project "task"`, verify mempal drawers appear under other-project's project_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)