### PR TITLE
fix(patterns): replace hardcoded --model-spec with --tier routing in SA skill (#1360)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.694"
+version = "0.1.695"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/sa/skills/sa/SKILL.md
+++ b/patterns/sa/skills/sa/SKILL.md
@@ -415,30 +415,37 @@ scripts/csa/session-wait-until-done.sh "$SID"
 
 ### Canonical LLM dispatch form
 
-For Layer 0 manager dispatch, prefer an explicit `--model-spec` command over
-assembling `--tool`/`--tier`/`--force-ignore-tier-setting` combinations:
+For Layer 0 manager dispatch, route through the tier config and pin only the
+tool when the manager needs a specific CLI:
 
 ```bash
 SID=$(csa run \
   --sa-mode true \
-  --model-spec codex/openai/gpt-5.4/xhigh \
-  --no-failover \
+  --tier tier-4-critical \
+  --tool codex \
   --timeout 7200 \
   --prompt-file "$PROMPT_FILE")
 ```
 
 Why this is the canonical Layer 0 dispatch form:
 
-- `--model-spec` is a single-string explicit encoding of tool/provider/model/thinking
-- `--no-failover` prevents silent fallback when the manager expects codex specifically
+- `--tier` resolves model and thinking budget from tier config, keeping model
+  versions in one source of truth
+- `--tool` forces the desired tool (for example, codex) while still respecting
+  the tier's model selection
+- tier routing owns fallback, so `--no-failover` is not needed here
 - `--timeout 7200` is the sprint-safe default for long-running employee work
 
-Default to this form unless the user explicitly asks for tier-based routing or a different tool.
+Reserve `--model-spec` for one-off debugging overrides only; never document it
+as a reusable dispatch pattern. Default to this form unless the user explicitly
+asks for a different tool.
 
 ## Model Selection Guidelines
 
 - Tool and thinking budget are determined by the tier system in
-  `~/.config/cli-sub-agent/config.toml`. Do NOT hardcode `--tool` or `--thinking`.
+  `~/.config/cli-sub-agent/config.toml`. Do NOT hardcode model versions or
+  `--thinking`. Use `--tool` only when a workflow explicitly requires a
+  particular CLI.
 - Cross-review should prefer a different model family than the original author
   (configured via `[review] tool = "auto"`).
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `--model-spec codex/openai/gpt-5.4/xhigh` with `--tier tier-4-critical --tool codex` in SA skill canonical dispatch template
- Update explanation text to document why tier routing is preferred (single source of truth for model versions)
- Add guidance to reserve `--model-spec` for one-off debugging only

Closes #1360

## Test plan

- [x] `grep -r 'model-spec' patterns/sa/` shows no hardcoded model versions
- [x] Debate patterns' variable-based `--model-spec ${VAR}` left untouched (correct)
- [x] `just pre-commit` passes
- [x] `csa review --diff` verdict: PASS (session 01KR6263JMFJ1M8BS2M26CJVTF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)