### PR TITLE
fix(csa-scheduler): exclude write-restricted tools from csa run tier races (#1410)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.718"
+version = "0.1.719"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.718"
+version = "0.1.719"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -330,7 +330,9 @@ pub(crate) async fn handle_run(
         pipeline::resolve_effective_idle_timeout_seconds(config.as_ref(), idle_timeout, timeout)
     };
     let run_started_at = Instant::now();
-    let needs_edit = task_needs_edit.unwrap_or(false);
+    // csa run is a write operation by default: exclude read-only tools from tier races
+    // unless the prompt explicitly indicates a read-only task.
+    let needs_edit = task_needs_edit.unwrap_or(true);
     let strategy_result = resolve_tool_by_strategy(
         &strategy,
         model_spec.as_deref(),

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -88,7 +88,7 @@ pub(crate) fn validate_model_spec_tier_conflict(
 /// - model: optional model string (from CLI, with alias resolution applied)
 ///
 /// When tool is None, uses tier-based round-robin selection.
-/// `needs_edit`: when true, filters out tools with `allow_edit_existing_files = false`.
+/// `needs_edit`: when true, excludes tools with any write restriction (allow_edit_existing_files or allow_write_new_files false).
 /// `tool_is_auto_resolved`: when true, the `tool` param was auto-selected (not user CLI),
 ///   so it should not trigger tier enforcement blocking.
 pub(crate) fn resolve_tool_and_model(
@@ -317,14 +317,13 @@ pub(crate) fn resolve_tool_and_model(
                 .map(|c| c.resolve_alias(m))
                 .unwrap_or_else(|| m.to_string())
         });
-        // Try round-robin rotation first (needs project root to persist state)
-        if let Ok(Some((tool_name_str, tier_model_spec))) =
-            csa_scheduler::resolve_tier_tool_rotated(cfg, "default", project_root, needs_edit)
-        {
-            let tool_name = parse_tool_name(&tool_name_str)?;
-            return Ok((tool_name, Some(tier_model_spec), resolved_model));
+        // Round-robin rotation; write-restriction errors propagate, I/O errors fall through.
+        match csa_scheduler::resolve_tier_tool_rotated(cfg, "default", project_root, needs_edit) {
+            Ok(Some((s, spec))) => return Ok((parse_tool_name(&s)?, Some(spec), resolved_model)),
+            Err(e) if csa_scheduler::is_no_writable_tier_tool_error(&e) => return Err(e),
+            _ => {}
         }
-        // Fallback: original non-rotating selection (also respects edit restrictions)
+        // Fallback: original non-rotating selection (also respects write restrictions)
         if let Some((tool_name_str, tier_model_spec)) =
             cfg.resolve_tier_tool_filtered("default", needs_edit)
         {

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -592,10 +592,10 @@ impl ProjectConfig {
         self.resolve_tier_tool_filtered(task_type, false)
     }
 
-    /// Resolve tier-based tool selection with edit restriction filtering.
+    /// Resolve tier-based tool selection with write restriction filtering.
     ///
-    /// When `needs_edit` is true, skips tools whose
-    /// `restrictions.allow_edit_existing_files` is `false`.
+    /// When `needs_edit` is true, skips tools that are not fully write-capable
+    /// (i.e., tools where `allow_edit_existing_files` or `allow_write_new_files` is false).
     pub fn resolve_tier_tool_filtered(
         &self,
         task_type: &str,
@@ -627,7 +627,7 @@ impl ProjectConfig {
             if !self.is_tool_enabled(tool_name) {
                 continue;
             }
-            if needs_edit && !self.can_tool_edit_existing(tool_name) {
+            if needs_edit && !self.is_tool_write_capable(tool_name) {
                 continue;
             }
             return Some((tool_name.to_string(), model_spec_str.clone()));

--- a/crates/csa-config/src/config_runtime.rs
+++ b/crates/csa-config/src/config_runtime.rs
@@ -311,6 +311,15 @@ impl ProjectConfig {
         !self.can_tool_edit_existing(tool) && !self.can_tool_write_new(tool)
     }
 
+    /// Returns true when the tool has no write restrictions at all.
+    ///
+    /// A tool is write-capable only if both `allow_edit_existing_files` and
+    /// `allow_write_new_files` are true (or absent, which defaults to true).
+    /// Tools that fail either check are excluded from `csa run` tier races.
+    pub fn is_tool_write_capable(&self, tool: &str) -> bool {
+        self.can_tool_edit_existing(tool) && self.can_tool_write_new(tool)
+    }
+
     /// Returns the writable paths for a tool's filesystem sandbox.
     ///
     /// Priority chain (REPLACE semantics):

--- a/crates/csa-scheduler/src/lib.rs
+++ b/crates/csa-scheduler/src/lib.rs
@@ -13,7 +13,7 @@ pub use failover::{FailoverAction, FallbackChain, decide_failover};
 pub use rate_limit::{
     RateLimitDetected, detect_rate_limit, requires_init_failure_window, within_init_failure_window,
 };
-pub use rotation::resolve_tier_tool_rotated;
+pub use rotation::{is_no_writable_tier_tool_error, resolve_tier_tool_rotated};
 pub use seed_session::{
     SeedCandidate, evict_excess_seeds, find_seed_session, find_seed_session_for_native_fork,
     is_seed_valid,

--- a/crates/csa-scheduler/src/rotation.rs
+++ b/crates/csa-scheduler/src/rotation.rs
@@ -36,8 +36,10 @@ pub struct RotationState {
 /// tier are disabled or filtered out.
 ///
 /// `task_type` is used to look up the tier via `tier_mapping` (falls back
-/// to tier3).  `needs_edit` filters out tools whose `allow_edit_existing_files`
-/// restriction is false.
+/// to tier3).  `needs_edit` filters out tools that are not fully write-capable
+/// (either `allow_edit_existing_files = false` or `allow_write_new_files = false`).
+/// Returns `Err` when `needs_edit` is true and all enabled tools in the tier have
+/// write restrictions — the caller should surface this as a hard error.
 pub fn resolve_tier_tool_rotated(
     config: &ProjectConfig,
     task_type: &str,
@@ -71,8 +73,10 @@ pub fn resolve_tier_tool_rotated(
             if !config.is_tool_enabled(tool_name) {
                 return None;
             }
-            // Skip tools that can't edit when editing is needed
-            if needs_edit && !config.can_tool_edit_existing(tool_name) {
+            // Skip tools that are not fully write-capable when writing is needed.
+            // A tool must have both allow_edit_existing_files and allow_write_new_files
+            // set to true (or absent) to qualify for csa run races.
+            if needs_edit && !config.is_tool_write_capable(tool_name) {
                 return None;
             }
             Some((i, tool_name.to_string(), spec.clone()))
@@ -80,6 +84,25 @@ pub fn resolve_tier_tool_rotated(
         .collect();
 
     if eligible.is_empty() {
+        // When needs_edit is true and there are enabled tools that were filtered
+        // out due to write restrictions, return a clear error instead of silently
+        // falling through — the caller cannot fix this by trying a fallback.
+        if needs_edit {
+            let has_enabled_write_restricted = tier.models.iter().any(|spec| {
+                let t = spec.split('/').next().unwrap_or("");
+                config.is_tool_enabled(t) && !config.is_tool_write_capable(t)
+            });
+            if has_enabled_write_restricted {
+                return Err(anyhow::anyhow!(
+                    "No writable tool available in tier '{}': all enabled tools have write \
+                     restrictions (allow_edit_existing_files = false or \
+                     allow_write_new_files = false). \
+                     Check [tools.<name>.restrictions] in your config, or use \
+                     --force to bypass tier routing.",
+                    tier_name
+                ));
+            }
+        }
         return Ok(None);
     }
 
@@ -138,6 +161,14 @@ pub fn resolve_tier_tool_rotated(
     })?;
 
     Ok(result)
+}
+
+/// Returns true when the error was produced because all enabled tier tools have write restrictions.
+///
+/// Callers that need to distinguish this hard error from "no tier configured" (which is
+/// `Ok(None)`) should use this predicate rather than matching on error message strings.
+pub fn is_no_writable_tier_tool_error(e: &anyhow::Error) -> bool {
+    e.to_string().contains("No writable tool available in tier")
 }
 
 /// Resolve tier name from task_type via config tier_mapping, with fallback.

--- a/crates/csa-scheduler/src/rotation_tests_tail.rs
+++ b/crates/csa-scheduler/src/rotation_tests_tail.rs
@@ -428,16 +428,166 @@ fn test_rotated_skips_restricted_tool_when_needs_edit() {
 }
 
 #[test]
-fn test_rotated_returns_none_when_all_restricted_and_needs_edit() {
+fn test_rotated_returns_err_when_all_restricted_and_needs_edit() {
     let temp = tempdir().unwrap();
     let config = make_config_with_restrictions(
         vec!["gemini-cli/google/gemini-2.5-pro/0"],
         vec!["gemini-cli"],
     );
 
-    let result = resolve_tier_tool_rotated(&config, "default", temp.path(), true).unwrap();
+    let result = resolve_tier_tool_rotated(&config, "default", temp.path(), true);
     assert!(
-        result.is_none(),
-        "Should return None when only tool is restricted and needs_edit"
+        result.is_err(),
+        "Should return Err when only tool is write-restricted and needs_edit"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("No writable tool available in tier"),
+        "Error should identify the write-restriction cause: {err_msg}"
+    );
+}
+
+#[test]
+fn test_rotated_err_when_fully_readonly_and_needs_edit() {
+    let temp = tempdir().unwrap();
+    // Simulate user config with both write restrictions set to false
+    let mut tools = HashMap::new();
+    tools.insert(
+        "gemini-cli".to_string(),
+        ToolConfig {
+            restrictions: Some(ToolRestrictions {
+                allow_edit_existing_files: false,
+                allow_write_new_files: false,
+            }),
+            ..Default::default()
+        },
+    );
+    let mut tiers = HashMap::new();
+    use csa_config::TierConfig;
+    tiers.insert(
+        "tier3".to_string(),
+        TierConfig {
+            description: "test tier".to_string(),
+            models: vec!["gemini-cli/google/gemini-2.5-pro/0".to_string()],
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    let mut tier_mapping = HashMap::new();
+    tier_mapping.insert("default".to_string(), "tier3".to_string());
+    use csa_config::ProjectMeta;
+    let config = ProjectConfig {
+        schema_version: 1,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: Default::default(),
+        acp: Default::default(),
+        tools,
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping,
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        github: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    let result = resolve_tier_tool_rotated(&config, "default", temp.path(), true);
+    assert!(
+        result.is_err(),
+        "Should return Err when gemini-cli has both write restrictions false"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("No writable tool available in tier"),
+        "Error should mention no writable tool: {err_msg}"
+    );
+    assert!(
+        err_msg.contains("allow_edit_existing_files = false or allow_write_new_files = false"),
+        "Error should mention the specific restrictions: {err_msg}"
+    );
+}
+
+#[test]
+fn test_rotated_ok_when_all_restricted_but_no_edit_needed() {
+    let temp = tempdir().unwrap();
+    let _xdg = ScopedXdgOverride::new(&temp);
+    // Same fully read-only config — but needs_edit=false (csa review / csa debate context)
+    let mut tools = HashMap::new();
+    tools.insert(
+        "gemini-cli".to_string(),
+        ToolConfig {
+            restrictions: Some(ToolRestrictions {
+                allow_edit_existing_files: false,
+                allow_write_new_files: false,
+            }),
+            ..Default::default()
+        },
+    );
+    let mut tiers = HashMap::new();
+    use csa_config::TierConfig;
+    tiers.insert(
+        "tier3".to_string(),
+        TierConfig {
+            description: "test tier".to_string(),
+            models: vec!["gemini-cli/google/gemini-2.5-pro/0".to_string()],
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    let mut tier_mapping = HashMap::new();
+    tier_mapping.insert("default".to_string(), "tier3".to_string());
+    use csa_config::ProjectMeta;
+    let config = ProjectConfig {
+        schema_version: 1,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: Default::default(),
+        acp: Default::default(),
+        tools,
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping,
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        github: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    // needs_edit=false → read-only tools are eligible (csa review/debate context)
+    let result = resolve_tier_tool_rotated(&config, "default", temp.path(), false)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        result.0, "gemini-cli",
+        "Fully read-only tool should be selectable when needs_edit=false"
     );
 }


### PR DESCRIPTION
## Summary
- Filter out tools with write restrictions (`allow_edit_existing_files = false` or `allow_write_new_files = false`) from `csa run` tier races
- Add `is_tool_write_capable()` to `RuntimeConfig` for unified write-capability check
- Return hard error when all enabled tier tools have write restrictions instead of silent fallback
- Add `is_no_writable_tier_tool_error()` predicate for caller-side error classification

Closes #1410

## Test plan
- [x] `test_rotated_returns_err_when_all_restricted_and_needs_edit` — all-readonly tier returns Err
- [x] `test_rotated_err_when_fully_readonly_and_needs_edit` — both restrictions false triggers error
- [x] Existing rotation tests pass (non-restricted tools unaffected)
- [x] `just pre-commit` passes
- [x] CSA review verdict: PASS (session 01KRQJZZZDTPZDQ32DQSX8CF8D)