### PR TITLE
fix(scheduler): detect codex stdout quota errors for tier failover (#1473)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.749"
+version = "0.1.750"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.749"
+version = "0.1.750"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_tmux_jsonl.rs
+++ b/crates/csa-executor/src/transport_tmux_jsonl.rs
@@ -179,11 +179,10 @@ pub(super) async fn watch_jsonl_for_turn(
                         Some(JsonlEvent::AssistantText(text)) => {
                             collected_text.push_str(&text);
                         }
-                        Some(JsonlEvent::ResultText(text)) => {
-                            if collected_text.is_empty() {
-                                collected_text = text;
-                            }
+                        Some(JsonlEvent::ResultText(text)) if collected_text.is_empty() => {
+                            collected_text = text;
                         }
+                        Some(JsonlEvent::ResultText(_)) => {}
                         Some(JsonlEvent::TurnDuration) => {
                             return Ok(collected_text);
                         }

--- a/crates/csa-executor/src/transport_tmux_jsonl.rs
+++ b/crates/csa-executor/src/transport_tmux_jsonl.rs
@@ -51,19 +51,46 @@ pub(super) fn validate_jsonl_schema(jsonl_path: &Path) -> Result<()> {
 #[derive(Debug)]
 pub(super) enum JsonlEvent {
     AssistantText(String),
+    /// Final text from a "result" event (fallback when no assistant text seen).
+    ResultText(String),
     TurnDuration,
     CompactBoundary,
 }
 
 /// Parse a single JSONL line into a `JsonlEvent`.
 pub(super) fn parse_jsonl_line(line: &str) -> Option<JsonlEvent> {
-    let value: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
+    let trimmed = line.trim();
+    let value: serde_json::Value = match serde_json::from_str(trimmed) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                line_preview = &trimmed[..trimmed.len().min(120)],
+                "tmux transport: failed to parse JSONL line"
+            );
+            return None;
+        }
+    };
     let event_type = value.get("type")?.as_str()?;
 
     match event_type {
         "assistant" => {
             let text = extract_assistant_text(&value).unwrap_or_default();
             Some(JsonlEvent::AssistantText(text))
+        }
+        "result" => {
+            // Fallback text source — same as xurl-core's claude provider:
+            // use `value.result` when no assistant text was collected.
+            let text = value
+                .get("result")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if text.is_empty() {
+                None
+            } else {
+                Some(JsonlEvent::ResultText(text))
+            }
         }
         "system" => {
             let subtype = value.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
@@ -151,6 +178,11 @@ pub(super) async fn watch_jsonl_for_turn(
                     match parse_jsonl_line(&line) {
                         Some(JsonlEvent::AssistantText(text)) => {
                             collected_text.push_str(&text);
+                        }
+                        Some(JsonlEvent::ResultText(text)) => {
+                            if collected_text.is_empty() {
+                                collected_text = text;
+                            }
                         }
                         Some(JsonlEvent::TurnDuration) => {
                             return Ok(collected_text);

--- a/crates/csa-executor/src/transport_tmux_tests.rs
+++ b/crates/csa-executor/src/transport_tmux_tests.rs
@@ -113,6 +113,27 @@ fn parses_assistant_multiple_text_blocks() {
 }
 
 #[test]
+fn parses_result_event_text() {
+    let line = r#"{"type":"result","result":"final answer","session_id":"abc123"}"#;
+    match parse_jsonl_line(line) {
+        Some(JsonlEvent::ResultText(t)) => assert_eq!(t, "final answer"),
+        other => panic!("expected ResultText, got {other:?}"),
+    }
+}
+
+#[test]
+fn result_event_empty_text_returns_none() {
+    let line = r#"{"type":"result","result":"","session_id":"abc123"}"#;
+    assert!(parse_jsonl_line(line).is_none());
+}
+
+#[test]
+fn result_event_no_result_field_returns_none() {
+    let line = r#"{"type":"result","session_id":"abc123"}"#;
+    assert!(parse_jsonl_line(line).is_none());
+}
+
+#[test]
 fn ignores_unknown_event_type() {
     let line = r#"{"type":"human","message":{"content":"hello"}}"#;
     assert!(parse_jsonl_line(line).is_none());
@@ -222,6 +243,39 @@ async fn watcher_resets_on_compact_boundary() {
 
     let result = watch_jsonl_for_turn(&path, 10).await.unwrap();
     assert_eq!(result, "NEW");
+}
+
+#[tokio::test]
+async fn watcher_uses_result_text_as_fallback() {
+    let tmp = TempDir::new().unwrap();
+    let path = write_jsonl(
+        tmp.path(),
+        "result_fallback.jsonl",
+        &[
+            r#"{"type":"result","result":"fallback text","session_id":"abc"}"#,
+            r#"{"type":"system","subtype":"turn_duration","durationMs":100}"#,
+        ],
+    );
+
+    let result = watch_jsonl_for_turn(&path, 10).await.unwrap();
+    assert_eq!(result, "fallback text");
+}
+
+#[tokio::test]
+async fn watcher_prefers_assistant_over_result() {
+    let tmp = TempDir::new().unwrap();
+    let path = write_jsonl(
+        tmp.path(),
+        "assistant_wins.jsonl",
+        &[
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"from assistant"}]}}"#,
+            r#"{"type":"result","result":"from result","session_id":"abc"}"#,
+            r#"{"type":"system","subtype":"turn_duration","durationMs":100}"#,
+        ],
+    );
+
+    let result = watch_jsonl_for_turn(&path, 10).await.unwrap();
+    assert_eq!(result, "from assistant");
 }
 
 #[tokio::test]

--- a/crates/csa-scheduler/src/rate_limit.rs
+++ b/crates/csa-scheduler/src/rate_limit.rs
@@ -88,18 +88,21 @@ pub fn detect_rate_limit(
         .iter()
         .chain(failover_patterns_for_tool(tool_name).iter())
     {
-        let haystack = if pattern.quota_exhausted {
-            &stderr_lower
-        } else {
-            &combined_lower
-        };
-        if haystack.contains(pattern.pattern) {
+        // Always search combined (stderr+stdout) so codex quota errors emitted
+        // as JSON on stdout are detected. The exit_code!=0 precondition already
+        // filters normal successful output.
+        //
+        // quota_exhausted is only confirmed when the pattern also appears in
+        // stderr (stdout-only matches could be tool output echoing the phrase,
+        // so we still failover but don't mark it as permanent quota exhaustion).
+        if combined_lower.contains(pattern.pattern) {
+            let confirmed_quota = pattern.quota_exhausted && stderr_lower.contains(pattern.pattern);
             return Some(RateLimitDetected {
                 tool: tool_name.to_string(),
                 matched_pattern: pattern.pattern.to_string(),
                 reason: pattern.reason.to_string(),
                 advance_to_next_model: pattern.advance_to_next_model,
-                quota_exhausted: pattern.quota_exhausted,
+                quota_exhausted: confirmed_quota,
                 model_spec: model_spec.map(String::from),
             });
         }

--- a/crates/csa-scheduler/src/rate_limit_tests.rs
+++ b/crates/csa-scheduler/src/rate_limit_tests.rs
@@ -501,6 +501,49 @@ fn test_quota_exhausted_patterns_do_not_set_quota_from_stdout() {
     }
 }
 
+// --- #1473: codex quota error in stdout JSON triggers failover ---
+
+#[test]
+fn test_codex_usage_limit_in_stdout_json_triggers_failover() {
+    let detected = detect_rate_limit(
+        "codex",
+        "",
+        r#"{"type":"error","message":"You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now, or try again at 3:50 AM."}"#,
+        1,
+        Some("codex/openai/gpt-5.3-codex-spark/xhigh"),
+    )
+    .expect("codex stdout usage limit should classify for failover");
+    assert_eq!(detected.matched_pattern, "usage limit");
+    assert!(
+        detected.advance_to_next_model,
+        "must advance to next tier model on codex quota hit"
+    );
+    assert!(
+        !detected.quota_exhausted,
+        "stdout-only match should not set permanent quota flag"
+    );
+    assert_eq!(
+        detected.model_spec.as_deref(),
+        Some("codex/openai/gpt-5.3-codex-spark/xhigh")
+    );
+}
+
+#[test]
+fn test_codex_usage_limit_in_stderr_sets_quota_exhausted() {
+    let detected = detect_rate_limit(
+        "codex",
+        "Error: Usage limit exceeded for this account",
+        "",
+        1,
+        None,
+    )
+    .expect("codex stderr usage limit should classify");
+    assert!(
+        detected.quota_exhausted,
+        "stderr-confirmed match should set permanent quota flag"
+    );
+}
+
 #[test]
 fn test_transient_rate_limit_patterns_still_match_stdout() {
     let detected = detect_rate_limit(

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -42,6 +42,21 @@ After mktd completes, use `csa todo epic show` to view the story DAG and
 
 Each story follows: branch from main -> mktd (story-specific) -> dev2merge -> merge to main.
 
+### Tier Configuration
+
+`TIER` controls which tier the four RECON sub-sessions (Dimensions 1–4) use.
+When unset, RECON defaults to `tier-1-quick` (lightweight exploration).
+Set `TIER` to a heavier tier when RECON needs deeper analysis:
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `TIER` | (empty) | RECON uses `tier-1-quick` |
+| `TIER=tier-2-standard` | — | RECON uses `tier-2-standard` |
+| `TIER=tier-4-critical` | — | RECON uses `tier-4-critical` |
+
+The resolved value is written to `RECON_TIER` in Step 1.5 and applied to all four RECON csa steps.
+Debate and Revise phases always use the tier specified at the step level (`tier-2-standard` / `tier-3-complex`).
+
 ## Step 0: Phase 0.5 — Auto Session Discovery
 
 Tool: bash
@@ -92,13 +107,15 @@ PY
 
 Tool: bash
 
-Resolve planning language for TODO content.
-Priority:
+Resolve planning language for TODO content, and initialize `RECON_TIER` for RECON sub-sessions.
+Priority (language):
 1) Explicit `${USER_LANGUAGE}`
 2) Environment `${CSA_USER_LANGUAGE}`
 3) Script-aware detection from `${FEATURE}`
 4) Default to Chinese (Simplified) when script is mixed/unknown
 5) Fallback to Chinese (Simplified) when `${FEATURE}` is empty
+
+Priority (RECON tier): `${TIER}` if set; else `tier-1-quick`.
 
 ```bash
 # --- Intensity detection (CSA_VAR side-effect, stripped from STEP_OUTPUT) ---
@@ -108,6 +125,13 @@ if [[ "${INTENSITY:-full}" == "light" ]]; then
 else
   echo "Planning intensity: full" >&2
   echo "CSA_VAR:INTENSITY_IS_LIGHT=false"
+fi
+
+# --- RECON tier propagation: caller-specified TIER takes precedence; default to tier-1-quick ---
+if [[ -n "${TIER:-}" ]]; then
+  echo "CSA_VAR:RECON_TIER=${TIER}"
+else
+  echo "CSA_VAR:RECON_TIER=tier-1-quick"
 fi
 
 # --- Language detection (result is the step's logical output) ---
@@ -154,7 +178,7 @@ echo "Chinese (Simplified)"
 
 Tool: csa
 Session: ${STEP_1_OUTPUT}
-Tier: tier-1-quick
+Tier: ${RECON_TIER}
 Note: RECON steps are read-only (`workspace_access = "read-only"`); auto-routing is safe here because no tool writes files, so `allow_edit` restrictions do not apply. Any tool in the tier can explore.
 
 Analyze codebase structure relevant to ${FEATURE}.
@@ -168,7 +192,7 @@ Working directory: ${CWD}
 
 Tool: csa
 Session: ${STEP_1_OUTPUT}
-Tier: tier-1-quick
+Tier: ${RECON_TIER}
 Note: RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
 
 Find existing patterns or similar features to ${FEATURE} in this codebase.
@@ -182,7 +206,7 @@ Working directory: ${CWD}
 
 Tool: csa
 Session: ${STEP_1_OUTPUT}
-Tier: tier-1-quick
+Tier: ${RECON_TIER}
 Note: RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
 
 Identify constraints and risks for implementing ${FEATURE}.
@@ -196,7 +220,7 @@ Working directory: ${CWD}
 
 Tool: csa
 Session: ${STEP_1_OUTPUT}
-Tier: tier-1-quick
+Tier: ${RECON_TIER}
 Note: RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
 
 Identify the semantic invariants and concurrency assumptions for ${FEATURE}.

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -114,6 +114,12 @@ name = "INTENSITY"
 name = "INTENSITY_IS_LIGHT"
 
 [[workflow.variables]]
+name = "TIER"
+
+[[workflow.variables]]
+name = "RECON_TIER"
+
+[[workflow.variables]]
 name = "USER_LANGUAGE"
 
 [[workflow.steps]]
@@ -187,6 +193,13 @@ else
   echo "CSA_VAR:INTENSITY_IS_LIGHT=false"
 fi
 
+# --- RECON tier propagation: caller-specified TIER takes precedence; default to tier-1-quick ---
+if [[ -n "${TIER:-}" ]]; then
+  echo "CSA_VAR:RECON_TIER=${TIER}"
+else
+  echo "CSA_VAR:RECON_TIER=tier-1-quick"
+fi
+
 # --- Language detection (result is the step's logical output) ---
 if [[ -n "${USER_LANGUAGE:-}" ]]; then
   printf '%s\n' "${USER_LANGUAGE}"
@@ -242,7 +255,7 @@ Report: relevant files (path + purpose, max 20), key types, module dependencies,
 Working directory: ${CWD}"""
 # RECON steps are read-only (workspace_access = "read-only"); auto-routing is safe here because
 # no tool writes files, so allow_edit restrictions do not apply. Any tool in the tier can explore.
-tier = "tier-1-quick"
+tier = "${RECON_TIER}"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"
 
@@ -259,7 +272,7 @@ CONSTRAINT ANCHOR: If the user prompt specifies an architectural approach or tar
 Report: file paths with approach, reusable components, conventions to follow.
 Working directory: ${CWD}"""
 # RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
-tier = "tier-1-quick"
+tier = "${RECON_TIER}"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"
 
@@ -276,7 +289,7 @@ CONSTRAINT ANCHOR: If the user prompt specifies scope boundaries (target crate, 
 Report: potential breaking changes, security considerations, performance, compatibility.
 Working directory: ${CWD}"""
 # RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
-tier = "tier-1-quick"
+tier = "${RECON_TIER}"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"
 
@@ -297,7 +310,7 @@ Report using these keys:
 
 Working directory: ${CWD}"""
 # RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
-tier = "tier-1-quick"
+tier = "${RECON_TIER}"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"
 


### PR DESCRIPTION
## Summary

- **Root cause**: `detect_rate_limit` in `rate_limit.rs` restricted `quota_exhausted` pattern search to stderr only. Codex emits quota errors as JSON on stdout (`{"type":"error","message":"You've hit your usage limit..."}`), so they were never detected, preventing tier failover.
- **Fix**: Always search combined stderr+stdout for pattern matching. `quota_exhausted` flag is only confirmed when the pattern also appears in stderr (prevents false positives from stdout echoes).
- **mktd RECON**: Added `TIER`→`RECON_TIER` variable propagation so callers can control which tier RECON sub-sessions use (default: `tier-1-quick`).
- **JSONL reliability**: Added "result" event handling (xurl-core alignment) as fallback text source, plus JSON parse error logging.

## Verified

Tested with real quota-exhausted GPT-5.3-Codex-Spark:
- Before: `csa run --tier tier-1-quick` → immediate failure (exit_code=1)
- After: Spark quota error → detected → failover to next codex model → session completes successfully (exit_code=0)

Session: `01KS50TFH3PFMWSAQB9SGP9WAK` (result.toml confirms success after failover)

## Test plan

- [x] 42 rate_limit tests pass (including new codex stdout quota scenario)
- [x] 31 tmux transport tests pass (including result event + fallback tests)
- [x] 2087/2092 full suite pass (5 pre-existing env-dependent failures)
- [x] Real-world failover test with quota-exhausted Spark model
- [x] pre-commit 32/32 pass
- [x] codex review: PASS (CLEAN, 0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)