### PR TITLE
fix(review): align verdict.json decision with empty findings and PASS text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.792"
+version = "0.1.793"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -277,6 +277,69 @@ fn persist_review_sidecars_returns_fail_exit_for_has_issues_artifact() {
     assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
 }
 
+#[test]
+fn issue_1593_clean_verdict_artifact_writes_gate_marker_despite_stale_fail_meta() {
+    let project_dir = exact_test_setup_git_repo();
+    exact_test_run_git(project_dir.path(), &["checkout", "-b", "fix-1593-test"]);
+    let _state_home = test_env_lock::ScopedTestEnvVar::set(
+        "XDG_STATE_HOME",
+        project_dir.path().join("state"),
+    );
+    let session_id = "01TEST1593CLEANVERDICT0000";
+    let session_dir = csa_session::get_session_dir(project_dir.path(), session_id)
+        .expect("resolve session dir");
+    std::fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
+
+    let review_text = concat!(
+        "<!-- CSA:SECTION:summary -->\n",
+        "PASS\n",
+        "<!-- CSA:SECTION:summary:END -->\n\n",
+        "<!-- CSA:SECTION:details -->\n",
+        "No blocking findings.\n\n",
+        "```findings.toml\n",
+        "findings = []\n",
+        "```\n",
+        "<!-- CSA:SECTION:details:END -->\n",
+    );
+    let full_output = serde_json::to_string(&serde_json::json!({
+        "type": "item.completed",
+        "item": {
+            "type": "agent_message",
+            "text": review_text
+        }
+    }))
+    .expect("serialize transcript line");
+    std::fs::write(session_dir.join("output").join("full.md"), full_output)
+        .expect("write full output");
+    csa_session::persist_structured_output(&session_dir, review_text)
+        .expect("persist structured output");
+
+    let mut meta = exact_test_make_review_meta(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    meta.head_sha = csa_session::detect_git_head(project_dir.path()).expect("detect HEAD");
+    meta.scope = "range:main...HEAD".to_string();
+
+    let persisted_exit_code = review_cmd::persist_review_sidecars_if_session_exists(
+        project_dir.path(),
+        &meta,
+        Some(session_id),
+    );
+
+    assert_eq!(persisted_exit_code, Some(0));
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: csa_session::ReviewVerdictArtifact =
+        serde_json::from_str(&std::fs::read_to_string(&verdict_path).unwrap()).unwrap();
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|count| *count == 0));
+
+    let marker_path =
+        crate::review_gate::marker_path(project_dir.path(), "fix-1593-test", &meta.head_sha);
+    assert!(
+        marker_path.exists(),
+        "clean derived verdict should write the pre-push gate marker"
+    );
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn execute_review_marks_unavailable_when_all_tier_models_fail() {

--- a/crates/cli-sub-agent/src/review_cmd_flow.rs
+++ b/crates/cli-sub-agent/src/review_cmd_flow.rs
@@ -40,11 +40,17 @@ pub(crate) fn persist_review_sidecars_if_session_exists(
     persist_review_meta(project_root, meta);
     persist_review_findings_toml(project_root, meta);
     persist_review_verdict(project_root, meta, &[], Vec::new());
-    crate::review_gate::maybe_write_gate_marker_from_meta(project_root, meta);
-    Some(persisted_review_verdict_exit_code(
-        project_root,
-        persistable_session_id,
-    ))
+    let verdict_exit_code =
+        persisted_review_verdict_exit_code(project_root, persistable_session_id);
+    if verdict_exit_code == 0 {
+        crate::review_gate::maybe_write_review_gate_marker(
+            project_root,
+            &meta.head_sha,
+            persistable_session_id,
+            &meta.scope,
+        );
+    }
+    Some(verdict_exit_code)
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_gate.rs
+++ b/crates/cli-sub-agent/src/review_gate.rs
@@ -162,18 +162,6 @@ pub(crate) fn write_review_gate_marker(
     }
 }
 
-/// Write a gate marker from a [`csa_session::state::ReviewSessionMeta`] when its
-/// decision is Pass.  No-op for non-Pass decisions.
-pub(crate) fn maybe_write_gate_marker_from_meta(
-    project_root: &Path,
-    meta: &csa_session::state::ReviewSessionMeta,
-) {
-    if meta.decision != csa_core::types::ReviewDecision::Pass.as_str() {
-        return;
-    }
-    maybe_write_review_gate_marker(project_root, &meta.head_sha, &meta.session_id, &meta.scope);
-}
-
 /// Write a gate marker when `verdict == "CLEAN"`.  No-op for any other verdict.
 pub(crate) fn maybe_write_gate_marker_for_clean(
     project_root: &Path,


### PR DESCRIPTION
## Summary

- Fixes verdict.json writing `decision: fail` when findings are empty and review text says PASS
- Ensures verdict decision is derived from actual findings state, not stale defaults
- Adds test covering: empty findings + PASS text → verdict.json must have `decision: pass`

## Test plan

- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo test -p cli-sub-agent verdict` — 122 tests pass
- [x] `csa review --range main...HEAD` PASS (session 01KSEJAXXGSXV62KPHSA7EJASE)

Closes #1593

🤖 Generated with [Claude Code](https://claude.com/claude-code)