### PR TITLE
fix(cli-sub-agent): detect session completion via output/result.toml fallback (#1370)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.699"
+version = "0.1.700"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.699"
+version = "0.1.700"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::fs;
 use std::os::fd::AsRawFd;
 
 /// Exit code reserved for `csa session wait` memory warning early-exit.
@@ -251,7 +252,7 @@ where
                 )?;
                 synthetic = reconciled.synthetic;
                 if reconciled.result_became_available {
-                    loaded_result = load_completed_daemon_result_adaptive(
+                    loaded_result = load_completed_daemon_result_with_fallback(
                         effective_root,
                         &resolved.session_id,
                         &session_dir,
@@ -274,7 +275,7 @@ where
             return Ok(exit_code);
         }
 
-        if let Some(result) = load_completed_daemon_result_adaptive(
+        if let Some(result) = load_completed_daemon_result_with_fallback(
             effective_root,
             &resolved.session_id,
             &session_dir,
@@ -299,7 +300,7 @@ where
         let reconciled =
             reconcile_dead_active_session(effective_root, &resolved.session_id, "session wait")?;
         if reconciled.result_became_available
-            && let Some(result) = load_completed_daemon_result_adaptive(
+            && let Some(result) = load_completed_daemon_result_with_fallback(
                 effective_root,
                 &resolved.session_id,
                 &session_dir,
@@ -328,7 +329,7 @@ where
         }
 
         if !session_has_terminal_process(&session_dir) {
-            if let Some(result) = load_completed_daemon_result_adaptive(
+            if let Some(result) = load_completed_daemon_result_with_fallback(
                 effective_root,
                 &resolved.session_id,
                 &session_dir,
@@ -594,6 +595,61 @@ fn load_completed_daemon_result_adaptive(
     } else {
         load_completed_daemon_result(project_root, session_id, session_dir)
     }
+}
+
+/// Check for result.toml in the output/ subdirectory as fallback completion detection.
+/// This handles cases where the session completed and wrote output/result.toml but
+/// the main result.toml wasn't created (e.g., when state.toml turn_count stays 0).
+fn load_output_result_fallback(
+    session_dir: &std::path::Path,
+) -> Result<Option<csa_session::SessionResult>> {
+    let output_result_path = session_dir
+        .join("output")
+        .join(csa_session::result::RESULT_FILE_NAME);
+    if !output_result_path.is_file() {
+        return Ok(None);
+    }
+
+    tracing::debug!(
+        path = %output_result_path.display(),
+        "Found output/result.toml as fallback completion signal"
+    );
+
+    let contents = fs::read_to_string(&output_result_path)?;
+    let result: csa_session::SessionResult = toml::from_str(&contents)?;
+    Ok(Some(result))
+}
+
+/// Enhanced version of load_completed_daemon_result_with_fallback that includes
+/// fallback check for output/result.toml when main result.toml doesn't exist.
+fn load_completed_daemon_result_with_fallback(
+    project_root: &std::path::Path,
+    session_id: &str,
+    session_dir: &std::path::Path,
+    is_cross_project: bool,
+) -> Result<Option<csa_session::SessionResult>> {
+    // First try the normal result loading path
+    if let Some(result) = load_completed_daemon_result_adaptive(
+        project_root,
+        session_id,
+        session_dir,
+        is_cross_project,
+    )? {
+        return Ok(Some(result));
+    }
+
+    // If no main result found and daemon is not alive, check output/result.toml as fallback
+    if !session_has_terminal_process(session_dir)
+        && let Some(output_result) = load_output_result_fallback(session_dir)?
+    {
+        tracing::info!(
+            session_id,
+            "Session completion detected via output/result.toml fallback"
+        );
+        return Ok(Some(output_result));
+    }
+
+    Ok(None)
 }
 
 fn emit_wait_completion_signal(


### PR DESCRIPTION
## Summary
- Adds fallback completion detection in `csa session wait`: when `state.toml` stays stuck at `turn_count=0` / `phase="active"`, checks `output/result.toml` existence as secondary signal
- New `load_output_result_fallback()` only triggers when daemon process is no longer alive, preventing false positives on in-progress sessions
- Wraps existing `load_completed_daemon_result_adaptive()` in `load_completed_daemon_result_with_fallback()` at all 4 call sites

Closes #1370

## Test plan
- [x] `cargo check -p cli-sub-agent` passes
- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` verdict PASS (session `01KRCHD2AD2YMG4AWPHMCD9MAE`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)