### PR TITLE
fix(run): strip CSA env vars from post-exec gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.796"
+version = "0.1.797"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.796"
+version = "0.1.797"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -103,6 +103,17 @@ fn git_worktree_has_status_changes(project_root: &Path) -> Result<bool> {
     Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
 }
 
+fn strip_inherited_csa_env(cmd: &mut Command) {
+    for var in csa_executor::CHILD_PROCESS_STRIPPED_ENV_VARS {
+        cmd.env_remove(var);
+    }
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("CSA_") {
+            cmd.env_remove(key);
+        }
+    }
+}
+
 pub(super) fn execute_post_exec_gate_command(
     command: &str,
     project_root: &Path,
@@ -118,6 +129,7 @@ pub(super) fn execute_post_exec_gate_command(
             .current_dir(&project_root)
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
+        strip_inherited_csa_env(&mut cmd);
 
         #[cfg(unix)]
         {

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -1,6 +1,8 @@
 use super::{
-    PostExecGateCommandOutcome, PostExecGateOutcome, maybe_run_post_exec_gate_with_runner,
+    PostExecGateCommandOutcome, PostExecGateOutcome, execute_post_exec_gate_command,
+    maybe_run_post_exec_gate_with_runner,
 };
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_config::{PostExecGateConfig, ProjectConfig, ProjectMeta, ResourcesConfig, RunConfig};
 use csa_session::create_session_fresh;
@@ -82,6 +84,32 @@ fn create_session_at_current_head(project_root: &Path) -> String {
     )
     .expect("create session")
     .meta_session_id
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn execute_post_exec_gate_strips_inherited_csa_env() {
+    let _lock = TEST_ENV_LOCK.clone().lock_owned().await;
+    let project_dir = tempdir().unwrap();
+    let _session_guard = ScopedEnvVarRestore::set("CSA_SESSION_ID", "01KTESTGATEENV000000000000");
+    let _depth_guard = ScopedEnvVarRestore::set("CSA_DEPTH", "7");
+    let _root_guard = ScopedEnvVarRestore::set("CSA_PROJECT_ROOT", project_dir.path());
+    let _dir_guard = ScopedEnvVarRestore::set("CSA_SESSION_DIR", project_dir.path().join("state"));
+    let _future_guard = ScopedEnvVarRestore::set("CSA_UNLISTED_GATE_ENV", "must-not-leak");
+
+    let outcome = execute_post_exec_gate_command(
+        r#"test -z "${CSA_SESSION_ID+x}" &&
+           test -z "${CSA_DEPTH+x}" &&
+           test -z "${CSA_PROJECT_ROOT+x}" &&
+           test -z "${CSA_SESSION_DIR+x}" &&
+           test -z "${CSA_UNLISTED_GATE_ENV+x}""#,
+        project_dir.path(),
+        30,
+    )
+    .await
+    .expect("post-exec gate command should run");
+
+    assert_eq!(outcome, PostExecGateCommandOutcome::Exited(Some(0)));
 }
 
 #[tokio::test]

--- a/crates/csa-executor/src/executor_env.rs
+++ b/crates/csa-executor/src/executor_env.rs
@@ -9,7 +9,7 @@ use tokio::process::Command;
 ///
 /// The list removes recursive-invocation guards, hook bypass switches, and
 /// session-scoped CSA values that must be rebuilt for each fresh session.
-pub(crate) const STRIPPED_ENV_VARS: &[&str] = &[
+pub const STRIPPED_ENV_VARS: &[&str] = &[
     "CLAUDECODE",
     "CLAUDE_CODE_ENTRYPOINT",
     "LEFTHOOK",

--- a/crates/csa-executor/src/lib.rs
+++ b/crates/csa-executor/src/lib.rs
@@ -26,6 +26,7 @@ pub use context_loader::{
 };
 pub use csa_process::ExecutionResult;
 pub use design_context::{extract_design_sections, format_design_context};
+pub use executor::executor_env::STRIPPED_ENV_VARS as CHILD_PROCESS_STRIPPED_ENV_VARS;
 pub use executor::{ExecuteOptions, Executor, SandboxContext};
 pub use install_hints::{
     CLAUDE_CODE_ACP_INSTALL_HINT, CLAUDE_CODE_CLI_INSTALL_HINT, GEMINI_CLI_INSTALL_HINT,


### PR DESCRIPTION
## Summary

- Strips all `CSA_*` environment variables before spawning the post-exec gate command
- Prevents test failures caused by inherited CSA session env vars (e.g. `CSA_SESSION_ID`, `CSA_DEPTH`)
- Reuses the existing `STRIPPED_ENV_VARS` pattern from executor env module
- Adds regression test verifying gate command environment is clean

Closes #1608

## Test plan

- [ ] `cargo test -p csa-executor test_build_command_parent_session_env` passes
- [ ] `cargo test -p cli-sub-agent` passes (including post-exec gate tests)
- [ ] `cargo clippy --workspace --all-features -- -D warnings` clean
- [ ] `csa run --tool codex` with post-exec gate enabled — gate no longer fails from env pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CSA Review: session 01KSH8ET5EKE1913HH27RDK3B3 — gemini-cli PASS