### PR TITLE
fix(cli-sub-agent): bypass recall read output guard when stdout is piped (#1412)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.719"
+version = "0.1.720"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.719"
+version = "0.1.720"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/recall_cmd.rs
+++ b/crates/cli-sub-agent/src/recall_cmd.rs
@@ -1,7 +1,7 @@
 //! recall_cmd — main-agent session history tracking and xurl-based recovery.
 
 use std::fs::{self, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -148,7 +148,9 @@ fn handle_recall_read(session: &str) -> Result<()> {
     let session_ref = resolve_session_ref(session)?;
     let content = render_session_markdown(&session_ref)?;
 
-    if let Some(message) = output_guard_message(&session_ref.sid, &content) {
+    if std::io::stdout().is_terminal()
+        && let Some(message) = output_guard_message(&session_ref.sid, &content)
+    {
         println!("{message}");
         return Ok(());
     }


### PR DESCRIPTION
## Summary
- Add `std::io::stdout().is_terminal()` check to `handle_recall_read()` so the OUTPUT_TOO_LARGE guard only fires on TTY output
- When stdout is piped (e.g., `csa recall read <sid> | tail -200`), the full content flows through to the pipe consumer
- Fixes the self-contradicting hint that suggested piping to tail while blocking all pipe output

Closes #1412

## Test plan
- [x] Existing `output_guard_triggers_at_threshold` and `output_guard_allows_small_output` tests pass (guard function unchanged)
- [x] `just pre-commit` passes (clippy clean with collapsed if-let)
- [x] CSA review verdict: PASS (session 01KRQKGV4NWK2DZSQXECDHGKFJ)