### PR TITLE
fix(csa-session): continue polling when PID detection misses but liveness signals exist (#1396)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.711"
+version = "0.1.712"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -441,15 +441,21 @@ where
                 );
                 return Ok(exit_code);
             }
-            eprintln!(
-                "Session {} has no live daemon process and no terminal result packet.",
-                resolved.session_id,
-            );
-            eprintln!(
-                "Run `csa session result --session {}` for diagnostics.",
-                resolved.session_id
-            );
-            return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
+            if csa_process::ToolLiveness::is_alive(&session_dir) {
+                // PID detection missed but filesystem liveness signals say alive;
+                // continue polling so the timeout (exit 124) fires instead of exit 1.
+                tracing::debug!(session_id = %resolved.session_id, "alive; no terminal PID");
+            } else {
+                eprintln!(
+                    "Session {} has no live daemon process and no terminal result packet.",
+                    resolved.session_id,
+                );
+                eprintln!(
+                    "Run `csa session result --session {}` for diagnostics.",
+                    resolved.session_id
+                );
+                return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
+            }
         }
 
         if let (Some(limit_mb), Some(sample_at)) = (memory_warn_mb, next_memory_sample_at)

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -752,5 +752,7 @@ mod tail_tests;
 mod tail_tests_recovery;
 #[path = "session_cmds_tests_tail_wait.rs"]
 mod tail_tests_wait;
+#[path = "session_cmds_tests_tail_wait_liveness.rs"]
+mod tail_tests_wait_liveness;
 #[path = "session_cmds_tests_tail_wait_lock.rs"]
 mod tail_tests_wait_lock;

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
@@ -1,0 +1,101 @@
+use super::*;
+use crate::session_cmds_daemon::{
+    WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome, handle_session_wait_with_hooks,
+};
+use crate::test_env_lock::TEST_ENV_LOCK;
+use tempfile::tempdir;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+/// When PID-level detection misses (session_has_terminal_process=false) but broader
+/// filesystem liveness signals remain (is_alive=true due to recent session writes),
+/// the wait must continue polling and eventually return 124 (timeout) — not 1 (failure).
+///
+/// Regression test for #1396.
+#[test]
+fn handle_session_wait_continues_polling_when_pid_missing_but_liveness_signals_present() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    // Create session with no daemon.pid or lock files — session_has_terminal_process returns
+    // false. The session directory itself was just written (state.toml), so
+    // ToolLiveness::is_alive returns true via has_recent_session_write_signal.
+    let session = create_session(
+        project,
+        Some("wait-pid-missing-liveness-present"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+
+    // Verify preconditions: no PID signals, but recent filesystem writes make is_alive=true.
+    assert!(
+        !csa_process::ToolLiveness::has_live_process(&session_dir),
+        "test requires session_has_terminal_process=false: no live process"
+    );
+    assert!(
+        !csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir),
+        "test requires session_has_terminal_process=false: no daemon pid"
+    );
+    assert!(
+        csa_process::ToolLiveness::is_alive(&session_dir),
+        "recent session writes must make is_alive return true"
+    );
+
+    let exit_code = handle_session_wait_with_hooks(
+        session_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {},
+    )
+    .expect("wait should succeed");
+
+    assert_eq!(
+        exit_code, 124,
+        "wait must time out (124) not report failure (1) when liveness signals exist"
+    );
+}


### PR DESCRIPTION
## Summary
- When `session_has_terminal_process` returns false but `ToolLiveness::is_alive` detects recent filesystem activity, the wait loop now continues polling instead of returning exit 1 immediately
- This lets the timeout mechanism (exit 124) fire properly, preventing premature failure reports for active sessions where PID-based detection has a timing gap
- Adds regression test verifying wait returns 124 (timeout) instead of 1 (failure) when liveness signals exist

Closes #1396

## Test plan
- [x] New test `handle_session_wait_continues_polling_when_pid_missing_but_liveness_signals_present` passes
- [x] `cargo test -p cli-sub-agent` passes
- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` verdict: PASS (0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)