### PR TITLE
fix(recall): live xurl query for latest session discovery (#1426)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.726"
+version = "0.1.727"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.726"
+version = "0.1.727"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/recall_cmd.rs
+++ b/crates/cli-sub-agent/src/recall_cmd.rs
@@ -341,18 +341,24 @@ fn resolve_session_ref(selector: &str, project_root: &Path) -> Result<SessionRef
     let current_project = project_root.display().to_string();
 
     if trimmed.eq_ignore_ascii_case("latest") {
+        // Prefer live xurl query — it always resolves the provider's
+        // most-recent main-agent session for this project, regardless of
+        // whether CSA was ever invoked here.  Fall back to history only
+        // when no provider has a matching live session.
+        if let Some(session_ref) = live_query_main_session(project_root) {
+            return Ok(session_ref);
+        }
         let filtered_entries: Vec<_> = entries
             .iter()
             .filter(|entry| entry.project == current_project)
             .collect();
-        return latest_history_entry(&filtered_entries)
-            .map(entry_to_session_ref)
-            .with_context(|| {
-                format!(
-                    "No recall history for project {}. Use `csa recall list --all` to see all projects.",
-                    current_project
-                )
-            });
+        if let Some(entry) = latest_history_entry(&filtered_entries) {
+            return Ok(entry_to_session_ref(entry));
+        }
+        anyhow::bail!(
+            "No recall history for project {}. Use `csa recall list --all` to see all projects.",
+            current_project
+        );
     }
 
     if let Ok(index) = trimmed.parse::<usize>() {
@@ -404,6 +410,39 @@ fn resolve_session_ref(selector: &str, project_root: &Path) -> Result<SessionRef
         sid: trimmed.to_string(),
         provider: xurl_core::ProviderKind::Claude.to_string(),
     })
+}
+
+/// Live-query xurl for the current project's main-agent session.
+///
+/// This bypasses the history file entirely, probing each provider for
+/// the most recent main thread that belongs to `project_root`. Returns
+/// `None` when no provider has a matching session.
+fn live_query_main_session(project_root: &Path) -> Option<SessionRef> {
+    let roots = provider_roots().ok()?;
+    for &provider in RECALL_PROVIDERS {
+        let query = xurl_core::ThreadQuery {
+            uri: format!("{}://", provider),
+            provider,
+            role: Some("main".to_string()),
+            q: None,
+            limit: 1,
+            ignored_params: Vec::new(),
+        };
+        let Ok(result) = xurl_core::query_threads(&query, &roots) else {
+            continue;
+        };
+        let Some(thread) = result.items.first() else {
+            continue;
+        };
+        if !thread_belongs_to_project(&thread.thread_source, project_root, provider) {
+            continue;
+        }
+        return Some(SessionRef {
+            sid: thread.thread_id.clone(),
+            provider: provider.to_string(),
+        });
+    }
+    None
 }
 
 fn latest_history_entry<'a>(


### PR DESCRIPTION
## Summary

- `resolve_session_ref("latest")` now does a **live xurl query** to discover the current project's main-agent session, instead of relying solely on the history file
- This fixes the case where users run Claude Code directly (without CSA invocation) — their sessions are now discoverable by `csa recall` without any prior recording
- Live query is preferred over history; history serves as fallback when no provider has a matching live session

Root cause: `record_main_agent_session` was only called during CSA pipeline execution (`pipeline_session_exec.rs:259`), so projects where CSA was never invoked had no recall history.

Closes #1426.

## Test plan

- [x] `cargo test -p cli-sub-agent -- recall` — 25 tests pass
- [x] `cargo clippy -p cli-sub-agent -- -D warnings` — clean
- [x] `just pre-commit` — exit 0
- [x] codex review (session `01KRRNFGG4FGMBMXK8EPVT29KB`) — findings empty, verdict PASS
- [ ] Manual: `csa recall read --page 0` from a project with no CSA history resolves the current Claude session
- [ ] Manual: `csa recall read --page 1` shows previous compact page when session has been compacted

🤖 Generated with [Claude Code](https://claude.com/claude-code)