### PR TITLE
feat(csa-executor): use prompt file for tmux transport (#1498)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.764"
+version = "0.1.765"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_factory.rs
+++ b/crates/csa-executor/src/transport_factory.rs
@@ -15,9 +15,9 @@ pub enum TransportMode {
     Acp,
     OpenaiCompat,
     /// Experimental: tmux-backed interactive transport for claude-code.
-    /// Claude runs inside a detached tmux session; prompt delivery is via
-    /// `tmux load-buffer`/`paste-buffer`; output is read from the JSONL
-    /// conversation log.
+    /// Claude runs inside a detached tmux session; the prompt is written to a
+    /// temp file and tmux receives only a short file-read instruction; output
+    /// is read from the JSONL conversation log.
     Tmux,
 }
 

--- a/crates/csa-executor/src/transport_tmux.rs
+++ b/crates/csa-executor/src/transport_tmux.rs
@@ -14,7 +14,8 @@
 //! 2. Spawn `tmux new-session -d -s csa-<ULID> -- /path/to/claude --dangerously-skip-permissions`
 //!    with `CSA_SESSION_DIR` and `CSA_RESULT_TOML_PATH_CONTRACT` env vars injected
 //! 3. Wait for Claude TUI readiness (poll tmux pane for `❯` prompt)
-//! 4. Send prompt: `tmux load-buffer` → `paste-buffer` → `send-keys Enter`
+//! 4. Write prompt to a temp file, then send a short file-read instruction
+//!    through tmux
 //! 5. Discover new JSONL: diff snapshot to find newly created `.jsonl` file
 //! 6. Tail JSONL until `type=system subtype=turn_duration` marker
 //! 7. Read output: prefer `output/result.toml` (if child wrote it), fall back to JSONL text
@@ -58,10 +59,12 @@ const SESSION_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 /// Kills the tmux session on Drop so no orphan sessions are left behind.
 struct TmuxCleanupGuard {
     session_name: String,
+    prompt_file_path: PathBuf,
 }
 
 impl Drop for TmuxCleanupGuard {
     fn drop(&mut self) {
+        remove_prompt_file(&self.prompt_file_path);
         let _ = Command::new("tmux")
             .args(["kill-session", "-t", &self.session_name])
             .stdout(Stdio::null())
@@ -164,20 +167,68 @@ use jsonl::{validate_jsonl_schema, watch_jsonl_for_turn};
 
 // ── Prompt delivery ───────────────────────────────────────────────────────────
 
-/// Deliver `prompt` to the tmux session via load-buffer / paste-buffer / Enter.
+/// Return the temp-file path used to hand a prompt to Claude Code.
+fn prompt_file_path_for_session(session_name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("csa-prompt-{session_name}.md"))
+}
+
+fn write_prompt_file(prompt_file_path: &Path, prompt: &str) -> Result<()> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options
+        .open(prompt_file_path)
+        .with_context(|| format!("creating tmux prompt file {}", prompt_file_path.display()))?;
+    use std::io::Write;
+    file.write_all(prompt.as_bytes())
+        .with_context(|| format!("writing tmux prompt file {}", prompt_file_path.display()))?;
+    Ok(())
+}
+
+fn remove_prompt_file(prompt_file_path: &Path) {
+    if let Err(e) = fs::remove_file(prompt_file_path)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            error = %e,
+            path = %prompt_file_path.display(),
+            "tmux transport: failed to remove prompt file"
+        );
+    }
+}
+
+fn prompt_file_instruction(prompt_file_path: &Path) -> String {
+    format!(
+        "Read and execute the prompt in this file: {}\n\
+         Treat the file contents as the full user request, and do not summarize the file first.",
+        prompt_file_path.display()
+    )
+}
+
+/// Deliver `prompt` to the tmux session by writing it to `prompt_file_path`,
+/// then submitting a short instruction that references the file.
 ///
-/// This is safer than `send-keys` for prompts containing special characters,
-/// shell metacharacters, multi-byte UTF-8, or large payloads.
+/// This avoids tmux input-buffer limits and keeps prompt escaping out of the
+/// interactive transport path.
 ///
 /// A delay between paste-buffer and Enter is required because Claude Code's
 /// TUI uses bracketed-paste mode: the paste event must finish processing before
 /// Enter can submit the message.
-async fn deliver_prompt(session_name: &str, prompt: &str) -> Result<()> {
+async fn deliver_prompt(session_name: &str, prompt: &str, prompt_file_path: &Path) -> Result<()> {
+    write_prompt_file(prompt_file_path, prompt)?;
+    let instruction = prompt_file_instruction(prompt_file_path);
+
     // Use a named buffer (session_name) to avoid cross-session races when
     // multiple CSA tmux sessions run concurrently.
     let buffer_name = session_name;
 
-    // load-buffer reads from stdin; pipe the raw prompt text in.
+    // load-buffer reads from stdin; pipe only the short file instruction in.
     let mut load = Command::new("tmux")
         .args(["load-buffer", "-b", buffer_name, "-"])
         .stdin(Stdio::piped())
@@ -190,7 +241,7 @@ async fn deliver_prompt(session_name: &str, prompt: &str) -> Result<()> {
         use std::io::Write;
         let mut stdin = stdin;
         stdin
-            .write_all(prompt.as_bytes())
+            .write_all(instruction.as_bytes())
             .context("writing prompt to tmux load-buffer stdin")?;
     }
     let status = load.wait().context("tmux load-buffer wait")?;
@@ -210,13 +261,7 @@ async fn deliver_prompt(session_name: &str, prompt: &str) -> Result<()> {
     }
 
     // Wait for Claude Code's TUI to finish processing the bracketed paste.
-    // Large prompts (>10K chars) need more time for the TUI to render.
-    let paste_settle = if prompt.len() > 10_000 {
-        Duration::from_millis(1000)
-    } else {
-        Duration::from_millis(200)
-    };
-    sleep(paste_settle).await;
+    sleep(Duration::from_millis(200)).await;
 
     // Send Enter to submit the prompt.
     let status = Command::new("tmux")
@@ -428,6 +473,7 @@ impl TmuxTransport {
         session: Option<&MetaSessionState>,
     ) -> Result<TransportResult> {
         let session_name = Self::session_name();
+        let prompt_file_path = prompt_file_path_for_session(&session_name);
         tracing::debug!(
             session = %session_name,
             work_dir = %work_dir.display(),
@@ -513,21 +559,24 @@ impl TmuxTransport {
         // RAII guard: kills the session when this function exits (normal or panic).
         let _guard = TmuxCleanupGuard {
             session_name: session_name.clone(),
+            prompt_file_path: prompt_file_path.clone(),
         };
 
         Self::wait_for_readiness(&session_name).await?;
         tracing::debug!(session = %session_name, "tmux transport: Claude ready");
 
-        deliver_prompt(&session_name, prompt).await?;
+        deliver_prompt(&session_name, prompt, &prompt_file_path).await?;
         tracing::debug!(
             session = %session_name,
             prompt_len = prompt.len(),
+            prompt_file = %prompt_file_path.display(),
             "tmux transport: prompt delivered"
         );
 
         // JSONL is created after Claude processes the first prompt.
         let (jsonl_path, provider_session_id) =
             discover_new_jsonl(&jsonl_dir, &before_snapshot).await?;
+        remove_prompt_file(&prompt_file_path);
         tracing::debug!(
             jsonl = %jsonl_path.display(),
             session_id = %provider_session_id,

--- a/crates/csa-executor/src/transport_tmux_tests.rs
+++ b/crates/csa-executor/src/transport_tmux_tests.rs
@@ -356,6 +356,78 @@ async fn discover_new_jsonl_times_out_when_no_new_file() {
     );
 }
 
+// ── prompt-file delivery ─────────────────────────────────────────────────
+
+#[test]
+fn prompt_file_path_uses_session_scoped_temp_file() {
+    let path = prompt_file_path_for_session("csa-01ARZ3NDEKTSV4RRFFQ69G5FAV");
+
+    assert_eq!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some("csa-prompt-csa-01ARZ3NDEKTSV4RRFFQ69G5FAV.md")
+    );
+    assert!(path.starts_with(std::env::temp_dir()));
+}
+
+#[test]
+fn prompt_file_instruction_references_file_without_embedding_prompt() {
+    let tmp = TempDir::new().unwrap();
+    let prompt_file = tmp.path().join("prompt.md");
+    let long_prompt = "x".repeat(64 * 1024);
+
+    let instruction = prompt_file_instruction(&prompt_file);
+
+    assert!(instruction.contains(&prompt_file.display().to_string()));
+    assert!(!instruction.contains(&long_prompt));
+    assert!(
+        instruction.len() < 512,
+        "file instruction should stay short, got {} bytes",
+        instruction.len()
+    );
+}
+
+#[test]
+fn write_prompt_file_persists_full_prompt_once() {
+    let tmp = TempDir::new().unwrap();
+    let prompt_file = tmp.path().join("prompt.md");
+    let prompt = "full prompt\nwith shell chars: $HOME && $(rm -rf nope)\n";
+
+    write_prompt_file(&prompt_file, prompt).unwrap();
+
+    assert_eq!(fs::read_to_string(&prompt_file).unwrap(), prompt);
+    let err = write_prompt_file(&prompt_file, "second write").unwrap_err();
+    assert!(
+        err.to_string().contains("creating tmux prompt file"),
+        "expected create_new failure context, got: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn write_prompt_file_uses_owner_only_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    let prompt_file = tmp.path().join("prompt.md");
+
+    write_prompt_file(&prompt_file, "secret prompt").unwrap();
+
+    let mode = fs::metadata(&prompt_file).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600);
+}
+
+#[test]
+fn remove_prompt_file_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let prompt_file = tmp.path().join("prompt.md");
+    fs::write(&prompt_file, "prompt").unwrap();
+
+    remove_prompt_file(&prompt_file);
+    remove_prompt_file(&prompt_file);
+
+    assert!(!prompt_file.exists());
+}
+
 // ── try_read_contract_result ─────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- Write long prompts to temp file instead of inline tmux send-keys
- Avoids tmux input buffer truncation for large SA-mode prompts
- Temp file cleaned up on session end
- Add unit tests for file-based prompt delivery

Closes #1498

## Test plan
- [x] `cargo test` passes for new transport_tmux_tests
- [x] `just pre-commit` clean
- [x] Tier-4 review PASS/CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)