### PR TITLE
fix(patterns): inline post-merge checkout into pr-bot merge steps (#1401)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.714"
+version = "0.1.715"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -1874,6 +1874,15 @@ fi
 # shellcheck disable=SC2086
 gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
 
+# --- Inline post-merge checkout (defense-in-depth for #1401) ---
+_SYNC_BRANCH="${DEFAULT_BRANCH:-}"
+if [ -z "${_SYNC_BRANCH}" ]; then
+  _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
+fi
+if [ -n "${_SYNC_BRANCH}" ]; then
+  git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
+fi
+
 # Write pr-bot completion marker (deterministic gate for pre-merge hook).
 MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"
 MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG}"
@@ -1941,6 +1950,15 @@ fi
 # shellcheck disable=SC2086
 gh pr merge "${WORKFLOW_BRANCH}-clean" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
 
+# --- Inline post-merge checkout (defense-in-depth for #1401) ---
+_SYNC_BRANCH="${DEFAULT_BRANCH:-}"
+if [ -z "${_SYNC_BRANCH}" ]; then
+  _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
+fi
+if [ -n "${_SYNC_BRANCH}" ]; then
+  git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
+fi
+
 # Write pr-bot completion marker (deterministic gate for pre-merge hook).
 MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"
 MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG}"
@@ -1986,6 +2004,15 @@ if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; the
 fi
 # shellcheck disable=SC2086
 gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
+
+# --- Inline post-merge checkout (defense-in-depth for #1401) ---
+_SYNC_BRANCH="${DEFAULT_BRANCH:-}"
+if [ -z "${_SYNC_BRANCH}" ]; then
+  _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
+fi
+if [ -n "${_SYNC_BRANCH}" ]; then
+  git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
+fi
 
 # Write pr-bot completion marker (deterministic gate for pre-merge hook).
 MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -2288,6 +2288,15 @@ fi
 # shellcheck disable=SC2086
 gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
 
+# --- Inline post-merge checkout (defense-in-depth for #1401) ---
+_SYNC_BRANCH="${DEFAULT_BRANCH:-}"
+if [ -z "${_SYNC_BRANCH}" ]; then
+  _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
+fi
+if [ -n "${_SYNC_BRANCH}" ]; then
+  git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
+fi
+
 # Write pr-bot completion marker (deterministic gate for pre-merge hook).
 MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"
 MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG}"
@@ -2356,6 +2365,15 @@ fi
 # shellcheck disable=SC2086
 gh pr merge "${WORKFLOW_BRANCH}-clean" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
 
+# --- Inline post-merge checkout (defense-in-depth for #1401) ---
+_SYNC_BRANCH="${DEFAULT_BRANCH:-}"
+if [ -z "${_SYNC_BRANCH}" ]; then
+  _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
+fi
+if [ -n "${_SYNC_BRANCH}" ]; then
+  git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
+fi
+
 # Write pr-bot completion marker (deterministic gate for pre-merge hook).
 MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"
 MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG}"
@@ -2402,6 +2420,15 @@ if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; the
 fi
 # shellcheck disable=SC2086
 gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
+
+# --- Inline post-merge checkout (defense-in-depth for #1401) ---
+_SYNC_BRANCH="${DEFAULT_BRANCH:-}"
+if [ -z "${_SYNC_BRANCH}" ]; then
+  _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
+fi
+if [ -n "${_SYNC_BRANCH}" ]; then
+  git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
+fi
 
 # Write pr-bot completion marker (deterministic gate for pre-merge hook).
 MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"


### PR DESCRIPTION
## Summary
- Inlines `git checkout <default-branch> && git pull --ff-only` directly into each pr-bot merge step (Steps 20, 22, 23) after `gh pr merge` succeeds
- Best-effort (`|| true`) — never fails the merge step since the merge itself already succeeded
- Keeps Step 24 as a safety-net no-op for pipelines that skip inline checkout
- Syncs PATTERN.md documentation per Rule 027

Closes #1401

## Test plan
- [ ] Verify `weave compile patterns/pr-bot/workflow.toml` passes
- [ ] Run dev2merge pipeline end-to-end and confirm worktree lands on main after merge
- [ ] Verify Step 24 still works as fallback when inline checkout is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)