### PR TITLE
fix(cli-sub-agent): recall records only matching-project main sessions (#1355)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.691"
+version = "0.1.692"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.691"
+version = "0.1.692"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/recall_cmd.rs
+++ b/crates/cli-sub-agent/src/recall_cmd.rs
@@ -38,8 +38,12 @@ pub(crate) fn handle_recall(cmd: RecallCommands) -> Result<()> {
     }
 }
 
+fn recall_allowed_at_depth(depth: u32) -> bool {
+    depth == 0
+}
+
 pub(crate) fn spawn_recall_record_if_needed(project_root: &Path) {
-    if crate::pipeline_env::current_csa_depth() != 0 {
+    if !recall_allowed_at_depth(crate::pipeline_env::current_csa_depth()) {
         return;
     }
 
@@ -424,5 +428,21 @@ mod tests {
         let lines = vec!["0", "match one", "2", "match two", "4"];
         let ranges = matching_ranges(&lines, "match", 1);
         assert_eq!(ranges, vec![(0, 4)]);
+    }
+
+    #[test]
+    fn recall_allowed_only_at_main_agent_depth() {
+        assert!(
+            recall_allowed_at_depth(0),
+            "main agent (depth=0) must be recorded"
+        );
+        assert!(
+            !recall_allowed_at_depth(1),
+            "depth=1 child session must not be recorded"
+        );
+        assert!(
+            !recall_allowed_at_depth(5),
+            "deeply nested child (depth=5) must not be recorded"
+        );
     }
 }

--- a/crates/cli-sub-agent/src/recall_cmd.rs
+++ b/crates/cli-sub-agent/src/recall_cmd.rs
@@ -42,6 +42,18 @@ fn recall_allowed_at_depth(depth: u32) -> bool {
     depth == 0
 }
 
+fn thread_belongs_to_project(thread_source: &str, project_root: &Path) -> bool {
+    let encoded = project_root.display().to_string().replace('/', "-");
+    let Some(parent) = std::path::Path::new(thread_source).parent() else {
+        return false;
+    };
+    let dir_name = parent
+        .file_name()
+        .map(|n| n.to_string_lossy())
+        .unwrap_or_default();
+    dir_name.as_ref() == encoded
+}
+
 pub(crate) fn spawn_recall_record_if_needed(project_root: &Path) {
     if !recall_allowed_at_depth(crate::pipeline_env::current_csa_depth()) {
         return;
@@ -72,6 +84,15 @@ pub(crate) async fn record_main_agent_session(project_root: &Path) -> Result<()>
         debug!("recall: no Claude main thread available");
         return Ok(());
     };
+
+    if !thread_belongs_to_project(&thread.thread_source, project_root) {
+        debug!(
+            thread_source = %thread.thread_source,
+            project = %project_root.display(),
+            "recall: skipping — session belongs to a different project"
+        );
+        return Ok(());
+    }
 
     let entry = RecallHistoryEntry {
         ts: Utc::now().to_rfc3339(),
@@ -444,5 +465,19 @@ mod tests {
             !recall_allowed_at_depth(5),
             "deeply nested child (depth=5) must not be recorded"
         );
+    }
+
+    #[test]
+    fn thread_belongs_to_matching_project() {
+        let source = "/home/obj/.claude/projects/-home-obj-project-github-user-repo/abc.jsonl";
+        let root = Path::new("/home/obj/project/github/user/repo");
+        assert!(thread_belongs_to_project(source, root));
+    }
+
+    #[test]
+    fn thread_rejects_different_project() {
+        let source = "/home/obj/.claude/projects/-home-obj-project-github-user-other/abc.jsonl";
+        let root = Path::new("/home/obj/project/github/user/repo");
+        assert!(!thread_belongs_to_project(source, root));
     }
 }


### PR DESCRIPTION
## Summary
- Extract `recall_allowed_at_depth()` function with unit tests for depth-0 guard
- Add `thread_belongs_to_project()` filter: compares xurl thread_source directory against encoded project_root, preventing cross-project session pollution
- Version bump to 0.1.692

## Root cause
All `csa run` invocations from Claude Code run at CSA_DEPTH=0, so the depth guard alone cannot distinguish main agent from sub-agent calls. When CSA dispatches to different projects (warifu-ee, anima-world-kernel), xurl returns sessions from those projects' Claude directories, recording wrong session IDs in the history file.

## Fix
After xurl query, verify that the discovered thread's source path belongs to the same project directory as the invocation's project_root. Cross-project sessions are silently skipped with a debug log.

## Test plan
- [x] `just pre-commit` passes (4458 + 4688 tests, 0 failures)
- [x] `thread_belongs_to_matching_project` test: matching path returns true
- [x] `thread_rejects_different_project` test: different path returns false
- [x] `recall_allowed_only_at_main_agent_depth` test: depth=0 allowed, depth>0 rejected
- [x] Two codex reviews: both returned findings=[], severity_counts all zero (verdict=fail is #1352 pre-existing bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1355