### PR TITLE
fix(mktd): skip RECON dimensions in light mode and expose step stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.782"
+version = "0.1.783"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.782"
+version = "0.1.783"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -105,6 +105,9 @@ pub(super) async fn execute_bash_step(
     if !stdout.is_empty() {
         eprint!("{stdout}");
     }
+    if !stderr_str.is_empty() {
+        eprint!("{stderr_str}");
+    }
     Ok(StepExecutionOutcome {
         exit_code: output.status.code().unwrap_or(1),
         output: stdout,
@@ -139,7 +142,7 @@ async fn spawn_bash(
         .env("CSA_INTERNAL_INVOCATION", "1")
         .current_dir(project_root)
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::piped())
         .output()
         .await
 }

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -26,6 +26,9 @@ use super::{
     substitute_vars,
 };
 
+const STEP_FAILURE_STDERR_TAIL_LINES: usize = 20;
+const STEP_FAILURE_STDERR_TAIL_MAX_CHARS: usize = 4000;
+
 #[path = "plan_cmd_step_target.rs"]
 mod step_target;
 pub(crate) use step_target::{StepTarget, resolve_step_tool, step_readonly_project_root};
@@ -459,7 +462,7 @@ pub(crate) async fn execute_step_with_workflow(
         _ => 1,
     };
 
-    let mut last_result = None;
+    let mut last_failure = None;
 
     for attempt in 1..=max_attempts {
         if attempt > 1 {
@@ -517,7 +520,7 @@ pub(crate) async fn execute_step_with_workflow(
                     exit_code: 1,
                     output: String::new(),
                     session_id: None,
-                    stderr: String::new(),
+                    stderr: format!("{err:#}"),
                 }
             }
         };
@@ -546,11 +549,19 @@ pub(crate) async fn execute_step_with_workflow(
             };
         }
 
-        last_result = Some(outcome.exit_code);
+        last_failure = Some(outcome);
     }
 
-    let exit_code = last_result.unwrap_or(1);
+    let exit_code = last_failure
+        .as_ref()
+        .map(|outcome| outcome.exit_code)
+        .unwrap_or(1);
     let duration = start.elapsed().as_secs_f64();
+    let failure_stderr = last_failure
+        .as_ref()
+        .map(|outcome| outcome.stderr.as_str())
+        .unwrap_or_default();
+    let failure_error = format_step_failure_error(exit_code, failure_stderr);
 
     // Handle on_fail
     match &step.on_fail {
@@ -566,7 +577,7 @@ pub(crate) async fn execute_step_with_workflow(
                 exit_code,
                 duration_secs: duration,
                 skipped: true,
-                error: Some(format!("Skipped after failure (exit code {exit_code})")),
+                error: Some(format!("Skipped after failure ({failure_error})")),
                 output: None,
                 session_id: None,
             }
@@ -584,7 +595,7 @@ pub(crate) async fn execute_step_with_workflow(
                 duration_secs: duration,
                 skipped: false,
                 error: Some(format!(
-                    "Delegate('{target}') not supported in v1; step failed with exit code {exit_code}"
+                    "Delegate('{target}') not supported in v1; step failed with {failure_error}"
                 )),
                 output: None,
                 session_id: None,
@@ -600,10 +611,45 @@ pub(crate) async fn execute_step_with_workflow(
                 exit_code,
                 duration_secs: duration,
                 skipped: false,
-                error: Some(format!("Exit code {exit_code}")),
+                error: Some(failure_error),
                 output: None,
                 session_id: None,
             }
         }
     }
+}
+
+fn format_step_failure_error(exit_code: i32, stderr: &str) -> String {
+    let mut error = format!("Exit code {exit_code}");
+    if let Some(stderr_tail) = stderr_tail(stderr) {
+        error.push_str(&format!(
+            "\nstderr (last {STEP_FAILURE_STDERR_TAIL_LINES} lines):\n{stderr_tail}"
+        ));
+    }
+    error
+}
+
+fn stderr_tail(stderr: &str) -> Option<String> {
+    let mut lines = stderr
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .rev()
+        .take(STEP_FAILURE_STDERR_TAIL_LINES)
+        .collect::<Vec<_>>();
+    if lines.is_empty() {
+        return None;
+    }
+    lines.reverse();
+    let mut tail = lines.join("\n");
+    if tail.len() > STEP_FAILURE_STDERR_TAIL_MAX_CHARS {
+        let keep_from = tail
+            .char_indices()
+            .rev()
+            .find_map(|(idx, _)| {
+                (tail.len() - idx <= STEP_FAILURE_STDERR_TAIL_MAX_CHARS).then_some(idx)
+            })
+            .unwrap_or(0);
+        tail = format!("...{}", &tail[keep_from..]);
+    }
+    Some(tail)
 }

--- a/crates/cli-sub-agent/src/plan_cmd_tests_step_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_step_failure.rs
@@ -1,0 +1,44 @@
+use super::super::*;
+use std::collections::HashMap;
+use weave::compiler::{FailAction, PlanStep};
+
+#[tokio::test]
+async fn execute_step_failure_reports_stderr_tail() {
+    let step = PlanStep {
+        id: 1,
+        title: "stderr failure".into(),
+        tool: Some("bash".into()),
+        prompt:
+            "```bash\nfor i in $(seq 1 25); do printf 'err-%02d\\n' \"$i\" >&2; done\nexit 1\n```"
+                .into(),
+        tier: None,
+        depends_on: vec![],
+        on_fail: FailAction::Abort,
+        condition: None,
+        loop_var: None,
+        session: None,
+        workspace_access: None,
+    };
+    let vars = HashMap::new();
+    let tmp = tempfile::tempdir().unwrap();
+    let result = execute_step(&step, &vars, tmp.path(), None, None, None).await;
+
+    assert_eq!(result.exit_code, 1);
+    let error = result.error.as_deref().unwrap_or_default();
+    assert!(
+        error.contains("Exit code 1"),
+        "failure summary must keep exit code: {error}"
+    );
+    assert!(
+        error.contains("stderr (last 20 lines):"),
+        "failure summary must label stderr tail: {error}"
+    );
+    assert!(
+        error.contains("err-25"),
+        "failure summary must include final stderr line: {error}"
+    );
+    assert!(
+        !error.contains("err-01"),
+        "failure summary must keep only the stderr tail: {error}"
+    );
+}

--- a/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
@@ -5,6 +5,9 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use weave::compiler::{FailAction, PlanStep, VariableDecl, plan_from_toml};
 
+#[path = "plan_cmd_tests_step_failure.rs"]
+mod tests_step_failure;
+
 #[tokio::test]
 async fn execute_step_skips_when_condition_is_false() {
     let step = PlanStep {

--- a/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
@@ -55,6 +55,36 @@ fn dev2merge_workflow_marks_mktsk_step_manual() {
 }
 
 #[test]
+fn mktd_light_mode_skips_recon_dimensions() {
+    let workflow_path = workspace_root().join("patterns/mktd/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+
+    for step_id in 3..=6 {
+        let step = plan
+            .steps
+            .iter()
+            .find(|step| step.id == step_id)
+            .unwrap_or_else(|| panic!("missing mktd RECON step {step_id}"));
+        assert_eq!(
+            step.condition.as_deref(),
+            Some("!(${INTENSITY_IS_LIGHT})"),
+            "mktd light mode must skip RECON step {step_id}"
+        );
+    }
+
+    let pattern = std::fs::read_to_string(workspace_root().join("patterns/mktd/PATTERN.md"))
+        .expect("read mktd pattern");
+    assert_eq!(
+        pattern
+            .matches("Condition: !(${INTENSITY_IS_LIGHT})")
+            .count(),
+        4,
+        "PATTERN.md must stay synced with workflow RECON conditions"
+    );
+}
+
+#[test]
 fn pr_bot_debate_audit_reads_step12_output_and_prompt_has_comment_context() {
     let workflow_path = workspace_root().join("patterns/pr-bot/workflow.toml");
     let workflow = std::fs::read_to_string(&workflow_path).unwrap();

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -177,6 +177,7 @@ echo "Chinese (Simplified)"
 ## Step 2: Phase 1 — RECON Dimension 1 (Structure)
 
 Tool: csa
+Condition: !(${INTENSITY_IS_LIGHT})
 Session: ${STEP_1_OUTPUT}
 Tier: ${RECON_TIER}
 Workspace Access: read-only
@@ -194,6 +195,7 @@ Working directory: ${CWD}
 ## Step 3: Phase 1 — RECON Dimension 2 (Patterns)
 
 Tool: csa
+Condition: !(${INTENSITY_IS_LIGHT})
 Session: ${STEP_1_OUTPUT}
 Tier: ${RECON_TIER}
 Workspace Access: read-only
@@ -211,6 +213,7 @@ Working directory: ${CWD}
 ## Step 4: Phase 1 — RECON Dimension 3 (Constraints)
 
 Tool: csa
+Condition: !(${INTENSITY_IS_LIGHT})
 Session: ${STEP_1_OUTPUT}
 Tier: ${RECON_TIER}
 Workspace Access: read-only
@@ -228,6 +231,7 @@ Working directory: ${CWD}
 ## Step 4a: Phase 1 — RECON Dimension 4 (Semantic Invariants)
 
 Tool: csa
+Condition: !(${INTENSITY_IS_LIGHT})
 Session: ${STEP_1_OUTPUT}
 Tier: ${RECON_TIER}
 Workspace Access: read-only

--- a/patterns/mktd/skills/mktd/SKILL.md
+++ b/patterns/mktd/skills/mktd/SKILL.md
@@ -39,7 +39,7 @@ Generate a structured TODO plan for a feature through five phases: parallel CSA 
 | Mode | Phases | Use Case |
 |------|--------|----------|
 | `full` | All phases including threat model + debate | Default: significant changes |
-| `light` | RECON → DRAFT → SPEC → SAVE → APPROVE (skips threat model, debate, revision) | Small changes (≤2 code files, <50 insertions) |
+| `light` | DRAFT → SPEC → SAVE → APPROVE (skips RECON, threat model, debate, revision) | Small changes (≤2 code files, <50 insertions) |
 
 Pass via `--var INTENSITY=light` when invoking the workflow. dev2merge auto-selects based on change size.
 
@@ -68,7 +68,7 @@ breaks prompt-guard propagation.
 
 ### Step-by-Step
 
-1. **Phase 1 -- RECON** (4 parallel CSA calls, tier-1):
+1. **Phase 1 -- RECON** *(skipped in light mode)* (4 parallel CSA calls, tier-1):
    - RECON CSA calls are read-only by contract: workflow steps MUST set `workspace_access = "read-only"`, which plan execution maps to a read-only project-root sandbox, and each RECON prompt MUST explicitly prohibit file edits or git-state writes.
    - **Dimension 1 (Structure)**: Analyze codebase structure relevant to the feature (files, types, dependencies, entry points).
    - **Dimension 2 (Patterns)**: Find existing similar features or reusable components.
@@ -82,7 +82,7 @@ breaks prompt-guard propagation.
    - No cross-crate dependency analysis needed
    This avoids the cold-start cost (~10K+ tokens per RECON session) for trivial changes. The orchestrator documents skipped RECON in the TODO draft with: `RECON: skipped (small task, context sufficient)`.
 2. **Phase 1.5 -- LANGUAGE DETECTION**: Resolve language by priority: `${USER_LANGUAGE}` override -> `${CSA_USER_LANGUAGE}` env -> script-aware detect from `${FEATURE}` -> default Chinese (Simplified) when script is mixed/unknown -> fallback Chinese (Simplified) when `${FEATURE}` is empty. This language is captured as `${STEP_2_OUTPUT}`.
-3. **Phase 2 -- DRAFT**: Synthesize CSA findings into a structured TODO plan with checkbox items, executor tags ([Main], [Sub:developer], [Skill:commit], [CSA:tool]), and descriptions in `${STEP_2_OUTPUT}`. Every task MUST include a mechanically verifiable `DONE WHEN:` line. Technical terms, code snippets, commit scope strings, and executor tags remain in English.
+3. **Phase 2 -- DRAFT**: Synthesize CSA findings into a structured TODO plan with checkbox items, executor tags ([Main], [Sub:developer], [Skill:commit], [CSA:tool]), and descriptions in `${STEP_2_OUTPUT}`. In light mode, RECON findings are intentionally empty and the draft uses the supplied feature brief plus already-available context. Every task MUST include a mechanically verifiable `DONE WHEN:` line. Technical terms, code snippets, commit scope strings, and executor tags remain in English.
 4. **Phase 2.5 -- THREAT MODEL** *(skipped in light mode)*: Review each new API surface for security concerns (sensitive data flows, hostile input, information exposure, safe defaults), plus concurrency-specific failure modes: concurrent writers, TOCTOU / rollback / cleanup races, state-machine invariants under concurrent transitions, and file-write atomicity. If the task is a default-change task (changes a default value, default transport, default tool, default feature gate, or default config field), emit an `existing-config x upgrade-path` matrix covering legitimate pre-change user states, pre-change behavior, post-change behavior, and whether a gap exists. Each matrix row with `Gap = Yes` MUST be tagged `[Security]` or `[Compat]` and added as a Phase-2.5-generated TODO item. Non-default-change tasks skip the matrix.
 5. **Phase 3 -- DEBATE** *(skipped in light mode)*: Run explicit `csa debate` (uses global `[debate]` config) via bash step, then normalize stdout into an evidence packet with headers: `DEBATE_EVIDENCE`, `VALID_CONCERNS`, `SUGGESTED_CHANGES`, `OVERALL_ASSESSMENT`. The red-team MUST enumerate every TODO-plan assumption and construct a counterexample scenario for each.
 6. **Phase 3.5 -- DEBATE VALIDATION** *(skipped in light mode)*: Hard-fail if required evidence headers, mapped verdict (`READY|REVISE`), raw verdict (`APPROVE|REVISE|REJECT|UNKNOWN`), or confidence are missing.

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -245,6 +245,7 @@ on_fail = "abort"
 id = 3
 title = "Phase 1 — RECON Dimension 1 (Structure)"
 tool = "csa"
+condition = "!(${INTENSITY_IS_LIGHT})"
 workspace_access = "read-only"
 prompt = """
 Analyze codebase structure relevant to ${FEATURE}.
@@ -265,6 +266,7 @@ session = "${STEP_1_OUTPUT}"
 id = 4
 title = "Phase 1 — RECON Dimension 2 (Patterns)"
 tool = "csa"
+condition = "!(${INTENSITY_IS_LIGHT})"
 workspace_access = "read-only"
 prompt = """
 Find existing patterns or similar features to ${FEATURE} in this codebase.
@@ -284,6 +286,7 @@ session = "${STEP_1_OUTPUT}"
 id = 5
 title = "Phase 1 — RECON Dimension 3 (Constraints)"
 tool = "csa"
+condition = "!(${INTENSITY_IS_LIGHT})"
 workspace_access = "read-only"
 prompt = """
 Identify constraints and risks for implementing ${FEATURE}.
@@ -303,6 +306,7 @@ session = "${STEP_1_OUTPUT}"
 id = 6
 title = "Phase 1 — RECON Dimension 4 (Semantic Invariants)"
 tool = "csa"
+condition = "!(${INTENSITY_IS_LIGHT})"
 workspace_access = "read-only"
 prompt = """
 Identify the semantic invariants and concurrency assumptions for ${FEATURE}.


### PR DESCRIPTION
## Summary
- Add `when` conditions to skip RECON Dimension 1-4 steps in light mode
- Expose last N lines of stderr when a weave step fails
- Add tests for step skip conditions and stderr tail capture

Closes #1554

## Test plan
- [x] New tests in `plan_cmd_tests_step_failure.rs` and `plan_cmd_tests_workflows.rs`
- [x] `just pre-commit` passes