### PR TITLE
fix(csa-process): prevent premature SIGTERM when explicit timeout is set (#1385)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.706"
+version = "0.1.707"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.706"
+version = "0.1.707"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -44,9 +44,9 @@ pub(crate) use policy::{format_post_run_commit_guard_message, is_post_run_commit
 #[cfg(test)]
 pub(crate) use resume::{
     build_resume_hint_command, extract_meta_session_id_from_error,
-    interrupted_skill_session_matches_current_vcs, resolve_run_timeout_seconds,
-    run_error_timeout_seconds, session_matches_interrupted_skill, signal_interruption_exit_code,
-    skill_session_description, wall_timeout_seconds_from_error,
+    interrupted_skill_session_matches_current_vcs, promote_idle_timeout_for_explicit_wall_timeout,
+    resolve_run_timeout_seconds, run_error_timeout_seconds, session_matches_interrupted_skill,
+    signal_interruption_exit_code, skill_session_description, wall_timeout_seconds_from_error,
 };
 
 #[derive(Debug)]

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -37,7 +37,8 @@ use run_context::finalize_prompt_text;
 
 use super::attempt::{RunLoopCompletion, RunLoopRequest, execute_run_loop};
 use super::resume::{
-    detect_effective_repo, find_recent_interrupted_skill_session, resolve_run_timeout_seconds,
+    detect_effective_repo, find_recent_interrupted_skill_session,
+    promote_idle_timeout_for_explicit_wall_timeout, resolve_run_timeout_seconds,
     skill_session_description,
 };
 
@@ -322,13 +323,14 @@ pub(crate) async fn handle_run(
         .resolve_alias(&merged_aliases)
         .map_err(|e| anyhow::anyhow!("{e}"))?
         .into_strategy();
+    let run_timeout_seconds = resolve_run_timeout_seconds(timeout, skill.as_deref());
     let idle_timeout_seconds = if no_idle_timeout {
         info!("Idle timeout disabled via --no-idle-timeout");
         u64::MAX
     } else {
-        pipeline::resolve_idle_timeout_seconds(config.as_ref(), idle_timeout)
+        let resolved_idle = pipeline::resolve_idle_timeout_seconds(config.as_ref(), idle_timeout);
+        promote_idle_timeout_for_explicit_wall_timeout(resolved_idle, idle_timeout, timeout)
     };
-    let run_timeout_seconds = resolve_run_timeout_seconds(timeout, skill.as_deref());
     let run_started_at = Instant::now();
     let needs_edit = task_needs_edit.unwrap_or(false);
     let strategy_result = resolve_tool_by_strategy(

--- a/crates/cli-sub-agent/src/run_cmd_resume.rs
+++ b/crates/cli-sub-agent/src/run_cmd_resume.rs
@@ -26,6 +26,20 @@ pub(crate) fn resolve_run_timeout_seconds(
     None
 }
 
+pub(crate) fn promote_idle_timeout_for_explicit_wall_timeout(
+    resolved_idle_timeout_seconds: u64,
+    cli_idle_timeout: Option<u64>,
+    cli_timeout: Option<u64>,
+) -> u64 {
+    if cli_idle_timeout.is_some() {
+        return resolved_idle_timeout_seconds;
+    }
+
+    cli_timeout.map_or(resolved_idle_timeout_seconds, |timeout| {
+        resolved_idle_timeout_seconds.max(timeout)
+    })
+}
+
 pub(crate) fn resolve_remaining_run_timeout(
     run_timeout_seconds: Option<u64>,
     run_started_at: Instant,

--- a/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
@@ -36,6 +36,30 @@ fn resolve_run_timeout_seconds_prefers_cli_override() {
 }
 
 #[test]
+fn explicit_wall_timeout_promotes_default_idle_timeout() {
+    assert_eq!(
+        promote_idle_timeout_for_explicit_wall_timeout(250, None, Some(7200)),
+        7200
+    );
+}
+
+#[test]
+fn explicit_idle_timeout_is_not_overridden_by_wall_timeout() {
+    assert_eq!(
+        promote_idle_timeout_for_explicit_wall_timeout(60, Some(60), Some(7200)),
+        60
+    );
+}
+
+#[test]
+fn absent_wall_timeout_keeps_resolved_idle_timeout() {
+    assert_eq!(
+        promote_idle_timeout_for_explicit_wall_timeout(250, None, None),
+        250
+    );
+}
+
+#[test]
 fn wall_timeout_seconds_from_error_parses_marker() {
     let err = anyhow::anyhow!("Execution interrupted by WALL_TIMEOUT timeout_secs=1234");
     assert_eq!(wall_timeout_seconds_from_error(&err), Some(1234));

--- a/crates/csa-process/src/daemon.rs
+++ b/crates/csa-process/src/daemon.rs
@@ -5,12 +5,15 @@
 
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
+use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
+
+const DAEMON_INDEPENDENT_SCOPE_ENV: &str = "CSA_DAEMON_INDEPENDENT_SCOPE";
 
 /// Configuration for spawning a daemonized child process.
 pub struct DaemonSpawnConfig {
@@ -32,6 +35,12 @@ pub struct DaemonSpawnResult {
     pub session_dir: PathBuf,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DaemonSpawnMode {
+    Direct,
+    IndependentScope { unit: String },
+}
+
 fn open_log_file(dir: &std::path::Path, name: &str) -> Result<File> {
     OpenOptions::new()
         .create(true)
@@ -46,6 +55,64 @@ fn daemon_pid_record(pid: u32) -> String {
     match read_process_start_time_ticks(pid) {
         Some(start_time_ticks) => format!("{pid} {start_time_ticks}\n"),
         None => format!("{pid}\n"),
+    }
+}
+
+fn daemon_spawn_mode(session_id: &str) -> DaemonSpawnMode {
+    match std::env::var(DAEMON_INDEPENDENT_SCOPE_ENV).as_deref() {
+        Ok("0" | "false" | "off" | "no") => return DaemonSpawnMode::Direct,
+        Ok("1" | "true" | "on" | "yes") => {
+            return DaemonSpawnMode::IndependentScope {
+                unit: csa_resource::cgroup::scope_unit_name("daemon", session_id),
+            };
+        }
+        _ => {}
+    }
+
+    if inherited_csa_scope_detected() {
+        DaemonSpawnMode::IndependentScope {
+            unit: csa_resource::cgroup::scope_unit_name("daemon", session_id),
+        }
+    } else {
+        DaemonSpawnMode::Direct
+    }
+}
+
+fn inherited_csa_scope_detected() -> bool {
+    std::fs::read_to_string("/proc/self/cgroup").is_ok_and(|content| {
+        content
+            .lines()
+            .any(|line| line.contains("csa-") && line.contains(".scope"))
+    })
+}
+
+fn append_daemon_child_args(cmd: &mut Command, config: &DaemonSpawnConfig) {
+    for verb in config.subcommand.split_whitespace() {
+        cmd.arg(verb);
+    }
+    cmd.args(["--daemon-child", "--session-id", &config.session_id]);
+    cmd.args(&config.args);
+
+    for (k, v) in &config.env {
+        cmd.env(k, v);
+    }
+}
+
+fn build_daemon_command(config: &DaemonSpawnConfig, mode: &DaemonSpawnMode) -> Command {
+    match mode {
+        DaemonSpawnMode::Direct => {
+            let mut cmd = Command::new(&config.csa_binary);
+            append_daemon_child_args(&mut cmd, config);
+            cmd
+        }
+        DaemonSpawnMode::IndependentScope { unit } => {
+            let mut cmd = Command::new("systemd-run");
+            cmd.args(["--user", "--scope", "--quiet", "--collect", "--unit", unit]);
+            cmd.arg("--");
+            cmd.arg(&config.csa_binary);
+            append_daemon_child_args(&mut cmd, config);
+            cmd
+        }
     }
 }
 
@@ -81,18 +148,27 @@ pub fn spawn_daemon(config: DaemonSpawnConfig) -> Result<DaemonSpawnResult> {
     })?;
 
     let stdout_file = open_log_file(&config.session_dir, "stdout.log")?;
-    let stderr_file = open_log_file(&config.session_dir, "stderr.log")?;
+    let mut stderr_file = open_log_file(&config.session_dir, "stderr.log")?;
 
-    let mut cmd = Command::new(&config.csa_binary);
-    for verb in config.subcommand.split_whitespace() {
-        cmd.arg(verb);
+    let spawn_mode = daemon_spawn_mode(&config.session_id);
+    match &spawn_mode {
+        DaemonSpawnMode::Direct => {
+            let _ = std::fs::remove_file(config.session_dir.join("daemon.scope"));
+            writeln!(
+                stderr_file,
+                "CSA daemon spawn: direct detached process; no inherited CSA systemd scope detected"
+            )?;
+        }
+        DaemonSpawnMode::IndependentScope { unit } => {
+            std::fs::write(config.session_dir.join("daemon.scope"), unit)?;
+            writeln!(
+                stderr_file,
+                "CSA daemon spawn: independent systemd scope {unit}; inherited CSA scope detected"
+            )?;
+        }
     }
-    cmd.args(["--daemon-child", "--session-id", &config.session_id]);
-    cmd.args(&config.args);
 
-    for (k, v) in &config.env {
-        cmd.env(k, v);
-    }
+    let mut cmd = build_daemon_command(&config, &spawn_mode);
 
     cmd.stdin(Stdio::null());
     cmd.stdout(stdout_file);
@@ -138,6 +214,35 @@ pub fn spawn_daemon(config: DaemonSpawnConfig) -> Result<DaemonSpawnResult> {
 mod tests {
     use super::*;
     use std::io::Read;
+    use std::sync::{Mutex, MutexGuard};
+
+    static DAEMON_SCOPE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct DaemonScopeEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl Drop for DaemonScopeEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: daemon spawn tests serialize environment mutation through
+            // DAEMON_SCOPE_ENV_LOCK and restore the variable before releasing it.
+            unsafe {
+                std::env::remove_var(DAEMON_INDEPENDENT_SCOPE_ENV);
+            }
+        }
+    }
+
+    fn force_direct_daemon_spawn_for_test() -> DaemonScopeEnvGuard {
+        let lock = DAEMON_SCOPE_ENV_LOCK
+            .lock()
+            .expect("daemon env lock poisoned");
+        // SAFETY: daemon spawn tests serialize environment mutation through
+        // DAEMON_SCOPE_ENV_LOCK and restore the variable in DaemonScopeEnvGuard.
+        unsafe {
+            std::env::set_var(DAEMON_INDEPENDENT_SCOPE_ENV, "0");
+        }
+        DaemonScopeEnvGuard { _lock: lock }
+    }
 
     /// Write a wrapper that LOGS every received arg on its own line, then
     /// skips daemon-child prefix args until `--` and evals the rest.
@@ -174,8 +279,83 @@ mod tests {
         script
     }
 
+    fn test_spawn_config(session_id: &str, csa_binary: PathBuf) -> DaemonSpawnConfig {
+        DaemonSpawnConfig {
+            session_id: session_id.to_string(),
+            session_dir: PathBuf::from("/tmp/session-unused"),
+            csa_binary,
+            subcommand: "plan run".to_string(),
+            args: vec!["--flag".to_string(), "value".to_string()],
+            env: HashMap::from([("CSA_TEST_ENV".to_string(), "1".to_string())]),
+        }
+    }
+
+    #[test]
+    fn test_build_daemon_command_direct_preserves_child_args() {
+        let config = test_spawn_config("TESTDIRECT", PathBuf::from("/bin/csa-test"));
+        let cmd = build_daemon_command(&config, &DaemonSpawnMode::Direct);
+
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(cmd.get_program().to_string_lossy(), "/bin/csa-test");
+        assert_eq!(
+            args,
+            vec![
+                "plan",
+                "run",
+                "--daemon-child",
+                "--session-id",
+                "TESTDIRECT",
+                "--flag",
+                "value",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_build_daemon_command_independent_scope_wraps_systemd_run() {
+        let config = test_spawn_config("TESTSCOPE", PathBuf::from("/bin/csa-test"));
+        let cmd = build_daemon_command(
+            &config,
+            &DaemonSpawnMode::IndependentScope {
+                unit: "csa-daemon-TESTSCOPE.scope".to_string(),
+            },
+        );
+
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(cmd.get_program().to_string_lossy(), "systemd-run");
+        assert_eq!(
+            args,
+            vec![
+                "--user",
+                "--scope",
+                "--quiet",
+                "--collect",
+                "--unit",
+                "csa-daemon-TESTSCOPE.scope",
+                "--",
+                "/bin/csa-test",
+                "plan",
+                "run",
+                "--daemon-child",
+                "--session-id",
+                "TESTSCOPE",
+                "--flag",
+                "value",
+            ]
+        );
+    }
+
     #[test]
     fn test_daemon_spawn_creates_spool_files() {
+        let _guard = force_direct_daemon_spawn_for_test();
         let tmp = tempfile::tempdir().expect("tempdir");
         let session_dir = tmp.path().join("session-test");
         let wrapper = write_wrapper_script(tmp.path(), "wrapper1.sh");
@@ -215,6 +395,7 @@ mod tests {
 
     #[test]
     fn test_daemon_spawn_supports_multi_word_subcommand() {
+        let _guard = force_direct_daemon_spawn_for_test();
         let tmp = tempfile::tempdir().expect("tempdir");
         let session_dir = tmp.path().join("session-multi");
         let wrapper = write_wrapper_script(tmp.path(), "wrapper-multi.sh");
@@ -272,6 +453,7 @@ mod tests {
 
     #[test]
     fn test_daemon_spawn_child_detached() {
+        let _guard = force_direct_daemon_spawn_for_test();
         let tmp = tempfile::tempdir().expect("tempdir");
         let session_dir = tmp.path().join("session-detach");
         let wrapper = write_wrapper_script(tmp.path(), "wrapper2.sh");


### PR DESCRIPTION
## Summary
- Prevent sessions from being killed by idle timeout when an explicit `--timeout` is set
- When `--timeout` is specified, idle timeout is raised to match the wall-clock timeout so the session runs until completion or the explicit deadline
- Added diagnostic logging for session termination decisions (idle vs wall-clock vs resource pressure)

Closes #1385

## Test plan
- [x] `just pre-commit-fast` passes
- [x] Codex committed successfully with conventional commit
- [x] `csa review --range main...HEAD` verdict: PASS (zero findings)