### PR TITLE
fix(review): pass verdict when parent findings are empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.797"
+version = "0.1.798"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.797"
+version = "0.1.798"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -393,9 +393,6 @@ fn parent_review_decision(
     }
     let consensus_decision =
         ReviewDecision::from_str(final_verdict).unwrap_or(ReviewDecision::Uncertain);
-    if consensus_decision == ReviewDecision::Fail {
-        return ReviewDecision::Fail;
-    }
     if artifact
         .findings
         .iter()
@@ -403,15 +400,18 @@ fn parent_review_decision(
     {
         return ReviewDecision::Fail;
     }
-    if consensus_decision == ReviewDecision::Pass {
-        return ReviewDecision::Pass;
-    }
     if artifact.findings.is_empty()
         || artifact
             .findings
             .iter()
             .all(|finding| finding.severity == Severity::Low)
     {
+        return ReviewDecision::Pass;
+    }
+    if consensus_decision == ReviewDecision::Fail {
+        return ReviewDecision::Fail;
+    }
+    if consensus_decision == ReviewDecision::Pass {
         return ReviewDecision::Pass;
     }
     consensus_decision

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
@@ -443,7 +443,7 @@ fn consensus_artifacts_copy_child_only_findings_into_parent_session_outputs() {
 }
 
 #[test]
-fn write_multi_reviewer_parent_artifacts_preserves_has_issues_consensus_with_empty_findings() {
+fn write_multi_reviewer_parent_artifacts_promotes_empty_findings_to_pass() {
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let temp = tempdir().expect("tempdir should be created");
     let session_dir = temp.path().display().to_string();
@@ -510,8 +510,8 @@ fn write_multi_reviewer_parent_artifacts_preserves_has_issues_consensus_with_emp
             .expect("review-verdict.json should exist"),
     )
     .expect("review verdict should parse");
-    assert_eq!(verdict.decision, ReviewDecision::Fail);
-    assert_eq!(verdict.verdict_legacy, crate::review_consensus::HAS_ISSUES);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, crate::review_consensus::CLEAN);
     assert!(verdict.severity_counts.values().all(|count| *count == 0));
 
     let findings_toml: FindingsFile = toml::from_str(
@@ -522,7 +522,7 @@ fn write_multi_reviewer_parent_artifacts_preserves_has_issues_consensus_with_emp
     assert!(
         fs::read_to_string(output_dir.join("summary.md"))
             .expect("summary should exist")
-            .starts_with("Final verdict: HAS_ISSUES")
+            .starts_with("Final verdict: CLEAN")
     );
 
     let written_meta: csa_session::state::ReviewSessionMeta = serde_json::from_str(
@@ -530,9 +530,9 @@ fn write_multi_reviewer_parent_artifacts_preserves_has_issues_consensus_with_emp
             .expect("review_meta.json should exist"),
     )
     .expect("review meta should parse");
-    assert_eq!(written_meta.decision, ReviewDecision::Fail.as_str());
-    assert_eq!(written_meta.verdict, crate::review_consensus::HAS_ISSUES);
-    assert_eq!(written_meta.exit_code, 1);
+    assert_eq!(written_meta.decision, ReviewDecision::Pass.as_str());
+    assert_eq!(written_meta.verdict, crate::review_consensus::CLEAN);
+    assert_eq!(written_meta.exit_code, 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes consensus verdict derivation to emit `pass` when all parent findings are empty and severity counts are all zero
- The previous fix (#1602) addressed per-reviewer verdict alignment but missed the parent artifact consolidation path
- When no reviewer emits blocking findings, the consolidated verdict must be `pass`, not `fail`

Closes #1614

## Test plan

- [ ] `cargo clippy --workspace --all-features -- -D warnings` clean
- [ ] Updated parent artifact tests verify empty findings → pass verdict
- [ ] `csa review` on a clean diff no longer produces false FAIL with empty findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

CSA Review: session 01KSHKENMRG7NXF2ME4S29KH4N — claude-code PASS (verdict.json false-FAIL is the bug being fixed)