### PR TITLE
fix(session): align exit codes with structured verdict artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.785"
+version = "0.1.786"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.785"
+version = "0.1.786"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
@@ -165,7 +165,7 @@ fn debate_pre_session_all_fail_yields_unavailable() {
     )
     .expect("pre-session all-fail should synthesize unavailable");
 
-    assert_eq!(finalized.exit_code, 1);
+    assert_eq!(finalized.exit_code, 2);
     let rendered_json: serde_json::Value =
         serde_json::from_str(&finalized.rendered_output).expect("json output");
     assert_eq!(rendered_json["verdict"], "UNAVAILABLE");
@@ -234,7 +234,7 @@ fn debate_nonzero_with_explicit_verdict_is_reclassified_success() {
     .unwrap();
 
     let output = r#"<!-- CSA:SECTION:summary -->
-Verdict: stop and ask the user before retrying.
+Verdict: APPROVE
 <!-- CSA:SECTION:summary:END -->
 "#;
     let finalized = debate_cmd::finalize_debate_outcome(
@@ -271,4 +271,77 @@ Verdict: stop and ask the user before retrying.
         .expect("saved result");
     assert_eq!(saved.status, "success");
     assert_eq!(saved.exit_code, 0);
+}
+
+#[test]
+fn debate_nonzero_with_revise_artifact_exits_failure() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let _env_lock = test_env_lock::TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = DebateExactEnvVarGuard::set("HOME", temp.path());
+    let _state_guard = DebateExactEnvVarGuard::set("XDG_STATE_HOME", &state_home);
+
+    let project_root = temp.path();
+    let session = create_session(project_root, Some("debate"), None, Some("codex")).unwrap();
+    save_result(
+        project_root,
+        &session.meta_session_id,
+        &csa_session::SessionResult {
+            status: "failure".to_string(),
+            exit_code: 1,
+            summary: "tool exited non-zero".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: chrono::Utc::now(),
+            completed_at: chrono::Utc::now(),
+            events_count: 0,
+            artifacts: Vec::new(),
+            peak_memory_mb: None,
+            fallback_chain: None,
+            manager_fields: Default::default(),
+        },
+    )
+    .unwrap();
+
+    let output = r#"<!-- CSA:SECTION:summary -->
+Verdict: REVISE
+<!-- CSA:SECTION:summary:END -->
+"#;
+    let finalized = debate_cmd::finalize_debate_outcome(
+        project_root,
+        csa_core::types::OutputFormat::Text,
+        Some(pipeline::SessionExecutionResult {
+            execution: csa_process::ExecutionResult {
+                output: output.to_string(),
+                stderr_output: String::new(),
+                summary: "debate verdict produced".to_string(),
+                exit_code: 1,
+                peak_memory_mb: None,
+            },
+            meta_session_id: session.meta_session_id.clone(),
+            provider_session_id: None,
+            changed_paths: None,
+        }),
+        debate_cmd::DebateFinalizeContext {
+            all_tier_models_failed: false,
+            resolved_tier_name: None,
+            failures: &[],
+            debate_mode: debate_cmd::DebateMode::Heterogeneous,
+            output_header: None,
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+        },
+    )
+    .expect("revise verdict should finalize");
+
+    assert_eq!(finalized.exit_code, 1);
+    let saved = csa_session::load_result(project_root, &session.meta_session_id)
+        .unwrap()
+        .expect("saved result");
+    assert_eq!(saved.status, "failure");
+    assert_eq!(saved.exit_code, 1);
 }

--- a/crates/cli-sub-agent/src/debate_cmd_finalize.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_finalize.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{fs, path::Path};
 
 use anyhow::Result;
 use csa_core::types::{OutputFormat, ToolName};
@@ -6,8 +6,8 @@ use tracing::warn;
 
 use super::{DebateMode, render_debate_cli_output};
 use crate::debate_cmd_output::{
-    DebateOutputHeader, DebateSummary, append_debate_artifacts_to_result, extract_debate_summary,
-    persist_debate_output_artifacts, render_debate_output,
+    DebateOutputHeader, DebateSummary, DebateVerdict, append_debate_artifacts_to_result,
+    extract_debate_summary, persist_debate_output_artifacts, render_debate_output,
 };
 use crate::tier_model_fallback::{
     TierAttemptFailure, format_all_models_failed_reason, persist_fallback_result_fields,
@@ -56,7 +56,7 @@ pub(crate) fn finalize_debate_outcome(
     execution: Option<crate::pipeline::SessionExecutionResult>,
     context: DebateFinalizeContext<'_>,
 ) -> Result<FinalizedDebateOutcome> {
-    let (exit_code, meta_session_id, persisted_session_id, output, debate_summary) =
+    let (_exit_code, meta_session_id, persisted_session_id, output, debate_summary) =
         match (context.all_tier_models_failed, execution) {
             (true, Some(execution)) => {
                 let persisted_session_id = resolve_persisted_debate_session_id(
@@ -134,11 +134,17 @@ pub(crate) fn finalize_debate_outcome(
             (false, None) => unreachable!("debate tier candidate list is never empty"),
         };
 
-    if let Some(session_id) = persisted_session_id.as_deref() {
+    let final_exit_code = if let Some(session_id) = persisted_session_id.as_deref() {
         let session_dir = csa_session::get_session_dir(project_root, session_id)?;
         let artifacts = persist_debate_output_artifacts(&session_dir, &debate_summary, &output)?;
+        let artifact_exit_code = persisted_debate_verdict_exit_code(&session_dir);
         append_debate_artifacts_to_result(project_root, session_id, &artifacts, &debate_summary)?;
-        persist_debate_exit_code(project_root, session_id, exit_code, &debate_summary.summary)?;
+        persist_debate_exit_code(
+            project_root,
+            session_id,
+            artifact_exit_code,
+            &debate_summary.summary,
+        )?;
         if let (Some(original_tool), Some(fallback_tool)) =
             (context.original_tool, context.fallback_tool)
         {
@@ -150,7 +156,10 @@ pub(crate) fn finalize_debate_outcome(
                 context.fallback_reason,
             );
         }
-    }
+        artifact_exit_code
+    } else {
+        crate::verdict_exit_code::INFRASTRUCTURE_FAILURE_EXIT_CODE
+    };
 
     let rendered_output = render_debate_cli_output(
         output_format,
@@ -160,9 +169,40 @@ pub(crate) fn finalize_debate_outcome(
         context.output_header,
     )?;
     Ok(FinalizedDebateOutcome {
-        exit_code,
+        exit_code: final_exit_code,
         rendered_output,
     })
+}
+
+fn persisted_debate_verdict_exit_code(session_dir: &Path) -> i32 {
+    let verdict_path = session_dir.join("output").join("debate-verdict.json");
+    let raw = match fs::read_to_string(&verdict_path) {
+        Ok(raw) => raw,
+        Err(error) => {
+            warn!(
+                path = %verdict_path.display(),
+                error = %error,
+                "Missing or unreadable debate verdict artifact; treating as infrastructure failure"
+            );
+            return crate::verdict_exit_code::INFRASTRUCTURE_FAILURE_EXIT_CODE;
+        }
+    };
+    let artifact = match serde_json::from_str::<DebateVerdict>(&raw) {
+        Ok(artifact) => artifact,
+        Err(error) => {
+            warn!(
+                path = %verdict_path.display(),
+                error = %error,
+                "Invalid debate verdict artifact; treating as infrastructure failure"
+            );
+            return crate::verdict_exit_code::INFRASTRUCTURE_FAILURE_EXIT_CODE;
+        }
+    };
+
+    crate::verdict_exit_code::exit_code_from_debate_verdict(
+        artifact.verdict.as_str(),
+        artifact.decision.as_deref(),
+    )
 }
 
 fn output_has_explicit_debate_verdict(output: &str) -> bool {

--- a/crates/cli-sub-agent/src/debate_cmd_output.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_output.rs
@@ -5,18 +5,18 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use chrono::Utc;
 use csa_session::SessionArtifact;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::debate_cmd::DebateMode;
 
 const DEBATE_VERDICT_REL_PATH: &str = "output/debate-verdict.json";
 const DEBATE_TRANSCRIPT_REL_PATH: &str = "output/debate-transcript.md";
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub(crate) struct DebateVerdict {
-    verdict: String,
+    pub(crate) verdict: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    decision: Option<String>,
+    pub(crate) decision: Option<String>,
     confidence: String,
     summary: String,
     key_points: Vec<String>,

--- a/crates/cli-sub-agent/src/debate_cmd_round4_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_round4_tests.rs
@@ -254,7 +254,7 @@ fn debate_pre_session_all_fail_yields_unavailable() {
     )
     .expect("pre-session all-fail should synthesize unavailable");
 
-    assert_eq!(finalized.exit_code, 1);
+    assert_eq!(finalized.exit_code, 2);
     let rendered_json: serde_json::Value =
         serde_json::from_str(&finalized.rendered_output).expect("json output");
     assert_eq!(rendered_json["verdict"], "UNAVAILABLE");

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -107,6 +107,7 @@ mod todo_errors_cmd;
 mod todo_ref_cmd;
 mod tool_version;
 mod triage_cmd;
+mod verdict_exit_code;
 #[cfg(test)]
 include!("review_cmd_exact_tests.rs");
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_commit.rs
@@ -376,6 +376,29 @@ fn commit_workflow_followup_step_hints_match_renumbered_pattern() {
     }
 }
 
+#[test]
+fn commit_workflow_step20_requires_head_to_change_after_git_commit() {
+    let commit_pattern =
+        std::fs::read_to_string(workspace_root().join("patterns/commit/PATTERN.md")).unwrap();
+    let commit_workflow =
+        std::fs::read_to_string(workspace_root().join("patterns/commit/workflow.toml")).unwrap();
+
+    for content in [&commit_pattern, &commit_workflow] {
+        assert!(
+            content.contains("HEAD_BEFORE_COMMIT=\"$(git rev-parse HEAD)\""),
+            "commit step must record HEAD before git commit"
+        );
+        assert!(
+            content.contains("HEAD_AFTER_COMMIT=\"$(git rev-parse HEAD)\""),
+            "commit step must record HEAD after git commit"
+        );
+        assert!(
+            content.contains("git commit reported success but HEAD did not change"),
+            "commit step must fail if hooks or commit plumbing leave HEAD unchanged"
+        );
+    }
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn commit_workflow_test_gate_aborts_before_following_steps() {

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -24,7 +24,7 @@ use csa_session::state::ReviewSessionMeta;
 use tracing::{debug, error, warn};
 #[path = "review_cmd_output.rs"]
 mod output;
-use output::is_worktree_submodule;
+use output::{is_worktree_submodule, persist_review_result_exit_code};
 #[path = "review_cmd_bug_class.rs"]
 mod bug_class_pipeline;
 #[path = "review_cmd_check_verdict.rs"]
@@ -371,11 +371,15 @@ pub(crate) async fn handle_review(args: ReviewArgs, current_depth: u32) -> Resul
             timestamp: chrono::Utc::now(),
             diff_fingerprint,
         };
-        persist_review_sidecars_if_session_exists(
+        let persisted_verdict_exit_code = persist_review_sidecars_if_session_exists(
             &project_root,
             &review_meta,
             result.persistable_session_id.as_deref(),
         );
+        let effective_exit_code = persisted_verdict_exit_code.unwrap_or(effective_exit_code);
+        if let Some(session_id) = result.persistable_session_id.as_deref() {
+            persist_review_result_exit_code(&project_root, session_id, effective_exit_code);
+        }
         if verdict != CLEAN {
             dirty_tree::maybe_emit_dirty_tree_hint(
                 &project_root,

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -249,6 +249,34 @@ fn persist_verdict_refreshes_on_fix_reuse_session() {
     assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&0));
 }
 
+#[test]
+fn persist_review_sidecars_returns_fail_exit_for_has_issues_artifact() {
+    let project_dir = exact_test_setup_git_repo();
+    let _state_home = test_env_lock::ScopedTestEnvVar::set(
+        "XDG_STATE_HOME",
+        project_dir.path().join("state"),
+    );
+    let session_id = "01TESTVERDICTFAIL000000000";
+    let session_dir = csa_session::get_session_dir(project_dir.path(), session_id)
+        .expect("resolve session dir");
+    std::fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
+    let mut meta = exact_test_make_review_meta(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    meta.status_reason = Some("test_blocking_verdict".to_string());
+
+    let persisted_exit_code = review_cmd::persist_review_sidecars_if_session_exists(
+        project_dir.path(),
+        &meta,
+        Some(session_id),
+    );
+
+    assert_eq!(persisted_exit_code, Some(1));
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: csa_session::ReviewVerdictArtifact =
+        serde_json::from_str(&std::fs::read_to_string(&verdict_path).unwrap()).unwrap();
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn execute_review_marks_unavailable_when_all_tier_models_fail() {
@@ -435,11 +463,12 @@ async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metad
     if verdict_path.exists() {
         std::fs::remove_file(&verdict_path).unwrap();
     }
-    review_cmd::persist_review_sidecars_if_session_exists(
+    let persisted_exit_code = review_cmd::persist_review_sidecars_if_session_exists(
         project_dir.path(),
         &meta,
         result.persistable_session_id.as_deref(),
     );
+    assert_eq!(persisted_exit_code, Some(0));
     let artifact: csa_session::ReviewVerdictArtifact =
         serde_json::from_str(&std::fs::read_to_string(&verdict_path).unwrap()).unwrap();
     assert_eq!(artifact.routed_to, result.routed_to);
@@ -488,11 +517,9 @@ async fn execute_review_unavailable_does_not_persist_session_artifacts() {
         timestamp: chrono::Utc::now(),
         diff_fingerprint: None,
     };
-    review_cmd::persist_review_sidecars_if_session_exists(
-        project_dir.path(),
-        &meta,
-        None,
-    );
+    let persisted_exit_code =
+        review_cmd::persist_review_sidecars_if_session_exists(project_dir.path(), &meta, None);
+    assert_eq!(persisted_exit_code, None);
 
     let unknown_output = csa_session::get_session_root(project_dir.path())
         .unwrap()

--- a/crates/cli-sub-agent/src/review_cmd_flow.rs
+++ b/crates/cli-sub-agent/src/review_cmd_flow.rs
@@ -4,7 +4,9 @@ use csa_session::state::ReviewSessionMeta;
 #[cfg(test)]
 use super::execute;
 use super::findings_toml::persist_review_findings_toml;
-use super::output::{persist_review_meta, persist_review_verdict};
+use super::output::{
+    persist_review_meta, persist_review_verdict, persisted_review_verdict_exit_code,
+};
 #[cfg(test)]
 use crate::review_routing::ReviewRoutingMetadata;
 #[cfg(test)]
@@ -32,15 +34,17 @@ pub(crate) fn persist_review_sidecars_if_session_exists(
     project_root: &std::path::Path,
     meta: &ReviewSessionMeta,
     persistable_session_id: Option<&str>,
-) {
-    if persistable_session_id.is_none() {
-        return;
-    }
+) -> Option<i32> {
+    let persistable_session_id = persistable_session_id?;
 
     persist_review_meta(project_root, meta);
     persist_review_findings_toml(project_root, meta);
     persist_review_verdict(project_root, meta, &[], Vec::new());
     crate::review_gate::maybe_write_gate_marker_from_meta(project_root, meta);
+    Some(persisted_review_verdict_exit_code(
+        project_root,
+        persistable_session_id,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -1,6 +1,5 @@
-use std::fs;
 use std::path::Path;
-use std::str::FromStr;
+use std::{fs, str::FromStr};
 
 use anyhow::Result;
 use csa_core::gemini::RATE_LIMIT_PATTERNS;
@@ -11,8 +10,6 @@ use csa_executor::{
 use csa_session::output_parser::parse_sections;
 use csa_session::state::{ReviewSessionMeta, write_review_meta};
 use csa_session::{Finding, OutputSection, ReviewVerdictArtifact, Severity, write_review_verdict};
-use regex::Regex;
-use serde::Deserialize;
 use tracing::{debug, warn};
 
 #[path = "review_cmd_output_artifacts.rs"]
@@ -21,20 +18,28 @@ mod artifacts;
 mod clean_detection;
 #[path = "review_cmd_output_diagnostics.rs"]
 mod diagnostics;
+#[path = "review_cmd_output_exit.rs"]
+mod exit_code;
 #[path = "review_cmd_output_summary.rs"]
 mod summary_artifact;
+#[path = "review_cmd_output_text.rs"]
+mod text;
 use artifacts::{
     has_blocking_severity, json_severity_counts_if_present, load_findings_toml_from_output,
     load_review_artifact_from_output, severity_counts_are_zero, severity_counts_for_artifact,
     severity_counts_for_findings_toml,
 };
-use clean_detection::{
-    contains_clean_phrase, review_contains_prose_clean_conclusion, strip_prompt_guards,
-};
+use clean_detection::{review_contains_prose_clean_conclusion, strip_prompt_guards};
 pub(crate) use diagnostics::detect_tool_diagnostic;
 pub(super) use diagnostics::{ReviewerOutcome, print_reviewer_outcomes};
+pub(super) use exit_code::{persist_review_result_exit_code, persisted_review_verdict_exit_code};
 pub(super) use summary_artifact::{
     ensure_review_summary_artifact, is_edit_restriction_summary, truncate_review_result_summary,
+};
+pub(super) use text::extract_review_text;
+use text::{
+    derive_decision_from_text, parse_overall_risk_from_text, severity_counts_from_text,
+    zero_severity_counts,
 };
 
 const REVIEW_RESULT_SUMMARY_MAX_CHARS: usize = 200;
@@ -60,24 +65,6 @@ impl ToolReviewFailureKind {
             }
         }
     }
-}
-
-#[derive(Debug, Deserialize)]
-struct TranscriptEvent {
-    #[serde(rename = "type")]
-    event_type: String,
-    #[serde(default)]
-    item: Option<TranscriptItem>,
-    #[serde(default)]
-    result: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct TranscriptItem {
-    #[serde(rename = "type")]
-    item_type: String,
-    #[serde(default)]
-    text: Option<String>,
 }
 
 /// Prefer structured review sections (summary/details) when available to avoid
@@ -258,7 +245,6 @@ pub(super) fn persist_review_verdict(
         }
     }
 }
-
 #[cfg(test)]
 pub(crate) fn persist_review_verdict_for_tests(
     project_root: &Path,
@@ -464,106 +450,6 @@ fn full_output_is_effectively_empty(session_dir: &Path) -> Result<bool, anyhow::
         .all(|line| line.starts_with('{')))
 }
 
-pub(super) fn extract_review_text(raw_output: &str) -> Option<String> {
-    let mut transcript_messages = Vec::new();
-    let mut saw_json_line = false;
-
-    for line in raw_output.lines().filter(|line| !line.trim().is_empty()) {
-        let event = match serde_json::from_str::<TranscriptEvent>(line) {
-            Ok(event) => {
-                saw_json_line = true;
-                event
-            }
-            Err(_) if !saw_json_line => continue,
-            Err(_) => return Some(raw_output.to_string()),
-        };
-        if event.event_type == "result" {
-            if let Some(text) = event.result.filter(|text| looks_like_review_message(text)) {
-                transcript_messages.push(text);
-            }
-            continue;
-        }
-
-        let Some(item) = event.item else {
-            continue;
-        };
-        if event.event_type == "item.completed"
-            && item.item_type == "agent_message"
-            && let Some(text) = item.text.filter(|text| looks_like_review_message(text))
-        {
-            transcript_messages.push(text);
-        }
-    }
-
-    if transcript_messages.is_empty() {
-        return if saw_json_line {
-            None
-        } else {
-            Some(raw_output.to_string())
-        };
-    }
-
-    transcript_messages.pop()
-}
-
-fn looks_like_review_message(text: &str) -> bool {
-    has_structured_review_content(text)
-        || contains_verdict_token(text, "PASS")
-        || contains_verdict_token(text, "CLEAN")
-        || contains_verdict_token(text, "FAIL")
-        || contains_verdict_token(text, "HAS_ISSUES")
-        || contains_verdict_token(text, "UNAVAILABLE")
-        || contains_verdict_token(text, "UNCERTAIN")
-        || contains_clean_phrase(text)
-        || text.lines().any(|line| {
-            is_findings_header(line) || line.to_ascii_lowercase().contains("overall risk")
-        })
-}
-
-fn zero_severity_counts() -> std::collections::BTreeMap<Severity, u32> {
-    [
-        (Severity::Critical, 0),
-        (Severity::High, 0),
-        (Severity::Medium, 0),
-        (Severity::Low, 0),
-    ]
-    .into_iter()
-    .collect()
-}
-
-fn severity_counts_from_text(text: &str) -> std::collections::BTreeMap<Severity, u32> {
-    let marker_re =
-        Regex::new(r"(?i)\[(critical|high|medium|low|info|p[0-4])\]").expect("valid regex");
-    let mut counts = zero_severity_counts();
-
-    for captures in marker_re.captures_iter(text) {
-        let severity = match captures.get(1).map(|m| m.as_str().to_ascii_lowercase()) {
-            Some(level) if level == "critical" => Severity::Critical,
-            Some(level) if level == "high" => Severity::High,
-            Some(level) if level == "medium" => Severity::Medium,
-            Some(level) if level == "low" => Severity::Low,
-            Some(level) if level == "info" => Severity::Low,
-            Some(level) if level == "p0" => Severity::Critical,
-            Some(level) if level == "p1" => Severity::High,
-            Some(level) if level == "p2" => Severity::Medium,
-            Some(level) if level == "p3" || level == "p4" => Severity::Low,
-            _ => continue,
-        };
-        *counts.entry(severity).or_insert(0) += 1;
-    }
-
-    counts
-}
-
-fn parse_overall_risk_from_text(text: &str) -> Option<String> {
-    let risk_re = Regex::new(r"(?im)\boverall risk\b\s*:?\s*(critical|high|medium|low)\b")
-        .expect("valid regex");
-    risk_re
-        .captures(text)
-        .and_then(|captures| captures.get(1))
-        .map(|level| level.as_str().to_ascii_lowercase())
-}
-
 /// Derive the review decision from structured severity counts, not summary-text
 /// keywords or stale `meta.decision` values (#1045).
 /// Blocking severities fail; low-only findings pass; zero findings and zero
@@ -635,48 +521,6 @@ fn derive_decision_from_severity_counts(
     }
 
     Ok(ReviewDecision::Pass)
-}
-
-fn derive_decision_from_text(
-    text: &str,
-    counts: &std::collections::BTreeMap<Severity, u32>,
-    overall_risk: Option<&str>,
-) -> ReviewDecision {
-    // Only blocking severities (critical/high/medium) cause fail; low-only is advisory (#1048 M2).
-    if has_blocking_severity(counts) {
-        return ReviewDecision::Fail;
-    }
-    if !severity_counts_are_zero(counts)
-        && (contains_verdict_token(text, "FAIL") || contains_verdict_token(text, "HAS_ISSUES"))
-    {
-        return ReviewDecision::Fail; // #1352: token alone without evidence must not fail
-    }
-    if contains_verdict_token(text, "UNAVAILABLE") {
-        return ReviewDecision::Unavailable;
-    }
-    if contains_verdict_token(text, "SKIP") {
-        return ReviewDecision::Skip;
-    }
-    if contains_verdict_token(text, "UNCERTAIN") {
-        return ReviewDecision::Uncertain;
-    }
-    if (contains_verdict_token(text, "PASS")
-        || contains_verdict_token(text, "CLEAN")
-        || contains_clean_phrase(text))
-        && overall_risk.is_none_or(|risk| risk.eq_ignore_ascii_case("low"))
-    {
-        return ReviewDecision::Pass;
-    }
-    if text.lines().any(is_findings_header)
-        && contains_clean_phrase(text)
-        && overall_risk.is_none_or(|risk| risk.eq_ignore_ascii_case("low"))
-    {
-        return ReviewDecision::Pass;
-    }
-    if overall_risk.is_some_and(|risk| !risk.eq_ignore_ascii_case("low")) {
-        return ReviewDecision::Fail;
-    }
-    ReviewDecision::Uncertain
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -777,19 +621,6 @@ pub(super) fn detect_tool_review_failure(
 }
 
 pub(in crate::review_cmd) use clean_detection::is_review_output_empty;
-
-fn contains_verdict_token(haystack: &str, token: &str) -> bool {
-    haystack
-        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
-        .any(|part| part.eq_ignore_ascii_case(token))
-}
-
-fn is_findings_header(line: &str) -> bool {
-    let trimmed = line.trim();
-    let normalized = trimmed.trim_start_matches('#').trim();
-    normalized.eq_ignore_ascii_case("findings")
-        || normalized.eq_ignore_ascii_case("review findings")
-}
 
 #[cfg(test)]
 #[path = "review_cmd_output_fix_reuse_tests.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -2,7 +2,7 @@ use std::{fs, path::Path};
 
 use anyhow::Result;
 
-use super::extract_review_text;
+use super::text::extract_review_text;
 
 pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();

--- a/crates/cli-sub-agent/src/review_cmd_output_exit.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_exit.rs
@@ -1,0 +1,83 @@
+use std::fs;
+use std::path::Path;
+
+use csa_session::ReviewVerdictArtifact;
+use tracing::warn;
+
+pub(in crate::review_cmd) fn persisted_review_verdict_exit_code(
+    project_root: &Path,
+    session_id: &str,
+) -> i32 {
+    let session_dir = match csa_session::get_session_dir(project_root, session_id) {
+        Ok(session_dir) => session_dir,
+        Err(error) => {
+            warn!(
+                session_id,
+                error = %error,
+                "Cannot resolve session dir for persisted review verdict; treating as infrastructure failure"
+            );
+            return crate::verdict_exit_code::INFRASTRUCTURE_FAILURE_EXIT_CODE;
+        }
+    };
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let raw = match fs::read_to_string(&verdict_path) {
+        Ok(raw) => raw,
+        Err(error) => {
+            warn!(
+                session_id,
+                path = %verdict_path.display(),
+                error = %error,
+                "Missing or unreadable review verdict artifact; treating as infrastructure failure"
+            );
+            return crate::verdict_exit_code::INFRASTRUCTURE_FAILURE_EXIT_CODE;
+        }
+    };
+    let artifact = match serde_json::from_str::<ReviewVerdictArtifact>(&raw) {
+        Ok(artifact) => artifact,
+        Err(error) => {
+            warn!(
+                session_id,
+                path = %verdict_path.display(),
+                error = %error,
+                "Invalid review verdict artifact; treating as infrastructure failure"
+            );
+            return crate::verdict_exit_code::INFRASTRUCTURE_FAILURE_EXIT_CODE;
+        }
+    };
+
+    crate::verdict_exit_code::exit_code_from_review_decision(artifact.decision)
+}
+
+pub(in crate::review_cmd) fn persist_review_result_exit_code(
+    project_root: &Path,
+    session_id: &str,
+    exit_code: i32,
+) {
+    let mut result = match csa_session::load_result(project_root, session_id) {
+        Ok(Some(result)) => result,
+        Ok(None) => return,
+        Err(error) => {
+            warn!(
+                session_id,
+                error = %error,
+                "Failed to load review result.toml for verdict exit-code alignment"
+            );
+            return;
+        }
+    };
+    if result.exit_code == exit_code
+        && result.status == csa_session::SessionResult::status_from_exit_code(exit_code)
+    {
+        return;
+    }
+
+    result.exit_code = exit_code;
+    result.status = csa_session::SessionResult::status_from_exit_code(exit_code);
+    if let Err(error) = csa_session::save_result(project_root, session_id, &result) {
+        warn!(
+            session_id,
+            error = %error,
+            "Failed to persist review result.toml verdict exit-code alignment"
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_text.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_text.rs
@@ -1,0 +1,179 @@
+use csa_core::types::ReviewDecision;
+use csa_session::Severity;
+use regex::Regex;
+use serde::Deserialize;
+
+use super::artifacts::{has_blocking_severity, severity_counts_are_zero};
+use super::clean_detection::contains_clean_phrase;
+
+#[derive(Debug, Deserialize)]
+struct TranscriptEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    item: Option<TranscriptItem>,
+    #[serde(default)]
+    result: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptItem {
+    #[serde(rename = "type")]
+    item_type: String,
+    #[serde(default)]
+    text: Option<String>,
+}
+
+pub(in crate::review_cmd) fn extract_review_text(raw_output: &str) -> Option<String> {
+    let mut transcript_messages = Vec::new();
+    let mut saw_json_line = false;
+
+    for line in raw_output.lines().filter(|line| !line.trim().is_empty()) {
+        let event = match serde_json::from_str::<TranscriptEvent>(line) {
+            Ok(event) => {
+                saw_json_line = true;
+                event
+            }
+            Err(_) if !saw_json_line => continue,
+            Err(_) => return Some(raw_output.to_string()),
+        };
+        if event.event_type == "result" {
+            if let Some(text) = event.result.filter(|text| looks_like_review_message(text)) {
+                transcript_messages.push(text);
+            }
+            continue;
+        }
+
+        let Some(item) = event.item else {
+            continue;
+        };
+        if event.event_type == "item.completed"
+            && item.item_type == "agent_message"
+            && let Some(text) = item.text.filter(|text| looks_like_review_message(text))
+        {
+            transcript_messages.push(text);
+        }
+    }
+
+    if transcript_messages.is_empty() {
+        return if saw_json_line {
+            None
+        } else {
+            Some(raw_output.to_string())
+        };
+    }
+
+    transcript_messages.pop()
+}
+
+fn looks_like_review_message(text: &str) -> bool {
+    super::has_structured_review_content(text)
+        || contains_verdict_token(text, "PASS")
+        || contains_verdict_token(text, "CLEAN")
+        || contains_verdict_token(text, "FAIL")
+        || contains_verdict_token(text, "HAS_ISSUES")
+        || contains_verdict_token(text, "UNAVAILABLE")
+        || contains_verdict_token(text, "UNCERTAIN")
+        || contains_clean_phrase(text)
+        || text.lines().any(|line| {
+            is_findings_header(line) || line.to_ascii_lowercase().contains("overall risk")
+        })
+}
+
+pub(super) fn zero_severity_counts() -> std::collections::BTreeMap<Severity, u32> {
+    [
+        (Severity::Critical, 0),
+        (Severity::High, 0),
+        (Severity::Medium, 0),
+        (Severity::Low, 0),
+    ]
+    .into_iter()
+    .collect()
+}
+
+pub(super) fn severity_counts_from_text(text: &str) -> std::collections::BTreeMap<Severity, u32> {
+    let marker_re =
+        Regex::new(r"(?i)\[(critical|high|medium|low|info|p[0-4])\]").expect("valid regex");
+    let mut counts = zero_severity_counts();
+
+    for captures in marker_re.captures_iter(text) {
+        let severity = match captures.get(1).map(|m| m.as_str().to_ascii_lowercase()) {
+            Some(level) if level == "critical" => Severity::Critical,
+            Some(level) if level == "high" => Severity::High,
+            Some(level) if level == "medium" => Severity::Medium,
+            Some(level) if level == "low" => Severity::Low,
+            Some(level) if level == "info" => Severity::Low,
+            Some(level) if level == "p0" => Severity::Critical,
+            Some(level) if level == "p1" => Severity::High,
+            Some(level) if level == "p2" => Severity::Medium,
+            Some(level) if level == "p3" || level == "p4" => Severity::Low,
+            _ => continue,
+        };
+        *counts.entry(severity).or_insert(0) += 1;
+    }
+
+    counts
+}
+
+pub(super) fn parse_overall_risk_from_text(text: &str) -> Option<String> {
+    let risk_re = Regex::new(r"(?im)\boverall risk\b\s*:?\s*(critical|high|medium|low)\b")
+        .expect("valid regex");
+    risk_re
+        .captures(text)
+        .and_then(|captures| captures.get(1))
+        .map(|level| level.as_str().to_ascii_lowercase())
+}
+
+pub(super) fn derive_decision_from_text(
+    text: &str,
+    counts: &std::collections::BTreeMap<Severity, u32>,
+    overall_risk: Option<&str>,
+) -> ReviewDecision {
+    if has_blocking_severity(counts) {
+        return ReviewDecision::Fail;
+    }
+    if !severity_counts_are_zero(counts)
+        && (contains_verdict_token(text, "FAIL") || contains_verdict_token(text, "HAS_ISSUES"))
+    {
+        return ReviewDecision::Fail;
+    }
+    if contains_verdict_token(text, "UNAVAILABLE") {
+        return ReviewDecision::Unavailable;
+    }
+    if contains_verdict_token(text, "SKIP") {
+        return ReviewDecision::Skip;
+    }
+    if contains_verdict_token(text, "UNCERTAIN") {
+        return ReviewDecision::Uncertain;
+    }
+    if (contains_verdict_token(text, "PASS")
+        || contains_verdict_token(text, "CLEAN")
+        || contains_clean_phrase(text))
+        && overall_risk.is_none_or(|risk| risk.eq_ignore_ascii_case("low"))
+    {
+        return ReviewDecision::Pass;
+    }
+    if text.lines().any(is_findings_header)
+        && contains_clean_phrase(text)
+        && overall_risk.is_none_or(|risk| risk.eq_ignore_ascii_case("low"))
+    {
+        return ReviewDecision::Pass;
+    }
+    if overall_risk.is_some_and(|risk| !risk.eq_ignore_ascii_case("low")) {
+        return ReviewDecision::Fail;
+    }
+    ReviewDecision::Uncertain
+}
+
+fn contains_verdict_token(haystack: &str, token: &str) -> bool {
+    haystack
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .any(|part| part.eq_ignore_ascii_case(token))
+}
+
+fn is_findings_header(line: &str) -> bool {
+    let trimmed = line.trim();
+    let normalized = trimmed.trim_start_matches('#').trim();
+    normalized.eq_ignore_ascii_case("findings")
+        || normalized.eq_ignore_ascii_case("review findings")
+}

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -46,16 +46,6 @@ fn verdict_from_decision(decision: ReviewDecision) -> &'static str {
     }
 }
 
-fn exit_code_from_decision(decision: ReviewDecision) -> i32 {
-    match decision {
-        ReviewDecision::Pass => 0,
-        ReviewDecision::Fail
-        | ReviewDecision::Skip
-        | ReviewDecision::Uncertain
-        | ReviewDecision::Unavailable => 1,
-    }
-}
-
 fn explicit_review_decision_for_execution(
     raw_output: &str,
     exit_code: i32,
@@ -149,7 +139,7 @@ pub(super) fn resolve_single_review_result(
         )
     };
     let verdict = verdict_from_decision(decision);
-    let effective_exit_code = exit_code_from_decision(decision);
+    let effective_exit_code = crate::verdict_exit_code::exit_code_from_review_decision(decision);
 
     SingleReviewResolution {
         sanitized,
@@ -230,7 +220,7 @@ pub(super) fn build_reviewer_outcome(
         } else {
             sanitize_review_output(&result.execution.output)
         },
-        exit_code: exit_code_from_decision(decision),
+        exit_code: crate::verdict_exit_code::exit_code_from_review_decision(decision),
         diagnostic: diagnostic
             .or_else(|| auth_prompt_failure.then(|| AUTH_PROMPT_DIAGNOSTIC.to_string()))
             .or_else(|| tool_unavailable_reason.clone()),
@@ -357,7 +347,9 @@ pub(super) fn build_unavailable_reviewer_outcome(
         tool: reviewer_tool,
         session_id: format!("reviewer-{}-unavailable", reviewer_index + 1),
         output: format!("{REVIEW_UNAVAILABLE_PREFIX}{reason}\n"),
-        exit_code: 1,
+        exit_code: crate::verdict_exit_code::exit_code_from_review_decision(
+            ReviewDecision::Unavailable,
+        ),
         verdict: UNAVAILABLE,
         diagnostic: Some(reason),
     }

--- a/crates/cli-sub-agent/src/verdict_exit_code.rs
+++ b/crates/cli-sub-agent/src/verdict_exit_code.rs
@@ -1,0 +1,76 @@
+use csa_core::types::ReviewDecision;
+
+pub(crate) const INFRASTRUCTURE_FAILURE_EXIT_CODE: i32 = 2;
+
+pub(crate) fn exit_code_from_review_decision(decision: ReviewDecision) -> i32 {
+    match decision {
+        ReviewDecision::Pass => 0,
+        ReviewDecision::Fail
+        | ReviewDecision::Skip
+        | ReviewDecision::Uncertain
+        | ReviewDecision::Unavailable => 1,
+    }
+}
+
+pub(crate) fn exit_code_from_debate_verdict(verdict: &str, decision: Option<&str>) -> i32 {
+    if token_is_success(decision) || token_is_success(Some(verdict)) {
+        return 0;
+    }
+
+    if token_is_failure(decision) || token_is_failure(Some(verdict)) {
+        return 1;
+    }
+
+    INFRASTRUCTURE_FAILURE_EXIT_CODE
+}
+
+fn token_is_success(token: Option<&str>) -> bool {
+    token.is_some_and(|token| {
+        matches!(
+            token.trim().to_ascii_uppercase().as_str(),
+            "APPROVE" | "PASS" | "CLEAN"
+        )
+    })
+}
+
+fn token_is_failure(token: Option<&str>) -> bool {
+    token.is_some_and(|token| {
+        matches!(
+            token.trim().to_ascii_uppercase().as_str(),
+            "REVISE" | "REJECT" | "FAIL" | "HAS_ISSUES" | "UNAVAILABLE"
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_pass_maps_to_zero() {
+        assert_eq!(exit_code_from_review_decision(ReviewDecision::Pass), 0);
+    }
+
+    #[test]
+    fn review_fail_maps_to_one() {
+        assert_eq!(exit_code_from_review_decision(ReviewDecision::Fail), 1);
+    }
+
+    #[test]
+    fn debate_approve_maps_to_zero() {
+        assert_eq!(exit_code_from_debate_verdict("APPROVE", None), 0);
+    }
+
+    #[test]
+    fn debate_revise_maps_to_one() {
+        assert_eq!(exit_code_from_debate_verdict("REVISE", None), 1);
+    }
+
+    #[test]
+    fn debate_unknown_maps_to_infrastructure_failure() {
+        assert_eq!(
+            exit_code_from_debate_verdict("MAYBE", None),
+            INFRASTRUCTURE_FAILURE_EXIT_CODE
+        );
+    }
+}

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -487,7 +487,13 @@ if [ -n "${UNSTAGED_BEFORE_COMMIT}" ]; then
 fi
 
 trap 'rm -f "${COMMIT_MESSAGE_FILE_LOCAL}"' EXIT
+HEAD_BEFORE_COMMIT="$(git rev-parse HEAD)"
 git commit -F "${COMMIT_MESSAGE_FILE_LOCAL}"
+HEAD_AFTER_COMMIT="$(git rev-parse HEAD)"
+if [ "${HEAD_AFTER_COMMIT}" = "${HEAD_BEFORE_COMMIT}" ]; then
+  echo "ERROR: git commit reported success but HEAD did not change; treating as commit failure." >&2
+  exit 1
+fi
 echo '<!-- CSA:NEXT_STEP cmd="cumulative branch review (Step 21) or publish" required=true -->'
 ```
 

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -553,7 +553,13 @@ if [ -n "${UNSTAGED_BEFORE_COMMIT}" ]; then
 fi
 
 trap 'rm -f "${COMMIT_MESSAGE_FILE_LOCAL}"' EXIT
+HEAD_BEFORE_COMMIT="$(git rev-parse HEAD)"
 git commit -F "${COMMIT_MESSAGE_FILE_LOCAL}"
+HEAD_AFTER_COMMIT="$(git rev-parse HEAD)"
+if [ "${HEAD_AFTER_COMMIT}" = "${HEAD_BEFORE_COMMIT}" ]; then
+  echo "ERROR: git commit reported success but HEAD did not change; treating as commit failure." >&2
+  exit 1
+fi
 echo '<!-- CSA:NEXT_STEP cmd="cumulative branch review (Step 21) or publish" required=true -->'
 ```"""
 on_fail = "abort"


### PR DESCRIPTION
## Summary
- Add `verdict_exit_code` module enforcing exit code ↔ verdict artifact contract
- Review: CLEAN verdict → exit 0, HAS_ISSUES → exit 1, no artifact → exit 2
- Debate: align exit code with debate verdict output
- Commit skill: detect blocked commits and return correct exit code
- Extract review output text formatting into dedicated module

Closes #1585

## Test plan
- [x] New tests in `review_cmd_exact_tests.rs`, `debate_cmd_exact_tests.rs`, `plan_cmd_tests_commit.rs`
- [x] `cargo test --workspace` passes
- [x] `cargo clippy` clean
- [x] `just pre-commit` passes