### PR TITLE
fix(executor): align tmux transport env propagation with CLI transport (#1467)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.748"
+version = "0.1.749"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.748"
+version = "0.1.749"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -32,7 +32,7 @@ use arg_helpers::{
 };
 
 #[path = "executor_env.rs"]
-mod executor_env;
+pub(crate) mod executor_env;
 #[path = "executor_pre_session.rs"]
 mod pre_session;
 #[path = "executor_prompt_helpers.rs"]

--- a/crates/csa-executor/src/transport_tmux.rs
+++ b/crates/csa-executor/src/transport_tmux.rs
@@ -368,18 +368,9 @@ impl TmuxTransport {
         let mut cmd = tokio::process::Command::new("tmux");
         cmd.args(&tmux_args);
 
-        // Strip CSA recursion guards from the child's environment.
-        for var in [
-            "CLAUDECODE",
-            "CLAUDE_CODE_ENTRYPOINT",
-            "LEFTHOOK",
-            "LEFTHOOK_SKIP",
-            "CSA_SESSION_ID",
-            "CSA_SESSION_DIR",
-            "CSA_PARENT_SESSION",
-            "CSA_PARENT_SESSION_DIR",
-            "CSA_DAEMON_SESSION_DIR",
-        ] {
+        // Strip inherited CSA/hook env vars, then re-inject the current
+        // session's values via extra_env (populated by execute_session).
+        for var in crate::executor::executor_env::STRIPPED_ENV_VARS {
             cmd.env_remove(var);
         }
 
@@ -423,8 +414,9 @@ impl TmuxTransport {
 
     /// Full session lifecycle: snapshot → spawn → ready → prompt → discover → watch.
     ///
-    /// When `session_dir` is provided, the transport injects `CSA_SESSION_DIR` and
-    /// `CSA_RESULT_TOML_PATH_CONTRACT` into the tmux environment, enables
+    /// When `session` is provided, the transport injects the full CSA session env
+    /// (`CSA_SESSION_ID`, `CSA_DEPTH`, `CSA_PROJECT_ROOT`, `CSA_TOOL`,
+    /// `CSA_RESULT_TOML_PATH_CONTRACT`, etc.) into the tmux environment, enables
     /// result.toml reading as the preferred output source, and creates a JSONL
     /// symlink in the session output directory for xurl/recall audit access.
     async fn execute_session(
@@ -433,7 +425,7 @@ impl TmuxTransport {
         work_dir: &Path,
         extra_env: Option<&HashMap<String, String>>,
         idle_timeout_seconds: u64,
-        session_dir: Option<PathBuf>,
+        session: Option<&MetaSessionState>,
     ) -> Result<TransportResult> {
         let session_name = Self::session_name();
         tracing::debug!(
@@ -460,20 +452,54 @@ impl TmuxTransport {
             _ => (None, None),
         };
 
-        // Merge caller-provided env with CSA session env vars so Claude Code
-        // inside tmux can write to the result.toml contract path.
-        let merged_env = {
+        // Merge caller-provided env with full CSA session env vars, aligned
+        // with inject_cli_session_env in transport_cli.rs.
+        let (merged_env, session_dir) = {
             let mut env = extra_env.cloned().unwrap_or_default();
-            if let Some(dir) = &session_dir {
-                env.insert("CSA_SESSION_DIR".into(), dir.to_string_lossy().into_owned());
+            let mut dir = None;
+            if let Some(session) = session {
+                env.insert("CSA_SESSION_ID".into(), session.meta_session_id.clone());
                 env.insert(
-                    csa_session::RESULT_TOML_PATH_CONTRACT_ENV.into(),
-                    csa_session::contract_result_path(dir)
-                        .to_string_lossy()
-                        .into_owned(),
+                    "CSA_DEPTH".into(),
+                    (session.genealogy.depth + 1).to_string(),
                 );
+                env.insert("CSA_PROJECT_ROOT".into(), session.project_path.clone());
+                env.insert("CSA_TOOL".into(), "claude-code".into());
+                if let Ok(current_tool) = std::env::var("CSA_TOOL") {
+                    env.insert("CSA_PARENT_TOOL".into(), current_tool);
+                }
+                if let Some(parent) = session.genealogy.parent_session_id.as_deref() {
+                    env.insert("CSA_PARENT_SESSION".into(), parent.to_string());
+                }
+                if let Ok(session_dir_path) = csa_session::manager::get_session_dir(
+                    Path::new(&session.project_path),
+                    &session.meta_session_id,
+                ) {
+                    env.insert(
+                        "CSA_SESSION_DIR".into(),
+                        session_dir_path.to_string_lossy().into_owned(),
+                    );
+                    env.insert(
+                        csa_session::RESULT_TOML_PATH_CONTRACT_ENV.into(),
+                        csa_session::contract_result_path(&session_dir_path)
+                            .to_string_lossy()
+                            .into_owned(),
+                    );
+                    dir = Some(session_dir_path);
+                }
+                if let Some(parent) = session.genealogy.parent_session_id.as_deref()
+                    && let Ok(parent_dir) = csa_session::manager::get_session_dir(
+                        Path::new(&session.project_path),
+                        parent,
+                    )
+                {
+                    env.insert(
+                        "CSA_PARENT_SESSION_DIR".into(),
+                        parent_dir.to_string_lossy().into_owned(),
+                    );
+                }
             }
-            env
+            (env, dir)
         };
 
         Self::spawn_tmux(
@@ -591,14 +617,12 @@ impl Transport for TmuxTransport {
         }
 
         let work_dir = PathBuf::from(&session.project_path);
-        let session_dir =
-            csa_session::manager::get_session_dir(&work_dir, &session.meta_session_id).ok();
         self.execute_session(
             prompt,
             &work_dir,
             extra_env,
             options.idle_timeout_seconds,
-            session_dir,
+            Some(session),
         )
         .await
     }


### PR DESCRIPTION
## Summary
- Use shared `STRIPPED_ENV_VARS` list instead of hardcoded subset for env stripping
- Inject full CSA session env set (`CSA_SESSION_ID`, `CSA_DEPTH`, `CSA_PROJECT_ROOT`, `CSA_TOOL`, `CSA_PARENT_TOOL`, `CSA_PARENT_SESSION`, `CSA_PARENT_SESSION_DIR`) matching `inject_cli_session_env` behavior
- Expose `executor_env` module as `pub(crate)` for cross-module reuse

## Test plan
- [x] 26 tmux transport tests pass
- [x] `just fmt && just clippy && just test` clean
- [x] `csa review --range main...HEAD` verdict: PASS

Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)