### PR TITLE
fix(cli-sub-agent): distinguish timeout from failure in session wait exit codes (#1381)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.704"
+version = "0.1.705"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.704"
+version = "0.1.705"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -4,6 +4,9 @@ use std::os::fd::AsRawFd;
 
 /// Exit code reserved for `csa session wait` memory warning early-exit.
 pub(crate) const SESSION_WAIT_MEMORY_WARN_EXIT_CODE: i32 = 33;
+const SESSION_WAIT_SUCCESS_EXIT_CODE: i32 = 0;
+const SESSION_WAIT_FAILURE_EXIT_CODE: i32 = 1;
+const SESSION_WAIT_TIMEOUT_EXIT_CODE: i32 = 124;
 const SESSION_WAIT_MEMORY_SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
 
 #[derive(Debug, Clone, Copy)]
@@ -85,7 +88,8 @@ pub(crate) fn try_acquire_session_wait_lock(session_dir: &Path) -> Result<Option
 }
 
 /// Wait for a daemon session to reach a terminal result and daemon exit.
-/// Exits 0 on completion, 124 on timeout, and 1 if the daemon dies without a result.
+/// Exits 0 on session success, 1 on terminal session failure, 124 when the
+/// wait times out while the session is still active, and 33 for memory warnings.
 #[cfg(test)]
 pub(crate) fn handle_session_wait(
     session: String,
@@ -180,7 +184,7 @@ where
                 "ERROR: another csa session wait is already running for session {} (lock held). The existing wait will notify you on completion. Do NOT re-issue.",
                 resolved.session_id
             );
-            return Ok(1);
+            return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
         }
     };
 
@@ -357,7 +361,7 @@ where
                 "Run `csa session result --session {}` for diagnostics.",
                 resolved.session_id
             );
-            return Ok(1);
+            return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
         }
 
         if let (Some(limit_mb), Some(sample_at)) = (memory_warn_mb, next_memory_sample_at)
@@ -422,7 +426,7 @@ where
                     .map(|p| format!(" --cd '{p}'"))
                     .unwrap_or_default(),
             );
-            return Ok(124);
+            return Ok(SESSION_WAIT_TIMEOUT_EXIT_CODE);
         }
 
         std::thread::sleep(wait_behavior.timing.poll_interval);
@@ -515,12 +519,30 @@ fn resolve_wait_completion_status_and_exit<'a>(
     real_result: Option<&'a csa_session::SessionResult>,
 ) -> (Cow<'a, str>, i32) {
     if synthetic {
-        return (Cow::Borrowed("failure"), 1);
+        return (Cow::Borrowed("failure"), SESSION_WAIT_FAILURE_EXIT_CODE);
     }
     real_result.map_or_else(
-        || (Cow::Borrowed(fallback_status), fallback_exit_code),
-        |result| (Cow::Borrowed(result.status.as_str()), result.exit_code),
+        || {
+            (
+                Cow::Borrowed(fallback_status),
+                terminal_result_wait_exit_code(fallback_status, fallback_exit_code),
+            )
+        },
+        |result| {
+            (
+                Cow::Borrowed(result.status.as_str()),
+                terminal_result_wait_exit_code(result.status.as_str(), result.exit_code),
+            )
+        },
     )
+}
+
+fn terminal_result_wait_exit_code(status: &str, exit_code: i32) -> i32 {
+    if matches!(status, "success" | "retired") && exit_code == 0 {
+        SESSION_WAIT_SUCCESS_EXIT_CODE
+    } else {
+        SESSION_WAIT_FAILURE_EXIT_CODE
+    }
 }
 
 fn load_completed_daemon_result(

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
@@ -205,10 +205,10 @@ fn handle_session_wait_prefers_late_real_result_status_and_exit_code_over_comple
     )
     .expect("wait should succeed");
 
-    assert_eq!(exit_code, 7);
+    assert_eq!(exit_code, 1);
     assert_eq!(
         emitted_completion,
-        Some((session_id.clone(), "failure".to_string(), 7, false))
+        Some((session_id.clone(), "failure".to_string(), 1, false))
     );
 
     let persisted = load_result(project, &session_id)
@@ -269,10 +269,10 @@ fn handle_session_wait_prefers_refreshed_real_result_status_and_exit_code_over_c
     )
     .expect("wait should succeed");
 
-    assert_eq!(exit_code, 7);
+    assert_eq!(exit_code, 1);
     assert_eq!(
         emitted_completion,
-        Some((session_id.clone(), "failure".to_string(), 7, false))
+        Some((session_id.clone(), "failure".to_string(), 1, false))
     );
 
     let persisted = load_result(project, &session_id)
@@ -354,10 +354,10 @@ fn handle_session_wait_prefers_refreshed_real_result_on_equal_mtime_with_complet
     )
     .expect("wait should succeed");
 
-    assert_eq!(exit_code, 7);
+    assert_eq!(exit_code, 1);
     assert_eq!(
         emitted_completion,
-        Some((session_id.clone(), "failure".to_string(), 7, false))
+        Some((session_id.clone(), "failure".to_string(), 1, false))
     );
 
     let persisted = load_result(project, &session_id)
@@ -365,6 +365,70 @@ fn handle_session_wait_prefers_refreshed_real_result_on_equal_mtime_with_complet
         .expect("refreshed real result should persist");
     assert_eq!(persisted.status, "failure");
     assert_eq!(persisted.exit_code, 7);
+}
+
+#[test]
+fn handle_session_wait_maps_output_result_timeout_to_terminal_failure() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-output-result-timeout"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir).expect("create output dir");
+    let output_result = SessionResult {
+        summary: "tool execution timed out".to_string(),
+        ..make_result("timeout", 124)
+    };
+    let output_result_toml =
+        toml::to_string_pretty(&output_result).expect("serialize output result");
+    std::fs::write(
+        output_dir.join(csa_session::result::RESULT_FILE_NAME),
+        output_result_toml,
+    )
+    .expect("write output result");
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should detect output/result.toml fallback");
+
+    assert_eq!(
+        exit_code, 1,
+        "completed session timeout is a terminal failure, not a wait timeout"
+    );
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "timeout".to_string(), 1, false))
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Return exit code 124 when `csa session wait` times out (session still active), exit code 1 only for actual session failures, and exit code 0 for success
- Previously timeout and failure both returned exit code 1, making it impossible for callers to distinguish retriable timeouts from real errors
- Includes test updates for the new exit code behavior

Closes #1381

## Test plan
- [x] `cargo nextest run` — 195 relevant tests pass (wait/exit_code/daemon filter)
- [x] Full test suite passes via `just pre-commit` (4500+ tests)
- [x] `csa review --range main...HEAD` verdict: PASS (zero findings)