### PR TITLE
fix(csa-resource): support file extra-writable paths (#1495)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.759"
+version = "0.1.760"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.759"
+version = "0.1.760"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -4,6 +4,7 @@
 //! Handles enforcement mode checking, capability detection, config resolution,
 //! and first-turn telemetry recording.
 
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 
 use csa_config::ProjectConfig;
@@ -33,25 +34,27 @@ fn resolve_session_dir_for_sandbox(project_root: &Path, session_id: &str) -> Pat
     })
 }
 
-fn validate_writable_sources_exist(
+fn resolve_and_prepare_writable_sources(
     paths: &[PathBuf],
     project_root: &Path,
     source_label: &str,
     removal_target: &str,
-) -> Result<(), String> {
-    for path in paths {
-        let candidate = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            project_root.join(path)
-        };
+) -> Result<Vec<PathBuf>, String> {
+    let resolved = csa_resource::isolation_plan::resolve_writable_paths(paths, project_root)
+        .map_err(|e| format!("{source_label} validation failed: {e}"))?;
+
+    for (path, candidate) in paths.iter().zip(resolved.iter()) {
         match candidate.try_exists() {
             Ok(true) => {}
             Ok(false) => {
-                return Err(format!(
-                    "{source_label} path '{}' does not exist. Create it first or remove the {removal_target}.",
-                    path.display()
-                ));
+                if path_looks_like_file(path) {
+                    prepare_missing_file_source(candidate, path, source_label)?;
+                } else {
+                    return Err(format!(
+                        "{source_label} path '{}' does not exist. Create it first or remove the {removal_target}.",
+                        path.display()
+                    ));
+                }
             }
             Err(error) => {
                 return Err(format!(
@@ -61,7 +64,42 @@ fn validate_writable_sources_exist(
             }
         }
     }
-    Ok(())
+    Ok(resolved)
+}
+
+fn path_looks_like_file(path: &Path) -> bool {
+    path.extension().is_some()
+}
+
+fn prepare_missing_file_source(
+    candidate: &Path,
+    original: &Path,
+    source_label: &str,
+) -> Result<(), String> {
+    let parent = candidate.parent().ok_or_else(|| {
+        format!(
+            "{source_label} path '{}' has no parent directory for file pre-creation.",
+            original.display()
+        )
+    })?;
+    std::fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "{source_label} path '{}' parent '{}' could not be created before session launch: {error}",
+            original.display(),
+            parent.display()
+        )
+    })?;
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(candidate)
+        .map(|_| ())
+        .map_err(|error| {
+            format!(
+                "{source_label} path '{}' could not be created before session launch: {error}",
+                original.display()
+            )
+        })
 }
 
 pub(crate) fn validate_run_extra_writable_sources_exist(
@@ -74,12 +112,17 @@ pub(crate) fn validate_run_extra_writable_sources_exist(
         return Ok(());
     }
     if !extra_writable.is_empty() {
-        validate_writable_sources_exist(extra_writable, project_root, "--extra-writable", "flag")?;
+        resolve_and_prepare_writable_sources(
+            extra_writable,
+            project_root,
+            "--extra-writable",
+            "flag",
+        )?;
     }
     if let Some(cfg) = config
         && !cfg.filesystem_sandbox.extra_writable.is_empty()
     {
-        validate_writable_sources_exist(
+        resolve_and_prepare_writable_sources(
             &cfg.filesystem_sandbox.extra_writable,
             project_root,
             "filesystem_sandbox.extra_writable",
@@ -188,23 +231,15 @@ pub(crate) fn resolve_sandbox_options(
             }
             // CLI --extra-writable / --expose-readable (no-config path).
             if !extra_writable.is_empty() {
-                if let Err(message) = validate_writable_sources_exist(
+                let resolved = match resolve_and_prepare_writable_sources(
                     extra_writable,
                     project_root,
                     "--extra-writable",
                     "flag",
                 ) {
-                    return SandboxResolution::RequiredButUnavailable(message);
-                }
-                let resolved = match csa_resource::isolation_plan::resolve_writable_paths(
-                    extra_writable,
-                    project_root,
-                ) {
                     Ok(paths) => paths,
-                    Err(e) => {
-                        return SandboxResolution::RequiredButUnavailable(format!(
-                            "--extra-writable validation failed: {e}"
-                        ));
+                    Err(message) => {
+                        return SandboxResolution::RequiredButUnavailable(message);
                     }
                 };
                 for path in resolved {
@@ -379,23 +414,15 @@ pub(crate) fn resolve_sandbox_options(
             // No per-tool override — apply global extra_writable paths.
             let fs_config = &cfg.filesystem_sandbox;
             if !fs_config.extra_writable.is_empty() {
-                if let Err(message) = validate_writable_sources_exist(
+                let resolved = match resolve_and_prepare_writable_sources(
                     &fs_config.extra_writable,
                     project_root,
                     "filesystem_sandbox.extra_writable",
                     "config entry",
                 ) {
-                    return SandboxResolution::RequiredButUnavailable(message);
-                }
-                let resolved = match csa_resource::isolation_plan::resolve_writable_paths(
-                    &fs_config.extra_writable,
-                    project_root,
-                ) {
                     Ok(paths) => paths,
-                    Err(e) => {
-                        return SandboxResolution::RequiredButUnavailable(format!(
-                            "filesystem_sandbox.extra_writable validation failed: {e}"
-                        ));
+                    Err(message) => {
+                        return SandboxResolution::RequiredButUnavailable(message);
                     }
                 };
                 for path in resolved {
@@ -420,23 +447,15 @@ pub(crate) fn resolve_sandbox_options(
 
     // CLI --extra-writable paths: always appended (APPEND semantics, not REPLACE).
     if !no_fs_sandbox && !extra_writable.is_empty() {
-        if let Err(message) = validate_writable_sources_exist(
+        let resolved = match resolve_and_prepare_writable_sources(
             extra_writable,
             project_root,
             "--extra-writable",
             "flag",
         ) {
-            return SandboxResolution::RequiredButUnavailable(message);
-        }
-        let resolved = match csa_resource::isolation_plan::resolve_writable_paths(
-            extra_writable,
-            project_root,
-        ) {
             Ok(paths) => paths,
-            Err(e) => {
-                return SandboxResolution::RequiredButUnavailable(format!(
-                    "--extra-writable validation failed: {e}"
-                ));
+            Err(message) => {
+                return SandboxResolution::RequiredButUnavailable(message);
             }
         };
         for path in resolved {

--- a/crates/cli-sub-agent/src/pipeline_sandbox_extra_writable_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_extra_writable_tests.rs
@@ -103,6 +103,68 @@ enforcement_mode = "best-effort"
 }
 
 #[test]
+fn test_extra_writable_creates_missing_file_source_before_sandbox_launch() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let state_file = project_root.path().join("state/e2e-test-state.json");
+    let cfg = parse_project_config(
+        r#"
+[resources]
+memory_max_mb = 2048
+enforcement_mode = "best-effort"
+"#,
+    );
+
+    let extra = vec![PathBuf::from("state/e2e-test-state.json")];
+    let result = resolve_sandbox_options(
+        Some(&cfg),
+        "codex",
+        "test-session",
+        project_root.path(),
+        StreamMode::BufferOnly,
+        120,
+        600,
+        Some(120),
+        false,
+        false,
+        &extra,
+        &[],
+    );
+
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("Expected missing file-like --extra-writable path to be prepared");
+    };
+    assert!(
+        state_file.is_file(),
+        "missing file-like --extra-writable path should be pre-created"
+    );
+
+    let sandbox = opts.sandbox.expect("expected sandbox context");
+    assert!(
+        sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&state_file.canonicalize().unwrap()),
+        "prepared file should remain the writable mount source, got: {:?}",
+        sandbox.isolation_plan.writable_paths
+    );
+}
+
+#[test]
+fn test_run_extra_writable_pre_daemon_validation_creates_missing_file_source() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let state_file = project_root.path().join("nested/state.json");
+    let extra = vec![PathBuf::from("nested/state.json")];
+
+    validate_run_extra_writable_sources_exist(None, project_root.path(), false, &extra)
+        .expect("missing file-like --extra-writable path should be prepared before daemon spawn");
+
+    assert!(
+        state_file.is_file(),
+        "pre-daemon validation should create the file source for bwrap"
+    );
+}
+
+#[test]
 fn test_run_extra_writable_pre_daemon_validation_rejects_nonexistent_path() {
     let project_root = tempfile::tempdir().expect("project root tempdir");
     let missing = project_root.path().join("missing-extra");

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -87,8 +87,8 @@ impl BwrapCommandBuilder {
         cmd.args(["--dev", "/dev"]);
         cmd.args(["--proc", "/proc"]);
 
-        // Writable bind mounts (after tmpfs). /tmp itself is skipped; /tmp
-        // sub-paths get pre-created mount points inside the fresh tmpfs.
+        // Writable bind mounts (after tmpfs). File paths under /tmp only need
+        // parent dirs; creating the file path as a dir breaks bwrap file binds.
         let tmp_prefix = Path::new("/tmp");
         for path in &self.writable_paths {
             let s = path.to_string_lossy();
@@ -101,7 +101,9 @@ impl BwrapCommandBuilder {
                     let p = parent.to_string_lossy();
                     cmd.args(["--dir", &p]);
                 }
-                cmd.args(["--dir", &s]);
+                if !(path.is_file() || (!path.exists() && path.extension().is_some())) {
+                    cmd.args(["--dir", &s]);
+                }
                 cmd.args(["--bind", &s, &s]);
             } else {
                 cmd.args(["--bind", &s, &s]);

--- a/crates/csa-resource/tests/bwrap_extra_writable_file.rs
+++ b/crates/csa-resource/tests/bwrap_extra_writable_file.rs
@@ -1,0 +1,55 @@
+use std::path::Path;
+use std::process::Command;
+
+use csa_resource::BwrapCommandBuilder;
+
+fn command_args(cmd: &Command) -> Vec<String> {
+    format!("{cmd:?}")
+        .split('"')
+        .enumerate()
+        .filter_map(|(i, s)| if i % 2 == 1 { Some(s.to_owned()) } else { None })
+        .collect()
+}
+
+#[test]
+fn bwrap_extra_writable_tmp_file_does_not_create_directory_target() {
+    let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+    builder.with_writable_path(Path::new("/tmp/e2e-test-state.json"));
+    let cmd = builder.build();
+    let args = command_args(&cmd);
+
+    assert!(
+        !args
+            .windows(2)
+            .any(|window| window[0] == "--dir" && window[1] == "/tmp/e2e-test-state.json"),
+        "file writable path must not be created as a sandbox directory; args: {args:?}"
+    );
+    assert!(
+        args.windows(3).any(|window| {
+            window[0] == "--bind"
+                && window[1] == "/tmp/e2e-test-state.json"
+                && window[2] == "/tmp/e2e-test-state.json"
+        }),
+        "file writable path should still be bind-mounted; args: {args:?}"
+    );
+}
+
+#[test]
+fn bwrap_extra_writable_nested_tmp_file_creates_parent_only() {
+    let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+    builder.with_writable_path(Path::new("/tmp/csa/state.json"));
+    let cmd = builder.build();
+    let args = command_args(&cmd);
+
+    assert!(
+        args.windows(2)
+            .any(|window| window[0] == "--dir" && window[1] == "/tmp/csa"),
+        "nested file writable path should create its parent in tmpfs; args: {args:?}"
+    );
+    assert!(
+        !args
+            .windows(2)
+            .any(|window| window[0] == "--dir" && window[1] == "/tmp/csa/state.json"),
+        "nested file writable path must not create the file path as a directory; args: {args:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- Fix bwrap failure when `--extra-writable` includes file paths (not directories)
- Detect file vs directory paths and use appropriate bwrap binding strategy
- Add unit tests for file and directory extra-writable path handling

Closes #1495

## Test plan
- [x] `cargo test` passes for new bwrap_extra_writable_file tests
- [x] `cargo test` passes for pipeline_sandbox_extra_writable tests
- [x] `just pre-commit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)