### PR TITLE
fix(csa-process): graceful fallback when systemd-run fails in nested CSA (#1402)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.715"
+version = "0.1.716"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.715"
+version = "0.1.716"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-process/src/daemon.rs
+++ b/crates/csa-process/src/daemon.rs
@@ -51,6 +51,15 @@ fn open_log_file(dir: &std::path::Path, name: &str) -> Result<File> {
         .with_context(|| format!("failed to create {name} in {}", dir.display()))
 }
 
+fn open_log_file_append(dir: &std::path::Path, name: &str) -> Result<File> {
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .open(dir.join(name))
+        .with_context(|| format!("failed to open {name} for append in {}", dir.display()))
+}
+
 fn daemon_pid_record(pid: u32) -> String {
     match read_process_start_time_ticks(pid) {
         Some(start_time_ticks) => format!("{pid} {start_time_ticks}\n"),
@@ -70,8 +79,17 @@ fn daemon_spawn_mode(session_id: &str) -> DaemonSpawnMode {
     }
 
     if inherited_csa_scope_detected() {
-        DaemonSpawnMode::IndependentScope {
-            unit: csa_resource::cgroup::scope_unit_name("daemon", session_id),
+        if csa_resource::sandbox::has_systemd_user_scope() {
+            DaemonSpawnMode::IndependentScope {
+                unit: csa_resource::cgroup::scope_unit_name("daemon", session_id),
+            }
+        } else {
+            tracing::warn!(
+                "inherited CSA systemd scope detected but `systemd-run --user --scope` probe \
+                 failed (dbus likely unavailable in nested CSA subprocess); \
+                 daemon will spawn as direct detached process"
+            );
+            DaemonSpawnMode::Direct
         }
     } else {
         DaemonSpawnMode::Direct
@@ -185,9 +203,39 @@ pub fn spawn_daemon(config: DaemonSpawnConfig) -> Result<DaemonSpawnResult> {
         });
     }
 
-    let mut child = cmd
-        .spawn()
-        .context("failed to spawn daemon child process")?;
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(scope_err) if matches!(spawn_mode, DaemonSpawnMode::IndependentScope { .. }) => {
+            // systemd-run binary not found or exec failed; fall back to direct detach.
+            tracing::warn!(
+                error = %scope_err,
+                "daemon spawn via systemd scope failed; retrying as direct detached process"
+            );
+            let stdout2 = open_log_file_append(&config.session_dir, "stdout.log")?;
+            let mut stderr2 = open_log_file_append(&config.session_dir, "stderr.log")?;
+            writeln!(
+                stderr2,
+                "CSA daemon spawn: scope spawn failed ({scope_err}), retrying as direct detached process"
+            )?;
+            let _ = std::fs::remove_file(config.session_dir.join("daemon.scope"));
+            let mut cmd2 = build_daemon_command(&config, &DaemonSpawnMode::Direct);
+            cmd2.stdin(Stdio::null());
+            cmd2.stdout(stdout2);
+            cmd2.stderr(stderr2);
+            // SAFETY: same as above.
+            unsafe {
+                cmd2.pre_exec(|| {
+                    if libc::setsid() == -1 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+            cmd2.spawn()
+                .context("daemon spawn retry (direct mode) also failed")?
+        }
+        Err(e) => return Err(e).context("failed to spawn daemon child process"),
+    };
 
     let pid = child.id();
 
@@ -240,6 +288,18 @@ mod tests {
         // DAEMON_SCOPE_ENV_LOCK and restore the variable in DaemonScopeEnvGuard.
         unsafe {
             std::env::set_var(DAEMON_INDEPENDENT_SCOPE_ENV, "0");
+        }
+        DaemonScopeEnvGuard { _lock: lock }
+    }
+
+    fn force_independent_scope_for_test() -> DaemonScopeEnvGuard {
+        let lock = DAEMON_SCOPE_ENV_LOCK
+            .lock()
+            .expect("daemon env lock poisoned");
+        // SAFETY: daemon spawn tests serialize environment mutation through
+        // DAEMON_SCOPE_ENV_LOCK and restore the variable in DaemonScopeEnvGuard.
+        unsafe {
+            std::env::set_var(DAEMON_INDEPENDENT_SCOPE_ENV, "1");
         }
         DaemonScopeEnvGuard { _lock: lock }
     }
@@ -448,6 +508,59 @@ mod tests {
         assert!(
             contents.contains("got="),
             "stdout should still contain 'got=' (exec ran), got: {contents:?}"
+        );
+    }
+
+    /// Verify that when IndependentScope is forced but systemd-run cannot be found
+    /// in PATH, spawn_daemon retries with Direct mode and still succeeds.
+    ///
+    /// Simulates the nested-CSA-subprocess scenario where the env override forces
+    /// IndependentScope but dbus / systemd-run is absent (ENOENT at exec time).
+    #[test]
+    fn test_daemon_spawn_falls_back_to_direct_when_scope_spawn_fails() {
+        let _env_guard = force_independent_scope_for_test();
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session_dir = tmp.path().join("session-fallback");
+        let wrapper = write_wrapper_script(tmp.path(), "wrapper-fallback.sh");
+
+        // Replace PATH with the (empty) tmp dir so that `systemd-run` cannot be
+        // resolved, causing cmd.spawn() to return Err(NotFound) and triggering
+        // the retry path.  The csa_binary uses an absolute path so no PATH
+        // lookup is needed for the Direct-mode retry.
+        let original_path = std::env::var("PATH").unwrap_or_default();
+        // SAFETY: test serialises env mutation via DAEMON_SCOPE_ENV_LOCK.
+        unsafe {
+            std::env::set_var("PATH", tmp.path().as_os_str());
+        }
+
+        let config = DaemonSpawnConfig {
+            session_id: "TEST_FALLBACK".to_string(),
+            session_dir: session_dir.clone(),
+            csa_binary: wrapper,
+            subcommand: "run".to_string(),
+            args: vec!["--".to_string(), "echo scope-fallback-ok".to_string()],
+            env: HashMap::new(),
+        };
+
+        let result = spawn_daemon(config);
+
+        // Restore PATH before asserting so it is always restored even on failure.
+        // SAFETY: restoring the saved value.
+        unsafe {
+            std::env::set_var("PATH", original_path);
+        }
+
+        let result = result.expect("spawn_daemon should succeed via direct fallback");
+        assert!(result.pid > 0);
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let contents = std::fs::read_to_string(session_dir.join("stdout.log"))
+            .expect("stdout.log must exist after daemon spawn");
+        assert!(
+            contents.contains("scope-fallback-ok"),
+            "expected 'scope-fallback-ok' in stdout (direct fallback output), got: {contents:?}"
         );
     }
 

--- a/crates/csa-resource/src/lib.rs
+++ b/crates/csa-resource/src/lib.rs
@@ -25,4 +25,4 @@ pub use guard::{ResourceGuard, ResourceLimits};
 pub use isolation_plan::{EnforcementMode, IsolationPlan, IsolationPlanBuilder};
 pub use landlock::apply_landlock_rules;
 pub use rlimit::apply_rlimits;
-pub use sandbox::{ResourceCapability, detect_resource_capability};
+pub use sandbox::{ResourceCapability, detect_resource_capability, has_systemd_user_scope};

--- a/crates/csa-resource/src/sandbox.rs
+++ b/crates/csa-resource/src/sandbox.rs
@@ -62,7 +62,10 @@ fn has_cgroup_v2() -> bool {
 /// that the systemd user instance is available and scope creation works.
 /// Previously used `--dry-run` which requires systemd >= 253 (not 236 as
 /// documented) and silently fails on older versions like Debian 12 (systemd 252).
-fn has_systemd_user_scope() -> bool {
+///
+/// Returns `false` when dbus is unavailable (e.g., nested CSA subprocesses
+/// running inside a bwrap/Landlock sandbox without a user bus socket).
+pub fn has_systemd_user_scope() -> bool {
     Command::new("systemd-run")
         .args(["--user", "--scope", "--quiet", "/bin/true"])
         .stdin(std::process::Stdio::null())


### PR DESCRIPTION
## Summary
- Adds probe-first check in `daemon_spawn_mode()`: verifies `systemd-run --user --scope` is functional before choosing `IndependentScope` mode
- Adds spawn-retry fallback in `spawn_daemon()`: if scope spawn fails at exec time, retries with `Direct` mode
- Makes `has_systemd_user_scope()` public in `csa-resource` for cross-crate access
- Adds test `test_daemon_spawn_falls_back_to_direct_when_scope_spawn_fails`

Closes #1402
Closes #1405

## Test plan
- [ ] `cargo test -p csa-process -- daemon` passes including new fallback test
- [ ] Run `csa review` from inside a CSA subprocess (Layer 1 Employee) — should degrade gracefully instead of failing with dbus error

🤖 Generated with [Claude Code](https://claude.com/claude-code)