### PR TITLE
feat(cli): expand CALLER_HINT to forbid manual polling (#1336)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.682"
+version = "0.1.683"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.682"
+version = "0.1.683"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -9,6 +9,8 @@
 const NO_STACK_WAKEUP_WARNING: &str = "do NOT stack ScheduleWakeup, /loop, or sleep loops on top";
 const BACKGROUND_WAIT_RECOMMENDATION: &str = "with run_in_background: true";
 const TASK_NOTIFICATION_WAKE_SIGNAL: &str = "The task-notification IS your wake signal";
+const NO_MANUAL_POLLING_DIRECTIVE: &str =
+    "ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID";
 
 const RUN_CMD_DAEMON_SRC: &str = include_str!("run_cmd_daemon.rs");
 const PLAN_CMD_DAEMON_SRC: &str = include_str!("plan_cmd_daemon.rs");
@@ -51,6 +53,10 @@ fn assert_wait_hint_contract(block: &str, site: &str) {
     assert!(
         !block.contains("in a SEPARATE Bash call"),
         "{site} CALLER_HINT must not lead with the old foreground-wait phrasing"
+    );
+    assert!(
+        block.contains(NO_MANUAL_POLLING_DIRECTIVE),
+        "{site} CALLER_HINT must forbid manual polling (ls/cat/wc/grep on session-dir, state.toml reads, ps checks)"
     );
 }
 
@@ -110,6 +116,10 @@ fn session_cmds_daemon_wait_retry_wait_hint_warns_no_stack_wakeup() {
         retry.contains(NO_STACK_WAKEUP_WARNING),
         "retry_wait CALLER_HINT must warn against ScheduleWakeup/loop stacking"
     );
+    assert!(
+        retry.contains(NO_MANUAL_POLLING_DIRECTIVE),
+        "retry_wait CALLER_HINT must forbid manual polling (ls/cat/wc/grep on session-dir, state.toml reads, ps checks)"
+    );
 }
 
 #[test]
@@ -122,5 +132,9 @@ fn session_cmds_daemon_wait_next_session_hint_warns_no_stack_wakeup() {
     assert!(
         next.contains(NO_STACK_WAKEUP_WARNING),
         "next_session CALLER_HINT must warn against ScheduleWakeup/loop stacking"
+    );
+    assert!(
+        next.contains(NO_MANUAL_POLLING_DIRECTIVE),
+        "next_session CALLER_HINT must forbid manual polling (ls/cat/wc/grep on session-dir, state.toml reads, ps checks)"
     );
 }

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -213,7 +213,9 @@ pub(crate) fn spawn_and_exit(
         "<!-- CSA:CALLER_HINT action=\"wait\" \
          rule=\"Call 'csa session wait --session {id}{cd}' with run_in_background: true. \
          The task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top. \
-         NEVER batch multiple waits in a for/while loop; use one backgrounded Bash tool call per session.\" -->",
+         NEVER batch multiple waits in a for/while loop; use one backgrounded Bash tool call per session. \
+         FORBIDDEN after backgrounding: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
+         any manual polling wastes caller tokens with zero benefit.\" -->",
         id = result.session_id,
         cd = cd_hint,
     );

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -248,7 +248,9 @@ pub(crate) fn spawn_and_exit(
         "<!-- CSA:CALLER_HINT action=\"wait\" \
          rule=\"Call 'csa session wait --session {id}{cd}' with run_in_background: true. \
          The task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top. \
-         NEVER batch multiple waits in a for/while loop; use one backgrounded Bash tool call per session.\" -->",
+         NEVER batch multiple waits in a for/while loop; use one backgrounded Bash tool call per session. \
+         FORBIDDEN after backgrounding: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
+         any manual polling wastes caller tokens with zero benefit.\" -->",
         id = result.session_id,
         cd = cd_hint,
     );

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -412,7 +412,9 @@ where
                  rule=\"Process this output NOW and generate tokens to warm your KV cache, \
                  then call 'csa session wait --session {sid}{cd}' again in a NEW Bash call. \
                  NEVER batch multiple session waits in one Bash call. \
-                 If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens.\" -->",
+                 If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens. \
+                 FORBIDDEN: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
+                 any manual polling wastes caller tokens with zero benefit.\" -->",
                 sid = resolved.session_id,
                 cd = cd
                     .as_ref()
@@ -612,7 +614,9 @@ fn emit_wait_completion_signal(
          rule=\"If you have more sessions to wait for, call each 'csa session wait' \
          in a SEPARATE Bash call. NEVER batch. \
          Generate tokens between waits to keep your KV cache warm. \
-         If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens.\" -->"
+         If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens. \
+         FORBIDDEN: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
+         any manual polling wastes caller tokens with zero benefit.\" -->"
     );
 }
 


### PR DESCRIPTION
## Summary

- Expanded all 4 CSA:CALLER_HINT emit sites with explicit anti-polling directives
- Added `NO_MANUAL_POLLING_DIRECTIVE` contract constant with test assertions
- FORBIDDEN: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID
- Makes clear that backgrounded `csa session wait` task-notification is the only wake signal

Closes #1336

## Test plan

- [x] `just pre-commit` passes
- [x] New test assertions verify anti-polling text in all 4 hint sites
- [x] All workspace tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)