### PR TITLE
feat(skill): CSA-managed inactive skills repo (#1477)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.751"
+version = "0.1.752"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.751"
+version = "0.1.752"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -45,6 +45,9 @@ pub use cli_checklist::*;
 #[path = "cli_memory.rs"]
 mod cli_memory;
 pub use cli_memory::*;
+#[path = "cli_skill.rs"]
+mod cli_skill;
+pub use cli_skill::*;
 
 #[derive(Parser)]
 #[command(name = "csa", version = build_version())]
@@ -679,22 +682,6 @@ pub enum ConfigCommands {
         #[arg(long)]
         cd: Option<String>,
     },
-}
-
-#[derive(Subcommand)]
-pub enum SkillCommands {
-    /// Install skills from a GitHub repository
-    Install {
-        /// GitHub repo URL or user/repo format (e.g., "user/repo" or "https://github.com/user/repo")
-        source: String,
-
-        /// Target tool to install skills for (claude-code, codex, opencode). Defaults to claude-code.
-        #[arg(long)]
-        target: Option<String>,
-    },
-
-    /// List installed skills
-    List,
 }
 
 #[derive(Subcommand)]

--- a/crates/cli-sub-agent/src/cli_skill.rs
+++ b/crates/cli-sub-agent/src/cli_skill.rs
@@ -1,0 +1,47 @@
+//! Clap definitions for the `csa skill` subcommand group.
+
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum SkillCommands {
+    /// Install skills from a GitHub repository
+    Install {
+        /// GitHub repo URL or user/repo format (e.g., "user/repo" or "https://github.com/user/repo")
+        source: String,
+
+        /// Target tool to install skills for (claude-code, codex, opencode). Defaults to claude-code.
+        #[arg(long)]
+        target: Option<String>,
+    },
+
+    /// List installed skills (active in .claude/skills/ and managed in state dir)
+    List,
+
+    /// Run a CSA-managed skill by name
+    Run {
+        /// Skill name (must exist in the managed skill repo)
+        name: String,
+
+        /// Optional prompt to pass to the skill session
+        #[arg(trailing_var_arg = true)]
+        prompt: Vec<String>,
+    },
+
+    /// Add a new skill to the CSA-managed skill repo
+    Add {
+        /// Skill name (simple identifier, no path separators)
+        name: String,
+    },
+
+    /// Edit an existing CSA-managed skill in $EDITOR
+    Edit {
+        /// Skill name
+        name: String,
+    },
+
+    /// Detect and commit any untracked changes in the managed skill repo
+    Scan,
+
+    /// Push the managed skill repo to a private GitHub backup remote
+    Backup,
+}

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -87,7 +87,10 @@ mod session_guard;
 mod session_observability;
 mod setup_cmds;
 mod skill_cmds;
+mod skill_dispatch;
+mod skill_repo;
 mod skill_resolver;
+mod skill_run_cmd;
 #[cfg(any(feature = "parallel-tasks", test))]
 pub mod task_lock;
 #[cfg(test)]
@@ -110,9 +113,8 @@ include!("review_round10_exact_tests.rs");
 include!("debate_cmd_exact_tests.rs");
 
 use cli::{
-    Cli, Commands, ConfigCommands, DoctorSubcommand, McpHubCommands, SetupCommands, SkillCommands,
-    TiersCommands, TodoCommands, TodoRefCommands, handle_tokuin, handle_xurl,
-    validate_command_args,
+    Cli, Commands, ConfigCommands, DoctorSubcommand, McpHubCommands, SetupCommands, TiersCommands,
+    TodoCommands, TodoRefCommands, handle_tokuin, handle_xurl, validate_command_args,
 };
 use csa_core::types::OutputFormat;
 use main_bootstrap::{
@@ -630,14 +632,12 @@ async fn run() -> Result<()> {
                 mcp_hub::handle_gen_skill_command(socket).await?;
             }
         },
-        Commands::Skill { cmd } => match cmd {
-            SkillCommands::Install { source, target } => {
-                skill_cmds::handle_skill_install(source, target)?;
+        Commands::Skill { cmd } => {
+            let code = skill_dispatch::dispatch(cmd, current_depth, output_format).await?;
+            if code != 0 {
+                exit_current_process(code);
             }
-            SkillCommands::List => {
-                skill_cmds::handle_skill_list()?;
-            }
-        },
+        }
         Commands::Setup { cmd } => match cmd {
             SetupCommands::ClaudeCode => {
                 setup_cmds::handle_setup_claude_code()?;

--- a/crates/cli-sub-agent/src/skill_cmds.rs
+++ b/crates/cli-sub-agent/src/skill_cmds.rs
@@ -5,6 +5,10 @@ use std::process::Command;
 use tempfile::TempDir;
 use tracing::info;
 
+use crate::skill_repo::{
+    SkillRepoManager, git_commit_all, git_commit_paths, skill_repo_root, validate_skill_name,
+};
+
 /// Handle skill install command
 pub(crate) fn handle_skill_install(source: String, target: Option<String>) -> Result<()> {
     // 1. Parse source to get user/repo
@@ -41,37 +45,333 @@ pub(crate) fn handle_skill_install(source: String, target: Option<String>) -> Re
     Ok(())
 }
 
-/// Handle skill list command
+/// Handle skill list command — shows both active (.claude/skills/) and managed (state dir) skills.
 pub(crate) fn handle_skill_list() -> Result<()> {
-    let skills_dir = get_claude_skills_dir()?;
+    let mut any = false;
 
-    if !skills_dir.exists() {
-        eprintln!("No skills directory found at: {}", skills_dir.display());
-        return Ok(());
+    // --- Active skills (project + global .claude/skills/) ---
+    let active_dirs = collect_active_skill_dirs();
+    let mut active_skills: Vec<(String, PathBuf)> = Vec::new();
+    for dir in &active_dirs {
+        if !dir.exists() {
+            continue;
+        }
+        for entry in fs::read_dir(dir)?.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) if !n.starts_with('.') => n.to_string(),
+                _ => continue,
+            };
+            if path.join("SKILL.md").exists() {
+                active_skills.push((name, path));
+            }
+        }
+    }
+    active_skills.sort_by(|a, b| a.0.cmp(&b.0));
+    active_skills.dedup_by(|a, b| a.0 == b.0);
+
+    if !active_skills.is_empty() {
+        eprintln!("Active skills (.claude/skills/):\n");
+        for (name, path) in &active_skills {
+            let title = read_skill_title(path).unwrap_or_else(|| name.clone());
+            println!("  {name} [active] - {title}");
+        }
+        any = true;
     }
 
-    let entries: Vec<_> = fs::read_dir(&skills_dir)?
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir())
-        .collect();
-
-    if entries.is_empty() {
-        eprintln!("No skills installed.");
-        return Ok(());
+    // --- Managed skills (CSA state dir) ---
+    let mgr = SkillRepoManager::new()?;
+    let managed = mgr.list_skills()?;
+    if !managed.is_empty() {
+        if any {
+            eprintln!();
+        }
+        eprintln!("Managed skills (csa skill repo):\n");
+        for name in &managed {
+            let path = mgr.root().join(name);
+            let title = read_skill_title(&path).unwrap_or_else(|| name.clone());
+            println!("  {name} [managed] - {title}");
+        }
+        any = true;
     }
 
-    eprintln!("Installed skills:\n");
-    for entry in entries {
-        let skill_name = entry.file_name().to_string_lossy().to_string();
-        let skill_path = entry.path();
-
-        // Try to read SKILL.md to get title
-        let title = read_skill_title(&skill_path).unwrap_or_else(|| skill_name.clone());
-
-        println!("  {skill_name} - {title}");
+    if !any {
+        eprintln!(
+            "No skills found. Use `csa skill install <repo>` or `csa skill add <name>` to add skills."
+        );
     }
 
     Ok(())
+}
+
+/// Handle `csa skill add <name>`.
+///
+/// Creates `<name>/SKILL.md` (and optional `.skill.toml`) in the managed skill
+/// repo and commits the new files. Rollback on pre-commit failure: removes the
+/// directory and resets the git index.
+pub(crate) fn handle_skill_add(name: String) -> Result<()> {
+    validate_skill_name(&name)?;
+
+    let mgr = SkillRepoManager::new()?;
+    mgr.ensure_init()?;
+
+    mgr.with_write_lock(|| {
+        let skill_dir = mgr.root().join(&name);
+
+        if skill_dir.exists() {
+            anyhow::bail!("Skill '{name}' already exists at {}", skill_dir.display());
+        }
+
+        fs::create_dir_all(&skill_dir)
+            .with_context(|| format!("create skill dir {}", skill_dir.display()))?;
+
+        let skill_md_path = skill_dir.join("SKILL.md");
+        let template = skill_md_template(&name);
+        fs::write(&skill_md_path, &template)
+            .with_context(|| format!("write {}", skill_md_path.display()))?;
+
+        let rel_skill_md = format!("{name}/SKILL.md");
+        match git_commit_paths(mgr.root(), &[&rel_skill_md], &format!("add skill: {name}")) {
+            Ok(_) => {
+                eprintln!("Skill '{name}' created at {}", skill_dir.display());
+                Ok(())
+            }
+            Err(e) => {
+                // Rollback: remove files and reset git index.
+                let _ = fs::remove_dir_all(&skill_dir);
+                let _ = Command::new("git")
+                    .args(["reset", "HEAD", "--", &format!("{name}/")])
+                    .current_dir(mgr.root())
+                    .output();
+                Err(e).with_context(|| format!("failed to commit new skill '{name}'; rolled back"))
+            }
+        }
+    })
+}
+
+/// Handle `csa skill edit <name>`.
+///
+/// Two-phase lock: opens `$EDITOR` outside the lock so concurrent reads are
+/// not blocked during editing. Acquires the write lock only after the editor
+/// exits, detects changes, and commits if the content was modified.
+pub(crate) fn handle_skill_edit(name: String) -> Result<()> {
+    validate_skill_name(&name)?;
+
+    let mgr = SkillRepoManager::new()?;
+    let skill_dir = mgr.root().join(&name);
+    let skill_md_path = skill_dir.join("SKILL.md");
+
+    if !skill_md_path.exists() {
+        anyhow::bail!(
+            "Skill '{name}' not found in managed repo at {}",
+            skill_md_path.display()
+        );
+    }
+
+    // Read content before editing for change detection.
+    let before = fs::read_to_string(&skill_md_path)
+        .with_context(|| format!("read {}", skill_md_path.display()))?;
+
+    // Phase 1: open editor WITHOUT holding the write lock.
+    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+    let status = Command::new(&editor)
+        .arg(&skill_md_path)
+        .status()
+        .with_context(|| format!("failed to launch editor '{editor}'"))?;
+
+    if !status.success() {
+        anyhow::bail!("Editor exited with non-zero status: {}", status);
+    }
+
+    // Phase 2: acquire write lock, check for changes, commit.
+    mgr.with_write_lock(|| {
+        let after = fs::read_to_string(&skill_md_path)
+            .with_context(|| format!("read {}", skill_md_path.display()))?;
+
+        if after == before {
+            eprintln!("No changes detected in '{name}'.");
+            return Ok(());
+        }
+
+        let rel_skill_md = format!("{name}/SKILL.md");
+        git_commit_paths(mgr.root(), &[&rel_skill_md], &format!("edit skill: {name}"))?;
+        eprintln!("Skill '{name}' saved.");
+        Ok(())
+    })
+}
+
+/// Handle `csa skill scan`.
+///
+/// Detects dirty state in the managed skill repo and commits all changes.
+/// No-op when the repo is clean.
+pub(crate) fn handle_skill_scan() -> Result<()> {
+    let mgr = SkillRepoManager::new()?;
+    mgr.ensure_init()?;
+
+    mgr.with_write_lock(|| {
+        let committed = git_commit_all(mgr.root(), "scan: commit untracked skill changes")?;
+        if committed {
+            eprintln!("Skill repo: changes committed.");
+        } else {
+            eprintln!("Skill repo: nothing to commit.");
+        }
+        Ok(())
+    })
+}
+
+/// Handle `csa skill backup`.
+///
+/// Pushes the managed skill repo to a private GitHub backup remote.
+/// Creates the remote repo on first run via `gh repo create`.
+/// Uses default `gh` auth (not GH_CONFIG_DIR=~/.config/gh-aider).
+pub(crate) fn handle_skill_backup() -> Result<()> {
+    let repo_root = skill_repo_root()?;
+    if !repo_root.exists() {
+        anyhow::bail!("Managed skill repo not initialised. Run `csa skill add` first.");
+    }
+
+    // Determine GitHub username from `gh api user`.
+    let user_out = Command::new("gh")
+        .args(["api", "user", "--jq", ".login"])
+        .output()
+        .context("run gh api user (is gh CLI installed?)")?;
+    if !user_out.status.success() {
+        anyhow::bail!(
+            "gh api user failed: {}",
+            String::from_utf8_lossy(&user_out.stderr)
+        );
+    }
+    let username = String::from_utf8_lossy(&user_out.stdout).trim().to_string();
+    if username.is_empty() {
+        anyhow::bail!("Could not determine GitHub username from gh CLI");
+    }
+
+    let hostname = gethostname();
+    let remote_name = "backup";
+    let repo_name = format!("csa-skills-{hostname}");
+    let remote_url = format!("https://github.com/{username}/{repo_name}");
+
+    // Check whether the remote already exists.
+    let remote_check = Command::new("git")
+        .args(["remote", "get-url", remote_name])
+        .current_dir(&repo_root)
+        .output()
+        .context("git remote get-url")?;
+
+    if !remote_check.status.success() {
+        // Create GitHub repo if it does not exist yet.
+        eprintln!("Creating private GitHub repo: {username}/{repo_name}");
+        let create_out = Command::new("gh")
+            .args([
+                "repo",
+                "create",
+                &format!("{username}/{repo_name}"),
+                "--private",
+                "--description",
+                "CSA-managed skill backup",
+            ])
+            .output()
+            .context("gh repo create")?;
+
+        if !create_out.status.success() {
+            let stderr = String::from_utf8_lossy(&create_out.stderr);
+            // Tolerate "already exists" — just add the remote.
+            if !stderr.contains("already exists") {
+                anyhow::bail!("gh repo create failed: {stderr}");
+            }
+        }
+
+        // Add remote.
+        let add_out = Command::new("git")
+            .args(["remote", "add", remote_name, &remote_url])
+            .current_dir(&repo_root)
+            .output()
+            .context("git remote add")?;
+        if !add_out.status.success() {
+            anyhow::bail!(
+                "git remote add failed: {}",
+                String::from_utf8_lossy(&add_out.stderr)
+            );
+        }
+    }
+
+    // Determine current branch name.
+    let branch_out = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(&repo_root)
+        .output()
+        .context("git rev-parse HEAD")?;
+    let branch = if branch_out.status.success() {
+        String::from_utf8_lossy(&branch_out.stdout)
+            .trim()
+            .to_string()
+    } else {
+        "main".to_string()
+    };
+
+    // Push to backup remote. No --no-verify needed: skill repo is isolated (no project hooks).
+    eprintln!("Pushing to {remote_name}/{branch} ({remote_url})");
+    let push_out = Command::new("git")
+        .args(["push", remote_name, &branch])
+        .current_dir(&repo_root)
+        .output()
+        .context("git push")?;
+    if !push_out.status.success() {
+        anyhow::bail!(
+            "git push failed: {}",
+            String::from_utf8_lossy(&push_out.stderr)
+        );
+    }
+
+    eprintln!("Backup complete: {remote_url}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Collect all directories to search for active skills.
+fn collect_active_skill_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    // Project-local
+    if let Ok(cwd) = std::env::current_dir() {
+        dirs.push(cwd.join(".claude").join("skills"));
+        dirs.push(cwd.join(".csa").join("skills"));
+    }
+
+    // Global ~/.claude/skills/
+    if let Some(base) = directories::BaseDirs::new() {
+        dirs.push(base.home_dir().join(".claude").join("skills"));
+    }
+
+    dirs
+}
+
+/// Return the current hostname (best-effort, falls back to "host").
+fn gethostname() -> String {
+    Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "host".to_string())
+}
+
+/// Default SKILL.md template for a new managed skill.
+fn skill_md_template(name: &str) -> String {
+    format!(
+        "# {name}\n\n<!-- Describe what this skill does and when to invoke it. -->\n\n## Usage\n\nProvide task description as the prompt to `csa skill run {name}`.\n"
+    )
 }
 
 /// Parse GitHub source to extract user/repo

--- a/crates/cli-sub-agent/src/skill_dispatch.rs
+++ b/crates/cli-sub-agent/src/skill_dispatch.rs
@@ -1,0 +1,40 @@
+//! Dispatch handler for all `csa skill` subcommands.
+
+use anyhow::Result;
+use csa_core::types::OutputFormat;
+
+use crate::cli::SkillCommands;
+use crate::{skill_cmds, skill_run_cmd};
+
+/// Dispatch a `csa skill` subcommand, returning an exit code.
+pub(crate) async fn dispatch(
+    cmd: SkillCommands,
+    current_depth: u32,
+    output_format: OutputFormat,
+) -> Result<i32> {
+    match cmd {
+        SkillCommands::Install { source, target } => {
+            skill_cmds::handle_skill_install(source, target)?;
+        }
+        SkillCommands::List => {
+            skill_cmds::handle_skill_list()?;
+        }
+        SkillCommands::Add { name } => {
+            skill_cmds::handle_skill_add(name)?;
+        }
+        SkillCommands::Edit { name } => {
+            skill_cmds::handle_skill_edit(name)?;
+        }
+        SkillCommands::Scan => {
+            skill_cmds::handle_skill_scan()?;
+        }
+        SkillCommands::Backup => {
+            skill_cmds::handle_skill_backup()?;
+        }
+        SkillCommands::Run { name, prompt } => {
+            return skill_run_cmd::handle_skill_run(name, prompt, current_depth, output_format)
+                .await;
+        }
+    }
+    Ok(0)
+}

--- a/crates/cli-sub-agent/src/skill_repo.rs
+++ b/crates/cli-sub-agent/src/skill_repo.rs
@@ -1,0 +1,415 @@
+//! CSA-managed skill repository under `~/.local/state/cli-sub-agent/skills/`.
+//!
+//! An isolated git repository that stores user-managed "inactive" skills —
+//! skills that LLMs should not auto-invoke, only user-triggered via
+//! `csa skill run`. Lifecycle is managed by the `csa skill` subcommand group.
+
+use anyhow::{Context, Result};
+use csa_config::paths;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const LOCK_FILE: &str = ".lock";
+
+/// Manages the CSA-controlled skill git repository.
+pub(crate) struct SkillRepoManager {
+    root: PathBuf,
+}
+
+impl SkillRepoManager {
+    /// Create a manager pointing at the canonical skill repo root.
+    pub fn new() -> Result<Self> {
+        let root = skill_repo_root()?;
+        Ok(Self { root })
+    }
+
+    /// Root directory of the managed skill repo.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Ensure the skill repo exists as a valid git repository.
+    ///
+    /// Idempotent — safe to call multiple times. Creates the directory, runs
+    /// `git init`, configures a local user identity, and writes `.gitignore`
+    /// that excludes `.lock`.
+    pub fn ensure_init(&self) -> Result<()> {
+        fs::create_dir_all(&self.root)
+            .with_context(|| format!("create skill repo dir {}", self.root.display()))?;
+        ensure_git_init(&self.root)
+    }
+
+    /// Execute `f` while holding an exclusive write lock on the skill repo.
+    pub fn with_write_lock<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce() -> Result<T>,
+    {
+        fs::create_dir_all(&self.root)
+            .with_context(|| format!("create skill repo dir {}", self.root.display()))?;
+        let lock_path = self.root.join(LOCK_FILE);
+        let lock_file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("open skill repo lock {}", lock_path.display()))?;
+        let mut lock = fd_lock::RwLock::new(lock_file);
+        let _guard = lock
+            .write()
+            .map_err(|e| anyhow::anyhow!("failed to acquire skill repo write lock: {e}"))?;
+        f()
+    }
+
+    /// List all skill names present in the repo (each subdirectory with a SKILL.md).
+    pub fn list_skills(&self) -> Result<Vec<String>> {
+        if !self.root.exists() {
+            return Ok(vec![]);
+        }
+        let entries = fs::read_dir(&self.root)
+            .with_context(|| format!("read skill repo dir {}", self.root.display()))?;
+        let mut names = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            // Skip hidden directories (.git, etc.)
+            if name.starts_with('.') {
+                continue;
+            }
+            if path.join("SKILL.md").exists() {
+                names.push(name);
+            }
+        }
+        names.sort();
+        Ok(names)
+    }
+}
+
+/// Return the canonical path for the managed skill repo:
+/// `~/.local/state/cli-sub-agent/skills/`
+pub(crate) fn skill_repo_root() -> Result<PathBuf> {
+    let state = paths::state_dir_write().context("XDG state directory is unavailable")?;
+    Ok(state.join("skills"))
+}
+
+/// Validate a skill name: no path separators, no `..`, no null bytes, non-empty.
+pub(crate) fn validate_skill_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("skill name must not be empty");
+    }
+    if name.contains('/') || name.contains('\\') {
+        anyhow::bail!("skill name must not contain path separators: '{name}'");
+    }
+    if name.contains("..") {
+        anyhow::bail!("skill name must not contain '..': '{name}'");
+    }
+    if name.contains('\0') {
+        anyhow::bail!("skill name must not contain null bytes");
+    }
+    Ok(())
+}
+
+/// Strip prompt-injection and CSA pseudo-tags from SKILL.md content.
+///
+/// Removes:
+/// - `<system-reminder>...</system-reminder>` blocks (block-level)
+/// - `<csa-caller-prompt-injection>...</csa-caller-prompt-injection>` blocks
+/// - `<!-- CSA:SECTION:... -->` single-line markers
+///
+/// Does NOT truncate or modify legitimate Markdown/template syntax
+/// (e.g. `{{var}}`, `## System Requirements`, triple-backtick fences).
+pub(crate) fn sanitize_skill_md(content: &str) -> String {
+    let mut result = String::with_capacity(content.len());
+    let mut in_system_reminder = false;
+    let mut in_csa_injection = false;
+
+    for line in content.lines() {
+        let lower = line.to_ascii_lowercase();
+        let trimmed_lower = lower.trim();
+
+        // Detect opening tags (may appear on their own line or inline).
+        if trimmed_lower.contains("<system-reminder") {
+            in_system_reminder = true;
+        }
+        if trimmed_lower.contains("<csa-caller-prompt-injection") {
+            in_csa_injection = true;
+        }
+
+        if in_system_reminder || in_csa_injection {
+            // Check for closing tags before skipping the line.
+            if trimmed_lower.contains("</system-reminder>") {
+                in_system_reminder = false;
+            }
+            if trimmed_lower.contains("</csa-caller-prompt-injection>") {
+                in_csa_injection = false;
+            }
+            continue;
+        }
+
+        // Strip <!-- CSA:SECTION:... --> single-line markers.
+        let trimmed = line.trim();
+        if trimmed.starts_with("<!-- CSA:SECTION:") && trimmed.ends_with("-->") {
+            continue;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // Preserve original trailing-newline presence.
+    if !content.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    result
+}
+
+/// Stage and commit specific paths in the skill repo.
+///
+/// Returns `true` if a commit was made, `false` when there was nothing to commit.
+pub(crate) fn git_commit_paths(dir: &Path, paths: &[&str], message: &str) -> Result<bool> {
+    let mut add_args: Vec<&str> = vec!["add", "--"];
+    add_args.extend_from_slice(paths);
+    let out = Command::new("git")
+        .args(&add_args)
+        .current_dir(dir)
+        .output()
+        .context("git add")?;
+    if !out.status.success() {
+        anyhow::bail!("git add: {}", String::from_utf8_lossy(&out.stderr));
+    }
+
+    let mut diff_args: Vec<&str> = vec!["diff", "--cached", "--quiet", "--"];
+    diff_args.extend_from_slice(paths);
+    let status = Command::new("git")
+        .args(&diff_args)
+        .current_dir(dir)
+        .output()
+        .context("git diff --cached")?;
+    if status.status.code() == Some(0) {
+        return Ok(false); // nothing staged
+    }
+
+    let mut commit_args: Vec<&str> = vec!["commit", "-m", message, "--"];
+    commit_args.extend_from_slice(paths);
+    let out = Command::new("git")
+        .args(&commit_args)
+        .current_dir(dir)
+        .output()
+        .context("git commit")?;
+    if !out.status.success() {
+        anyhow::bail!("git commit: {}", String::from_utf8_lossy(&out.stderr));
+    }
+    Ok(true)
+}
+
+/// Stage all changes (`git add -A`) and commit.
+///
+/// Returns `true` if a commit was made.
+pub(crate) fn git_commit_all(dir: &Path, message: &str) -> Result<bool> {
+    let out = Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(dir)
+        .output()
+        .context("git add -A")?;
+    if !out.status.success() {
+        anyhow::bail!("git add -A: {}", String::from_utf8_lossy(&out.stderr));
+    }
+
+    let status = Command::new("git")
+        .args(["diff", "--cached", "--quiet"])
+        .current_dir(dir)
+        .output()
+        .context("git diff --cached")?;
+    if status.status.code() == Some(0) {
+        return Ok(false);
+    }
+
+    let out = Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(dir)
+        .output()
+        .context("git commit")?;
+    if !out.status.success() {
+        anyhow::bail!("git commit: {}", String::from_utf8_lossy(&out.stderr));
+    }
+    Ok(true)
+}
+
+/// Ensure `dir` is a git repository with `.gitignore` excluding `.lock`.
+fn ensure_git_init(dir: &Path) -> Result<()> {
+    let git_dir = dir.join(".git");
+    if !git_dir.exists() {
+        let out = Command::new("git")
+            .args(["init"])
+            .current_dir(dir)
+            .output()
+            .context("git init")?;
+        if !out.status.success() {
+            anyhow::bail!("git init: {}", String::from_utf8_lossy(&out.stderr));
+        }
+
+        let _ = Command::new("git")
+            .args(["config", "user.email", "csa-skills@localhost"])
+            .current_dir(dir)
+            .output();
+        let _ = Command::new("git")
+            .args(["config", "user.name", "CSA Skills"])
+            .current_dir(dir)
+            .output();
+    }
+    ensure_gitignore(dir)
+}
+
+fn ensure_gitignore(dir: &Path) -> Result<()> {
+    let gitignore = dir.join(".gitignore");
+    if gitignore.exists() {
+        let content = fs::read_to_string(&gitignore).context("read .gitignore")?;
+        if content.lines().any(|l| l.trim() == ".lock") {
+            return Ok(());
+        }
+        let mut new_content = content;
+        if !new_content.ends_with('\n') && !new_content.is_empty() {
+            new_content.push('\n');
+        }
+        new_content.push_str(".lock\n");
+        fs::write(&gitignore, new_content).context("update .gitignore")?;
+    } else {
+        fs::write(&gitignore, ".lock\n").context("write .gitignore")?;
+    }
+
+    let _ = Command::new("git")
+        .args(["add", "--", ".gitignore"])
+        .current_dir(dir)
+        .output();
+    let _ = Command::new("git")
+        .args([
+            "commit",
+            "-m",
+            "bootstrap: add .gitignore",
+            "--",
+            ".gitignore",
+        ])
+        .current_dir(dir)
+        .output();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_manager(dir: &Path) -> SkillRepoManager {
+        SkillRepoManager {
+            root: dir.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn test_ensure_init_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+
+        mgr.ensure_init().unwrap();
+        assert!(tmp.path().join(".git").exists());
+        assert!(tmp.path().join(".gitignore").exists());
+
+        // Second call is idempotent
+        mgr.ensure_init().unwrap();
+    }
+
+    #[test]
+    fn test_gitignore_excludes_lock() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        let gitignore = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+        assert!(gitignore.contains(".lock"), "gitignore must exclude .lock");
+    }
+
+    #[test]
+    fn test_validate_skill_name() {
+        assert!(validate_skill_name("my-skill").is_ok());
+        assert!(validate_skill_name("foo_bar").is_ok());
+        assert!(validate_skill_name("").is_err());
+        assert!(validate_skill_name("../escape").is_err());
+        assert!(validate_skill_name("foo/bar").is_err());
+        assert!(validate_skill_name("foo\\bar").is_err());
+        assert!(validate_skill_name("foo..bar").is_err());
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_strips_system_reminder() {
+        let input = "# My Skill\n<system-reminder>INJECT</system-reminder>\nReal content\n";
+        let out = sanitize_skill_md(input);
+        assert!(!out.contains("INJECT"));
+        assert!(!out.contains("<system-reminder>"));
+        assert!(out.contains("Real content"));
+        assert!(out.contains("# My Skill"));
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_strips_csa_injection() {
+        let input =
+            "Before\n<csa-caller-prompt-injection>bad</csa-caller-prompt-injection>\nAfter\n";
+        let out = sanitize_skill_md(input);
+        assert!(!out.contains("bad"));
+        assert!(out.contains("Before"));
+        assert!(out.contains("After"));
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_strips_csa_section_markers() {
+        let input = "<!-- CSA:SECTION:summary -->\nContent\n<!-- CSA:SECTION:summary:END -->\n";
+        let out = sanitize_skill_md(input);
+        assert!(!out.contains("<!-- CSA:SECTION:"));
+        assert!(out.contains("Content"));
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_preserves_template_syntax() {
+        let input = "# Skill\n{{var}}\n## System Requirements\nOk\n";
+        let out = sanitize_skill_md(input);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_multiline_block() {
+        let input = "top\n<system-reminder>\nline1\nline2\n</system-reminder>\nbottom\n";
+        let out = sanitize_skill_md(input);
+        assert!(!out.contains("line1"));
+        assert!(!out.contains("line2"));
+        assert!(out.contains("top"));
+        assert!(out.contains("bottom"));
+    }
+
+    #[test]
+    fn test_list_skills_empty() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+        assert_eq!(mgr.list_skills().unwrap(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_list_skills_finds_skills() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        fs::create_dir_all(tmp.path().join("my-skill")).unwrap();
+        fs::write(tmp.path().join("my-skill/SKILL.md"), "# My Skill\n").unwrap();
+
+        let skills = mgr.list_skills().unwrap();
+        assert_eq!(skills, vec!["my-skill"]);
+    }
+}

--- a/crates/cli-sub-agent/src/skill_resolver.rs
+++ b/crates/cli-sub-agent/src/skill_resolver.rs
@@ -5,12 +5,13 @@
 //! - Optional superproject root when current root is a git submodule
 //!
 //! Search order:
-//! 1. `./.csa/skills/<name>/`                    (project-local, CSA-specific)
-//! 2. `./.claude/skills/<name>/`                 (project-local, Claude Code compat)
-//! 3. `<superproject>/.csa/skills/<name>/`       (submodule only)
-//! 4. `<superproject>/.claude/skills/<name>/`    (submodule only)
-//! 5. `~/.config/cli-sub-agent/skills/<name>/`   (global user)
-//! 6. `<global_store>/<name>/<commit>/`          (weave global store via lockfiles)
+//! 1. `./.csa/skills/<name>/`                             (project-local, CSA-specific)
+//! 2. `./.claude/skills/<name>/`                          (project-local, Claude Code compat)
+//! 3. `<superproject>/.csa/skills/<name>/`                (submodule only)
+//! 4. `<superproject>/.claude/skills/<name>/`             (submodule only)
+//! 5. `~/.config/cli-sub-agent/skills/<name>/`            (global user config)
+//! 6. `~/.local/state/cli-sub-agent/skills/<name>/`       (CSA-managed inactive skills)
+//! 7. `<global_store>/<name>/<commit>/`                   (weave global store via lockfiles)
 
 use anyhow::{Context, Result, bail};
 use csa_config::paths;
@@ -18,6 +19,8 @@ use std::path::{Path, PathBuf};
 
 use weave::package::{self, SourceKind};
 use weave::parser::{AgentConfig, SkillConfig, parse_skill_config};
+
+use crate::skill_repo::sanitize_skill_md;
 
 /// A skill resolved from disk, ready for injection into a CSA run.
 #[derive(Debug, Clone)]
@@ -51,8 +54,11 @@ pub(crate) fn resolve_skill(name: &str, project_root: &Path) -> Result<ResolvedS
     for dir in &candidates {
         let skill_md_path = dir.join("SKILL.md");
         if skill_md_path.is_file() {
-            let skill_md = std::fs::read_to_string(&skill_md_path)
+            let raw_skill_md = std::fs::read_to_string(&skill_md_path)
                 .with_context(|| format!("failed to read {}", skill_md_path.display()))?;
+
+            // Strip prompt-injection tags before the content reaches any LLM.
+            let skill_md = sanitize_skill_md(&raw_skill_md);
 
             let config = load_skill_config(dir)?;
 
@@ -99,12 +105,17 @@ fn search_paths_with_store(
         search_roots.push(root.join(".claude").join("skills").join(name));
     }
 
-    // 3. Global user: ~/.config/cli-sub-agent/skills/<name>/ (legacy fallback supported)
+    // 5. Global user config: ~/.config/cli-sub-agent/skills/<name>/ (legacy fallback supported)
     if let Some(config_dir) = paths::config_dir() {
         search_roots.push(config_dir.join("skills").join(name));
     }
 
-    // 4. Weave global store: match locked packages by name.
+    // 6. CSA-managed inactive skills: ~/.local/state/cli-sub-agent/skills/<name>/
+    if let Some(state_dir) = paths::state_dir_write() {
+        search_roots.push(state_dir.join("skills").join(name));
+    }
+
+    // 7. Weave global store: match locked packages by name.
     if let Some(store) = store_root {
         for root in &repo_roots {
             if let Some(lockfile_path) = package::find_lockfile(root)

--- a/crates/cli-sub-agent/src/skill_run_cmd.rs
+++ b/crates/cli-sub-agent/src/skill_run_cmd.rs
@@ -1,0 +1,70 @@
+//! Async handler for `csa skill run` — delegates to the standard CSA run pipeline.
+
+use anyhow::Result;
+use csa_core::types::OutputFormat;
+
+use crate::goal_loop;
+
+/// Run a named skill via the standard CSA run pipeline.
+///
+/// Equivalent to `csa run --skill <name> [prompt]`.
+pub(crate) async fn handle_skill_run(
+    name: String,
+    prompt: Vec<String>,
+    current_depth: u32,
+    output_format: OutputFormat,
+) -> Result<i32> {
+    let prompt_str = if prompt.is_empty() {
+        None
+    } else {
+        Some(prompt.join(" "))
+    };
+
+    goal_loop::handle_run_or_goal(goal_loop::GoalRunRequest {
+        goal_criteria: None,
+        tool: None,
+        auto_route: None,
+        hint_difficulty: None,
+        skill: Some(name),
+        prompt: prompt_str,
+        prompt_flag: None,
+        prompt_file: None,
+        inline_context_from_review_session: None,
+        session: None,
+        last: false,
+        fork_from: None,
+        fork_last: false,
+        fork_from_caller: false,
+        description: None,
+        fork_call: false,
+        return_to: None,
+        parent: None,
+        ephemeral: false,
+        allow_base_branch_working: false,
+        cd: None,
+        model_spec: None,
+        model: None,
+        thinking: None,
+        force: false,
+        force_override_user_config: false,
+        allow_fallback: false,
+        no_failover: false,
+        fast_but_more_cost: false,
+        wait: false,
+        idle_timeout: None,
+        initial_response_timeout: None,
+        timeout: None,
+        no_idle_timeout: false,
+        no_memory: false,
+        memory_query: None,
+        current_depth,
+        output_format,
+        stream_mode: csa_process::StreamMode::BufferOnly,
+        tier: None,
+        force_ignore_tier_setting: false,
+        no_fs_sandbox: false,
+        extra_writable: vec![],
+        extra_readable: vec![],
+    })
+    .await
+}

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -101,6 +101,22 @@ command = "echo post-run: session={session_id} exit={exit_code}"
 timeout_secs = 30
 ```
 
+#### Auto-scan managed skills after each session (opt-in)
+
+If you use `csa skill add` to maintain a managed skill repo, you can configure
+`post_run` to automatically commit any in-place edits you make to skill files
+during a session:
+
+```toml
+[post_run]
+enabled = true
+command = "csa skill scan"
+timeout_secs = 30
+```
+
+This is a no-op when no files changed. It is **opt-in** — CSA does not enable
+this by default.
+
 ### `post_review`
 
 Fires after `csa review` produces its final result (including after a `--fix`


### PR DESCRIPTION
## Summary

- New `csa skill` subcommands: `run`, `add`, `edit`, `backup`, `scan` for managing inactive skills in a CSA-managed git repo at `~/.local/state/cli-sub-agent/skills/`
- Skills stored in isolated git repo with `fd_lock::RwLock` cross-process locking
- `skill_resolver.rs` extended with state dir search path (priority 5)
- New `sanitize_skill_md()` function strips XML injection tags without truncating content
- `csa skill list` shows `[active]` and `[managed]` labels
- `csa skill backup` creates/pushes to private GitHub repo
- PostRun hook documentation for auto-commit via `csa skill scan`

## Files changed (11 files, +957 -71)

- `skill_repo.rs` (new, 415 lines) — SkillRepoManager with git lifecycle + flock
- `cli_skill.rs` (new) — Extracted SkillCommands enum with 7 subcommands
- `skill_cmds.rs` — Extended with add/edit/scan/backup/list handlers
- `skill_dispatch.rs` (new) — Dispatch helper
- `skill_run_cmd.rs` (new) — Skill run delegation
- `skill_resolver.rs` — Added state dir search path
- `docs/hooks.md` — PostRun hook configuration example

## Test plan

- [x] `cargo clippy --workspace --all-features` clean
- [x] `just pre-commit` passes
- [x] csa review PASS verdict (session 01KS5H83D3, zero findings)
- [ ] Phase 4 tests (follow-up: unit + integration + security tests)

Closes #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)