### PR TITLE
fix(review): verdict no longer writes unavailable when findings are empty (#1340)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.685"
+version = "0.1.686"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -587,20 +587,21 @@ fn derive_decision_from_severity_counts(
         return Ok(ReviewDecision::Fail);
     }
 
-    // Skip/Unavailable: deliberate infrastructure signals, propagate as-is.
-    if let Some(meta @ (ReviewDecision::Skip | ReviewDecision::Unavailable)) = meta_decision {
-        return Ok(meta);
+    // Skip: deliberate "no diff to review" signal, propagate as-is.
+    if let Some(ReviewDecision::Skip) = meta_decision {
+        return Ok(ReviewDecision::Skip);
     }
-    let needs_prose_tiebreak = matches!(
+    // Unavailable NOT propagated: genuine failures are handled via the status_reason
+    // fast-path before this function. Unavailable in meta_decision here means the
+    // raw output contained the UNAVAILABLE token (prompt injection noise). Zero findings
+    // is conclusive — fall through to Pass. (#1340)
+
+    // #1140/#1144: Uncertain/Fail meta with zero structured evidence → prose tiebreak.
+    if matches!(
         meta_decision,
         Some(ReviewDecision::Uncertain | ReviewDecision::Fail)
-    ) && severity_counts_are_zero(severity_counts);
-
-    // #1140/#1144: when meta.decision is Uncertain or legacy Fail but the
-    // structured findings are empty and severity counts are all zero, trust
-    // explicit PASS/CLEAN prose as the tiebreaker; otherwise preserve the
-    // caller-provided meta decision.
-    if needs_prose_tiebreak {
+    ) && severity_counts_are_zero(severity_counts)
+    {
         return Ok(if prose_clean_check()? {
             ReviewDecision::Pass
         } else {
@@ -608,16 +609,10 @@ fn derive_decision_from_severity_counts(
         });
     }
 
-    // At this point: zero severity counts, empty findings, non-severe overall_risk,
-    // and meta_decision is either Pass, Fail, or None. Prose clean check is a tiebreaker
-    // only when meta_decision is None (no verdict token was parsed from output).
     if meta_decision == Some(ReviewDecision::Pass) || prose_clean_check()? {
         return Ok(ReviewDecision::Pass);
     }
 
-    // No findings, no prose clean marker, meta_decision is Fail or None:
-    // keep the legacy zero-findings fallback as Pass unless the tie-break above
-    // already preserved an explicit Fail/Uncertain meta decision.
     Ok(ReviewDecision::Pass)
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -761,3 +761,6 @@ fn persisted_review_artifact_deserializes_optional_overall_risk() {
 
 #[path = "review_cmd_output_verdict_1045_tests.rs"]
 mod verdict_1045_tests;
+
+#[path = "review_cmd_output_verdict_1340_tests.rs"]
+mod verdict_1340_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1340_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1340_tests.rs
@@ -1,0 +1,158 @@
+use super::*;
+
+// ─── #1340 regression tests: Unavailable meta_decision must not override empty findings ─
+
+/// #1340 Case 1: meta.decision=unavailable (from text-parse noise) + empty
+/// findings.toml → review-verdict.json must write decision=pass.
+///
+/// Regression: UNAVAILABLE token in prompt-injection text caused
+/// parse_review_decision_token to return Unavailable, which then propagated
+/// through derive_decision_from_severity_counts even though findings were empty.
+#[test]
+fn issue_1340_unavailable_meta_with_empty_findings_toml_emits_pass() {
+    let session_id = "01TEST1340UNAVAILABLEFINDS0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1340-unavailable-empty-findings", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // Summary says PASS — matches the real-world session 01KR2S11132Q9WNFQ7HK3AT966
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\n**PASS** — Auto-commit fix. No blocking findings.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    // meta.decision = "unavailable" simulates text-parse contamination by prompt injection
+    let meta =
+        make_review_meta_with_decision(session_id, ReviewDecision::Unavailable, "UNAVAILABLE");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1340: Unavailable meta + empty findings.toml must yield pass, not unavailable"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|v| *v == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1340 Case 2: meta.decision=unavailable + empty findings.toml + no summary section
+/// → still emits pass (zero-findings default, not text-parse dependent).
+#[test]
+fn issue_1340_unavailable_meta_with_empty_findings_toml_no_summary_emits_pass() {
+    let session_id = "01TEST1340UNAVAILABLENOSUM0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1340-unavailable-no-summary", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // No summary.md — verdict must still be Pass from zero-findings evidence alone
+
+    let meta =
+        make_review_meta_with_decision(session_id, ReviewDecision::Unavailable, "UNAVAILABLE");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1340: Unavailable meta + empty findings.toml (no summary) must still yield pass"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1340 Case 3: Verify genuine status_reason path still emits Unavailable.
+///
+/// When status_reason is set (real infrastructure failure), persist_review_verdict
+/// takes the fast-path that uses meta.decision directly — Unavailable is preserved.
+#[test]
+fn issue_1340_status_reason_set_preserves_unavailable() {
+    let session_id = "01TEST1340STATUSREASONFAIL0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1340-status-reason-unavailable", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    // findings.toml is empty (would otherwise indicate pass)
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+
+    // status_reason = Some → genuine infrastructure failure → fast-path bypasses
+    // derive_review_verdict_artifact and uses meta.decision directly
+    let mut meta =
+        make_review_meta_with_decision(session_id, ReviewDecision::Unavailable, "UNAVAILABLE");
+    meta.status_reason = Some("gemini_auth_prompt".to_string());
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Unavailable,
+        "#1340: status_reason set means genuine failure — Unavailable must be preserved"
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1340 Case 4: actual fail with HIGH findings is unaffected by the fix.
+#[test]
+fn issue_1340_high_finding_with_unavailable_meta_emits_fail() {
+    let session_id = "01TEST1340HIGHFINDINGUNAVAIL";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1340-high-finding-unavailable-meta", session_id);
+
+    let json_findings = vec![make_finding(Severity::High, "real-high")];
+    let json_artifact = json!({
+        "findings": json_findings,
+        "severity_summary": SeveritySummary { critical: 0, high: 1, medium: 0, low: 0 },
+        "overall_risk": "high"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&json_artifact).expect("serialize"),
+    )
+    .expect("write review-findings.json");
+
+    let meta =
+        make_review_meta_with_decision(session_id, ReviewDecision::Unavailable, "UNAVAILABLE");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1340: HIGH finding with Unavailable meta must still yield Fail"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}


### PR DESCRIPTION
## Summary

- Fixed review verdict extraction writing "unavailable" when findings are empty and summary says PASS
- Root cause: `derive_decision_from_severity_counts` propagated `Unavailable` as-is even when findings=[] and severity counts=0. The `Unavailable` came from prompt injection content containing UNAVAILABLE keyword being misinterpreted by `parse_review_decision_token`
- Fix: removed `Unavailable` from the propagate-as-is branch; it now falls through to prose check and zero-findings Pass default
- Genuine infrastructure Unavailable handled earlier via `status_reason` fast-path in `persist_review_verdict`

Closes #1340

## Test plan

- [x] `just pre-commit` passes
- [x] 4 new tests covering: empty findings→pass, PASS in summary, Unavailable fallthrough, genuine unavailable
- [x] All 2062 crate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)