### PR TITLE
fix(cli): improve timeout error message and downgrade weave upgrade warning (#1479, #1482)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.754"
+version = "0.1.755"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.754"
+version = "0.1.755"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -335,20 +335,52 @@ fn validate_timeout(
     {
         return Err(clap::Error::raw(
             clap::error::ErrorKind::ValueValidation,
-            timeout_validation_message(min_timeout),
+            timeout_validation_message(t, min_timeout),
         ));
     }
     Ok(())
 }
 
-fn timeout_validation_message(min_timeout: u64) -> String {
+fn timeout_validation_message(given: u64, min_timeout: u64) -> String {
     let min_minutes = min_timeout / 60;
+    let suggested = build_suggested_command(given, min_timeout);
     format!(
         "Absolute timeout (--timeout) must be at least {min_timeout} seconds ({min_minutes} minutes). \
          Short timeouts waste tokens because the agent starts working but gets killed before producing output. \
          Record this in your CLAUDE.md or memory: CSA minimum timeout is {min_timeout} seconds. \
-         Use --timeout >= {min_timeout}, or inspect the effective floor with `csa config get execution.min_timeout_seconds`."
+         Use --timeout >= {min_timeout}, or inspect the effective floor with `csa config get execution.min_timeout_seconds`.\n\
+         Suggested: {suggested}"
     )
+}
+
+fn build_suggested_command(given: u64, min_timeout: u64) -> String {
+    let args: Vec<String> = std::env::args().collect();
+    let given_str = given.to_string();
+    let min_str = min_timeout.to_string();
+
+    let mut result = args.clone();
+    let mut replaced = false;
+    let mut i = 0;
+
+    while i < result.len() {
+        if result[i] == "--timeout" && i + 1 < result.len() && result[i + 1] == given_str {
+            result[i + 1] = min_str.clone();
+            replaced = true;
+            break;
+        }
+        if result[i] == format!("--timeout={given_str}") {
+            result[i] = format!("--timeout={min_str}");
+            replaced = true;
+            break;
+        }
+        i += 1;
+    }
+
+    if replaced {
+        result.join(" ")
+    } else {
+        format!("csa ... --timeout {min_str}")
+    }
 }
 
 #[derive(clap::Args)]
@@ -504,12 +536,22 @@ mod tests {
             !rendered.contains("Configure via [execution] min_timeout_seconds"),
             "error text should not encourage lowering the configured safety floor"
         );
+        assert!(
+            rendered.contains("Suggested:"),
+            "error should include a ready-to-copy corrected command"
+        );
+        assert!(
+            rendered.contains("--timeout 1800"),
+            "suggestion should show the corrected floor timeout"
+        );
     }
 
     #[test]
     fn timeout_validation_message_guides_toward_effective_floor() {
-        let rendered = timeout_validation_message(2400);
+        let rendered = timeout_validation_message(1200, 2400);
         assert!(rendered.contains("Use --timeout >= 2400"));
         assert!(rendered.contains("effective floor"));
+        assert!(rendered.contains("Suggested:"));
+        assert!(rendered.contains("--timeout 2400"));
     }
 }

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -274,10 +274,10 @@ async fn run() -> Result<()> {
             }
 
             if !success {
-                let msg = "auto weave upgrade failed after 3 attempts (non-fatal). \
-                           Disable with [execution] auto_weave_upgrade = false";
-                tracing::warn!(msg);
-                eprintln!("warning: {msg}");
+                tracing::debug!(
+                    "auto weave upgrade failed after 3 attempts (non-fatal). \
+                     Disable with [execution] auto_weave_upgrade = false"
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

- **#1479**: Timeout rejection error now includes a ready-to-copy corrected command with `--timeout 1800`
- **#1482**: Non-fatal weave upgrade warning downgraded from `warn!` to `debug!` — no longer clutters session output

## Files changed (4 files, +67 -25)

- `cli_review.rs` — Enhanced timeout error message with suggested command
- `main.rs` — Downgraded weave upgrade warning to debug level

## Test plan

- [x] `just pre-commit` passes
- [x] csa review PASS verdict (session 01KS5S2GWM, zero findings)

Closes #1479
Closes #1482

🤖 Generated with [Claude Code](https://claude.com/claude-code)