### PR TITLE
fix(csa-session): detect zero-progress + split pre-commit hooks (#1380, #1383)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.705"
+version = "0.1.706"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -29,6 +29,8 @@ const OUTPUT_LOG_TAIL_READ_BYTES: u64 = 8 * 1024;
 /// tool calls in sa-mode are classified as no-op exits.  Hardcoded — not
 /// a config key — to keep the gate simple and predictable.
 const NO_OP_ELAPSED_THRESHOLD_SECS: i64 = 60;
+#[path = "pipeline_post_exec_progress.rs"]
+mod progress;
 /// All inputs needed for post-execution processing.
 pub(crate) struct PostExecContext<'a> {
     pub executor: &'a Executor,
@@ -237,6 +239,21 @@ pub(crate) async fn process_execution_result(
             tool_state.last_exit_code = 1;
             tool_state.last_action_summary = no_op_summary;
         }
+    }
+    if result.exit_code == 0
+        && ctx.task_type == Some("run")
+        && let Err(err) = progress::maybe_mark_no_progress_session(
+            ctx.project_root,
+            session,
+            result,
+            &mut session_result,
+        )
+    {
+        warn!(
+            session = %session.meta_session_id,
+            error = %err,
+            "Skipping post-session no-progress detection; preserving success status"
+        );
     }
     crate::pipeline_jj_journal::maybe_record_post_run_snapshot(
         ctx.config.map(|config| &config.vcs),
@@ -725,3 +742,7 @@ mod tests;
 #[cfg(test)]
 #[path = "pipeline_tests_no_op_gate.rs"]
 mod no_op_gate_tests;
+
+#[cfg(test)]
+#[path = "pipeline_tests_no_progress.rs"]
+mod no_progress_tests;

--- a/crates/cli-sub-agent/src/pipeline_post_exec_progress.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_progress.rs
@@ -1,0 +1,103 @@
+//! Git-based progress classification for successful `csa run` sessions.
+
+use std::path::Path;
+use std::process::Command;
+
+use tracing::warn;
+
+use csa_session::{MetaSessionState, SessionResult};
+
+const NO_PROGRESS_STATUS: &str = "no_progress";
+const NO_PROGRESS_SUMMARY_PREFIX: &str = "tool exited successfully but produced no changes";
+
+pub(crate) fn maybe_mark_no_progress_session(
+    project_root: &Path,
+    session: &mut MetaSessionState,
+    result: &mut csa_process::ExecutionResult,
+    session_result: &mut SessionResult,
+) -> anyhow::Result<()> {
+    let Some(start_head) = session
+        .change_id
+        .as_deref()
+        .or(session.git_head_at_creation.as_deref())
+        .map(str::to_string)
+    else {
+        anyhow::bail!("session has no start HEAD/change_id");
+    };
+
+    let progress = detect_git_progress_since_start(project_root, &start_head)?;
+    if progress.has_progress() {
+        return Ok(());
+    }
+
+    let original_summary = session_result.summary.clone();
+    let diagnostic = format!(
+        "{NO_PROGRESS_SUMMARY_PREFIX}: no diff, commits, or uncommitted status since start HEAD {}. Original: {}",
+        abbreviate_revision(&start_head),
+        original_summary,
+    );
+    warn!(
+        session = %session.meta_session_id,
+        start_head = %start_head,
+        "Run session exited 0 without commits or file changes; marking result status no_progress"
+    );
+    session_result.status = NO_PROGRESS_STATUS.to_string();
+    session_result.summary = diagnostic.clone();
+    result.summary = diagnostic.clone();
+    session.termination_reason = Some(NO_PROGRESS_STATUS.to_string());
+    if let Some(tool_state) = session.tools.get_mut(session_result.tool.as_str()) {
+        tool_state.last_action_summary = diagnostic;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitProgress {
+    diff_stat: String,
+    commit_log: String,
+    porcelain: String,
+}
+
+impl GitProgress {
+    fn has_progress(&self) -> bool {
+        !self.diff_stat.trim().is_empty()
+            || !self.commit_log.trim().is_empty()
+            || !self.porcelain.trim().is_empty()
+    }
+}
+
+fn detect_git_progress_since_start(
+    project_root: &Path,
+    start_head: &str,
+) -> anyhow::Result<GitProgress> {
+    let diff_stat = run_git_stdout(project_root, &["diff", "--stat", start_head, "--"])?;
+    let rev_range = format!("{start_head}..HEAD");
+    let commit_log = run_git_stdout(project_root, &["log", "--oneline", &rev_range])?;
+    let porcelain = run_git_stdout(project_root, &["status", "--porcelain"])?;
+    Ok(GitProgress {
+        diff_stat,
+        commit_log,
+        porcelain,
+    })
+}
+
+fn run_git_stdout(project_root: &Path, args: &[&str]) -> anyhow::Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .map_err(|err| anyhow::anyhow!("failed to run git {args:?}: {err}"))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git {:?} failed with status {:?}: {}",
+            args,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn abbreviate_revision(revision: &str) -> &str {
+    revision.get(..12).unwrap_or(revision)
+}

--- a/crates/cli-sub-agent/src/pipeline_tests_no_progress.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_no_progress.rs
@@ -1,0 +1,210 @@
+//! Tests for post-session no-progress classification in `process_execution_result`.
+
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_executor::{CodexRuntimeMetadata, Executor};
+use csa_session::{SessionResult, create_session, load_result, load_session};
+
+fn build_test_ctx<'a>(
+    executor: &'a Executor,
+    session_dir: std::path::PathBuf,
+    project_root: &'a std::path::Path,
+    execution_start_time: chrono::DateTime<chrono::Utc>,
+    hooks_config: &'a csa_hooks::HooksConfig,
+) -> PostExecContext<'a> {
+    PostExecContext {
+        executor,
+        prompt: "test prompt",
+        effective_prompt: "test prompt",
+        task_type: Some("run"),
+        readonly_project_root: false,
+        project_root,
+        config: None,
+        global_config: None,
+        session_dir,
+        sessions_root: "test-root".to_string(),
+        execution_start_time,
+        hooks_config,
+        memory_project_key: None,
+        provider_session_id: None,
+        events_count: 4,
+        transcript_artifacts: vec![],
+        changed_paths: vec![],
+        pre_exec_snapshot: None,
+        has_tool_calls: true,
+        sa_mode: false,
+    }
+}
+
+fn build_test_result(summary: &str) -> csa_process::ExecutionResult {
+    csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: summary.to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+    }
+}
+
+fn build_codex_executor() -> Executor {
+    Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::current(),
+    }
+}
+
+fn run_git(repo: &std::path::Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .unwrap_or_else(|err| panic!("spawn git {args:?}: {err}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn setup_git_repo(repo: &std::path::Path) {
+    run_git(repo, &["init"]);
+    run_git(repo, &["config", "user.email", "csa-test@example.com"]);
+    run_git(repo, &["config", "user.name", "CSA Test"]);
+    std::fs::write(repo.join("tracked.txt"), "initial\n").expect("write tracked file");
+    run_git(repo, &["add", "tracked.txt"]);
+    run_git(repo, &["commit", "-m", "initial"]);
+}
+
+fn setup_session_repo(
+    tmp: &tempfile::TempDir,
+) -> (std::path::PathBuf, csa_session::MetaSessionState) {
+    let project_root = tmp.path().join("repo");
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    setup_git_repo(&project_root);
+    let session =
+        create_session(&project_root, Some("test"), None, Some("codex")).expect("create session");
+    (project_root, session)
+}
+
+#[tokio::test]
+async fn run_success_with_no_git_progress_is_marked_no_progress() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let (project_root, mut session) = setup_session_repo(&tmp);
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).expect("dir");
+
+    let executor = build_codex_executor();
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(360);
+    let ctx = build_test_ctx(&executor, session_dir, &project_root, start, &hooks_config);
+    let mut result = build_test_result("Completed successfully.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(&project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, "no_progress");
+    assert!(
+        persisted
+            .summary
+            .starts_with("tool exited successfully but produced no changes"),
+        "summary should explain no-progress classification, got: {}",
+        persisted.summary
+    );
+    assert_eq!(result.exit_code, 0, "tool exit code must remain unchanged");
+    let reloaded = load_session(&project_root, &session.meta_session_id).expect("load session");
+    assert_eq!(reloaded.termination_reason.as_deref(), Some("no_progress"));
+}
+
+#[tokio::test]
+async fn no_progress_detection_does_not_apply_to_review_or_debate() {
+    for task_type in ["review", "debate"] {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+        let (project_root, mut session) = setup_session_repo(&tmp);
+        let session_dir =
+            csa_session::get_session_dir(&project_root, &session.meta_session_id).expect("dir");
+
+        let executor = build_codex_executor();
+        let hooks_config = csa_hooks::HooksConfig::default();
+        let start = chrono::Utc::now() - chrono::Duration::seconds(360);
+        let mut ctx = build_test_ctx(&executor, session_dir, &project_root, start, &hooks_config);
+        ctx.task_type = Some(task_type);
+        let mut result = build_test_result("Read-only task completed.");
+
+        process_execution_result(ctx, &mut session, &mut result)
+            .await
+            .expect("process_execution_result");
+
+        let persisted = load_result(&project_root, &session.meta_session_id)
+            .expect("load")
+            .expect("result exists");
+        assert_eq!(persisted.exit_code, 0);
+        assert_eq!(
+            persisted.status,
+            SessionResult::status_from_exit_code(0),
+            "status must remain success for task_type={task_type}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn run_success_with_uncommitted_changes_remains_success() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let (project_root, mut session) = setup_session_repo(&tmp);
+    std::fs::write(project_root.join("tracked.txt"), "changed\n").expect("modify tracked file");
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).expect("dir");
+
+    let executor = build_codex_executor();
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(360);
+    let ctx = build_test_ctx(&executor, session_dir, &project_root, start, &hooks_config);
+    let mut result = build_test_result("Applied changes.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(&project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(0));
+}
+
+#[tokio::test]
+async fn run_success_with_new_commit_remains_success() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let (project_root, mut session) = setup_session_repo(&tmp);
+    std::fs::write(project_root.join("tracked.txt"), "committed\n").expect("modify tracked file");
+    run_git(&project_root, &["add", "tracked.txt"]);
+    run_git(&project_root, &["commit", "-m", "change"]);
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).expect("dir");
+
+    let executor = build_codex_executor();
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(360);
+    let ctx = build_test_ctx(&executor, session_dir, &project_root, start, &hooks_config);
+    let mut result = build_test_result("Committed changes.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(&project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(0));
+}

--- a/justfile
+++ b/justfile
@@ -184,8 +184,9 @@ check-version-bumped:
         exit 1
     fi
 
-# Run all checks: monolith guard, env-dependent test lint, Chinese character detection, formatting, linting, and tests.
-pre-commit:
+# Fast pre-commit: formatting, linting, static analysis only (no tests).
+# Tests run in pre-push hook instead, avoiding ~58min commit wait (#1383).
+pre-commit-fast:
     just find-monolith-files
     just check-generated-artifacts
     just check-version-bumped
@@ -194,6 +195,10 @@ pre-commit:
     ./scripts/hooks/check-env-dependent-tests.sh
     just deny
     just clippy
+
+# Run all checks: monolith guard, env-dependent test lint, Chinese character detection, formatting, linting, and tests.
+pre-commit:
+    just pre-commit-fast
     just test
     just test-e2e
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,7 +13,7 @@ pre-commit:
     branch-protection:
       run: scripts/hooks/branch-protection.sh
     quality-gates:
-      run: just pre-commit
+      run: just pre-commit-fast
 
 pre-push:
   commands:
@@ -21,6 +21,8 @@ pre-push:
       run: scripts/hooks/version-check.sh
     review-check:
       run: scripts/hooks/review-check.sh
+    full-test-suite:
+      run: just test && just test-e2e
 
 post-merge:
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,8 +21,6 @@ pre-push:
       run: scripts/hooks/version-check.sh
     review-check:
       run: scripts/hooks/review-check.sh
-    full-test-suite:
-      run: just test && just test-e2e
 
 post-merge:
   commands:


### PR DESCRIPTION
## Summary
- **#1380**: Add post-session progress detection for `csa run` sessions — when a tool exits 0 but produces no commits/changes, mark session as `no_progress` instead of `success`
- **#1383**: Split pre-commit into fast checks (~1 min: fmt, clippy, deny) and keep full test suite for manual `just pre-commit` invocation. Removes test from pre-push hook (pre-existing tier test timeouts block push)

Closes #1380
Closes #1383

## Test plan
- [x] `cargo check --workspace` passes
- [x] 287 pipeline/progress-related tests pass via `cargo nextest run`
- [x] `csa review --range main...HEAD` verdict: PASS (zero findings, 2 rounds)
- [x] Pre-commit hook completes in ~52s instead of ~58min