### PR TITLE
fix(cli-sub-agent): pre-spawn model-tool compat validation (#1413)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.722"
+version = "0.1.723"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.722"
+version = "0.1.723"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::ToolName;
 use csa_executor::{Executor, ModelSpec, ThinkingBudget};
-use csa_session::TokenUsage;
 
 #[path = "run_helpers_atomic_commit.rs"]
 mod atomic_commit;
@@ -13,12 +12,16 @@ mod atomic_commit;
 mod edit_requirement;
 #[path = "run_helpers_inline_review_context.rs"]
 mod inline_review_context;
+#[path = "run_helpers_model_compat.rs"]
+pub(crate) mod model_compat;
 #[path = "run_helpers_prompt.rs"]
 mod prompt;
 #[path = "run_helpers_routing_conflict.rs"]
 mod routing_conflict;
 #[path = "run_helpers_routing_request.rs"]
 mod routing_request;
+#[path = "run_helpers_token_parse.rs"]
+mod token_parse;
 #[path = "run_helpers_tool_availability.rs"]
 mod tool_availability;
 #[cfg(test)]
@@ -34,6 +37,9 @@ pub(crate) use prompt::{
 };
 pub(crate) use routing_conflict::{is_routing_conflict, routing_conflict_error};
 pub(crate) use routing_request::RoutingRequest;
+pub(crate) use token_parse::parse_token_usage;
+#[cfg(test)]
+pub(crate) use token_parse::{extract_cost, extract_number};
 pub(crate) use tool_availability::{
     ToolBinaryAvailability, is_tool_binary_available_for_config, resolved_claude_code_transport,
     resolved_codex_transport, resolved_tool_binary_name, tool_binary_availability,
@@ -291,6 +297,14 @@ pub(crate) fn resolve_tool_and_model(
                 model_name_for_tier_validation(resolved_model.as_deref()),
             )?;
         }
+        // Pre-spawn compatibility check: catch known-incompatible model/tool combinations
+        // before a session is spawned (e.g. o4-mini with codex ChatGPT accounts).
+        // Skipped when the model matches the tool's configured default_model.
+        if let Some(ref m) = resolved_model {
+            let configured_default =
+                config.and_then(|cfg| cfg.tool_default_model(tool_name.as_str()));
+            model_compat::validate_tool_model_compat(tool_name, m, configured_default)?;
+        }
         return Ok((tool_name, None, resolved_model));
     }
 
@@ -483,104 +497,6 @@ pub(crate) fn truncate_prompt(s: &str, max_len: usize) -> String {
 
         format!("{substring}...")
     }
-}
-
-/// Parse token usage from tool output (best-effort, returns None on failure).
-///
-/// Looks for common patterns in stdout/stderr:
-/// - "tokens: N" or "Tokens: N" or "total_tokens: N"
-/// - "input_tokens: N" / "output_tokens: N"
-/// - "cost: $N.NN" or "estimated_cost: $N.NN"
-pub(crate) fn parse_token_usage(output: &str) -> Option<TokenUsage> {
-    let mut usage = TokenUsage::default();
-    let mut found_any = false;
-
-    // Simple pattern matching without regex
-    for line in output.lines() {
-        let line_lower = line.to_lowercase();
-
-        // Parse input_tokens
-        if let Some(pos) = line_lower.find("input_tokens")
-            && let Some(val) = extract_number(&line[pos..])
-        {
-            usage.input_tokens = Some(val);
-            found_any = true;
-        }
-
-        // Parse output_tokens
-        if let Some(pos) = line_lower.find("output_tokens")
-            && let Some(val) = extract_number(&line[pos..])
-        {
-            usage.output_tokens = Some(val);
-            found_any = true;
-        }
-
-        // Parse total_tokens
-        if let Some(pos) = line_lower.find("total_tokens") {
-            if let Some(val) = extract_number(&line[pos..]) {
-                usage.total_tokens = Some(val);
-                found_any = true;
-            }
-        } else if let Some(pos) = line_lower.find("tokens:") {
-            // Only match standalone "tokens:" — skip if preceded by a letter or
-            // underscore (e.g. "input_tokens:" or "output_tokens:" already
-            // handled above).
-            let prev = line_lower.as_bytes().get(pos.wrapping_sub(1)).copied();
-            let is_standalone = pos == 0 || !matches!(prev, Some(b'a'..=b'z' | b'A'..=b'Z' | b'_'));
-            if is_standalone && let Some(val) = extract_number(&line[pos..]) {
-                usage.total_tokens = Some(val);
-                found_any = true;
-            }
-        }
-
-        // Parse cost (look for "$N.NN" pattern)
-        if line_lower.contains("cost")
-            && let Some(val) = extract_cost(line)
-        {
-            usage.estimated_cost_usd = Some(val);
-            found_any = true;
-        }
-    }
-
-    // Calculate total_tokens if not found but input/output are available
-    if usage.total_tokens.is_none()
-        && let (Some(input), Some(output)) = (usage.input_tokens, usage.output_tokens)
-    {
-        usage.total_tokens = Some(input + output);
-        found_any = true;
-    }
-
-    if found_any { Some(usage) } else { None }
-}
-
-/// Extract a number after colon or equals sign.
-fn extract_number(text: &str) -> Option<u64> {
-    // Find colon or equals
-    let start = text.find(':')?;
-    let after_colon = &text[start + 1..];
-
-    // Take first word after colon
-    let num_str: String = after_colon
-        .chars()
-        .skip_while(|c| c.is_whitespace())
-        .take_while(|c| c.is_ascii_digit())
-        .collect();
-
-    num_str.parse().ok()
-}
-
-/// Extract cost value after $ sign.
-fn extract_cost(text: &str) -> Option<f64> {
-    let start = text.find('$')?;
-    let after_dollar = &text[start + 1..];
-
-    // Take digits and decimal point
-    let num_str: String = after_dollar
-        .chars()
-        .take_while(|c| c.is_ascii_digit() || *c == '.')
-        .collect();
-
-    num_str.parse().ok()
 }
 
 /// Result of resolving a tool from a tier's models list.
@@ -784,6 +700,10 @@ mod transport_tests;
 #[cfg(test)]
 #[path = "run_helpers_model_spec_tests.rs"]
 mod model_spec_tests;
+
+#[cfg(test)]
+#[path = "run_helpers_compat_tests.rs"]
+mod compat_tests;
 
 #[cfg(test)]
 #[path = "run_helpers_override_tests.rs"]

--- a/crates/cli-sub-agent/src/run_helpers_compat_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_compat_tests.rs
@@ -1,0 +1,247 @@
+use csa_core::types::ToolName;
+
+use super::model_compat::{
+    CODEX_CHATGPT_COMPATIBLE_MODELS, CODEX_CHATGPT_INCOMPATIBLE_MODELS, validate_tool_model_compat,
+};
+
+// --- unit tests for validate_tool_model_compat ---
+
+#[test]
+fn codex_rejects_o4_mini() {
+    let err = validate_tool_model_compat(ToolName::Codex, "o4-mini", None).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("'o4-mini' is not supported"),
+        "expected incompatibility message, got: {msg}"
+    );
+    assert!(
+        msg.contains("ChatGPT account"),
+        "expected ChatGPT mention: {msg}"
+    );
+    assert!(
+        msg.contains("gpt-5.5"),
+        "expected compatible model hint: {msg}"
+    );
+    assert!(
+        msg.contains("default_model"),
+        "expected suppression hint: {msg}"
+    );
+}
+
+#[test]
+fn codex_rejects_o4_mini_with_thinking_suffix() {
+    // "o4-mini/high" has base model "o4-mini" — still incompatible.
+    let err = validate_tool_model_compat(ToolName::Codex, "o4-mini/high", None).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("is not supported"),
+        "thinking suffix should not bypass check: {msg}"
+    );
+}
+
+#[test]
+fn codex_accepts_o4_mini_high_as_distinct_model() {
+    // "o4-mini-high" uses a hyphen, not a slash — it is a different model, not
+    // "o4-mini" with a thinking budget.
+    let result = validate_tool_model_compat(ToolName::Codex, "o4-mini-high", None);
+    assert!(
+        result.is_ok(),
+        "o4-mini-high is a distinct model and should be accepted: {result:?}"
+    );
+}
+
+#[test]
+fn codex_accepts_all_known_compatible_models() {
+    for &model in CODEX_CHATGPT_COMPATIBLE_MODELS {
+        let result = validate_tool_model_compat(ToolName::Codex, model, None);
+        assert!(
+            result.is_ok(),
+            "known-compatible model '{model}' was rejected: {result:?}"
+        );
+    }
+}
+
+#[test]
+fn codex_bypasses_check_when_model_matches_configured_default() {
+    // User explicitly configured o4-mini as default_model → accept it.
+    let result = validate_tool_model_compat(ToolName::Codex, "o4-mini", Some("o4-mini"));
+    assert!(
+        result.is_ok(),
+        "configured default_model should bypass compatibility check: {result:?}"
+    );
+}
+
+#[test]
+fn codex_bypasses_check_when_default_model_has_thinking_suffix() {
+    // default_model = "o4-mini/high" → base is "o4-mini" → matches "o4-mini".
+    let result = validate_tool_model_compat(ToolName::Codex, "o4-mini", Some("o4-mini/high"));
+    assert!(
+        result.is_ok(),
+        "default_model with thinking suffix should bypass check: {result:?}"
+    );
+}
+
+#[test]
+fn codex_bypasses_check_when_model_has_suffix_and_default_does_not() {
+    // model = "o4-mini/high", default_model = "o4-mini" → bases both "o4-mini" → bypass.
+    let result = validate_tool_model_compat(ToolName::Codex, "o4-mini/high", Some("o4-mini"));
+    assert!(
+        result.is_ok(),
+        "model with thinking suffix should match plain default_model: {result:?}"
+    );
+}
+
+#[test]
+fn non_codex_tools_accept_o4_mini_without_restriction() {
+    for tool in [
+        ToolName::ClaudeCode,
+        ToolName::GeminiCli,
+        ToolName::Opencode,
+    ] {
+        let result = validate_tool_model_compat(tool, "o4-mini", None);
+        assert!(
+            result.is_ok(),
+            "tool {tool:?} should have no model restrictions: {result:?}"
+        );
+    }
+}
+
+#[test]
+fn incompatible_models_list_is_non_empty() {
+    assert!(
+        !CODEX_CHATGPT_INCOMPATIBLE_MODELS.is_empty(),
+        "incompatible models list must not be empty"
+    );
+}
+
+#[test]
+fn compatible_models_list_is_non_empty() {
+    assert!(
+        !CODEX_CHATGPT_COMPATIBLE_MODELS.is_empty(),
+        "compatible models hint list must not be empty"
+    );
+}
+
+// --- integration tests via resolve_tool_and_model ---
+
+#[test]
+fn resolve_tool_and_model_rejects_incompatible_codex_model() {
+    // With no tiers configured, an explicit --tool codex --model o4-mini
+    // should fail with a compatibility error before session spawn.
+    let result = super::resolve_tool_and_model(super::RoutingRequest {
+        tool: Some(ToolName::Codex),
+        model: Some("o4-mini"),
+        thinking: Some("medium"),
+        ..super::RoutingRequest::new(std::path::Path::new("/tmp"))
+    });
+    assert!(result.is_err(), "should fail for incompatible model");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("is not supported"),
+        "expected compat error: {msg}"
+    );
+}
+
+#[test]
+fn resolve_tool_and_model_rejects_incompatible_model_with_force_ignore_tier() {
+    use super::tier_tests::config_with_tier;
+
+    let _guard =
+        crate::test_env_lock::ScopedTestEnvVar::set(super::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let cfg = config_with_tier("tier-1", vec!["codex/openai/gpt-5.5/high"], &["codex"]);
+
+    // --force-ignore-tier-setting with incompatible model should still fail.
+    let result = super::resolve_tool_and_model(super::RoutingRequest {
+        tool: Some(ToolName::Codex),
+        model: Some("o4-mini"),
+        thinking: Some("medium"),
+        config: Some(&cfg),
+        force_ignore_tier_setting: true,
+        ..super::RoutingRequest::new(std::path::Path::new("/tmp"))
+    });
+    assert!(result.is_err(), "should fail for incompatible model");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("is not supported"),
+        "expected compat error: {msg}"
+    );
+}
+
+#[test]
+fn resolve_tool_and_model_accepts_compatible_codex_model_with_force_ignore_tier() {
+    use super::tier_tests::config_with_tier;
+
+    let _guard =
+        crate::test_env_lock::ScopedTestEnvVar::set(super::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let cfg = config_with_tier("tier-1", vec!["codex/openai/gpt-5.5/high"], &["codex"]);
+
+    let result = super::resolve_tool_and_model(super::RoutingRequest {
+        tool: Some(ToolName::Codex),
+        model: Some("gpt-5.5"),
+        thinking: Some("high"),
+        config: Some(&cfg),
+        force_ignore_tier_setting: true,
+        ..super::RoutingRequest::new(std::path::Path::new("/tmp"))
+    });
+    assert!(result.is_ok(), "gpt-5.5 should be accepted: {result:?}");
+    let (tool, _, model) = result.unwrap();
+    assert_eq!(tool, ToolName::Codex);
+    assert_eq!(model.as_deref(), Some("gpt-5.5"));
+}
+
+#[test]
+fn resolve_tool_and_model_skips_compat_check_when_configured_default() {
+    use csa_config::{ProjectConfig, ToolConfig};
+    use std::collections::HashMap;
+
+    let _guard =
+        crate::test_env_lock::ScopedTestEnvVar::set(super::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+
+    // Build a config where codex has default_model = "o4-mini".
+    let mut tools = HashMap::new();
+    tools.insert(
+        "codex".to_string(),
+        ToolConfig {
+            enabled: true,
+            default_model: Some("o4-mini".to_string()),
+            ..Default::default()
+        },
+    );
+    let cfg = ProjectConfig {
+        schema_version: csa_config::config::CURRENT_SCHEMA_VERSION,
+        project: Default::default(),
+        resources: Default::default(),
+        acp: Default::default(),
+        tools,
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        github: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    // Even though "o4-mini" is ordinarily incompatible, configured default bypasses the check.
+    let result = super::resolve_tool_and_model(super::RoutingRequest {
+        tool: Some(ToolName::Codex),
+        model: Some("o4-mini"),
+        thinking: Some("medium"),
+        config: Some(&cfg),
+        ..super::RoutingRequest::new(std::path::Path::new("/tmp"))
+    });
+    assert!(
+        result.is_ok(),
+        "configured default_model should bypass compat check: {result:?}"
+    );
+}

--- a/crates/cli-sub-agent/src/run_helpers_model_compat.rs
+++ b/crates/cli-sub-agent/src/run_helpers_model_compat.rs
@@ -1,0 +1,64 @@
+//! Pre-spawn model-tool compatibility validation.
+//!
+//! Catches known-incompatible model selections before a session is spawned,
+//! saving tokens and surfacing a clear error rather than a cryptic runtime
+//! failure. This is primarily a safety net for `--force-ignore-tier-setting`,
+//! where tier configuration would otherwise guarantee a compatible model.
+
+use anyhow::Result;
+use csa_core::types::ToolName;
+use csa_executor::ThinkingBudget;
+
+/// Codex ChatGPT-account-incompatible models.
+///
+/// These are rejected by codex when using a ChatGPT subscription rather than
+/// an OpenAI API key. The codex CLI surfaces this at runtime:
+/// "The '<model>' model is not supported when using Codex with a ChatGPT account."
+pub(crate) const CODEX_CHATGPT_INCOMPATIBLE_MODELS: &[&str] = &["o4-mini"];
+
+/// Well-known codex ChatGPT-account-compatible models, listed in error hints.
+pub(crate) const CODEX_CHATGPT_COMPATIBLE_MODELS: &[&str] =
+    &["gpt-5.5", "o3", "o4-mini-high", "gpt-4.1", "gpt-4o"];
+
+/// Validate that `model` is compatible with `tool` before spawning a session.
+///
+/// Thinking-budget suffixes (e.g. `/high`) are stripped before comparison so
+/// both `o4-mini` and `o4-mini/high` are caught, while `o4-mini-high` (a
+/// distinct model with no `/` suffix) is accepted.
+///
+/// When `default_model` matches the base model name, validation is skipped —
+/// an explicit `[tools.<name>].default_model` in user config signals intentional
+/// use, and the user accepts the consequence.
+pub(crate) fn validate_tool_model_compat(
+    tool: ToolName,
+    model: &str,
+    default_model: Option<&str>,
+) -> Result<()> {
+    let (base_model, _) = ThinkingBudget::try_split_from_model(model);
+
+    // When the model matches the tool's configured default, skip validation.
+    if default_model.is_some_and(|dm| {
+        let (dm_base, _) = ThinkingBudget::try_split_from_model(dm);
+        dm_base == base_model
+    }) {
+        return Ok(());
+    }
+
+    match tool {
+        ToolName::Codex => validate_codex_model_compat(base_model),
+        _ => Ok(()),
+    }
+}
+
+fn validate_codex_model_compat(model: &str) -> Result<()> {
+    if CODEX_CHATGPT_INCOMPATIBLE_MODELS.contains(&model) {
+        let compatible = CODEX_CHATGPT_COMPATIBLE_MODELS.join(", ");
+        anyhow::bail!(
+            "'{model}' is not supported when using codex with a ChatGPT account.\n\
+             Compatible models: {compatible}\n\
+             To suppress this check, set this model as the configured default in \
+             [tools.codex].default_model in your config."
+        );
+    }
+    Ok(())
+}

--- a/crates/cli-sub-agent/src/run_helpers_token_parse.rs
+++ b/crates/cli-sub-agent/src/run_helpers_token_parse.rs
@@ -1,0 +1,101 @@
+//! Token usage and cost parsing from tool output.
+
+use csa_session::TokenUsage;
+
+/// Parse token usage from tool output (best-effort, returns None on failure).
+///
+/// Looks for common patterns in stdout/stderr:
+/// - "tokens: N" or "Tokens: N" or "total_tokens: N"
+/// - "input_tokens: N" / "output_tokens: N"
+/// - "cost: $N.NN" or "estimated_cost: $N.NN"
+pub(crate) fn parse_token_usage(output: &str) -> Option<TokenUsage> {
+    let mut usage = TokenUsage::default();
+    let mut found_any = false;
+
+    // Simple pattern matching without regex
+    for line in output.lines() {
+        let line_lower = line.to_lowercase();
+
+        // Parse input_tokens
+        if let Some(pos) = line_lower.find("input_tokens")
+            && let Some(val) = extract_number(&line[pos..])
+        {
+            usage.input_tokens = Some(val);
+            found_any = true;
+        }
+
+        // Parse output_tokens
+        if let Some(pos) = line_lower.find("output_tokens")
+            && let Some(val) = extract_number(&line[pos..])
+        {
+            usage.output_tokens = Some(val);
+            found_any = true;
+        }
+
+        // Parse total_tokens
+        if let Some(pos) = line_lower.find("total_tokens") {
+            if let Some(val) = extract_number(&line[pos..]) {
+                usage.total_tokens = Some(val);
+                found_any = true;
+            }
+        } else if let Some(pos) = line_lower.find("tokens:") {
+            // Only match standalone "tokens:" — skip if preceded by a letter or
+            // underscore (e.g. "input_tokens:" or "output_tokens:" already
+            // handled above).
+            let prev = line_lower.as_bytes().get(pos.wrapping_sub(1)).copied();
+            let is_standalone = pos == 0 || !matches!(prev, Some(b'a'..=b'z' | b'A'..=b'Z' | b'_'));
+            if is_standalone && let Some(val) = extract_number(&line[pos..]) {
+                usage.total_tokens = Some(val);
+                found_any = true;
+            }
+        }
+
+        // Parse cost (look for "$N.NN" pattern)
+        if line_lower.contains("cost")
+            && let Some(val) = extract_cost(line)
+        {
+            usage.estimated_cost_usd = Some(val);
+            found_any = true;
+        }
+    }
+
+    // Calculate total_tokens if not found but input/output are available
+    if usage.total_tokens.is_none()
+        && let (Some(input), Some(output)) = (usage.input_tokens, usage.output_tokens)
+    {
+        usage.total_tokens = Some(input + output);
+        found_any = true;
+    }
+
+    if found_any { Some(usage) } else { None }
+}
+
+/// Extract a number after colon or equals sign.
+pub(crate) fn extract_number(text: &str) -> Option<u64> {
+    // Find colon or equals
+    let start = text.find(':')?;
+    let after_colon = &text[start + 1..];
+
+    // Take first word after colon
+    let num_str: String = after_colon
+        .chars()
+        .skip_while(|c| c.is_whitespace())
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+
+    num_str.parse().ok()
+}
+
+/// Extract cost value after $ sign.
+pub(crate) fn extract_cost(text: &str) -> Option<f64> {
+    let start = text.find('$')?;
+    let after_dollar = &text[start + 1..];
+
+    // Take digits and decimal point
+    let num_str: String = after_dollar
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+
+    num_str.parse().ok()
+}


### PR DESCRIPTION
## Summary
- Add pre-spawn model-tool compatibility validation before session creation
- Codex with ChatGPT accounts rejects certain models (e.g. `o4-mini`); CSA now fails fast with a clear error listing compatible alternatives
- Extract model compatibility logic into `run_helpers_model_compat` module
- Refactor token parsing into `run_helpers_token_parse` module (split from monolithic `run_helpers`)

Closes #1413

## Test plan
- [x] New `run_helpers_compat_tests` with comprehensive model-tool compatibility scenarios
- [x] `just pre-commit` passes
- [x] CSA review verdict: PASS (session 01KRQSQJAS4R3B1868WRND9KEF)