### PR TITLE
fix(session): verdict pass when zero findings (#1362)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "chrono",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "chrono",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "chrono",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "axum",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "chrono",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "chrono",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.695"
+version = "0.1.696"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.695"
+version = "0.1.696"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use tracing::{error, info, warn};
 
+use crate::bug_class::{CONSOLIDATED_REVIEW_ARTIFACT_FILE, SINGLE_REVIEW_ARTIFACT_FILE};
 use crate::review_routing::ReviewRoutingMetadata;
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::ToolName;
@@ -245,18 +246,23 @@ fn persist_fix_final_artifacts(
                         "Failed to write output/findings.toml after CLEAN convergence"
                     );
                 }
-                // Clear stale review-findings.json so the cross-check in
-                // derive_review_verdict_artifact does not override the
-                // cleanly-converged empty findings.toml (#1045 round 4).
-                let stale_json = session_dir.join("review-findings.json");
-                if stale_json.exists()
-                    && let Err(error) = std::fs::remove_file(&stale_json)
-                {
-                    warn!(
-                        session_id = %review_meta.session_id,
-                        error = %error,
-                        "Failed to remove stale review-findings.json after CLEAN convergence"
-                    );
+                // Clear stale review JSON artifacts so the verdict loader does
+                // not override the cleanly-converged empty findings.toml.
+                for artifact_file in [
+                    SINGLE_REVIEW_ARTIFACT_FILE,
+                    CONSOLIDATED_REVIEW_ARTIFACT_FILE,
+                ] {
+                    let stale_artifact = session_dir.join(artifact_file);
+                    if let Err(error) = std::fs::remove_file(&stale_artifact)
+                        && error.kind() != std::io::ErrorKind::NotFound
+                    {
+                        warn!(
+                            session_id = %review_meta.session_id,
+                            artifact_file,
+                            error = %error,
+                            "Failed to remove stale review artifact after CLEAN convergence"
+                        );
+                    }
                 }
                 // Clear the synthetic-empty sidecar marker so
                 // derive_review_verdict_artifact does not fall through to
@@ -496,6 +502,59 @@ mod tests {
         );
 
         // Verdict must report pass.
+        let verdict_path = session_dir.join("output").join("review-verdict.json");
+        let artifact: csa_session::ReviewVerdictArtifact =
+            serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+                .expect("parse verdict");
+        assert_eq!(artifact.decision, ReviewDecision::Pass);
+        assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&0));
+    }
+
+    /// Stale consolidated review artifact with a HIGH finding must be cleared
+    /// on clean convergence, otherwise it takes precedence over the clean
+    /// findings.toml and forces a false fail.
+    #[test]
+    fn persist_fix_final_artifacts_clears_stale_consolidated_findings_json_on_clean() {
+        let project_root = temp_project_root("persist-fix-stale-consolidated-json");
+        let _state_home = ScopedTestEnvVar::set("XDG_STATE_HOME", project_root.join("state"));
+        let session_id = unique_session_id("01FIXSTALECONSOLIDATED");
+        let session_dir = create_session_dir(&project_root, &session_id);
+
+        let stale_consolidated_json = serde_json::json!({
+            "findings": [{
+                "severity": "high",
+                "fid": "stale-consolidated-high",
+                "file": "src/lib.rs",
+                "line": 42,
+                "rule_id": "rule.stale-consolidated",
+                "summary": "Stale high finding from consolidated artifact",
+                "engine": "review-consensus"
+            }],
+            "severity_summary": { "critical": 0, "high": 1, "medium": 0, "low": 0 },
+            "overall_risk": "high"
+        });
+        fs::write(
+            session_dir.join(crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE),
+            serde_json::to_vec_pretty(&stale_consolidated_json)
+                .expect("serialize stale consolidated json"),
+        )
+        .expect("write stale consolidated review-findings.json");
+
+        persist_fix_final_artifacts(&project_root, &make_clean_review_meta(&session_id), true);
+
+        let findings_path = session_dir.join("output").join("findings.toml");
+        let parsed: FindingsFile =
+            toml::from_str(&fs::read_to_string(&findings_path).expect("read findings.toml"))
+                .expect("parse findings.toml");
+        assert_eq!(parsed, FindingsFile::default());
+
+        assert!(
+            !session_dir
+                .join(crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE)
+                .exists(),
+            "review-findings-consolidated.json should be removed after clean convergence"
+        );
+
         let verdict_path = session_dir.join("output").join("review-verdict.json");
         let artifact: csa_session::ReviewVerdictArtifact =
             serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))

--- a/crates/cli-sub-agent/src/review_cmd_output_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_artifacts.rs
@@ -1,10 +1,12 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use csa_session::{Finding, FindingsFile, Severity, SeveritySummary};
 use serde::Deserialize;
 use tracing::warn;
+
+use crate::bug_class::{CONSOLIDATED_REVIEW_ARTIFACT_FILE, SINGLE_REVIEW_ARTIFACT_FILE};
 
 #[derive(Debug, Deserialize)]
 pub(super) struct PersistedReviewArtifact {
@@ -19,10 +21,9 @@ pub(super) struct PersistedReviewArtifact {
 pub(super) fn load_review_artifact_from_output(
     session_dir: &Path,
 ) -> Result<Option<PersistedReviewArtifact>, anyhow::Error> {
-    let findings_path = session_dir.join("review-findings.json");
-    if !findings_path.exists() {
+    let Some(findings_path) = review_artifact_path(session_dir) else {
         return Ok(None);
-    }
+    };
 
     let contents = fs::read_to_string(&findings_path)
         .map_err(|error| anyhow::anyhow!("read {}: {error}", findings_path.display()))?;
@@ -38,7 +39,7 @@ pub(super) fn load_review_artifact_from_output(
             warn!(
                 path = %findings_path.display(),
                 error = %error,
-                "Failed to parse review-findings.json; treating as zero-findings"
+                "Failed to parse review artifact JSON; treating as zero-findings"
             );
             Ok(Some(PersistedReviewArtifact {
                 findings: Vec::new(),
@@ -47,6 +48,16 @@ pub(super) fn load_review_artifact_from_output(
             }))
         }
     }
+}
+
+fn review_artifact_path(session_dir: &Path) -> Option<PathBuf> {
+    [
+        CONSOLIDATED_REVIEW_ARTIFACT_FILE,
+        SINGLE_REVIEW_ARTIFACT_FILE,
+    ]
+    .into_iter()
+    .map(|artifact_file| session_dir.join(artifact_file))
+    .find(|artifact_path| artifact_path.is_file())
 }
 
 pub(super) fn load_findings_toml_from_output(
@@ -95,7 +106,7 @@ pub(super) fn severity_counts_for_artifact(
     counts
 }
 
-/// Load severity counts from review-findings.json when present.
+/// Load severity counts from persisted review JSON when present.
 ///
 /// Returns `Some(counts)` if JSON exists and has any non-zero counts (even
 /// low-only). Returns `None` if JSON is absent, unparseable, or all-zero.

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -777,3 +777,6 @@ mod verdict_1349_tests;
 
 #[path = "review_cmd_output_verdict_1352_tests.rs"]
 mod verdict_1352_tests;
+
+#[path = "review_cmd_output_verdict_1362_tests.rs"]
+mod verdict_1362_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1362_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1362_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+/// #1362: synthetic-empty findings.toml must not force the verdict pipeline
+/// back to stale fail meta when the persisted review JSON and summary both say clean.
+#[test]
+fn issue_1362_empty_consolidated_findings_and_pass_summary_emits_pass() {
+    let session_id = "01TEST1362PASSZEROFINDS000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1362-pass-zero-findings", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write synthetic findings.toml");
+    fs::write(
+        session_dir.join("output").join(".findings.toml.synthetic"),
+        "",
+    )
+    .expect("write synthetic marker");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nPASS\n\nNo serious issues found.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist pass summary");
+
+    let review_artifact = json!({
+        "findings": [],
+        "severity_summary": SeveritySummary { critical: 0, high: 0, medium: 0, low: 0 },
+        "review_mode": "standard",
+        "schema_version": "1.0",
+        "session_id": session_id,
+        "timestamp": chrono::Utc::now()
+    });
+    fs::write(
+        session_dir.join(crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE),
+        serde_json::to_vec_pretty(&review_artifact).expect("serialize review artifact"),
+    )
+    .expect("write consolidated review artifact");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1362: empty review JSON + PASS summary must emit pass, not stale fail meta"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|count| *count == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1362_consolidated_blocking_finding_still_fails() {
+    let session_id = "01TEST1362HIGHFINDING00000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1362-high-finding", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write synthetic findings.toml");
+    fs::write(
+        session_dir.join("output").join(".findings.toml.synthetic"),
+        "",
+    )
+    .expect("write synthetic marker");
+
+    let review_artifact = json!({
+        "findings": [make_finding(Severity::High, "real-high")],
+        "severity_summary": SeveritySummary { critical: 0, high: 1, medium: 0, low: 0 },
+        "review_mode": "standard",
+        "schema_version": "1.0",
+        "session_id": session_id,
+        "timestamp": chrono::Utc::now()
+    });
+    fs::write(
+        session_dir.join(crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE),
+        serde_json::to_vec_pretty(&review_artifact).expect("serialize review artifact"),
+    )
+    .expect("write consolidated review artifact");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use anyhow::{Context, Result};
 use csa_core::env::CSA_SESSION_DIR_ENV_KEY;
 use csa_core::types::ReviewDecision;
-use csa_session::review_artifact::{Finding, ReviewArtifact};
+use csa_session::review_artifact::{Finding, ReviewArtifact, Severity};
 use csa_session::state::{ReviewSessionMeta, write_review_meta};
 use csa_session::{
     FindingsFile, ReviewFinding, ReviewFindingFileRange, ReviewVerdictArtifact,
@@ -94,26 +94,34 @@ pub(super) fn write_multi_reviewer_parent_artifacts(
     };
     let reviewer_artifacts = load_multi_reviewer_artifacts(&session_dir, reviewers)?;
     let consolidated = build_consolidated_artifact(reviewer_artifacts, &session_id);
+    let parent_decision =
+        parent_review_decision(&consolidated, final_verdict, all_reviewers_unavailable);
+    let parent_verdict = parent_legacy_verdict(parent_decision, final_verdict);
     write_consolidated_artifact(&consolidated, &session_dir)?;
     write_parent_findings_toml(&session_dir, &consolidated)?;
     write_parent_review_verdict(
         &session_dir,
         &session_id,
         &consolidated,
-        final_verdict,
-        all_reviewers_unavailable,
+        parent_decision,
+        &parent_verdict,
     )?;
     if let Some(meta) = parent_review_meta {
-        write_review_meta(&session_dir, meta).context("failed to write parent review_meta.json")?;
+        let mut meta = meta.clone();
+        meta.decision = parent_decision.as_str().to_string();
+        meta.verdict = parent_verdict.clone();
+        meta.exit_code = if parent_decision.is_clean() { 0 } else { 1 };
+        write_review_meta(&session_dir, &meta)
+            .context("failed to write parent review_meta.json")?;
         crate::review_gate::maybe_write_gate_marker_for_clean(
             project_root,
             &meta.head_sha,
-            final_verdict,
+            &meta.verdict,
             outcomes.first().map(|o| o.session_id.as_str()),
             &meta.scope,
         );
     }
-    write_parent_review_summary(&session_dir, outcomes, final_verdict)?;
+    write_parent_review_summary(&session_dir, outcomes, &parent_verdict)?;
     write_parent_review_details(&session_dir, outcomes)?;
     Ok(())
 }
@@ -208,23 +216,61 @@ fn write_parent_review_verdict(
     session_dir: &Path,
     session_id: &str,
     artifact: &ReviewArtifact,
-    final_verdict: &str,
-    all_reviewers_unavailable: bool,
+    decision: ReviewDecision,
+    verdict_legacy: &str,
 ) -> Result<()> {
-    let decision = if all_reviewers_unavailable {
-        ReviewDecision::Unavailable
-    } else {
-        ReviewDecision::from_str(final_verdict).unwrap_or(ReviewDecision::Uncertain)
-    };
     let verdict = ReviewVerdictArtifact::from_parts(
         session_id.to_string(),
         decision,
-        final_verdict.to_string(),
+        verdict_legacy.to_string(),
         &artifact.findings,
         Vec::new(),
     );
     write_review_verdict(session_dir, &verdict)
         .context("failed to write parent output/review-verdict.json")
+}
+
+fn parent_review_decision(
+    artifact: &ReviewArtifact,
+    final_verdict: &str,
+    all_reviewers_unavailable: bool,
+) -> ReviewDecision {
+    if all_reviewers_unavailable {
+        return ReviewDecision::Unavailable;
+    }
+    if artifact
+        .findings
+        .iter()
+        .any(|finding| is_blocking_severity(&finding.severity))
+    {
+        return ReviewDecision::Fail;
+    }
+    if artifact.findings.is_empty()
+        || artifact
+            .findings
+            .iter()
+            .all(|finding| finding.severity == Severity::Low)
+    {
+        return ReviewDecision::Pass;
+    }
+    ReviewDecision::from_str(final_verdict).unwrap_or(ReviewDecision::Uncertain)
+}
+
+fn is_blocking_severity(severity: &Severity) -> bool {
+    matches!(
+        severity,
+        Severity::Critical | Severity::High | Severity::Medium
+    )
+}
+
+fn parent_legacy_verdict(decision: ReviewDecision, fallback: &str) -> String {
+    match decision {
+        ReviewDecision::Pass => CLEAN.to_string(),
+        ReviewDecision::Fail => HAS_ISSUES.to_string(),
+        ReviewDecision::Skip | ReviewDecision::Uncertain | ReviewDecision::Unavailable => {
+            fallback.to_string()
+        }
+    }
 }
 
 fn write_parent_review_summary(
@@ -447,6 +493,100 @@ mod tests {
         .expect("review verdict should parse");
         assert_eq!(verdict.decision, ReviewDecision::Fail);
         assert_eq!(verdict.severity_counts[&Severity::High], 1);
+    }
+
+    #[test]
+    fn write_multi_reviewer_parent_artifacts_empty_findings_override_fail_consensus() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let temp = tempdir().expect("tempdir should be created");
+        let session_dir = temp.path().display().to_string();
+        let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
+        let _session_id_guard =
+            ScopedEnvVarRestore::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
+        let _daemon_session_dir_guard = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_DIR");
+        let _daemon_session_id_guard = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_ID");
+
+        let reviewer_dir = temp.path().join("reviewer-1");
+        fs::create_dir_all(&reviewer_dir).expect("reviewer dir should be created");
+        fs::write(
+            reviewer_dir.join("review-findings.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "verdict": "PASS",
+                "summary": "No blocking findings in main...HEAD.",
+                "findings": []
+            }))
+            .expect("artifact should serialize"),
+        )
+        .expect("review artifact should be written");
+
+        let outcomes = vec![super::super::output::ReviewerOutcome {
+            reviewer_index: 0,
+            tool: ToolName::Codex,
+            session_id: "01CHILDSESSION0000000000000".to_string(),
+            output: "Reviewer wrote a clean findings artifact.".to_string(),
+            exit_code: 1,
+            verdict: crate::review_consensus::HAS_ISSUES,
+            diagnostic: None,
+        }];
+        let parent_meta = csa_session::state::ReviewSessionMeta {
+            session_id: "01PARENTSESSION000000000000".to_string(),
+            head_sha: "abcdef1234567890".to_string(),
+            decision: ReviewDecision::Fail.as_str().to_string(),
+            verdict: crate::review_consensus::HAS_ISSUES.to_string(),
+            status_reason: None,
+            routed_to: None,
+            primary_failure: None,
+            failure_reason: None,
+            tool: "consensus".to_string(),
+            scope: "range:main...HEAD".to_string(),
+            exit_code: 1,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 1,
+            timestamp: chrono::Utc::now(),
+            diff_fingerprint: Some("sha256:test".to_string()),
+        };
+
+        write_multi_reviewer_parent_artifacts(
+            temp.path(),
+            1,
+            &outcomes,
+            crate::review_consensus::HAS_ISSUES,
+            false,
+            Some(&parent_meta),
+        )
+        .expect("parent artifacts should be produced");
+
+        let output_dir = temp.path().join("output");
+        let verdict: ReviewVerdictArtifact = serde_json::from_str(
+            &fs::read_to_string(output_dir.join("review-verdict.json"))
+                .expect("review-verdict.json should exist"),
+        )
+        .expect("review verdict should parse");
+        assert_eq!(verdict.decision, ReviewDecision::Pass);
+        assert_eq!(verdict.verdict_legacy, crate::review_consensus::CLEAN);
+        assert!(verdict.severity_counts.values().all(|count| *count == 0));
+
+        let findings_toml: FindingsFile = toml::from_str(
+            &fs::read_to_string(output_dir.join("findings.toml"))
+                .expect("findings.toml should exist"),
+        )
+        .expect("findings.toml should parse");
+        assert!(findings_toml.findings.is_empty());
+        assert!(
+            fs::read_to_string(output_dir.join("summary.md"))
+                .expect("summary should exist")
+                .starts_with("Final verdict: CLEAN")
+        );
+
+        let written_meta: csa_session::state::ReviewSessionMeta = serde_json::from_str(
+            &fs::read_to_string(temp.path().join("review_meta.json"))
+                .expect("review_meta.json should exist"),
+        )
+        .expect("review meta should parse");
+        assert_eq!(written_meta.decision, ReviewDecision::Pass.as_str());
+        assert_eq!(written_meta.verdict, crate::review_consensus::CLEAN);
+        assert_eq!(written_meta.exit_code, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix verdict extraction producing `"decision": "fail"` when review has zero findings and summary says PASS
- Root cause: `review_cmd_parent_artifacts.rs` defaulted to fail consensus when consolidated findings were empty
- Also fixed: `review_cmd_output_artifacts.rs` empty-findings verdict, `review_cmd_fix.rs` stale consolidated artifact cleanup

Fixes #1362

## Dogfood verification
The fix was self-verified: the pre-push review gate was blocked by the very bug being fixed (chicken-and-egg). After installing the fixed binary (0.1.696), the review correctly produced `"decision": "pass"` with zero findings.

## Test plan
- [x] New tests in `review_cmd_output_verdict_1362_tests.rs` covering zero-findings PASS scenario
- [x] Updated parent artifacts tests for empty-findings override
- [x] `just pre-commit` passes
- [x] Self-dogfood: review round 4 produced correct `pass` verdict with 0.1.696

🤖 Generated with [Claude Code](https://claude.com/claude-code)