### PR TITLE
fix(review): unify check-verdict session discovery with verdict marker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.787"
+version = "0.1.788"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.787"
+version = "0.1.788"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -165,6 +165,16 @@ pub(crate) fn check_review_verdict_for_target(
     required_scope: &str,
     expected_diff_fingerprint: Option<&str>,
 ) -> Result<Option<ReviewVerdictMatch>> {
+    if let Some(found) = check_review_verdict_marker(
+        project_root,
+        branch,
+        head_sha,
+        required_scope,
+        expected_diff_fingerprint,
+    )? {
+        return Ok(Some(found));
+    }
+
     let session_root = csa_session::get_session_root(project_root).with_context(|| {
         format!(
             "failed to resolve CSA session root for {}",
@@ -281,6 +291,109 @@ pub(crate) fn check_review_verdict_for_target(
         session_id: latest.session_id,
         scope: latest.scope,
         head_sha: latest.head_sha,
+    }))
+}
+
+fn check_review_verdict_marker(
+    project_root: &Path,
+    branch: &str,
+    head_sha: &str,
+    required_scope: &str,
+    expected_diff_fingerprint: Option<&str>,
+) -> Result<Option<ReviewVerdictMatch>> {
+    let Some(marker) = crate::review_gate::read_review_gate_marker(project_root, branch, head_sha)
+    else {
+        return Ok(None);
+    };
+    debug!(
+        session_id = %marker.session_id,
+        marker_branch = %marker.branch,
+        expected_branch = branch,
+        marker_head_sha = %marker.head_sha,
+        expected_head_sha = head_sha,
+        marker_scope = %marker.scope,
+        expected_scope = required_scope,
+        marker_verdict = %marker.verdict,
+        marker_timestamp = %marker.timestamp,
+        "Checking review verdict marker"
+    );
+
+    if marker.branch != branch
+        || marker.head_sha != head_sha
+        || marker.scope != required_scope
+        || !verdict_token_is_pass(&marker.verdict)
+    {
+        debug!(
+            session_id = %marker.session_id,
+            "Review verdict marker is stale for requested target"
+        );
+        return Ok(None);
+    }
+
+    let session_root = csa_session::get_session_root(project_root).with_context(|| {
+        format!(
+            "failed to resolve CSA session root for {}",
+            project_root.display()
+        )
+    })?;
+    let session_dir = session_root.join("sessions").join(&marker.session_id);
+    if !session_dir.exists() {
+        debug!(
+            session_id = %marker.session_id,
+            session_dir = %session_dir.display(),
+            "Review verdict marker points to missing session"
+        );
+        return Ok(None);
+    }
+
+    let Some(meta) = read_review_meta(&session_dir)? else {
+        debug!(
+            session_id = %marker.session_id,
+            session_dir = %session_dir.display(),
+            "Review verdict marker session is missing review_meta.json"
+        );
+        return Ok(None);
+    };
+    if meta.head_sha != head_sha || meta.scope != required_scope {
+        debug!(
+            session_id = %marker.session_id,
+            meta_head_sha = %meta.head_sha,
+            expected_head_sha = head_sha,
+            meta_scope = %meta.scope,
+            expected_scope = required_scope,
+            "Review verdict marker session did not match head SHA or scope"
+        );
+        return Ok(None);
+    }
+    if !diff_fingerprint_matches(&meta, expected_diff_fingerprint) {
+        debug!(
+            session_id = %marker.session_id,
+            meta_diff_fingerprint = ?meta.diff_fingerprint,
+            ?expected_diff_fingerprint,
+            "Review verdict marker session did not match diff fingerprint"
+        );
+        return Ok(None);
+    }
+    if !review_meta_or_artifact_is_pass(&session_dir, &meta)? {
+        debug!(
+            session_id = %marker.session_id,
+            decision = %meta.decision,
+            verdict = %meta.verdict,
+            "Review verdict marker session is not PASS/CLEAN"
+        );
+        return Ok(None);
+    }
+
+    debug!(
+        session_id = %meta.session_id,
+        scope = %meta.scope,
+        head_sha = %meta.head_sha,
+        "Review verdict marker matched PASS/CLEAN session"
+    );
+    Ok(Some(ReviewVerdictMatch {
+        session_id: meta.session_id,
+        scope: meta.scope,
+        head_sha: meta.head_sha,
     }))
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_tests.rs
@@ -117,6 +117,15 @@ fn set_task_type(project_root: &Path, session_id: &str, task_type: &str) {
     csa_session::save_session(&session).expect("save session");
 }
 
+fn set_session_branch(project_root: &Path, session_id: &str, branch: &str) {
+    let mut session = csa_session::load_session(project_root, session_id).expect("load session");
+    session.branch = Some(branch.to_string());
+    if let Some(identity) = session.vcs_identity.as_mut() {
+        identity.ref_name = Some(branch.to_string());
+    }
+    csa_session::save_session(&session).expect("save session");
+}
+
 fn set_review_diff_fingerprint(
     project_root: &Path,
     session_id: &str,
@@ -203,6 +212,41 @@ fn check_verdict_finds_pass_for_current_branch_head_and_full_diff() {
     )
     .unwrap()
     .expect("expected matching verdict");
+    assert_eq!(found.session_id, session_id);
+}
+
+#[test]
+fn check_verdict_reads_review_marker_before_session_scan() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let temp = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", temp.path().join("state"));
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    let branch = "feature";
+    let head_sha = "abcdef1234567890";
+    let session_id = write_review_session(
+        &project,
+        branch,
+        head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        ReviewDecision::Pass,
+        "CLEAN",
+    );
+    crate::review_gate::write_review_gate_marker(
+        &project,
+        branch,
+        head_sha,
+        &session_id,
+        REQUIRED_FULL_DIFF_SCOPE,
+    );
+
+    set_session_branch(&project, &session_id, "other-branch");
+
+    let found =
+        check_review_verdict_for_target(&project, branch, head_sha, REQUIRED_FULL_DIFF_SCOPE, None)
+            .unwrap()
+            .expect("marker should identify the matching verdict session");
     assert_eq!(found.session_id, session_id);
 }
 

--- a/crates/cli-sub-agent/src/review_gate.rs
+++ b/crates/cli-sub-agent/src/review_gate.rs
@@ -12,6 +12,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
+use serde::Deserialize;
 use tracing::{debug, warn};
 
 /// Number of characters from HEAD SHA used in the marker filename.
@@ -26,6 +27,22 @@ const GATE_DIR: &str = ".csa/state/review-gate";
 /// Statistics returned by [`gc_review_gate_markers`].
 pub(crate) struct GcReviewGateStats {
     pub markers_removed: u64,
+}
+
+/// Parsed review-gate marker content.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ReviewGateMarker {
+    pub session_id: String,
+    pub timestamp: String,
+    pub branch: String,
+    pub head_sha: String,
+    pub scope: String,
+    #[serde(default = "default_marker_verdict")]
+    pub verdict: String,
+}
+
+fn default_marker_verdict() -> String {
+    "CLEAN".to_string()
 }
 
 /// Return the review-gate directory for the given project root.
@@ -62,8 +79,45 @@ pub(crate) fn marker_path(project_root: &Path, branch: &str, head_sha: &str) -> 
 fn marker_toml(session_id: &str, branch: &str, head_sha: &str, scope: &str) -> String {
     let ts = Utc::now().to_rfc3339();
     format!(
-        "session_id = {session_id:?}\ntimestamp = {ts:?}\nbranch = {branch:?}\nhead_sha = {head_sha:?}\nscope = {scope:?}\n"
+        "session_id = {session_id:?}\ntimestamp = {ts:?}\nbranch = {branch:?}\nhead_sha = {head_sha:?}\nscope = {scope:?}\nverdict = \"CLEAN\"\n"
     )
+}
+
+/// Read the deterministic marker for the current branch and commit.
+///
+/// Best-effort: corrupt or unreadable markers are treated as absent so callers
+/// can fall back to the slower session scan.
+pub(crate) fn read_review_gate_marker(
+    project_root: &Path,
+    branch: &str,
+    head_sha: &str,
+) -> Option<ReviewGateMarker> {
+    let path = marker_path(project_root, branch, head_sha);
+    if !path.exists() {
+        return None;
+    }
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) => {
+            warn!(
+                path = %path.display(),
+                error = %e,
+                "Failed to read review-gate marker; falling back to session scan"
+            );
+            return None;
+        }
+    };
+    match toml::from_str(&raw) {
+        Ok(marker) => Some(marker),
+        Err(e) => {
+            warn!(
+                path = %path.display(),
+                error = %e,
+                "Failed to parse review-gate marker; falling back to session scan"
+            );
+            None
+        }
+    }
 }
 
 /// Write a review-gate marker for a passing review.
@@ -319,6 +373,15 @@ mod tests {
         let content = fs::read_to_string(&path).unwrap();
         assert!(content.contains("SID001"));
         assert!(content.contains("range:main...HEAD"));
+        assert!(content.contains("verdict = \"CLEAN\""));
+        let marker = read_review_gate_marker(project_root, "feat/test", "abc1234567890")
+            .expect("marker should parse");
+        assert_eq!(marker.session_id, "SID001");
+        assert_eq!(marker.branch, "feat/test");
+        assert_eq!(marker.head_sha, "abc1234567890");
+        assert_eq!(marker.scope, "range:main...HEAD");
+        assert_eq!(marker.verdict, "CLEAN");
+        assert!(!marker.timestamp.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Review now writes a deterministic verdict marker file after completion, recording session ID, branch, range/scope, verdict, commit SHA, and timestamp
- `check-verdict` reads from this marker file first, falling back to session search only if marker is missing/stale
- Eliminates the #1 recurring blocker in Codex dogfood: review passes but check-verdict cannot find the session (5 duplicate issues)

## Test plan

- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo test -p cli-sub-agent verdict_marker` passes
- [x] `csa review --check-verdict --range main...HEAD` PASS (session 01KSE4A8XQKQWRFYPQG15EE8JK)

Closes #1587
Closes #1549
Closes #1559
Closes #1561
Closes #1573
Closes #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)