### PR TITLE
chore(patterns): move recall skill to git-tracked pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.693"
+version = "0.1.694"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.693"
+version = "0.1.694"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/recall/.skill.toml
+++ b/patterns/recall/.skill.toml
@@ -1,0 +1,9 @@
+[skill]
+name = "recall"
+version = "0.1.0"
+
+[agent]
+tier = "tier-1-quick"
+max_turns = 10
+workspace_access = "readonly"
+tools = [{ tool = "auto" }]

--- a/patterns/recall/skills/recall/SKILL.md
+++ b/patterns/recall/skills/recall/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: recall
+description: Recover main-agent context after `/clear`, `/compact`, or lost local thread state by using `csa recall` against recorded Claude main sessions.
+---
+
+# Recall
+
+Use this skill when you need to recover recent main-agent context without dumping an entire thread into the current session.
+
+## When to use
+
+- After `/clear` or `/compact` when the current agent lost conversational context
+- When you need to inspect what the main Claude thread was discussing
+- When you want a targeted search over the most recent main-agent session
+
+## Commands
+
+```bash
+csa recall list --limit 10
+csa recall read latest
+csa recall read 3 | tail -100
+csa recall read <session-id> | rg "keyword"
+csa recall search "keyword"
+```
+
+## Safe patterns
+
+- Start with `csa recall list` to pick the right session.
+- Prefer `csa recall read <selector> | tail -100` for large threads.
+- Prefer `csa recall search "term"` before reading the full markdown.
+- Treat numeric selectors as 1-based history indexes: `1` is the most recent session.
+
+## Safety warnings
+
+- Never paste a full recalled session back into the active prompt unless strictly necessary.
+- Never run `csa recall read latest` unbounded on a large session; use `tail`, `rg`, or both.
+- If `csa recall read` prints `OUTPUT_TOO_LARGE`, narrow the view instead of retrying the full dump.


### PR DESCRIPTION
## Summary
- Move `recall` skill from `.claude/skills/` (gitignored) to `patterns/recall/` (git-tracked)
- Adds `.skill.toml` and `skills/recall/SKILL.md` under the pattern directory
- `.claude/skills/recall` is now a symlink to the pattern, consistent with all other skills

## Test plan
- [x] `just pre-commit` passes
- [x] Skill appears in available skills list via symlink resolution
- [x] `csa recall list` works correctly after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)