### PR TITLE
fix(review): retire intermediate tier-failover sessions to prevent premature Failed status (#1475)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.750"
+version = "0.1.751"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -45,7 +45,7 @@ use failures::{
     build_gemini_api_key_retry_env, classify_review_failover_reason,
     classify_review_failure_result, enforce_review_artifact_contract,
     extract_meta_session_id_from_error, maybe_synthesize_missing_review_result,
-    repair_completed_review_restriction_result,
+    repair_completed_review_restriction_result, retire_tier_failover_session,
 };
 
 const REVIEWER_SUB_SESSION_TASK_TYPE: &str = "reviewer_sub_session";
@@ -326,6 +326,19 @@ pub(crate) async fn execute_review_with_tier_filter(
                         "Review tier model failed before execution completed; advancing to next configured model"
                     );
                     if attempt_index + 1 < candidates.len() {
+                        // Ensure a result.toml exists for the failed attempt so the
+                        // superseded marker can be written, then retire the session to
+                        // prevent "Failed" from appearing in `csa session list` during
+                        // the failover window (#1475).
+                        maybe_synthesize_missing_review_result(
+                            project_root,
+                            *attempt_tool,
+                            execution_started_at,
+                            &err,
+                        );
+                        if let Some(session_id) = extract_meta_session_id_from_error(&err) {
+                            retire_tier_failover_session(project_root, &session_id);
+                        }
                         continue;
                     }
                     maybe_synthesize_missing_review_result(
@@ -515,6 +528,9 @@ pub(crate) async fn execute_review_with_tier_filter(
                     ),
                 });
             }
+            // Retire the failed intermediate session so `csa session list` shows
+            // "Retired" rather than "Failed" during the failover window (#1475).
+            retire_tier_failover_session(project_root, &execution.meta_session_id);
             continue;
         }
 

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -1,4 +1,5 @@
 use super::*;
+use csa_session::{PhaseEvent, SessionPhase};
 
 pub(super) fn classify_review_failover_reason(
     tool: ToolName,
@@ -194,6 +195,57 @@ fn classify_review_failure(
 fn truncate_for_summary(text: &str, max_chars: usize) -> String {
     let truncated: String = text.chars().take(max_chars).collect();
     truncated.trim().replace('\n', " ")
+}
+
+/// Status written to result.toml for tier-failover intermediate attempts.
+///
+/// Prevents `csa session list` from showing "Failed" during the window between
+/// a tier-failover attempt and the next model's result (#1475).
+pub(super) const TIER_FAILOVER_SUPERSEDED_STATUS: &str = "tier_failover_superseded";
+
+/// Mark an intermediate tier-failover session so it shows as "Retired" in
+/// `csa session list` rather than "Failed" during the failover transition.
+///
+/// Called before `continue`-ing to the next tier candidate so that the
+/// window where the failed session's result.toml is visible does not
+/// mislead operators or callers (including `csa session wait`).
+pub(super) fn retire_tier_failover_session(project_root: &Path, session_id: &str) {
+    if let Ok(Some(mut result)) = load_result(project_root, session_id) {
+        result.status = TIER_FAILOVER_SUPERSEDED_STATUS.to_string();
+        if let Err(e) = save_result(project_root, session_id, &result) {
+            warn!(
+                session_id,
+                error = %e,
+                "Failed to mark tier-failover session as superseded in result.toml"
+            );
+        }
+    }
+    match load_session(project_root, session_id) {
+        Ok(mut session_state) => {
+            if let Err(e) = session_state.apply_phase_event(PhaseEvent::Retired) {
+                warn!(
+                    session_id,
+                    error = %e,
+                    "Skipping phase transition for tier-failover superseded session; forcing Retired"
+                );
+                session_state.phase = SessionPhase::Retired;
+            }
+            if let Err(e) = save_session(&session_state) {
+                warn!(
+                    session_id,
+                    error = %e,
+                    "Failed to retire tier-failover superseded session"
+                );
+            }
+        }
+        Err(e) => {
+            warn!(
+                session_id,
+                error = %e,
+                "Failed to load session state for tier-failover retirement"
+            );
+        }
+    }
 }
 
 fn fail_review_execution(

--- a/crates/cli-sub-agent/src/session_cmds_list.rs
+++ b/crates/cli-sub-agent/src/session_cmds_list.rs
@@ -141,6 +141,11 @@ pub(super) fn status_from_phase_and_result(
         "success" => "Failed",
         "failure" | "timeout" | "signal" => "Failed",
         "error" => "Error",
+        // Intermediate tier-failover attempts are superseded and should not
+        // surface as "Failed" while the failover chain is still in progress
+        // (#1475). The session is retired immediately after being superseded,
+        // so this branch only fires during the very short window before GC.
+        "tier_failover_superseded" => "Retired",
         _ if result.exit_code != 0 => "Failed",
         _ => "Error",
     }

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -178,6 +178,24 @@ fn retired_phase_shows_retired_when_result_succeeded() {
     );
 }
 
+// #1475: tier-failover superseded sessions ───────────────────────────────────
+//
+// Intermediate tier-failover attempts write a special status so they show as
+// "Retired" rather than "Failed" during the failover window.
+
+#[test]
+fn tier_failover_superseded_shows_retired_not_failed() {
+    let superseded = make_result("tier_failover_superseded", 1);
+    assert_eq!(
+        status_from_phase_and_result(&SessionPhase::Active, Some(&superseded)),
+        "Retired"
+    );
+    assert_eq!(
+        status_from_phase_and_result(&SessionPhase::Retired, Some(&superseded)),
+        "Retired"
+    );
+}
+
 // #1118 part D ────────────────────────────────────────────────────────────────
 //
 // Active sessions whose `last_accessed` has not advanced for >= the stale

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.738"
-weave = "0.1.738"
+csa = "0.1.750"
+weave = "0.1.750"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- During tier failover, intermediate failed sessions are now marked `tier_failover_superseded` and retired immediately
- `csa session list` shows "Retired" instead of "Failed" while the failover chain is still in progress
- Both pre-execution error and post-execution failure failover paths handle retirement

## Changes

- `review_cmd_execute.rs`: Call `retire_tier_failover_session()` before `continue` in both failover paths
- `review_cmd_execute_failures.rs`: New `retire_tier_failover_session()` function — updates result.toml status + transitions session phase to Retired
- `session_cmds_list.rs`: Map `tier_failover_superseded` → "Retired" in display logic
- `session_cmds_tests.rs`: Test verifying superseded sessions render as "Retired"
- Version bump 0.1.750 → 0.1.751

## Test plan

- [x] `tier_failover_superseded_shows_retired_not_failed` test passes
- [x] `just pre-commit` passes (fmt, clippy, deny, all checks green)
- [x] csa review PASS verdict (session 01KS553QEZA)

Closes #1475

🤖 Generated with [Claude Code](https://claude.com/claude-code)