### PR TITLE
fix(mktd): enforce read-only RECON with prompt + sandbox defense in depth (#1493, #1501)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.763"
+version = "0.1.764"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.763"
+version = "0.1.764"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -61,6 +61,7 @@ pub(super) struct CsaStepExecutionOptions<'a> {
     pub(super) model_spec: Option<&'a str>,
     pub(super) forwarded_session: Option<&'a str>,
     pub(super) no_fs_sandbox: bool,
+    pub(super) readonly_project_root: bool,
 }
 
 pub(super) async fn run_with_heartbeat<F, T>(
@@ -294,9 +295,9 @@ pub(super) async fn execute_csa_step(
             ParentSessionSource::ExplicitOnly,
             SessionCreationMode::FreshChild,
             options.no_fs_sandbox,
-            false, // readonly_project_root
-            &[],   // extra_writable
-            &[],   // extra_readable
+            options.readonly_project_root,
+            &[], // extra_writable
+            &[], // extra_readable
         )
     };
     let result = match execute_once(session_arg.clone()).await {

--- a/crates/cli-sub-agent/src/plan_cmd_override_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_override_tests.rs
@@ -29,6 +29,7 @@ fn resolve_step_tool_all_explicit_tools() {
             condition: None,
             loop_var: None,
             session: None,
+            workspace_access: None,
         };
         let target = resolve_step_tool(&step, None, None, None).unwrap();
         if expect_direct_bash {
@@ -83,6 +84,7 @@ async fn execute_step_tool_override_replaces_csa_tool() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
     // Even with tool_override=claude-code, bash step must still run as bash
@@ -116,6 +118,7 @@ async fn execute_step_note_skips_without_dispatch() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
 
@@ -140,6 +143,7 @@ async fn execute_step_manual_returns_resumable_handoff() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
 
@@ -177,6 +181,7 @@ async fn execute_step_await_user_returns_instructions() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
 
@@ -215,6 +220,7 @@ fn tool_override_clears_model_spec() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let target = resolve_step_tool(&step, None, None, None).unwrap();
     // Without override: should be CsaTool with codex
@@ -265,6 +271,7 @@ fn tool_override_does_not_affect_weave_include() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let target = resolve_step_tool(&step, None, None, None).unwrap();
     // Simulate override: WeaveInclude must pass through unchanged
@@ -342,6 +349,7 @@ async fn execute_step_bash_captures_stdout_in_output() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
     let result = execute_step(&step, &vars, tmp.path(), None, None, None).await;
@@ -373,6 +381,7 @@ async fn execute_plan_injects_step_output_variables() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -385,6 +394,7 @@ async fn execute_plan_injects_step_output_variables() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };
@@ -424,6 +434,7 @@ async fn execute_plan_skipped_step_injects_empty_output() {
                 condition: Some("${NEVER_SET}".into()),
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -436,6 +447,7 @@ async fn execute_plan_skipped_step_injects_empty_output() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };
@@ -473,6 +485,7 @@ async fn execute_step_csa_empty_prompt_warns_without_panic() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
     let result = execute_step(&step, &vars, tmp.path(), None, None, None).await;
@@ -502,6 +515,7 @@ fn resolve_step_tool_respects_tool_override() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
 
     // Without override: should resolve to gemini-cli as specified in step.tool
@@ -541,6 +555,7 @@ fn resolve_step_tool_respects_model_spec_override() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
 
     let tool_override = ToolName::Codex;

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -11,6 +11,7 @@ use csa_core::types::ToolName;
 use csa_executor::ModelSpec;
 use csa_hooks::format_next_step_directive;
 use weave::compiler::{ExecutionPlan, FailAction, PlanStep};
+use weave::parser::WorkspaceAccess;
 
 use super::plan_cmd_assignment::{
     extract_output_assignment_markers, should_inject_assignment_markers,
@@ -210,6 +211,10 @@ pub(crate) fn resolve_step_tool(
     }
 
     Ok(StepTarget::csa(ToolName::Codex, None))
+}
+
+pub(crate) fn step_readonly_project_root(step: &PlanStep) -> bool {
+    matches!(step.workspace_access, Some(WorkspaceAccess::ReadOnly))
 }
 
 fn parse_tool_name(tool: &str) -> Result<ToolName> {
@@ -640,6 +645,7 @@ pub(crate) async fn execute_step_with_workflow(
                 tier_name,
             } => {
                 let prompt = csa_prompt.as_deref().unwrap_or_default();
+                let readonly_project_root = step_readonly_project_root(step);
                 execute_csa_step_with_tier_failover(
                     &label,
                     prompt,
@@ -648,6 +654,7 @@ pub(crate) async fn execute_step_with_workflow(
                         initial_model_spec: model_spec.as_deref(),
                         tier_name: tier_name.as_deref(),
                         forwarded_session: csa_session.as_deref(),
+                        readonly_project_root,
                     },
                     step_ctx,
                     start,

--- a/crates/cli-sub-agent/src/plan_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests.rs
@@ -1,6 +1,8 @@
 use super::*;
+use crate::plan_cmd::plan_cmd_steps::step_readonly_project_root;
 use std::collections::{HashMap, HashSet};
 use weave::compiler::{FailAction, PlanStep, VariableDecl};
+use weave::parser::WorkspaceAccess;
 
 #[test]
 fn safe_plan_name_normalizes_non_alphanumeric_characters() {
@@ -485,6 +487,7 @@ fn should_inject_assignment_markers_only_for_bash_steps() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let codex_step = PlanStep {
         id: 2,
@@ -497,6 +500,7 @@ fn should_inject_assignment_markers_only_for_bash_steps() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let tier_only_step = PlanStep {
         id: 3,
@@ -509,11 +513,37 @@ fn should_inject_assignment_markers_only_for_bash_steps() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
 
     assert!(should_inject_assignment_markers(&bash_step));
     assert!(!should_inject_assignment_markers(&codex_step));
     assert!(!should_inject_assignment_markers(&tier_only_step));
+}
+
+#[test]
+fn step_readonly_project_root_follows_workspace_access_contract() {
+    let mut step = PlanStep {
+        id: 1,
+        title: "recon".into(),
+        tool: Some("csa".into()),
+        prompt: String::new(),
+        tier: None,
+        depends_on: vec![],
+        on_fail: FailAction::Abort,
+        condition: None,
+        loop_var: None,
+        session: None,
+        workspace_access: Some(WorkspaceAccess::ReadOnly),
+    };
+
+    assert!(step_readonly_project_root(&step));
+
+    step.workspace_access = Some(WorkspaceAccess::Mutating);
+    assert!(!step_readonly_project_root(&step));
+
+    step.workspace_access = None;
+    assert!(!step_readonly_project_root(&step));
 }
 
 #[test]
@@ -559,6 +589,7 @@ fn resolve_step_tool_explicit_bash_returns_direct_bash() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let target = resolve_step_tool(&step, None, None, None).unwrap();
     assert!(
@@ -580,6 +611,7 @@ fn resolve_step_tool_explicit_codex() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let target = resolve_step_tool(&step, None, None, None).unwrap();
     assert!(matches!(
@@ -604,6 +636,7 @@ fn resolve_step_tool_fallback_no_config() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let target = resolve_step_tool(&step, None, None, None).unwrap();
     assert!(matches!(
@@ -628,6 +661,7 @@ fn resolve_step_tool_weave_returns_include_marker() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let target = resolve_step_tool(&step, None, None, None).unwrap();
     assert!(matches!(target, StepTarget::WeaveInclude));
@@ -646,6 +680,7 @@ fn resolve_step_tool_unknown_tool_errors() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     assert!(resolve_step_tool(&step, None, None, None).is_err());
 }

--- a/crates/cli-sub-agent/src/plan_cmd_tests_chunked.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_chunked.rs
@@ -47,6 +47,7 @@ async fn execute_plan_chunked_single_step() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -59,6 +60,7 @@ async fn execute_plan_chunked_single_step() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };
@@ -107,6 +109,7 @@ async fn execute_plan_chunked_resume() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -119,6 +122,7 @@ async fn execute_plan_chunked_resume() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 3,
@@ -131,6 +135,7 @@ async fn execute_plan_chunked_resume() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };
@@ -252,6 +257,7 @@ async fn execute_plan_chunked_skips_condition_false_and_runs_next() {
                 condition: Some("${NONEXISTENT}".into()),
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -264,6 +270,7 @@ async fn execute_plan_chunked_skips_condition_false_and_runs_next() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };
@@ -319,6 +326,7 @@ async fn execute_plan_chunked_resume_skips_condition_false_no_infinite_loop() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -331,6 +339,7 @@ async fn execute_plan_chunked_resume_skips_condition_false_no_infinite_loop() {
                 condition: Some("${NONEXISTENT}".into()),
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 3,
@@ -343,6 +352,7 @@ async fn execute_plan_chunked_resume_skips_condition_false_no_infinite_loop() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };

--- a/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
@@ -139,6 +139,7 @@ async fn execute_step_csa_nested_plan_uses_fresh_child_session() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
 
     let vars = HashMap::new();
@@ -415,6 +416,7 @@ async fn commit_workflow_test_gate_aborts_before_following_steps() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -427,6 +429,7 @@ async fn commit_workflow_test_gate_aborts_before_following_steps() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };

--- a/crates/cli-sub-agent/src/plan_cmd_tests_manual_handoff.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_manual_handoff.rs
@@ -19,6 +19,7 @@ fn manual_handoff_plan() -> ExecutionPlan {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -31,6 +32,7 @@ fn manual_handoff_plan() -> ExecutionPlan {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     }

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -23,6 +23,7 @@ async fn execute_step_with_workflow_exposes_runtime_paths_to_bash() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
@@ -18,6 +18,7 @@ async fn execute_step_skips_when_condition_is_false() {
         condition: Some("${SOME_VAR}".into()),
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
     let tmp = tempfile::tempdir().unwrap();
@@ -42,6 +43,7 @@ async fn execute_step_runs_when_condition_is_true() {
         condition: Some("${FLAG}".into()),
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let mut vars = HashMap::new();
     vars.insert("FLAG".into(), "yes".into());
@@ -68,6 +70,7 @@ async fn execute_step_skips_loop_with_nonzero_exit() {
             max_iterations: 10,
         }),
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
     let tmp = tempfile::tempdir().unwrap();
@@ -89,6 +92,7 @@ async fn execute_step_skips_weave_include() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
     let tmp = tempfile::tempdir().unwrap();
@@ -115,6 +119,7 @@ async fn execute_step_bash_runs_code_block() {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     };
     let vars = HashMap::new();
     let tmp = tempfile::tempdir().unwrap();
@@ -176,6 +181,7 @@ async fn execute_plan_stops_for_await_user() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -188,6 +194,7 @@ async fn execute_plan_stops_for_await_user() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };
@@ -478,6 +485,7 @@ async fn execute_plan_skips_false_condition_cleanly() {
                 condition: Some("${FLAG}".into()),
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -490,6 +498,7 @@ async fn execute_plan_skips_false_condition_cleanly() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };
@@ -529,6 +538,7 @@ async fn execute_plan_runs_true_condition_steps() {
             condition: Some("${FLAG}".into()),
             loop_var: None,
             session: None,
+            workspace_access: None,
         }],
     };
     let mut vars = HashMap::new();
@@ -563,6 +573,7 @@ async fn execute_plan_allows_prefixed_marker_to_drive_next_condition() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -575,6 +586,7 @@ async fn execute_plan_allows_prefixed_marker_to_drive_next_condition() {
                 condition: Some("${FLAG}".into()),
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };
@@ -617,6 +629,7 @@ async fn execute_plan_does_not_inject_markers_from_failed_steps() {
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
             PlanStep {
                 id: 2,
@@ -629,6 +642,7 @@ async fn execute_plan_does_not_inject_markers_from_failed_steps() {
                 condition: Some("${FLAG}".into()),
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             },
         ],
     };

--- a/crates/cli-sub-agent/src/plan_cmd_tier_failover.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tier_failover.rs
@@ -19,6 +19,7 @@ pub(super) struct TierFailoverParams<'a> {
     pub(super) initial_model_spec: Option<&'a str>,
     pub(super) tier_name: Option<&'a str>,
     pub(super) forwarded_session: Option<&'a str>,
+    pub(super) readonly_project_root: bool,
 }
 
 /// Execute a CSA step with tier-level failover.
@@ -80,6 +81,7 @@ pub(super) async fn execute_csa_step_with_tier_failover(
                         params.forwarded_session
                     },
                     no_fs_sandbox: step_ctx.no_fs_sandbox,
+                    readonly_project_root: params.readonly_project_root,
                 },
             ),
             step_started_at,

--- a/crates/weave/src/compiler.rs
+++ b/crates/weave/src/compiler.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 
-use crate::parser::{Block, SkillDocument};
+use crate::parser::{Block, SkillDocument, WorkspaceAccess};
 
 // ---------------------------------------------------------------------------
 // Plan types
@@ -45,6 +45,8 @@ pub struct PlanStep {
     pub loop_var: Option<LoopSpec>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_access: Option<WorkspaceAccess>,
 }
 
 /// How to handle a step failure.
@@ -122,6 +124,11 @@ static CONDITION_HINT_RE: LazyLock<Regex> =
 /// Matches a `Session: <id|template>` line at the start of a step body.
 static SESSION_HINT_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^Session:\s*(.+)\s*$").expect("valid regex"));
+
+/// Matches a `Workspace Access: read-only|mutating` line at the start of a step body.
+static WORKSPACE_ACCESS_HINT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^Workspace\s+Access:\s*(read-only|mutating)\s*$").expect("valid regex")
+});
 
 /// Matches a `MaxIterations: <n>` line at the start of a step body (FOR loops).
 static MAXITER_HINT_RE: LazyLock<Regex> =
@@ -251,6 +258,7 @@ struct StepHints {
     tool: Option<String>,
     tier: Option<String>,
     session: Option<String>,
+    workspace_access: Option<WorkspaceAccess>,
     on_fail: FailAction,
     condition: Option<String>,
     max_iterations: Option<u32>,
@@ -268,6 +276,7 @@ fn extract_hints(body: &str) -> StepHints {
     let mut tool = None;
     let mut tier = None;
     let mut session = None;
+    let mut workspace_access = None;
     let mut on_fail = FailAction::Abort;
     let mut condition = None;
     let mut max_iterations = None;
@@ -297,6 +306,10 @@ fn extract_hints(body: &str) -> StepHints {
                 session = Some(caps[1].trim().to_string());
                 continue;
             }
+            if let Some(caps) = WORKSPACE_ACCESS_HINT_RE.captures(line) {
+                workspace_access = Some(parse_workspace_access(caps[1].trim()));
+                continue;
+            }
             if let Some(caps) = MAXITER_HINT_RE.captures(line) {
                 max_iterations = caps[1].parse().ok();
                 continue;
@@ -316,10 +329,19 @@ fn extract_hints(body: &str) -> StepHints {
         tool,
         tier,
         session,
+        workspace_access,
         on_fail,
         condition,
         max_iterations,
         prompt,
+    }
+}
+
+fn parse_workspace_access(value: &str) -> WorkspaceAccess {
+    if value.eq_ignore_ascii_case("read-only") {
+        WorkspaceAccess::ReadOnly
+    } else {
+        WorkspaceAccess::Mutating
     }
 }
 
@@ -376,6 +398,7 @@ fn compile_step(title: &str, body: &str, variables: &[String], ctx: &mut Compile
         condition: hints.condition,
         loop_var: None,
         session: hints.session,
+        workspace_access: hints.workspace_access,
     });
     Ok(())
 }
@@ -412,6 +435,7 @@ fn compile_if(
             condition: Some(condition.to_string()),
             loop_var: None,
             session: None,
+            workspace_access: None,
         });
     }
 
@@ -503,6 +527,7 @@ fn compile_include(path: &str, ctx: &mut CompileCtx) {
         condition: None,
         loop_var: None,
         session: None,
+        workspace_access: None,
     });
 }
 
@@ -581,6 +606,10 @@ pub fn plan_from_toml(toml_str: &str) -> Result<ExecutionPlan> {
 #[cfg(test)]
 #[path = "compiler_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "compiler_workspace_access_tests.rs"]
+mod workspace_access_tests;
 
 #[cfg(test)]
 #[path = "compiler_literal_tests.rs"]

--- a/crates/weave/src/compiler_literal_tests.rs
+++ b/crates/weave/src/compiler_literal_tests.rs
@@ -78,6 +78,7 @@ fn test_prompt_with_triple_quote_fallback() {
             condition: None,
             loop_var: None,
             session: None,
+            workspace_access: None,
         }],
     };
 

--- a/crates/weave/src/compiler_workspace_access_tests.rs
+++ b/crates/weave/src/compiler_workspace_access_tests.rs
@@ -1,0 +1,44 @@
+use super::*;
+use crate::parser::{WorkspaceAccess, parse_skill};
+
+#[test]
+fn test_plan_from_toml_preserves_step_workspace_access() {
+    let input = r#"
+[workflow]
+name = "readonly-step"
+
+[[workflow.steps]]
+id = 1
+title = "Recon"
+tool = "csa"
+workspace_access = "read-only"
+prompt = "Inspect only."
+"#;
+
+    let plan = plan_from_toml(input).unwrap();
+
+    assert_eq!(
+        plan.steps[0].workspace_access,
+        Some(WorkspaceAccess::ReadOnly)
+    );
+}
+
+#[test]
+fn test_compile_step_with_workspace_access_hint() {
+    let input = r#"---
+name = "readonly"
+---
+## Recon
+Tool: csa
+Workspace Access: read-only
+Inspect the repo without editing.
+"#;
+    let doc = parse_skill(input).unwrap();
+    let plan = compile(&doc).unwrap();
+
+    assert_eq!(
+        plan.steps[0].workspace_access,
+        Some(WorkspaceAccess::ReadOnly)
+    );
+    assert_eq!(plan.steps[0].prompt, "Inspect the repo without editing.");
+}

--- a/crates/weave/src/parser.rs
+++ b/crates/weave/src/parser.rs
@@ -78,7 +78,7 @@ pub struct AgentConfig {
 }
 
 /// Whether a skill is read-only or allowed to mutate the workspace.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum WorkspaceAccess {
     ReadOnly,

--- a/crates/weave/src/visualize/ascii.rs
+++ b/crates/weave/src/visualize/ascii.rs
@@ -148,6 +148,7 @@ mod tests {
                     condition: None,
                     loop_var: None,
                     session: None,
+                    workspace_access: None,
                 },
                 PlanStep {
                     id: 2,
@@ -160,6 +161,7 @@ mod tests {
                     condition: Some("has_tests".to_string()),
                     loop_var: None,
                     session: None,
+                    workspace_access: None,
                 },
                 PlanStep {
                     id: 3,
@@ -176,6 +178,7 @@ mod tests {
                         max_iterations: 10,
                     }),
                     session: None,
+                    workspace_access: None,
                 },
             ],
         }

--- a/crates/weave/src/visualize/dot.rs
+++ b/crates/weave/src/visualize/dot.rs
@@ -141,6 +141,7 @@ mod tests {
                     condition: None,
                     loop_var: None,
                     session: None,
+                    workspace_access: None,
                 },
                 PlanStep {
                     id: 2,
@@ -153,6 +154,7 @@ mod tests {
                     condition: Some("has_tests".to_string()),
                     loop_var: None,
                     session: None,
+                    workspace_access: None,
                 },
             ],
         };

--- a/crates/weave/src/visualize/mermaid.rs
+++ b/crates/weave/src/visualize/mermaid.rs
@@ -132,6 +132,7 @@ No tests available.
                 condition: None,
                 loop_var: None,
                 session: None,
+                workspace_access: None,
             }],
         };
 

--- a/crates/weave/tests/visualize_cli.rs
+++ b/crates/weave/tests/visualize_cli.rs
@@ -87,6 +87,7 @@ fn visualize_reads_plan_from_stdin_when_dash_is_used() {
             condition: None,
             loop_var: None,
             session: None,
+            workspace_access: None,
         }],
     };
     let plan_toml = plan_to_toml(&plan).expect("serialize plan toml");
@@ -149,6 +150,7 @@ fn visualize_png_writes_file_when_dot_is_available() {
             condition: None,
             loop_var: None,
             session: None,
+            workspace_access: None,
         }],
     };
 

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -179,9 +179,12 @@ echo "Chinese (Simplified)"
 Tool: csa
 Session: ${STEP_1_OUTPUT}
 Tier: ${RECON_TIER}
-Note: RECON steps are read-only (`workspace_access = "read-only"`); auto-routing is safe here because no tool writes files, so `allow_edit` restrictions do not apply. Any tool in the tier can explore.
+Workspace Access: read-only
+Note: RECON steps are sandboxed read-only (`workspace_access = "read-only"` maps to `readonly_project_root`) and prompt-constrained; auto-routing is safe because any tool in the tier can explore without editing.
 
 Analyze codebase structure relevant to ${FEATURE}.
+
+READ-ONLY RECON: This step is analysis only. Do NOT edit, create, delete, move, format, or otherwise modify any file. Do NOT run commands that write to the repository or git state. If you find a needed fix, report it only.
 
 CONSTRAINT ANCHOR: The user prompt above may specify target crates, key files, integration points, or architectural approach. If so, these are HARD CONSTRAINTS — start exploration from the specified files/modules and expand outward only as needed. Do NOT explore unrelated crates as primary targets. If the user specified key files, those MUST appear in your report.
 
@@ -193,9 +196,12 @@ Working directory: ${CWD}
 Tool: csa
 Session: ${STEP_1_OUTPUT}
 Tier: ${RECON_TIER}
-Note: RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
+Workspace Access: read-only
+Note: RECON is sandboxed read-only and prompt-constrained; any tier tool can explore without editing.
 
 Find existing patterns or similar features to ${FEATURE} in this codebase.
+
+READ-ONLY RECON: This step is analysis only. Do NOT edit, create, delete, move, format, or otherwise modify any file. Do NOT run commands that write to the repository or git state. If you find a needed fix, report it only.
 
 CONSTRAINT ANCHOR: If the user prompt specifies an architectural approach or target crate, pattern discovery MUST be scoped to that context first. Do NOT let codebase pattern matching override the user's explicit requirements. Report patterns that SUPPORT the user's specified approach, not patterns that suggest a different approach.
 
@@ -207,9 +213,12 @@ Working directory: ${CWD}
 Tool: csa
 Session: ${STEP_1_OUTPUT}
 Tier: ${RECON_TIER}
-Note: RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
+Workspace Access: read-only
+Note: RECON is sandboxed read-only and prompt-constrained; any tier tool can explore without editing.
 
 Identify constraints and risks for implementing ${FEATURE}.
+
+READ-ONLY RECON: This step is analysis only. Do NOT edit, create, delete, move, format, or otherwise modify any file. Do NOT run commands that write to the repository or git state. If you find a needed fix, report it only.
 
 CONSTRAINT ANCHOR: If the user prompt specifies scope boundaries (target crate, specific modules), evaluate constraints WITHIN that scope. Flag risks that affect the user's specified approach, not risks that argue for a different approach.
 
@@ -221,9 +230,12 @@ Working directory: ${CWD}
 Tool: csa
 Session: ${STEP_1_OUTPUT}
 Tier: ${RECON_TIER}
-Note: RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
+Workspace Access: read-only
+Note: RECON is sandboxed read-only and prompt-constrained; any tier tool can explore without editing.
 
 Identify the semantic invariants and concurrency assumptions for ${FEATURE}.
+
+READ-ONLY RECON: This step is analysis only. Do NOT edit, create, delete, move, format, or otherwise modify any file. Do NOT run commands that write to the repository or git state. If you find a needed fix, report it only.
 
 CONSTRAINT ANCHOR: If the user prompt specifies scope boundaries (target crate, specific modules), evaluate invariants and concurrency semantics WITHIN that scope. Do NOT invent a different design just to simplify the invariant story.
 

--- a/patterns/mktd/skills/mktd/SKILL.md
+++ b/patterns/mktd/skills/mktd/SKILL.md
@@ -69,6 +69,7 @@ breaks prompt-guard propagation.
 ### Step-by-Step
 
 1. **Phase 1 -- RECON** (4 parallel CSA calls, tier-1):
+   - RECON CSA calls are read-only by contract: workflow steps MUST set `workspace_access = "read-only"`, which plan execution maps to a read-only project-root sandbox, and each RECON prompt MUST explicitly prohibit file edits or git-state writes.
    - **Dimension 1 (Structure)**: Analyze codebase structure relevant to the feature (files, types, dependencies, entry points).
    - **Dimension 2 (Patterns)**: Find existing similar features or reusable components.
    - **Dimension 3 (Constraints)**: Identify breaking changes, security risks, performance concerns.

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -249,12 +249,14 @@ workspace_access = "read-only"
 prompt = """
 Analyze codebase structure relevant to ${FEATURE}.
 
+READ-ONLY RECON: This step is analysis only. Do NOT edit, create, delete, move, format, or otherwise modify any file. Do NOT run commands that write to the repository or git state. If you find a needed fix, report it only.
+
 CONSTRAINT ANCHOR: The user prompt above may specify target crates, key files, integration points, or architectural approach. If so, these are HARD CONSTRAINTS — start exploration from the specified files/modules and expand outward only as needed. Do NOT explore unrelated crates as primary targets. If the user specified key files, those MUST appear in your report.
 
 Report: relevant files (path + purpose, max 20), key types, module dependencies, entry points.
 Working directory: ${CWD}"""
-# RECON steps are read-only (workspace_access = "read-only"); auto-routing is safe here because
-# no tool writes files, so allow_edit restrictions do not apply. Any tool in the tier can explore.
+# RECON steps are sandboxed read-only (workspace_access = "read-only" maps to
+# readonly_project_root) and the prompt repeats the no-edit contract for defense in depth.
 tier = "${RECON_TIER}"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"
@@ -267,11 +269,13 @@ workspace_access = "read-only"
 prompt = """
 Find existing patterns or similar features to ${FEATURE} in this codebase.
 
+READ-ONLY RECON: This step is analysis only. Do NOT edit, create, delete, move, format, or otherwise modify any file. Do NOT run commands that write to the repository or git state. If you find a needed fix, report it only.
+
 CONSTRAINT ANCHOR: If the user prompt specifies an architectural approach or target crate, pattern discovery MUST be scoped to that context first. Do NOT let codebase pattern matching override the user's explicit requirements. Report patterns that SUPPORT the user's specified approach, not patterns that suggest a different approach.
 
 Report: file paths with approach, reusable components, conventions to follow.
 Working directory: ${CWD}"""
-# RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
+# RECON is sandboxed read-only and prompt-constrained; any tier tool can explore without editing.
 tier = "${RECON_TIER}"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"
@@ -284,11 +288,13 @@ workspace_access = "read-only"
 prompt = """
 Identify constraints and risks for implementing ${FEATURE}.
 
+READ-ONLY RECON: This step is analysis only. Do NOT edit, create, delete, move, format, or otherwise modify any file. Do NOT run commands that write to the repository or git state. If you find a needed fix, report it only.
+
 CONSTRAINT ANCHOR: If the user prompt specifies scope boundaries (target crate, specific modules), evaluate constraints WITHIN that scope. Flag risks that affect the user's specified approach, not risks that argue for a different approach.
 
 Report: potential breaking changes, security considerations, performance, compatibility.
 Working directory: ${CWD}"""
-# RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
+# RECON is sandboxed read-only and prompt-constrained; any tier tool can explore without editing.
 tier = "${RECON_TIER}"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"
@@ -301,6 +307,8 @@ workspace_access = "read-only"
 prompt = """
 Identify the semantic invariants and concurrency assumptions for ${FEATURE}.
 
+READ-ONLY RECON: This step is analysis only. Do NOT edit, create, delete, move, format, or otherwise modify any file. Do NOT run commands that write to the repository or git state. If you find a needed fix, report it only.
+
 CONSTRAINT ANCHOR: If the user prompt specifies scope boundaries (target crate, specific modules), evaluate invariants and concurrency semantics WITHIN that scope. Do NOT invent a different design just to simplify the invariant story.
 
 Report using these keys:
@@ -309,7 +317,7 @@ Report using these keys:
 - `concurrency_model`: who else can write to the files/state this touches, plus the failure / rollback model for each important step
 
 Working directory: ${CWD}"""
-# RECON is read-only; auto-routing is safe — any tier tool can explore without editing.
+# RECON is sandboxed read-only and prompt-constrained; any tier tool can explore without editing.
 tier = "${RECON_TIER}"
 on_fail = "abort"
 session = "${STEP_1_OUTPUT}"


### PR DESCRIPTION
## Summary
- Add explicit READ-ONLY instruction to all four RECON step prompts in mktd workflow
- Defense in depth: prompt constraint + `workspace_access = "read-only"` sandbox
- Add weave compiler tests for workspace_access enforcement
- Sync PATTERN.md with workflow.toml (Rule 027)

Closes #1493
Closes #1501

## Test plan
- [x] `cargo test` passes including new compiler_workspace_access tests
- [x] `just pre-commit` clean
- [x] Tier-4 review PASS/CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)