### PR TITLE
fix(pipeline): skip post-exec gate for no-edit sessions (#1515, #1516)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.768"
+version = "0.1.769"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.767"
+version = "0.1.768"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.768"
+version = "0.1.769"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.767"
+version = "0.1.768"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -278,6 +278,11 @@ pub(crate) async fn process_execution_result(
     }
     if result.exit_code == 0
         && ctx.task_type == Some("run")
+        && !result_sidecar::status_is_success(&ctx.session_dir)
+        && session.turn_count <= 1
+        && !ctx.has_tool_calls
+        && ctx.changed_paths.is_empty()
+        && elapsed_secs < NO_OP_ELAPSED_THRESHOLD_SECS
         && let Err(err) = progress::maybe_mark_no_progress_session(
             ctx.project_root,
             session,

--- a/crates/cli-sub-agent/src/pipeline_tests_no_progress.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_no_progress.rs
@@ -55,6 +55,12 @@ fn build_codex_executor() -> Executor {
     }
 }
 
+fn write_result_sidecar(session_dir: &std::path::Path, contents: &str) {
+    let path = session_dir.join(csa_session::CONTRACT_RESULT_ARTIFACT_PATH);
+    std::fs::create_dir_all(path.parent().expect("sidecar parent")).expect("create output dir");
+    std::fs::write(path, contents).expect("write result sidecar");
+}
+
 fn run_git(repo: &std::path::Path, args: &[&str]) {
     let output = std::process::Command::new("git")
         .args(args)
@@ -90,7 +96,7 @@ fn setup_session_repo(
 }
 
 #[tokio::test]
-async fn run_success_with_no_git_progress_is_marked_no_progress() {
+async fn run_success_with_no_git_progress_and_tool_calls_remains_success() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let _sandbox = ScopedSessionSandbox::new(&tmp).await;
     let (project_root, mut session) = setup_session_repo(&tmp);
@@ -101,6 +107,76 @@ async fn run_success_with_no_git_progress_is_marked_no_progress() {
     let hooks_config = csa_hooks::HooksConfig::default();
     let start = chrono::Utc::now() - chrono::Duration::seconds(360);
     let ctx = build_test_ctx(&executor, session_dir, &project_root, start, &hooks_config);
+    let mut result = build_test_result("Completed successfully.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(&project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(0));
+    assert_eq!(result.exit_code, 0, "tool exit code must remain unchanged");
+    let reloaded = load_session(&project_root, &session.meta_session_id).expect("load session");
+    assert_ne!(reloaded.termination_reason.as_deref(), Some("no_progress"));
+}
+
+#[tokio::test]
+async fn run_success_with_success_sidecar_and_no_git_progress_remains_success() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let (project_root, mut session) = setup_session_repo(&tmp);
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).expect("dir");
+    write_result_sidecar(
+        &session_dir,
+        r#"[result]
+status = "success"
+summary = "external orchestration passed"
+"#,
+    );
+
+    let executor = build_codex_executor();
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(15);
+    let mut ctx = build_test_ctx(&executor, session_dir, &project_root, start, &hooks_config);
+    ctx.has_tool_calls = false;
+    let mut result = build_test_result("External orchestration passed.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(&project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 0);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(0));
+    assert!(
+        !persisted
+            .summary
+            .starts_with("tool exited successfully but produced no changes"),
+        "success sidecar must suppress no-progress classification, got: {}",
+        persisted.summary
+    );
+    assert_eq!(result.exit_code, 0);
+}
+
+#[tokio::test]
+async fn run_success_with_low_evidence_no_git_progress_is_marked_no_progress() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let (project_root, mut session) = setup_session_repo(&tmp);
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).expect("dir");
+
+    let executor = build_codex_executor();
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(15);
+    let mut ctx = build_test_ctx(&executor, session_dir, &project_root, start, &hooks_config);
+    ctx.has_tool_calls = false;
     let mut result = build_test_result("Completed successfully.");
 
     process_execution_result(ctx, &mut session, &mut result)

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -14,8 +14,9 @@ use super::attempt_exec::{
     run_ephemeral_without_timeout, run_persistent_with_timeout, run_persistent_without_timeout,
 };
 use super::attempt_support::{
-    allow_cross_tool_failover, build_failover_context_addendum,
-    persist_fork_timeout_result_if_missing, resolve_attempt_initial_response_timeout_seconds,
+    allow_cross_tool_failover, build_failover_context_addendum, merge_retry_changed_paths,
+    merge_run_loop_changed_paths, persist_fork_timeout_result_if_missing,
+    resolve_attempt_initial_response_timeout_seconds,
 };
 use super::policy::is_post_run_commit_policy_block;
 use super::resume::{
@@ -91,6 +92,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
     let enforce_tier =
         !request.force && !request.force_ignore_tier_setting && !request.user_model_spec_explicit;
     let mut accumulated_changed_paths: Vec<String> = Vec::new();
+    let mut all_attempt_change_snapshots_available = true;
     let (result, changed_paths) = loop {
         attempts += 1;
         let mut fresh_spawn_preflight_override = false;
@@ -668,9 +670,11 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 &tried_tools,
             )
         {
-            if let Some(paths) = exec_changed_paths {
-                accumulated_changed_paths.extend(paths);
-            }
+            merge_retry_changed_paths(
+                &mut accumulated_changed_paths,
+                &mut all_attempt_change_snapshots_available,
+                exec_changed_paths,
+            );
             runtime_fallback_attempts += 1;
             warn!(
                 from = %tool_name_str,
@@ -723,9 +727,11 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 new_tool,
                 new_model_spec,
             } => {
-                if let Some(paths) = exec_changed_paths {
-                    accumulated_changed_paths.extend(paths);
-                }
+                merge_retry_changed_paths(
+                    &mut accumulated_changed_paths,
+                    &mut all_attempt_change_snapshots_available,
+                    exec_changed_paths,
+                );
                 // Build xurl context recovery addendum so the failover
                 // tool can retrieve the original session's conversation.
                 failover_context_addendum =
@@ -746,19 +752,11 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             _ => break (exec_result, exec_changed_paths),
         }
     };
-    let changed_paths = {
-        let mut merged = accumulated_changed_paths;
-        if let Some(final_paths) = changed_paths {
-            merged.extend(final_paths);
-        }
-        if merged.is_empty() {
-            None
-        } else {
-            merged.sort();
-            merged.dedup();
-            Some(merged)
-        }
-    };
+    let changed_paths = merge_run_loop_changed_paths(
+        accumulated_changed_paths,
+        all_attempt_change_snapshots_available,
+        changed_paths,
+    );
     Ok(RunLoopCompletion::Completed(Box::new(RunLoopOutcome {
         result,
         current_tool,

--- a/crates/cli-sub-agent/src/run_cmd_attempt_support.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_support.rs
@@ -70,6 +70,36 @@ pub(crate) fn build_failover_context_addendum(
     ))
 }
 
+pub(crate) fn merge_retry_changed_paths(
+    accumulated_changed_paths: &mut Vec<String>,
+    all_attempt_change_snapshots_available: &mut bool,
+    attempt_changed_paths: Option<Vec<String>>,
+) {
+    match attempt_changed_paths {
+        Some(paths) => accumulated_changed_paths.extend(paths),
+        None => *all_attempt_change_snapshots_available = false,
+    }
+}
+
+pub(crate) fn merge_run_loop_changed_paths(
+    mut accumulated_changed_paths: Vec<String>,
+    mut all_attempt_change_snapshots_available: bool,
+    final_changed_paths: Option<Vec<String>>,
+) -> Option<Vec<String>> {
+    match final_changed_paths {
+        Some(paths) => accumulated_changed_paths.extend(paths),
+        None => all_attempt_change_snapshots_available = false,
+    }
+
+    if !all_attempt_change_snapshots_available {
+        return None;
+    }
+
+    accumulated_changed_paths.sort();
+    accumulated_changed_paths.dedup();
+    Some(accumulated_changed_paths)
+}
+
 pub(crate) fn persist_fork_timeout_result_if_missing(
     project_root: &Path,
     is_fork: bool,
@@ -95,4 +125,38 @@ pub(crate) fn persist_fork_timeout_result_if_missing(
         execution_start_time,
         &err,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_run_loop_changed_paths;
+
+    #[test]
+    fn merge_run_loop_changed_paths_preserves_known_empty_delta() {
+        let merged = merge_run_loop_changed_paths(Vec::new(), true, Some(Vec::new()));
+
+        assert_eq!(merged, Some(Vec::new()));
+    }
+
+    #[test]
+    fn merge_run_loop_changed_paths_returns_unknown_when_any_snapshot_is_missing() {
+        let merged =
+            merge_run_loop_changed_paths(vec!["src/lib.rs".to_string()], false, Some(vec![]));
+
+        assert_eq!(merged, None);
+    }
+
+    #[test]
+    fn merge_run_loop_changed_paths_deduplicates_known_paths() {
+        let merged = merge_run_loop_changed_paths(
+            vec!["src/lib.rs".to_string()],
+            true,
+            Some(vec!["src/lib.rs".to_string(), "src/main.rs".to_string()]),
+        );
+
+        assert_eq!(
+            merged,
+            Some(vec!["src/lib.rs".to_string(), "src/main.rs".to_string()])
+        );
+    }
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -30,40 +30,77 @@ fn is_post_exec_gate_exempt_prompt(prompt_text: &str) -> bool {
 fn post_exec_gate_requires_changes(
     project_root: &Path,
     skip_on_no_changes: bool,
+    session_id: Option<&str>,
     changed_paths: Option<&[String]>,
 ) -> Result<bool> {
     if !skip_on_no_changes || !crate::run_cmd::is_git_worktree(project_root) {
         return Ok(true);
     }
 
+    let start_head = session_id.and_then(|id| session_start_head(project_root, id));
     if let Some(paths) = changed_paths {
-        if paths.is_empty() {
-            return Ok(false);
+        if !paths.is_empty() {
+            return Ok(true);
         }
-        return git_diff_has_changes(project_root);
+        return git_head_changed_since(project_root, start_head.as_deref());
     }
 
-    git_diff_has_changes(project_root)
+    if git_head_changed_since(project_root, start_head.as_deref())? {
+        return Ok(true);
+    }
+    git_worktree_has_status_changes(project_root)
 }
 
-fn git_diff_has_changes(project_root: &Path) -> Result<bool> {
+fn session_start_head(project_root: &Path, session_id: &str) -> Option<String> {
+    csa_session::load_session(project_root, session_id)
+        .ok()
+        .and_then(|session| session.git_head_at_creation)
+        .filter(|head| !head.trim().is_empty())
+}
+
+fn git_head_changed_since(project_root: &Path, start_head: Option<&str>) -> Result<bool> {
+    let Some(start_head) = start_head.map(str::trim).filter(|head| !head.is_empty()) else {
+        return Ok(false);
+    };
+
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(project_root)
-        .args(["diff", "--quiet", "HEAD", "--"])
+        .args(["rev-parse", "--verify", "HEAD"])
         .output()
         .with_context(|| {
             format!(
-                "failed to inspect git diff for post-exec gate in {}",
+                "failed to inspect git HEAD for post-exec gate in {}",
                 project_root.display()
             )
         })?;
 
-    match output.status.code() {
-        Some(0) => Ok(false),
-        Some(1) => Ok(true),
-        _ => Ok(true),
+    if !output.status.success() {
+        return Ok(true);
     }
+
+    let current_head = String::from_utf8_lossy(&output.stdout);
+    Ok(current_head.trim() != start_head)
+}
+
+fn git_worktree_has_status_changes(project_root: &Path) -> Result<bool> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["status", "--porcelain=v1", "--untracked-files=all"])
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to inspect git status for post-exec gate in {}",
+                project_root.display()
+            )
+        })?;
+
+    if !output.status.success() {
+        return Ok(true);
+    }
+
+    Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
 }
 
 pub(super) fn execute_post_exec_gate_command(
@@ -151,6 +188,7 @@ where
     if !post_exec_gate_requires_changes(
         project_root,
         gate_config.skip_on_no_changes,
+        session_id,
         changed_paths,
     )? {
         return Ok(PostExecGateOutcome::Skipped);

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -37,26 +37,33 @@ fn post_exec_gate_requires_changes(
     }
 
     if let Some(paths) = changed_paths {
-        return Ok(!paths.is_empty());
+        if paths.is_empty() {
+            return Ok(false);
+        }
+        return git_diff_has_changes(project_root);
     }
 
+    git_diff_has_changes(project_root)
+}
+
+fn git_diff_has_changes(project_root: &Path) -> Result<bool> {
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(project_root)
-        .args(["status", "--porcelain"])
+        .args(["diff", "--quiet", "HEAD", "--"])
         .output()
         .with_context(|| {
             format!(
-                "failed to inspect git status for post-exec gate in {}",
+                "failed to inspect git diff for post-exec gate in {}",
                 project_root.display()
             )
         })?;
 
-    if !output.status.success() {
-        return Ok(true);
+    match output.status.code() {
+        Some(0) => Ok(false),
+        Some(1) => Ok(true),
+        _ => Ok(true),
     }
-
-    Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
 }
 
 pub(super) fn execute_post_exec_gate_command(

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -2,6 +2,7 @@ use super::{
     PostExecGateCommandOutcome, PostExecGateOutcome, maybe_run_post_exec_gate_with_runner,
 };
 use csa_config::{PostExecGateConfig, ProjectConfig, ProjectMeta, ResourcesConfig, RunConfig};
+use csa_session::create_session_fresh;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -58,6 +59,27 @@ fn init_clean_git_repo(project_root: &Path) {
     std::fs::write(project_root.join("tracked.txt"), "initial\n").expect("write tracked file");
     run(&["add", "tracked.txt"]);
     run(&["commit", "-m", "initial"]);
+}
+
+fn run_git(project_root: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git command failed: {:?}", args);
+}
+
+fn create_session_at_current_head(project_root: &Path) -> String {
+    create_session_fresh(
+        project_root,
+        Some("post-exec gate test"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session")
+    .meta_session_id
 }
 
 #[tokio::test]
@@ -212,7 +234,7 @@ async fn post_exec_gate_skips_when_dirty_worktree_is_pre_existing() {
 }
 
 #[tokio::test]
-async fn post_exec_gate_skips_when_changed_paths_have_no_tracked_diff() {
+async fn post_exec_gate_runs_when_changed_paths_are_non_empty() {
     let project_dir = tempdir().unwrap();
     init_clean_git_repo(project_dir.path());
     std::fs::create_dir(project_dir.path().join("just-temp")).unwrap();
@@ -222,6 +244,7 @@ async fn post_exec_gate_skips_when_changed_paths_have_no_tracked_diff() {
     )
     .unwrap();
 
+    let calls = Arc::new(Mutex::new(Vec::new()));
     let config = project_config_with_gate(PostExecGateConfig::default());
     let changed_paths = vec!["just-temp/stderr.log".to_string()];
     let outcome = maybe_run_post_exec_gate_with_runner(
@@ -230,16 +253,24 @@ async fn post_exec_gate_skips_when_changed_paths_have_no_tracked_diff() {
         Some("01TESTPOSTEXECGATEARTIFACT00"),
         Some(&config),
         Some(&changed_paths),
-        |_command, _cwd, _timeout_seconds| {
-            Box::pin(async move {
-                panic!("runner must not execute when changed paths have no tracked diff");
-            })
+        {
+            let calls = Arc::clone(&calls);
+            move |command, cwd, timeout_seconds| {
+                let calls = Arc::clone(&calls);
+                let command = command.to_string();
+                let cwd = cwd.to_path_buf();
+                Box::pin(async move {
+                    calls.lock().unwrap().push((command, cwd, timeout_seconds));
+                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                })
+            }
         },
     )
     .await
-    .expect("untracked test artifacts should skip gate");
+    .expect("explicit changed paths should run gate");
 
-    assert_eq!(outcome, PostExecGateOutcome::Skipped);
+    assert_eq!(outcome, PostExecGateOutcome::Passed);
+    assert_eq!(calls.lock().unwrap().len(), 1);
 }
 
 #[tokio::test]
@@ -272,6 +303,82 @@ async fn post_exec_gate_runs_when_session_introduced_changes() {
     )
     .await
     .expect("session-introduced changes should run gate");
+
+    assert_eq!(outcome, PostExecGateOutcome::Passed);
+    assert_eq!(calls.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn post_exec_gate_runs_when_session_committed_changes() {
+    let project_dir = tempdir().unwrap();
+    init_clean_git_repo(project_dir.path());
+    let session_id = create_session_at_current_head(project_dir.path());
+    std::fs::write(project_dir.path().join("tracked.txt"), "committed\n").unwrap();
+    run_git(project_dir.path(), &["add", "tracked.txt"]);
+    run_git(project_dir.path(), &["commit", "-m", "change tracked"]);
+
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    let changed_paths: Vec<String> = Vec::new();
+    let outcome = maybe_run_post_exec_gate_with_runner(
+        project_dir.path(),
+        "Implement and commit the fix",
+        Some(&session_id),
+        Some(&config),
+        Some(&changed_paths),
+        {
+            let calls = Arc::clone(&calls);
+            move |command, cwd, timeout_seconds| {
+                let calls = Arc::clone(&calls);
+                let command = command.to_string();
+                let cwd = cwd.to_path_buf();
+                Box::pin(async move {
+                    calls.lock().unwrap().push((command, cwd, timeout_seconds));
+                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                })
+            }
+        },
+    )
+    .await
+    .expect("committed session changes should run gate");
+
+    assert_eq!(outcome, PostExecGateOutcome::Passed);
+    assert_eq!(calls.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn post_exec_gate_runs_when_untracked_source_exists_without_changed_paths() {
+    let project_dir = tempdir().unwrap();
+    init_clean_git_repo(project_dir.path());
+    std::fs::write(
+        project_dir.path().join("new_source.rs"),
+        "fn new_source() {}\n",
+    )
+    .unwrap();
+
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    let outcome = maybe_run_post_exec_gate_with_runner(
+        project_dir.path(),
+        "Create a new Rust source file",
+        Some("01TESTPOSTEXECGATEUNTRACKED"),
+        Some(&config),
+        None,
+        {
+            let calls = Arc::clone(&calls);
+            move |command, cwd, timeout_seconds| {
+                let calls = Arc::clone(&calls);
+                let command = command.to_string();
+                let cwd = cwd.to_path_buf();
+                Box::pin(async move {
+                    calls.lock().unwrap().push((command, cwd, timeout_seconds));
+                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                })
+            }
+        },
+    )
+    .await
+    .expect("untracked source changes should run gate");
 
     assert_eq!(outcome, PostExecGateOutcome::Passed);
     assert_eq!(calls.lock().unwrap().len(), 1);

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -212,9 +212,41 @@ async fn post_exec_gate_skips_when_dirty_worktree_is_pre_existing() {
 }
 
 #[tokio::test]
+async fn post_exec_gate_skips_when_changed_paths_have_no_tracked_diff() {
+    let project_dir = tempdir().unwrap();
+    init_clean_git_repo(project_dir.path());
+    std::fs::create_dir(project_dir.path().join("just-temp")).unwrap();
+    std::fs::write(
+        project_dir.path().join("just-temp").join("stderr.log"),
+        "ice\n",
+    )
+    .unwrap();
+
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    let changed_paths = vec!["just-temp/stderr.log".to_string()];
+    let outcome = maybe_run_post_exec_gate_with_runner(
+        project_dir.path(),
+        "Run external test orchestration",
+        Some("01TESTPOSTEXECGATEARTIFACT00"),
+        Some(&config),
+        Some(&changed_paths),
+        |_command, _cwd, _timeout_seconds| {
+            Box::pin(async move {
+                panic!("runner must not execute when changed paths have no tracked diff");
+            })
+        },
+    )
+    .await
+    .expect("untracked test artifacts should skip gate");
+
+    assert_eq!(outcome, PostExecGateOutcome::Skipped);
+}
+
+#[tokio::test]
 async fn post_exec_gate_runs_when_session_introduced_changes() {
     let project_dir = tempdir().unwrap();
     init_clean_git_repo(project_dir.path());
+    std::fs::write(project_dir.path().join("tracked.txt"), "changed\n").unwrap();
 
     let calls = Arc::new(Mutex::new(Vec::new()));
     let config = project_config_with_gate(PostExecGateConfig::default());


### PR DESCRIPTION
## Summary

- Skip post-exec build gate (`just pre-commit`) when session produces no repository changes, preventing false failures from pre-existing issues (e.g., rustc ICE)
- Report success instead of `no_progress` when tool exits 0 with no diff — some tasks legitimately produce only external artifacts
- Compare current HEAD against session starting HEAD to detect agent-committed changes
- Check for untracked source files alongside `git diff`
- Extract `changed_paths` merge logic into dedicated helper functions with missing-snapshot tracking

## Closes

- Closes #1515
- Closes #1516

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p cli-sub-agent` passes
- [x] `just pre-commit` passes
- [x] Tier-4 review: PASS/CLEAN (0 findings, round 2)
- [x] New unit tests for no-edit skip logic and committed-change detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)