### PR TITLE
feat(config): support tools.codex.fast_mode for persistent fast mode (#1429)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.728"
+version = "0.1.729"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.728"
+version = "0.1.729"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -36,7 +36,8 @@ use fast_mode::{debate_execution_env_options, warn_if_fast_mode_has_no_codex_deb
 
 #[path = "debate_cmd_readonly.rs"]
 mod readonly;
-pub(crate) use readonly::{ANTI_RECURSION_PREAMBLE, with_readonly_session_env};
+use readonly::build_debate_instruction;
+pub(crate) use readonly::with_readonly_session_env;
 
 /// Debate execution mode indicating model diversity level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -341,7 +342,18 @@ pub(crate) async fn handle_debate(
         tier_active,
         tier_filter.as_ref(),
     );
-    warn_if_fast_mode_has_no_codex_debate_candidate(args.fast_but_more_cost, &candidates);
+    let effective_fast_mode = args.fast_but_more_cost
+        || config
+            .as_ref()
+            .and_then(|c| c.tools.get("codex"))
+            .and_then(|t| t.fast_mode)
+            .unwrap_or(false)
+        || global_config
+            .tools
+            .get("codex")
+            .and_then(|t| t.fast_mode)
+            .unwrap_or(false);
+    warn_if_fast_mode_has_no_codex_debate_candidate(effective_fast_mode, &candidates);
 
     if args.dry_run {
         let Some((attempt_tool, attempt_model_spec)) = candidates.first() else {
@@ -361,7 +373,7 @@ pub(crate) async fn handle_debate(
             false,
         )
         .await?;
-        if args.fast_but_more_cost {
+        if effective_fast_mode {
             executor.enable_codex_fast_mode();
         }
         let summary = DebateDryRunSummary {
@@ -410,7 +422,7 @@ pub(crate) async fn handle_debate(
             false,
         )
         .await?;
-        if args.fast_but_more_cost {
+        if effective_fast_mode {
             executor.enable_codex_fast_mode();
         }
         let base_env_owned = global_config.build_execution_env(
@@ -768,23 +780,6 @@ fn should_retry_debate_after_error(
 async fn wait_for_still_working_backoff() {
     tracing::info!("Tool still working, waiting before next attempt...");
     tokio::time::sleep(STILL_WORKING_BACKOFF).await;
-}
-
-/// Build a debate instruction that passes parameters to the debate skill.
-///
-/// The debate tool loads the debate skill from the project's `.claude/skills/`
-/// directory and follows its instructions autonomously. We only pass parameters.
-/// An anti-recursion preamble is prepended (see GitHub issue #272).
-fn build_debate_instruction(question: &str, is_continuation: bool, rounds: u32) -> String {
-    if is_continuation {
-        format!(
-            "{ANTI_RECURSION_PREAMBLE}Use the debate skill. continuation=true. rounds={rounds}. question={question}"
-        )
-    } else {
-        format!(
-            "{ANTI_RECURSION_PREAMBLE}Use the debate skill. rounds={rounds}. question={question}"
-        )
-    }
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/debate_cmd_fast_mode.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_fast_mode.rs
@@ -11,10 +11,10 @@ pub(crate) fn debate_execution_env_options(no_failover: bool) -> ExecutionEnvOpt
 }
 
 pub(crate) fn warn_if_fast_mode_has_no_codex_debate_candidate(
-    fast_but_more_cost: bool,
+    effective_fast_mode: bool,
     candidates: &[(ToolName, Option<String>)],
 ) {
-    if fast_but_more_cost && !candidates.iter().any(|(tool, _)| *tool == ToolName::Codex) {
+    if effective_fast_mode && !candidates.iter().any(|(tool, _)| *tool == ToolName::Codex) {
         eprintln!(
             "warning: --fast-but-more-cost only affects codex; no codex debate attempt is in the resolved candidate set."
         );

--- a/crates/cli-sub-agent/src/debate_cmd_readonly.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_readonly.rs
@@ -21,6 +21,27 @@ pub(crate) fn with_readonly_session_env(
 /// `pipeline::load_and_validate` (hard reject above `MAX_RECURSION_DEPTH`), so
 /// blanket "never call csa" text here would break the documented fractal
 /// recursion contract (Layer 1 -> Layer 2 is legitimate).
+/// Build a debate instruction that passes parameters to the debate skill.
+///
+/// The debate tool loads the debate skill from the project's `.claude/skills/`
+/// directory and follows its instructions autonomously. We only pass parameters.
+/// An anti-recursion preamble is prepended (see GitHub issue #272).
+pub(crate) fn build_debate_instruction(
+    question: &str,
+    is_continuation: bool,
+    rounds: u32,
+) -> String {
+    if is_continuation {
+        format!(
+            "{ANTI_RECURSION_PREAMBLE}Use the debate skill. continuation=true. rounds={rounds}. question={question}"
+        )
+    } else {
+        format!(
+            "{ANTI_RECURSION_PREAMBLE}Use the debate skill. rounds={rounds}. question={question}"
+        )
+    }
+}
+
 pub(crate) const ANTI_RECURSION_PREAMBLE: &str = "\
 CONTEXT: You are running INSIDE a CSA subprocess (csa review / csa debate). \
 Perform the debate task DIRECTLY using your own capabilities \

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -86,11 +86,11 @@ fn review_execution_env_options(no_failover: bool) -> ExecutionEnvOptions {
 }
 
 fn warn_if_fast_mode_has_no_codex_review_candidate(
-    fast_but_more_cost: bool,
+    effective_fast_mode: bool,
     warn_no_codex_fast_mode: bool,
     candidates: &[(ToolName, Option<String>)],
 ) {
-    if fast_but_more_cost
+    if effective_fast_mode
         && warn_no_codex_fast_mode
         && !candidates.iter().any(|(tool, _)| *tool == ToolName::Codex)
     {
@@ -199,6 +199,16 @@ pub(crate) async fn execute_review_with_tier_filter(
             "Ignoring inherited CSA_SESSION_ID for `csa review`; pass --session to resume explicitly"
         );
     }
+    let effective_fast_mode = fast_but_more_cost
+        || project_config
+            .and_then(|c| c.tools.get("codex"))
+            .and_then(|t| t.fast_mode)
+            .unwrap_or(false)
+        || global_config
+            .tools
+            .get("codex")
+            .and_then(|t| t.fast_mode)
+            .unwrap_or(false);
     let candidates = ordered_tier_candidates(
         tool,
         tier_model_spec.as_deref(),
@@ -209,7 +219,7 @@ pub(crate) async fn execute_review_with_tier_filter(
         tier_filter.as_ref(),
     );
     warn_if_fast_mode_has_no_codex_review_candidate(
-        fast_but_more_cost,
+        effective_fast_mode,
         warn_no_codex_fast_mode,
         &candidates,
     );
@@ -233,7 +243,7 @@ pub(crate) async fn execute_review_with_tier_filter(
             false,
         )
         .await?;
-        if fast_but_more_cost {
+        if effective_fast_mode {
             executor.enable_codex_fast_mode();
         }
 

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -1,15 +1,12 @@
 use anyhow::Result;
 use csa_config::{ExecutionEnvOptions, GlobalConfig, ProjectConfig};
-use csa_core::types::{OutputFormat, ToolName, ToolSelectionStrategy};
+use csa_core::types::{OutputFormat, ToolSelectionStrategy};
 use csa_executor::structured_output_instructions_for_fork_call;
 use csa_lock::slot::{
     SlotAcquireResult, ToolSlot, acquire_slot_blocking, format_slot_diagnostic, slot_usage,
     try_acquire_slot,
 };
-use std::{
-    path::{Path, PathBuf},
-    time::Instant,
-};
+use std::time::Instant;
 use tracing::{info, warn};
 
 use super::attempt_exec::{
@@ -39,68 +36,9 @@ use crate::run_cmd_tool_selection::{
 };
 use crate::run_helpers::{is_tool_binary_available_for_config, parse_tool_name};
 
-pub(crate) struct RunLoopRequest<'a> {
-    pub(crate) strategy: ToolSelectionStrategy,
-    pub(crate) initial_tool: ToolName,
-    pub(crate) initial_model_spec: Option<String>,
-    pub(crate) user_model_spec_explicit: bool,
-    pub(crate) initial_model: Option<String>,
-    pub(crate) runtime_fallback_candidates: Vec<ToolName>,
-    pub(crate) project_root: &'a Path,
-    pub(crate) config: Option<&'a ProjectConfig>,
-    pub(crate) global_config: &'a GlobalConfig,
-    pub(crate) prompt_text: &'a str,
-    pub(crate) skill: Option<&'a str>,
-    pub(crate) skill_session_tag: Option<String>,
-    pub(crate) description: Option<String>,
-    pub(crate) parent: Option<String>,
-    pub(crate) output_format: OutputFormat,
-    pub(crate) stream_mode: csa_process::StreamMode,
-    pub(crate) thinking: Option<&'a str>,
-    pub(crate) force: bool,
-    pub(crate) force_override_user_config: bool,
-    pub(crate) force_ignore_tier_setting: bool,
-    pub(crate) no_failover: bool,
-    pub(crate) fast_but_more_cost: bool,
-    pub(crate) wait: bool,
-    pub(crate) idle_timeout_seconds: u64,
-    pub(crate) cli_idle_timeout: Option<u64>,
-    pub(crate) cli_initial_response_timeout: Option<u64>,
-    pub(crate) no_idle_timeout: bool,
-    pub(crate) run_timeout_seconds: Option<u64>,
-    pub(crate) run_started_at: Instant,
-    pub(crate) is_fork: bool,
-    pub(crate) is_auto_seed_fork: bool,
-    pub(crate) ephemeral: bool,
-    pub(crate) fork_call: bool,
-    pub(crate) session_arg: Option<String>,
-    pub(crate) effective_session_arg: Option<String>,
-    pub(crate) tier_auto_select: bool,
-    pub(crate) failover_on_crash_enabled: bool,
-    pub(crate) resolved_tier_name: Option<&'a str>,
-    pub(crate) context_load_options: Option<&'a csa_executor::ContextLoadOptions>,
-    pub(crate) memory_injection: pipeline::MemoryInjectionOptions,
-    pub(crate) pre_session_hook: Option<csa_hooks::PreSessionHookInvocation>,
-    pub(crate) task_needs_edit: Option<bool>,
-    pub(crate) no_fs_sandbox: bool,
-    pub(crate) extra_writable: Vec<PathBuf>,
-    pub(crate) extra_readable: Vec<PathBuf>,
-    pub(crate) branch_guard: crate::run_helpers_branch_guard::BranchGuardRuntime,
-}
-
-pub(crate) enum RunLoopCompletion {
-    Exit(i32),
-    Completed(Box<RunLoopOutcome>),
-}
-
-pub(crate) struct RunLoopOutcome {
-    pub(crate) result: csa_process::ExecutionResult,
-    pub(crate) current_tool: ToolName,
-    pub(crate) executed_session_id: Option<String>,
-    pub(crate) fork_resolution: Option<ForkResolution>,
-    /// Ordered list of tools skipped due to rate-limit/quota failover before this result.
-    pub(crate) fallback_chain: csa_scheduler::FallbackChain,
-}
+#[path = "run_cmd_attempt_types.rs"]
+mod types;
+pub(crate) use types::{RunLoopCompletion, RunLoopOutcome, RunLoopRequest};
 
 pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunLoopCompletion> {
     // Compute max failover attempts: count total models across ALL tiers to
@@ -170,7 +108,19 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             matches!(request.strategy, ToolSelectionStrategy::Explicit(_)),
         )
         .await?;
-        if request.fast_but_more_cost {
+        let fast_mode = request.fast_but_more_cost
+            || request
+                .config
+                .and_then(|c| c.tools.get("codex"))
+                .and_then(|t| t.fast_mode)
+                .unwrap_or(false)
+            || request
+                .global_config
+                .tools
+                .get("codex")
+                .and_then(|t| t.fast_mode)
+                .unwrap_or(false);
+        if fast_mode {
             executor.enable_codex_fast_mode();
         }
 

--- a/crates/cli-sub-agent/src/run_cmd_attempt_types.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_types.rs
@@ -1,0 +1,76 @@
+//! Data types for the `csa run` execution loop.
+//!
+//! Extracted from `run_cmd_attempt.rs` to stay under the 800-line monolith limit.
+
+use csa_config::{GlobalConfig, ProjectConfig};
+use csa_core::types::{OutputFormat, ToolName, ToolSelectionStrategy};
+use csa_executor::ContextLoadOptions;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use crate::pipeline::MemoryInjectionOptions;
+use crate::run_cmd_fork::ForkResolution;
+use crate::run_helpers_branch_guard::BranchGuardRuntime;
+
+pub(crate) struct RunLoopRequest<'a> {
+    pub(crate) strategy: ToolSelectionStrategy,
+    pub(crate) initial_tool: ToolName,
+    pub(crate) initial_model_spec: Option<String>,
+    pub(crate) user_model_spec_explicit: bool,
+    pub(crate) initial_model: Option<String>,
+    pub(crate) runtime_fallback_candidates: Vec<ToolName>,
+    pub(crate) project_root: &'a Path,
+    pub(crate) config: Option<&'a ProjectConfig>,
+    pub(crate) global_config: &'a GlobalConfig,
+    pub(crate) prompt_text: &'a str,
+    pub(crate) skill: Option<&'a str>,
+    pub(crate) skill_session_tag: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) parent: Option<String>,
+    pub(crate) output_format: OutputFormat,
+    pub(crate) stream_mode: csa_process::StreamMode,
+    pub(crate) thinking: Option<&'a str>,
+    pub(crate) force: bool,
+    pub(crate) force_override_user_config: bool,
+    pub(crate) force_ignore_tier_setting: bool,
+    pub(crate) no_failover: bool,
+    pub(crate) fast_but_more_cost: bool,
+    pub(crate) wait: bool,
+    pub(crate) idle_timeout_seconds: u64,
+    pub(crate) cli_idle_timeout: Option<u64>,
+    pub(crate) cli_initial_response_timeout: Option<u64>,
+    pub(crate) no_idle_timeout: bool,
+    pub(crate) run_timeout_seconds: Option<u64>,
+    pub(crate) run_started_at: Instant,
+    pub(crate) is_fork: bool,
+    pub(crate) is_auto_seed_fork: bool,
+    pub(crate) ephemeral: bool,
+    pub(crate) fork_call: bool,
+    pub(crate) session_arg: Option<String>,
+    pub(crate) effective_session_arg: Option<String>,
+    pub(crate) tier_auto_select: bool,
+    pub(crate) failover_on_crash_enabled: bool,
+    pub(crate) resolved_tier_name: Option<&'a str>,
+    pub(crate) context_load_options: Option<&'a ContextLoadOptions>,
+    pub(crate) memory_injection: MemoryInjectionOptions,
+    pub(crate) pre_session_hook: Option<csa_hooks::PreSessionHookInvocation>,
+    pub(crate) task_needs_edit: Option<bool>,
+    pub(crate) no_fs_sandbox: bool,
+    pub(crate) extra_writable: Vec<PathBuf>,
+    pub(crate) extra_readable: Vec<PathBuf>,
+    pub(crate) branch_guard: BranchGuardRuntime,
+}
+
+pub(crate) enum RunLoopCompletion {
+    Exit(i32),
+    Completed(Box<RunLoopOutcome>),
+}
+
+pub(crate) struct RunLoopOutcome {
+    pub(crate) result: csa_process::ExecutionResult,
+    pub(crate) current_tool: ToolName,
+    pub(crate) executed_session_id: Option<String>,
+    pub(crate) fork_resolution: Option<ForkResolution>,
+    /// Ordered list of tools skipped due to rate-limit/quota failover before this result.
+    pub(crate) fallback_chain: csa_scheduler::FallbackChain,
+}

--- a/crates/csa-config/src/config_tests.rs
+++ b/crates/csa-config/src/config_tests.rs
@@ -781,3 +781,16 @@ fn test_enforce_tool_enabled_disabled_tool_returns_error() {
         "error must mention override flag: {msg}"
     );
 }
+
+#[test]
+fn test_tool_config_fast_mode_true_parses() {
+    let toml_str = r#"fast_mode = true"#;
+    let cfg: ToolConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(cfg.fast_mode, Some(true));
+}
+
+#[test]
+fn test_tool_config_fast_mode_absent_defaults_to_none() {
+    let cfg: ToolConfig = toml::from_str("").unwrap();
+    assert_eq!(cfg.fast_mode, None);
+}

--- a/crates/csa-config/src/config_tool.rs
+++ b/crates/csa-config/src/config_tool.rs
@@ -108,6 +108,11 @@ pub struct ToolConfig {
     /// filesystem sandbox settings for this specific tool.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub filesystem_sandbox: Option<ToolFilesystemSandboxConfig>,
+    /// Codex-only: enable fast mode (2× cost, faster output).
+    /// Equivalent to `--fast-but-more-cost` CLI flag; applies to every codex
+    /// session in this project when true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fast_mode: Option<bool>,
 }
 
 impl Default for ToolConfig {
@@ -131,6 +136,7 @@ impl Default for ToolConfig {
             base_url: None,
             api_key: None,
             filesystem_sandbox: None,
+            fast_mode: None,
         }
     }
 }

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -726,6 +726,11 @@ pub struct GlobalToolConfig {
     /// Defaults to true so startup-time MCP degradation is non-fatal.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_degraded_mcp: Option<bool>,
+    /// Codex-only: enable fast mode (2× cost, faster output).
+    /// Equivalent to `--fast-but-more-cost` CLI flag; applies to all codex
+    /// sessions when true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fast_mode: Option<bool>,
 }
 
 fn default_max_concurrent() -> u32 {

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -24,6 +24,7 @@ max_concurrent = 3  # Default max parallel instances per tool
 #
 # [tools.codex]
 # max_concurrent = 3
+# fast_mode = true  # 2x cost, faster output
 # [tools.codex.env]
 # OPENAI_API_KEY = "sk-..."
 #


### PR DESCRIPTION
## Summary

- Add `fast_mode: Option<bool>` to `ToolConfig` in csa-config for persistent codex fast mode
- Read config value in `csa run`, `csa review`, and `csa debate` command paths (OR with CLI `--fast-but-more-cost` flag)
- Update warning functions to trigger when config fast_mode is set without codex in candidate set
- Add config template entry (commented out) and deserialization tests

Closes #1429

## Test plan

- [ ] `cargo test` passes
- [ ] `just pre-commit` passes
- [ ] Verify `csa run --fast-but-more-cost` still works (CLI flag path unchanged)
- [ ] Verify config `[tools.codex] fast_mode = true` enables codex fast mode without CLI flag
- [ ] Verify warning emitted when fast_mode enabled but no codex in candidate set

🤖 Generated with [Claude Code](https://claude.com/claude-code)