### PR TITLE
feat(review): add deslop dimension for AI-generated redundancy detection (#1523)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.778"
+version = "0.1.779"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.778"
+version = "0.1.779"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/csa-review/skills/csa-review/references/review-protocol.md
+++ b/patterns/csa-review/skills/csa-review/references/review-protocol.md
@@ -236,6 +236,27 @@ Apply these dimensions in all review passes in addition to the general checklist
 - `unknown` focus:
   - apply only the general-purpose checklist in this protocol (no framework-specific expansion)
 
+### Deslop Dimension (all languages)
+
+Detect AI-generated code redundancy patterns. Severity: LOW-MEDIUM (advisory).
+
+- **Narration comments**: comments that restate what the code does ("increment the counter",
+  "return the result") rather than explaining WHY. Well-named identifiers make these redundant.
+- **Defensive over-handling**: try/catch or error handling around infallible operations,
+  `.unwrap_or_default()` on values that are always `Some`/`Ok`.
+- **Over-nesting**: deeply nested if/match that could be flattened with early returns or
+  guard clauses. 3+ nesting levels is a signal.
+- **Redundant type annotations**: explicit types where the compiler can infer them
+  (`let x: Vec<String> = Vec::new()` → `let x = Vec::<String>::new()`).
+- **Duplicated logic**: copy-pasted blocks that should be a shared helper or extracted function.
+- **Verbose error messages**: error strings that duplicate the context already in the call stack
+  or the error type itself.
+- **Premature abstraction**: helper functions called from exactly one site, trait impls for
+  a single concrete type, generic parameters used with only one concrete type.
+
+Report deslop findings as LOW severity unless they significantly inflate module token count
+(approaching or exceeding 8K tokens), in which case use MEDIUM.
+
 ### Pass 1: Broad Issue Discovery (maximize recall)
 Scan all changed code for:
 - Correctness issues


### PR DESCRIPTION
## Summary
- Added deslop review dimension to `review-protocol.md` detecting 7 AI-generated code redundancy patterns:
  - Narration comments restating code
  - Defensive over-handling of infallible operations
  - Over-nesting (3+ levels) that could use early returns
  - Redundant type annotations where inference suffices
  - Duplicated logic that should be shared helpers
  - Verbose error messages duplicating call stack context
  - Premature abstraction (single-use helpers/traits/generics)
- LOW severity default, MEDIUM when inflating module toward 8K token budget
- Auto-loaded via existing `references/review-protocol.md` reference in workflow

## Test plan
- [x] PATTERN.md and workflow.toml already reference review-protocol.md dimensions
- [x] Review PASS (session 01KSAEP61Z501KQE2THK8CGQNC)

Closes #1523

🤖 Generated with [Claude Code](https://claude.com/claude-code)