### PR TITLE
feat(tokuin): add tree-sitter AST-based token estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "chrono",
@@ -547,6 +547,8 @@ dependencies = [
  "toml_edit 0.25.11+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-rust",
  "ulid",
  "weave",
  "which 8.0.2",
@@ -701,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -721,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "chrono",
@@ -739,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -755,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "chrono",
@@ -769,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -797,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "chrono",
@@ -816,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "axum",
@@ -853,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -872,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "chrono",
@@ -891,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -907,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "chrono",
@@ -925,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "chrono",
@@ -951,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3295,6 +3297,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3480,6 +3483,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -4234,6 +4243,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4517,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.791"
+version = "0.1.792"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.791"
+version = "0.1.792"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -80,4 +80,6 @@ glob = "0.3"
 ignore = "0.4"
 tantivy = "0.25"
 tokuin = { git = "https://github.com/RyderFreeman4Logos/tokuin.git", default-features = false, features = ["conservative"] }
+tree-sitter = "0.26.9"
+tree-sitter-rust = "0.24.2"
 xurl-core = { git = "https://github.com/Xuanwo/xurl.git" }

--- a/crates/cli-sub-agent/Cargo.toml
+++ b/crates/cli-sub-agent/Cargo.toml
@@ -47,6 +47,8 @@ ignore.workspace = true
 regex.workspace = true
 sha2.workspace = true
 tokuin.workspace = true
+tree-sitter.workspace = true
+tree-sitter-rust.workspace = true
 xurl-core.workspace = true
 
 [dev-dependencies]

--- a/crates/cli-sub-agent/src/cli_tokuin.rs
+++ b/crates/cli-sub-agent/src/cli_tokuin.rs
@@ -3,9 +3,19 @@
 
 use anyhow::{Context, Result};
 use clap::Subcommand;
+use serde::Serialize;
 use std::path::PathBuf;
+use tree_sitter::{Node, Parser};
 
 const DEFAULT_MODEL: &str = "gpt-4o";
+const DEFAULT_AST_BUDGET: usize = 8_000;
+const RUST_AST_NODE_KINDS: &[&str] = &[
+    "function_item",
+    "impl_item",
+    "struct_item",
+    "enum_item",
+    "mod_item",
+];
 
 #[derive(Subcommand)]
 pub enum TokuinCommands {
@@ -26,6 +36,10 @@ pub enum TokuinCommands {
         /// Token budget threshold — exit non-zero if any file exceeds this
         #[arg(long)]
         budget: Option<usize>,
+
+        /// Enable Rust tree-sitter AST-aware token breakdown
+        #[arg(long)]
+        ast: bool,
     },
     /// List supported model names for the OpenAI BPE tokenizer
     Models,
@@ -38,9 +52,49 @@ pub fn handle_tokuin(cmd: TokuinCommands) -> Result<()> {
             model,
             json,
             budget,
-        } => handle_estimate(files, model, json, budget),
+            ast,
+        } => handle_estimate(files, model, json, budget, ast),
         TokuinCommands::Models => handle_models(),
     }
+}
+
+#[derive(Debug, Serialize)]
+struct EstimateFileOutput {
+    file: String,
+    tokens: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ast_breakdown: Option<AstBreakdown>,
+}
+
+#[derive(Debug, Serialize)]
+struct AstBreakdown {
+    language: Option<&'static str>,
+    total_tokens: usize,
+    budget: usize,
+    nodes: Vec<AstNodeBreakdown>,
+    split_suggestions: Vec<AstSplitSuggestion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warning: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct AstNodeBreakdown {
+    kind: String,
+    name: String,
+    tokens: usize,
+    start_line: usize,
+    end_line: usize,
+    start_byte: usize,
+    end_byte: usize,
+    children: Vec<AstNodeBreakdown>,
+}
+
+#[derive(Debug, Serialize)]
+struct AstSplitSuggestion {
+    after_node: String,
+    line: usize,
+    accumulated_tokens: usize,
+    reason: String,
 }
 
 fn resolve_model(model: &str) -> &str {
@@ -56,6 +110,7 @@ fn handle_estimate(
     model: String,
     json: bool,
     budget: Option<usize>,
+    ast: bool,
 ) -> Result<()> {
     use tokuin::tokenizers::{ConservativeTokenizer, Tokenizer};
 
@@ -68,6 +123,7 @@ fn handle_estimate(
 
     let mut results = Vec::new();
     let mut exceeded = false;
+    let ast_budget = budget.unwrap_or(DEFAULT_AST_BUDGET);
 
     for file in &files {
         let content = std::fs::read_to_string(file)
@@ -83,47 +139,74 @@ fn handle_estimate(
             exceeded = true;
         }
 
-        results.push((file.display().to_string(), tokens));
+        let ast_breakdown = ast
+            .then(|| build_ast_breakdown(file, &content, tokens, ast_budget, &tokenizer))
+            .transpose()?;
+
+        if let Some(AstBreakdown {
+            warning: Some(warning),
+            ..
+        }) = &ast_breakdown
+        {
+            eprintln!("{}: {warning}", file.display());
+        }
+
+        results.push(EstimateFileOutput {
+            file: file.display().to_string(),
+            tokens,
+            ast_breakdown,
+        });
     }
 
     if json {
         if results.len() == 1 {
-            let (ref path, tokens) = results[0];
-            let obj = serde_json::json!({
-                "file": path,
+            let result = &results[0];
+            let mut obj = serde_json::json!({
+                "file": result.file,
                 "model": resolved,
                 "tokenizer": "conservative",
-                "tokens": tokens,
+                "tokens": result.tokens,
             });
+            if let Some(ast_breakdown) = &result.ast_breakdown {
+                obj["ast_breakdown"] = serde_json::to_value(ast_breakdown)?;
+            }
             println!("{}", serde_json::to_string_pretty(&obj)?);
         } else {
             let arr: Vec<_> = results
                 .iter()
-                .map(|(path, tokens)| {
-                    serde_json::json!({
-                        "file": path,
-                        "tokens": tokens,
-                    })
+                .map(|result| {
+                    let mut obj = serde_json::json!({
+                        "file": result.file,
+                        "tokens": result.tokens,
+                    });
+                    if let Some(ast_breakdown) = &result.ast_breakdown {
+                        obj["ast_breakdown"] = serde_json::to_value(ast_breakdown)?;
+                    }
+                    Ok::<_, serde_json::Error>(obj)
                 })
-                .collect();
+                .collect::<std::result::Result<_, _>>()?;
             let obj = serde_json::json!({
                 "model": resolved,
                 "tokenizer": "conservative",
                 "files": arr,
-                "total": results.iter().map(|(_, t)| t).sum::<usize>(),
+                "total": results.iter().map(|result| result.tokens).sum::<usize>(),
             });
             println!("{}", serde_json::to_string_pretty(&obj)?);
         }
     } else {
-        for (path, tokens) in &results {
+        for result in &results {
             if results.len() == 1 {
-                println!("{tokens}");
+                println!("{}", result.tokens);
             } else {
                 let marker = budget
-                    .filter(|&limit| *tokens > limit)
+                    .filter(|&limit| result.tokens > limit)
                     .map(|_| " OVER")
                     .unwrap_or("");
-                println!("{tokens}\t{path}{marker}");
+                println!("{}\t{}{}", result.tokens, result.file, marker);
+            }
+
+            if let Some(breakdown) = &result.ast_breakdown {
+                print_ast_breakdown(breakdown);
             }
         }
     }
@@ -133,6 +216,205 @@ fn handle_estimate(
     }
 
     Ok(())
+}
+
+fn build_ast_breakdown<T: tokuin::tokenizers::Tokenizer>(
+    file: &std::path::Path,
+    content: &str,
+    total_tokens: usize,
+    budget: usize,
+    tokenizer: &T,
+) -> Result<AstBreakdown> {
+    if file.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+        return Ok(AstBreakdown {
+            language: None,
+            total_tokens,
+            budget,
+            nodes: Vec::new(),
+            split_suggestions: Vec::new(),
+            warning: Some(
+                "AST mode currently supports only Rust files; used flat estimation".into(),
+            ),
+        });
+    }
+
+    let mut parser = Parser::new();
+    let language = tree_sitter_rust::LANGUAGE;
+    parser
+        .set_language(&language.into())
+        .context("Failed to load tree-sitter Rust grammar")?;
+
+    let tree = parser
+        .parse(content, None)
+        .ok_or_else(|| anyhow::anyhow!("tree-sitter failed to parse Rust source"))?;
+    let root = tree.root_node();
+    let nodes = collect_ast_children(root, content, tokenizer)?;
+    let split_suggestions = suggest_split_points(root, content, total_tokens, budget, tokenizer)?;
+
+    Ok(AstBreakdown {
+        language: Some("rust"),
+        total_tokens,
+        budget,
+        nodes,
+        split_suggestions,
+        warning: root.has_error().then(|| {
+            "tree-sitter parsed Rust source with syntax errors; AST ranges may be approximate"
+                .into()
+        }),
+    })
+}
+
+fn collect_ast_children<T: tokuin::tokenizers::Tokenizer>(
+    parent: Node<'_>,
+    content: &str,
+    tokenizer: &T,
+) -> Result<Vec<AstNodeBreakdown>> {
+    let mut cursor = parent.walk();
+    let mut children = Vec::new();
+    for child in parent.children(&mut cursor) {
+        if is_ast_breakdown_node(child) {
+            children.push(build_ast_node(child, content, tokenizer)?);
+        } else {
+            children.extend(collect_ast_children(child, content, tokenizer)?);
+        }
+    }
+    children.sort_by(|a, b| {
+        b.tokens
+            .cmp(&a.tokens)
+            .then_with(|| a.start_line.cmp(&b.start_line))
+    });
+    Ok(children)
+}
+
+fn build_ast_node<T: tokuin::tokenizers::Tokenizer>(
+    node: Node<'_>,
+    content: &str,
+    tokenizer: &T,
+) -> Result<AstNodeBreakdown> {
+    let snippet = &content[node.start_byte()..node.end_byte()];
+    let tokens = tokenizer
+        .count_tokens(snippet)
+        .map_err(|e| anyhow::anyhow!("Failed to count tokens for AST node: {e}"))?;
+    let children = collect_ast_children(node, content, tokenizer)?;
+
+    Ok(AstNodeBreakdown {
+        kind: node.kind().to_string(),
+        name: node_name(node, content),
+        tokens,
+        start_line: node.start_position().row + 1,
+        end_line: node.end_position().row + 1,
+        start_byte: node.start_byte(),
+        end_byte: node.end_byte(),
+        children,
+    })
+}
+
+fn suggest_split_points<T: tokuin::tokenizers::Tokenizer>(
+    root: Node<'_>,
+    content: &str,
+    total_tokens: usize,
+    budget: usize,
+    tokenizer: &T,
+) -> Result<Vec<AstSplitSuggestion>> {
+    if total_tokens <= budget {
+        return Ok(Vec::new());
+    }
+
+    let mut top_level_nodes = Vec::new();
+    let mut cursor = root.walk();
+    for child in root.children(&mut cursor) {
+        if is_ast_breakdown_node(child) {
+            top_level_nodes.push(child);
+        }
+    }
+
+    let mut suggestions = Vec::new();
+    let mut accumulated = 0usize;
+    for node in top_level_nodes {
+        let snippet = &content[node.start_byte()..node.end_byte()];
+        let tokens = tokenizer
+            .count_tokens(snippet)
+            .map_err(|e| anyhow::anyhow!("Failed to count tokens for split suggestion: {e}"))?;
+        accumulated = accumulated.saturating_add(tokens);
+        if accumulated >= budget {
+            suggestions.push(AstSplitSuggestion {
+                after_node: format!("{} {}", node.kind(), node_name(node, content)),
+                line: node.end_position().row + 1,
+                accumulated_tokens: accumulated,
+                reason: format!(
+                    "Split after this top-level item to keep chunks near the {budget}-token budget"
+                ),
+            });
+            accumulated = 0;
+        }
+    }
+
+    Ok(suggestions)
+}
+
+fn is_ast_breakdown_node(node: Node<'_>) -> bool {
+    RUST_AST_NODE_KINDS.contains(&node.kind())
+}
+
+fn node_name(node: Node<'_>, content: &str) -> String {
+    match node.kind() {
+        "impl_item" => impl_label(node, content),
+        _ => node
+            .child_by_field_name("name")
+            .and_then(|name| name.utf8_text(content.as_bytes()).ok())
+            .map(str::to_string)
+            .unwrap_or_else(|| node.kind().to_string()),
+    }
+}
+
+fn impl_label(node: Node<'_>, content: &str) -> String {
+    let snippet = &content[node.start_byte()..node.end_byte()];
+    snippet
+        .lines()
+        .next()
+        .unwrap_or("impl")
+        .split('{')
+        .next()
+        .unwrap_or("impl")
+        .trim()
+        .chars()
+        .take(96)
+        .collect()
+}
+
+fn print_ast_breakdown(breakdown: &AstBreakdown) {
+    if let Some(language) = breakdown.language {
+        println!(
+            "AST ({language}): {} tokens, budget {}",
+            breakdown.total_tokens, breakdown.budget
+        );
+        for node in &breakdown.nodes {
+            print_ast_node(node, 1);
+        }
+        if !breakdown.split_suggestions.is_empty() {
+            println!("Split suggestions:");
+            for suggestion in &breakdown.split_suggestions {
+                println!(
+                    "  after {} at line {} ({} tokens): {}",
+                    suggestion.after_node,
+                    suggestion.line,
+                    suggestion.accumulated_tokens,
+                    suggestion.reason
+                );
+            }
+        }
+    }
+}
+
+fn print_ast_node(node: &AstNodeBreakdown, depth: usize) {
+    let indent = "  ".repeat(depth);
+    println!(
+        "{indent}{} {}: {} tokens (lines {}-{})",
+        node.kind, node.name, node.tokens, node.start_line, node.end_line
+    );
+    for child in &node.children {
+        print_ast_node(child, depth + 1);
+    }
 }
 
 fn handle_models() -> Result<()> {
@@ -166,4 +448,91 @@ fn handle_models() -> Result<()> {
     println!("      approximates Claude counts conservatively.");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokuin::tokenizers::{ConservativeTokenizer, Tokenizer};
+
+    fn tokenizer() -> ConservativeTokenizer {
+        ConservativeTokenizer::new("gpt-4o").expect("test tokenizer should initialize")
+    }
+
+    #[test]
+    fn ast_breakdown_collects_rust_items_and_impl_children() {
+        let source = r#"
+mod inner {
+    pub fn nested() {}
+}
+
+pub struct Widget {
+    id: u64,
+}
+
+impl Widget {
+    pub fn new(id: u64) -> Self {
+        Self { id }
+    }
+}
+
+enum Mode {
+    Fast,
+    Slow,
+}
+"#;
+        let tokenizer = tokenizer();
+        let breakdown = build_ast_breakdown(
+            std::path::Path::new("sample.rs"),
+            source,
+            tokenizer.count_tokens(source).unwrap(),
+            1,
+            &tokenizer,
+        )
+        .unwrap();
+
+        assert_eq!(breakdown.language, Some("rust"));
+        assert!(breakdown.warning.is_none());
+        assert!(breakdown.split_suggestions.len() > 1);
+
+        let names: Vec<_> = breakdown
+            .nodes
+            .iter()
+            .map(|node| node.name.as_str())
+            .collect();
+        assert!(names.contains(&"inner"));
+        assert!(names.contains(&"Widget"));
+        assert!(names.contains(&"Mode"));
+
+        let widget_impl = breakdown
+            .nodes
+            .iter()
+            .find(|node| node.kind == "impl_item")
+            .expect("impl item should be present");
+        assert!(widget_impl.children.iter().any(|node| node.name == "new"));
+        assert!(
+            breakdown
+                .nodes
+                .windows(2)
+                .all(|pair| pair[0].tokens >= pair[1].tokens)
+        );
+    }
+
+    #[test]
+    fn ast_breakdown_falls_back_for_non_rust_files() {
+        let tokenizer = tokenizer();
+        let breakdown = build_ast_breakdown(
+            std::path::Path::new("notes.md"),
+            "# Notes",
+            3,
+            DEFAULT_AST_BUDGET,
+            &tokenizer,
+        )
+        .unwrap();
+
+        assert_eq!(breakdown.language, None);
+        assert!(breakdown.nodes.is_empty());
+        assert!(breakdown.split_suggestions.is_empty());
+        assert!(breakdown.warning.unwrap().contains("supports only Rust"));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `--ast` flag to `csa tokuin estimate` for tree-sitter AST-aware token estimation
- Parses Rust files with tree-sitter-rust, provides per-function/per-impl/per-struct token breakdown
- Suggests natural split points for files exceeding token budget (8K default)
- Non-Rust files gracefully fall back to flat estimation

## Test plan

- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo test --workspace` passes (all tests)
- [x] `cargo fmt --check` passes
- [x] `csa review --range main...HEAD` PASS (session 01KSEG2JBPKESTBV6RM1C1PDPP)

Closes #1525

🤖 Generated with [Claude Code](https://claude.com/claude-code)