### PR TITLE
fix(csa-executor): whitelist csa todo/config/tokuin in executor anti-recursion guard (#1387)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.709"
+version = "0.1.710"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.709"
+version = "0.1.710"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/executor_csa_guard.rs
+++ b/crates/cli-sub-agent/src/executor_csa_guard.rs
@@ -1,0 +1,197 @@
+//! Runtime guard for `csa` commands invoked from skill executor sessions.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use crate::cli::{
+    Commands, ConfigCommands, PlanCommands, TodoCommands, TodoRefCommands, TokuinCommands,
+};
+
+const CSA_SKILL_MODE_ENV: &str = "CSA_SKILL_MODE";
+const CSA_SKILL_MODE_EXECUTOR: &str = "executor";
+
+const EXECUTOR_SAFE_CSA_COMMAND_PREFIXES: &[&[&str]] = &[
+    &["todo", "create"],
+    &["todo", "save"],
+    &["todo", "ref", "add"],
+    &["todo", "ref", "list"],
+    &["todo", "ref", "show"],
+    &["todo", "show"],
+    &["todo", "list"],
+    &["todo", "find"],
+    &["tokuin", "estimate"],
+    &["config", "get"],
+    &["config", "show"],
+];
+
+pub(crate) fn enforce(command: &Commands) -> Result<()> {
+    if !is_active() {
+        return Ok(());
+    }
+
+    let prefix = command_prefix(command);
+    if is_safe_prefix(&prefix) {
+        tracing::info!(
+            command = %format_command_prefix(&prefix),
+            "allowed non-recursive csa command in executor mode"
+        );
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "executor mode blocks recursive csa command `{}`. Allowed non-recursive csa command prefixes: {}",
+        format_command_prefix(&prefix),
+        format_safe_prefixes(),
+    );
+}
+
+pub(crate) fn mark_skill_executor_env(env: &mut Option<HashMap<String, String>>, is_skill: bool) {
+    if is_skill {
+        env.get_or_insert_with(Default::default).insert(
+            CSA_SKILL_MODE_ENV.to_string(),
+            CSA_SKILL_MODE_EXECUTOR.to_string(),
+        );
+    }
+}
+
+fn is_active() -> bool {
+    std::env::var(CSA_SKILL_MODE_ENV)
+        .map(|value| value.trim().eq_ignore_ascii_case(CSA_SKILL_MODE_EXECUTOR))
+        .unwrap_or(false)
+}
+
+fn is_safe_prefix(prefix: &[&str]) -> bool {
+    EXECUTOR_SAFE_CSA_COMMAND_PREFIXES.contains(&prefix)
+}
+
+fn command_prefix(command: &Commands) -> Vec<&'static str> {
+    match command {
+        Commands::Run { .. } => vec!["run"],
+        Commands::Review(_) => vec!["review"],
+        Commands::Debate(_) => vec!["debate"],
+        Commands::Plan {
+            cmd: PlanCommands::Run { .. },
+        } => vec!["plan", "run"],
+        Commands::Todo { cmd } => todo_prefix(cmd),
+        Commands::Config { cmd } => config_prefix(cmd),
+        Commands::Tokuin {
+            cmd: TokuinCommands::Estimate { .. },
+        } => vec!["tokuin", "estimate"],
+        Commands::Hunt(_) => vec!["hunt"],
+        Commands::Arch(_) => vec!["arch"],
+        Commands::Triage(_) => vec!["triage"],
+        Commands::Mktsk(_) => vec!["mktsk"],
+        Commands::Session { .. } => vec!["session"],
+        Commands::Push(_) => vec!["push"],
+        Commands::Merge(_) => vec!["merge"],
+        Commands::Audit { .. } => vec!["audit"],
+        Commands::Init { .. } => vec!["init"],
+        Commands::Gc(_) => vec!["gc"],
+        Commands::Memory { .. } => vec!["memory"],
+        Commands::Eval { .. } => vec!["eval"],
+        Commands::Doctor { .. } => vec!["doctor"],
+        Commands::Batch { .. } => vec!["batch"],
+        Commands::McpServer => vec!["mcp-server"],
+        Commands::McpHub { .. } => vec!["mcp-hub"],
+        Commands::Skill { .. } => vec!["skill"],
+        Commands::Setup { .. } => vec!["setup"],
+        Commands::Tiers { .. } => vec!["tiers"],
+        Commands::Checklist { .. } => vec!["checklist"],
+        Commands::Dev2merge(_) => vec!["dev2merge"],
+        Commands::Migrate { .. } => vec!["migrate"],
+        Commands::SelfUpdate { .. } => vec!["self-update"],
+        Commands::ClaudeSubAgent(_) => vec!["claude-sub-agent"],
+        Commands::Xurl { .. } => vec!["xurl"],
+        Commands::Recall(_) => vec!["recall"],
+        Commands::Hooks { .. } => vec!["hooks"],
+    }
+}
+
+fn todo_prefix(cmd: &TodoCommands) -> Vec<&'static str> {
+    match cmd {
+        TodoCommands::Create { .. } => vec!["todo", "create"],
+        TodoCommands::Save { .. } => vec!["todo", "save"],
+        TodoCommands::List { .. } => vec!["todo", "list"],
+        TodoCommands::Find { .. } => vec!["todo", "find"],
+        TodoCommands::Show { .. } => vec!["todo", "show"],
+        TodoCommands::Ref { cmd } => match cmd {
+            TodoRefCommands::Add { .. } => vec!["todo", "ref", "add"],
+            TodoRefCommands::List { .. } => vec!["todo", "ref", "list"],
+            TodoRefCommands::Show { .. } => vec!["todo", "ref", "show"],
+            TodoRefCommands::ImportTranscript { .. } => vec!["todo", "ref", "import-transcript"],
+        },
+        TodoCommands::Diff { .. } => vec!["todo", "diff"],
+        TodoCommands::History { .. } => vec!["todo", "history"],
+        TodoCommands::Update { .. } => vec!["todo", "update"],
+        TodoCommands::Status { .. } => vec!["todo", "status"],
+        TodoCommands::Dag { .. } => vec!["todo", "dag"],
+        TodoCommands::Epic { .. } => vec!["todo", "epic"],
+    }
+}
+
+fn config_prefix(cmd: &ConfigCommands) -> Vec<&'static str> {
+    match cmd {
+        ConfigCommands::Get { .. } => vec!["config", "get"],
+        ConfigCommands::Show { .. } => vec!["config", "show"],
+        ConfigCommands::Edit { .. } => vec!["config", "edit"],
+        ConfigCommands::Validate { .. } => vec!["config", "validate"],
+        ConfigCommands::Set { .. } => vec!["config", "set"],
+    }
+}
+
+fn format_command_prefix(prefix: &[&str]) -> String {
+    format!("csa {}", prefix.join(" "))
+}
+
+fn format_safe_prefixes() -> String {
+    EXECUTOR_SAFE_CSA_COMMAND_PREFIXES
+        .iter()
+        .map(|prefix| format_command_prefix(prefix))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_prefixes_allow_todo_persistence_commands() {
+        for prefix in [
+            &["todo", "create"][..],
+            &["todo", "save"][..],
+            &["todo", "ref", "add"][..],
+            &["todo", "ref", "list"][..],
+            &["todo", "ref", "show"][..],
+            &["todo", "show"][..],
+            &["todo", "list"][..],
+            &["todo", "find"][..],
+            &["tokuin", "estimate"][..],
+            &["config", "get"][..],
+            &["config", "show"][..],
+        ] {
+            assert!(
+                is_safe_prefix(prefix),
+                "prefix should be allowed: {prefix:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn safe_prefixes_block_recursive_execution_commands() {
+        for prefix in [
+            &["run"][..],
+            &["review"][..],
+            &["debate"][..],
+            &["plan", "run"][..],
+            &["todo", "ref", "import-transcript"][..],
+            &["config", "set"][..],
+        ] {
+            assert!(
+                !is_safe_prefix(prefix),
+                "prefix should be blocked: {prefix:?}"
+            );
+        }
+    }
+}

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -23,6 +23,7 @@ mod edit_restriction_guard;
 mod error_hints;
 mod error_report;
 mod eval_cmd;
+mod executor_csa_guard;
 mod gc;
 mod gh_env;
 mod goal_loop;
@@ -119,7 +120,6 @@ use sa_mode::apply_sa_mode_prompt_guard;
 mod migrate_cmd;
 mod sa_mode;
 
-// Re-export for tests that reference `crate::validate_sa_mode`.
 #[cfg(test)]
 pub(crate) use sa_mode::validate_sa_mode;
 
@@ -196,6 +196,7 @@ async fn run() -> Result<()> {
     if let Err(err) = validate_command_args(&command, min_timeout) {
         err.exit();
     }
+    executor_csa_guard::enforce(&command)?;
 
     let sa_mode_active = apply_sa_mode_prompt_guard(&command, current_depth, output_format)?;
 

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -1,4 +1,3 @@
-//! Execution loop for `csa run`, extracted from `run_cmd.rs` to keep module sizes manageable.
 use anyhow::Result;
 use csa_config::{ExecutionEnvOptions, GlobalConfig, ProjectConfig};
 use csa_core::types::{OutputFormat, ToolName, ToolSelectionStrategy};
@@ -44,7 +43,7 @@ pub(crate) struct RunLoopRequest<'a> {
     pub(crate) strategy: ToolSelectionStrategy,
     pub(crate) initial_tool: ToolName,
     pub(crate) initial_model_spec: Option<String>,
-    pub(crate) user_model_spec_explicit: bool, // CLI `--model-spec`: exact selection, disables tier enforcement.
+    pub(crate) user_model_spec_explicit: bool,
     pub(crate) initial_model: Option<String>,
     pub(crate) runtime_fallback_candidates: Vec<ToolName>,
     pub(crate) project_root: &'a Path,
@@ -349,10 +348,11 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             effective_session_arg = new_eff;
         }
 
-        let extra_env = request.global_config.build_execution_env(
+        let mut extra_env = request.global_config.build_execution_env(
             tool_name_str,
             ExecutionEnvOptions::from_no_failover(request.no_failover),
         );
+        crate::executor_csa_guard::mark_skill_executor_env(&mut extra_env, request.skill.is_some());
         let mut effective_prompt = if let Some(ref fork_res) = fork_resolution {
             if let Some(ref ctx) = fork_res.context_prefix {
                 info!(


### PR DESCRIPTION
## Summary
- Whitelist safe `csa` subcommands (todo, config, tokuin) in executor anti-recursion guard
- `csa todo create/save/ref` are data persistence commands that cannot cause recursion — they are now allowed in executor mode (mktd)
- `csa run/review/debate/plan run` remain blocked to prevent infinite recursion
- Fixes mktd executor Phase 4 (SAVE) which requires `csa todo create` to persist plans

Closes #1387

## Test plan
- [x] `just pre-commit-fast` passes
- [x] Codex committed with conventional commit
- [x] `csa review --range main...HEAD` verdict: PASS (zero findings)