### PR TITLE
fix(justfile): auto-create target symlink destination in pre-commit (#1499)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.765"
+version = "0.1.766"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/justfile
+++ b/justfile
@@ -28,6 +28,11 @@ _check_writable path attempted:
     path="{{path}}"
     attempted="{{attempted}}"
     resolved_path="$(readlink -f "$path" 2>/dev/null || printf '%s' "$path")"
+    # When path is a symlink, ensure the resolved destination directory exists
+    if [ -L "$path" ]; then
+        symlink_target="$(readlink "$path")"
+        mkdir -p "$symlink_target" 2>/dev/null || true
+    fi
     mkdir -p "$path" 2>/dev/null || true
     probe="$path/.csa-write-probe.$$"
     if touch "$probe" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Auto-create symlink destination directory when target/ is a symlink
- Prevents nextest failure when the symlink target disappears (disk issue, clean)

Closes #1499

## Test plan
- [x] `just check-cargo-target-writable` passes
- [x] `just pre-commit` clean
- [x] Tier-4 review PASS/CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)