### PR TITLE
fix(cli-sub-agent): honor successful result sidecars in no-op gate (#1496)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.760"
+version = "0.1.761"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.760"
+version = "0.1.761"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -31,6 +31,8 @@ const OUTPUT_LOG_TAIL_READ_BYTES: u64 = 8 * 1024;
 const NO_OP_ELAPSED_THRESHOLD_SECS: i64 = 60;
 #[path = "pipeline_post_exec_progress.rs"]
 mod progress;
+#[path = "pipeline_post_exec_result_sidecar.rs"]
+mod result_sidecar;
 /// All inputs needed for post-execution processing.
 pub(crate) struct PostExecContext<'a> {
     pub executor: &'a Executor,
@@ -221,6 +223,7 @@ pub(crate) async fn process_execution_result(
     if ctx.sa_mode
         && ctx.task_type.is_none_or(|t| t == "run")
         && result.exit_code == 0
+        && !result_sidecar::status_is_success(&ctx.session_dir)
         && session.turn_count <= 1
         && !ctx.has_tool_calls
         && ctx.changed_paths.is_empty()

--- a/crates/cli-sub-agent/src/pipeline_post_exec_result_sidecar.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_result_sidecar.rs
@@ -1,0 +1,23 @@
+use std::fs;
+use std::path::Path;
+
+pub(super) fn status_is_success(session_dir: &Path) -> bool {
+    let path = session_dir.join(csa_session::CONTRACT_RESULT_ARTIFACT_PATH);
+    let Ok(contents) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(toml::Value::Table(table)) = toml::from_str::<toml::Value>(&contents) else {
+        return false;
+    };
+
+    let nested = table
+        .get("result")
+        .and_then(|value| value.as_table())
+        .and_then(|table| table.get("status"));
+    let flat = table.get("status");
+
+    nested
+        .or(flat)
+        .and_then(|value| value.as_str())
+        .is_some_and(|status| status.eq_ignore_ascii_case("success"))
+}

--- a/crates/cli-sub-agent/src/pipeline_tests_no_op_gate.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_no_op_gate.rs
@@ -60,6 +60,13 @@ fn build_failed_test_result(summary: &str, stderr: &str) -> csa_process::Executi
     }
 }
 
+fn write_result_sidecar(session_dir: &std::path::Path, contents: &str) {
+    let path = session_dir.join(csa_session::CONTRACT_RESULT_ARTIFACT_PATH);
+    std::fs::create_dir_all(path.parent().expect("result sidecar parent"))
+        .expect("create output dir");
+    std::fs::write(path, contents).expect("write output/result.toml");
+}
+
 #[tokio::test]
 async fn permanent_tool_quota_sets_tool_exhausted_phase() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -153,6 +160,109 @@ async fn no_op_gate_triggers_when_sa_mode_and_zero_tools_and_short_elapsed() {
     assert_eq!(
         result.exit_code, 1,
         "ExecutionResult exit_code must also be rewritten"
+    );
+}
+
+#[tokio::test]
+async fn no_op_gate_preserves_success_when_result_sidecar_reports_success() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+    write_result_sidecar(
+        &session_dir,
+        r#"[result]
+status = "success"
+summary = "PASS"
+"#,
+    );
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(15);
+    let ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        true,
+    );
+    let mut result = build_test_result("PASS");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(0));
+    assert!(
+        !persisted.summary.starts_with("no-op exit detected"),
+        "success sidecar must suppress no-op rewrite, got: {}",
+        persisted.summary
+    );
+    assert_eq!(result.exit_code, 0);
+}
+
+#[tokio::test]
+async fn no_op_gate_still_triggers_when_result_sidecar_reports_failure() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session =
+        create_session(project_root, Some("test"), None, Some("claude-code")).expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+    write_result_sidecar(
+        &session_dir,
+        r#"[result]
+status = "failure"
+summary = "not done"
+"#,
+    );
+
+    let executor = Executor::ClaudeCode {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: ClaudeCodeRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(15);
+    let ctx = build_test_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        false,
+        true,
+    );
+    let mut result = build_test_result("I'll start by exploring the codebase.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 1);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(1));
+    assert!(
+        persisted.summary.starts_with("no-op exit detected"),
+        "failure sidecar must not suppress no-op rewrite, got: {}",
+        persisted.summary
     );
 }
 


### PR DESCRIPTION
## Summary
- Fix false-positive no-op detection when session actually completed successfully
- Check result.toml sidecar for success status before applying no-op heuristic
- Add unit tests for refined no-op gate logic

Closes #1496

## Test plan
- [x] `cargo test` passes for new pipeline_tests_no_op_gate tests
- [x] `just pre-commit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)