### PR TITLE
fix(recall): newest-first 0-based page numbering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.724"
+version = "0.1.725"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.724"
+version = "0.1.725"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_recall.rs
+++ b/crates/cli-sub-agent/src/cli_recall.rs
@@ -20,12 +20,14 @@ pub enum RecallCommands {
     /// Render a recorded session as markdown
     Read {
         /// Session ID, `latest`, or a 1-based history index
+        #[arg(default_value = "latest")]
         session: String,
 
-        /// Show only page N (positive: from start, negative: from end; -1 = last/current page).
+        /// Page number (newest-first): 0 = current page (after last compact),
+        /// 1 = previous page, 2 = before that, and so on.
         /// Bypasses the OUTPUT_TOO_LARGE guard.
-        #[arg(long, allow_negative_numbers = true)]
-        page: Option<i32>,
+        #[arg(long)]
+        page: Option<u32>,
     },
 
     /// Search the most recent recorded session for a literal query
@@ -34,9 +36,14 @@ pub enum RecallCommands {
         query: String,
     },
 
-    /// List compact-event page boundaries in a recorded session
+    /// List compact-event page boundaries (newest-first).
+    ///
+    /// Page 0 is the content after the most recent compact event (the
+    /// "current" page).  Page 1 is between the second-to-last and last
+    /// compact, and so on.
     Pages {
         /// Session ID, `latest`, or a 1-based history index
+        #[arg(default_value = "latest")]
         session: String,
     },
 }

--- a/crates/cli-sub-agent/src/recall_cmd.rs
+++ b/crates/cli-sub-agent/src/recall_cmd.rs
@@ -148,7 +148,7 @@ fn handle_recall_list(limit: usize) -> Result<()> {
     Ok(())
 }
 
-fn handle_recall_read(session: &str, page: Option<i32>) -> Result<()> {
+fn handle_recall_read(session: &str, page: Option<u32>) -> Result<()> {
     let session_ref = resolve_session_ref(session)?;
     let content = render_session_markdown(&session_ref)?;
 
@@ -168,7 +168,8 @@ fn handle_recall_read(session: &str, page: Option<i32>) -> Result<()> {
     let idx = pages::resolve_page_index(page_n, total).with_context(|| {
         format!(
             "Page {page_n} is out of range: session has {total} page(s) \
-             (use negative values to count from the end)"
+             (0 = current/newest, {} = oldest)",
+            total.saturating_sub(1)
         )
     })?;
     print!("{}", page_list[idx]);
@@ -186,15 +187,18 @@ fn handle_recall_pages(session: &str) -> Result<()> {
     }
 
     let timestamps = pages::extract_jsonl_compact_timestamps(&resolved.path);
+    let total = page_list.len();
 
+    struct PageInfo {
+        line_start: usize,
+        line_end: usize,
+        ts: String,
+        size_kb: usize,
+    }
+
+    let mut infos = Vec::with_capacity(total);
     let mut line_cursor = 1usize;
-    println!(
-        "{:<6} {:<15} {:<22} {:<8} Note",
-        "Page", "Lines", "Timestamp", "Size"
-    );
-    println!("{}", "-".repeat(70));
     for (i, page_content) in page_list.iter().enumerate() {
-        let page_num = i + 1;
         let page_line_count = page_content.lines().count().max(1);
         let line_start = line_cursor;
         let line_end = line_cursor + page_line_count - 1;
@@ -205,18 +209,34 @@ fn handle_recall_pages(session: &str) -> Result<()> {
             .and_then(Option::as_ref)
             .map_or_else(|| String::from("-"), |ts| pages::format_timestamp_short(ts));
         let size_kb = page_content.len().div_ceil(1024);
-        let note = if i == 0 { "" } else { "(compact)" };
+        infos.push(PageInfo {
+            line_start,
+            line_end,
+            ts,
+            size_kb,
+        });
+    }
 
+    println!(
+        "{:<6} {:<15} {:<22} {:<8} Note",
+        "Page", "Lines", "Timestamp", "Size"
+    );
+    println!("{}", "-".repeat(70));
+    for (page_num, info) in infos.iter().rev().enumerate() {
+        let note = if page_num == 0 { "(current)" } else { "" };
         println!(
             "{:<6} {:<15} {:<22} {:<8} {}",
             page_num,
-            format!("{line_start}-{line_end}"),
-            ts,
-            format!("{size_kb}KB"),
+            format!("{}-{}", info.line_start, info.line_end),
+            info.ts,
+            format!("{}KB", info.size_kb),
             note,
         );
     }
-    println!("\nTotal pages: {}", page_list.len());
+    println!(
+        "\nTotal pages: {} (page 0 = current, higher = older)",
+        total
+    );
     Ok(())
 }
 

--- a/crates/cli-sub-agent/src/recall_cmd_pages.rs
+++ b/crates/cli-sub-agent/src/recall_cmd_pages.rs
@@ -22,9 +22,8 @@ pub(super) fn is_compact_heading(line: &str) -> bool {
 
 /// Splits rendered markdown into pages at each `## N. Context Compacted` heading.
 ///
-/// Page 1 = everything before the first compact heading.
-/// Page N+1 = from the Nth compact heading to (but not including) the next one.
-/// Returns a single page containing the full content when no compact headings exist.
+/// Returns pages in chronological order. The caller maps user-facing page
+/// numbers (0 = newest) via [`resolve_page_index`].
 pub(super) fn split_markdown_pages(content: &str) -> Vec<String> {
     let mut pages: Vec<String> = Vec::new();
     let mut current_start = 0usize;
@@ -58,21 +57,17 @@ fn line_byte_offsets(content: &str) -> impl Iterator<Item = (usize, &str)> {
     })
 }
 
-/// Converts a signed page number to a 0-based index into a slice of `total` pages.
+/// Converts a 0-based newest-first page number to an index into the
+/// chronological page list.
 ///
-/// Positive: 1-based from start. Negative: -1 = last, -2 = second to last.
-/// Returns `None` if out of range or zero.
-pub(super) fn resolve_page_index(page: i32, total: usize) -> Option<usize> {
-    if page == 0 || total == 0 {
+/// Page 0 = last (newest) page, page 1 = second-to-last, etc.
+/// Returns `None` if `page >= total`.
+pub(super) fn resolve_page_index(page: u32, total: usize) -> Option<usize> {
+    let n = page as usize;
+    if n >= total {
         return None;
     }
-    if page > 0 {
-        let idx = (page as usize).checked_sub(1)?;
-        if idx < total { Some(idx) } else { None }
-    } else {
-        let offset = (-page) as usize;
-        total.checked_sub(offset)
-    }
+    Some(total - 1 - n)
 }
 
 /// Reads the JSONL file at `path` and returns one timestamp entry per page:
@@ -213,30 +208,30 @@ mod tests {
     }
 
     #[test]
-    fn resolve_page_index_positive() {
-        assert_eq!(resolve_page_index(1, 3), Some(0));
-        assert_eq!(resolve_page_index(2, 3), Some(1));
-        assert_eq!(resolve_page_index(3, 3), Some(2));
-        assert_eq!(resolve_page_index(4, 3), None, "out of range");
+    fn resolve_page_index_newest_first() {
+        assert_eq!(
+            resolve_page_index(0, 3),
+            Some(2),
+            "0 = newest (last chronological)"
+        );
+        assert_eq!(resolve_page_index(1, 3), Some(1), "1 = previous");
+        assert_eq!(
+            resolve_page_index(2, 3),
+            Some(0),
+            "2 = oldest (first chronological)"
+        );
+        assert_eq!(resolve_page_index(3, 3), None, "out of range");
     }
 
     #[test]
-    fn resolve_page_index_negative() {
-        assert_eq!(resolve_page_index(-1, 3), Some(2), "-1 = last");
-        assert_eq!(resolve_page_index(-2, 3), Some(1), "-2 = second to last");
-        assert_eq!(resolve_page_index(-3, 3), Some(0), "-3 = first");
-        assert_eq!(resolve_page_index(-4, 3), None, "too negative");
-    }
-
-    #[test]
-    fn resolve_page_index_zero_is_invalid() {
-        assert_eq!(resolve_page_index(0, 3), None, "page 0 is invalid");
+    fn resolve_page_index_single_page() {
+        assert_eq!(resolve_page_index(0, 1), Some(0), "only page");
+        assert_eq!(resolve_page_index(1, 1), None, "out of range");
     }
 
     #[test]
     fn resolve_page_index_empty_returns_none() {
-        assert_eq!(resolve_page_index(1, 0), None);
-        assert_eq!(resolve_page_index(-1, 0), None);
+        assert_eq!(resolve_page_index(0, 0), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Page numbers now count from newest: `--page 0` = current page (after last compact), `--page 1` = previous page, etc.
- `session` argument defaults to `latest` on both `read` and `pages` subcommands, so `csa recall read --page 0` works without specifying a session ID.
- `csa recall pages` displays rows newest-first with `(current)` annotation on page 0.
- Improved `--help` text for both `--page` flag and `pages` subcommand.

Closes the UX issue where page numbering was 1-based oldest-first (unintuitive for the primary use-case of reading the most recent pre-compact content).

## Test plan
- [x] `cargo test -p cli-sub-agent -- recall_cmd` passes (21 tests)
- [x] `just pre-commit` passes
- [ ] Manual: `csa recall read --page 0` returns current page
- [ ] Manual: `csa recall pages` shows newest-first ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)