### PR TITLE
feat(pipeline): plan context injection to combat goal drift (#1451)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.739"
+version = "0.1.740"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.739"
+version = "0.1.740"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -36,6 +36,9 @@ mod result_contract;
 #[path = "pipeline_design_context.rs"]
 pub(crate) mod design_context;
 
+#[path = "pipeline_plan_context.rs"]
+pub(crate) mod plan_context;
+
 #[path = "pipeline_session_exec.rs"]
 mod session_exec;
 

--- a/crates/cli-sub-agent/src/pipeline_design_context.rs
+++ b/crates/cli-sub-agent/src/pipeline_design_context.rs
@@ -13,6 +13,7 @@ use tracing::{debug, info};
 #[derive(Debug, Default)]
 pub(crate) struct FirstTurnContext {
     pub project_context: Option<String>,
+    pub plan_context: Option<String>,
     pub design_context: Option<String>,
 }
 
@@ -21,6 +22,7 @@ pub(crate) fn load_first_turn_context(
     session_project_path: &str,
     project_root: &Path,
     context_load_options: Option<&csa_executor::ContextLoadOptions>,
+    plan_injection_enabled: bool,
 ) -> FirstTurnContext {
     // Project context (CLAUDE.md, AGENTS.md).
     let opts = context_load_options.cloned().unwrap_or_default();
@@ -42,8 +44,16 @@ pub(crate) fn load_first_turn_context(
         info!(bytes = dc.len(), "Injecting design context into prompt");
     });
 
+    let plan_context = plan_injection_enabled
+        .then(|| super::plan_context::load_plan_context(project_root))
+        .flatten()
+        .inspect(|pc| {
+            info!(bytes = pc.len(), "Injecting plan context into prompt");
+        });
+
     FirstTurnContext {
         project_context,
+        plan_context,
         design_context,
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_design_context.rs
+++ b/crates/cli-sub-agent/src/pipeline_design_context.rs
@@ -84,3 +84,96 @@ fn detect_branch(project_root: &Path) -> Option<String> {
     let backend = csa_session::vcs_backends::create_vcs_backend(project_root);
     backend.current_branch(project_root).ok().flatten()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+    use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoManager};
+    use std::{fs, path::Path, process::Command};
+    use tempfile::tempdir;
+
+    const TEST_BRANCH: &str = "feat/plan-context";
+
+    fn run_git(project_root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(project_root)
+            .output()
+            .expect("git should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_git_branch(project_root: &Path, branch: &str) {
+        fs::create_dir_all(project_root).expect("create project root");
+        run_git(project_root, &["init", "-q"]);
+        run_git(project_root, &["config", "user.email", "test@example.com"]);
+        run_git(project_root, &["config", "user.name", "Test User"]);
+        run_git(project_root, &["commit", "--allow-empty", "-m", "initial"]);
+        run_git(project_root, &["checkout", "-q", "-b", branch]);
+    }
+
+    fn criterion() -> SpecCriterion {
+        SpecCriterion {
+            kind: CriterionKind::Scenario,
+            id: "scenario-plan-context".to_string(),
+            description: "Active plan context is injected on the first turn.".to_string(),
+            status: CriterionStatus::Pending,
+        }
+    }
+
+    #[test]
+    fn first_turn_context_respects_plan_injection_flag() {
+        let _env_lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
+        let temp = tempdir().expect("tempdir");
+        let state_home = temp.path().join("state");
+        fs::create_dir_all(&state_home).expect("create state dir");
+        let _home = ScopedEnvVarRestore::set("HOME", temp.path());
+        let _state = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+
+        let project_root = temp.path().join("project");
+        init_git_branch(&project_root, TEST_BRANCH);
+        let manager = TodoManager::new(&project_root).expect("todo manager");
+        let plan = manager
+            .create("Goal drift prevention", Some(TEST_BRANCH))
+            .expect("plan");
+        manager
+            .save_spec(
+                &plan.timestamp,
+                &SpecDocument {
+                    plan_ulid: plan.timestamp.clone(),
+                    summary: "Keep first-turn prompts aligned with the active plan.".to_string(),
+                    criteria: vec![criterion()],
+                    ..SpecDocument::default()
+                },
+            )
+            .expect("save spec");
+
+        let enabled_context = load_first_turn_context(
+            project_root.to_str().expect("utf-8 project path"),
+            &project_root,
+            None,
+            true,
+        );
+        let plan_context = enabled_context
+            .plan_context
+            .expect("enabled plan injection should load plan context");
+        assert!(plan_context.contains("<plan-context>"));
+        assert!(plan_context.contains("Plan: Goal drift prevention"));
+        assert!(plan_context.contains("Branch: feat/plan-context"));
+        assert!(plan_context.contains("scenario-plan-context"));
+
+        let disabled_context = load_first_turn_context(
+            project_root.to_str().expect("utf-8 project path"),
+            &project_root,
+            None,
+            false,
+        );
+        assert!(disabled_context.plan_context.is_none());
+    }
+}

--- a/crates/cli-sub-agent/src/pipeline_plan_context.rs
+++ b/crates/cli-sub-agent/src/pipeline_plan_context.rs
@@ -1,0 +1,227 @@
+//! Read-only TODO plan context formatter for prompt injection.
+//!
+//! The formatter intentionally reads only TODO metadata and `spec.toml`.
+//! Reference files are not part of this context because they can contain
+//! untrusted bulk content.
+
+use std::path::Path;
+
+use csa_todo::{
+    CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoManager, TodoPlan,
+};
+use tracing::{debug, warn};
+
+const PLAN_CONTEXT_MAX_LINES: usize = 30;
+
+/// Load a lightweight plan context for the current branch.
+///
+/// Returns `None` when branch detection fails, no TODO plan exists for the
+/// branch, or TODO state cannot be read.
+pub(crate) fn load_plan_context(project_root: &Path) -> Option<String> {
+    let branch = detect_branch(project_root)?;
+    debug!(branch = %branch, "Checking for plan context");
+
+    let manager = TodoManager::new(project_root).ok()?;
+    load_plan_context_for_branch(&manager, &branch)
+}
+
+fn load_plan_context_for_branch(manager: &TodoManager, branch: &str) -> Option<String> {
+    let plan = match manager.find_by_branch(branch) {
+        Ok(plans) => plans.into_iter().next()?,
+        Err(error) => {
+            warn!(branch, error = %error, "Failed to find TODO plan for branch");
+            return None;
+        }
+    };
+
+    let spec = match manager.load_spec(&plan.timestamp) {
+        Ok(spec) => spec,
+        Err(error) => {
+            warn!(
+                branch,
+                plan = %plan.timestamp,
+                error = %error,
+                "Failed to load TODO plan spec"
+            );
+            None
+        }
+    };
+
+    Some(format_plan_context(&plan, spec.as_ref()))
+}
+
+fn format_plan_context(plan: &TodoPlan, spec: Option<&SpecDocument>) -> String {
+    let branch = plan.metadata.branch.as_deref().unwrap_or("(none)");
+    let mut lines = vec![
+        "<plan-context>".to_string(),
+        format!("Plan: {}", escape_xml_text(&plan.metadata.title)),
+        format!("Branch: {}", escape_xml_text(branch)),
+        format!("Current phase: {}", plan.metadata.status),
+        "Checklist / DONE WHEN criteria:".to_string(),
+    ];
+
+    match spec {
+        Some(spec) if !spec.criteria.is_empty() => {
+            lines.extend(spec.criteria.iter().map(format_criterion_checkbox));
+        }
+        Some(_) => lines.push("(spec.toml has no criteria)".to_string()),
+        None => lines.push("(no spec.toml criteria found)".to_string()),
+    }
+
+    lines.push("</plan-context>".to_string());
+    truncate_plan_context_lines(lines).join("\n")
+}
+
+fn format_criterion_checkbox(criterion: &SpecCriterion) -> String {
+    let checked = match criterion.status {
+        CriterionStatus::Verified => "x",
+        CriterionStatus::Pending | CriterionStatus::Failed => " ",
+    };
+    let status_suffix = match criterion.status {
+        CriterionStatus::Pending => "",
+        CriterionStatus::Verified => " (verified)",
+        CriterionStatus::Failed => " (failed)",
+    };
+
+    format!(
+        "- [{checked}] [{}] {}: {}{}",
+        criterion_kind_label(criterion.kind),
+        escape_xml_text(&criterion.id),
+        escape_xml_text(&criterion.description),
+        status_suffix
+    )
+}
+
+fn criterion_kind_label(kind: CriterionKind) -> &'static str {
+    match kind {
+        CriterionKind::Scenario => "scenario",
+        CriterionKind::Property => "property",
+        CriterionKind::Check => "check",
+    }
+}
+
+fn truncate_plan_context_lines(mut lines: Vec<String>) -> Vec<String> {
+    if lines.len() <= PLAN_CONTEXT_MAX_LINES {
+        return lines;
+    }
+
+    let keep_count = PLAN_CONTEXT_MAX_LINES - 2;
+    let omitted_count = lines.len().saturating_sub(keep_count + 1);
+    lines.truncate(keep_count);
+    lines.push(format!(
+        "<!-- truncated: omitted {omitted_count} line(s) to keep plan-context <= {PLAN_CONTEXT_MAX_LINES} lines -->"
+    ));
+    lines.push("</plan-context>".to_string());
+    lines
+}
+
+fn escape_xml_text(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Auto-detect current branch via VCS abstraction (supports both git and jj).
+fn detect_branch(project_root: &Path) -> Option<String> {
+    let backend = csa_session::vcs_backends::create_vcs_backend(project_root);
+    backend.current_branch(project_root).ok().flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use csa_todo::{SpecCriterion, TodoStatus};
+    use tempfile::tempdir;
+
+    fn criterion(id: &str, status: CriterionStatus) -> SpecCriterion {
+        SpecCriterion {
+            kind: CriterionKind::Scenario,
+            id: id.to_string(),
+            description: format!("{id} must pass."),
+            status,
+        }
+    }
+
+    #[test]
+    fn plan_context_renders_structure_and_spec_checkboxes() {
+        let dir = tempdir().expect("tempdir");
+        let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+        let plan = manager
+            .create("Goal drift prevention", Some("feat/plan-context"))
+            .expect("plan");
+        manager
+            .update_status(&plan.timestamp, TodoStatus::Implementing)
+            .expect("status");
+        let spec = SpecDocument {
+            plan_ulid: plan.timestamp.clone(),
+            summary: "Keep sessions aligned to the active plan.".to_string(),
+            criteria: vec![
+                criterion("scenario-pending", CriterionStatus::Pending),
+                criterion("scenario-verified", CriterionStatus::Verified),
+                criterion("scenario-failed", CriterionStatus::Failed),
+            ],
+            ..SpecDocument::default()
+        };
+        manager
+            .save_spec(&plan.timestamp, &spec)
+            .expect("save spec");
+
+        let context = load_plan_context_for_branch(&manager, "feat/plan-context")
+            .expect("context should render");
+
+        assert!(context.starts_with("<plan-context>\n"));
+        assert!(context.contains("Plan: Goal drift prevention\n"));
+        assert!(context.contains("Branch: feat/plan-context\n"));
+        assert!(context.contains("Current phase: implementing\n"));
+        assert!(context.contains("Checklist / DONE WHEN criteria:\n"));
+        assert!(context.contains("- [ ] [scenario] scenario-pending: scenario-pending must pass."));
+        assert!(context.contains(
+            "- [x] [scenario] scenario-verified: scenario-verified must pass. (verified)"
+        ));
+        assert!(
+            context
+                .contains("- [ ] [scenario] scenario-failed: scenario-failed must pass. (failed)")
+        );
+        assert!(context.ends_with("</plan-context>"));
+        assert!(context.lines().count() <= PLAN_CONTEXT_MAX_LINES);
+    }
+
+    #[test]
+    fn plan_context_truncates_long_specs_to_thirty_lines() {
+        let dir = tempdir().expect("tempdir");
+        let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+        let plan = manager
+            .create("Long spec", Some("feat/long-spec"))
+            .expect("plan");
+        let spec = SpecDocument {
+            plan_ulid: plan.timestamp.clone(),
+            summary: "Long criteria list.".to_string(),
+            criteria: (0..40)
+                .map(|index| criterion(&format!("criterion-{index:02}"), CriterionStatus::Pending))
+                .collect(),
+            ..SpecDocument::default()
+        };
+        manager
+            .save_spec(&plan.timestamp, &spec)
+            .expect("save spec");
+
+        let context = load_plan_context_for_branch(&manager, "feat/long-spec")
+            .expect("context should render");
+
+        assert_eq!(context.lines().count(), PLAN_CONTEXT_MAX_LINES);
+        assert!(context.contains("Plan: Long spec\n"));
+        assert!(context.contains("Branch: feat/long-spec\n"));
+        assert!(context.contains("Current phase: draft\n"));
+        assert!(context.contains("<!-- truncated: omitted"));
+        assert!(context.ends_with("</plan-context>"));
+    }
+
+    #[test]
+    fn plan_context_returns_none_when_branch_has_no_plan() {
+        let dir = tempdir().expect("tempdir");
+        let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+        assert!(load_plan_context_for_branch(&manager, "feat/missing").is_none());
+    }
+}

--- a/crates/cli-sub-agent/src/pipeline_prompt_cache.rs
+++ b/crates/cli-sub-agent/src/pipeline_prompt_cache.rs
@@ -34,6 +34,13 @@ impl PromptAssembly {
             }
         }
 
+        if let Some(plan_context) = context.plan_context {
+            if !self.dynamic_prompt.ends_with('\n') {
+                self.dynamic_prompt.push('\n');
+            }
+            self.dynamic_prompt.push_str(&plan_context);
+        }
+
         if let Some(design_context) = context.design_context {
             if !self.dynamic_prompt.ends_with('\n') {
                 self.dynamic_prompt.push('\n');
@@ -103,6 +110,7 @@ mod tests {
             project_context: Some(
                 "<context-file path=\"CLAUDE.md\">\nstatic\n</context-file>\n\n".to_string(),
             ),
+            plan_context: Some("<plan-context>\ndynamic plan\n</plan-context>".to_string()),
             design_context: Some("<design-context>\ndynamic design\n</design-context>".to_string()),
         }
     }
@@ -122,7 +130,8 @@ mod tests {
         assert!(!prompt.contains(STATIC_START));
         assert!(!prompt.contains(STATIC_END));
         assert!(prompt.starts_with("STATIC RESTRICTION\n\n<context-file"));
-        assert!(prompt.contains("user task\n<design-context>"));
+        assert!(prompt.contains("user task\n<plan-context>"));
+        assert!(prompt.contains("</plan-context>\n<design-context>"));
         assert!(prompt.ends_with("<csa-output-format>static</csa-output-format>"));
     }
 
@@ -147,6 +156,7 @@ mod tests {
         let static_end = prompt.find(STATIC_END).expect("static end marker");
         let dynamic_warning = prompt.find("dynamic warning").expect("dynamic warning");
         let user_task = prompt.find("user task").expect("user task");
+        let plan = prompt.find("<plan-context>").expect("plan context");
         let memory = prompt.find("<memory>dynamic</memory>").expect("memory");
         let guard = prompt.find("<guard>dynamic guard</guard>").expect("guard");
 
@@ -157,7 +167,8 @@ mod tests {
         assert!(output_format < static_end);
         assert!(static_end < dynamic_warning);
         assert!(dynamic_warning < user_task);
-        assert!(user_task < memory);
+        assert!(user_task < plan);
+        assert!(plan < memory);
         assert!(memory < guard);
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -212,7 +212,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     super::lefthook_auto_install::spawn_lefthook_setup_if_needed(project_root);
     // Spawn background review-gate auto-setup if configured (non-blocking, rate-limited).
     crate::setup_cmds::spawn_review_gate_setup_if_needed(project_root, global_config);
-
     let memory_project_key = resolve_memory_project_key(project_root);
     let cd = crate::pipeline_env::resolve_cooldown_seconds(config);
     let depth = crate::pipeline_env::current_csa_depth();
@@ -391,6 +390,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             &session.project_path,
             project_root,
             context_load_options,
+            config.is_none_or(|cfg| cfg.session.resolved_plan_injection()),
         );
         prompt_assembly.add_first_turn_context(first_turn_context);
     }

--- a/crates/cli-sub-agent/src/plan_cmd_override_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_override_tests.rs
@@ -232,6 +232,7 @@ fn tool_override_clears_model_spec() {
         StepTarget::CsaTool { .. } => StepTarget::CsaTool {
             tool_name: override_tool,
             model_spec: None,
+            tier_name: None,
         },
         other => other,
     };
@@ -239,6 +240,7 @@ fn tool_override_clears_model_spec() {
         StepTarget::CsaTool {
             tool_name,
             model_spec,
+            tier_name: _,
         } => {
             assert_eq!(tool_name, ToolName::ClaudeCode, "tool must be overridden");
             assert!(
@@ -271,6 +273,7 @@ fn tool_override_does_not_affect_weave_include() {
         StepTarget::CsaTool { .. } => StepTarget::CsaTool {
             tool_name: override_tool,
             model_spec: None,
+            tier_name: None,
         },
         other => other,
     };
@@ -291,6 +294,7 @@ async fn run_with_heartbeat_returns_success_exit_code() {
                 super::plan_cmd_exec::StepExecutionOutcome {
                     exit_code: 0,
                     output: "ok".into(),
+                    stderr: String::new(),
                     session_id: None,
                 },
             )

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -788,4 +788,4 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
 
 #[cfg(test)]
 #[path = "review_cmd_tests_barrel.rs"]
-mod tests_barrel;
+pub(crate) mod tests;

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -19,7 +19,7 @@ fn assume_review_tools_available() -> (OwnedMutexGuard<()>, ScopedEnvVarRestore)
         ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1"),
     )
 }
-pub(super) fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
+pub(crate) fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
     let mut tool_map = HashMap::new();
     for tool in csa_config::global::all_known_tools() {
         tool_map.insert(
@@ -132,7 +132,7 @@ fn run_git(repo: &std::path::Path, args: &[&str]) {
     );
 }
 
-pub(super) fn setup_git_repo() -> TempDir {
+pub(crate) fn setup_git_repo() -> TempDir {
     let temp = TempDir::new().expect("create tempdir");
     run_git(temp.path(), &["init"]);
     run_git(temp.path(), &["config", "user.email", "test@example.com"]);

--- a/crates/cli-sub-agent/src/review_cmd_tests_barrel.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_barrel.rs
@@ -1,3 +1,6 @@
+pub(in crate::review_cmd::tests) use super::*;
+pub(crate) use tests::{ScopedEnvVarRestore, project_config_with_enabled_tools, setup_git_repo};
+
 #[path = "review_cmd_tests_safety_preamble.rs"]
 mod safety_preamble_tests;
 #[path = "review_cmd_tests.rs"]

--- a/crates/csa-config/src/config_session.rs
+++ b/crates/csa-config/src/config_session.rs
@@ -81,6 +81,12 @@ pub struct SessionConfig {
     /// `<!-- CSA:SECTION:<id> -->` delimiters for machine-readable parsing.
     #[serde(default = "default_true")]
     pub structured_output: bool,
+    /// Inject the active plan into session prompts.
+    ///
+    /// `None` preserves the default-on behavior while still allowing global
+    /// and project config to override each other through the normal TOML merge.
+    #[serde(default)]
+    pub plan_injection: Option<bool>,
     /// Maximum age (seconds) for a seed session to remain valid.
     /// Sessions older than this are not eligible as fork sources.
     #[serde(default = "default_seed_max_age_secs")]
@@ -209,6 +215,7 @@ impl Default for SessionConfig {
             transcript_enabled: false,
             transcript_redaction: true,
             structured_output: true,
+            plan_injection: None,
             seed_max_age_secs: default_seed_max_age_secs(),
             auto_seed_fork: true,
             max_seed_sessions: default_max_seed_sessions(),
@@ -231,6 +238,7 @@ impl SessionConfig {
         !self.transcript_enabled
             && self.transcript_redaction
             && self.structured_output
+            && self.plan_injection.is_none()
             && self.seed_max_age_secs == default_seed_max_age_secs()
             && self.auto_seed_fork
             && self.max_seed_sessions == default_max_seed_sessions()
@@ -271,6 +279,10 @@ impl SessionConfig {
     pub fn resolved_spool_keep_rotated(&self) -> bool {
         self.spool_keep_rotated
             .unwrap_or(DEFAULT_SPOOL_KEEP_ROTATED)
+    }
+
+    pub fn resolved_plan_injection(&self) -> bool {
+        self.plan_injection.unwrap_or(true)
     }
 
     /// Resolve the fork prefix token budget, clamping out-of-range values.

--- a/crates/csa-config/src/config_tests_tail.rs
+++ b/crates/csa-config/src/config_tests_tail.rs
@@ -370,6 +370,67 @@ transcript_enabled = false
 }
 
 #[test]
+fn test_session_config_plan_injection_defaults_to_true_when_missing() {
+    let toml_str = r#"
+transcript_enabled = false
+"#;
+    let cfg: SessionConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(cfg.plan_injection, None);
+    assert!(cfg.resolved_plan_injection());
+    assert!(cfg.is_default());
+}
+
+#[test]
+fn test_session_config_deserializes_plan_injection_override() {
+    let toml_str = r#"
+plan_injection = false
+"#;
+    let cfg: SessionConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(cfg.plan_injection, Some(false));
+    assert!(!cfg.resolved_plan_injection());
+    assert!(!cfg.is_default());
+}
+
+#[test]
+fn test_session_plan_injection_project_overrides_global() {
+    let dir = tempdir().unwrap();
+
+    let user_dir = dir.path().join("user");
+    std::fs::create_dir_all(&user_dir).unwrap();
+    let user_path = user_dir.join("config.toml");
+    std::fs::write(
+        &user_path,
+        r#"
+        [session]
+        plan_injection = true
+    "#,
+    )
+    .unwrap();
+
+    let project_dir = dir.path().join("project").join(".csa");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    let project_path = project_dir.join("config.toml");
+    std::fs::write(
+        &project_path,
+        r#"
+        [project]
+        name = "test-project"
+
+        [session]
+        plan_injection = false
+    "#,
+    )
+    .unwrap();
+
+    let config = ProjectConfig::load_with_paths(Some(&user_path), &project_path)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(config.session.plan_injection, Some(false));
+    assert!(!config.session.resolved_plan_injection());
+}
+
+#[test]
 fn test_session_config_default_does_not_require_commit_on_mutation() {
     let cfg = SessionConfig::default();
     assert!(!cfg.require_commit_on_mutation);

--- a/crates/csa-process/src/daemon.rs
+++ b/crates/csa-process/src/daemon.rs
@@ -8,7 +8,7 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::process::CommandExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
@@ -41,7 +41,7 @@ enum DaemonSpawnMode {
     IndependentScope { unit: String },
 }
 
-fn open_log_file(dir: &std::path::Path, name: &str) -> Result<File> {
+fn open_log_file(dir: &Path, name: &str) -> Result<File> {
     OpenOptions::new()
         .create(true)
         .write(true)
@@ -51,7 +51,7 @@ fn open_log_file(dir: &std::path::Path, name: &str) -> Result<File> {
         .with_context(|| format!("failed to create {name} in {}", dir.display()))
 }
 
-fn open_log_file_append(dir: &std::path::Path, name: &str) -> Result<File> {
+fn open_log_file_append(dir: &Path, name: &str) -> Result<File> {
     OpenOptions::new()
         .create(true)
         .append(true)
@@ -117,6 +117,14 @@ fn append_daemon_child_args(cmd: &mut Command, config: &DaemonSpawnConfig) {
 }
 
 fn build_daemon_command(config: &DaemonSpawnConfig, mode: &DaemonSpawnMode) -> Command {
+    build_daemon_command_with_systemd_run(config, mode, Path::new("systemd-run"))
+}
+
+fn build_daemon_command_with_systemd_run(
+    config: &DaemonSpawnConfig,
+    mode: &DaemonSpawnMode,
+    systemd_run: &Path,
+) -> Command {
     match mode {
         DaemonSpawnMode::Direct => {
             let mut cmd = Command::new(&config.csa_binary);
@@ -124,7 +132,7 @@ fn build_daemon_command(config: &DaemonSpawnConfig, mode: &DaemonSpawnMode) -> C
             cmd
         }
         DaemonSpawnMode::IndependentScope { unit } => {
-            let mut cmd = Command::new("systemd-run");
+            let mut cmd = Command::new(systemd_run);
             cmd.args(["--user", "--scope", "--quiet", "--collect", "--unit", unit]);
             cmd.arg("--");
             cmd.arg(&config.csa_binary);
@@ -158,6 +166,13 @@ fn read_process_start_time_ticks(_pid: u32) -> Option<u64> {
 /// Spawn a detached daemon process with setsid, stdin=/dev/null,
 /// stdout/stderr redirected to spool files in the session directory.
 pub fn spawn_daemon(config: DaemonSpawnConfig) -> Result<DaemonSpawnResult> {
+    spawn_daemon_with_systemd_run(config, Path::new("systemd-run"))
+}
+
+fn spawn_daemon_with_systemd_run(
+    config: DaemonSpawnConfig,
+    systemd_run: &Path,
+) -> Result<DaemonSpawnResult> {
     std::fs::create_dir_all(&config.session_dir).with_context(|| {
         format!(
             "failed to create session dir {}",
@@ -186,7 +201,7 @@ pub fn spawn_daemon(config: DaemonSpawnConfig) -> Result<DaemonSpawnResult> {
         }
     }
 
-    let mut cmd = build_daemon_command(&config, &spawn_mode);
+    let mut cmd = build_daemon_command_with_systemd_run(&config, &spawn_mode, systemd_run);
 
     cmd.stdin(Stdio::null());
     cmd.stdout(stdout_file);
@@ -511,8 +526,8 @@ mod tests {
         );
     }
 
-    /// Verify that when IndependentScope is forced but systemd-run cannot be found
-    /// in PATH, spawn_daemon retries with Direct mode and still succeeds.
+    /// Verify that when IndependentScope is forced but systemd-run cannot be
+    /// spawned, spawn_daemon retries with Direct mode and still succeeds.
     ///
     /// Simulates the nested-CSA-subprocess scenario where the env override forces
     /// IndependentScope but dbus / systemd-run is absent (ENOENT at exec time).
@@ -524,15 +539,7 @@ mod tests {
         let session_dir = tmp.path().join("session-fallback");
         let wrapper = write_wrapper_script(tmp.path(), "wrapper-fallback.sh");
 
-        // Replace PATH with the (empty) tmp dir so that `systemd-run` cannot be
-        // resolved, causing cmd.spawn() to return Err(NotFound) and triggering
-        // the retry path.  The csa_binary uses an absolute path so no PATH
-        // lookup is needed for the Direct-mode retry.
-        let original_path = std::env::var("PATH").unwrap_or_default();
-        // SAFETY: test serialises env mutation via DAEMON_SCOPE_ENV_LOCK.
-        unsafe {
-            std::env::set_var("PATH", tmp.path().as_os_str());
-        }
+        let missing_systemd_run = tmp.path().join("missing-systemd-run");
 
         let config = DaemonSpawnConfig {
             session_id: "TEST_FALLBACK".to_string(),
@@ -543,13 +550,7 @@ mod tests {
             env: HashMap::new(),
         };
 
-        let result = spawn_daemon(config);
-
-        // Restore PATH before asserting so it is always restored even on failure.
-        // SAFETY: restoring the saved value.
-        unsafe {
-            std::env::set_var("PATH", original_path);
-        }
+        let result = spawn_daemon_with_systemd_run(config, &missing_systemd_run);
 
         let result = result.expect("spawn_daemon should succeed via direct fallback");
         assert!(result.pid > 0);

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -1,6 +1,5 @@
 //! Isolation plan: combines resource and filesystem capabilities into a
 //! single, builder-configured plan that executors can apply uniformly.
-
 use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 
@@ -13,10 +12,6 @@ pub const DEFAULT_SANDBOX_TMPDIR: &str = "/tmp";
 
 #[path = "isolation_plan_codex.rs"]
 mod codex_paths;
-
-// ---------------------------------------------------------------------------
-// EnforcementMode (local copy)
-// ---------------------------------------------------------------------------
 
 /// Sandbox enforcement mode.
 ///
@@ -790,6 +785,9 @@ fn detect_superproject_root(project_root: &Path) -> Option<PathBuf> {
 
     None
 }
+
+#[cfg(test)]
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
 #[path = "isolation_plan_tests.rs"]

--- a/crates/csa-resource/src/isolation_plan_path_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_path_tests.rs
@@ -1,8 +1,5 @@
 use super::*;
 use std::ffi::OsString;
-use std::sync::Mutex;
-
-static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 struct ScopedEnvVar {
     key: &'static str,

--- a/crates/csa-resource/src/isolation_plan_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_tests.rs
@@ -1,8 +1,5 @@
 use super::*;
 use std::ffi::OsString;
-use std::sync::Mutex;
-
-static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 struct ScopedEnvVar {
     key: &'static str,
@@ -115,6 +112,7 @@ fn test_builder_off_forces_none() {
 
 #[test]
 fn test_tool_defaults_claude_code() {
+    let _guard = ENV_LOCK.lock().unwrap();
     let project = PathBuf::from("/tmp/project");
     let session = PathBuf::from("/tmp/session");
 
@@ -226,6 +224,7 @@ fn test_tool_defaults_landlock_uses_session_tmpdir() {
 
 #[test]
 fn test_cargo_and_rustup_paths_presence_matches_filesystem() {
+    let _guard = ENV_LOCK.lock().unwrap();
     // Verify that cargo/rustup paths are included correctly based on env
     // vars and filesystem state.  This test runs against the real HOME.
     let project = PathBuf::from("/tmp/project");
@@ -546,6 +545,7 @@ fn test_parent_tool_defaults_expose_existing_codex_home_for_nested_csa() {
 
 #[test]
 fn test_tool_defaults_gemini_cli() {
+    let _guard = ENV_LOCK.lock().unwrap();
     let project = PathBuf::from("/tmp/project");
     let session = PathBuf::from("/tmp/session");
 
@@ -589,6 +589,7 @@ fn test_tool_defaults_gemini_cli() {
 
 #[test]
 fn test_tool_defaults_opencode() {
+    let _guard = ENV_LOCK.lock().unwrap();
     let project = PathBuf::from("/tmp/project");
     let session = PathBuf::from("/tmp/session");
 
@@ -665,6 +666,7 @@ fn test_validate_accepts_tmp_subpath() {
 
 #[test]
 fn test_validate_accepts_home_subpath() {
+    let _guard = ENV_LOCK.lock().unwrap();
     if let Some(home) = home_dir() {
         let result = validate_writable_paths(&[home.join("workspace")], Path::new("/tmp/project"));
         assert!(result.is_ok());

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,21 @@ Leave it off if soft fallback is acceptable; turn it on when debate diversity is
 
 Successful `csa run` employee sessions now pass through a configurable post-exec gate before CSA returns success to the caller. Configure it under `[run.post_exec_gate]`; the default is enabled, runs `just pre-commit`, times out after 600 seconds, and skips itself when `git status --porcelain` is clean so read-only or no-op runs do not pay the extra gate cost.
 
+### `[session]` -- Session Prompt Behavior
+
+```toml
+[session]
+plan_injection = true
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `plan_injection` | Boolean | `true` | Inject the active plan into session prompts. Set to `false` to disable plan prompt injection for sessions in this config scope. |
+
+The setting is optional. When omitted from both global and project config, CSA
+behaves as if `plan_injection = true`. Project config overrides the global value
+through the standard config merge.
+
 ### `[project]` -- Metadata
 
 | Field | Type | Default | Description |


### PR DESCRIPTION
## Summary

- Add `[session].plan_injection` config toggle (default `true`) to control whether plan context is injected into sub-agent sessions
- Implement read-only plan context formatter that extracts lightweight (<30 line) summaries from `spec.toml` / TODO plan metadata
- Integrate plan context injection into session executor's first-turn prompt assembly
- Respects untrusted-content boundary: only injects from task_plan/spec.toml, never from `csa todo ref` content

Inspired by [OthmanAdi/planning-with-files](https://github.com/OthmanAdi/planning-with-files) PreToolUse hook pattern.

Closes #1451

## Test plan

- [ ] `cargo test -p csa-config` — config field parsing and default behavior
- [ ] `cargo test` — full workspace tests pass
- [ ] `just pre-commit` — pre-commit gates pass
- [ ] Manual: `csa run` with a branch-linked TODO plan shows `<plan-context>` in prompt
- [ ] Manual: `csa run` without a plan silently skips injection

## Review

- CSA review session `01KRZ1KRXFB0ATV51TS3SKAVT4`: **PASS** (CLEAN, 0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)