### PR TITLE
fix(mktd): add workspace_access read-only to RECON steps (#1433)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.730"
+version = "0.1.731"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.730"
+version = "0.1.731"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -232,6 +232,7 @@ on_fail = "abort"
 id = 3
 title = "Phase 1 — RECON Dimension 1 (Structure)"
 tool = "csa"
+workspace_access = "read-only"
 prompt = """
 Analyze codebase structure relevant to ${FEATURE}.
 
@@ -247,6 +248,7 @@ session = "${STEP_1_OUTPUT}"
 id = 4
 title = "Phase 1 — RECON Dimension 2 (Patterns)"
 tool = "csa"
+workspace_access = "read-only"
 prompt = """
 Find existing patterns or similar features to ${FEATURE} in this codebase.
 
@@ -262,6 +264,7 @@ session = "${STEP_1_OUTPUT}"
 id = 5
 title = "Phase 1 — RECON Dimension 3 (Constraints)"
 tool = "csa"
+workspace_access = "read-only"
 prompt = """
 Identify constraints and risks for implementing ${FEATURE}.
 
@@ -277,6 +280,7 @@ session = "${STEP_1_OUTPUT}"
 id = 6
 title = "Phase 1 — RECON Dimension 4 (Semantic Invariants)"
 tool = "csa"
+workspace_access = "read-only"
 prompt = """
 Identify the semantic invariants and concurrency assumptions for ${FEATURE}.
 


### PR DESCRIPTION
## Summary

- Add `workspace_access = "read-only"` to all 4 RECON dimension steps in mktd workflow
- Prevents gemini-cli (first in tier-1-quick) from attempting file edits during read-only reconnaissance
- Root cause: gemini-cli tried `replace` tool during RECON → exit 1 → workflow abort

Closes #1433

## Test plan

- [ ] `weave compile patterns/mktd/workflow.toml` passes
- [ ] `just pre-commit` passes
- [ ] Verify RECON steps in isonomia-ee/ce no longer abort (requires gemini-cli daily quota)

🤖 Generated with [Claude Code](https://claude.com/claude-code)