### PR TITLE
fix(csa-process): install SIGTERM handler and panic hook for daemon completion (#1395)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.712"
+version = "0.1.713"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -119,10 +119,67 @@ pub(crate) fn check_daemon_flags(
 
         // Install stderr rotation so daemon stderr.log is bounded.
         stderr_rotation = install_daemon_stderr_rotation(sid, cd);
+
+        // Install panic hook so daemon-completion.toml is written even on panic.
+        install_daemon_panic_hook();
+
+        // Spawn a background task that writes daemon-completion.toml on SIGTERM/SIGINT.
+        // This runs inside the tokio runtime (we are inside `#[tokio::main]`).
+        spawn_daemon_signal_handler();
     }
     Ok(DaemonChildGuard {
         _stderr_rotation: stderr_rotation,
     })
+}
+
+/// Install a custom panic hook that writes `daemon-completion.toml` before
+/// chaining to the default hook (preserving backtrace output).
+///
+/// Exit code 101 is Rust's conventional panic exit code.
+fn install_daemon_panic_hook() {
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        crate::session_cmds_daemon::persist_daemon_completion_from_env(101);
+        prev_hook(info);
+    }));
+}
+
+/// Spawn a tokio task that listens for SIGTERM and SIGINT, writes
+/// `daemon-completion.toml` with the conventional signal exit code
+/// (128 + signal number), then exits.
+fn spawn_daemon_signal_handler() {
+    tokio::spawn(async {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+            let mut sigterm = match signal(SignalKind::terminate()) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("failed to register daemon SIGTERM handler: {e}");
+                    return;
+                }
+            };
+            let mut sigint = match signal(SignalKind::interrupt()) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("failed to register daemon SIGINT handler: {e}");
+                    return;
+                }
+            };
+            tokio::select! {
+                _ = sigterm.recv() => {
+                    // 128 + 15 (SIGTERM) = 143
+                    crate::session_cmds_daemon::persist_daemon_completion_from_env(143);
+                    std::process::exit(143);
+                }
+                _ = sigint.recv() => {
+                    // 128 + 2 (SIGINT) = 130
+                    crate::session_cmds_daemon::persist_daemon_completion_from_env(130);
+                    std::process::exit(130);
+                }
+            }
+        }
+    });
 }
 
 /// Best-effort stderr rotation install for daemon child processes.


### PR DESCRIPTION
## Summary
- Installs a SIGTERM/SIGINT signal handler via `tokio::signal::unix` in daemon child processes that writes `daemon-completion.toml` before exiting (exit codes 143/130 respectively)
- Installs a panic hook that writes `daemon-completion.toml` with exit code 101 before chaining to the previous hook
- Both are installed in `check_daemon_flags` after env var setup, only in the daemon child path

Previously, daemon processes that received SIGTERM or panicked would die without writing `daemon-completion.toml`, leaving sessions in limbo with no completion markers or diagnostics.

Closes #1395

## Test plan
- [x] `cargo test -p cli-sub-agent -- run_cmd_daemon` (13/13 passed)
- [x] `cargo test -p cli-sub-agent -- session_cmds_daemon` (30/30 passed)
- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` verdict: PASS (0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)