### PR TITLE
feat(session): spill large manager reports to artifacts (#1329)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.679"
+version = "0.1.680"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.679"
+version = "0.1.680"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -205,8 +205,8 @@ fn default_recursion_depth() -> u32 {
 }
 
 pub use super::config_session::{
-    DEFAULT_COOLDOWN_SECS, ExecutionConfig, HooksSection, PostExecGateConfig, RunConfig,
-    SessionConfig, SnapshotTrigger, VcsConfig,
+    DEFAULT_COOLDOWN_SECS, DEFAULT_RESULT_REPORT_SPILL_THRESHOLD_BYTES, ExecutionConfig,
+    HooksSection, PostExecGateConfig, RunConfig, SessionConfig, SnapshotTrigger, VcsConfig,
 };
 pub use super::config_tool::{
     ToolConfig, ToolFilesystemSandboxConfig, ToolRestrictions, TransportKind,
@@ -657,6 +657,7 @@ schema_version = 1
 [session]
 transcript_enabled = false
 transcript_redaction = true
+# result_report_spill_threshold_bytes = 10240
 # require_commit_on_mutation = true
 [resources]
 min_free_memory_mb = 4096

--- a/crates/csa-config/src/config_session.rs
+++ b/crates/csa-config/src/config_session.rs
@@ -121,6 +121,13 @@ pub struct SessionConfig {
     /// Only effective when `tool_output_compression` is enabled.
     #[serde(default = "default_tool_output_threshold_bytes")]
     pub tool_output_threshold_bytes: u64,
+    /// Byte threshold above which manager-facing report text spills to an artifact.
+    ///
+    /// Applies to `[report].summary`, `[report].what_was_done`, and
+    /// `[report].key_decisions` combined when CSA publishes `output/result.toml`.
+    /// Set to `0` to disable spillover.
+    #[serde(default = "default_result_report_spill_threshold_bytes")]
+    pub result_report_spill_threshold_bytes: u64,
     /// Cooldown period (seconds) between consecutive session launches.
     ///
     /// Prevents rapid-fire session creation that can exhaust API quotas or
@@ -146,6 +153,13 @@ fn default_max_seed_sessions() -> u32 {
 
 fn default_tool_output_threshold_bytes() -> u64 {
     8192
+}
+
+/// Default spillover threshold for manager-facing report text fields.
+pub const DEFAULT_RESULT_REPORT_SPILL_THRESHOLD_BYTES: u64 = 10 * 1024;
+
+fn default_result_report_spill_threshold_bytes() -> u64 {
+    DEFAULT_RESULT_REPORT_SPILL_THRESHOLD_BYTES
 }
 
 /// Default cooldown between consecutive session launches (seconds).
@@ -184,6 +198,7 @@ impl Default for SessionConfig {
             spool_keep_rotated: None,
             tool_output_compression: false,
             tool_output_threshold_bytes: default_tool_output_threshold_bytes(),
+            result_report_spill_threshold_bytes: default_result_report_spill_threshold_bytes(),
             cooldown_seconds: default_cooldown_secs(),
             stderr_drain_timeout_secs: default_stderr_drain_timeout_secs(),
         }
@@ -204,6 +219,8 @@ impl SessionConfig {
             && self.spool_keep_rotated.is_none()
             && !self.tool_output_compression
             && self.tool_output_threshold_bytes == default_tool_output_threshold_bytes()
+            && self.result_report_spill_threshold_bytes
+                == default_result_report_spill_threshold_bytes()
             && self.cooldown_seconds == default_cooldown_secs()
             && self.stderr_drain_timeout_secs == default_stderr_drain_timeout_secs()
     }

--- a/crates/csa-config/src/config_tests_tail.rs
+++ b/crates/csa-config/src/config_tests_tail.rs
@@ -269,6 +269,10 @@ fn test_session_config_default_has_structured_output_enabled() {
     assert!(cfg.structured_output);
     assert_eq!(cfg.resolved_spool_max_mb(), 32);
     assert!(cfg.resolved_spool_keep_rotated());
+    assert_eq!(
+        cfg.result_report_spill_threshold_bytes,
+        DEFAULT_RESULT_REPORT_SPILL_THRESHOLD_BYTES
+    );
 }
 
 #[test]
@@ -348,6 +352,24 @@ fn test_session_config_is_default_reflects_spool_overrides() {
 
     let cfg = SessionConfig {
         spool_keep_rotated: Some(false),
+        ..Default::default()
+    };
+    assert!(!cfg.is_default());
+}
+
+#[test]
+fn test_session_config_deserializes_result_report_spill_threshold() {
+    let toml_str = r#"
+result_report_spill_threshold_bytes = 2048
+"#;
+    let cfg: SessionConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(cfg.result_report_spill_threshold_bytes, 2048);
+}
+
+#[test]
+fn test_session_config_is_default_reflects_result_report_spill_threshold() {
+    let cfg = SessionConfig {
+        result_report_spill_threshold_bytes: 2048,
         ..Default::default()
     };
     assert!(!cfg.is_default());

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -27,10 +27,10 @@ pub mod weave_lock;
 
 pub use acp::AcpConfig;
 pub use config::{
-    DEFAULT_COOLDOWN_SECS, EnforcementMode, ExecutionConfig, HooksSection, PostExecGateConfig,
-    ProjectConfig, ProjectMeta, RunConfig, SessionConfig, SnapshotTrigger, TierConfig,
-    TierStrategy, ToolConfig, ToolFilesystemSandboxConfig, ToolResourceProfile, ToolRestrictions,
-    VcsConfig,
+    DEFAULT_COOLDOWN_SECS, DEFAULT_RESULT_REPORT_SPILL_THRESHOLD_BYTES, EnforcementMode,
+    ExecutionConfig, HooksSection, PostExecGateConfig, ProjectConfig, ProjectMeta, RunConfig,
+    SessionConfig, SnapshotTrigger, TierConfig, TierStrategy, ToolConfig,
+    ToolFilesystemSandboxConfig, ToolResourceProfile, ToolRestrictions, VcsConfig,
 };
 pub use config_filesystem_sandbox::FilesystemSandboxConfig;
 pub use config_resources::ResourcesConfig;

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -25,6 +25,9 @@ const RUNTIME_RESULT_KEYS: [&str; 11] = [
     "artifacts",
 ];
 
+#[path = "manager_result_spillover.rs"]
+mod manager_result_spillover;
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SaveOptions {
     /// When true, an empty manager_fields save deletes any existing
@@ -65,14 +68,39 @@ pub fn save_result_with_options(
     options: SaveOptions,
 ) -> Result<()> {
     let base_dir = super::resolve_write_base_dir(project_path, session_id)?;
-    save_result_in(&base_dir, session_id, result, options)
+    let spill_threshold_bytes =
+        manager_result_spillover::resolve_report_spill_threshold_bytes(project_path);
+    save_result_in_with_threshold(
+        &base_dir,
+        session_id,
+        result,
+        options,
+        spill_threshold_bytes,
+    )
 }
 
+#[cfg(test)]
 pub(crate) fn save_result_in(
     base_dir: &Path,
     session_id: &str,
     result: &SessionResult,
     options: SaveOptions,
+) -> Result<()> {
+    save_result_in_with_threshold(
+        base_dir,
+        session_id,
+        result,
+        options,
+        csa_config::DEFAULT_RESULT_REPORT_SPILL_THRESHOLD_BYTES,
+    )
+}
+
+fn save_result_in_with_threshold(
+    base_dir: &Path,
+    session_id: &str,
+    result: &SessionResult,
+    options: SaveOptions,
+    spill_threshold_bytes: u64,
 ) -> Result<()> {
     validate_session_id(session_id)?;
     let session_dir = super::get_session_dir_in(base_dir, session_id);
@@ -99,8 +127,8 @@ pub(crate) fn save_result_in(
     }
 
     let mut persisted_result = result.clone();
-    let manager_sidecar = persisted_result.manager_fields.as_sidecar();
-    let preserve_existing_manager_sidecar = manager_sidecar.is_some()
+    let requested_manager_sidecar = persisted_result.manager_fields.as_sidecar();
+    let preserve_existing_manager_sidecar = requested_manager_sidecar.is_some()
         || (!options.clear_stale_manager_sidecar && manager_sidecar_exists(&session_dir));
     if has_custom_schema {
         let Some(contents) = existing_contents.as_deref() else {
@@ -113,6 +141,24 @@ pub(crate) fn save_result_in(
         &mut persisted_result,
         preserve_existing_manager_sidecar,
     )?;
+    let manager_sidecar = if let Some(sidecar) = requested_manager_sidecar {
+        Some(
+            manager_result_spillover::prepare_manager_sidecar_for_publish(
+                &session_dir,
+                &mut persisted_result,
+                sidecar,
+                spill_threshold_bytes,
+            )?,
+        )
+    } else if preserve_existing_manager_sidecar {
+        manager_result_spillover::load_existing_manager_sidecar_for_publish(
+            &session_dir,
+            &mut persisted_result,
+            spill_threshold_bytes,
+        )?
+    } else {
+        None
+    };
     if manager_sidecar.is_none() && preserve_existing_manager_sidecar {
         ensure_result_artifact(&mut persisted_result, CONTRACT_RESULT_ARTIFACT_PATH);
     } else {
@@ -531,133 +577,4 @@ pub(crate) fn list_artifacts_in(base_dir: &Path, session_id: &str) -> Result<Vec
     }
     artifacts.sort();
     Ok(artifacts)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::redact_result_sidecar_value;
-    use super::*;
-    use chrono::Utc;
-    use tempfile::tempdir;
-
-    #[test]
-    fn manager_result_redaction_preserves_toml_datetime_values() {
-        let sidecar = toml::toml! {
-            started_at = 2026-04-19T12:34:56Z
-            [auth]
-            token = "secret-token"
-        }
-        .into();
-
-        let redacted = redact_result_sidecar_value(&sidecar).expect("redacted sidecar");
-
-        assert!(matches!(
-            redacted.get("started_at"),
-            Some(toml::Value::Datetime(_))
-        ));
-        assert_eq!(
-            redacted
-                .get("auth")
-                .and_then(toml::Value::as_table)
-                .and_then(|table| table.get("token")),
-            Some(&toml::Value::String("[REDACTED]".to_string()))
-        );
-    }
-
-    #[test]
-    fn manager_result_redaction_preserves_nested_json_string_redaction() {
-        let sidecar = toml::toml! {
-            payload = "{\"secret\":\"top-secret\"}"
-        }
-        .into();
-
-        let redacted = redact_result_sidecar_value(&sidecar).expect("redacted sidecar");
-        let payload = redacted
-            .get("payload")
-            .and_then(toml::Value::as_str)
-            .expect("payload string");
-
-        assert!(!payload.contains("top-secret"));
-        assert!(payload.contains("[REDACTED]"));
-    }
-
-    #[test]
-    fn load_result_in_ignores_orphaned_sidecar() {
-        let td = tempdir().expect("tempdir");
-        let session_id = crate::validate::new_session_id();
-        let session_dir = super::super::get_session_dir_in(td.path(), &session_id);
-        std::fs::create_dir_all(session_dir.join("output")).expect("create output dir");
-        let result_path = session_dir.join(RESULT_FILE_NAME);
-
-        let now = Utc::now();
-        let turn_1_result = SessionResult {
-            status: "success".to_string(),
-            exit_code: 0,
-            summary: "turn 1".to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now,
-            events_count: 1,
-            artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
-            peak_memory_mb: None,
-            manager_fields: crate::result::SessionManagerFields {
-                report: Some(
-                    toml::toml! {
-                        [repo_write_audit]
-                        added = ["turn-1.txt"]
-                    }
-                    .into(),
-                ),
-                ..Default::default()
-            },
-        };
-        save_result_in(
-            td.path(),
-            &session_id,
-            &turn_1_result,
-            SaveOptions::default(),
-        )
-        .expect("save turn 1");
-
-        let turn_2_result = SessionResult {
-            summary: "turn 2".to_string(),
-            manager_fields: Default::default(),
-            ..turn_1_result
-        };
-        save_result_in(
-            td.path(),
-            &session_id,
-            &turn_2_result,
-            SaveOptions::default(),
-        )
-        .expect("save turn 2");
-
-        let mut turn_2_envelope: SessionResult =
-            toml::from_str(&std::fs::read_to_string(&result_path).expect("read turn 2 envelope"))
-                .expect("parse turn 2 envelope");
-        turn_2_envelope
-            .artifacts
-            .retain(|artifact| artifact.path != CONTRACT_RESULT_ARTIFACT_PATH);
-        let contents =
-            toml::to_string_pretty(&turn_2_envelope).expect("serialize orphaned envelope");
-        write_file_atomically(&result_path, &contents).expect("persist orphaned envelope");
-
-        let reloaded = load_result_in(td.path(), &session_id)
-            .expect("load result")
-            .expect("result should exist");
-        assert!(
-            reloaded
-                .artifacts
-                .iter()
-                .all(|artifact| artifact.path != CONTRACT_RESULT_ARTIFACT_PATH),
-            "turn 2 envelope must not advertise the manager sidecar"
-        );
-        assert!(
-            reloaded.manager_fields.as_sidecar().is_none(),
-            "orphaned sidecar must not leak prior manager fields into turn 2"
-        );
-    }
 }

--- a/crates/csa-session/src/manager_result_spillover.rs
+++ b/crates/csa-session/src/manager_result_spillover.rs
@@ -1,0 +1,560 @@
+use super::*;
+
+const LARGE_OUTPUT_ARTIFACT_PATH: &str = "artifacts/large-output-report.md";
+const REPORT_SUMMARY_PREVIEW_CHARS: usize = 240;
+const REPORT_BODY_PREVIEW_CHARS: usize = 480;
+const REPORT_DECISION_PREVIEW_CHARS: usize = 160;
+
+pub(super) fn resolve_report_spill_threshold_bytes(project_path: &Path) -> u64 {
+    match csa_config::ProjectConfig::load(project_path) {
+        Ok(Some(config)) => config.session.result_report_spill_threshold_bytes,
+        Ok(None) => csa_config::DEFAULT_RESULT_REPORT_SPILL_THRESHOLD_BYTES,
+        Err(error) => {
+            tracing::warn!(
+                path = %project_path.display(),
+                error = %error,
+                "Failed to load session spillover config; using default threshold"
+            );
+            csa_config::DEFAULT_RESULT_REPORT_SPILL_THRESHOLD_BYTES
+        }
+    }
+}
+
+pub(super) fn load_existing_manager_sidecar_for_publish(
+    session_dir: &Path,
+    result: &mut SessionResult,
+    spill_threshold_bytes: u64,
+) -> Result<Option<toml::Value>> {
+    let sidecar_path = session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH);
+    match load_optional_result_sidecar(session_dir, CONTRACT_RESULT_ARTIFACT_PATH) {
+        Ok(Some(sidecar)) => Ok(Some(prepare_manager_sidecar_for_publish(
+            session_dir,
+            result,
+            sidecar,
+            spill_threshold_bytes,
+        )?)),
+        Ok(None) => Ok(None),
+        Err(error) => {
+            tracing::warn!(
+                path = %sidecar_path.display(),
+                error = %error,
+                "Failed to load existing manager sidecar for spillover processing; preserving original file"
+            );
+            Ok(None)
+        }
+    }
+}
+
+pub(super) fn prepare_manager_sidecar_for_publish(
+    session_dir: &Path,
+    result: &mut SessionResult,
+    mut sidecar: toml::Value,
+    spill_threshold_bytes: u64,
+) -> Result<toml::Value> {
+    if spill_threshold_bytes == 0 {
+        return Ok(sidecar);
+    }
+
+    let Some(sidecar_table) = sidecar.as_table_mut() else {
+        return Ok(sidecar);
+    };
+    let Some(report_table) = sidecar_table
+        .get_mut("report")
+        .and_then(toml::Value::as_table_mut)
+    else {
+        return Ok(sidecar);
+    };
+
+    let summary = report_table
+        .get("summary")
+        .and_then(toml::Value::as_str)
+        .map(ToOwned::to_owned);
+    let what_was_done = report_table
+        .get("what_was_done")
+        .and_then(toml::Value::as_str)
+        .map(ToOwned::to_owned);
+    let key_decisions = report_table
+        .get("key_decisions")
+        .and_then(toml::Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(toml::Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let combined_bytes = summary.as_deref().map_or(0, str::len)
+        + what_was_done.as_deref().map_or(0, str::len)
+        + key_decisions.iter().map(String::len).sum::<usize>();
+    if combined_bytes as u64 <= spill_threshold_bytes {
+        return Ok(sidecar);
+    }
+
+    let artifact_contract_path = format!("$CSA_SESSION_DIR/{LARGE_OUTPUT_ARTIFACT_PATH}");
+    let artifact_content = render_large_output_artifact(
+        spill_threshold_bytes,
+        combined_bytes as u64,
+        summary.as_deref(),
+        what_was_done.as_deref(),
+        &key_decisions,
+    );
+    let artifact_disk_path = session_dir.join(LARGE_OUTPUT_ARTIFACT_PATH);
+    write_file_atomically(&artifact_disk_path, &artifact_content).with_context(|| {
+        format!(
+            "Failed to write large output spillover artifact: {}",
+            artifact_disk_path.display()
+        )
+    })?;
+    let artifact_size_bytes = artifact_content.len() as u64;
+    upsert_session_artifact(
+        result,
+        LARGE_OUTPUT_ARTIFACT_PATH,
+        Some(artifact_size_bytes),
+    );
+
+    let reverse_prompt = format!(
+        "Run `rg <pattern> {artifact_contract_path}` to search findings, or `head -100 {artifact_contract_path}` for summary"
+    );
+    let summary_source = summary
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            what_was_done
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .or_else(|| {
+            key_decisions
+                .iter()
+                .find(|value| !value.trim().is_empty())
+                .map(String::as_str)
+        })
+        .unwrap_or("Manager-facing report spilled to artifact");
+    let summary_preview = format!(
+        "{} [full report: {}]",
+        truncate_with_ellipsis(summary_source, REPORT_SUMMARY_PREVIEW_CHARS),
+        artifact_contract_path
+    );
+    report_table.insert("summary".to_string(), toml::Value::String(summary_preview));
+    if let Some(full_what_was_done) = what_was_done.as_deref() {
+        report_table.insert(
+            "what_was_done".to_string(),
+            toml::Value::String(format!(
+                "{} [truncated; full report: {}]",
+                truncate_with_ellipsis(full_what_was_done, REPORT_BODY_PREVIEW_CHARS),
+                artifact_contract_path
+            )),
+        );
+    }
+    if !key_decisions.is_empty() {
+        let mut decision_preview = key_decisions
+            .iter()
+            .take(3)
+            .map(|value| truncate_with_ellipsis(value, REPORT_DECISION_PREVIEW_CHARS))
+            .collect::<Vec<_>>();
+        if key_decisions.len() > 3
+            || key_decisions
+                .iter()
+                .take(3)
+                .zip(decision_preview.iter())
+                .any(|(original, truncated)| original != truncated)
+        {
+            decision_preview.push(format!(
+                "Additional decisions truncated; full list: {artifact_contract_path}"
+            ));
+        }
+        report_table.insert(
+            "key_decisions".to_string(),
+            toml::Value::Array(
+                decision_preview
+                    .into_iter()
+                    .map(toml::Value::String)
+                    .collect(),
+            ),
+        );
+    }
+
+    let artifacts_table = sidecar_table
+        .entry("artifacts".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    let Some(artifacts_table) = artifacts_table.as_table_mut() else {
+        return Ok(sidecar);
+    };
+    artifacts_table.insert(
+        "large_output_path".to_string(),
+        toml::Value::String(artifact_contract_path),
+    );
+    artifacts_table.insert(
+        "large_output_size_bytes".to_string(),
+        toml::Value::Integer(artifact_size_bytes as i64),
+    );
+    artifacts_table.insert(
+        "reverse_prompt".to_string(),
+        toml::Value::String(reverse_prompt),
+    );
+
+    Ok(sidecar)
+}
+
+fn render_large_output_artifact(
+    threshold_bytes: u64,
+    combined_bytes: u64,
+    summary: Option<&str>,
+    what_was_done: Option<&str>,
+    key_decisions: &[String],
+) -> String {
+    let mut content = String::new();
+    content.push_str("# Large Output Spillover\n\n");
+    content.push_str(&format!(
+        "Combined report text ({combined_bytes} bytes) exceeded the configured threshold ({threshold_bytes} bytes).\n\n"
+    ));
+    if let Some(summary) = summary {
+        content.push_str("## Summary\n\n");
+        content.push_str(summary);
+        content.push_str("\n\n");
+    }
+    if let Some(what_was_done) = what_was_done {
+        content.push_str("## What Was Done\n\n");
+        content.push_str(what_was_done);
+        content.push_str("\n\n");
+    }
+    if !key_decisions.is_empty() {
+        content.push_str("## Key Decisions\n\n");
+        for decision in key_decisions {
+            content.push_str("- ");
+            content.push_str(decision);
+            content.push('\n');
+        }
+    }
+    content
+}
+
+fn truncate_with_ellipsis(input: &str, max_chars: usize) -> String {
+    let total_chars = input.chars().count();
+    if total_chars <= max_chars {
+        return input.to_string();
+    }
+    let take_chars = max_chars.saturating_sub(3);
+    let mut truncated = input.chars().take(take_chars).collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+fn upsert_session_artifact(
+    result: &mut SessionResult,
+    artifact_path: &str,
+    size_bytes: Option<u64>,
+) {
+    if let Some(existing) = result
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.path == artifact_path)
+    {
+        existing.size_bytes = size_bytes;
+        return;
+    }
+    result.artifacts.push(SessionArtifact {
+        path: artifact_path.to_string(),
+        line_count: None,
+        size_bytes,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use tempfile::tempdir;
+
+    #[test]
+    fn manager_result_redaction_preserves_toml_datetime_values() {
+        let sidecar = toml::toml! {
+            started_at = 2026-04-19T12:34:56Z
+            [auth]
+            token = "secret-token"
+        }
+        .into();
+
+        let redacted = redact_result_sidecar_value(&sidecar).expect("redacted sidecar");
+
+        assert!(matches!(
+            redacted.get("started_at"),
+            Some(toml::Value::Datetime(_))
+        ));
+        assert_eq!(
+            redacted
+                .get("auth")
+                .and_then(toml::Value::as_table)
+                .and_then(|table| table.get("token")),
+            Some(&toml::Value::String("[REDACTED]".to_string()))
+        );
+    }
+
+    #[test]
+    fn manager_result_redaction_preserves_nested_json_string_redaction() {
+        let sidecar = toml::toml! {
+            payload = "{\"secret\":\"top-secret\"}"
+        }
+        .into();
+
+        let redacted = redact_result_sidecar_value(&sidecar).expect("redacted sidecar");
+        let payload = redacted
+            .get("payload")
+            .and_then(toml::Value::as_str)
+            .expect("payload string");
+
+        assert!(!payload.contains("top-secret"));
+        assert!(payload.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn load_result_in_ignores_orphaned_sidecar() {
+        let td = tempdir().expect("tempdir");
+        let session_id = crate::validate::new_session_id();
+        let session_dir = super::super::super::get_session_dir_in(td.path(), &session_id);
+        std::fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+        let result_path = session_dir.join(RESULT_FILE_NAME);
+
+        let now = Utc::now();
+        let turn_1_result = SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "turn 1".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 1,
+            artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
+            peak_memory_mb: None,
+            manager_fields: crate::result::SessionManagerFields {
+                report: Some(
+                    toml::toml! {
+                        [repo_write_audit]
+                        added = ["turn-1.txt"]
+                    }
+                    .into(),
+                ),
+                ..Default::default()
+            },
+        };
+        save_result_in(
+            td.path(),
+            &session_id,
+            &turn_1_result,
+            SaveOptions::default(),
+        )
+        .expect("save turn 1");
+
+        let turn_2_result = SessionResult {
+            summary: "turn 2".to_string(),
+            manager_fields: Default::default(),
+            ..turn_1_result
+        };
+        save_result_in(
+            td.path(),
+            &session_id,
+            &turn_2_result,
+            SaveOptions::default(),
+        )
+        .expect("save turn 2");
+
+        let mut turn_2_envelope: SessionResult =
+            toml::from_str(&std::fs::read_to_string(&result_path).expect("read turn 2 envelope"))
+                .expect("parse turn 2 envelope");
+        turn_2_envelope
+            .artifacts
+            .retain(|artifact| artifact.path != CONTRACT_RESULT_ARTIFACT_PATH);
+        let contents =
+            toml::to_string_pretty(&turn_2_envelope).expect("serialize orphaned envelope");
+        write_file_atomically(&result_path, &contents).expect("persist orphaned envelope");
+
+        let reloaded = load_result_in(td.path(), &session_id)
+            .expect("load result")
+            .expect("result should exist");
+        assert!(
+            reloaded
+                .artifacts
+                .iter()
+                .all(|artifact| artifact.path != CONTRACT_RESULT_ARTIFACT_PATH),
+            "turn 2 envelope must not advertise the manager sidecar"
+        );
+        assert!(
+            reloaded.manager_fields.as_sidecar().is_none(),
+            "orphaned sidecar must not leak prior manager fields into turn 2"
+        );
+    }
+
+    #[test]
+    fn save_result_in_spills_large_existing_manager_report_to_artifact() {
+        let td = tempdir().expect("tempdir");
+        let state =
+            super::super::super::create_session_in(td.path(), td.path(), None, None, Some("codex"))
+                .expect("create session");
+        let session_dir =
+            super::super::super::get_session_dir_in(td.path(), &state.meta_session_id);
+
+        let long_summary = "summary ".repeat(40);
+        let long_body = "implemented detailed steps ".repeat(30);
+        let long_decisions = vec![
+            "decision A ".repeat(20),
+            "decision B ".repeat(20),
+            "decision C ".repeat(20),
+            "decision D ".repeat(20),
+        ];
+        let sidecar = toml::Value::Table(
+            [
+                (
+                    "report".to_string(),
+                    toml::Value::Table(
+                        [
+                            (
+                                "summary".to_string(),
+                                toml::Value::String(long_summary.clone()),
+                            ),
+                            (
+                                "what_was_done".to_string(),
+                                toml::Value::String(long_body.clone()),
+                            ),
+                            (
+                                "key_decisions".to_string(),
+                                toml::Value::Array(
+                                    long_decisions
+                                        .iter()
+                                        .cloned()
+                                        .map(toml::Value::String)
+                                        .collect(),
+                                ),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                ),
+                (
+                    "artifacts".to_string(),
+                    toml::Value::Table(
+                        [(
+                            "commit_hash".to_string(),
+                            toml::Value::String("abc1234".to_string()),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        std::fs::write(
+            session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH),
+            toml::to_string_pretty(&sidecar).expect("serialize sidecar"),
+        )
+        .expect("write sidecar");
+
+        let now = Utc::now();
+        let runtime_result = SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "runtime summary".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 1,
+            artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
+            peak_memory_mb: None,
+            manager_fields: Default::default(),
+        };
+        save_result_in_with_threshold(
+            td.path(),
+            &state.meta_session_id,
+            &runtime_result,
+            SaveOptions::default(),
+            256,
+        )
+        .expect("save result");
+
+        let reloaded = load_result_in(td.path(), &state.meta_session_id)
+            .expect("load result")
+            .expect("result should exist");
+        assert!(
+            reloaded
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.path == CONTRACT_RESULT_ARTIFACT_PATH)
+        );
+        assert!(
+            reloaded
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.path == LARGE_OUTPUT_ARTIFACT_PATH),
+            "runtime envelope should advertise the spillover artifact"
+        );
+
+        let spilled_sidecar =
+            load_optional_result_sidecar(&session_dir, CONTRACT_RESULT_ARTIFACT_PATH)
+                .expect("load sidecar")
+                .expect("sidecar should exist");
+        assert_eq!(
+            spilled_sidecar
+                .get("artifacts")
+                .and_then(|value| value.get("commit_hash"))
+                .and_then(toml::Value::as_str),
+            Some("abc1234")
+        );
+        assert_eq!(
+            spilled_sidecar
+                .get("artifacts")
+                .and_then(|value| value.get("large_output_path"))
+                .and_then(toml::Value::as_str),
+            Some("$CSA_SESSION_DIR/artifacts/large-output-report.md")
+        );
+        assert!(
+            spilled_sidecar
+                .get("artifacts")
+                .and_then(|value| value.get("reverse_prompt"))
+                .and_then(toml::Value::as_str)
+                .is_some_and(|value| value.contains("head -100")),
+            "reverse_prompt should guide selective artifact reads"
+        );
+        assert!(
+            spilled_sidecar
+                .get("report")
+                .and_then(|value| value.get("summary"))
+                .and_then(toml::Value::as_str)
+                .is_some_and(|value| {
+                    value.contains(
+                        "[full report: $CSA_SESSION_DIR/artifacts/large-output-report.md]",
+                    )
+                })
+        );
+
+        let artifact_contents =
+            std::fs::read_to_string(session_dir.join(LARGE_OUTPUT_ARTIFACT_PATH))
+                .expect("read spillover artifact");
+        assert!(artifact_contents.contains(&long_summary));
+        assert!(artifact_contents.contains(&long_body));
+        assert!(artifact_contents.contains(&long_decisions[3]));
+    }
+
+    #[test]
+    fn resolve_report_spill_threshold_uses_project_config_override() {
+        let td = tempdir().expect("tempdir");
+        let config_dir = td.path().join(".csa");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "schema_version = 1\n[session]\nresult_report_spill_threshold_bytes = 2048\n",
+        )
+        .expect("write config");
+
+        assert_eq!(resolve_report_spill_threshold_bytes(td.path()), 2048);
+    }
+}


### PR DESCRIPTION
## Summary

- Added automatic spillover for large result.toml report fields to session artifacts
- When combined report text exceeds configurable threshold (default 10KB), full content is written to `$CSA_SESSION_DIR/artifacts/large-output-report.md`
- Truncated summary remains in result.toml for manager consumption
- Added `reverse_prompt` field in `[artifacts]` with hints for caller to selectively consume (e.g., `rg <pattern> <path>`)
- Configurable via `[session].result_report_spill_threshold_bytes` (0 to disable)
- Dedicated spillover module to satisfy monolith gate limits

Closes #1329

## Test plan

- [x] `just pre-commit` passes
- [x] 6 new tests covering spillover detection, file writing, config threshold
- [x] All existing tests pass
- [ ] Manual: dispatch a session producing >10KB report, verify artifact file + truncated result.toml + reverse_prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)