### PR TITLE
feat(skill): add --inject flag for direct skill prompt emission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.758"
+version = "0.1.759"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_skill.rs
+++ b/crates/cli-sub-agent/src/cli_skill.rs
@@ -22,6 +22,11 @@ pub enum SkillCommands {
         /// Skill name (must exist in the managed skill repo)
         name: String,
 
+        /// Emit the skill prompt to stdout for the calling agent to execute directly,
+        /// instead of spawning a CSA session.
+        #[arg(long)]
+        inject: bool,
+
         /// Optional prompt to pass to the skill session
         #[arg(trailing_var_arg = true)]
         prompt: Vec<String>,

--- a/crates/cli-sub-agent/src/skill_dispatch.rs
+++ b/crates/cli-sub-agent/src/skill_dispatch.rs
@@ -31,7 +31,14 @@ pub(crate) async fn dispatch(
         SkillCommands::Backup => {
             skill_cmds::handle_skill_backup()?;
         }
-        SkillCommands::Run { name, prompt } => {
+        SkillCommands::Run {
+            name,
+            inject,
+            prompt,
+        } => {
+            if inject {
+                return skill_run_cmd::handle_skill_inject(name, prompt).await;
+            }
             return skill_run_cmd::handle_skill_run(name, prompt, current_depth, output_format)
                 .await;
         }

--- a/crates/cli-sub-agent/src/skill_run_cmd.rs
+++ b/crates/cli-sub-agent/src/skill_run_cmd.rs
@@ -1,9 +1,38 @@
-//! Async handler for `csa skill run` — delegates to the standard CSA run pipeline.
+//! Async handler for `csa skill run` — delegates to the standard CSA run pipeline
+//! or emits the skill prompt for direct execution (`--inject`).
 
 use anyhow::Result;
 use csa_core::types::OutputFormat;
 
 use crate::goal_loop;
+use crate::skill_resolver;
+
+/// Emit the resolved skill prompt to stdout for the calling agent to execute
+/// directly, bypassing CSA session creation.
+pub(crate) async fn handle_skill_inject(name: String, prompt: Vec<String>) -> Result<i32> {
+    let project_root = std::env::current_dir()?;
+    let resolved = skill_resolver::resolve_skill(&name, &project_root)?;
+
+    let prompt_str = if prompt.is_empty() {
+        String::new()
+    } else {
+        prompt.join(" ")
+    };
+
+    println!("<skill-injection name=\"{name}\">");
+    println!("You MUST execute the following skill instructions directly. Do NOT delegate to csa.");
+    if !prompt_str.is_empty() {
+        println!();
+        println!("## Input");
+        println!();
+        println!("{prompt_str}");
+    }
+    println!();
+    println!("{}", resolved.skill_md);
+    println!("</skill-injection>");
+
+    Ok(0)
+}
 
 /// Run a named skill via the standard CSA run pipeline.
 ///


### PR DESCRIPTION
## Summary

- Adds `--inject` flag to `csa skill run <name>` that emits the resolved SKILL.md content to stdout wrapped in `<skill-injection>` tags, instead of spawning a CSA session
- Lets the calling agent execute skill instructions directly, avoiding CSA cold-start overhead (~10-60K tokens) for orchestration-type skills (quality-gate, commit, etc.)
- Same SKILL.md serves both paths: `--inject` for direct execution, without flag for full CSA session

Closes #1451

## Test plan

- [x] `cargo check --bin csa` passes
- [x] `cargo test -p cli-sub-agent -- skill` (103 tests pass)
- [x] `just pre-commit` passes
- [x] Manual test: `csa skill run commit --inject "test"` outputs tagged content
- [x] Manual test: `csa skill run commit --inject` (no prompt) omits Input section
- [x] Manual test: `csa skill run nonexistent --inject` errors correctly
- [x] `csa review --range main...HEAD` verdict: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)