### PR TITLE
fix(cli-sub-agent): skip post-exec gate for unchanged dirty worktree (#1497)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.761"
+version = "0.1.762"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.761"
+version = "0.1.762"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -464,6 +464,8 @@ pub(crate) struct SessionExecutionResult {
     pub execution: ExecutionResult,
     pub meta_session_id: String,
     pub provider_session_id: Option<String>,
+    /// Paths changed by this session when git snapshots were available.
+    pub changed_paths: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -433,11 +433,8 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     // Check git status for both commit_guard and hook changed_paths variable.
     let is_git = crate::run_cmd::is_git_worktree(project_root);
     let inside_git_worktree = commit_guard_enabled && is_git;
-    let pre_run_workspace = if is_git {
-        crate::run_cmd::capture_git_workspace_snapshot(project_root, require_commit_on_mutation)
-    } else {
-        None
-    };
+    let capture_snapshot = session_exec_audit::capture_git_workspace_snapshot_if_needed;
+    let pre_run_workspace = capture_snapshot(is_git, project_root, require_commit_on_mutation);
     let tool_state =
         ensure_tool_state_initialized(&mut session, executor, &resolved_provider_session_id)
             .await?;
@@ -699,11 +696,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         );
     }
     // Post-run git snapshot for commit guard + changed_paths hook vars.
-    let post_run_workspace = if is_git {
-        crate::run_cmd::capture_git_workspace_snapshot(project_root, require_commit_on_mutation)
-    } else {
-        None
-    };
+    let post_run_workspace = capture_snapshot(is_git, project_root, require_commit_on_mutation);
     let pre_fingerprints = pre_run_workspace
         .as_ref()
         .map(session_exec_audit::snapshot_to_fingerprints);
@@ -716,7 +709,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         pre_fingerprints.as_ref(),
         post_fingerprints.as_ref(),
     );
-
+    let snapshots_available = pre_run_workspace.is_some() && post_run_workspace.is_some();
     if commit_guard_enabled {
         let commit_guard = crate::run_cmd::evaluate_post_run_commit_guard(
             pre_run_workspace.as_ref(),
@@ -772,7 +765,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         provider_session_id: provider_session_id.clone(),
         events_count,
         transcript_artifacts,
-        changed_paths,
+        changed_paths: changed_paths.clone(),
         pre_exec_snapshot,
         has_tool_calls: transport_result.metadata.has_tool_calls
             || transport_result.metadata.has_execute_tool_calls,
@@ -796,5 +789,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         execution: result,
         meta_session_id: session.meta_session_id.clone(),
         provider_session_id,
+        changed_paths: snapshots_available.then_some(changed_paths),
     })
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_audit.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_audit.rs
@@ -11,6 +11,15 @@ pub(super) fn snapshot_to_fingerprints(
     }
 }
 
+pub(super) fn capture_git_workspace_snapshot_if_needed(
+    is_git: bool,
+    project_root: &Path,
+    deep_fingerprint: bool,
+) -> Option<crate::run_cmd::GitWorkspaceSnapshot> {
+    is_git
+        .then(|| crate::run_cmd::capture_git_workspace_snapshot(project_root, deep_fingerprint))?
+}
+
 pub(super) fn capture_pre_execution_snapshot(
     project_root: &Path,
 ) -> Option<crate::pipeline_post_exec::PreExecutionSnapshot> {

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -370,6 +370,7 @@ pub(crate) async fn execute_review_with_tier_filter(
                             meta_session_id: extract_meta_session_id_from_error(&err)
                                 .unwrap_or_else(|| "unknown".to_string()),
                             provider_session_id: None,
+                            changed_paths: None,
                         },
                         persistable_session_id: extract_meta_session_id_from_error(&err),
                         executed_tool: *attempt_tool,

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -332,6 +332,7 @@ mod tests {
                 },
                 meta_session_id: "01TESTRESULT".to_string(),
                 provider_session_id: None,
+                changed_paths: None,
             },
             persistable_session_id: Some("01TESTRESULT".to_string()),
             executed_tool: ToolName::Codex,

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -90,7 +90,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
     let mut vcs_probe_cache = crate::run_helpers_branch_guard::VcsProbeCache::default();
     let enforce_tier =
         !request.force && !request.force_ignore_tier_setting && !request.user_model_spec_explicit;
-    let result = loop {
+    let (result, changed_paths) = loop {
         attempts += 1;
         let mut fresh_spawn_preflight_override = false;
 
@@ -450,7 +450,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             .await
         }?;
 
-        let exec_result = match attempt_execution {
+        let (exec_result, exec_changed_paths) = match attempt_execution {
             AttemptExecution::TimedOut => {
                 let timeout_resume_session = executed_session_id
                     .clone()
@@ -478,8 +478,14 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 return Ok(RunLoopCompletion::Exit(exit_code));
             }
             AttemptExecution::Exit(exit_code) => return Ok(RunLoopCompletion::Exit(exit_code)),
-            AttemptExecution::Finished(Ok(result)) => result,
-            AttemptExecution::Finished(Err(e)) => {
+            AttemptExecution::Finished {
+                result: Ok(result),
+                changed_paths: attempt_changed_paths,
+            } => (result, attempt_changed_paths),
+            AttemptExecution::Finished {
+                result: Err(e),
+                changed_paths: _,
+            } => {
                 if let Some(timeout_secs) =
                     run_error_timeout_seconds(&e, request.run_timeout_seconds)
                 {
@@ -686,7 +692,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
         }
 
         if is_post_run_commit_policy_block(&exec_result.summary) {
-            break exec_result;
+            break (exec_result, exec_changed_paths);
         }
 
         match evaluate_rate_limit_failover(
@@ -730,13 +736,14 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 );
                 continue;
             }
-            _ => break exec_result,
+            _ => break (exec_result, exec_changed_paths),
         }
     };
     Ok(RunLoopCompletion::Completed(Box::new(RunLoopOutcome {
         result,
         current_tool,
         executed_session_id,
+        changed_paths,
         fork_resolution,
         fallback_chain,
     })))

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -90,6 +90,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
     let mut vcs_probe_cache = crate::run_helpers_branch_guard::VcsProbeCache::default();
     let enforce_tier =
         !request.force && !request.force_ignore_tier_setting && !request.user_model_spec_explicit;
+    let mut accumulated_changed_paths: Vec<String> = Vec::new();
     let (result, changed_paths) = loop {
         attempts += 1;
         let mut fresh_spawn_preflight_override = false;
@@ -667,6 +668,9 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 &tried_tools,
             )
         {
+            if let Some(paths) = exec_changed_paths {
+                accumulated_changed_paths.extend(paths);
+            }
             runtime_fallback_attempts += 1;
             warn!(
                 from = %tool_name_str,
@@ -719,6 +723,9 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 new_tool,
                 new_model_spec,
             } => {
+                if let Some(paths) = exec_changed_paths {
+                    accumulated_changed_paths.extend(paths);
+                }
                 // Build xurl context recovery addendum so the failover
                 // tool can retrieve the original session's conversation.
                 failover_context_addendum =
@@ -737,6 +744,19 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 continue;
             }
             _ => break (exec_result, exec_changed_paths),
+        }
+    };
+    let changed_paths = {
+        let mut merged = accumulated_changed_paths;
+        if let Some(final_paths) = changed_paths {
+            merged.extend(final_paths);
+        }
+        if merged.is_empty() {
+            None
+        } else {
+            merged.sort();
+            merged.dedup();
+            Some(merged)
         }
     };
     Ok(RunLoopCompletion::Completed(Box::new(RunLoopOutcome {

--- a/crates/cli-sub-agent/src/run_cmd_attempt_exec.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_exec.rs
@@ -16,7 +16,10 @@ use crate::pipeline;
 use crate::run_cmd_fork::{ForkResolution, cleanup_pre_created_fork_session};
 
 pub(super) enum AttemptExecution {
-    Finished(Result<csa_process::ExecutionResult, anyhow::Error>),
+    Finished {
+        result: Result<csa_process::ExecutionResult, anyhow::Error>,
+        changed_paths: Option<Vec<String>>,
+    },
     Exit(i32),
     TimedOut,
 }
@@ -58,7 +61,10 @@ pub(super) async fn run_ephemeral_with_timeout(
     )
     .await
     {
-        Ok(result) => AttemptExecution::Finished(result),
+        Ok(result) => AttemptExecution::Finished {
+            result,
+            changed_paths: None,
+        },
         Err(_) => AttemptExecution::TimedOut,
     };
     Ok(execution)
@@ -73,8 +79,8 @@ pub(super) async fn run_ephemeral_without_timeout(
         _temp_dir.path(),
         request.project_root.display()
     );
-    Ok(AttemptExecution::Finished(
-        request
+    Ok(AttemptExecution::Finished {
+        result: request
             .executor
             .execute_in(
                 request.effective_prompt,
@@ -85,7 +91,8 @@ pub(super) async fn run_ephemeral_without_timeout(
                 direct_entry_resolved_timeout(request.initial_response_timeout_seconds),
             )
             .await,
-    ))
+        changed_paths: None,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -298,7 +305,10 @@ async fn execute_persistent(
     {
         Ok(session_result) => {
             *executed_session_id = Some(session_result.meta_session_id);
-            AttemptExecution::Finished(Ok(session_result.execution))
+            AttemptExecution::Finished {
+                result: Ok(session_result.execution),
+                changed_paths: session_result.changed_paths,
+            }
         }
         Err(e) => {
             let error_msg = e.to_string();
@@ -315,7 +325,10 @@ async fn execute_persistent(
                 println!("{}", serde_json::to_string_pretty(&json_error)?);
                 AttemptExecution::Exit(1)
             } else {
-                AttemptExecution::Finished(Err(e))
+                AttemptExecution::Finished {
+                    result: Err(e),
+                    changed_paths: None,
+                }
             }
         }
     };

--- a/crates/cli-sub-agent/src/run_cmd_attempt_types.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_types.rs
@@ -75,6 +75,7 @@ pub(crate) struct RunLoopOutcome {
     pub(crate) result: csa_process::ExecutionResult,
     pub(crate) current_tool: ToolName,
     pub(crate) executed_session_id: Option<String>,
+    pub(crate) changed_paths: Option<Vec<String>>,
     pub(crate) fork_resolution: Option<ForkResolution>,
     /// Ordered list of tools skipped due to rate-limit/quota failover before this result.
     pub(crate) fallback_chain: csa_scheduler::FallbackChain,

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -602,6 +602,7 @@ pub(crate) async fn handle_run(
     let result = loop_outcome.result;
     let current_tool = loop_outcome.current_tool;
     let executed_session_id = loop_outcome.executed_session_id;
+    let changed_paths = loop_outcome.changed_paths;
     let fork_resolution = loop_outcome.fork_resolution;
 
     if result.exit_code == 0 {
@@ -613,6 +614,7 @@ pub(crate) async fn handle_run(
             &gate_prompt_text,
             executed_session_id.as_deref(),
             config.as_ref(),
+            changed_paths.as_deref(),
             execute_post_exec_gate_command,
         )
         .await

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -27,9 +27,17 @@ fn is_post_exec_gate_exempt_prompt(prompt_text: &str) -> bool {
     prompt.starts_with("# REVIEW:") || prompt.starts_with("# DEBATE:")
 }
 
-fn post_exec_gate_requires_changes(project_root: &Path, skip_on_no_changes: bool) -> Result<bool> {
+fn post_exec_gate_requires_changes(
+    project_root: &Path,
+    skip_on_no_changes: bool,
+    changed_paths: Option<&[String]>,
+) -> Result<bool> {
     if !skip_on_no_changes || !crate::run_cmd::is_git_worktree(project_root) {
         return Ok(true);
+    }
+
+    if let Some(paths) = changed_paths {
+        return Ok(!paths.is_empty());
     }
 
     let output = std::process::Command::new("git")
@@ -119,6 +127,7 @@ pub(super) async fn maybe_run_post_exec_gate_with_runner<F>(
     prompt_text: &str,
     session_id: Option<&str>,
     config: Option<&ProjectConfig>,
+    changed_paths: Option<&[String]>,
     runner: F,
 ) -> Result<PostExecGateOutcome>
 where
@@ -132,7 +141,11 @@ where
         return Ok(PostExecGateOutcome::Skipped);
     }
 
-    if !post_exec_gate_requires_changes(project_root, gate_config.skip_on_no_changes)? {
+    if !post_exec_gate_requires_changes(
+        project_root,
+        gate_config.skip_on_no_changes,
+        changed_paths,
+    )? {
         return Ok(PostExecGateOutcome::Skipped);
     }
 

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -73,6 +73,7 @@ async fn post_exec_gate_passes_when_command_succeeds() {
         "Implement the fix in tracked.txt",
         Some("01TESTPOSTEXECGATEPASS0000000"),
         Some(&config),
+        None,
         {
             let calls = Arc::clone(&calls);
             move |command, cwd, timeout_seconds| {
@@ -112,6 +113,7 @@ async fn post_exec_gate_failure_returns_structured_diagnostic() {
         "Implement the fix in tracked.txt",
         Some("01TESTPOSTEXECGATEFAIL0000000"),
         Some(&config),
+        None,
         |_command, _cwd, _timeout_seconds| {
             Box::pin(async { Ok(PostExecGateCommandOutcome::Exited(Some(3))) })
         },
@@ -139,6 +141,7 @@ async fn post_exec_gate_skips_when_worktree_is_clean() {
         "Implement the fix in tracked.txt",
         Some("01TESTPOSTEXECGATESKIP0000000"),
         Some(&config),
+        None,
         |_command, _cwd, _timeout_seconds| {
             Box::pin(async move {
                 panic!("runner must not execute when worktree is clean");
@@ -164,6 +167,7 @@ async fn post_exec_gate_skips_review_and_debate_prompts() {
             prompt,
             Some("01TESTPOSTEXECGATEREVIEW00000"),
             Some(&config),
+            None,
             |_command, _cwd, _timeout_seconds| {
                 Box::pin(async move {
                     panic!("runner must not execute for review/debate prompts");
@@ -175,4 +179,68 @@ async fn post_exec_gate_skips_review_and_debate_prompts() {
 
         assert_eq!(outcome, PostExecGateOutcome::Skipped);
     }
+}
+
+#[tokio::test]
+async fn post_exec_gate_skips_when_dirty_worktree_is_pre_existing() {
+    let project_dir = tempdir().unwrap();
+    init_clean_git_repo(project_dir.path());
+    std::fs::write(
+        project_dir.path().join("tracked.txt"),
+        "pre-existing dirty\n",
+    )
+    .unwrap();
+
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    let changed_paths: Vec<String> = Vec::new();
+    let outcome = maybe_run_post_exec_gate_with_runner(
+        project_dir.path(),
+        "Read files and write external test results",
+        Some("01TESTPOSTEXECGATEPREEXIST000"),
+        Some(&config),
+        Some(&changed_paths),
+        |_command, _cwd, _timeout_seconds| {
+            Box::pin(async move {
+                panic!("runner must not execute when this session changed no paths");
+            })
+        },
+    )
+    .await
+    .expect("pre-existing dirty worktree should skip gate when delta is empty");
+
+    assert_eq!(outcome, PostExecGateOutcome::Skipped);
+}
+
+#[tokio::test]
+async fn post_exec_gate_runs_when_session_introduced_changes() {
+    let project_dir = tempdir().unwrap();
+    init_clean_git_repo(project_dir.path());
+
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    let changed_paths = vec!["tracked.txt".to_string()];
+    let outcome = maybe_run_post_exec_gate_with_runner(
+        project_dir.path(),
+        "Implement the fix in tracked.txt",
+        Some("01TESTPOSTEXECGATEDELTA00000"),
+        Some(&config),
+        Some(&changed_paths),
+        {
+            let calls = Arc::clone(&calls);
+            move |command, cwd, timeout_seconds| {
+                let calls = Arc::clone(&calls);
+                let command = command.to_string();
+                let cwd = cwd.to_path_buf();
+                Box::pin(async move {
+                    calls.lock().unwrap().push((command, cwd, timeout_seconds));
+                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                })
+            }
+        },
+    )
+    .await
+    .expect("session-introduced changes should run gate");
+
+    assert_eq!(outcome, PostExecGateOutcome::Passed);
+    assert_eq!(calls.lock().unwrap().len(), 1);
 }


### PR DESCRIPTION
## Summary
- Skip post-exec gate when worktree dirty state is pre-existing (not introduced by session)
- Accumulate changed_paths across retry attempts to prevent data loss on failover
- Add tests for post-exec gate with pre-existing dirty state

Closes #1497

## Test plan
- [x] `cargo test` passes for new post-exec gate tests
- [x] `just pre-commit` clean
- [x] Review round 1 caught changed_paths accumulation bug — fixed in follow-up commit
- [x] Review round 2 PASS/CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)