### PR TITLE
fix(csa-process): extend idle timeout override to review and debate sessions (#1388)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.710"
+version = "0.1.711"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.710"
+version = "0.1.711"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -314,21 +314,22 @@ pub(crate) async fn handle_debate(
         resolved_model_spec.is_some(),
     );
 
-    let idle_timeout_seconds =
-        crate::pipeline::resolve_idle_timeout_seconds(config.as_ref(), args.idle_timeout);
+    let stream_mode = resolve_debate_stream_mode(args.stream_stdout, args.no_stream_stdout);
+    let timeout_seconds =
+        resolve_debate_timeout_seconds(args.timeout, Some(global_config.debate.timeout_seconds));
+    let idle_timeout_seconds = crate::pipeline::resolve_effective_idle_timeout_seconds(
+        config.as_ref(),
+        args.idle_timeout,
+        timeout_seconds,
+    );
     let initial_response_timeout_seconds =
-        crate::pipeline::resolve_initial_response_timeout_for_tool(
+        crate::pipeline::resolve_effective_initial_response_timeout_for_tool(
             config.as_ref(),
             args.initial_response_timeout,
             args.idle_timeout,
+            timeout_seconds,
             tool.as_str(),
         );
-
-    // Resolve stream mode from CLI flags (default: BufferOnly for debate)
-    let stream_mode = resolve_debate_stream_mode(args.stream_stdout, args.no_stream_stdout);
-
-    let timeout_seconds =
-        resolve_debate_timeout_seconds(args.timeout, Some(global_config.debate.timeout_seconds));
     let wall_clock_start = Instant::now();
     let readonly_project_root = global_config.debate.readonly_sandbox.unwrap_or(false);
     let candidates = tier_model_fallback::ordered_tier_candidates(

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -87,6 +87,29 @@ pub(crate) fn resolve_idle_timeout_seconds(
         .unwrap_or(DEFAULT_IDLE_TIMEOUT_SECONDS)
 }
 
+pub(crate) fn promote_idle_timeout_for_explicit_wall_timeout(
+    resolved_idle_timeout_seconds: u64,
+    cli_idle_timeout: Option<u64>,
+    wall_timeout: Option<u64>,
+) -> u64 {
+    if cli_idle_timeout.is_some() {
+        return resolved_idle_timeout_seconds;
+    }
+
+    wall_timeout.map_or(resolved_idle_timeout_seconds, |timeout| {
+        resolved_idle_timeout_seconds.max(timeout)
+    })
+}
+
+pub(crate) fn resolve_effective_idle_timeout_seconds(
+    config: Option<&ProjectConfig>,
+    cli_idle_timeout: Option<u64>,
+    wall_timeout: Option<u64>,
+) -> u64 {
+    let resolved_idle = resolve_idle_timeout_seconds(config, cli_idle_timeout);
+    promote_idle_timeout_for_explicit_wall_timeout(resolved_idle, cli_idle_timeout, wall_timeout)
+}
+
 /// Resolve the initial-response timeout (seconds).
 ///
 /// Priority: CLI override > project config > default (120s).
@@ -143,6 +166,30 @@ pub(crate) fn resolve_initial_response_timeout_for_tool(
         .or_else(|| config.and_then(|cfg| cfg.resources.initial_response_timeout_seconds));
 
     resolve_initial_response_timeout_with_default(config, configured, per_tool_default(tool_name))
+}
+
+pub(crate) fn resolve_effective_initial_response_timeout_for_tool(
+    config: Option<&ProjectConfig>,
+    cli_initial_response_timeout: Option<u64>,
+    cli_idle_timeout: Option<u64>,
+    wall_timeout: Option<u64>,
+    tool_name: &str,
+) -> Option<u64> {
+    let resolved = resolve_initial_response_timeout_for_tool(
+        config,
+        cli_initial_response_timeout,
+        cli_idle_timeout,
+        tool_name,
+    );
+
+    if cli_initial_response_timeout.is_some() {
+        return resolved;
+    }
+
+    match (resolved, wall_timeout) {
+        (Some(response_timeout), Some(timeout)) => Some(response_timeout.max(timeout)),
+        _ => resolved,
+    }
 }
 
 pub(crate) fn resolve_liveness_dead_seconds(config: Option<&ProjectConfig>) -> u64 {

--- a/crates/cli-sub-agent/src/pipeline_execute.rs
+++ b/crates/cli-sub-agent/src/pipeline_execute.rs
@@ -48,6 +48,13 @@ pub(crate) async fn execute_transport_with_signal(
             tokio::pin!(timeout_future);
             tokio::select! {
                 _ = sigterm.recv() => {
+                    warn!(
+                        session_id = %session.meta_session_id,
+                        task_type = session.task_context.task_type.as_deref().unwrap_or("unknown"),
+                        tool = %executor.tool_name(),
+                        wall_timeout_secs = ?wall_timeout.map(|timeout| timeout.as_secs()),
+                        "Session received SIGTERM; classifying as external signal, not CSA idle or wall-clock timeout"
+                    );
                     record_session_termination(
                         project_root,
                         session,
@@ -78,6 +85,13 @@ pub(crate) async fn execute_transport_with_signal(
                 _ = &mut timeout_future => {
                     let timeout_secs = wall_timeout.map_or(1, |timeout| timeout.as_secs().max(1));
                     let summary = format!("Execution timed out after {timeout_secs}s");
+                    warn!(
+                        session_id = %session.meta_session_id,
+                        task_type = session.task_context.task_type.as_deref().unwrap_or("unknown"),
+                        tool = %executor.tool_name(),
+                        timeout_secs,
+                        "Session wall-clock timeout fired"
+                    );
                     record_session_termination(
                         project_root,
                         session,
@@ -155,7 +169,10 @@ pub(crate) async fn execute_transport_with_signal(
     };
 
     match exec_result {
-        Ok(result) => Ok(result),
+        Ok(result) => {
+            log_signal_exit_diagnostic(session, &result.execution);
+            Ok(result)
+        }
         Err(e) => {
             // Record a failure result with accurate timing: started_at is when
             // execution began (before ACP init), not "now", fixing the
@@ -237,6 +254,59 @@ pub(crate) async fn execute_transport_with_signal(
             Err(e).context("Failed to execute tool via transport")
         }
     }
+}
+
+fn log_signal_exit_diagnostic(
+    session: &MetaSessionState,
+    execution: &csa_process::ExecutionResult,
+) {
+    let task_type = session.task_context.task_type.as_deref();
+    if !matches!(task_type, Some("review" | "debate")) {
+        return;
+    }
+    if !matches!(execution.exit_code, 124 | 137 | 143) {
+        return;
+    }
+
+    let diagnosis = diagnose_signal_exit(session, execution);
+    warn!(
+        session_id = %session.meta_session_id,
+        task_type = task_type.unwrap_or("unknown"),
+        exit_code = execution.exit_code,
+        termination_reason = ?session.termination_reason,
+        diagnosis,
+        summary = %execution.summary,
+        "Review/debate tool process ended with signal-like status"
+    );
+}
+
+fn diagnose_signal_exit(
+    session: &MetaSessionState,
+    execution: &csa_process::ExecutionResult,
+) -> &'static str {
+    let summary = execution.summary.to_ascii_lowercase();
+    let stderr = execution.stderr_output.to_ascii_lowercase();
+    let haystack = format!("{summary}\n{stderr}");
+
+    if session.termination_reason.as_deref() == Some("timeout") || execution.exit_code == 124 {
+        return "wall_clock_timeout";
+    }
+    if haystack.contains("initial_response_timeout") {
+        return "initial_response_timeout";
+    }
+    if haystack.contains("idle timeout") {
+        return "idle_timeout";
+    }
+    if haystack.contains("oom") || haystack.contains("memory") {
+        return "oom_or_memory_limit";
+    }
+    if execution.exit_code == 143 || session.termination_reason.as_deref() == Some("sigterm") {
+        return "external_sigterm";
+    }
+    if execution.exit_code == 137 {
+        return "sigkill_or_oom";
+    }
+    "external_signal"
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -282,6 +282,22 @@ fn resolve_idle_timeout_uses_config_then_default() {
 }
 
 #[test]
+fn explicit_wall_timeout_promotes_effective_idle_timeout() {
+    assert_eq!(
+        resolve_effective_idle_timeout_seconds(None, None, Some(1800)),
+        1800
+    );
+}
+
+#[test]
+fn explicit_idle_timeout_is_not_promoted_by_wall_timeout() {
+    assert_eq!(
+        resolve_effective_idle_timeout_seconds(None, Some(60), Some(1800)),
+        60
+    );
+}
+
+#[test]
 fn resolve_liveness_dead_seconds_uses_config_then_default() {
     let cfg = ProjectConfig {
         schema_version: CURRENT_SCHEMA_VERSION,
@@ -688,6 +704,8 @@ fn enforce_result_toml_contract_now(
 
 #[path = "pipeline_tests_contract.rs"]
 mod contract_tests;
+#[path = "pipeline_tests_effective_timeout.rs"]
+mod effective_timeout_tests;
 #[path = "pipeline_tests_initial_response.rs"]
 mod initial_response_tests;
 #[path = "pipeline_tests_locking.rs"]

--- a/crates/cli-sub-agent/src/pipeline_tests_effective_timeout.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_effective_timeout.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+#[test]
+fn initial_response_timeout_promotes_to_wall_timeout() {
+    assert_eq!(
+        resolve_effective_initial_response_timeout_for_tool(None, None, None, Some(1800), "codex"),
+        Some(1800)
+    );
+}
+
+#[test]
+fn initial_response_timeout_respects_explicit_initial_response_timeout() {
+    assert_eq!(
+        resolve_effective_initial_response_timeout_for_tool(
+            None,
+            Some(90),
+            None,
+            Some(1800),
+            "codex",
+        ),
+        Some(90)
+    );
+}
+
+#[test]
+fn initial_response_timeout_keeps_disabled_timeout_disabled() {
+    assert_eq!(
+        resolve_effective_initial_response_timeout_for_tool(
+            None,
+            None,
+            Some(1800),
+            Some(1800),
+            "codex",
+        ),
+        None
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -1,4 +1,6 @@
 use crate::cli::ReviewArgs;
+use crate::pipeline::resolve_effective_initial_response_timeout_for_tool;
+#[cfg(test)]
 use crate::pipeline::resolve_initial_response_timeout_for_tool;
 use crate::review_consensus::{
     CLEAN, agreement_level, build_multi_reviewer_instruction, consensus_strategy_label,
@@ -332,12 +334,16 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
 
     // Resolve stream mode from CLI flags (default: BufferOnly for review)
     let stream_mode = resolve_review_stream_mode(args.stream_stdout, args.no_stream_stdout);
-    let idle_timeout_seconds =
-        crate::pipeline::resolve_idle_timeout_seconds(config.as_ref(), args.idle_timeout);
-    let initial_response_timeout_seconds = resolve_initial_response_timeout_for_tool(
+    let idle_timeout_seconds = crate::pipeline::resolve_effective_idle_timeout_seconds(
+        config.as_ref(),
+        args.idle_timeout,
+        args.timeout,
+    );
+    let initial_response_timeout_seconds = resolve_effective_initial_response_timeout_for_tool(
         config.as_ref(),
         args.initial_response_timeout,
         args.idle_timeout,
+        args.timeout,
         tool.as_str(),
     );
 
@@ -641,12 +647,14 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             });
         let reviewer_tier_name = resolved_tier_name.clone();
         let reviewer_thinking = review_thinking.clone();
-        let reviewer_initial_response_timeout_seconds = resolve_initial_response_timeout_for_tool(
-            reviewer_config.as_ref(),
-            args.initial_response_timeout,
-            args.idle_timeout,
-            reviewer_tool.as_str(),
-        );
+        let reviewer_initial_response_timeout_seconds =
+            resolve_effective_initial_response_timeout_for_tool(
+                reviewer_config.as_ref(),
+                args.initial_response_timeout,
+                args.idle_timeout,
+                args.timeout,
+                reviewer_tool.as_str(),
+            );
         join_set.spawn(async move {
             let session_result = execute_review_with_tier_filter(
                 reviewer_tool,

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -34,6 +34,8 @@ pub(crate) use policy::{
 pub(crate) use shell::detect_no_verify_commit_commands;
 
 #[cfg(test)]
+pub(crate) use crate::pipeline::promote_idle_timeout_for_explicit_wall_timeout;
+#[cfg(test)]
 pub(crate) use git::{PostRunCommitGuard, changed_paths_from_status, tracked_paths_from_status};
 #[cfg(test)]
 pub(crate) use policy::{
@@ -44,9 +46,9 @@ pub(crate) use policy::{format_post_run_commit_guard_message, is_post_run_commit
 #[cfg(test)]
 pub(crate) use resume::{
     build_resume_hint_command, extract_meta_session_id_from_error,
-    interrupted_skill_session_matches_current_vcs, promote_idle_timeout_for_explicit_wall_timeout,
-    resolve_run_timeout_seconds, run_error_timeout_seconds, session_matches_interrupted_skill,
-    signal_interruption_exit_code, skill_session_description, wall_timeout_seconds_from_error,
+    interrupted_skill_session_matches_current_vcs, resolve_run_timeout_seconds,
+    run_error_timeout_seconds, session_matches_interrupted_skill, signal_interruption_exit_code,
+    skill_session_description, wall_timeout_seconds_from_error,
 };
 
 #[derive(Debug)]

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -37,8 +37,7 @@ use run_context::finalize_prompt_text;
 
 use super::attempt::{RunLoopCompletion, RunLoopRequest, execute_run_loop};
 use super::resume::{
-    detect_effective_repo, find_recent_interrupted_skill_session,
-    promote_idle_timeout_for_explicit_wall_timeout, resolve_run_timeout_seconds,
+    detect_effective_repo, find_recent_interrupted_skill_session, resolve_run_timeout_seconds,
     skill_session_description,
 };
 
@@ -328,8 +327,7 @@ pub(crate) async fn handle_run(
         info!("Idle timeout disabled via --no-idle-timeout");
         u64::MAX
     } else {
-        let resolved_idle = pipeline::resolve_idle_timeout_seconds(config.as_ref(), idle_timeout);
-        promote_idle_timeout_for_explicit_wall_timeout(resolved_idle, idle_timeout, timeout)
+        pipeline::resolve_effective_idle_timeout_seconds(config.as_ref(), idle_timeout, timeout)
     };
     let run_started_at = Instant::now();
     let needs_edit = task_needs_edit.unwrap_or(false);

--- a/crates/cli-sub-agent/src/run_cmd_resume.rs
+++ b/crates/cli-sub-agent/src/run_cmd_resume.rs
@@ -26,20 +26,6 @@ pub(crate) fn resolve_run_timeout_seconds(
     None
 }
 
-pub(crate) fn promote_idle_timeout_for_explicit_wall_timeout(
-    resolved_idle_timeout_seconds: u64,
-    cli_idle_timeout: Option<u64>,
-    cli_timeout: Option<u64>,
-) -> u64 {
-    if cli_idle_timeout.is_some() {
-        return resolved_idle_timeout_seconds;
-    }
-
-    cli_timeout.map_or(resolved_idle_timeout_seconds, |timeout| {
-        resolved_idle_timeout_seconds.max(timeout)
-    })
-}
-
 pub(crate) fn resolve_remaining_run_timeout(
     run_timeout_seconds: Option<u64>,
     run_started_at: Instant,


### PR DESCRIPTION
## Summary
- Extend the #1385 idle timeout override to cover review and debate sessions, not just `csa run`
- Review/debate sessions were still being killed by aggressive idle timeout (12s-3min) because the fix only applied to the `csa run` code path
- Now all session types (run, review, debate) respect explicit `--timeout` for idle timeout suppression
- Added diagnostic logging for SIGTERM on review/debate sessions

Closes #1388

## Test plan
- [x] `just pre-commit-fast` passes
- [x] Codex committed with conventional commit
- [x] `csa review --range main...HEAD` verdict: PASS (zero findings)