### PR TITLE
feat(skill): migrate 6 inactive skills to CSA-managed repo (#1477)

### DIFF
--- a/.claude/skills/nohup-poll
+++ b/.claude/skills/nohup-poll
@@ -1,1 +1,0 @@
-../../skills/nohup-poll

--- a/.claude/skills/quality-gate
+++ b/.claude/skills/quality-gate
@@ -1,1 +1,0 @@
-../../skills/quality-gate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.757"
+version = "0.1.758"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.757"
+version = "0.1.758"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/justfile
+++ b/justfile
@@ -429,10 +429,18 @@ install-skills target=".claude/skills":
 			fi
 		done
 	done
-	# Also install independent skills from skills/ directory
+	# Also install independent skills from skills/ directory.
+	# Skills listed in MANAGED_SKILLS are inactive (user-triggered only via
+	# `csa skill run`) and should NOT be symlinked into .claude/skills/
+	# to avoid consuming context-window tokens.
+	MANAGED_SKILLS="nohup-poll pattern-creator quality-gate split-project-docs"
 	for skill_dir in "${repo_root}"/skills/*/; do
 		[ -d "$skill_dir" ] || continue
 		skill_name=$(basename "$skill_dir")
+		if echo " ${MANAGED_SKILLS} " | grep -q " ${skill_name} "; then
+			echo "  skip (managed): ${skill_name}"
+			continue
+		fi
 		target_path="{{target}}/${skill_name}"
 		if [ -L "$target_path" ]; then
 			echo "  skip (symlink exists): ${skill_name}"

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -6,7 +6,7 @@ Note: Workflow logic is defined in `./patterns/`. `skills/csa-review` and
 `skills/debate` are kept as compatibility shims so `csa skill install` still
 installs the workflow entrypoints required by `csa review` and `csa debate`.
 
-## Global Persona Skills (7)
+## Global Persona Skills (6)
 
 | Skill | Description |
 |---|---|
@@ -16,7 +16,21 @@ installs the workflow entrypoints required by `csa review` and `csa debate`.
 | `csa-rust-dev` | Comprehensive Rust development guidance for architecture, implementation, and standards. |
 | `csa-security` | Adversarial security analysis to identify vulnerabilities before release. |
 | `csa-test-gen` | Core-first test design and TDD guidance following the test pyramid. |
-| `nohup-poll` | Launch long-running commands via nohup and poll at `kv_cache.long_poll_seconds` (default 240s) to keep KV cache warm. |
+
+## CSA-Managed Skills (6)
+
+Inactive skills migrated to `~/.local/state/cli-sub-agent/skills/` via `csa skill add`.
+These are NOT symlinked into `.claude/skills/` to avoid consuming context-window tokens.
+Invoke via `csa skill run <name>`.
+
+| Skill | Description |
+|---|---|
+| `health` | Claude Code configuration health audit (six-layer framework). |
+| `mcp-hub-routing-guide` | MCP Hub routing, server setup, and troubleshooting reference. |
+| `nohup-poll` | Launch long-running commands via nohup with KV cache-warm polling. |
+| `pattern-creator` | Create CSA patterns (PATTERN.md + skill + workflow.toml). |
+| `quality-gate` | Repository quality gate infrastructure builder (hooks, CI guards, merge protection). |
+| `split-project-docs` | Split monolith documentation into AGENTS.md-style progressive disclosure. |
 
 ## Compatibility Workflow Skills (2)
 


### PR DESCRIPTION
## Summary
- Migrates 6 inactive skills from `.claude/skills/` to CSA-managed repo (`~/.local/state/cli-sub-agent/skills/`) to reduce context-window token consumption (~1335 lines saved)
- Adds `MANAGED_SKILLS` exclusion list to `just install-skills` recipe
- Updates `skills/AGENTS.md` with managed skill classification
- Removes tracked `.claude/skills/` symlinks for migrated skills

Migrated skills: health, mcp-hub-routing-guide, nohup-poll, pattern-creator, quality-gate, split-project-docs

Closes #1477 (Phase 5)

## Test plan
- [x] `just pre-commit` passes (all 2287 tests + 32 e2e)
- [x] `csa skill list` shows migrated skills as `[managed]`
- [x] `csa review --range main...HEAD` verdict: PASS/CLEAN
- [x] Git-tracked source files in `skills/` preserved (compile-time test intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)