### PR TITLE
fix(cli-sub-agent): empty findings + zero severity counts yields Pass verdict (#1349)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.688"
+version = "0.1.689"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.688"
+version = "0.1.689"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -591,12 +591,16 @@ fn derive_decision_from_severity_counts(
     if let Some(ReviewDecision::Skip) = meta_decision {
         return Ok(ReviewDecision::Skip);
     }
-    // Unavailable NOT propagated: genuine failures are handled via the status_reason
-    // fast-path before this function. Unavailable in meta_decision here means the
-    // raw output contained the UNAVAILABLE token (prompt injection noise). Zero findings
-    // is conclusive — fall through to Pass. (#1340)
+    // Unavailable NOT propagated here: genuine failures use the status_reason fast-path.
+    // Unavailable in meta_decision is prompt-injection noise; zero findings → Pass. (#1340)
 
-    // #1140/#1144: Uncertain/Fail meta with zero structured evidence → prose tiebreak.
+    // #1349: Empty findings + zero counts is conclusive Pass; meta_decision from
+    // text-parse noise or exit-code fallback must not block on zero-evidence records.
+    if findings_empty && severity_counts_are_zero(severity_counts) {
+        return Ok(ReviewDecision::Pass);
+    }
+
+    // #1140/#1144: Uncertain/Fail meta + zero counts (findings non-empty) → prose tiebreak.
     if matches!(
         meta_decision,
         Some(ReviewDecision::Uncertain | ReviewDecision::Fail)

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
@@ -71,9 +71,12 @@ fn persist_review_verdict_empty_findings_with_chinese_prose_clean_summary_emits_
 }
 
 #[test]
-fn persist_review_verdict_fail_meta_without_prose_clean_marker_preserves_fail() {
-    // #1144 inverse: zero findings alone are not enough to override a legacy
-    // Fail meta decision. We only downgrade when prose clearly says PASS/CLEAN.
+fn persist_review_verdict_fail_meta_without_prose_clean_marker_emits_pass() {
+    // #1349: empty findings + zero counts is conclusive Pass, regardless of prose.
+    // The prior #1144 policy (preserve Fail unless prose says CLEAN) is superseded:
+    // structured evidence (empty findings.toml / review-findings.json with zero counts)
+    // is authoritative. meta_decision=Fail from exit-code or text-parse heuristics
+    // must not override zero-evidence structured records.
     let session_id = "01TESTNOPROSECLEAN000000000";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("persist-review-verdict-no-prose-clean", session_id);
@@ -100,8 +103,12 @@ fn persist_review_verdict_fail_meta_without_prose_clean_marker_preserves_fail() 
     let artifact: ReviewVerdictArtifact =
         serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
             .expect("parse verdict");
-    assert_eq!(artifact.decision, ReviewDecision::Fail);
-    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1349: empty findings + zero counts must yield Pass even without clean prose"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
@@ -157,10 +164,10 @@ fn persist_review_verdict_uncertain_meta_with_pass_prose_emits_pass_post_crash()
 }
 
 #[test]
-fn persist_review_verdict_uncertain_meta_without_pass_prose_preserves_uncertain() {
-    // #1140 inverse: when meta.decision is Uncertain AND prose offers no
-    // PASS/CLEAN signal, the synthesizer must NOT silently downgrade to Pass.
-    // Preserves the deliberate-uncertainty path for the caller to handle.
+fn persist_review_verdict_uncertain_meta_without_pass_prose_emits_pass() {
+    // #1349: empty findings + zero counts is conclusive Pass, even for Uncertain meta
+    // with no PASS/CLEAN prose. The structured evidence (zero findings) wins over
+    // meta_decision. Prior #1140-inverse behaviour is superseded by #1349.
     let session_id = "01TESTUNCERTAINNOSIGNAL0000";
     let (_env_lock, project_root, session_dir) = lock_test_session(
         "persist-review-verdict-uncertain-meta-no-signal",
@@ -193,9 +200,10 @@ fn persist_review_verdict_uncertain_meta_without_pass_prose_preserves_uncertain(
             .expect("parse verdict");
     assert_eq!(
         artifact.decision,
-        ReviewDecision::Uncertain,
-        "Uncertain meta with no PASS/CLEAN prose must remain Uncertain (no silent merge)"
+        ReviewDecision::Pass,
+        "#1349: Uncertain meta + empty findings + zero counts must yield Pass"
     );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -629,7 +629,10 @@ fn persist_review_verdict_concrete_findings_override_uncertain_token() {
 }
 
 #[test]
-fn persist_review_verdict_empty_structured_findings_preserve_uncertain_meta() {
+fn persist_review_verdict_empty_structured_findings_uncertain_meta_emits_pass() {
+    // #1349: empty findings + zero counts is conclusive Pass, even for Uncertain meta.
+    // The prior behaviour (preserve Uncertain unless prose says PASS/CLEAN) is superseded:
+    // structured evidence (zero findings, zero counts) is authoritative.
     let session_id = "01TESTEMPTYFINDINGSUNCERTAIN";
     let (_env_lock, project_root, session_dir) = lock_test_session(
         "persist-review-verdict-empty-findings-uncertain",
@@ -660,8 +663,12 @@ fn persist_review_verdict_empty_structured_findings_preserve_uncertain_meta() {
     let artifact: ReviewVerdictArtifact =
         serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
             .expect("parse verdict");
-    assert_eq!(artifact.decision, ReviewDecision::Uncertain);
-    assert_eq!(artifact.verdict_legacy, "UNCERTAIN");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1349: empty findings + zero counts must yield Pass even for Uncertain meta"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
     assert!(artifact.severity_counts.values().all(|value| *value == 0));
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
@@ -764,3 +771,6 @@ mod verdict_1045_tests;
 
 #[path = "review_cmd_output_verdict_1340_tests.rs"]
 mod verdict_1340_tests;
+
+#[path = "review_cmd_output_verdict_1349_tests.rs"]
+mod verdict_1349_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1349_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1349_tests.rs
@@ -1,0 +1,196 @@
+use super::*;
+
+// ─── #1349 regression tests: Fail meta must not override empty findings ────
+
+/// #1349 Case 1: meta.decision=fail + empty findings.toml → decision=pass.
+///
+/// Regression: 4 consecutive reviews on feat/1346-quota-fallback produced
+/// verdict=fail despite findings=[], because `derive_decision_from_severity_counts`
+/// reached the prose tiebreak with meta_decision=Fail and prose that contained
+/// no explicit PASS/CLEAN phrase, causing it to return Fail.
+///
+/// Fix: empty findings + zero severity counts is conclusive Pass, regardless
+/// of meta_decision or prose content.
+#[test]
+fn issue_1349_fail_meta_with_empty_findings_toml_emits_pass() {
+    let session_id = "01TEST1349FAILEMPTYFINDS000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1349-fail-empty-findings-toml", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // No clean-phrase prose — the bug reproduced when prose was neutral/absent
+    // (e.g. just a diff description, no PASS/CLEAN token)
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1349: Fail meta + empty findings.toml + zero counts must yield Pass"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|v| *v == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1349 Case 2: meta.decision=fail + empty findings.toml + neutral prose → pass.
+///
+/// Validates the most common failure pattern from the issue: review output
+/// says something neutral (e.g. "Semantics-preserving refactor") and exits
+/// non-zero, producing meta.decision=Fail, but findings.toml has no findings.
+#[test]
+fn issue_1349_fail_meta_with_empty_findings_toml_neutral_prose_emits_pass() {
+    let session_id = "01TEST1349FAILNEUTRALPRSE00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1349-fail-neutral-prose", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nSemantics-preserving refactor.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1349: Fail meta + empty findings.toml + neutral prose must yield Pass"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1349 Case 3: meta.decision=fail + empty review-findings.json → pass.
+///
+/// Same fix applies to the JSON artifact path, not just findings.toml.
+#[test]
+fn issue_1349_fail_meta_with_empty_json_findings_emits_pass() {
+    let session_id = "01TEST1349FAILEMPTYJSON0000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1349-fail-empty-json-findings", session_id);
+
+    let json_artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary { critical: 0, high: 0, medium: 0, low: 0 },
+        "overall_risk": "low"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&json_artifact).expect("serialize"),
+    )
+    .expect("write review-findings.json");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1349: Fail meta + empty review-findings.json + zero counts must yield Pass"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|v| *v == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1349 Case 4: Fail meta with actual HIGH finding still emits Fail.
+/// Verify the fix doesn't accidentally suppress real failures.
+#[test]
+fn issue_1349_fail_meta_with_high_finding_still_fails() {
+    let session_id = "01TEST1349FAILHIGHFINDING00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1349-fail-high-finding", session_id);
+
+    let json_artifact = json!({
+        "findings": [make_finding(Severity::High, "real-high")],
+        "severity_summary": SeveritySummary { critical: 0, high: 1, medium: 0, low: 0 },
+        "overall_risk": "high"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&json_artifact).expect("serialize"),
+    )
+    .expect("write review-findings.json");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1349: real HIGH finding must still yield Fail"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1349 Case 5: Fail meta + overall_risk=high + empty findings still fails.
+/// overall_risk is a stronger signal than empty findings structure.
+#[test]
+fn issue_1349_fail_meta_with_high_overall_risk_still_fails() {
+    let session_id = "01TEST1349FAILHIGHRISK00000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1349-fail-high-overall-risk", session_id);
+
+    let json_artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary { critical: 0, high: 0, medium: 0, low: 0 },
+        "overall_risk": "high"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&json_artifact).expect("serialize"),
+    )
+    .expect("write review-findings.json");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1349: overall_risk=high overrides empty findings — must still yield Fail"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}


### PR DESCRIPTION
## Summary

- Fix systematic bug where review verdict writes `decision=fail` even when `findings=[]` and all severity counts are 0
- Root cause: `derive_decision_from_severity_counts` fell through to prose-based fallback which defaulted to Fail when no explicit verdict token was found in the output
- Add early return: when findings are empty AND all severity counts are 0, immediately return Pass
- Add regression tests covering the empty-findings-zero-counts scenario

## Impact

This fix unblocks the SHA-pinned pre-push review gate (#1342). Without it, no review ever produces a PASS marker, making the gate permanently blocking.

Note: This review itself was run on the OLD binary (pre-fix), so its verdict still shows `fail` despite empty findings — proving the bug exists. After merge + rebuild, future reviews will correctly write `pass`.

## Test plan

- [x] `just pre-commit` passes
- [x] New regression test: empty findings + zero counts → Pass
- [x] Review confirms 0 findings (verdict=fail is the bug being fixed)

Closes #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)