### PR TITLE
fix(executor,scheduler): restrict quota detection to stderr and compound patterns (#1460)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.743"
+version = "0.1.744"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.743"
+version = "0.1.744"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_codex_rate_limit.rs
+++ b/crates/csa-executor/src/transport_codex_rate_limit.rs
@@ -51,19 +51,11 @@ pub(crate) fn is_codex_transient_rate_limit_text(text: &str) -> bool {
 }
 
 pub(crate) fn is_codex_transient_rate_limit_result(execution: &ExecutionResult) -> bool {
-    execution.exit_code != 0
-        && is_codex_transient_rate_limit_text(&format!(
-            "{}\n{}",
-            execution.summary, execution.stderr_output
-        ))
+    execution.exit_code != 0 && is_codex_transient_rate_limit_text(&execution.stderr_output)
 }
 
 pub(crate) fn is_codex_permanent_quota_result(execution: &ExecutionResult) -> bool {
-    execution.exit_code != 0
-        && is_codex_permanent_quota_text(&format!(
-            "{}\n{}",
-            execution.summary, execution.stderr_output
-        ))
+    execution.exit_code != 0 && is_codex_permanent_quota_text(&execution.stderr_output)
 }
 
 pub(crate) fn apply_codex_rate_limit_retry_exhausted_summary(

--- a/crates/csa-executor/src/transport_codex_rate_limit.rs
+++ b/crates/csa-executor/src/transport_codex_rate_limit.rs
@@ -4,6 +4,25 @@ use csa_process::ExecutionResult;
 
 pub(crate) const CODEX_RATE_LIMIT_MAX_RETRIES: u8 = 3;
 pub(crate) const CODEX_RATE_LIMIT_RETRY_EXHAUSTED_REASON: &str = "codex_429_retry_exhausted";
+const CODEX_PERMANENT_QUOTA_PATTERNS: &[&str] = &[
+    CODEX_RATE_LIMIT_RETRY_EXHAUSTED_REASON,
+    "usage_limit_exceeded",
+    "usage limit",
+    "billing limit",
+    "billing cap",
+    "billing disabled",
+    "billing not enabled",
+    "billing hard limit",
+    "billing budget",
+    "monthly limit",
+    "monthly cap",
+    "monthly spending",
+    "monthly quota",
+    "spending cap",
+    "hard limit",
+    "insufficient_quota",
+    "daily quota",
+];
 
 pub(crate) fn codex_rate_limit_backoff(retry_count: u8) -> Duration {
     let capped = retry_count.min(CODEX_RATE_LIMIT_MAX_RETRIES.saturating_sub(1));
@@ -22,15 +41,9 @@ fn is_codex_rate_limited_text(text: &str) -> bool {
 
 fn is_codex_permanent_quota_text(text: &str) -> bool {
     let lowered = text.to_ascii_lowercase();
-    lowered.contains(CODEX_RATE_LIMIT_RETRY_EXHAUSTED_REASON)
-        || lowered.contains("usage_limit_exceeded")
-        || lowered.contains("usage limit")
-        || lowered.contains("billing")
-        || lowered.contains("monthly")
-        || lowered.contains("spending cap")
-        || lowered.contains("hard limit")
-        || lowered.contains("insufficient_quota")
-        || lowered.contains("daily quota")
+    CODEX_PERMANENT_QUOTA_PATTERNS
+        .iter()
+        .any(|pattern| lowered.contains(pattern))
 }
 
 pub(crate) fn is_codex_transient_rate_limit_text(text: &str) -> bool {
@@ -40,16 +53,16 @@ pub(crate) fn is_codex_transient_rate_limit_text(text: &str) -> bool {
 pub(crate) fn is_codex_transient_rate_limit_result(execution: &ExecutionResult) -> bool {
     execution.exit_code != 0
         && is_codex_transient_rate_limit_text(&format!(
-            "{}\n{}\n{}",
-            execution.summary, execution.stderr_output, execution.output
+            "{}\n{}",
+            execution.summary, execution.stderr_output
         ))
 }
 
 pub(crate) fn is_codex_permanent_quota_result(execution: &ExecutionResult) -> bool {
     execution.exit_code != 0
         && is_codex_permanent_quota_text(&format!(
-            "{}\n{}\n{}",
-            execution.summary, execution.stderr_output, execution.output
+            "{}\n{}",
+            execution.summary, execution.stderr_output
         ))
 }
 
@@ -67,3 +80,7 @@ pub(crate) fn apply_codex_rate_limit_retry_exhausted_summary(
     execution.stderr_output.push_str(&summary);
     execution.stderr_output.push('\n');
 }
+
+#[cfg(test)]
+#[path = "transport_codex_rate_limit_tests.rs"]
+mod tests;

--- a/crates/csa-executor/src/transport_codex_rate_limit_tests.rs
+++ b/crates/csa-executor/src/transport_codex_rate_limit_tests.rs
@@ -1,0 +1,36 @@
+use super::*;
+use csa_process::ExecutionResult;
+
+#[test]
+fn billing_code_content_not_false_positive() {
+    assert!(!is_codex_permanent_quota_text(
+        "implementing billing gate for enterprise"
+    ));
+    assert!(!is_codex_permanent_quota_text("fn process_billing_event()"));
+    assert!(!is_codex_permanent_quota_text(
+        "billing.rs: add monthly subscription handler"
+    ));
+}
+
+#[test]
+fn real_quota_errors_still_detected() {
+    assert!(is_codex_permanent_quota_text("billing limit exceeded"));
+    assert!(is_codex_permanent_quota_text("usage_limit_exceeded"));
+    assert!(is_codex_permanent_quota_text("insufficient_quota"));
+    assert!(is_codex_permanent_quota_text(
+        "monthly spending cap reached"
+    ));
+}
+
+#[test]
+fn stdout_billing_content_not_false_positive_in_result() {
+    let execution = ExecutionResult {
+        exit_code: 1,
+        summary: String::new(),
+        stderr_output: "connection timeout".to_string(),
+        output: "implementing billing gate for enterprise".to_string(),
+        ..Default::default()
+    };
+
+    assert!(!is_codex_permanent_quota_result(&execution));
+}

--- a/crates/csa-scheduler/src/rate_limit.rs
+++ b/crates/csa-scheduler/src/rate_limit.rs
@@ -81,12 +81,19 @@ pub fn detect_rate_limit(
         return None;
     }
 
-    let combined_lower = format!("{stderr}\n{stdout}").to_ascii_lowercase();
+    let stderr_lower = stderr.to_ascii_lowercase();
+    let stdout_lower = stdout.to_ascii_lowercase();
+    let combined_lower = format!("{stderr_lower}\n{stdout_lower}");
     for pattern in patterns_for_tool(tool_name)
         .iter()
         .chain(failover_patterns_for_tool(tool_name).iter())
     {
-        if combined_lower.contains(pattern.pattern) {
+        let haystack = if pattern.quota_exhausted {
+            &stderr_lower
+        } else {
+            &combined_lower
+        };
+        if haystack.contains(pattern.pattern) {
             return Some(RateLimitDetected {
                 tool: tool_name.to_string(),
                 matched_pattern: pattern.pattern.to_string(),

--- a/crates/csa-scheduler/src/rate_limit.rs
+++ b/crates/csa-scheduler/src/rate_limit.rs
@@ -375,7 +375,37 @@ fn patterns_for_tool(tool: &str) -> &'static [FailoverPattern] {
                 quota_exhausted: true,
             },
             FailoverPattern {
-                pattern: "billing",
+                pattern: "billing limit",
+                reason: "QUOTA_EXHAUSTED",
+                advance_to_next_model: true,
+                quota_exhausted: true,
+            },
+            FailoverPattern {
+                pattern: "billing cap",
+                reason: "QUOTA_EXHAUSTED",
+                advance_to_next_model: true,
+                quota_exhausted: true,
+            },
+            FailoverPattern {
+                pattern: "billing disabled",
+                reason: "QUOTA_EXHAUSTED",
+                advance_to_next_model: true,
+                quota_exhausted: true,
+            },
+            FailoverPattern {
+                pattern: "billing not enabled",
+                reason: "QUOTA_EXHAUSTED",
+                advance_to_next_model: true,
+                quota_exhausted: true,
+            },
+            FailoverPattern {
+                pattern: "billing hard limit",
+                reason: "QUOTA_EXHAUSTED",
+                advance_to_next_model: true,
+                quota_exhausted: true,
+            },
+            FailoverPattern {
+                pattern: "billing budget",
                 reason: "QUOTA_EXHAUSTED",
                 advance_to_next_model: true,
                 quota_exhausted: true,

--- a/crates/csa-scheduler/src/rate_limit_tests.rs
+++ b/crates/csa-scheduler/src/rate_limit_tests.rs
@@ -479,6 +479,45 @@ fn test_quota_exhausted_false_for_transient_rate_limits() {
 }
 
 #[test]
+fn test_quota_exhausted_patterns_do_not_set_quota_from_stdout() {
+    let stdout_only_quota_patterns = [
+        ("gemini-cli", "reason: QUOTA_EXHAUSTED"),
+        (
+            "codex",
+            "render_billing_disabled_banner monthly spending cap",
+        ),
+        ("claude-code", "429_quota_exhausted"),
+        ("opencode", "429_quota_exhausted"),
+        ("unknown-tool", "429_quota_exhausted"),
+    ];
+    for (tool, stdout) in stdout_only_quota_patterns {
+        let result = detect_rate_limit(tool, "process exited with status 1", stdout, 1, None);
+        if let Some(detected) = result {
+            assert!(
+                !detected.quota_exhausted,
+                "stdout-only quota pattern must not set quota_exhausted (tool={tool}, stdout={stdout})"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_transient_rate_limit_patterns_still_match_stdout() {
+    let detected = detect_rate_limit(
+        "codex",
+        "process exited with status 1",
+        "HTTP 429 Too Many Requests",
+        1,
+        None,
+    )
+    .expect("transient stdout rate limit should still classify");
+
+    assert_eq!(detected.matched_pattern, "429");
+    assert_eq!(detected.reason, "HTTP 429");
+    assert!(!detected.quota_exhausted);
+}
+
+#[test]
 fn test_gemini_retry_chain_exhausted_is_not_permanent_quota() {
     let result = detect_rate_limit(
         "gemini-cli",


### PR DESCRIPTION
## Summary
- Replace bare `billing`/`monthly` keywords with compound patterns (`billing limit`, `billing cap`, etc.) in both executor and scheduler codex quota detection
- Restrict executor quota/rate-limit detection to `stderr_output` only — previously scanned `summary + stderr + stdout`, causing false positives when codex works on billing-related code
- Restrict scheduler quota-exhausted pattern matching to stderr only for `quota_exhausted: true` patterns
- Add regression tests for false positive scenarios (billing code content, stdout-only billing references)

Fixes #1460

## Test plan
- [x] `cargo test -p csa-executor -- codex_rate` — 3 tests pass
- [x] `cargo test -p csa-scheduler -- rate_limit` — 40 tests pass
- [x] `just clippy` clean
- [x] `just pre-commit` pass
- [x] CSA review PASS/CLEAN (round 3, session 01KS0KDAFMAMDJW4NADD8AANV5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)