### PR TITLE
fix(plan): add tier-model failover to plan step executor (#1448)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.738"
+version = "0.1.739"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.738"
+version = "0.1.739"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -41,8 +41,14 @@ mod plan_cmd_flow;
 #[path = "plan_cmd_assignment.rs"]
 mod plan_cmd_assignment;
 
+#[path = "plan_cmd_tier_failover.rs"]
+mod plan_cmd_tier_failover;
+
 #[path = "plan_cmd_steps.rs"]
 mod plan_cmd_steps;
+#[cfg(test)]
+#[path = "plan_cmd_steps_test_helpers.rs"]
+mod plan_cmd_steps_test_helpers;
 #[cfg(test)]
 pub(crate) use plan_cmd_assignment::{
     extract_output_assignment_markers, is_assignment_marker_key, should_inject_assignment_markers,
@@ -51,7 +57,7 @@ pub(crate) use plan_cmd_flow::shell_escape_for_command;
 use plan_cmd_steps::{PlanRunContext, execute_plan_with_journal};
 pub(crate) use plan_cmd_steps::{StepResult, StepTarget, resolve_step_tool};
 #[cfg(test)]
-pub(crate) use plan_cmd_steps::{execute_plan, execute_step};
+pub(crate) use plan_cmd_steps_test_helpers::{execute_plan, execute_step};
 
 const PLAN_JOURNAL_SCHEMA_VERSION: u8 = 1;
 const PLAN_PIPELINE_SOURCE_DIRECT: &str = "direct-plan-run";

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -54,6 +54,7 @@ pub(super) struct StepExecutionOutcome {
     pub(super) exit_code: i32,
     pub(super) output: String,
     pub(super) session_id: Option<String>,
+    pub(super) stderr: String,
 }
 
 pub(super) struct CsaStepExecutionOptions<'a> {
@@ -130,6 +131,7 @@ pub(super) async fn execute_bash_step(
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr_str = String::from_utf8_lossy(&output.stderr).to_string();
     if !stdout.is_empty() {
         eprint!("{stdout}");
     }
@@ -137,6 +139,7 @@ pub(super) async fn execute_bash_step(
         exit_code: output.status.code().unwrap_or(1),
         output: stdout,
         session_id: None,
+        stderr: stderr_str,
     })
 }
 
@@ -321,6 +324,7 @@ pub(super) async fn execute_csa_step(
         exit_code: result.execution.exit_code,
         output: captured,
         session_id: Some(result.meta_session_id),
+        stderr: result.execution.stderr_output,
     })
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -16,14 +16,12 @@ use super::plan_cmd_assignment::{
     extract_output_assignment_markers, should_inject_assignment_markers,
     strip_assignment_marker_lines,
 };
-use super::plan_cmd_exec::{
-    CsaStepExecutionOptions, StepExecutionOutcome, execute_bash_step, execute_csa_step,
-    run_with_heartbeat,
-};
+use super::plan_cmd_exec::{StepExecutionOutcome, execute_bash_step, run_with_heartbeat};
 use super::plan_cmd_flow::{
     OrchestratorHandoff, find_next_step, format_orchestrator_message, format_plan_resume_command,
     orchestrator_handoff_mode,
 };
+use super::plan_cmd_tier_failover::{TierFailoverParams, execute_csa_step_with_tier_failover};
 use super::{
     PlanRunJournal, apply_repo_fingerprint, detect_repo_fingerprint, persist_plan_journal,
     substitute_vars,
@@ -46,6 +44,7 @@ pub(crate) enum StepTarget {
     CsaTool {
         tool_name: ToolName,
         model_spec: Option<String>,
+        tier_name: Option<String>,
     },
 }
 
@@ -54,6 +53,15 @@ impl StepTarget {
         Self::CsaTool {
             tool_name: tool,
             model_spec: spec,
+            tier_name: None,
+        }
+    }
+
+    fn csa_with_tier(tool: ToolName, spec: Option<String>, tier: String) -> Self {
+        Self::CsaTool {
+            tool_name: tool,
+            model_spec: spec,
+            tier_name: Some(tier),
         }
     }
 }
@@ -137,7 +145,11 @@ pub(crate) fn resolve_step_tool(
                             let parts: Vec<&str> = model_spec_str.splitn(4, '/').collect();
                             if parts.len() == 4 && cfg.is_tool_enabled(parts[0]) {
                                 let tool = parse_tool_name(parts[0])?;
-                                return Ok(StepTarget::csa(tool, Some(model_spec_str.clone())));
+                                return Ok(StepTarget::csa_with_tier(
+                                    tool,
+                                    Some(model_spec_str.clone()),
+                                    tier_name.clone(),
+                                ));
                             }
                         }
                     }
@@ -171,7 +183,11 @@ pub(crate) fn resolve_step_tool(
                     let parts: Vec<&str> = model_spec_str.splitn(4, '/').collect();
                     if parts.len() == 4 && cfg.is_tool_enabled(parts[0]) {
                         let tool = parse_tool_name(parts[0])?;
-                        return Ok(StepTarget::csa(tool, Some(model_spec_str.clone())));
+                        return Ok(StepTarget::csa_with_tier(
+                            tool,
+                            Some(model_spec_str.clone()),
+                            tier_name.clone(),
+                        ));
                     }
                 }
             }
@@ -203,36 +219,6 @@ fn parse_tool_name(tool: &str) -> Result<ToolName> {
         "claude-code" => Ok(ToolName::ClaudeCode),
         other => bail!("Unknown tool: {other}"),
     }
-}
-
-/// Execute all steps in the plan sequentially.
-///
-/// After each successful step, injects `STEP_<id>_OUTPUT` into the variables
-/// map so subsequent steps can reference prior outputs via `${STEP_1_OUTPUT}`.
-#[cfg(test)]
-pub(crate) async fn execute_plan(
-    plan: &ExecutionPlan,
-    variables: &HashMap<String, String>,
-    project_root: &Path,
-    config: Option<&ProjectConfig>,
-    tool_override: Option<&ToolName>,
-) -> Result<Vec<StepResult>> {
-    let workflow_path = project_root.join("workflow.toml");
-    let mut journal = PlanRunJournal::new(&plan.name, &workflow_path, variables.clone());
-    let completed = HashSet::new();
-    let mut run_ctx = PlanRunContext {
-        project_root,
-        workflow_path: &workflow_path,
-        config,
-        tool_override,
-        model_spec_override: None,
-        journal: &mut journal,
-        journal_path: None,
-        resume_completed_steps: &completed,
-        chunked: false,
-        no_fs_sandbox: false,
-    };
-    execute_plan_with_journal(plan, variables, &mut run_ctx).await
 }
 
 pub(super) async fn execute_plan_with_journal(
@@ -422,32 +408,6 @@ pub(super) async fn execute_plan_with_journal(
     Ok(results)
 }
 
-/// Execute a single step with on_fail handling.
-#[cfg(test)]
-pub(crate) async fn execute_step(
-    step: &PlanStep,
-    variables: &HashMap<String, String>,
-    project_root: &Path,
-    config: Option<&ProjectConfig>,
-    tool_override: Option<&ToolName>,
-    model_spec_override: Option<&String>,
-) -> StepResult {
-    let workflow_path_buf = project_root.join("workflow.toml");
-    execute_step_with_workflow(
-        step,
-        variables,
-        &StepExecutionContext {
-            project_root,
-            workflow_path: &workflow_path_buf,
-            config,
-            tool_override,
-            model_spec_override,
-            no_fs_sandbox: false,
-        },
-    )
-    .await
-}
-
 pub(crate) async fn execute_step_with_workflow(
     step: &PlanStep,
     variables: &HashMap<String, String>,
@@ -518,7 +478,7 @@ pub(crate) async fn execute_step_with_workflow(
     };
 
     // Apply --tool override: replace tool for all CSA steps (bash/weave unaffected).
-    // Clear model_spec since the tier-resolved spec may reference a different tool.
+    // Clear model_spec and tier_name since the override bypasses tier routing.
     let target = if let Some(override_tool) = step_ctx.tool_override {
         match target {
             StepTarget::CsaTool { .. } => {
@@ -531,6 +491,7 @@ pub(crate) async fn execute_step_with_workflow(
                 StepTarget::CsaTool {
                     tool_name: *override_tool,
                     model_spec: None,
+                    tier_name: None,
                 }
             }
             other => other,
@@ -674,22 +635,19 @@ pub(crate) async fn execute_step_with_workflow(
             StepTarget::CsaTool {
                 tool_name,
                 model_spec,
+                tier_name,
             } => {
                 let prompt = csa_prompt.as_deref().unwrap_or_default();
-                run_with_heartbeat(
+                execute_csa_step_with_tier_failover(
                     &label,
-                    execute_csa_step(
-                        &label,
-                        prompt,
-                        tool_name,
-                        step_ctx.project_root,
-                        step_ctx.config,
-                        CsaStepExecutionOptions {
-                            model_spec: model_spec.as_deref(),
-                            forwarded_session: csa_session.as_deref(),
-                            no_fs_sandbox: step_ctx.no_fs_sandbox,
-                        },
-                    ),
+                    prompt,
+                    &TierFailoverParams {
+                        initial_tool: tool_name,
+                        initial_model_spec: model_spec.as_deref(),
+                        tier_name: tier_name.as_deref(),
+                        forwarded_session: csa_session.as_deref(),
+                    },
+                    step_ctx,
                     start,
                 )
                 .await
@@ -707,6 +665,7 @@ pub(crate) async fn execute_step_with_workflow(
                     exit_code: 1,
                     output: String::new(),
                     session_id: None,
+                    stderr: String::new(),
                 }
             }
         };

--- a/crates/cli-sub-agent/src/plan_cmd_steps_test_helpers.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps_test_helpers.rs
@@ -1,0 +1,68 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use anyhow::Result;
+
+use csa_config::ProjectConfig;
+use csa_core::types::ToolName;
+use weave::compiler::ExecutionPlan;
+
+use super::PlanRunJournal;
+use super::plan_cmd_steps::{
+    PlanRunContext, StepExecutionContext, StepResult, execute_plan_with_journal,
+    execute_step_with_workflow,
+};
+
+/// Execute all steps in the plan sequentially.
+///
+/// After each successful step, injects `STEP_<id>_OUTPUT` into the variables
+/// map so subsequent steps can reference prior outputs via `${STEP_1_OUTPUT}`.
+pub(crate) async fn execute_plan(
+    plan: &ExecutionPlan,
+    variables: &HashMap<String, String>,
+    project_root: &Path,
+    config: Option<&ProjectConfig>,
+    tool_override: Option<&ToolName>,
+) -> Result<Vec<StepResult>> {
+    let workflow_path = project_root.join("workflow.toml");
+    let mut journal = PlanRunJournal::new(&plan.name, &workflow_path, variables.clone());
+    let completed = HashSet::new();
+    let mut run_ctx = PlanRunContext {
+        project_root,
+        workflow_path: &workflow_path,
+        config,
+        tool_override,
+        model_spec_override: None,
+        journal: &mut journal,
+        journal_path: None,
+        resume_completed_steps: &completed,
+        chunked: false,
+        no_fs_sandbox: false,
+    };
+    execute_plan_with_journal(plan, variables, &mut run_ctx).await
+}
+
+/// Execute a single step with on_fail handling.
+pub(crate) async fn execute_step(
+    step: &weave::compiler::PlanStep,
+    variables: &HashMap<String, String>,
+    project_root: &Path,
+    config: Option<&ProjectConfig>,
+    tool_override: Option<&ToolName>,
+    model_spec_override: Option<&String>,
+) -> StepResult {
+    let workflow_path_buf = project_root.join("workflow.toml");
+    execute_step_with_workflow(
+        step,
+        variables,
+        &StepExecutionContext {
+            project_root,
+            workflow_path: &workflow_path_buf,
+            config,
+            tool_override,
+            model_spec_override,
+            no_fs_sandbox: false,
+        },
+    )
+    .await
+}

--- a/crates/cli-sub-agent/src/plan_cmd_tier_failover.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tier_failover.rs
@@ -1,0 +1,137 @@
+use std::time::Instant;
+
+use anyhow::Result;
+use tracing::{info, warn};
+
+use csa_core::types::ToolName;
+
+use super::plan_cmd_exec::{
+    CsaStepExecutionOptions, StepExecutionOutcome, execute_csa_step, run_with_heartbeat,
+};
+use super::plan_cmd_steps::StepExecutionContext;
+use crate::tier_model_fallback::{
+    TierAttemptFailure, classify_next_model_failure_with_elapsed, format_all_models_failed_reason,
+    ordered_tier_candidates,
+};
+
+pub(super) struct TierFailoverParams<'a> {
+    pub(super) initial_tool: &'a ToolName,
+    pub(super) initial_model_spec: Option<&'a str>,
+    pub(super) tier_name: Option<&'a str>,
+    pub(super) forwarded_session: Option<&'a str>,
+}
+
+/// Execute a CSA step with tier-level failover.
+///
+/// When a tier is configured, builds the ordered candidate list and tries each
+/// model in sequence. On a failover-eligible failure (HTTP 400/429, rate limit,
+/// etc.), advances to the next model in the tier. Without a tier, behaves
+/// identically to a single `execute_csa_step` call.
+pub(super) async fn execute_csa_step_with_tier_failover(
+    label: &str,
+    prompt: &str,
+    params: &TierFailoverParams<'_>,
+    step_ctx: &StepExecutionContext<'_>,
+    step_started_at: Instant,
+) -> Result<StepExecutionOutcome> {
+    let global_config = csa_config::GlobalConfig::load().ok();
+    let candidates = ordered_tier_candidates(
+        *params.initial_tool,
+        params.initial_model_spec,
+        params.tier_name,
+        step_ctx.config,
+        global_config.as_ref(),
+        params.tier_name.is_some(),
+        None,
+    );
+
+    let mut failures: Vec<TierAttemptFailure> = Vec::new();
+
+    for (idx, (tool, model_spec)) in candidates.iter().enumerate() {
+        let attempt_start = Instant::now();
+        let is_fallback = idx > 0;
+        if is_fallback {
+            let spec_label = model_spec.as_deref().unwrap_or(tool.as_str());
+            info!(
+                "{label} - Tier failover: trying {spec_label} (candidate {}/{})…",
+                idx + 1,
+                candidates.len()
+            );
+            eprintln!(
+                "{label} - TIER FAILOVER → {spec_label} ({}/{})",
+                idx + 1,
+                candidates.len()
+            );
+        }
+
+        let result = run_with_heartbeat(
+            label,
+            execute_csa_step(
+                label,
+                prompt,
+                tool,
+                step_ctx.project_root,
+                step_ctx.config,
+                CsaStepExecutionOptions {
+                    model_spec: model_spec.as_deref(),
+                    forwarded_session: if is_fallback {
+                        None
+                    } else {
+                        params.forwarded_session
+                    },
+                    no_fs_sandbox: step_ctx.no_fs_sandbox,
+                },
+            ),
+            step_started_at,
+        )
+        .await;
+
+        match result {
+            Ok(outcome) if outcome.exit_code == 0 => return Ok(outcome),
+            Ok(outcome) => {
+                let elapsed = attempt_start.elapsed();
+                let detected = classify_next_model_failure_with_elapsed(
+                    tool.as_str(),
+                    &outcome.stderr,
+                    &outcome.output,
+                    outcome.exit_code,
+                    model_spec.as_deref(),
+                    Some(elapsed),
+                );
+                let spec_label = model_spec.as_deref().unwrap_or(tool.as_str());
+                if let Some(rate_limit) = detected
+                    && idx + 1 < candidates.len()
+                {
+                    warn!(
+                        "{label} - {spec_label} failed ({}); advancing to next tier model",
+                        rate_limit.reason
+                    );
+                    eprintln!("{label} - {spec_label} FAILOVER ({})", rate_limit.reason);
+                    failures.push(TierAttemptFailure {
+                        model_spec: spec_label.to_string(),
+                        reason: rate_limit.reason,
+                    });
+                    continue;
+                }
+                if let Some(reason) = format_all_models_failed_reason(params.tier_name, &failures) {
+                    warn!("{label} - {reason}");
+                }
+                return Ok(outcome);
+            }
+            Err(err) => {
+                if idx + 1 < candidates.len() {
+                    let spec_label = model_spec.as_deref().unwrap_or(tool.as_str());
+                    warn!("{label} - {spec_label} error: {err}; trying next tier model");
+                    failures.push(TierAttemptFailure {
+                        model_spec: spec_label.to_string(),
+                        reason: format!("error: {err}"),
+                    });
+                    continue;
+                }
+                return Err(err);
+            }
+        }
+    }
+
+    unreachable!("candidates list is never empty")
+}

--- a/crates/cli-sub-agent/src/plan_display.rs
+++ b/crates/cli-sub-agent/src/plan_display.rs
@@ -38,6 +38,7 @@ pub(crate) fn print_plan(
             Ok(StepTarget::CsaTool {
                 tool_name,
                 model_spec,
+                ..
             }) => match model_spec {
                 Some(s) => format!("{} ({})", tool_name.as_str(), s),
                 None => tool_name.as_str().to_string(),

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.732"
-weave = "0.1.732"
+csa = "0.1.738"
+weave = "0.1.738"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Plan steps with tier annotations now iterate through the tier's model fallback chain on failover-eligible failures (HTTP 400/429, rate limit, quota exhaustion)
- Previously, `resolve_step_tool` collapsed the tier into a single `(tool, model_spec)` pair and `execute_csa_step` tried only that one model — gemini-cli returning 400 caused the entire workflow to abort with no recovery
- `StepTarget::CsaTool` gains `tier_name` field so the executor can build the full fallback chain via `ordered_tier_candidates()`

## Changes
- **New**: `plan_cmd_tier_failover.rs` — `execute_csa_step_with_tier_failover()` loops through tier candidates using `classify_next_model_failure_with_elapsed()` for failover gating
- **Modified**: `plan_cmd_steps.rs` — `StepTarget::CsaTool` carries `tier_name`, `resolve_step_tool` preserves it
- **Modified**: `plan_cmd_exec.rs` — `StepExecutionOutcome` gains `stderr` field for failover pattern detection
- **Extracted**: `plan_cmd_steps_test_helpers.rs` — test-only `execute_plan`/`execute_step` helpers (monolith gate compliance)

Closes #1448

## Test plan
- [x] `cargo check --package cli-sub-agent` passes
- [x] `cargo clippy --package cli-sub-agent -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `csa review --range main...HEAD` verdict: PASS (session 01KRWHSC6ZZ)
- [ ] Manual: run `csa plan run patterns/mktd/workflow.toml` against a repo where gemini-cli returns 400 — verify it falls through to claude-code/codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)