### PR TITLE
fix(cli-sub-agent): gc evicts orphan slot locks with session_id=null (#1414)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.721"
+version = "0.1.722"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.721"
+version = "0.1.722"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -32,6 +32,12 @@ const RETIRE_AFTER_DAYS: i64 = 7;
 const STATE_DIR_SIZE_CACHE_FILENAME: &str = ".size-cache.toml";
 const RUNTIME_DIR_NAME: &str = "runtime";
 
+/// Grace period in seconds for newly-acquired slot locks with no session_id.
+///
+/// A lock is considered an orphan only after this window has passed; within it
+/// the process may still be mid-initialization and hasn't associated a session yet.
+const ORPHAN_SLOT_GRACE_SECS: i64 = 30;
+
 pub(crate) type RuntimeReapStats = reaper::RuntimeReapStats;
 
 pub(crate) fn handle_gc(
@@ -242,6 +248,7 @@ pub(crate) fn handle_gc(
     }
 
     let mut stale_slots_cleaned = 0;
+    let mut orphan_slots_cleaned = 0;
     if let Ok(slots_dir) = GlobalConfig::slots_dir()
         && slots_dir.exists()
         && let Ok(entries) = fs::read_dir(&slots_dir)
@@ -252,11 +259,20 @@ pub(crate) fn handle_gc(
                 if let Ok(slot_entries) = fs::read_dir(&tool_dir) {
                     for slot_entry in slot_entries.flatten() {
                         let path = slot_entry.path();
-                        if path.extension().is_some_and(|ext| ext == "lock")
-                            && let Ok(content) = fs::read_to_string(&path)
-                            && let Some(pid) = extract_pid_from_lock(&content)
-                            && !is_process_alive(pid)
-                        {
+                        if path.extension().is_none_or(|ext| ext != "lock") {
+                            continue;
+                        }
+                        let Ok(content) = fs::read_to_string(&path) else {
+                            continue;
+                        };
+                        let Some((pid, session_id_is_null, acquired_at)) =
+                            extract_slot_lock_info(&content)
+                        else {
+                            continue;
+                        };
+
+                        if !is_process_alive(pid) {
+                            // Dead PID — remove the stale slot file.
                             if dry_run {
                                 eprintln!(
                                     "[dry-run] Would clean stale slot: {:?} (dead PID {})",
@@ -271,6 +287,59 @@ pub(crate) fn handle_gc(
                                     pid
                                 );
                                 stale_slots_cleaned += 1;
+                            }
+                        } else if session_id_is_null {
+                            // PID is alive but slot has no session_id — orphan daemon from
+                            // a failed session launch that permanently occupies the slot.
+                            // Respect grace period: skip very recent locks that may be
+                            // mid-initialization and haven't associated a session yet.
+                            let age_secs = acquired_at
+                                .map(|at| {
+                                    chrono::Utc::now().signed_duration_since(at).num_seconds()
+                                })
+                                .unwrap_or(i64::MAX);
+                            if age_secs < ORPHAN_SLOT_GRACE_SECS {
+                                continue;
+                            }
+                            if dry_run {
+                                eprintln!(
+                                    "[dry-run] Would evict orphan slot: {:?} \
+                                     (alive PID {} with no session_id, age {}s)",
+                                    path.file_name(),
+                                    pid,
+                                    age_secs
+                                );
+                                orphan_slots_cleaned += 1;
+                            } else {
+                                // SIGTERM the orphan process so it can clean up, then remove
+                                // its slot file. flock(2) is per-open-file-description, not
+                                // per-path, so deleting the file lets new sessions create a
+                                // fresh slot immediately even if SIGTERM is slow.
+                                // SAFETY: kill(2) with SIGTERM is safe for any valid PID.
+                                // EPERM means the process exists but we lack permission — log
+                                // and proceed with file removal regardless.
+                                let kill_ret =
+                                    unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+                                if kill_ret != 0 {
+                                    let errno = std::io::Error::last_os_error();
+                                    warn!(
+                                        pid,
+                                        slot = ?path.file_name(),
+                                        error = %errno,
+                                        "SIGTERM failed for orphan slot PID; removing slot file anyway"
+                                    );
+                                }
+                                // Brief wait for graceful shutdown before removing the file.
+                                std::thread::sleep(std::time::Duration::from_millis(500));
+                                if fs::remove_file(&path).is_ok() {
+                                    warn!(
+                                        pid,
+                                        slot = ?path.file_name(),
+                                        age_secs,
+                                        "Evicted orphan slot lock (alive PID with no session_id)"
+                                    );
+                                    orphan_slots_cleaned += 1;
+                                }
                             }
                         }
                     }
@@ -293,6 +362,7 @@ pub(crate) fn handle_gc(
                 "transcripts_removed": transcript_stats.files_removed,
                 "transcript_bytes_reclaimed": transcript_stats.bytes_reclaimed,
                 "stale_slots_cleaned": stale_slots_cleaned,
+                "orphan_slots_cleaned": orphan_slots_cleaned,
                 "orphan_scopes_cleaned": orphan_scopes_cleaned,
                 "review_gate_markers_removed": review_gate_stats.markers_removed,
             });
@@ -328,6 +398,9 @@ pub(crate) fn handle_gc(
                 prefix, transcript_stats.files_removed, transcript_stats.bytes_reclaimed
             );
             eprintln!("{prefix}  Stale slots cleaned: {stale_slots_cleaned}");
+            if orphan_slots_cleaned > 0 {
+                eprintln!("{prefix}  Orphan slot locks evicted: {orphan_slots_cleaned}");
+            }
             eprintln!("{prefix}  Orphan cgroup scopes cleaned: {orphan_scopes_cleaned}");
             if review_gate_stats.markers_removed > 0 {
                 eprintln!(
@@ -363,6 +436,26 @@ fn extract_pid_from_lock(json_content: &str) -> Option<u32> {
     let v: serde_json::Value = serde_json::from_str(json_content).ok()?;
     let n = v.get("pid")?.as_u64()?;
     u32::try_from(n).ok()
+}
+
+/// Parse a slot lock file's JSON into `(pid, session_id_is_null, acquired_at)`.
+///
+/// `session_id_is_null` is `true` when the `session_id` field is JSON `null` or absent.
+/// `acquired_at` is `None` when the field is absent or unparseable.
+fn extract_slot_lock_info(
+    json_content: &str,
+) -> Option<(u32, bool, Option<chrono::DateTime<chrono::Utc>>)> {
+    let v: serde_json::Value = serde_json::from_str(json_content).ok()?;
+    let pid = u32::try_from(v.get("pid")?.as_u64()?).ok()?;
+    let session_id_is_null = match v.get("session_id") {
+        Some(s) => s.is_null(),
+        None => true, // absent field is treated the same as null
+    };
+    let acquired_at = v
+        .get("acquired_at")
+        .and_then(|t| t.as_str())
+        .and_then(|s| s.parse::<chrono::DateTime<chrono::Utc>>().ok());
+    Some((pid, session_id_is_null, acquired_at))
 }
 
 /// Returns `true` for valid-ULID non-hidden dirs in `sessions/` lacking `state.toml`.

--- a/crates/cli-sub-agent/src/gc_tests.rs
+++ b/crates/cli-sub-agent/src/gc_tests.rs
@@ -85,6 +85,97 @@ fn test_extract_pid_from_lock_overflow_rejected() {
 }
 
 #[test]
+fn test_extract_slot_lock_info_null_session_id() {
+    let json = r#"{"pid":12345,"tool_name":"claude-code","slot_index":0,"acquired_at":"2024-01-01T00:00:00Z","session_id":null}"#;
+    let (pid, session_id_is_null, acquired_at) = extract_slot_lock_info(json).unwrap();
+    assert_eq!(pid, 12345);
+    assert!(session_id_is_null);
+    assert!(acquired_at.is_some());
+}
+
+#[test]
+fn test_extract_slot_lock_info_with_session_id() {
+    let json = r#"{"pid":12345,"tool_name":"claude-code","slot_index":0,"acquired_at":"2024-01-01T00:00:00Z","session_id":"01ABC123DEF456GHJ789KLMNOP"}"#;
+    let (pid, session_id_is_null, _) = extract_slot_lock_info(json).unwrap();
+    assert_eq!(pid, 12345);
+    assert!(!session_id_is_null);
+}
+
+#[test]
+fn test_extract_slot_lock_info_missing_session_id_treated_as_null() {
+    // Absent session_id field is treated the same as JSON null.
+    let json =
+        r#"{"pid":99,"tool_name":"codex","slot_index":1,"acquired_at":"2024-01-01T00:00:00Z"}"#;
+    let (pid, session_id_is_null, _) = extract_slot_lock_info(json).unwrap();
+    assert_eq!(pid, 99);
+    assert!(session_id_is_null);
+}
+
+#[test]
+fn test_extract_slot_lock_info_missing_pid_returns_none() {
+    let json = r#"{"tool_name":"codex","slot_index":0,"acquired_at":"2024-01-01T00:00:00Z","session_id":null}"#;
+    assert!(extract_slot_lock_info(json).is_none());
+}
+
+#[test]
+fn test_extract_slot_lock_info_invalid_json_returns_none() {
+    assert!(extract_slot_lock_info("not json").is_none());
+    assert!(extract_slot_lock_info("").is_none());
+}
+
+#[test]
+fn test_extract_slot_lock_info_missing_acquired_at_is_ok() {
+    // acquired_at absence is tolerated — returns None for the timestamp.
+    let json = r#"{"pid":7,"tool_name":"opencode","slot_index":2,"session_id":null}"#;
+    let (pid, session_id_is_null, acquired_at) = extract_slot_lock_info(json).unwrap();
+    assert_eq!(pid, 7);
+    assert!(session_id_is_null);
+    assert!(acquired_at.is_none());
+}
+
+#[test]
+fn test_orphan_slot_grace_period_within_window() {
+    // A slot acquired 5 seconds ago is inside the 30s grace window and should be skipped.
+    let now = chrono::Utc::now();
+    let recent = (now - chrono::Duration::seconds(5)).to_rfc3339();
+    let json = format!(
+        r#"{{"pid":{},"tool_name":"claude-code","slot_index":0,"acquired_at":"{}","session_id":null}}"#,
+        std::process::id(),
+        recent
+    );
+    let (_, session_id_is_null, acquired_at) = extract_slot_lock_info(&json).unwrap();
+    assert!(session_id_is_null);
+    let age_secs = now
+        .signed_duration_since(acquired_at.unwrap())
+        .num_seconds();
+    assert!(
+        age_secs < ORPHAN_SLOT_GRACE_SECS,
+        "slot acquired {age_secs}s ago is within {ORPHAN_SLOT_GRACE_SECS}s grace window"
+    );
+}
+
+#[test]
+fn test_orphan_slot_grace_period_outside_window() {
+    // A slot acquired 60 seconds ago is outside the grace window and eligible for eviction.
+    let now = chrono::Utc::now();
+    let old = (now - chrono::Duration::seconds(60)).to_rfc3339();
+    let json = format!(
+        r#"{{"pid":{},"tool_name":"claude-code","slot_index":0,"acquired_at":"{}","session_id":null}}"#,
+        std::process::id(),
+        old
+    );
+    let (_, session_id_is_null, acquired_at) = extract_slot_lock_info(&json).unwrap();
+    assert!(session_id_is_null);
+    let age_secs = now
+        .signed_duration_since(acquired_at.unwrap())
+        .num_seconds();
+    assert!(
+        age_secs >= ORPHAN_SLOT_GRACE_SECS,
+        "slot acquired {age_secs}s ago is outside {ORPHAN_SLOT_GRACE_SECS}s grace window"
+    );
+}
+
+#[test]
 fn test_discover_finds_ancestor_and_descendant_roots() {
     let tmp = tempdir().unwrap();
     make_project_root(tmp.path(), &["home", "user"]);


### PR DESCRIPTION
## Summary
- Detect slot locks with `session_id: null` as orphan candidates during `csa gc`
- Dead PID orphans: remove lock file immediately
- Alive PID orphans: SIGTERM the process, then remove lock file
- Grace period: skip locks acquired within 30s (may be mid-initialization)
- Log each cleanup action for diagnostics

Closes #1414

## Test plan
- [x] New `gc_tests` with null-session-id orphan detection scenarios
- [x] `just pre-commit` passes
- [x] CSA review verdict: PASS (session 01KRQQJM9HX6137HQPKE9XF31H)