### PR TITLE
fix(csa-executor): inject CSA sub-agent identity preamble for claude-code prompts (#1397)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.713"
+version = "0.1.714"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -83,7 +83,6 @@ pub enum Executor {
 const fn default_codex_runtime_metadata() -> CodexRuntimeMetadata {
     CodexRuntimeMetadata::current()
 }
-
 const fn default_claude_runtime_metadata() -> ClaudeCodeRuntimeMetadata {
     ClaudeCodeRuntimeMetadata::current()
 }
@@ -292,6 +291,16 @@ impl Executor {
         session: &MetaSessionState,
         extra_env: Option<&HashMap<String, String>>,
     ) -> (Command, Option<Vec<u8>>) {
+        // Prepend CSA identity preamble for claude-code (#1397).
+        let preamble_buf;
+        let prompt = match self {
+            Self::ClaudeCode { .. } => {
+                preamble_buf =
+                    format!("{}{prompt}", Self::csa_sub_agent_identity_preamble(session));
+                preamble_buf.as_str()
+            }
+            _ => prompt,
+        };
         let mut cmd = self.build_base_command(session);
         if matches!(self, Self::GeminiCli { .. }) {
             Self::strip_gemini_inherited_env(&mut cmd);
@@ -389,9 +398,7 @@ impl Executor {
         Ok(result)
     }
 
-    /// Execute in a specific directory (for ephemeral sessions).
-    ///
-    /// `extra_env`: optional environment variables to inject (e.g., API keys from GlobalConfig).
+    /// Execute in a specific directory (ephemeral sessions, `extra_env` for API keys etc.).
     pub async fn execute_in(
         &self,
         prompt: &str,
@@ -707,9 +714,7 @@ impl Executor {
                 if thinking_budget.is_some() {
                     // gemini-cli (0.31+) no longer accepts thinking-budget flags.
                     // Ignore CSA thinking hints and let gemini-cli decide routing.
-                    tracing::debug!(
-                        "Ignoring thinking budget for gemini-cli because runtime no longer supports a thinking flag"
-                    );
+                    tracing::debug!("Ignoring thinking budget for gemini-cli: no flag support");
                 }
             }
             Self::Opencode {
@@ -760,12 +765,8 @@ impl Executor {
                 if let Some(model) = model_override {
                     cmd.arg("--model").arg(model);
                 }
-                // claude-code 2.x exposes thinking control via `--effort
-                // <level>` (low/medium/high/xhigh/max); the legacy
-                // `--thinking-budget <tokens>` flag was removed and any
-                // emission of it makes the binary exit with `unknown option`
-                // (#1124). `DefaultBudget` deliberately omits the flag so the
-                // tool applies its built-in default.
+                // claude-code 2.x: `--effort <level>`, not `--thinking-budget`
+                // (removed, #1124). DefaultBudget omits the flag entirely.
                 if let Some(budget) = thinking_budget
                     && let Some(level) = budget.claude_effort()
                 {

--- a/crates/csa-executor/src/executor_build_cmd_preamble_tests.rs
+++ b/crates/csa-executor/src/executor_build_cmd_preamble_tests.rs
@@ -1,0 +1,158 @@
+// ── CSA sub-agent identity preamble ────────────────────────────
+
+#[test]
+fn test_claude_code_prompt_includes_identity_preamble() {
+    let exec = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: crate::claude_runtime::claude_runtime_metadata(),
+    };
+    let session = make_test_session();
+    let (cmd, _stdin_data) = exec.build_command("implement feature X", None, &session, None);
+
+    let args: Vec<_> = cmd
+        .as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+
+    let prompt_arg = args
+        .iter()
+        .find(|a| a.contains("implement feature X"))
+        .expect("Should have prompt arg");
+
+    assert!(
+        prompt_arg.starts_with("<csa-sub-agent-context>"),
+        "claude-code prompt should start with CSA identity preamble"
+    );
+    assert!(
+        prompt_arg.contains("You are running INSIDE a CSA"),
+        "Preamble should state the agent is inside CSA"
+    );
+    assert!(
+        prompt_arg.contains(&session.meta_session_id),
+        "Preamble should contain the session ID"
+    );
+    assert!(
+        prompt_arg.contains("CSA_DEPTH=1"),
+        "Preamble should contain child depth (parent 0 + 1 = 1)"
+    );
+    assert!(
+        prompt_arg.contains("AGENTS.md rule 049 does not apply"),
+        "Preamble should explicitly exempt rule 049"
+    );
+    assert!(
+        prompt_arg.contains("</csa-sub-agent-context>"),
+        "Preamble should have closing tag"
+    );
+    assert!(
+        prompt_arg.ends_with("implement feature X"),
+        "Original prompt should follow the preamble"
+    );
+}
+
+#[test]
+fn test_claude_code_preamble_reflects_session_depth() {
+    let exec = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: crate::claude_runtime::claude_runtime_metadata(),
+    };
+    let mut session = make_test_session();
+    session.genealogy.depth = 3;
+
+    let (cmd, _stdin_data) = exec.build_command("deep task", None, &session, None);
+
+    let args: Vec<_> = cmd
+        .as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+
+    let prompt_arg = args
+        .iter()
+        .find(|a| a.contains("deep task"))
+        .expect("Should have prompt arg");
+
+    assert!(
+        prompt_arg.contains("CSA_DEPTH=4"),
+        "Preamble depth should be parent depth (3) + 1 = 4"
+    );
+}
+
+#[test]
+fn test_gemini_prompt_has_no_preamble() {
+    let exec = Executor::GeminiCli {
+        model_override: None,
+        thinking_budget: None,
+    };
+    let session = make_test_session();
+    let (cmd, _stdin_data) = exec.build_command("hello world", None, &session, None);
+
+    let args: Vec<_> = cmd
+        .as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        args.contains(&"hello world".to_string()),
+        "GeminiCli prompt should be unmodified"
+    );
+    assert!(
+        !args.iter().any(|a| a.contains("<csa-sub-agent-context>")),
+        "GeminiCli should NOT have CSA identity preamble"
+    );
+}
+
+#[test]
+fn test_codex_prompt_has_no_preamble() {
+    let exec = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: crate::codex_runtime::codex_runtime_metadata(),
+    };
+    let session = make_test_session();
+    let (cmd, _stdin_data) = exec.build_command("fix bug", None, &session, None);
+
+    let args: Vec<_> = cmd
+        .as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        args.contains(&"fix bug".to_string()),
+        "Codex prompt should be unmodified"
+    );
+    assert!(
+        !args.iter().any(|a| a.contains("<csa-sub-agent-context>")),
+        "Codex should NOT have CSA identity preamble"
+    );
+}
+
+#[test]
+fn test_opencode_prompt_has_no_preamble() {
+    let exec = Executor::Opencode {
+        model_override: None,
+        agent: None,
+        thinking_budget: None,
+    };
+    let session = make_test_session();
+    let (cmd, _stdin_data) = exec.build_command("write tests", None, &session, None);
+
+    let args: Vec<_> = cmd
+        .as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        args.contains(&"write tests".to_string()),
+        "Opencode prompt should be unmodified"
+    );
+    assert!(
+        !args.iter().any(|a| a.contains("<csa-sub-agent-context>")),
+        "Opencode should NOT have CSA identity preamble"
+    );
+}

--- a/crates/csa-executor/src/executor_build_cmd_tests.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests.rs
@@ -642,7 +642,19 @@ fn test_build_command_claude_args_structure() {
         "ThinkingBudget::Medium maps to --effort medium"
     );
     assert!(args.contains(&"-p".to_string()), "Should have -p flag");
-    assert!(args.contains(&"do stuff".to_string()), "Should have prompt");
+    // claude-code prompts are wrapped with a CSA sub-agent identity preamble
+    let prompt_arg = args
+        .iter()
+        .find(|a| a.contains("do stuff"))
+        .expect("Should have prompt containing 'do stuff'");
+    assert!(
+        prompt_arg.contains("<csa-sub-agent-context>"),
+        "claude-code prompt should include CSA identity preamble"
+    );
+    assert!(
+        prompt_arg.ends_with("do stuff"),
+        "Original prompt should be at the end"
+    );
 }
 
 #[test]
@@ -763,5 +775,6 @@ fn test_build_command_opencode_args_structure() {
     );
 }
 
+include!("executor_build_cmd_preamble_tests.rs");
 include!("executor_build_cmd_resume_tests.rs");
 include!("executor_build_cmd_tests_part2.rs");

--- a/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
@@ -90,10 +90,11 @@ fn test_build_command_with_empty_prompt() {
         .map(|a| a.to_string_lossy().to_string())
         .collect();
 
-    // Empty prompt should still be passed as an argument
+    // Empty prompt for claude-code still gets the identity preamble prepended
+    let has_preamble_arg = args.iter().any(|a| a.contains("<csa-sub-agent-context>"));
     assert!(
-        args.contains(&"".to_string()),
-        "Empty prompt should be present as an arg: {args:?}"
+        has_preamble_arg,
+        "Even empty claude-code prompt should get identity preamble: {args:?}"
     );
 }
 

--- a/crates/csa-executor/src/executor_prompt_helpers.rs
+++ b/crates/csa-executor/src/executor_prompt_helpers.rs
@@ -1,9 +1,27 @@
 use csa_core::types::{PromptTransport, ToolName, prompt_transport_capabilities};
+use csa_session::state::MetaSessionState;
 use tokio::process::Command;
 
 use super::{Executor, MAX_ARGV_PROMPT_LEN};
 
 impl Executor {
+    /// Generate a CSA sub-agent identity preamble for tools that load project rules
+    /// (e.g., claude-code loading AGENTS.md). Without this, the tool may refuse CSA-
+    /// formatted prompts by misapplying delegation rules against itself.
+    pub(super) fn csa_sub_agent_identity_preamble(session: &MetaSessionState) -> String {
+        let session_id = &session.meta_session_id;
+        let child_depth = session.genealogy.depth + 1;
+        format!(
+            "<csa-sub-agent-context>\n\
+             You are running INSIDE a CSA (cli-sub-agent) session as the delegated executor.\n\
+             CSA_SESSION_ID={session_id}, CSA_DEPTH={child_depth}.\n\
+             You ARE the sub-agent — execute the task directly.\n\
+             Do NOT re-delegate to `csa run` or suggest CSA dispatch.\n\
+             AGENTS.md rule 049 does not apply: you are already the CSA-dispatched agent.\n\
+             </csa-sub-agent-context>\n\n"
+        )
+    }
+
     /// Append minimal prompt args for execute_in.
     pub(super) fn append_prompt_args(&self, cmd: &mut Command, prompt: &str) {
         self.append_prompt_args_with_transport(cmd, prompt, PromptTransport::Argv);

--- a/crates/csa-executor/src/executor_prompt_transport_tests.rs
+++ b/crates/csa-executor/src/executor_prompt_transport_tests.rs
@@ -148,10 +148,17 @@ fn test_build_command_long_prompt_uses_stdin_for_claude_code() {
         args.contains(&"-p".to_string()),
         "claude-code must retain -p flag in stdin mode for pipe/non-interactive operation"
     );
-    assert_eq!(
-        stdin_data,
-        Some(prompt.as_bytes().to_vec()),
-        "claude-code should transport long prompts via stdin"
+    // claude-code prompt gets the identity preamble prepended, so stdin_data
+    // includes both the preamble and the original prompt.
+    let stdin_bytes = stdin_data.expect("claude-code should transport long prompts via stdin");
+    let stdin_str = String::from_utf8(stdin_bytes).expect("valid UTF-8");
+    assert!(
+        stdin_str.starts_with("<csa-sub-agent-context>"),
+        "stdin should start with CSA identity preamble"
+    );
+    assert!(
+        stdin_str.ends_with(&prompt),
+        "stdin should end with the original prompt"
     );
 }
 


### PR DESCRIPTION
## Summary
- Injects a `<csa-sub-agent-context>` XML preamble into claude-code prompts when running inside a CSA session
- The preamble identifies the claude-code instance as the CSA-dispatched executor and explicitly exempts it from AGENTS.md rule 049
- Only applied to ClaudeCode; other tools (codex, gemini-cli, opencode) receive unmodified prompts
- Adds 5 new tests covering preamble injection and non-injection for each tool type

Previously, claude-code loaded AGENTS.md rule 049 and refused CSA-formatted prompts, creating a circular refusal where it suggested re-dispatching via CSA while already being the CSA sub-agent.

Closes #1397

## Test plan
- [x] `cargo test -p csa-executor` — 285 passed, 1 ignored
- [x] `cargo check --workspace` clean
- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` verdict: PASS (0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)