### PR TITLE
feat(hints): inject codex yield_time_ms hint via caller detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.799"
+version = "0.1.800"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.799"
+version = "0.1.800"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -223,6 +223,10 @@ pub(crate) fn spawn_and_exit(
         id = result.session_id,
         cd = cd_hint,
     );
+    let codex_hint = crate::process_tree::codex_yield_hint();
+    if !codex_hint.is_empty() {
+        eprint!("{codex_hint}");
+    }
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
     std::process::exit(0);

--- a/crates/cli-sub-agent/src/process_tree.rs
+++ b/crates/cli-sub-agent/src/process_tree.rs
@@ -71,6 +71,21 @@ pub(crate) fn detect_ancestor_tool() -> Option<String> {
     None
 }
 
+const CODEX_YIELD_TIME_MS: u64 = 300_000;
+
+pub(crate) fn codex_yield_hint() -> String {
+    if detect_ancestor_tool().as_deref() != Some("codex") {
+        return String::new();
+    }
+    format!(
+        "\n<!-- CSA:CODEX_HINT yield_time_ms={ms} \
+         rule=\"You are running inside Codex. When calling 'csa session wait', \
+         pass yield_time_ms: {ms} (5 min) to avoid 10s re-polling that wastes tokens. \
+         Example tool call: shell({{ command: 'csa session wait --session <ID> --cd <PATH>', yield_time_ms: {ms} }})\" -->",
+        ms = CODEX_YIELD_TIME_MS,
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Platform: Linux — read /proc
 // ---------------------------------------------------------------------------

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -311,6 +311,10 @@ pub(crate) fn spawn_and_exit(
         id = result.session_id,
         cd = cd_hint,
     );
+    let codex_hint = crate::process_tree::codex_yield_hint();
+    if !codex_hint.is_empty() {
+        eprint!("{codex_hint}");
+    }
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
     std::process::exit(0);

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -513,6 +513,10 @@ where
                         .map(|p| format!(" --cd '{p}'"))
                         .unwrap_or_default(),
                 );
+                let codex_hint = crate::process_tree::codex_yield_hint();
+                if !codex_hint.is_empty() {
+                    eprint!("{codex_hint}");
+                }
                 return Ok(SESSION_WAIT_KV_WARM_EXIT_CODE);
             }
             // Defensive: daemon gone with no result.toml (rare; earlier loop branches usually exit-1 first).
@@ -594,6 +598,10 @@ fn emit_wait_completion_signal(
          FORBIDDEN: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
          any manual polling wastes caller tokens with zero benefit.\" -->"
     );
+    let codex_hint = crate::process_tree::codex_yield_hint();
+    if !codex_hint.is_empty() {
+        eprint!("{codex_hint}");
+    }
 }
 
 fn emit_wait_memory_warn_marker(session_id: &str, rss_mb: u64, limit_mb: u64) {


### PR DESCRIPTION
## Summary

- CSA detects when invoked from codex via process tree (`detect_ancestor_tool()`)
- Injects `<!-- CSA:CODEX_HINT yield_time_ms=300000 -->` directive at all CALLER_HINT emission points
- Advises codex to use 5-min yield instead of default 10s, reducing 300 poll cycles to ~10 per 50-min session
- Token savings: ~200K tokens per long CSA session when codex is the orchestrator

Closes #1617

## Test plan

- [x] `cargo check` — compiles
- [x] `cargo clippy --package cli-sub-agent` — clean
- [x] 24 related tests pass (caller_hints + process_tree)
- [x] CSA tier-4 review: PASS (session 01KSJ5V4KRJ3E6M3NG90F36T9B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)