### PR TITLE
fix(sandbox): bind-mount host /tmp into codex bwrap sandbox (#1528)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.772"
+version = "0.1.773"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.772"
+version = "0.1.773"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -87,13 +87,12 @@ impl BwrapCommandBuilder {
         cmd.args(["--dev", "/dev"]);
         cmd.args(["--proc", "/proc"]);
 
-        // Writable bind mounts (after tmpfs). File paths under /tmp only need
-        // parent dirs; creating the file path as a dir breaks bwrap file binds.
+        // Bind after tmpfs. /tmp itself is an explicit host tmpdir grant.
         let tmp_prefix = Path::new("/tmp");
         for path in &self.writable_paths {
             let s = path.to_string_lossy();
             if path == tmp_prefix {
-                continue;
+                cmd.args(["--bind", &s, &s]);
             } else if path.starts_with(tmp_prefix) {
                 if let Some(parent) = path.parent()
                     && parent != tmp_prefix
@@ -752,10 +751,8 @@ mod tests {
     }
 
     #[test]
-    fn test_bwrap_bare_tmp_is_not_bind_mounted() {
-        // writable_paths = ["/tmp"] should NOT produce --bind /tmp /tmp,
-        // because --tmpfs /tmp already makes /tmp writable.  Bind-mounting
-        // host /tmp would leak host temp files into the sandbox.
+    fn test_bwrap_bare_tmp_is_bind_mounted_when_explicitly_writable() {
+        // /tmp is an explicit config grant, not a request for empty tmpfs.
         let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
         builder.with_writable_path(Path::new("/tmp"));
         let cmd = builder.build();
@@ -767,13 +764,17 @@ mod tests {
             "--tmpfs /tmp must be present; args: {args:?}"
         );
 
-        // --bind /tmp /tmp must NOT exist
-        let has_bind_tmp = args
+        let tmpfs_pos = args
+            .windows(2)
+            .position(|w| w[0] == "--tmpfs" && w[1] == "/tmp")
+            .expect("--tmpfs /tmp must be present");
+        let bind_tmp_pos = args
             .windows(3)
-            .any(|w| w[0] == "--bind" && w[1] == "/tmp" && w[2] == "/tmp");
+            .position(|w| w[0] == "--bind" && w[1] == "/tmp" && w[2] == "/tmp")
+            .expect("--bind /tmp /tmp must be present");
         assert!(
-            !has_bind_tmp,
-            "bare /tmp must NOT be --bind mounted (would expose host /tmp); args: {args:?}"
+            tmpfs_pos < bind_tmp_pos,
+            "--bind /tmp /tmp must come after --tmpfs /tmp; args: {args:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fix bwrap sandbox to properly bind-mount host /tmp into codex sessions
- Sessions can now read files created on the host in /tmp without --no-fs-sandbox
- Preserves existing security model (writable paths config respected)

## Closes

- Closes #1528

## Test plan

- [x] `cargo check` passes
- [x] Tier-4 review: PASS/CLEAN (0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)