### PR TITLE
fix(cli): reject direct --tool before session creation when tiers configured (#1463)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.744"
+version = "0.1.745"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.744"
+version = "0.1.745"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -238,6 +238,7 @@ pub(crate) async fn handle_debate(
         effective_tier.as_deref(),
         args.force_override_user_config,
         args.force_ignore_tier_setting,
+        args.model_spec.is_some(),
     )?;
     crate::run_helpers::warn_if_tier_without_tool(args.tier.as_deref(), args_tool.is_some());
     let resolved_selection = match resolve_debate_selection(

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -11,6 +11,7 @@ use crate::cli::DebateArgs;
 use crate::debate_cmd_resolve::{
     DebateTierResolveCtx, resolve_debate_effective_tier_with_compound, resolve_debate_model,
     resolve_debate_selection, resolve_debate_tier_name,
+    validate_debate_direct_tool_tier_restriction,
 };
 use crate::debate_errors::{DebateErrorKind, classify_execution_error, classify_execution_outcome};
 use crate::run_helpers::resolve_prompt_with_file;
@@ -231,6 +232,13 @@ pub(crate) async fn handle_debate(
             debate_description: debate_description.as_str(),
             explicit_tool,
         })?;
+    validate_debate_direct_tool_tier_restriction(
+        args_tool.is_some(),
+        config.as_ref(),
+        effective_tier.as_deref(),
+        args.force_override_user_config,
+        args.force_ignore_tier_setting,
+    )?;
     crate::run_helpers::warn_if_tier_without_tool(args.tier.as_deref(), args_tool.is_some());
     let resolved_selection = match resolve_debate_selection(
         args_tool,

--- a/crates/cli-sub-agent/src/debate_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_resolve.rs
@@ -84,25 +84,16 @@ pub(crate) fn validate_debate_direct_tool_tier_restriction(
     effective_tier: Option<&str>,
     force_override_user_config: bool,
     force_ignore_tier_setting: bool,
+    model_spec_provided: bool,
 ) -> Result<()> {
-    let Some(cfg) = project_config else {
-        return Ok(());
-    };
-    let bypass_tier = force_ignore_tier_setting || force_override_user_config;
-    if cfg.tiers.is_empty() || bypass_tier || effective_tier.is_some() || !direct_tool_requested {
-        return Ok(());
-    }
-
-    let available: Vec<&str> = cfg.tiers.keys().map(|k| k.as_str()).collect();
-    let alias_hint = cfg.format_tier_aliases();
-    anyhow::bail!(
-        "Direct --tool is restricted when tiers are configured. \
-         Use --tier <name> to specify which tier's model/thinking config to use, \
-         --hint-difficulty <label> to route through [tier_mapping], \
-         or add --force-ignore-tier-setting to override. \
-         Available tiers: [{}]{alias_hint}",
-        available.join(", ")
-    );
+    crate::run_helpers::validate_direct_tool_tier_restriction(
+        direct_tool_requested,
+        project_config,
+        effective_tier,
+        force_override_user_config,
+        force_ignore_tier_setting,
+        model_spec_provided,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -156,6 +147,7 @@ pub(crate) fn resolve_debate_selection(
         cli_tier,
         force_override_user_config,
         force_ignore_tier_setting,
+        arg_model_spec.is_some(),
     )?;
 
     let tier_name = resolve_debate_tier_name(

--- a/crates/cli-sub-agent/src/debate_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_resolve.rs
@@ -78,6 +78,33 @@ pub(crate) struct ResolvedDebateSelection {
     pub(crate) tier_filter: Option<TierFilter>,
 }
 
+pub(crate) fn validate_debate_direct_tool_tier_restriction(
+    direct_tool_requested: bool,
+    project_config: Option<&ProjectConfig>,
+    effective_tier: Option<&str>,
+    force_override_user_config: bool,
+    force_ignore_tier_setting: bool,
+) -> Result<()> {
+    let Some(cfg) = project_config else {
+        return Ok(());
+    };
+    let bypass_tier = force_ignore_tier_setting || force_override_user_config;
+    if cfg.tiers.is_empty() || bypass_tier || effective_tier.is_some() || !direct_tool_requested {
+        return Ok(());
+    }
+
+    let available: Vec<&str> = cfg.tiers.keys().map(|k| k.as_str()).collect();
+    let alias_hint = cfg.format_tier_aliases();
+    anyhow::bail!(
+        "Direct --tool is restricted when tiers are configured. \
+         Use --tier <name> to specify which tier's model/thinking config to use, \
+         --hint-difficulty <label> to route through [tier_mapping], \
+         or add --force-ignore-tier-setting to override. \
+         Available tiers: [{}]{alias_hint}",
+        available.join(", ")
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn resolve_debate_selection(
     arg_tool: Option<ToolName>,
@@ -90,9 +117,6 @@ pub(crate) fn resolve_debate_selection(
     cli_tier: Option<&str>,
     force_ignore_tier_setting: bool,
 ) -> Result<ResolvedDebateSelection> {
-    let tiers_configured = project_config.is_some_and(|c| !c.tiers.is_empty());
-    let bypass_tier = force_ignore_tier_setting || force_override_user_config;
-
     crate::run_helpers::validate_tool_tier_override_flags(
         arg_tool.is_some(),
         cli_tier,
@@ -126,19 +150,13 @@ pub(crate) fn resolve_debate_selection(
 
     // Enforce tier routing: block direct --tool when tiers are configured,
     // unless --force-ignore-tier-setting (or --force-override-user-config) is active.
-    if tiers_configured && !bypass_tier && cli_tier.is_none() && arg_tool.is_some() {
-        let cfg = project_config.unwrap();
-        let available: Vec<&str> = cfg.tiers.keys().map(|k| k.as_str()).collect();
-        let alias_hint = cfg.format_tier_aliases();
-        anyhow::bail!(
-            "Direct --tool is restricted when tiers are configured. \
-             Use --tier <name> to specify which tier's model/thinking config to use, \
-             --hint-difficulty <label> to route through [tier_mapping], \
-             or add --force-ignore-tier-setting to override. \
-             Available tiers: [{}]{alias_hint}",
-            available.join(", ")
-        );
-    }
+    validate_debate_direct_tool_tier_restriction(
+        arg_tool.is_some(),
+        project_config,
+        cli_tier,
+        force_override_user_config,
+        force_ignore_tier_setting,
+    )?;
 
     let tier_name = resolve_debate_tier_name(
         project_config,

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -400,7 +400,7 @@ fn verify_debate_skill_no_fallback_without_skill() {
 }
 
 #[tokio::test]
-async fn handle_debate_persists_result_for_direct_tool_tier_rejection() {
+async fn handle_debate_rejects_direct_tool_tier_before_session_creation() {
     let project_dir = tempdir().unwrap();
     let mut sandbox = ScopedSessionSandbox::new(&project_dir).await;
     sandbox.track_env("CSA_SESSION_ID");
@@ -443,18 +443,9 @@ async fn handle_debate_persists_result_for_direct_tool_tier_rejection() {
     );
 
     let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
-    assert_eq!(sessions.len(), 1, "expected one failed debate session");
-
-    let result = csa_session::load_result(project_dir.path(), &sessions[0].meta_session_id)
-        .unwrap()
-        .expect("result.toml must be written for debate tier rejection");
-    assert_eq!(result.status, "failure");
-    assert_eq!(result.exit_code, 1);
-    assert!(result.summary.contains("pre-exec:"));
     assert!(
-        result
-            .summary
-            .contains("restricted when tiers are configured")
+        sessions.is_empty(),
+        "direct --tool tier rejection must happen before debate session creation"
     );
 }
 

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -82,7 +82,8 @@ use resolve::{
     ReviewProjectPromptOptions, build_review_instruction_for_project, derive_scope_for_project,
     resolve_review_effective_tier, resolve_review_model, resolve_review_selection,
     resolve_review_stream_mode, resolve_review_thinking, resolve_review_tier_name,
-    review_scope_allows_auto_discovery, verify_review_skill_available,
+    review_scope_allows_auto_discovery, validate_review_direct_tool_tier_restriction,
+    verify_review_skill_available,
 };
 use result_handling::{build_reviewer_outcome, resolve_single_review_result};
 #[rustfmt::skip]
@@ -102,6 +103,14 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
     else {
         return Ok(1);
     };
+    let (effective_tier, args_tool) = resolve_review_effective_tier(&args, config.as_ref())?;
+    validate_review_direct_tool_tier_restriction(
+        args_tool.is_some(),
+        config.as_ref(),
+        effective_tier.as_deref(),
+        args.force_override_user_config,
+        args.force_ignore_tier_setting,
+    )?;
     let pre_session_hook = csa_hooks::load_global_pre_session_hook_invocation();
     verify_review_skill_available(&project_root, args.allow_fallback)?;
     if is_worktree_submodule(&project_root) {
@@ -266,7 +275,6 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
 
     let detected_parent_tool = crate::run_helpers::detect_parent_tool();
     let parent_tool = crate::run_helpers::resolve_tool(detected_parent_tool, &global_config);
-    let (effective_tier, args_tool) = resolve_review_effective_tier(&args, config.as_ref())?;
     crate::run_helpers::warn_if_tier_without_tool(args.tier.as_deref(), args_tool.is_some());
     let resolved_selection = match resolve_review_selection(
         args_tool,

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -110,6 +110,7 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
         effective_tier.as_deref(),
         args.force_override_user_config,
         args.force_ignore_tier_setting,
+        args.model_spec.is_some(),
     )?;
     let pre_session_hook = csa_hooks::load_global_pre_session_hook_invocation();
     verify_review_skill_available(&project_root, args.allow_fallback)?;

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -89,25 +89,16 @@ pub(crate) fn validate_review_direct_tool_tier_restriction(
     effective_tier: Option<&str>,
     force_override_user_config: bool,
     force_ignore_tier_setting: bool,
+    model_spec_provided: bool,
 ) -> Result<()> {
-    let Some(cfg) = project_config else {
-        return Ok(());
-    };
-    let bypass_tier = force_ignore_tier_setting || force_override_user_config;
-    if cfg.tiers.is_empty() || bypass_tier || effective_tier.is_some() || !direct_tool_requested {
-        return Ok(());
-    }
-
-    let available: Vec<&str> = cfg.tiers.keys().map(|k| k.as_str()).collect();
-    let alias_hint = cfg.format_tier_aliases();
-    anyhow::bail!(
-        "Direct --tool is restricted when tiers are configured. \
-         Use --tier <name> to specify which tier's model/thinking config to use, \
-         --hint-difficulty <label> to route through [tier_mapping], \
-         or add --force-ignore-tier-setting to override. \
-         Available tiers: [{}]{alias_hint}",
-        available.join(", ")
-    );
+    crate::run_helpers::validate_direct_tool_tier_restriction(
+        direct_tool_requested,
+        project_config,
+        effective_tier,
+        force_override_user_config,
+        force_ignore_tier_setting,
+        model_spec_provided,
+    )
 }
 
 /// Returns (tool, optional_model_spec). When tier resolves, model_spec is set.
@@ -161,6 +152,7 @@ pub(crate) fn resolve_review_selection(
         cli_tier,
         force_override_user_config,
         force_ignore_tier_setting,
+        arg_model_spec.is_some(),
     )?;
 
     let tier_name = resolve_review_tier_name(

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -83,6 +83,33 @@ pub(crate) struct ResolvedReviewSelection {
     pub(crate) tier_filter: Option<TierFilter>,
 }
 
+pub(crate) fn validate_review_direct_tool_tier_restriction(
+    direct_tool_requested: bool,
+    project_config: Option<&ProjectConfig>,
+    effective_tier: Option<&str>,
+    force_override_user_config: bool,
+    force_ignore_tier_setting: bool,
+) -> Result<()> {
+    let Some(cfg) = project_config else {
+        return Ok(());
+    };
+    let bypass_tier = force_ignore_tier_setting || force_override_user_config;
+    if cfg.tiers.is_empty() || bypass_tier || effective_tier.is_some() || !direct_tool_requested {
+        return Ok(());
+    }
+
+    let available: Vec<&str> = cfg.tiers.keys().map(|k| k.as_str()).collect();
+    let alias_hint = cfg.format_tier_aliases();
+    anyhow::bail!(
+        "Direct --tool is restricted when tiers are configured. \
+         Use --tier <name> to specify which tier's model/thinking config to use, \
+         --hint-difficulty <label> to route through [tier_mapping], \
+         or add --force-ignore-tier-setting to override. \
+         Available tiers: [{}]{alias_hint}",
+        available.join(", ")
+    );
+}
+
 /// Returns (tool, optional_model_spec). When tier resolves, model_spec is set.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn resolve_review_selection(
@@ -96,9 +123,6 @@ pub(crate) fn resolve_review_selection(
     cli_tier: Option<&str>,
     force_ignore_tier_setting: bool,
 ) -> Result<ResolvedReviewSelection> {
-    let tiers_configured = project_config.is_some_and(|c| !c.tiers.is_empty());
-    let bypass_tier = force_ignore_tier_setting || force_override_user_config;
-
     crate::run_helpers::validate_tool_tier_override_flags(
         arg_tool.is_some(),
         cli_tier,
@@ -131,19 +155,13 @@ pub(crate) fn resolve_review_selection(
 
     // Enforce tier routing: block direct --tool when tiers are configured,
     // unless --force-ignore-tier-setting (or --force-override-user-config) is active.
-    if tiers_configured && !bypass_tier && cli_tier.is_none() && arg_tool.is_some() {
-        let cfg = project_config.unwrap();
-        let available: Vec<&str> = cfg.tiers.keys().map(|k| k.as_str()).collect();
-        let alias_hint = cfg.format_tier_aliases();
-        anyhow::bail!(
-            "Direct --tool is restricted when tiers are configured. \
-             Use --tier <name> to specify which tier's model/thinking config to use, \
-             --hint-difficulty <label> to route through [tier_mapping], \
-             or add --force-ignore-tier-setting to override. \
-             Available tiers: [{}]{alias_hint}",
-            available.join(", ")
-        );
-    }
+    validate_review_direct_tool_tier_restriction(
+        arg_tool.is_some(),
+        project_config,
+        cli_tier,
+        force_override_user_config,
+        force_ignore_tier_setting,
+    )?;
 
     let tier_name = resolve_review_tier_name(
         project_config,

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -662,7 +662,7 @@ fn install_pattern(project_root: &Path, name: &str) {
 }
 
 #[tokio::test]
-async fn handle_review_persists_result_for_direct_tool_tier_rejection() {
+async fn handle_review_rejects_direct_tool_tier_before_session_creation() {
     let project_dir = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
@@ -702,18 +702,9 @@ async fn handle_review_persists_result_for_direct_tool_tier_rejection() {
     );
 
     let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
-    assert_eq!(sessions.len(), 1, "expected one failed review session");
-
-    let result = csa_session::load_result(project_dir.path(), &sessions[0].meta_session_id)
-        .unwrap()
-        .expect("result.toml must be written for review tier rejection");
-    assert_eq!(result.status, "failure");
-    assert_eq!(result.exit_code, 1);
-    assert!(result.summary.contains("pre-exec:"));
     assert!(
-        result
-            .summary
-            .contains("restricted when tiers are configured")
+        sessions.is_empty(),
+        "direct --tool tier rejection must happen before review session creation"
     );
 }
 

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -74,6 +74,39 @@ pub(crate) fn validate_tool_tier_override_flags(
     Ok(())
 }
 
+pub(crate) fn validate_direct_tool_tier_restriction(
+    direct_tool_requested: bool,
+    project_config: Option<&ProjectConfig>,
+    effective_tier: Option<&str>,
+    force_override_user_config: bool,
+    force_ignore_tier_setting: bool,
+    model_spec_provided: bool,
+) -> Result<()> {
+    let Some(cfg) = project_config else {
+        return Ok(());
+    };
+    let bypass_tier = force_ignore_tier_setting || force_override_user_config;
+    if cfg.tiers.is_empty()
+        || bypass_tier
+        || effective_tier.is_some()
+        || !direct_tool_requested
+        || model_spec_provided
+    {
+        return Ok(());
+    }
+
+    let available: Vec<&str> = cfg.tiers.keys().map(|k| k.as_str()).collect();
+    let alias_hint = cfg.format_tier_aliases();
+    anyhow::bail!(
+        "Direct --tool is restricted when tiers are configured. \
+         Use --tier <name> to specify which tier's model/thinking config to use, \
+         --hint-difficulty <label> to route through [tier_mapping], \
+         or add --force-ignore-tier-setting to override. \
+         Available tiers: [{}]{alias_hint}",
+        available.join(", ")
+    );
+}
+
 pub(crate) fn validate_model_spec_tier_conflict(
     model_spec: Option<&str>,
     tier: Option<&str>,


### PR DESCRIPTION
## Summary
- Extract `validate_direct_tool_tier_restriction` to `run_helpers.rs` as shared helper for review and debate commands
- Call validation early in `handle_review`/`handle_debate` **before** session creation, preventing orphan sessions when `--tool` is used with tiers configured
- Allow `--model-spec` exact selections to bypass tier restriction (review R2-001/R2-002 finding)

Closes #1463

## Test plan
- [x] Existing tests updated: verify `sessions.is_empty()` (no orphan session created)
- [x] `cargo nextest run --workspace` — 4683 tests pass
- [x] `just pre-commit` passes (including monolith check at 792 lines)
- [x] CSA review round 2: PASS/CLEAN (0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)