### PR TITLE
fix(hooks): handle message values in git guard argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.780"
+version = "0.1.781"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.780"
+version = "0.1.781"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -107,18 +107,51 @@ if [ "${BLOCK_HOOKS_PATH_OVERRIDE}" = "true" ]; then
   exit 1
 fi
 
+EXPECT_COMMIT_VALUE=""
 for arg in "$@"; do
+  if [ -n "${EXPECT_COMMIT_VALUE}" ]; then
+    EXPECT_COMMIT_VALUE=""
+    continue
+  fi
+
   case "${arg}" in
     --no-verify|--no-verify=*)
       echo "BLOCKED: CSA git guard prohibits git commit --no-verify." >&2
       exit 1
       ;;
+    --)
+      break
+      ;;
+    --author|--cleanup|--date|--file|--fixup|--message|--pathspec-from-file|--reuse-message|--reedit-message|--squash|--template|--trailer)
+      EXPECT_COMMIT_VALUE="commit-option"
+      continue
+      ;;
+    --author=*|--cleanup=*|--date=*|--file=*|--fixup=*|--message=*|--pathspec-from-file=*|--reuse-message=*|--reedit-message=*|--squash=*|--template=*|--trailer=*)
+      continue
+      ;;
     --*)
       ;;
-    -?*n*|-n)
-      # Git commit uses -n as the short form of --no-verify.
-      echo "BLOCKED: CSA git guard prohibits git commit -n/short -n combinations." >&2
-      exit 1
+    -*)
+      # Git commit uses -n as the short form of --no-verify. Short options that
+      # take values consume the rest of the cluster or the next argument, so a
+      # leading dash inside that value must not be parsed as another option.
+      short_options="${arg#-}"
+      while [ -n "${short_options}" ]; do
+        short_option="${short_options:0:1}"
+        short_options="${short_options:1}"
+        case "${short_option}" in
+          n)
+            echo "BLOCKED: CSA git guard prohibits git commit -n/short -n combinations." >&2
+            exit 1
+            ;;
+          C|F|c|m|t)
+            if [ -z "${short_options}" ]; then
+              EXPECT_COMMIT_VALUE="commit-option"
+            fi
+            break
+            ;;
+        esac
+      done
       ;;
   esac
 done
@@ -393,6 +426,86 @@ mod tests {
         assert_eq!(
             String::from_utf8_lossy(&output.stdout).trim(),
             "commit --amend"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wrapper_allows_markdown_bullet_after_long_message_option() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let temp = tempfile::tempdir().unwrap();
+        let wrapper = temp.path().join("git");
+        write_executable(&wrapper, git_wrapper_script());
+
+        let fake_git = temp.path().join("real-git");
+        write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+        let output = std::process::Command::new(&wrapper)
+            .arg("commit")
+            .arg("--message")
+            .arg("fix(batch): count read failures as skipped")
+            .arg("--message")
+            .arg("- **Design Intent**: count failed reads as skipped")
+            .env("CSA_REAL_GIT", &fake_git)
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "commit --message fix(batch): count read failures as skipped --message - **Design Intent**: count failed reads as skipped"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wrapper_allows_leading_dash_after_short_message_option() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let temp = tempfile::tempdir().unwrap();
+        let wrapper = temp.path().join("git");
+        write_executable(&wrapper, git_wrapper_script());
+
+        let fake_git = temp.path().join("real-git");
+        write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+        let output = std::process::Command::new(&wrapper)
+            .arg("commit")
+            .arg("-m")
+            .arg("- leading dash is message text")
+            .env("CSA_REAL_GIT", &fake_git)
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "commit -m - leading dash is message text"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wrapper_allows_leading_dash_after_file_option() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let temp = tempfile::tempdir().unwrap();
+        let wrapper = temp.path().join("git");
+        write_executable(&wrapper, git_wrapper_script());
+
+        let fake_git = temp.path().join("real-git");
+        write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+        let output = std::process::Command::new(&wrapper)
+            .arg("commit")
+            .arg("-F")
+            .arg("-")
+            .env("CSA_REAL_GIT", &fake_git)
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "commit -F -"
         );
     }
 


### PR DESCRIPTION
## Summary
- Fix git guard false-positive that blocked `git commit --message "- markdown bullet"` by treating the leading dash as a flag
- Properly handle options that take mandatory values (`--message`, `-m`, `--author`, etc.)
- Add proper `--` end-of-options handling

Closes #1553

## Test plan
- [x] New test: `wrapper_allows_markdown_bullet_after_long_message_option`
- [x] Existing tests pass (no regression)
- [x] `just pre-commit` passes