### PR TITLE
feat(tokuin): pre-commit token budget gate + enhanced csa tokuin (#1518)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.775"
+version = "0.1.776"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.775"
+version = "0.1.776"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_tokuin.rs
+++ b/crates/cli-sub-agent/src/cli_tokuin.rs
@@ -5,52 +5,165 @@ use anyhow::{Context, Result};
 use clap::Subcommand;
 use std::path::PathBuf;
 
+const DEFAULT_MODEL: &str = "gpt-4o";
+
 #[derive(Subcommand)]
 pub enum TokuinCommands {
-    /// Estimate token count for a file
+    /// Estimate token count for one or more files
     Estimate {
-        /// Path to the file to estimate
-        file: PathBuf,
+        /// Paths to files to estimate
+        #[arg(required = true)]
+        files: Vec<PathBuf>,
 
-        /// Model to use for tokenization (default: gpt-4)
-        #[arg(long, default_value = "gpt-4")]
+        /// Model for OpenAI BPE tokenizer (conservative: returns max of BPE + chars/3)
+        #[arg(long, default_value = DEFAULT_MODEL)]
         model: String,
 
         /// Output as JSON
         #[arg(long)]
         json: bool,
+
+        /// Token budget threshold — exit non-zero if any file exceeds this
+        #[arg(long)]
+        budget: Option<usize>,
     },
+    /// List supported model names for the OpenAI BPE tokenizer
+    Models,
 }
 
 pub fn handle_tokuin(cmd: TokuinCommands) -> Result<()> {
     match cmd {
-        TokuinCommands::Estimate { file, model, json } => handle_estimate(file, model, json),
+        TokuinCommands::Estimate {
+            files,
+            model,
+            json,
+            budget,
+        } => handle_estimate(files, model, json, budget),
+        TokuinCommands::Models => handle_models(),
     }
 }
 
-fn handle_estimate(file: PathBuf, model: String, json: bool) -> Result<()> {
+fn resolve_model(model: &str) -> &str {
+    match model {
+        "claude" | "opus" | "sonnet" | "haiku" | "claude-4" => "gpt-4o",
+        "codex" | "gpt-5" | "gpt-5.5" => "gpt-4o",
+        other => other,
+    }
+}
+
+fn handle_estimate(
+    files: Vec<PathBuf>,
+    model: String,
+    json: bool,
+    budget: Option<usize>,
+) -> Result<()> {
     use tokuin::tokenizers::{ConservativeTokenizer, Tokenizer};
 
-    let content = std::fs::read_to_string(&file)
-        .with_context(|| format!("Failed to read file: {}", file.display()))?;
+    let resolved = resolve_model(&model);
+    let tokenizer = ConservativeTokenizer::new(resolved).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to create tokenizer for model '{model}' (resolved: '{resolved}'): {e}"
+        )
+    })?;
 
-    let tokenizer = ConservativeTokenizer::new(&model)
-        .map_err(|e| anyhow::anyhow!("Failed to create tokenizer for model '{model}': {e}"))?;
+    let mut results = Vec::new();
+    let mut exceeded = false;
 
-    let tokens = tokenizer
-        .count_tokens(&content)
-        .map_err(|e| anyhow::anyhow!("Failed to count tokens: {e}"))?;
+    for file in &files {
+        let content = std::fs::read_to_string(file)
+            .with_context(|| format!("Failed to read file: {}", file.display()))?;
+
+        let tokens = tokenizer
+            .count_tokens(&content)
+            .map_err(|e| anyhow::anyhow!("Failed to count tokens for {}: {e}", file.display()))?;
+
+        if let Some(limit) = budget
+            && tokens > limit
+        {
+            exceeded = true;
+        }
+
+        results.push((file.display().to_string(), tokens));
+    }
 
     if json {
-        let result = serde_json::json!({
-            "file": file.display().to_string(),
-            "model": model,
-            "tokens": tokens,
-        });
-        println!("{}", serde_json::to_string_pretty(&result)?);
+        if results.len() == 1 {
+            let (ref path, tokens) = results[0];
+            let obj = serde_json::json!({
+                "file": path,
+                "model": resolved,
+                "tokenizer": "conservative",
+                "tokens": tokens,
+            });
+            println!("{}", serde_json::to_string_pretty(&obj)?);
+        } else {
+            let arr: Vec<_> = results
+                .iter()
+                .map(|(path, tokens)| {
+                    serde_json::json!({
+                        "file": path,
+                        "tokens": tokens,
+                    })
+                })
+                .collect();
+            let obj = serde_json::json!({
+                "model": resolved,
+                "tokenizer": "conservative",
+                "files": arr,
+                "total": results.iter().map(|(_, t)| t).sum::<usize>(),
+            });
+            println!("{}", serde_json::to_string_pretty(&obj)?);
+        }
     } else {
-        println!("{tokens}");
+        for (path, tokens) in &results {
+            if results.len() == 1 {
+                println!("{tokens}");
+            } else {
+                let marker = budget
+                    .filter(|&limit| *tokens > limit)
+                    .map(|_| " OVER")
+                    .unwrap_or("");
+                println!("{tokens}\t{path}{marker}");
+            }
+        }
     }
+
+    if exceeded {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+fn handle_models() -> Result<()> {
+    let models = [
+        ("gpt-4o", "o200k_base", "GPT-4o / GPT-5 / GPT-5.5"),
+        ("gpt-4", "cl100k_base", "GPT-4 / GPT-4 Turbo"),
+        ("gpt-3.5-turbo", "cl100k_base", "GPT-3.5 Turbo"),
+    ];
+    let aliases = [
+        (
+            "claude / opus / sonnet / haiku",
+            "→ gpt-4o (conservative: max of BPE + chars/3)",
+        ),
+        ("codex / gpt-5 / gpt-5.5", "→ gpt-4o (o200k_base)"),
+    ];
+
+    println!("Supported models (OpenAI BPE tokenizer):");
+    println!();
+    for (name, bpe, desc) in &models {
+        println!("  {name:<20} {bpe:<16} {desc}");
+    }
+    println!();
+    println!("Aliases (resolved to closest BPE tokenizer):");
+    println!();
+    for (alias, target) in &aliases {
+        println!("  {alias:<40} {target}");
+    }
+    println!();
+    println!("Note: ConservativeTokenizer returns max(BPE count, chars/3).");
+    println!("      Claude models have ~65K vocab vs OpenAI's 200K — chars/3");
+    println!("      approximates Claude counts conservatively.");
 
     Ok(())
 }

--- a/crates/cli-sub-agent/src/executor_csa_guard.rs
+++ b/crates/cli-sub-agent/src/executor_csa_guard.rs
@@ -22,6 +22,7 @@ const EXECUTOR_SAFE_CSA_COMMAND_PREFIXES: &[&[&str]] = &[
     &["todo", "list"],
     &["todo", "find"],
     &["tokuin", "estimate"],
+    &["tokuin", "models"],
     &["config", "get"],
     &["config", "show"],
 ];
@@ -79,6 +80,9 @@ fn command_prefix(command: &Commands) -> Vec<&'static str> {
         Commands::Tokuin {
             cmd: TokuinCommands::Estimate { .. },
         } => vec!["tokuin", "estimate"],
+        Commands::Tokuin {
+            cmd: TokuinCommands::Models,
+        } => vec!["tokuin", "models"],
         Commands::Hunt(_) => vec!["hunt"],
         Commands::Arch(_) => vec!["arch"],
         Commands::Triage(_) => vec!["triage"],

--- a/justfile
+++ b/justfile
@@ -72,7 +72,7 @@ find-monolith-files:
     set -euo pipefail
     export MONOLITH_THRESHOLD_TOKENS="${MONOLITH_TOKEN_THRESHOLD:-8000}"
     export MONOLITH_THRESHOLD_LINES="${MONOLITH_LINE_THRESHOLD:-800}"
-    export MONOLITH_MODEL="${TOKUIN_MODEL:-gpt-4}"
+    export MONOLITH_MODEL="${TOKUIN_MODEL:-gpt-4o}"
 
     # Write check script to temp file (avoids export -f which fails under zsh $SHELL)
     CHECKER=$(mktemp)
@@ -84,13 +84,17 @@ find-monolith-files:
     threshold_lines="$MONOLITH_THRESHOLD_LINES"
     model="$MONOLITH_MODEL"
 
-    # --- Explicit excludes (customize per project) ---
+    exempt=false
+    # --- Explicit excludes (exempt but still warn) ---
     case "$file" in
-        *.lock|*lock.json|*lock.yaml) exit 0 ;;  # package manager locks
-        */AGENTS.md|*/FACTORY.md) exit 0 ;;        # auto-generated rule aggregation
-        */PATTERN.md|*/SKILL.md) exit 0 ;;         # workflow pattern definitions (single-purpose docs)
-        */workflow.toml) exit 0 ;;                   # weave workflow definitions
-        .test-target/*|.test-target/**) exit 0 ;;    # generated test target artifacts
+        *.lock|*lock.json|*lock.yaml) exit 0 ;;  # package manager locks (silent skip)
+        .test-target/*|.test-target/**) exit 0 ;;  # generated test artifacts (silent skip)
+        */AGENTS.md|*/FACTORY.md) exempt=true ;;
+        */PATTERN.md|*/SKILL.md) exempt=true ;;
+        */workflow.toml) exempt=true ;;
+        *_tests.rs|*_test.rs) exempt=true ;;       # dedicated test files
+        */tests/*.rs) exempt=true ;;               # integration test directory
+        */benches/*.rs) exempt=true ;;             # benchmark files
     esac
     [ -f "$file" ] || exit 0
     grep -Iq '' "$file" 2>/dev/null || exit 0  # skip binary files
@@ -112,25 +116,42 @@ find-monolith-files:
         echo "=========================================="
     }
 
+    monolith_warning() {
+        echo "WARNING: Exempt file exceeds budget ($1, limit: $2): $file"
+    }
+
     # Fast pre-filter: line count (zero-cost, no external tools)
     lines=$(wc -l < "$file" 2>/dev/null || echo 0)
     if [ "$lines" -gt "$threshold_lines" ]; then
+        if [ "$exempt" = true ]; then
+            monolith_warning "$lines lines" "$threshold_lines lines"
+            exit 0
+        fi
         monolith_error "$lines lines" "$threshold_lines lines"
         exit 1
     fi
 
-    # Accurate check: token count (requires tokuin; tolerates tokuin failures)
-    tokens=$(tokuin estimate --model "$model" --format json "$file" 2>/dev/null \
-        | jq -r '.tokens // 0' 2>/dev/null || echo 0)
+    # Conservative token count: csa tokuin estimate (max of OpenAI BPE + chars/3)
+    # Falls back to external tokuin, then to 0 (line check is the safety net)
+    tokens=$(csa tokuin estimate --model "$model" --json "$file" 2>/dev/null \
+        | jq -r '.tokens // 0' 2>/dev/null \
+        || tokuin estimate --model "$model" --format json "$file" 2>/dev/null \
+        | jq -r '.tokens // 0' 2>/dev/null \
+        || echo 0)
     [ -z "$tokens" ] && tokens=0
     if [ "$tokens" -gt "$threshold_tokens" ]; then
+        if [ "$exempt" = true ]; then
+            monolith_warning "$tokens tokens" "$threshold_tokens tokens"
+            exit 0
+        fi
         monolith_error "$tokens tokens" "$threshold_tokens tokens"
         exit 1
     fi
     SCRIPT
     chmod +x "$CHECKER"
 
-    git ls-files --recurse-submodules \
+    # Check staged files only (pre-commit scope); full-repo audit is `csa health`
+    git diff --cached --name-only --diff-filter=ACMR \
         | parallel --halt now,fail=1 "$CHECKER" {}
 
 # Fail if generated or scratch artifacts are staged for commit.


### PR DESCRIPTION
## Summary
- Pre-commit gate now checks **staged files only** (not all tracked files) against 8K token budget
- Exempt files (tests, AGENTS.md, SKILL.md, workflow.toml) produce **WARNING** instead of blocking ERROR
- Auto-detects test files (`*_tests.rs`, `tests/*.rs`, `benches/*.rs`) for exemption
- Uses `csa tokuin estimate` (ConservativeTokenizer: max of OpenAI BPE + chars/3) with external `tokuin` fallback
- Default model updated from `gpt-4` to `gpt-4o` (o200k_base)
- Multi-file support: `csa tokuin estimate file1 file2 ...` with total count
- `--budget` flag: exit non-zero if any file exceeds threshold
- Model aliases: `claude`/`opus`/`sonnet`/`codex`/`gpt-5` all resolve to `gpt-4o`
- New `csa tokuin models` subcommand listing supported models and aliases

## Test plan
- [x] `cargo check` and `just clippy` pass
- [x] `csa tokuin estimate --json Cargo.toml justfile` returns correct multi-file JSON
- [x] `csa tokuin estimate --budget 500 Cargo.toml` exits non-zero (806 > 500)
- [x] `csa tokuin models` lists supported models and aliases
- [x] `just find-monolith-files` passes on clean staging area
- [x] Review PASS (session 01KSA9HR6S8SMYCSYXM6YBQKC8)

Closes #1518

🤖 Generated with [Claude Code](https://claude.com/claude-code)