### PR TITLE
fix(cli-sub-agent): propagate --no-fs-sandbox to plan run (#1374)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.700"
+version = "0.1.701"
 dependencies = [
  "anyhow",
  "clap",
@@ -5181,9 +5181,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.700"
+version = "0.1.701"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_plan.rs
+++ b/crates/cli-sub-agent/src/cli_plan.rs
@@ -45,6 +45,10 @@ pub enum PlanCommands {
         #[arg(long)]
         cd: Option<String>,
 
+        /// Disable filesystem sandbox isolation (bwrap/landlock)
+        #[arg(long)]
+        no_fs_sandbox: bool,
+
         /// Block instead of daemonizing (auto for --dry-run/--chunked/--resume).
         #[arg(long)]
         foreground: bool,

--- a/crates/cli-sub-agent/src/dev2merge_cmd.rs
+++ b/crates/cli-sub-agent/src/dev2merge_cmd.rs
@@ -62,6 +62,7 @@ fn build_plan_run_args(
         chunked: false,
         resume: None,
         cd: None,
+        no_fs_sandbox: false,
         current_depth,
         pipeline_source: PlanRunPipelineSource::CliAlias,
     }
@@ -101,6 +102,9 @@ fn build_forwarded_plan_args(plan_args: &PlanRunArgs, sa_mode: Option<bool>) -> 
     if let Some(cd) = &plan_args.cd {
         forwarded.push("--cd".to_string());
         forwarded.push(cd.clone());
+    }
+    if plan_args.no_fs_sandbox {
+        forwarded.push("--no-fs-sandbox".to_string());
     }
     forwarded
 }
@@ -251,6 +255,34 @@ mod tests {
                 "MKTD_TIMEOUT_SECONDS=1800",
                 "--var",
                 "OTHER=value",
+            ]
+        );
+    }
+
+    #[test]
+    fn forwarded_args_include_no_fs_sandbox_when_requested() {
+        let mut plan_args = build_plan_run_args(
+            Dev2mergeArgs {
+                issue: None,
+                vars: vec![],
+                sa_mode: Some(true),
+                timeout: None,
+            },
+            0,
+            None,
+        );
+        plan_args.no_fs_sandbox = true;
+
+        let forwarded = build_forwarded_plan_args(&plan_args, Some(true));
+
+        assert_eq!(
+            forwarded,
+            vec![
+                "--pattern",
+                "dev2merge",
+                "--sa-mode",
+                "true",
+                "--no-fs-sandbox",
             ]
         );
     }

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -406,6 +406,7 @@ pub(crate) struct PlanRunArgs {
     pub chunked: bool,
     pub resume: Option<String>,
     pub cd: Option<String>,
+    pub no_fs_sandbox: bool,
     pub current_depth: u32,
     pub pipeline_source: PlanRunPipelineSource,
 }
@@ -427,6 +428,7 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
         chunked,
         resume,
         cd,
+        no_fs_sandbox,
         current_depth,
         pipeline_source,
     } = args;
@@ -579,6 +581,7 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
         journal_path: Some(&journal_path),
         resume_completed_steps: &resume_context.completed_steps,
         chunked,
+        no_fs_sandbox,
     };
 
     let results =

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -54,6 +54,7 @@ pub(crate) async fn dispatch(
         chunked,
         resume,
         cd,
+        no_fs_sandbox,
         foreground,
         daemon_child,
         session_id,
@@ -75,6 +76,7 @@ pub(crate) async fn dispatch(
         chunked,
         resume,
         cd,
+        no_fs_sandbox,
         current_depth,
         pipeline_source,
     };

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
@@ -13,6 +13,7 @@ fn make_args() -> PlanRunArgs {
         chunked: false,
         resume: None,
         cd: None,
+        no_fs_sandbox: false,
         current_depth: 0,
         pipeline_source: crate::plan_cmd::PlanRunPipelineSource::DirectPlanRun,
     }
@@ -85,6 +86,19 @@ fn forwarded_args_drop_foreground_flag() {
     // forwarded to the daemon child (which IS the worker, not a re-spawn).
     let forwarded = build_forwarded_plan_args(&argv);
     assert_eq!(forwarded, vec!["workflow.toml"]);
+}
+
+#[test]
+fn forwarded_args_preserve_no_fs_sandbox_flag() {
+    let argv = vec![
+        "csa".to_string(),
+        "plan".to_string(),
+        "run".to_string(),
+        "--no-fs-sandbox".to_string(),
+        "workflow.toml".to_string(),
+    ];
+    let forwarded = build_forwarded_plan_args(&argv);
+    assert_eq!(forwarded, vec!["--no-fs-sandbox", "workflow.toml"]);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -56,6 +56,12 @@ pub(super) struct StepExecutionOutcome {
     pub(super) session_id: Option<String>,
 }
 
+pub(super) struct CsaStepExecutionOptions<'a> {
+    pub(super) model_spec: Option<&'a str>,
+    pub(super) forwarded_session: Option<&'a str>,
+    pub(super) no_fs_sandbox: bool,
+}
+
 pub(super) async fn run_with_heartbeat<F, T>(
     label: &str,
     execution: F,
@@ -205,14 +211,13 @@ pub(super) async fn execute_csa_step(
     label: &str,
     prompt: &str,
     tool_name: &ToolName,
-    model_spec: Option<&str>,
-    forwarded_session: Option<&str>,
     project_root: &Path,
     config: Option<&ProjectConfig>,
+    options: CsaStepExecutionOptions<'_>,
 ) -> Result<StepExecutionOutcome> {
     info!("{} - Dispatching to {} ...", label, tool_name.as_str());
 
-    let executor = build_executor(tool_name, model_spec, None, None, config, false)?;
+    let executor = build_executor(tool_name, options.model_spec, None, None, config, false)?;
     check_tool_installed(executor.runtime_binary_name()).await?;
 
     let global_config = csa_config::GlobalConfig::load()?;
@@ -254,7 +259,8 @@ pub(super) async fn execute_csa_step(
         ),
     };
 
-    let session_arg = forwarded_session
+    let session_arg = options
+        .forwarded_session
         .map(str::trim)
         .filter(|session| !session.is_empty())
         .map(str::to_string);
@@ -284,7 +290,7 @@ pub(super) async fn execute_csa_step(
             None,
             ParentSessionSource::ExplicitOnly,
             SessionCreationMode::FreshChild,
-            false, // no_fs_sandbox
+            options.no_fs_sandbox,
             false, // readonly_project_root
             &[],   // extra_writable
             &[],   // extra_readable

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -13,7 +13,8 @@ use csa_hooks::format_next_step_directive;
 use weave::compiler::{ExecutionPlan, FailAction, PlanStep};
 
 use super::plan_cmd_exec::{
-    StepExecutionOutcome, execute_bash_step, execute_csa_step, run_with_heartbeat,
+    CsaStepExecutionOptions, StepExecutionOutcome, execute_bash_step, execute_csa_step,
+    run_with_heartbeat,
 };
 use super::plan_cmd_flow::{
     OrchestratorHandoff, find_next_step, format_orchestrator_message, format_plan_resume_command,
@@ -25,12 +26,8 @@ use super::{
 };
 
 const OUTPUT_ASSIGNMENT_MARKER_PREFIX: &str = "CSA_VAR:";
-
 /// Resolved execution target for a plan step.
-///
-/// Separates direct shell execution from AI tool dispatch so the routing
-/// is type-safe — `tool = "bash"` can never accidentally fall through to
-/// an AI tool's interactive confirmation flow.
+/// Keeps direct shell execution separate from AI dispatch so `tool = "bash"` never falls through.
 pub(crate) enum StepTarget {
     /// Execute bash code block directly via `tokio::process::Command`.
     DirectBash,
@@ -67,11 +64,9 @@ pub(crate) struct StepResult {
     pub(crate) duration_secs: f64,
     pub(crate) skipped: bool,
     pub(crate) error: Option<String>,
-    /// Captured output from step execution (stdout for bash, output/summary for CSA).
-    /// Available to subsequent steps as `${STEP_<id>_OUTPUT}`.
+    /// Captured step output, exposed to later steps as `${STEP_<id>_OUTPUT}`.
     pub(crate) output: Option<String>,
-    /// CSA meta session ID produced by this step.
-    /// Available to subsequent steps as `${STEP_<id>_SESSION}`.
+    /// CSA meta session ID, exposed to later steps as `${STEP_<id>_SESSION}`.
     pub(crate) session_id: Option<String>,
 }
 
@@ -84,14 +79,11 @@ pub(super) struct PlanRunContext<'a> {
     pub(super) journal_path: Option<&'a Path>,
     pub(super) resume_completed_steps: &'a HashSet<usize>,
     pub(super) chunked: bool,
+    pub(super) no_fs_sandbox: bool,
 }
 
-/// Resolve a step's execution target from its annotations and config.
-///
-/// Resolution order:
-/// 1. `step.tool` — explicit tool name (e.g. "bash", "claude-code", "codex")
-/// 2. `step.tier` — tier name looked up in config's `tiers` map
-/// 3. Fallback: default configured AI tool, or codex if no config is present
+/// Resolve a step target from its annotations and config.
+/// Order: explicit `step.tool`, then `step.tier`, then configured default or codex fallback.
 pub(crate) fn resolve_step_tool(
     step: &PlanStep,
     config: Option<&ProjectConfig>,
@@ -211,6 +203,7 @@ pub(crate) async fn execute_plan(
         journal_path: None,
         resume_completed_steps: &completed,
         chunked: false,
+        no_fs_sandbox: false,
     };
     execute_plan_with_journal(plan, variables, &mut run_ctx).await
 }
@@ -257,6 +250,7 @@ pub(super) async fn execute_plan_with_journal(
             run_ctx.workflow_path,
             run_ctx.config,
             run_ctx.tool_override,
+            run_ctx.no_fs_sandbox,
         )
         .await;
         let orchestrator_handoff = orchestrator_handoff_mode(step);
@@ -413,6 +407,7 @@ pub(crate) async fn execute_step(
         &workflow_path_buf,
         config,
         tool_override,
+        false,
     )
     .await
 }
@@ -424,6 +419,7 @@ pub(crate) async fn execute_step_with_workflow(
     workflow_path: &Path,
     config: Option<&ProjectConfig>,
     tool_override: Option<&ToolName>,
+    no_fs_sandbox: bool,
 ) -> StepResult {
     let start = Instant::now();
     let label = format!("[{}/{}]", step.id, step.title);
@@ -643,10 +639,13 @@ pub(crate) async fn execute_step_with_workflow(
                         &label,
                         prompt,
                         tool_name,
-                        model_spec.as_deref(),
-                        csa_session.as_deref(),
                         project_root,
                         config,
+                        CsaStepExecutionOptions {
+                            model_spec: model_spec.as_deref(),
+                            forwarded_session: csa_session.as_deref(),
+                            no_fs_sandbox,
+                        },
                     ),
                     start,
                 )
@@ -755,8 +754,7 @@ pub(crate) async fn execute_step_with_workflow(
     }
 }
 
-/// Remove `CSA_VAR:` lines from step output so that `STEP_<id>_OUTPUT`
-/// contains only the step's logical output, not assignment-marker metadata.
+/// Remove `CSA_VAR:` lines from step output so `STEP_<id>_OUTPUT` keeps only logical output.
 pub(crate) fn strip_assignment_marker_lines(output: &str) -> String {
     output
         .lines()

--- a/crates/cli-sub-agent/src/plan_cmd_tests_chunked.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_chunked.rs
@@ -23,6 +23,7 @@ fn make_chunked_run_ctx<'a>(
         journal_path,
         resume_completed_steps,
         chunked,
+        no_fs_sandbox: false,
     }
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -33,6 +33,7 @@ async fn execute_step_with_workflow_exposes_runtime_paths_to_bash() {
         &workflow_path,
         None,
         None,
+        false,
     )
     .await;
     assert_eq!(result.exit_code, 0, "bash step should succeed");

--- a/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
@@ -207,6 +207,7 @@ async fn execute_plan_stops_after_manual_handoff() {
         journal_path: Some(&journal_path),
         resume_completed_steps: &completed,
         chunked: false,
+        no_fs_sandbox: false,
     };
 
     let results = execute_plan_with_journal(&plan, &vars, &mut run_ctx)
@@ -268,6 +269,7 @@ async fn execute_plan_stops_for_await_user() {
         journal_path: Some(&journal_path),
         resume_completed_steps: &completed,
         chunked: false,
+        no_fs_sandbox: false,
     };
 
     let results = execute_plan_with_journal(&plan, &vars, &mut run_ctx)

--- a/crates/cli-sub-agent/src/sa_mode_tests.rs
+++ b/crates/cli-sub-agent/src/sa_mode_tests.rs
@@ -81,6 +81,18 @@ mod tests {
     }
 
     #[test]
+    fn plan_run_parses_no_fs_sandbox_flag() {
+        let plan_cli = Cli::try_parse_from(["csa", "plan", "run", "--no-fs-sandbox", "flow.toml"])
+            .expect("plan run cli should parse");
+        match plan_cli.command {
+            Commands::Plan { cmd } => match cmd {
+                PlanCommands::Run { no_fs_sandbox, .. } => assert!(no_fs_sandbox),
+            },
+            _ => panic!("expected plan command"),
+        }
+    }
+
+    #[test]
     fn top_level_help_lists_dev2merge_subcommand() {
         let help = Cli::command().render_long_help().to_string();
         assert!(


### PR DESCRIPTION
## Summary
- Add `--no-fs-sandbox` flag to `csa plan run` CLI args, matching `csa run`
- Propagate the flag to all inner `csa run` invocations within workflow steps
- Closes #1374

## Test plan
- [x] `csa plan run --no-fs-sandbox` accepted without CLI error
- [x] Flag propagated to inner csa run invocations
- [x] `just pre-commit` passes (32 tests)
- [x] Gemini review: PASS, 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)