### PR TITLE
fix(cli-sub-agent): emit dirty-tree hint when review findings reference uncommitted files (#1411)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.720"
+version = "0.1.721"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.720"
+version = "0.1.721"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -32,6 +32,8 @@ use output::{is_worktree_submodule, print_reviewer_outcomes};
 mod bug_class_pipeline;
 #[path = "review_cmd_check_verdict.rs"]
 mod check_verdict;
+#[path = "review_cmd_dirty_tree.rs"]
+mod dirty_tree;
 #[path = "review_cmd_execute.rs"]
 mod execute;
 #[path = "review_cmd_findings_toml.rs"]
@@ -463,6 +465,12 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             &review_meta,
             result.persistable_session_id.as_deref(),
         );
+        if verdict != CLEAN {
+            dirty_tree::maybe_emit_dirty_tree_hint(
+                &project_root,
+                result.persistable_session_id.as_deref(),
+            );
+        }
         mempal::maybe_capture_review_mempal(
             config.as_ref(),
             &global_config,

--- a/crates/cli-sub-agent/src/review_cmd_dirty_tree.rs
+++ b/crates/cli-sub-agent/src/review_cmd_dirty_tree.rs
@@ -1,0 +1,220 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use csa_session::{FindingsFile, get_session_dir};
+use tracing::debug;
+
+/// Returns the set of file paths (relative to project root) that have uncommitted
+/// changes in the working tree, according to `git diff --name-only HEAD`.
+pub(super) fn dirty_files_in_project(project_root: &Path) -> HashSet<String> {
+    let Ok(out) = std::process::Command::new("git")
+        .args(["diff", "--name-only", "HEAD"])
+        .current_dir(project_root)
+        .output()
+    else {
+        return HashSet::new();
+    };
+
+    if !out.status.success() {
+        return HashSet::new();
+    }
+
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
+}
+
+/// Reads `output/findings.toml` from `session_dir` and extracts all referenced file paths,
+/// sorted and deduplicated.
+pub(super) fn finding_file_paths_from_session(session_dir: &Path) -> Vec<String> {
+    let findings_path = session_dir.join("output").join("findings.toml");
+    let content = match std::fs::read_to_string(&findings_path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    match toml::from_str::<FindingsFile>(&content) {
+        Ok(findings_file) => {
+            let mut paths: Vec<String> = findings_file
+                .findings
+                .iter()
+                .flat_map(|f| f.file_ranges.iter().map(|r| r.path.clone()))
+                .collect();
+            paths.sort();
+            paths.dedup();
+            paths
+        }
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Returns finding file paths that appear in `dirty_files`.
+pub(super) fn intersect_dirty_finding_files(
+    finding_paths: &[String],
+    dirty_files: &HashSet<String>,
+) -> Vec<String> {
+    let mut result: Vec<String> = finding_paths
+        .iter()
+        .filter(|p| dirty_files.contains(p.as_str()))
+        .cloned()
+        .collect();
+    result.sort();
+    result
+}
+
+/// Detect finding file paths that have uncommitted changes in the working tree.
+///
+/// Returns an empty vec when no structured file paths are present in findings.toml
+/// or when the working tree is clean.
+pub(super) fn detect_dirty_tree_findings(project_root: &Path, session_dir: &Path) -> Vec<String> {
+    let finding_paths = finding_file_paths_from_session(session_dir);
+    if finding_paths.is_empty() {
+        debug!("No structured file paths in findings.toml; skipping dirty-tree check");
+        return Vec::new();
+    }
+
+    let dirty = dirty_files_in_project(project_root);
+    if dirty.is_empty() {
+        return Vec::new();
+    }
+
+    intersect_dirty_finding_files(&finding_paths, &dirty)
+}
+
+/// Resolve the session dir for `session_id` and emit dirty-tree hints for any findings
+/// that reference uncommitted files. No-op when the session dir cannot be resolved or
+/// when the working tree is clean.
+///
+/// Informational only — does not affect the review verdict.
+pub(super) fn maybe_emit_dirty_tree_hint(project_root: &Path, session_id: Option<&str>) {
+    let Some(session_id) = session_id else { return };
+    let Ok(session_dir) = get_session_dir(project_root, session_id) else {
+        return;
+    };
+    let dirty = detect_dirty_tree_findings(project_root, &session_dir);
+    emit_dirty_tree_hint(&dirty);
+}
+
+/// Emit a dirty-tree hint to stderr for each finding that references an uncommitted file.
+///
+/// Informational only — does not affect the review verdict.
+fn emit_dirty_tree_hint(dirty_finding_files: &[String]) {
+    for file in dirty_finding_files {
+        eprintln!(
+            "⚠ Finding references {file} which has uncommitted changes.\n  \
+             Review is based on committed HEAD, not the working tree.\n  \
+             Consider committing before re-review."
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intersect_dirty_finding_files_returns_overlap() {
+        let finding_paths = vec!["src/main.rs".to_string(), "src/lib.rs".to_string()];
+        let dirty: HashSet<String> = ["src/main.rs", "Cargo.toml"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let result = intersect_dirty_finding_files(&finding_paths, &dirty);
+        assert_eq!(result, vec!["src/main.rs"]);
+    }
+
+    #[test]
+    fn intersect_dirty_finding_files_returns_empty_when_no_overlap() {
+        let finding_paths = vec!["src/foo.rs".to_string()];
+        let dirty: HashSet<String> = ["src/bar.rs"].iter().map(|s| s.to_string()).collect();
+        let result = intersect_dirty_finding_files(&finding_paths, &dirty);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn intersect_dirty_finding_files_empty_inputs() {
+        let empty_dirty: HashSet<String> = HashSet::new();
+        assert!(intersect_dirty_finding_files(&[], &empty_dirty).is_empty());
+        assert!(
+            intersect_dirty_finding_files(&[], &["a.rs".to_string()].into_iter().collect())
+                .is_empty()
+        );
+        assert!(intersect_dirty_finding_files(&["a.rs".to_string()], &HashSet::new()).is_empty());
+    }
+
+    #[test]
+    fn finding_file_paths_extracts_sorted_deduped_paths() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let output_dir = tmp.path().join("output");
+        std::fs::create_dir_all(&output_dir).expect("create output dir");
+
+        let findings_toml = r#"
+[[findings]]
+id = "R01"
+severity = "high"
+description = "test finding"
+
+[[findings.file_ranges]]
+path = "crates/foo/src/lib.rs"
+start = 10
+
+[[findings.file_ranges]]
+path = "crates/bar/src/main.rs"
+start = 5
+
+[[findings]]
+id = "R02"
+severity = "medium"
+description = "another finding"
+
+[[findings.file_ranges]]
+path = "crates/foo/src/lib.rs"
+start = 42
+end = 50
+"#;
+        std::fs::write(output_dir.join("findings.toml"), findings_toml)
+            .expect("write findings.toml");
+
+        let paths = finding_file_paths_from_session(tmp.path());
+        assert_eq!(
+            paths,
+            vec!["crates/bar/src/main.rs", "crates/foo/src/lib.rs"]
+        );
+    }
+
+    #[test]
+    fn finding_file_paths_returns_empty_when_no_findings_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let paths = finding_file_paths_from_session(tmp.path());
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn finding_file_paths_returns_empty_when_no_file_ranges() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let output_dir = tmp.path().join("output");
+        std::fs::create_dir_all(&output_dir).expect("create output dir");
+
+        let findings_toml = r#"
+[[findings]]
+id = "R01"
+severity = "high"
+description = "finding with no file ranges"
+"#;
+        std::fs::write(output_dir.join("findings.toml"), findings_toml)
+            .expect("write findings.toml");
+
+        let paths = finding_file_paths_from_session(tmp.path());
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn detect_dirty_tree_findings_returns_empty_when_findings_toml_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // No findings.toml written — session_dir has no output/findings.toml
+        let result = detect_dirty_tree_findings(tmp.path(), tmp.path());
+        assert!(result.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `review_cmd_dirty_tree` module that detects when review findings reference files with uncommitted changes
- After findings are processed, check `git diff --name-only` against finding file paths
- Emit diagnostic warning to stderr when overlap is found, preventing the "I read the file and it looks fine" false-positive trap
- Warning is informational only — does not change review verdict

Closes #1411

## Test plan
- [x] New module with unit tests for dirty-tree detection logic
- [x] `just pre-commit` passes
- [x] CSA review verdict: PASS (session 01KRQP2792N6HE9WYDYTRVN3HJ)