### PR TITLE
fix(cli-sub-agent): verdict emits Pass when findings empty in full.md fallback (#1357)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.692"
+version = "0.1.693"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.692"
+version = "0.1.693"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -32,6 +32,7 @@ use clean_detection::{
     contains_clean_phrase, review_contains_prose_clean_conclusion, strip_prompt_guards,
 };
 pub(crate) use diagnostics::detect_tool_diagnostic;
+pub(super) use diagnostics::{ReviewerOutcome, print_reviewer_outcomes};
 pub(super) use summary_artifact::{
     ensure_review_summary_artifact, is_edit_restriction_summary, truncate_review_result_summary,
 };
@@ -59,18 +60,6 @@ impl ToolReviewFailureKind {
             }
         }
     }
-}
-
-#[derive(Debug, Clone)]
-pub(in crate::review_cmd) struct ReviewerOutcome {
-    pub reviewer_index: usize,
-    pub tool: ToolName,
-    pub session_id: String,
-    pub output: String,
-    pub exit_code: i32,
-    pub verdict: &'static str,
-    /// Tool-level diagnostic when the review failed due to tool issues (e.g. MCP).
-    pub diagnostic: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -399,7 +388,11 @@ fn derive_review_verdict_artifact(
     }
 
     if !full_output_is_effectively_empty(session_dir)? {
-        let decision = ReviewDecision::from_str(&meta.decision).unwrap_or(ReviewDecision::Fail);
+        let decision = if findings.is_empty() {
+            ReviewDecision::Pass
+        } else {
+            ReviewDecision::from_str(&meta.decision).unwrap_or(ReviewDecision::Fail)
+        };
         return Ok(ReviewVerdictArtifact::from_parts(
             meta.session_id.clone(),
             decision,
@@ -757,24 +750,6 @@ pub(super) fn detect_tool_review_failure(
         return None;
     }
     Some(ToolReviewFailureKind::GeminiAuthPromptDetected)
-}
-
-/// Print per-reviewer output and diagnostics for multi-reviewer mode.
-pub(super) fn print_reviewer_outcomes(outcomes: &[ReviewerOutcome]) {
-    for o in outcomes {
-        let r = o.reviewer_index + 1;
-        println!(
-            "===== Reviewer {r} ({}) | verdict={} | exit_code={} =====",
-            o.tool, o.verdict, o.exit_code
-        );
-        if let Some(ref d) = o.diagnostic {
-            eprintln!("[csa-review] Reviewer {r} tool failure: {d}");
-        }
-        print!("{}", o.output);
-        if !o.output.ends_with('\n') {
-            println!();
-        }
-    }
 }
 
 pub(in crate::review_cmd) use clean_detection::is_review_output_empty;

--- a/crates/cli-sub-agent/src/review_cmd_output_diagnostics.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_diagnostics.rs
@@ -1,5 +1,33 @@
 use super::*;
 
+#[derive(Debug, Clone)]
+pub(in crate::review_cmd) struct ReviewerOutcome {
+    pub reviewer_index: usize,
+    pub tool: ToolName,
+    pub session_id: String,
+    pub output: String,
+    pub exit_code: i32,
+    pub verdict: &'static str,
+    pub diagnostic: Option<String>,
+}
+
+pub(in crate::review_cmd) fn print_reviewer_outcomes(outcomes: &[ReviewerOutcome]) {
+    for o in outcomes {
+        let r = o.reviewer_index + 1;
+        println!(
+            "===== Reviewer {r} ({}) | verdict={} | exit_code={} =====",
+            o.tool, o.verdict, o.exit_code
+        );
+        if let Some(ref d) = o.diagnostic {
+            eprintln!("[csa-review] Reviewer {r} tool failure: {d}");
+        }
+        print!("{}", o.output);
+        if !o.output.ends_with('\n') {
+            println!();
+        }
+    }
+}
+
 /// Detect known tool-level diagnostic messages that indicate the review tool
 /// failed to actually perform a review (e.g., gemini-cli MCP connectivity issues).
 ///

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
@@ -367,12 +367,12 @@ fn issue_1045_r3_synthetic_empty_toml_missing_json_high_in_full_md_emits_fail() 
 }
 
 /// Case 9 (#1045 round 3): synthetic-empty findings.toml + NO review-findings.json
-/// + non-empty unstructured full.md → decision=fail.
+/// + non-empty unstructured full.md → decision=pass (#1357 override).
 ///
-/// full.md has content but no severity markers — fail-closed via the
-/// `!full_output_is_effectively_empty` fallback.
+/// full.md has content but no severity markers and no parseable findings.
+/// Zero-evidence records yield Pass per #1349/#1357.
 #[test]
-fn issue_1045_r3_synthetic_empty_toml_missing_json_nonempty_unstructured_full_md_emits_fail() {
+fn issue_1045_r3_synthetic_empty_toml_missing_json_nonempty_unstructured_full_md_emits_pass() {
     let session_id = "01TEST1045R3SYNTHNOJSUNSTR0";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("issue-1045-r3-synth-no-json-unstructured-full", session_id);
@@ -409,10 +409,10 @@ fn issue_1045_r3_synthetic_empty_toml_missing_json_nonempty_unstructured_full_md
             .expect("parse verdict");
     assert_eq!(
         artifact.decision,
-        ReviewDecision::Fail,
-        "#1045 round 3: synthetic-empty TOML + missing JSON + non-empty unstructured full.md must fail-closed"
+        ReviewDecision::Pass,
+        "#1357: synthetic-empty TOML + missing JSON + unstructured full.md + zero findings must yield Pass"
     );
-    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1352_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1352_tests.rs
@@ -191,3 +191,46 @@ fn issue_1352_corrupt_json_treated_as_absent_emits_pass() {
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+/// #1357 regression: synthetic-empty findings + no JSON + unstructured full.md
+/// with meta.decision=fail must yield Pass when findings vec is empty.
+#[test]
+fn issue_1357_synthetic_no_json_unstructured_full_md_emits_pass() {
+    let session_id = "01TEST1357SYNTHNOSTRUC00000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1357-synthetic-unstructured", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    fs::write(
+        session_dir.join("output").join(".findings.toml.synthetic"),
+        "",
+    )
+    .expect("write synthetic marker");
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        "Review process description in Chinese without structured findings markers.\n",
+    )
+    .expect("write full.md");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1357: synthetic-empty + no JSON + unstructured full.md + zero findings must yield Pass"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|v| *v == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}


### PR DESCRIPTION
## Summary
- When structured extraction fails (synthetic findings.toml) and full.md has unstructured content with no parseable severity markers, the verdict fallback was blindly trusting `meta.decision` (inherited from tool exit code). Codex may exit 1 even when no issues were found, causing false fail verdicts with zero severity counts.
- Now checks `findings.is_empty()` in the full.md-present fallback: empty findings yield Pass instead of inheriting meta.decision. Aligns with #1349's zero-evidence-equals-Pass principle.
- Extracts `ReviewerOutcome` and `print_reviewer_outcomes` into the diagnostics submodule to stay under the 800-line monolith limit.
- Updates issue_1045_r3 test expectation from Fail to Pass (zero-evidence records are conclusive Pass per #1349/#1357). Adds issue_1357 regression test.

Closes #1357

## Test plan
- [x] `just pre-commit` passes (4689 tests, 0 failures)
- [x] New `issue_1357_synthetic_no_json_unstructured_full_md_emits_pass` test validates the fix
- [x] Updated `issue_1045_r3` test aligns with zero-evidence-equals-Pass principle
- [x] Dogfooded: review session 01KR5ECCFWKDM2ND2JDT255MBS with old binary (0.1.692) reproduced the bug (verdict=fail, zero counts); session 01KR5ERJY97TZED4QXZZJER6PE with new binary (0.1.693) correctly emits verdict=pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)