### PR TITLE
fix(csa-session): detect and recover from stale session wait locks (#1384)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.707"
+version = "0.1.708"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.707"
+version = "0.1.708"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::fs;
+use std::io::{Seek, SeekFrom, Write};
 use std::os::fd::AsRawFd;
 
 /// Exit code reserved for `csa session wait` memory warning early-exit.
@@ -51,6 +52,11 @@ pub(crate) struct SessionWaitLock {
     file: std::fs::File,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+struct SessionWaitLockDiagnostic {
+    pid: u32,
+}
+
 impl Drop for SessionWaitLock {
     fn drop(&mut self) {
         // SAFETY: `self.file` owns a valid fd for the lock file.
@@ -62,18 +68,33 @@ impl Drop for SessionWaitLock {
 
 pub(crate) fn try_acquire_session_wait_lock(session_dir: &Path) -> Result<Option<SessionWaitLock>> {
     let lock_path = session_dir.join(".wait.lock");
-    let file = std::fs::OpenOptions::new()
+    let mut file = std::fs::OpenOptions::new()
         .create(true)
         .read(true)
         .write(true)
         .truncate(false)
         .open(&lock_path)?;
 
+    if try_flock_session_wait_file(&file)? {
+        write_session_wait_lock_diagnostic(&mut file)?;
+        return Ok(Some(SessionWaitLock { file }));
+    }
+
+    if lock_file_has_dead_wait_pid(&lock_path)?
+        && let Some(lock) = recover_stale_session_wait_lock(&lock_path)?
+    {
+        return Ok(Some(lock));
+    }
+
+    Ok(None)
+}
+
+fn try_flock_session_wait_file(file: &std::fs::File) -> Result<bool> {
     // SAFETY: `file` owns a valid fd and `LOCK_EX | LOCK_NB` is a standard
     // non-blocking advisory exclusive lock request.
     let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
     if rc == 0 {
-        return Ok(Some(SessionWaitLock { file }));
+        return Ok(true);
     }
 
     let err = std::io::Error::last_os_error();
@@ -81,10 +102,77 @@ pub(crate) fn try_acquire_session_wait_lock(session_dir: &Path) -> Result<Option
         err.raw_os_error(),
         Some(code) if code == libc::EWOULDBLOCK || code == libc::EAGAIN
     ) {
-        return Ok(None);
+        return Ok(false);
     }
 
     Err(err.into())
+}
+
+fn write_session_wait_lock_diagnostic(file: &mut std::fs::File) -> Result<()> {
+    let diagnostic = SessionWaitLockDiagnostic {
+        pid: std::process::id(),
+    };
+    let json = serde_json::to_string(&diagnostic)?;
+
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    file.write_all(json.as_bytes())?;
+    file.write_all(b"\n")?;
+    file.flush()?;
+    Ok(())
+}
+
+fn lock_file_has_dead_wait_pid(lock_path: &Path) -> Result<bool> {
+    let contents = match fs::read_to_string(lock_path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err.into()),
+    };
+    let Ok(diagnostic) = serde_json::from_str::<SessionWaitLockDiagnostic>(&contents) else {
+        return Ok(false);
+    };
+
+    Ok(!is_session_wait_lock_pid_alive(diagnostic.pid))
+}
+
+fn is_session_wait_lock_pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+
+    // SAFETY: kill(pid, 0) is a standard POSIX liveness probe and does not send
+    // a signal. EPERM still means a process exists but is not signalable by us.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+
+    !matches!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(code) if code == libc::ESRCH
+    )
+}
+
+fn recover_stale_session_wait_lock(lock_path: &Path) -> Result<Option<SessionWaitLock>> {
+    match fs::remove_file(lock_path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err.into()),
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)?;
+
+    if !try_flock_session_wait_file(&file)? {
+        return Ok(None);
+    }
+
+    write_session_wait_lock_diagnostic(&mut file)?;
+    Ok(Some(SessionWaitLock { file }))
 }
 
 /// Wait for a daemon session to reach a terminal result and daemon exit.

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
@@ -4,6 +4,8 @@ use crate::session_cmds_daemon::{
     try_acquire_session_wait_lock,
 };
 use crate::test_env_lock::TEST_ENV_LOCK;
+use std::io::Write;
+use std::os::fd::AsRawFd;
 use tempfile::tempdir;
 
 struct EnvVarGuard {
@@ -49,6 +51,71 @@ fn session_wait_lock_creates_dot_wait_lock_file_and_rejects_duplicates() {
         second_lock.is_none(),
         "second concurrent wait lock attempt should be rejected"
     );
+}
+
+#[test]
+fn session_wait_lock_reuses_unheld_stale_lock_file() {
+    let td = tempdir().expect("tempdir");
+    std::fs::write(td.path().join(".wait.lock"), r#"{"pid":1}"#).expect("write stale lock file");
+
+    let lock = try_acquire_session_wait_lock(td.path())
+        .expect("wait lock acquisition should not error")
+        .expect("unheld stale lock file should not block acquisition");
+
+    assert!(
+        td.path().join(".wait.lock").is_file(),
+        "wait lock file should remain present after acquisition"
+    );
+
+    drop(lock);
+}
+
+#[test]
+fn session_wait_lock_recovers_when_flock_holder_pid_is_dead() {
+    let td = tempdir().expect("tempdir");
+    let lock_path = td.path().join(".wait.lock");
+    let stale_pid = exited_child_pid();
+    let mut stale_file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .expect("open stale lock file");
+    writeln!(stale_file, "{{\"pid\":{stale_pid}}}").expect("write stale wait pid");
+    stale_file.flush().expect("flush stale wait pid");
+
+    // SAFETY: `stale_file` owns a valid fd; the test intentionally simulates a
+    // stale inherited flock whose diagnostic PID no longer exists.
+    let rc = unsafe { libc::flock(stale_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    assert_eq!(rc, 0, "test setup should acquire stale flock");
+
+    let recovered = try_acquire_session_wait_lock(td.path())
+        .expect("stale wait lock recovery should not error")
+        .expect("dead wait pid should allow lock recovery");
+    let duplicate = try_acquire_session_wait_lock(td.path())
+        .expect("duplicate wait lock check should not error");
+    assert!(
+        duplicate.is_none(),
+        "recovered live wait lock should still reject duplicates"
+    );
+
+    drop(recovered);
+    // SAFETY: `stale_file` still owns the fd for the old unlinked inode.
+    unsafe {
+        libc::flock(stale_file.as_raw_fd(), libc::LOCK_UN);
+    }
+}
+
+fn exited_child_pid() -> u32 {
+    let mut child = std::process::Command::new("sh")
+        .arg("-c")
+        .arg("exit 0")
+        .spawn()
+        .expect("spawn short-lived child");
+    let pid = child.id();
+    child.wait().expect("wait for short-lived child");
+    pid
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Detect stale session wait locks from dead processes (e.g., after caller context compaction)
- Use flock try-lock to distinguish genuinely held locks from orphaned lock files
- New `csa session wait` calls now succeed when the previous holder is dead, instead of erroring with "lock held"

Closes #1384

## Test plan
- [x] `just pre-commit-fast` passes
- [x] Codex committed with conventional commit
- [x] `csa review --range main...HEAD` verdict: PASS (zero findings)