### PR TITLE
feat(tokuin): switch to forked tokuin with conservative tokenizer (#1526)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "tokuin"
 version = "0.3.0"
-source = "git+https://github.com/nooscraft/tokuin.git#046ae29dd23fc630bdfe29b35255e0643e09c169"
+source = "git+https://github.com/RyderFreeman4Logos/tokuin.git#c68d1f804a4c172846716b7be99e9378e16512b7"
 dependencies = [
  "clap",
  "serde",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.774"
+version = "0.1.775"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.774"
+version = "0.1.775"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -79,5 +79,5 @@ sha2 = "0.10"
 glob = "0.3"
 ignore = "0.4"
 tantivy = "0.25"
-tokuin = { git = "https://github.com/nooscraft/tokuin.git", default-features = false, features = ["openai"] }
+tokuin = { git = "https://github.com/RyderFreeman4Logos/tokuin.git", default-features = false, features = ["conservative"] }
 xurl-core = { git = "https://github.com/Xuanwo/xurl.git" }

--- a/crates/cli-sub-agent/src/cli_tokuin.rs
+++ b/crates/cli-sub-agent/src/cli_tokuin.rs
@@ -29,12 +29,12 @@ pub fn handle_tokuin(cmd: TokuinCommands) -> Result<()> {
 }
 
 fn handle_estimate(file: PathBuf, model: String, json: bool) -> Result<()> {
-    use tokuin::tokenizers::{OpenAITokenizer, Tokenizer};
+    use tokuin::tokenizers::{ConservativeTokenizer, Tokenizer};
 
     let content = std::fs::read_to_string(&file)
         .with_context(|| format!("Failed to read file: {}", file.display()))?;
 
-    let tokenizer = OpenAITokenizer::new(&model)
+    let tokenizer = ConservativeTokenizer::new(&model)
         .map_err(|e| anyhow::anyhow!("Failed to create tokenizer for model '{model}': {e}"))?;
 
     let tokens = tokenizer

--- a/crates/csa-todo/src/token_estimate.rs
+++ b/crates/csa-todo/src/token_estimate.rs
@@ -2,11 +2,11 @@
 //!
 //! Two-tier strategy:
 //! - Small files (<32KB): chars / 3 heuristic (Chinese-friendly, fast)
-//! - Large files (>=32KB): precise count via tokuin's OpenAI tokenizer
+//! - Large files (>=32KB): conservative count via tokuin (max of OpenAI BPE + chars/3)
 
 use anyhow::{Context, Result};
 use std::path::Path;
-use tokuin::tokenizers::{OpenAITokenizer, Tokenizer};
+use tokuin::tokenizers::{ConservativeTokenizer, Tokenizer};
 
 /// File size threshold for switching from heuristic to precise tokenization.
 const PRECISE_THRESHOLD: u64 = 32_768;
@@ -41,9 +41,9 @@ pub fn estimate_tokens_heuristic(content: &str) -> usize {
     char_count / 3
 }
 
-/// Precise token estimate using tokuin's OpenAI BPE tokenizer.
+/// Conservative token estimate using tokuin (max of OpenAI BPE + chars/3).
 fn estimate_tokens_precise(content: &str) -> Result<usize> {
-    let tokenizer = OpenAITokenizer::new("gpt-4")
+    let tokenizer = ConservativeTokenizer::new("gpt-4o")
         .map_err(|e| anyhow::anyhow!("Failed to create tokenizer: {e}"))?;
     let count = tokenizer
         .count_tokens(content)

--- a/deny.toml
+++ b/deny.toml
@@ -66,5 +66,5 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/ZhangHanDong/agent-teams-rs.git",
     "https://github.com/Xuanwo/xurl.git",
-    "https://github.com/nooscraft/tokuin.git",
+    "https://github.com/RyderFreeman4Logos/tokuin.git",
 ]


### PR DESCRIPTION
## Summary
- Forked nooscraft/tokuin to RyderFreeman4Logos/tokuin
- Added `ConservativeTokenizer` that returns `max(OpenAI o200k_base, chars/3)` for conservative token estimation across Claude and GPT model families
- Updated CSA to use `conservative` feature flag and `ConservativeTokenizer` in both CLI and TODO token estimation
- Updated `deny.toml` to allow the fork URL

## Test plan
- [x] tokuin lib tests pass with `--features conservative` (36 tests)
- [x] CSA `cargo check` passes
- [x] `csa-todo` token estimation tests pass (7 tests)
- [x] Review PASS (session 01KSA86NJTZ8X65D9TMVQKSX7S)

Closes #1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)