### PR TITLE
feat(todo): SHA-256 plan attestation for tamper detection (#1453)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,6 +959,7 @@ dependencies = [
  "fd-lock",
  "regex",
  "serde",
+ "sha2",
  "tempfile",
  "tokuin",
  "toml 1.1.2+spec-1.1.0",
@@ -4516,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.741"
+version = "0.1.742"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.741"
+version = "0.1.742"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_todo.rs
+++ b/crates/cli-sub-agent/src/cli_todo.rs
@@ -42,6 +42,17 @@ pub enum TodoCommands {
         cd: Option<String>,
     },
 
+    /// Recompute and store the TODO.md attestation hash
+    Attest {
+        /// Timestamp of the TODO plan (default: latest)
+        #[arg(short, long)]
+        timestamp: Option<String>,
+
+        /// Working directory
+        #[arg(long)]
+        cd: Option<String>,
+    },
+
     /// Show diff of TODO plan changes
     Diff {
         /// Timestamp of the TODO plan (default: latest)

--- a/crates/cli-sub-agent/src/executor_csa_guard.rs
+++ b/crates/cli-sub-agent/src/executor_csa_guard.rs
@@ -14,6 +14,7 @@ const CSA_SKILL_MODE_EXECUTOR: &str = "executor";
 const EXECUTOR_SAFE_CSA_COMMAND_PREFIXES: &[&[&str]] = &[
     &["todo", "create"],
     &["todo", "save"],
+    &["todo", "attest"],
     &["todo", "ref", "add"],
     &["todo", "ref", "list"],
     &["todo", "ref", "show"],
@@ -112,6 +113,7 @@ fn todo_prefix(cmd: &TodoCommands) -> Vec<&'static str> {
     match cmd {
         TodoCommands::Create { .. } => vec!["todo", "create"],
         TodoCommands::Save { .. } => vec!["todo", "save"],
+        TodoCommands::Attest { .. } => vec!["todo", "attest"],
         TodoCommands::List { .. } => vec!["todo", "list"],
         TodoCommands::Find { .. } => vec!["todo", "find"],
         TodoCommands::Errors { .. } => vec!["todo", "errors"],

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -674,6 +674,7 @@ async fn run() -> Result<()> {
             } => {
                 todo_cmd::handle_save(timestamp, message, cd)?;
             }
+            TodoCommands::Attest { timestamp, cd } => todo_cmd::handle_attest(timestamp, cd)?,
             TodoCommands::Diff {
                 timestamp,
                 revision,

--- a/crates/cli-sub-agent/src/pipeline_plan_context.rs
+++ b/crates/cli-sub-agent/src/pipeline_plan_context.rs
@@ -7,7 +7,8 @@
 use std::path::Path;
 
 use csa_todo::{
-    CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoManager, TodoPlan,
+    CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoAttestationStatus,
+    TodoManager, TodoPlan,
 };
 use tracing::{debug, warn};
 
@@ -33,6 +34,27 @@ fn load_plan_context_for_branch(manager: &TodoManager, branch: &str) -> Option<S
             return None;
         }
     };
+
+    match manager.verify_attestation(&plan.timestamp) {
+        Ok(TodoAttestationStatus::Missing | TodoAttestationStatus::Valid) => {}
+        Ok(TodoAttestationStatus::Mismatch { .. }) => {
+            warn!(
+                branch,
+                plan = %plan.timestamp,
+                "[PLAN TAMPERED] Plan content does not match stored attestation hash"
+            );
+            return None;
+        }
+        Err(error) => {
+            warn!(
+                branch,
+                plan = %plan.timestamp,
+                error = %error,
+                "Failed to verify TODO plan attestation"
+            );
+            return None;
+        }
+    }
 
     let spec = match manager.load_spec(&plan.timestamp) {
         Ok(spec) => spec,
@@ -223,5 +245,17 @@ mod tests {
         let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
 
         assert!(load_plan_context_for_branch(&manager, "feat/missing").is_none());
+    }
+
+    #[test]
+    fn plan_context_refuses_tampered_plan() {
+        let dir = tempdir().expect("tempdir");
+        let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+        let plan = manager
+            .create("Protected plan", Some("feat/tamper"))
+            .expect("plan");
+        std::fs::write(plan.todo_md_path(), "# Tampered\n").expect("tamper");
+
+        assert!(load_plan_context_for_branch(&manager, "feat/tamper").is_none());
     }
 }

--- a/crates/cli-sub-agent/src/todo_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_cmd.rs
@@ -4,9 +4,14 @@ use csa_config::global::GlobalConfig;
 use csa_core::types::OutputFormat;
 use csa_hooks::{HookEvent, global_hooks_path, load_hooks_config, run_hooks_for_event};
 use csa_todo::dag::DependencyGraph;
-use csa_todo::{CriterionKind, CriterionStatus, SpecDocument, TodoManager, TodoStatus};
+use csa_todo::{
+    CriterionKind, CriterionStatus, SpecDocument, TodoAttestationStatus, TodoManager, TodoStatus,
+};
 use std::path::Path;
 use tracing::warn;
+
+const PLAN_TAMPERED_WARNING: &str =
+    "[PLAN TAMPERED] Plan content does not match stored attestation hash";
 
 /// Auto-detect current git branch. Returns None on detached HEAD or error.
 fn detect_current_branch(project_root: &Path) -> Option<String> {
@@ -114,6 +119,7 @@ pub(crate) fn handle_save(
     let manager = TodoManager::new(&project_root)?;
     let ts = resolve_timestamp(&manager, timestamp.as_deref())?;
     let plan = manager.load(&ts)?;
+    manager.ensure_attestation(&ts)?;
 
     let commit_msg = message.unwrap_or_else(|| format!("update: {}", plan.metadata.title));
     match csa_todo::git::save(manager.todos_dir(), &ts, &commit_msg)? {
@@ -155,6 +161,16 @@ pub(crate) fn handle_save(
         None => eprintln!("No changes to save for plan '{ts}'."),
     }
 
+    Ok(())
+}
+
+pub(crate) fn handle_attest(timestamp: Option<String>, cd: Option<String>) -> Result<()> {
+    let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+    let manager = TodoManager::new(&project_root)?;
+    let ts = resolve_timestamp(&manager, timestamp.as_deref())?;
+    let attestation = manager.attest(&ts)?;
+
+    eprintln!("Attested {ts} ({})", attestation.hash);
     Ok(())
 }
 
@@ -364,6 +380,8 @@ pub(crate) fn handle_show(
             std::fs::read_to_string(plan.todo_md_path())?
         };
 
+        warn_if_plan_tampered(&manager, &ts)?;
+
         if refs {
             let index = manager.list_references(&plan, true)?;
             content.push_str("\n---\n## References\n\n");
@@ -386,6 +404,23 @@ pub(crate) fn handle_show(
     }
 
     Ok(())
+}
+
+fn warn_if_plan_tampered(manager: &TodoManager, timestamp: &str) -> Result<()> {
+    if let Some(warning) = plan_attestation_warning(manager, timestamp)? {
+        eprintln!("{warning}");
+    }
+    Ok(())
+}
+
+fn plan_attestation_warning(
+    manager: &TodoManager,
+    timestamp: &str,
+) -> Result<Option<&'static str>> {
+    match manager.verify_attestation(timestamp)? {
+        TodoAttestationStatus::Missing | TodoAttestationStatus::Valid => Ok(None),
+        TodoAttestationStatus::Mismatch { .. } => Ok(Some(PLAN_TAMPERED_WARNING)),
+    }
 }
 
 fn render_spec_document(spec: &SpecDocument) -> String {
@@ -661,7 +696,8 @@ fn truncate(s: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument};
+    use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoManager};
+    use tempfile::tempdir;
 
     // --- truncate tests ---
 
@@ -727,6 +763,19 @@ mod tests {
             rendered.contains("- [pending] scenario scenario-show: show --spec renders criteria")
         );
         assert!(rendered.contains("- [failed] check check-failure: failed criteria are labeled"));
+    }
+
+    #[test]
+    fn plan_attestation_warning_reports_mismatch() {
+        let dir = tempdir().expect("tempdir");
+        let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+        let plan = manager.create("Warn on tamper", None).expect("plan");
+        std::fs::write(plan.todo_md_path(), "# Tampered\n").expect("tamper");
+
+        assert_eq!(
+            plan_attestation_warning(&manager, &plan.timestamp).expect("warning"),
+            Some(PLAN_TAMPERED_WARNING)
+        );
     }
 
     // --- resolve_timestamp tests ---

--- a/crates/csa-todo/Cargo.toml
+++ b/crates/csa-todo/Cargo.toml
@@ -15,6 +15,7 @@ chrono.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 regex.workspace = true
+sha2.workspace = true
 tokuin.workspace = true
 xurl-core.workspace = true
 

--- a/crates/csa-todo/src/lib.rs
+++ b/crates/csa-todo/src/lib.rs
@@ -20,10 +20,12 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
 const METADATA_FILE: &str = "metadata.toml";
 const TODO_MD_FILE: &str = "TODO.md";
+const ATTESTATION_FILE: &str = ".attestation";
 const SPEC_FILE: &str = "spec.toml";
 const EPIC_PLAN_FILE: &str = "epic-plan.toml";
 const LOCK_FILE: &str = ".lock";
@@ -124,6 +126,24 @@ pub struct TodoMetadata {
     pub updated_at: DateTime<Utc>,
 }
 
+/// SHA-256 attestation for the current TODO.md content.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TodoAttestation {
+    pub hash: String,
+    pub attested_at: DateTime<Utc>,
+}
+
+/// Result of comparing TODO.md with its stored attestation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TodoAttestationStatus {
+    Missing,
+    Valid,
+    Mismatch {
+        expected_hash: String,
+        actual_hash: String,
+    },
+}
+
 /// A TODO plan with its filesystem location and metadata.
 #[derive(Debug, Clone)]
 pub struct TodoPlan {
@@ -142,6 +162,10 @@ impl TodoPlan {
 
     pub fn todo_md_path(&self) -> PathBuf {
         self.todo_dir.join(TODO_MD_FILE)
+    }
+
+    pub fn attestation_path(&self) -> PathBuf {
+        self.todo_dir.join(ATTESTATION_FILE)
     }
 }
 
@@ -227,6 +251,7 @@ impl TodoManager {
             plan.metadata.updated_at = Utc::now();
             if updated_content != content {
                 atomic_write(&todo_path, updated_content.as_bytes())?;
+                self.write_attestation_for_content(&plan, updated_content.as_bytes())?;
             }
             self.write_metadata(&plan)?;
             Ok(plan)
@@ -253,8 +278,35 @@ impl TodoManager {
         self.with_write_lock(|| {
             let mut plan = self.load_inner(timestamp)?;
             atomic_write(&plan.todo_md_path(), content.as_bytes())?;
+            self.write_attestation_for_content(&plan, content.as_bytes())?;
             plan.metadata.updated_at = Utc::now();
             self.write_metadata(&plan)
+        })
+    }
+
+    /// Recompute and store the SHA-256 attestation for TODO.md.
+    pub fn attest(&self, timestamp: &str) -> Result<TodoAttestation> {
+        self.with_write_lock(|| {
+            let plan = self.load_inner(timestamp)?;
+            let content = read_todo_content(&plan)?;
+            self.write_attestation_for_content(&plan, &content)
+        })
+    }
+
+    /// Store an attestation when one is missing or no longer matches TODO.md.
+    pub fn ensure_attestation(&self, timestamp: &str) -> Result<TodoAttestation> {
+        self.with_write_lock(|| {
+            let plan = self.load_inner(timestamp)?;
+            let content = read_todo_content(&plan)?;
+            let actual_hash = hash_todo_content(&content);
+
+            if let Some(attestation) = self.read_attestation(&plan)?
+                && attestation.hash == actual_hash
+            {
+                return Ok(attestation);
+            }
+
+            self.write_attestation(&plan, actual_hash)
         })
     }
 
@@ -263,6 +315,25 @@ impl TodoManager {
     /// Load a TODO plan by timestamp.
     pub fn load(&self, timestamp: &str) -> Result<TodoPlan> {
         self.load_inner(timestamp)
+    }
+
+    /// Verify TODO.md against its stored attestation.
+    pub fn verify_attestation(&self, timestamp: &str) -> Result<TodoAttestationStatus> {
+        let plan = self.load_inner(timestamp)?;
+        let Some(attestation) = self.read_attestation(&plan)? else {
+            return Ok(TodoAttestationStatus::Missing);
+        };
+
+        let content = read_todo_content(&plan)?;
+        let actual_hash = hash_todo_content(&content);
+        if attestation.hash == actual_hash {
+            Ok(TodoAttestationStatus::Valid)
+        } else {
+            Ok(TodoAttestationStatus::Mismatch {
+                expected_hash: attestation.hash,
+                actual_hash,
+            })
+        }
     }
 
     /// Load the most recent TODO plan, or error if none exist.
@@ -448,6 +519,11 @@ impl TodoManager {
             return Err(e.context("Failed to write TODO.md (rolled back plan directory)"));
         }
 
+        if let Err(e) = self.write_attestation_for_content(&plan, initial_content.as_bytes()) {
+            let _ = std::fs::remove_dir_all(&plan.todo_dir);
+            return Err(e.context("Failed to write TODO attestation (rolled back plan directory)"));
+        }
+
         Ok(plan)
     }
 
@@ -479,6 +555,46 @@ impl TodoManager {
         atomic_write(&plan.metadata_path(), content.as_bytes())
     }
 
+    fn read_attestation(&self, plan: &TodoPlan) -> Result<Option<TodoAttestation>> {
+        let attestation_path = plan.attestation_path();
+        if !attestation_path.exists() {
+            return Ok(None);
+        }
+
+        let content = std::fs::read_to_string(&attestation_path).with_context(|| {
+            format!(
+                "Failed to read TODO attestation: {}",
+                attestation_path.display()
+            )
+        })?;
+        let attestation: TodoAttestation = toml::from_str(&content).with_context(|| {
+            format!(
+                "Failed to parse TODO attestation: {}",
+                attestation_path.display()
+            )
+        })?;
+        Ok(Some(attestation))
+    }
+
+    fn write_attestation_for_content(
+        &self,
+        plan: &TodoPlan,
+        content: &[u8],
+    ) -> Result<TodoAttestation> {
+        self.write_attestation(plan, hash_todo_content(content))
+    }
+
+    fn write_attestation(&self, plan: &TodoPlan, hash: String) -> Result<TodoAttestation> {
+        let attestation = TodoAttestation {
+            hash,
+            attested_at: Utc::now(),
+        };
+        let content =
+            toml::to_string_pretty(&attestation).context("Failed to serialize TODO attestation")?;
+        atomic_write(&plan.attestation_path(), content.as_bytes())?;
+        Ok(attestation)
+    }
+
     /// Acquire a write lock on the todos directory, execute `f`, then release.
     fn with_write_lock<T>(&self, f: impl FnOnce() -> Result<T>) -> Result<T> {
         std::fs::create_dir_all(&self.todos_dir).with_context(|| {
@@ -502,6 +618,16 @@ impl TodoManager {
 
         f()
     }
+}
+
+fn read_todo_content(plan: &TodoPlan) -> Result<Vec<u8>> {
+    let todo_path = plan.todo_md_path();
+    std::fs::read(&todo_path)
+        .with_context(|| format!("Failed to read TODO markdown: {}", todo_path.display()))
+}
+
+fn hash_todo_content(content: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(content))
 }
 
 /// Write data to a file atomically using temp-file + rename.

--- a/crates/csa-todo/src/lib_tests.rs
+++ b/crates/csa-todo/src/lib_tests.rs
@@ -39,6 +39,25 @@ fn test_create_plan() {
 }
 
 #[test]
+fn test_create_plan_writes_valid_attestation() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+    let plan = manager.create("Attested Plan", None).unwrap();
+
+    assert!(plan.attestation_path().exists());
+    assert_eq!(
+        manager.verify_attestation(&plan.timestamp).unwrap(),
+        TodoAttestationStatus::Valid
+    );
+
+    let attestation: TodoAttestation =
+        toml::from_str(&std::fs::read_to_string(plan.attestation_path()).unwrap()).unwrap();
+    let content = std::fs::read(plan.todo_md_path()).unwrap();
+    assert_eq!(attestation.hash, hash_todo_content(&content));
+}
+
+#[test]
 fn test_create_plan_no_branch() {
     let dir = tempdir().unwrap();
     let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
@@ -212,6 +231,50 @@ fn test_write_todo_md() {
 
     let read_back = std::fs::read_to_string(plan.todo_md_path()).unwrap();
     assert_eq!(read_back, new_content);
+    assert_eq!(
+        manager.verify_attestation(&plan.timestamp).unwrap(),
+        TodoAttestationStatus::Valid
+    );
+}
+
+#[test]
+fn test_verify_attestation_detects_manual_tamper() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+    let plan = manager.create("Tamper Test", None).unwrap();
+    std::fs::write(plan.todo_md_path(), "# Tampered\n").unwrap();
+
+    match manager.verify_attestation(&plan.timestamp).unwrap() {
+        TodoAttestationStatus::Mismatch {
+            expected_hash,
+            actual_hash,
+        } => assert_ne!(expected_hash, actual_hash),
+        other => panic!("expected mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_attest_repairs_manual_tamper() {
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+    let plan = manager.create("Repair Test", None).unwrap();
+    let edited = "# Legitimate manual edit\n";
+    std::fs::write(plan.todo_md_path(), edited).unwrap();
+
+    assert!(matches!(
+        manager.verify_attestation(&plan.timestamp).unwrap(),
+        TodoAttestationStatus::Mismatch { .. }
+    ));
+
+    let attestation = manager.attest(&plan.timestamp).unwrap();
+
+    assert_eq!(attestation.hash, hash_todo_content(edited.as_bytes()));
+    assert_eq!(
+        manager.verify_attestation(&plan.timestamp).unwrap(),
+        TodoAttestationStatus::Valid
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `csa todo save` now computes and stores a SHA-256 hash in `.attestation` companion file
- `csa todo show` verifies attestation hash, warns `[PLAN TAMPERED]` on mismatch
- `csa todo attest` subcommand re-computes hash after legitimate manual edits
- Plan injection (from #1451) checks attestation before injecting — refuses tampered plans
- Defense-in-depth: complements git tracking with runtime integrity verification

Closes #1453

## Test plan

- [ ] `cargo test` — unit tests for attestation write/verify/tamper-detect
- [ ] `just pre-commit` — pre-commit gates pass
- [ ] Manual: `csa todo save` creates `.attestation` file
- [ ] Manual: Modify plan file, `csa todo show` warns about tamper
- [ ] Manual: `csa todo attest` re-seals after legitimate edit

## Review

- Session `01KRZ9788A`: **PASS** (CLEAN, 0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)