### PR TITLE
fix(recall): live xurl query + multi-thread scan for session discovery (#1426)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.727"
+version = "0.1.728"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.727"
+version = "0.1.728"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/recall_cmd.rs
+++ b/crates/cli-sub-agent/src/recall_cmd.rs
@@ -417,6 +417,11 @@ fn resolve_session_ref(selector: &str, project_root: &Path) -> Result<SessionRef
 /// This bypasses the history file entirely, probing each provider for
 /// the most recent main thread that belongs to `project_root`. Returns
 /// `None` when no provider has a matching session.
+/// How many threads to fetch per provider when searching for a
+/// project-matching session.  The most-recent thread may belong to a
+/// different project, so we scan a small window.
+const LIVE_QUERY_SCAN_LIMIT: usize = 20;
+
 fn live_query_main_session(project_root: &Path) -> Option<SessionRef> {
     let roots = provider_roots().ok()?;
     for &provider in RECALL_PROVIDERS {
@@ -425,22 +430,20 @@ fn live_query_main_session(project_root: &Path) -> Option<SessionRef> {
             provider,
             role: Some("main".to_string()),
             q: None,
-            limit: 1,
+            limit: LIVE_QUERY_SCAN_LIMIT,
             ignored_params: Vec::new(),
         };
         let Ok(result) = xurl_core::query_threads(&query, &roots) else {
             continue;
         };
-        let Some(thread) = result.items.first() else {
-            continue;
-        };
-        if !thread_belongs_to_project(&thread.thread_source, project_root, provider) {
-            continue;
+        for thread in &result.items {
+            if thread_belongs_to_project(&thread.thread_source, project_root, provider) {
+                return Some(SessionRef {
+                    sid: thread.thread_id.clone(),
+                    provider: provider.to_string(),
+                });
+            }
         }
-        return Some(SessionRef {
-            sid: thread.thread_id.clone(),
-            provider: provider.to_string(),
-        });
     }
     None
 }


### PR DESCRIPTION
## Summary

- `resolve_session_ref("latest")` now does a **live xurl query** instead of relying solely on history file (which was only populated during CSA pipeline execution)
- Live query scans up to 20 threads per provider to find the first project-matching session (fixes the `limit=1` bug where the globally most-recent thread from another project caused a miss)
- Users can now `csa recall read --page N` from any project even without prior CSA invocation

Verified from `../colleague-skill`: 19 compact pages found, correct project content displayed.

Closes #1426.

## Test plan

- [x] `cargo test -p cli-sub-agent -- recall` — 25 tests pass
- [x] `cargo clippy` — clean
- [x] `just pre-commit` — exit 0
- [x] codex review (session `01KRRQ1EP7V9E93XS9AXK82QY6`) — findings empty, verdict PASS
- [x] Manual: `./target/release/csa recall pages` from colleague-skill → 19 pages found
- [x] Manual: `--page 0` shows correct project content (Twitter bot session)
- [x] Manual: `--page 1` shows compact boundary content

🤖 Generated with [Claude Code](https://claude.com/claude-code)