### PR TITLE
docs(skill): add module token budget section to prompt-crafting-guide (#1527)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.769"
+version = "0.1.770"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.769"
+version = "0.1.770"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/skills/csa/references/prompt-crafting-guide.md
+++ b/skills/csa/references/prompt-crafting-guide.md
@@ -212,6 +212,55 @@ When defining CSA-dispatched tools or writing prompts that reference tools:
 - Use semantically meaningful identifiers (not UUIDs)
 - Include 1-3 realistic usage examples for complex tools
 
+## Module Token Budget
+
+Per-file token budgets are an engineering constraint, not a style preference.
+
+### Quantitative Basis
+
+| Fact | Value | Source |
+|------|-------|--------|
+| Context rot onset | ~50K tokens (200K window) | Chroma Research 2025 |
+| Reliable utilization | 50-65% of window | Chroma Research 2025 |
+| System overhead (rules/tools/memory/skills) | 50-70K tokens | Measured |
+| 1000 lines of code | ~10,000 tokens | Wire Blog 2025 |
+| AI defect risk increase (code health < 9.0) | >= 30% | Borg & Tornhill 2025 |
+| CLAUDE.md compliance drop | > 200 lines | DEV Community 2026 |
+| AI token waste on locating vs solving | 80% on locating | Nesler 2025 |
+
+### The 8K Budget
+
+CSA enforces a per-file target of 8K tokens (pre-commit gate). Rationale:
+- 200K window - 60K overhead = 140K effective. Multi-turn tool calls halve
+  that to ~70K working context. At 8K per file, an agent can hold ~8 files
+  simultaneously with room for reasoning.
+- 8K tokens ≈ 800 lines of Rust. Aligns with CSA's existing 800-line soft
+  module limit and clippy cognitive_complexity thresholds.
+
+Files exceeding 8K tokens are blocked by pre-commit. Exempted files (test,
+generated, macro-heavy) still produce a WARNING.
+
+### Interface-First Interaction
+
+Interface documentation is 10x more token-efficient than source code.
+When interacting with modules outside your current scope:
+
+1. **First**: Use gitnexus_query/gitnexus_context or LSP to understand the API
+2. **Second**: Read doc comments and type signatures
+3. **Last resort**: Read implementation source (only when docs are insufficient)
+
+This is enforced by AGENTS.md Rule 063 (interface-first).
+
+### When to Split vs Exempt
+
+**Split when**: file has high token count AND high cognitive complexity.
+Pure data definitions (structs, enums, match tables) with low complexity
+are acceptable at higher token counts.
+
+**Exempt when**: test files (`cfg(test)`), generated code, parser combinators,
+macro definitions. These have inherently high token density but splitting
+reduces readability.
+
 ## Sources
 
 Anthropic: Claude 4 Best Practices, Context Engineering for Agents,


### PR DESCRIPTION
## Summary

- Add research-backed "Module Token Budget" section to prompt-crafting-guide.md
- Quantitative data table: context rot onset, reliable utilization, code health thresholds
- 8K per-file budget rationale and interface-first interaction pattern
- Split-vs-exempt guidelines

## Closes

- Closes #1527

## Test plan

- [x] Docs-only change
- [x] pre-commit passes
- [x] Tier-4 review: PASS (1 LOW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)