### PR TITLE
fix(hooks): skip pre-push review gate inside CSA executor sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.781"
+version = "0.1.782"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.781"
+version = "0.1.782"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/setup_cmds.rs
+++ b/crates/cli-sub-agent/src/setup_cmds.rs
@@ -219,6 +219,14 @@ if [ "${CSA_SKIP_REVIEW_CHECK:-0}" = "1" ]; then
   exit 0
 fi
 
+# CSA-managed executors run their own review gates in the workflow. Skipping
+# here prevents pre-push from recursively spawning csa review inside csa.
+CSA_DEPTH_VALUE="${CSA_DEPTH:-0}"
+if [ -n "${CSA_SESSION_ID:-}" ] || [[ "${CSA_DEPTH_VALUE}" =~ ^[0-9]+$ && "${CSA_DEPTH_VALUE}" -gt 0 ]]; then
+  echo "pre-push: Review gate skipped inside CSA executor session; CSA workflow owns review enforcement."
+  exit 0
+fi
+
 # Skip if csa is not installed in this repo
 if ! command -v csa >/dev/null 2>&1; then
   exit 0
@@ -539,6 +547,9 @@ fn report_review_gate_status(project_root: &Path) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod review_gate_script_tests;
 
 #[cfg(test)]
 mod review_gate_tests {

--- a/crates/cli-sub-agent/src/setup_cmds/review_gate_script_tests.rs
+++ b/crates/cli-sub-agent/src/setup_cmds/review_gate_script_tests.rs
@@ -1,0 +1,152 @@
+use super::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+
+fn run_quiet(command: &mut Command) {
+    let status = command
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
+fn init_review_check_repo() -> TempDir {
+    let td = TempDir::new().unwrap();
+
+    run_quiet(Command::new("git").args(["init"]).current_dir(td.path()));
+
+    for args in [
+        ["config", "user.email", "test@example.com"],
+        ["config", "user.name", "Test User"],
+    ] {
+        run_quiet(Command::new("git").args(args).current_dir(td.path()));
+    }
+
+    fs::write(td.path().join("tracked.txt"), "content\n").unwrap();
+    run_quiet(
+        Command::new("git")
+            .args(["add", "tracked.txt"])
+            .current_dir(td.path()),
+    );
+    run_quiet(
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(td.path()),
+    );
+    run_quiet(
+        Command::new("git")
+            .args(["checkout", "-b", "feature/review-check-test"])
+            .current_dir(td.path()),
+    );
+
+    install_review_check_script(td.path()).unwrap();
+    td
+}
+
+fn install_fake_csa(project_root: &Path) -> PathBuf {
+    let bin_dir = project_root.join("fake-bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let csa_path = bin_dir.join("csa");
+    fs::write(
+        &csa_path,
+        r#"#!/usr/bin/env bash
+printf 'called\n' > "${CSA_FAKE_CALLED}"
+exit 2
+"#,
+    )
+    .unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&csa_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&csa_path, perms).unwrap();
+    }
+
+    bin_dir
+}
+
+fn run_review_check(
+    project_root: &Path,
+    fake_bin: &Path,
+    fake_called_path: &Path,
+    csa_session_id: Option<&str>,
+    csa_depth: Option<&str>,
+) -> std::process::Output {
+    let path = format!(
+        "{}:{}",
+        fake_bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let mut command = Command::new("bash");
+    command
+        .arg("scripts/hooks/review-check.sh")
+        .current_dir(project_root)
+        .env("PATH", path)
+        .env("CSA_FAKE_CALLED", fake_called_path)
+        .env_remove("CSA_SKIP_REVIEW_CHECK")
+        .env_remove("CSA_SESSION_ID")
+        .env_remove("CSA_DEPTH");
+
+    if let Some(value) = csa_session_id {
+        command.env("CSA_SESSION_ID", value);
+    }
+    if let Some(value) = csa_depth {
+        command.env("CSA_DEPTH", value);
+    }
+
+    command.output().unwrap()
+}
+
+#[test]
+fn review_check_skips_inside_csa_session_id_executor() {
+    let td = init_review_check_repo();
+    let fake_bin = install_fake_csa(td.path());
+    let fake_called = td.path().join("csa-called");
+
+    let output = run_review_check(
+        td.path(),
+        &fake_bin,
+        &fake_called,
+        Some("01TESTSESSION000000000000"),
+        None,
+    );
+
+    assert!(output.status.success());
+    assert!(!fake_called.exists(), "review-check must not invoke csa");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Review gate skipped inside CSA executor session"));
+}
+
+#[test]
+fn review_check_skips_inside_nested_csa_depth() {
+    let td = init_review_check_repo();
+    let fake_bin = install_fake_csa(td.path());
+    let fake_called = td.path().join("csa-called");
+
+    let output = run_review_check(td.path(), &fake_bin, &fake_called, None, Some("1"));
+
+    assert!(output.status.success());
+    assert!(!fake_called.exists(), "review-check must not invoke csa");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Review gate skipped inside CSA executor session"));
+}
+
+#[test]
+fn review_check_still_invokes_csa_outside_executor() {
+    let td = init_review_check_repo();
+    let fake_bin = install_fake_csa(td.path());
+    let fake_called = td.path().join("csa-called");
+
+    let output = run_review_check(td.path(), &fake_bin, &fake_called, None, None);
+
+    assert!(!output.status.success());
+    assert!(
+        fake_called.exists(),
+        "manual pre-push path must still invoke csa"
+    );
+}

--- a/scripts/hooks/review-check.sh
+++ b/scripts/hooks/review-check.sh
@@ -31,6 +31,14 @@ if [ "${CSA_SKIP_REVIEW_CHECK:-0}" = "1" ]; then
   exit 0
 fi
 
+# CSA-managed executors run their own review gates in the workflow. Skipping
+# here prevents pre-push from recursively spawning csa review inside csa.
+CSA_DEPTH_VALUE="${CSA_DEPTH:-0}"
+if [ -n "${CSA_SESSION_ID:-}" ] || [[ "${CSA_DEPTH_VALUE}" =~ ^[0-9]+$ && "${CSA_DEPTH_VALUE}" -gt 0 ]]; then
+  echo "pre-push: Review gate skipped inside CSA executor session; CSA workflow owns review enforcement."
+  exit 0
+fi
+
 # Skip if not in a csa-managed project
 if ! command -v csa >/dev/null 2>&1; then
   exit 0


### PR DESCRIPTION
## Summary
- Detect CSA executor context (`CSA_SESSION_ID` / `CSA_DEPTH > 0`) in `review-check.sh`
- Skip the review gate when running inside CSA (the pipeline manages its own review)
- Add regression tests for the bypass logic

Closes #1555

## Test plan
- [x] New tests in `review_gate_script_tests.rs`
- [x] `just pre-commit` passes