### PR TITLE
perf(skills): relax SA/CSA thresholds for small tasks (#1431)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.729"
+version = "0.1.730"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/mktd/skills/mktd/SKILL.md
+++ b/patterns/mktd/skills/mktd/SKILL.md
@@ -74,6 +74,12 @@ breaks prompt-guard propagation.
    - **Dimension 3 (Constraints)**: Identify breaking changes, security risks, performance concerns.
    - **Dimension 4 (Semantic Invariants)**: Capture invariants, assumptions, concurrent writers, and failure/rollback model.
    - Main agent MUST NOT use Read/Glob/Grep/Bash for exploration.
+   
+   **RECON Skip Condition**: When ALL of the following are true, the orchestrator MAY skip CSA RECON and perform exploration directly (grep/read):
+   - Change touches ≤3 files AND ≤50 lines
+   - Relevant code is already in context OR locatable with ≤3 grep/read operations
+   - No cross-crate dependency analysis needed
+   This avoids the cold-start cost (~10K+ tokens per RECON session) for trivial changes. The orchestrator documents skipped RECON in the TODO draft with: `RECON: skipped (small task, context sufficient)`.
 2. **Phase 1.5 -- LANGUAGE DETECTION**: Resolve language by priority: `${USER_LANGUAGE}` override -> `${CSA_USER_LANGUAGE}` env -> script-aware detect from `${FEATURE}` -> default Chinese (Simplified) when script is mixed/unknown -> fallback Chinese (Simplified) when `${FEATURE}` is empty. This language is captured as `${STEP_2_OUTPUT}`.
 3. **Phase 2 -- DRAFT**: Synthesize CSA findings into a structured TODO plan with checkbox items, executor tags ([Main], [Sub:developer], [Skill:commit], [CSA:tool]), and descriptions in `${STEP_2_OUTPUT}`. Every task MUST include a mechanically verifiable `DONE WHEN:` line. Technical terms, code snippets, commit scope strings, and executor tags remain in English.
 4. **Phase 2.5 -- THREAT MODEL** *(skipped in light mode)*: Review each new API surface for security concerns (sensitive data flows, hostile input, information exposure, safe defaults), plus concurrency-specific failure modes: concurrent writers, TOCTOU / rollback / cleanup races, state-machine invariants under concurrent transitions, and file-write atomicity. If the task is a default-change task (changes a default value, default transport, default tool, default feature gate, or default config field), emit an `existing-config x upgrade-path` matrix covering legitimate pre-change user states, pre-change behavior, post-change behavior, and whether a gap exists. Each matrix row with `Gap = Yes` MUST be tagged `[Security]` or `[Compat]` and added as a Phase-2.5-generated TODO item. Non-default-change tasks skip the matrix.

--- a/patterns/sa/skills/sa/SKILL.md
+++ b/patterns/sa/skills/sa/SKILL.md
@@ -86,9 +86,29 @@ NEVER treat pre-existing failures as justification for LEFTHOOK=0.
 5. If confidence is low, trigger cross-review by another employee.
 6. **After PR creation, invoke `/pr-bot`** — this is MANDATORY. The pr-bot skill handles `@codex review` triggering, polling (10 min timeout), fallback to local review, and the full bot review loop. Layer 1 executors MUST invoke this skill; it is NOT optional.
 
-### Layer 0 Manager: What You MUST NEVER Do
+### Small Task Fast Path (COST OPTIMIZATION)
 
-Absolute prohibitions (SOP breach):
+When ALL of the following are true, Layer 0 MAY execute directly instead of dispatching CSA:
+
+1. **Scope**: total change is ≤30 lines across ≤3 files
+2. **Complexity**: mechanical edit (config field addition, rename, flag wiring, template update)
+3. **Context**: relevant code is already in the main agent's context window
+4. **Risk**: no security-sensitive paths, no cross-crate architectural changes
+
+In fast-path mode, Layer 0 may:
+- Read/edit the specific files being changed (not exploratory reading)
+- Run `just pre-commit` to validate
+- Commit directly on the feature branch
+
+Layer 0 MUST still delegate via CSA when:
+- Change exceeds 30 lines or 3 files
+- Design judgment is required (which approach? which abstraction?)
+- Security-sensitive code paths are involved
+- User explicitly requested SA mode or CSA delegation
+
+### Layer 0 Manager: What You MUST NEVER Do (Full SA Mode)
+
+When NOT in small-task fast path, these absolute prohibitions apply:
 
 - NEVER `Read` source files (`*.rs`, `*.ts`, `*.py`, etc.).
 - NEVER `Grep`/`Glob` source code.

--- a/skills/csa/SKILL.md
+++ b/skills/csa/SKILL.md
@@ -67,6 +67,25 @@ Why this is the canonical LLM-friendly form:
 
 Default to this form unless the user explicitly asks for tier-based routing or a different tool.
 
+## When NOT to Use CSA
+
+CSA session spawn has a fixed cold-start cost (~10K-60K tokens for rules/context ingestion).
+For small tasks, the cold-start cost can exceed the actual work cost by 10-20x.
+
+**Prefer native subagent (Agent tool) or direct execution when**:
+- Change is ≤30 lines across ≤3 files
+- Same model as main agent (cache sharing via native Agent)
+- No filesystem sandbox or resource isolation needed
+- No cross-tool heterogeneous review needed (e.g., codex write + gemini review)
+
+**Use CSA when**:
+- Cross-tool execution (different model/provider than main agent)
+- Filesystem sandbox isolation required (bwrap/landlock)
+- Memory/PID resource limits needed (cgroup)
+- Long-running task (>1h, may outlive main agent session)
+- Audit trail required (session metadata, review verdict, token tracking)
+- Task exceeds 100 lines or 5+ files
+
 ## Core Concepts
 
 - **Meta-Session**: Persistent workspace for a specific task, stored in `~/.local/state/csa/`.


### PR DESCRIPTION
## Summary

- SA skill: add "Small Task Fast Path" — Layer 0 may directly edit ≤30 lines / ≤3 files for mechanical changes
- mktd skill: add RECON skip condition for small changes (≤3 files / ≤50 lines)
- CSA skill: add "When NOT to Use CSA" decision guidance
- AGENTS.md rule 049: softened to allow native subagents for small research (≤3 queries)
- Task delegation table: updated CSA vs native subagent decision matrix

Closes #1431

## Test plan

- [ ] Verify SA skill loads correctly (`csa run --skill sa`)
- [ ] Verify mktd skill loads correctly with light mode
- [ ] Verify CSA skill guidance renders in help context
- [ ] Manual: confirm small task (e.g., config field add) can use fast path without CSA dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)