### PR TITLE
test(skill): comprehensive tests for CSA-managed skill repo (#1477)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.756"
+version = "0.1.757"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.756"
+version = "0.1.757"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/skill_cmds.rs
+++ b/crates/cli-sub-agent/src/skill_cmds.rs
@@ -683,4 +683,88 @@ mod tests {
         let result = read_skill_title(tmp.path());
         assert!(result.is_none());
     }
+
+    // --- skill_md_template tests ---
+
+    #[test]
+    fn skill_md_template_contains_name() {
+        let t = skill_md_template("my-tool");
+        assert!(t.contains("# my-tool"));
+        assert!(t.contains("csa skill run my-tool"));
+    }
+
+    // --- copy_dir_recursive tests ---
+
+    #[test]
+    fn copy_dir_recursive_copies_nested_files() {
+        let src = tempdir().unwrap();
+        let dest = tempdir().unwrap();
+        let dest_skill = dest.path().join("skill-copy");
+
+        fs::create_dir_all(src.path().join("sub")).unwrap();
+        fs::write(src.path().join("SKILL.md"), "# Root").unwrap();
+        fs::write(src.path().join("sub/data.txt"), "nested").unwrap();
+
+        copy_dir_recursive(src.path(), &dest_skill).unwrap();
+
+        assert!(dest_skill.join("SKILL.md").exists());
+        assert_eq!(
+            fs::read_to_string(dest_skill.join("sub/data.txt")).unwrap(),
+            "nested"
+        );
+    }
+
+    // --- copy_skills tests ---
+
+    #[test]
+    fn copy_skills_skips_existing() {
+        let src = tempdir().unwrap();
+        let dest = tempdir().unwrap();
+
+        fs::create_dir_all(src.path().join("existing")).unwrap();
+        fs::write(src.path().join("existing/SKILL.md"), "# src").unwrap();
+
+        fs::create_dir_all(dest.path().join("existing")).unwrap();
+        fs::write(dest.path().join("existing/SKILL.md"), "# dest-original").unwrap();
+
+        fs::create_dir_all(src.path().join("new-one")).unwrap();
+        fs::write(src.path().join("new-one/SKILL.md"), "# new").unwrap();
+
+        let installed = copy_skills(src.path(), dest.path()).unwrap();
+        assert_eq!(installed, vec!["new-one"]);
+
+        let existing_content = fs::read_to_string(dest.path().join("existing/SKILL.md")).unwrap();
+        assert_eq!(existing_content, "# dest-original");
+    }
+
+    #[test]
+    fn copy_skills_skips_non_dirs() {
+        let src = tempdir().unwrap();
+        let dest = tempdir().unwrap();
+
+        fs::write(src.path().join("README.md"), "not a skill dir").unwrap();
+
+        let installed = copy_skills(src.path(), dest.path()).unwrap();
+        assert!(installed.is_empty());
+    }
+
+    // --- collect_active_skill_dirs tests ---
+
+    #[test]
+    fn collect_active_skill_dirs_returns_expected_paths() {
+        let dirs = collect_active_skill_dirs();
+        assert!(
+            dirs.iter()
+                .any(|d| d.ends_with(".claude/skills") || d.ends_with(".csa/skills")),
+            "should contain .claude/skills or .csa/skills: {dirs:?}"
+        );
+    }
+
+    // --- gethostname tests ---
+
+    #[test]
+    fn gethostname_returns_nonempty() {
+        let name = gethostname();
+        assert!(!name.is_empty());
+    }
 }

--- a/crates/cli-sub-agent/src/skill_repo.rs
+++ b/crates/cli-sub-agent/src/skill_repo.rs
@@ -412,4 +412,254 @@ mod tests {
         let skills = mgr.list_skills().unwrap();
         assert_eq!(skills, vec!["my-skill"]);
     }
+
+    #[test]
+    fn test_list_skills_ignores_hidden_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        fs::create_dir_all(tmp.path().join(".hidden")).unwrap();
+        fs::write(tmp.path().join(".hidden/SKILL.md"), "# Hidden\n").unwrap();
+        fs::create_dir_all(tmp.path().join("visible")).unwrap();
+        fs::write(tmp.path().join("visible/SKILL.md"), "# Visible\n").unwrap();
+
+        let skills = mgr.list_skills().unwrap();
+        assert_eq!(skills, vec!["visible"]);
+    }
+
+    #[test]
+    fn test_list_skills_ignores_dirs_without_skill_md() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        fs::create_dir_all(tmp.path().join("no-skill-md")).unwrap();
+        fs::write(tmp.path().join("no-skill-md/README.md"), "# Readme\n").unwrap();
+
+        assert_eq!(mgr.list_skills().unwrap(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_list_skills_sorted() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        for name in &["zeta", "alpha", "mid"] {
+            fs::create_dir_all(tmp.path().join(name)).unwrap();
+            fs::write(tmp.path().join(name).join("SKILL.md"), "# Skill\n").unwrap();
+        }
+
+        let skills = mgr.list_skills().unwrap();
+        assert_eq!(skills, vec!["alpha", "mid", "zeta"]);
+    }
+
+    #[test]
+    fn test_list_skills_nonexistent_root() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(&tmp.path().join("does-not-exist"));
+        assert_eq!(mgr.list_skills().unwrap(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_with_write_lock_executes_closure() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        let result = mgr.with_write_lock(|| Ok(42)).unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn test_with_write_lock_propagates_error() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        let result: Result<()> = mgr.with_write_lock(|| anyhow::bail!("deliberate"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("deliberate"));
+    }
+
+    #[test]
+    fn test_with_write_lock_creates_lock_file() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+
+        mgr.with_write_lock(|| {
+            assert!(tmp.path().join(".lock").exists());
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn test_git_commit_paths_commits_file() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        fs::create_dir_all(tmp.path().join("s1")).unwrap();
+        fs::write(tmp.path().join("s1/SKILL.md"), "# S1\n").unwrap();
+
+        let committed = git_commit_paths(tmp.path(), &["s1/SKILL.md"], "add s1").unwrap();
+        assert!(committed);
+
+        let log = Command::new("git")
+            .args(["log", "--oneline", "-1"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        let msg = String::from_utf8_lossy(&log.stdout);
+        assert!(msg.contains("add s1"), "commit message: {msg}");
+    }
+
+    #[test]
+    fn test_git_commit_paths_noop_when_clean() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        fs::create_dir_all(tmp.path().join("s1")).unwrap();
+        fs::write(tmp.path().join("s1/SKILL.md"), "# S1\n").unwrap();
+        git_commit_paths(tmp.path(), &["s1/SKILL.md"], "first").unwrap();
+
+        let committed = git_commit_paths(tmp.path(), &["s1/SKILL.md"], "second").unwrap();
+        assert!(!committed);
+    }
+
+    #[test]
+    fn test_git_commit_all_commits_everything() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        fs::create_dir_all(tmp.path().join("a")).unwrap();
+        fs::write(tmp.path().join("a/SKILL.md"), "# A\n").unwrap();
+        fs::create_dir_all(tmp.path().join("b")).unwrap();
+        fs::write(tmp.path().join("b/SKILL.md"), "# B\n").unwrap();
+
+        let committed = git_commit_all(tmp.path(), "add all").unwrap();
+        assert!(committed);
+
+        let status = Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        let out = String::from_utf8_lossy(&status.stdout);
+        assert!(
+            out.trim().is_empty(),
+            "worktree dirty after commit_all: {out}"
+        );
+    }
+
+    #[test]
+    fn test_git_commit_all_noop_when_clean() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = make_manager(tmp.path());
+        mgr.ensure_init().unwrap();
+
+        let committed = git_commit_all(tmp.path(), "should noop").unwrap();
+        assert!(!committed);
+    }
+
+    #[test]
+    fn test_ensure_gitignore_appends_to_existing() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), "*.tmp\n").unwrap();
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+
+        ensure_gitignore(tmp.path()).unwrap();
+
+        let content = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+        assert!(content.contains("*.tmp"), "original entry preserved");
+        assert!(content.contains(".lock"), ".lock appended");
+    }
+
+    #[test]
+    fn test_ensure_git_init_sets_local_identity() {
+        let tmp = TempDir::new().unwrap();
+        ensure_git_init(tmp.path()).unwrap();
+
+        let email = Command::new("git")
+            .args(["config", "user.email"])
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+        let email_str = String::from_utf8_lossy(&email.stdout);
+        assert_eq!(email_str.trim(), "csa-skills@localhost");
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_case_insensitive_tags() {
+        let input = "before\n<System-Reminder>injected</System-Reminder>\nafter\n";
+        let out = sanitize_skill_md(input);
+        assert!(!out.contains("injected"));
+        assert!(out.contains("before"));
+        assert!(out.contains("after"));
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_interleaved_injection_types() {
+        // Two DIFFERENT tag types overlapping — both stripped independently.
+        let input = "top\n<system-reminder>\nsr-line\n</system-reminder>\n<csa-caller-prompt-injection>\ninj-line\n</csa-caller-prompt-injection>\nbottom\n";
+        let out = sanitize_skill_md(input);
+        assert!(!out.contains("sr-line"));
+        assert!(!out.contains("inj-line"));
+        assert!(out.contains("top"));
+        assert!(out.contains("bottom"));
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_preserves_html_comments() {
+        let input = "# Skill\n<!-- normal comment -->\nContent\n";
+        let out = sanitize_skill_md(input);
+        assert!(out.contains("<!-- normal comment -->"));
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_preserves_code_fences() {
+        let input = "```bash\necho '<system-reminder>not stripped</system-reminder>'\n```\n";
+        let out = sanitize_skill_md(input);
+        assert!(
+            !out.contains("not stripped"),
+            "tags inside code fences are still stripped for safety"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_empty_input() {
+        assert_eq!(sanitize_skill_md(""), "");
+    }
+
+    #[test]
+    fn test_sanitize_skill_md_no_trailing_newline_preserved() {
+        let input = "content";
+        let out = sanitize_skill_md(input);
+        assert_eq!(out, "content");
+    }
+
+    #[test]
+    fn test_validate_skill_name_with_null_bytes() {
+        assert!(validate_skill_name("foo\0bar").is_err());
+    }
+
+    #[test]
+    fn test_validate_skill_name_unicode_ok() {
+        assert!(validate_skill_name("skill-\u{00e9}t\u{00e9}").is_ok());
+    }
+
+    #[test]
+    fn test_validate_skill_name_dots_ok() {
+        assert!(validate_skill_name("my.skill").is_ok());
+        assert!(validate_skill_name("v1.2.3").is_ok());
+    }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.750"
-weave = "0.1.750"
+csa = "0.1.756"
+weave = "0.1.756"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Adds 28 new unit/integration tests across `skill_repo.rs` and `skill_cmds.rs` for Phase 4 of #1477
- Covers: write_lock behavior, git_commit_paths/git_commit_all, ensure_gitignore append, git identity, list_skills edge cases (hidden dirs, missing SKILL.md, sort order), sanitize_skill_md security (case-insensitive, interleaved types, HTML comments, code fences, empty input), validate_skill_name (null bytes, unicode, dots), copy_dir_recursive, copy_skills skip-existing, template generation
- Version bump to 0.1.757

## Test plan
- [x] `cargo test -p cli-sub-agent -- skill_repo::tests` (32 passed)
- [x] `cargo test -p cli-sub-agent -- skill_cmds::tests` (24 passed)
- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` verdict: PASS/CLEAN

Closes Phase 4 of #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)