### PR TITLE
feat(cli): warn when --tier used without explicit --tool (#1435)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "chrono",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.731"
+version = "0.1.732"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.731"
+version = "0.1.732"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -241,6 +241,7 @@ pub(crate) async fn handle_debate(
                 ));
             }
         };
+    crate::run_helpers::warn_if_tier_without_tool(args.tier.as_deref(), args.tool.is_some());
     let resolved_selection = match resolve_debate_selection(
         args.tool,
         args.model_spec.as_deref(),

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -174,7 +174,6 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             .await?;
 
             let summary = pipeline_result.summary_for_review();
-
             if !pipeline_result.passed {
                 match gate_mode {
                     csa_config::GateMode::Monitor => {
@@ -268,6 +267,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
     let detected_parent_tool = crate::run_helpers::detect_parent_tool();
     let parent_tool = crate::run_helpers::resolve_tool(detected_parent_tool, &global_config);
     let effective_tier = resolve_review_effective_tier(&args, config.as_ref())?;
+    crate::run_helpers::warn_if_tier_without_tool(args.tier.as_deref(), args.tool.is_some());
     let resolved_selection = match resolve_review_selection(
         args.tool,
         args.model_spec.as_deref(),

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -316,6 +316,8 @@ pub(crate) async fn handle_run(
         ));
     }
 
+    crate::run_helpers::warn_if_tier_without_tool(tier.as_deref(), user_explicit_tool);
+
     let strategy = skill_res
         .tool
         .unwrap_or(ToolArg::Auto)

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -86,6 +86,31 @@ pub(crate) fn validate_model_spec_tier_conflict(
     Ok(())
 }
 
+/// Returns true when `--tier` is specified without an explicit `--tool`.
+///
+/// Auto-routing in this case may silently select the wrong tool for the task
+/// (e.g., gemini-cli with allow_edit=false for write tasks).
+pub(crate) fn tier_without_tool_should_warn(tier: Option<&str>, tool_explicitly_set: bool) -> bool {
+    tier.is_some() && !tool_explicitly_set
+}
+
+/// Emit a warning when `--tier` is specified without `--tool`.
+///
+/// Backward-compatible: this is a warning only, not an error.
+pub(crate) fn warn_if_tier_without_tool(tier: Option<&str>, tool_explicitly_set: bool) {
+    if tier_without_tool_should_warn(tier, tool_explicitly_set) {
+        tracing::warn!(
+            tier = tier.unwrap_or(""),
+            "--tier without --tool uses auto-routing; \
+             specify --tool auto|claude-code|codex|gemini-cli to control tool selection"
+        );
+        eprintln!(
+            "warning: --tier without --tool uses auto-routing; \
+             specify --tool auto|claude-code|codex|gemini-cli to control tool selection"
+        );
+    }
+}
+
 /// Resolve tool and model from CLI args and config.
 ///
 /// Returns (tool, model_spec, model) where:

--- a/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
@@ -701,3 +701,31 @@ fn resolve_tool_and_model_invalid_tier_selector_includes_aliases_in_error() {
         "msg should show aliases: {msg}"
     );
 }
+
+// --- tier_without_tool_should_warn tests ---
+
+#[test]
+fn tier_without_tool_warns_when_tier_set_and_no_tool() {
+    assert!(super::tier_without_tool_should_warn(
+        Some("tier-1-quick"),
+        false
+    ));
+}
+
+#[test]
+fn tier_without_tool_no_warn_when_tool_explicitly_set() {
+    assert!(!super::tier_without_tool_should_warn(
+        Some("tier-1-quick"),
+        true
+    ));
+}
+
+#[test]
+fn tier_without_tool_no_warn_when_no_tier() {
+    assert!(!super::tier_without_tool_should_warn(None, false));
+}
+
+#[test]
+fn tier_without_tool_no_warn_when_neither() {
+    assert!(!super::tier_without_tool_should_warn(None, true));
+}

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -155,6 +155,7 @@ echo "Chinese (Simplified)"
 Tool: csa
 Session: ${STEP_1_OUTPUT}
 Tier: tier-1-quick
+Note: RECON steps are read-only (`workspace_access = "read-only"`); auto-routing is safe here because no tool writes files, so `allow_edit` restrictions do not apply. Any tool in the tier can explore.
 
 Analyze codebase structure relevant to ${FEATURE}.
 
@@ -168,6 +169,7 @@ Working directory: ${CWD}
 Tool: csa
 Session: ${STEP_1_OUTPUT}
 Tier: tier-1-quick
+Note: RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
 
 Find existing patterns or similar features to ${FEATURE} in this codebase.
 
@@ -181,6 +183,7 @@ Working directory: ${CWD}
 Tool: csa
 Session: ${STEP_1_OUTPUT}
 Tier: tier-1-quick
+Note: RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
 
 Identify constraints and risks for implementing ${FEATURE}.
 
@@ -194,6 +197,7 @@ Working directory: ${CWD}
 Tool: csa
 Session: ${STEP_1_OUTPUT}
 Tier: tier-1-quick
+Note: RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
 
 Identify the semantic invariants and concurrency assumptions for ${FEATURE}.
 

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -240,6 +240,8 @@ CONSTRAINT ANCHOR: The user prompt above may specify target crates, key files, i
 
 Report: relevant files (path + purpose, max 20), key types, module dependencies, entry points.
 Working directory: ${CWD}"""
+# RECON steps are read-only (workspace_access = "read-only"); auto-routing is safe here because
+# no tool writes files, so allow_edit restrictions do not apply. Any tool in the tier can explore.
 tier = "tier-1-quick"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"
@@ -256,6 +258,7 @@ CONSTRAINT ANCHOR: If the user prompt specifies an architectural approach or tar
 
 Report: file paths with approach, reusable components, conventions to follow.
 Working directory: ${CWD}"""
+# RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
 tier = "tier-1-quick"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"
@@ -272,6 +275,7 @@ CONSTRAINT ANCHOR: If the user prompt specifies scope boundaries (target crate, 
 
 Report: potential breaking changes, security considerations, performance, compatibility.
 Working directory: ${CWD}"""
+# RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
 tier = "tier-1-quick"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"
@@ -292,6 +296,7 @@ Report using these keys:
 - `concurrency_model`: who else can write to the files/state this touches, plus the failure / rollback model for each important step
 
 Working directory: ${CWD}"""
+# RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
 tier = "tier-1-quick"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"


### PR DESCRIPTION
## Summary

- Add `warn_tier_without_tool()` helper that emits a tracing::warn when `--tier` is specified without `--tool`
- Wire warning into `csa run`, `csa review`, and `csa debate` command paths
- Add mktd workflow comment explaining why auto-routing is acceptable for read-only RECON steps
- Add test verifying the warning function behavior

Closes #1435

## Test plan

- [ ] `cargo test` passes (including new `warn_tier_without_tool_*` tests)
- [ ] `just pre-commit` passes
- [ ] `csa run --tier tier-2-standard --sa-mode false "test"` emits warning about missing --tool
- [ ] `csa run --tier tier-2-standard --tool codex --sa-mode false "test"` does NOT emit warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)