### PR TITLE
fix(hints): add 2>/dev/null prohibition to caller hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.801"
+version = "0.1.802"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.801"
+version = "0.1.802"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -11,6 +11,7 @@ const BACKGROUND_WAIT_RECOMMENDATION: &str = "with run_in_background: true";
 const TASK_NOTIFICATION_WAKE_SIGNAL: &str = "The task-notification IS your wake signal";
 const NO_MANUAL_POLLING_DIRECTIVE: &str =
     "ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID";
+const NO_STDERR_SUPPRESS_DIRECTIVE: &str = "piping csa commands through 2>/dev/null";
 
 const RUN_CMD_DAEMON_SRC: &str = include_str!("run_cmd_daemon.rs");
 const PLAN_CMD_DAEMON_SRC: &str = include_str!("plan_cmd_daemon.rs");
@@ -57,6 +58,10 @@ fn assert_wait_hint_contract(block: &str, site: &str) {
     assert!(
         block.contains(NO_MANUAL_POLLING_DIRECTIVE),
         "{site} CALLER_HINT must forbid manual polling (ls/cat/wc/grep on session-dir, state.toml reads, ps checks)"
+    );
+    assert!(
+        block.contains(NO_STDERR_SUPPRESS_DIRECTIVE),
+        "{site} CALLER_HINT must forbid stderr suppression (2>/dev/null)"
     );
 }
 
@@ -120,6 +125,10 @@ fn session_cmds_daemon_wait_retry_wait_hint_warns_no_stack_wakeup() {
         retry.contains(NO_MANUAL_POLLING_DIRECTIVE),
         "retry_wait CALLER_HINT must forbid manual polling (ls/cat/wc/grep on session-dir, state.toml reads, ps checks)"
     );
+    assert!(
+        retry.contains(NO_STDERR_SUPPRESS_DIRECTIVE),
+        "retry_wait CALLER_HINT must forbid stderr suppression (2>/dev/null)"
+    );
 }
 
 #[test]
@@ -136,5 +145,9 @@ fn session_cmds_daemon_wait_next_session_hint_warns_no_stack_wakeup() {
     assert!(
         next.contains(NO_MANUAL_POLLING_DIRECTIVE),
         "next_session CALLER_HINT must forbid manual polling (ls/cat/wc/grep on session-dir, state.toml reads, ps checks)"
+    );
+    assert!(
+        next.contains(NO_STDERR_SUPPRESS_DIRECTIVE),
+        "next_session CALLER_HINT must forbid stderr suppression (2>/dev/null)"
     );
 }

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -219,7 +219,9 @@ pub(crate) fn spawn_and_exit(
          The task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top. \
          NEVER batch multiple waits in a for/while loop; use one backgrounded Bash tool call per session. \
          FORBIDDEN after backgrounding: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
-         any manual polling wastes caller tokens with zero benefit.\" -->",
+         any manual polling wastes caller tokens with zero benefit. \
+         FORBIDDEN: piping csa commands through 2>/dev/null. CSA errors on stderr are diagnostic — \
+         suppressing them hides invalid-argument errors and causes silent retry loops that waste thousands of tokens.\" -->",
         id = result.session_id,
         cd = cd_hint,
     );

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -307,7 +307,9 @@ pub(crate) fn spawn_and_exit(
          The task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top. \
          NEVER batch multiple waits in a for/while loop; use one backgrounded Bash tool call per session. \
          FORBIDDEN after backgrounding: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
-         any manual polling wastes caller tokens with zero benefit.\" -->",
+         any manual polling wastes caller tokens with zero benefit. \
+         FORBIDDEN: piping csa commands through 2>/dev/null. CSA errors on stderr are diagnostic — \
+         suppressing them hides invalid-argument errors and causes silent retry loops that waste thousands of tokens.\" -->",
         id = result.session_id,
         cd = cd_hint,
     );

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -8,10 +8,16 @@ mod next_step;
 mod result_loader;
 #[path = "session_cmds_daemon_wait_summary.rs"]
 mod summary;
+#[path = "session_cmds_daemon_wait_types.rs"]
+mod types;
 pub(crate) use lock::try_acquire_session_wait_lock;
 pub(crate) use next_step::synthesized_wait_next_step;
 use result_loader::{load_completed_daemon_result_with_fallback, refresh_result_for_wait};
 use summary::emit_wait_terminal_output;
+use types::WaitExecutionOptions;
+#[cfg(test)]
+pub(crate) use types::WaitLoopTiming;
+pub(crate) use types::{SessionWaitOutputMode, WaitBehavior, WaitReconciliationOutcome};
 
 /// Exit code reserved for `csa session wait` memory warning early-exit.
 pub(crate) const SESSION_WAIT_MEMORY_WARN_EXIT_CODE: i32 = 33;
@@ -23,70 +29,6 @@ const SESSION_WAIT_KV_WARM_EXIT_CODE: i32 = 0;
 /// Reserved for the rare case where the wait cap is reached but the session
 /// daemon is no longer alive and no result.toml was produced.
 const SESSION_WAIT_TIMEOUT_EXIT_CODE: i32 = 124;
-const SESSION_WAIT_MEMORY_SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SessionWaitOutputMode {
-    CompactText,
-    CompactJson,
-    Verbose,
-}
-
-impl SessionWaitOutputMode {
-    pub(crate) fn from_flags(verbose: bool, json: bool) -> Self {
-        if verbose || std::env::var("CSA_WAIT_VERBOSE").is_ok_and(|value| value == "1") {
-            return Self::Verbose;
-        }
-        if json {
-            return Self::CompactJson;
-        }
-        Self::CompactText
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct WaitLoopTiming {
-    pub(crate) poll_interval: std::time::Duration,
-    pub(crate) memory_sample_interval: std::time::Duration,
-}
-
-impl Default for WaitLoopTiming {
-    fn default() -> Self {
-        Self {
-            poll_interval: std::time::Duration::from_secs(1),
-            memory_sample_interval: SESSION_WAIT_MEMORY_SAMPLE_INTERVAL,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct WaitBehavior {
-    pub(crate) wait_timeout_secs: u64,
-    pub(crate) memory_warn_mb: Option<u64>,
-    pub(crate) timing: WaitLoopTiming,
-}
-
-impl WaitBehavior {
-    fn new(wait_timeout_secs: u64, memory_warn_mb: Option<u64>) -> Self {
-        Self {
-            wait_timeout_secs,
-            memory_warn_mb,
-            timing: WaitLoopTiming::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct WaitExecutionOptions {
-    behavior: WaitBehavior,
-    output_mode: SessionWaitOutputMode,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct WaitReconciliationOutcome {
-    pub(crate) result_became_available: bool,
-    pub(crate) synthetic: bool,
-}
 
 /// Wait for a daemon session to reach a terminal result and daemon exit.
 /// Exits 0 on session success, 1 on terminal session failure, 124 when the
@@ -506,7 +448,9 @@ where
                      NEVER batch multiple session waits in one Bash call. \
                      If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens. \
                      FORBIDDEN: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
-                     any manual polling wastes caller tokens with zero benefit.\" -->",
+                     any manual polling wastes caller tokens with zero benefit. \
+                     FORBIDDEN: piping csa commands through 2>/dev/null. CSA errors on stderr are diagnostic — \
+                     suppressing them hides invalid-argument errors and causes silent retry loops that waste thousands of tokens.\" -->",
                     sid = resolved.session_id,
                     cd = cd
                         .as_ref()
@@ -596,7 +540,9 @@ fn emit_wait_completion_signal(
          Generate tokens between waits to keep your KV cache warm. \
          If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens. \
          FORBIDDEN: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
-         any manual polling wastes caller tokens with zero benefit.\" -->"
+         any manual polling wastes caller tokens with zero benefit. \
+         FORBIDDEN: piping csa commands through 2>/dev/null. CSA errors on stderr are diagnostic — \
+         suppressing them hides invalid-argument errors and causes silent retry loops that waste thousands of tokens.\" -->"
     );
     let codex_hint = crate::process_tree::codex_yield_hint();
     if !codex_hint.is_empty() {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_types.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_types.rs
@@ -1,0 +1,62 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionWaitOutputMode {
+    CompactText,
+    CompactJson,
+    Verbose,
+}
+
+impl SessionWaitOutputMode {
+    pub(crate) fn from_flags(verbose: bool, json: bool) -> Self {
+        if verbose || std::env::var("CSA_WAIT_VERBOSE").is_ok_and(|value| value == "1") {
+            return Self::Verbose;
+        }
+        if json {
+            return Self::CompactJson;
+        }
+        Self::CompactText
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct WaitLoopTiming {
+    pub(crate) poll_interval: std::time::Duration,
+    pub(crate) memory_sample_interval: std::time::Duration,
+}
+
+impl Default for WaitLoopTiming {
+    fn default() -> Self {
+        Self {
+            poll_interval: std::time::Duration::from_secs(1),
+            memory_sample_interval: std::time::Duration::from_secs(15),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct WaitBehavior {
+    pub(crate) wait_timeout_secs: u64,
+    pub(crate) memory_warn_mb: Option<u64>,
+    pub(crate) timing: WaitLoopTiming,
+}
+
+impl WaitBehavior {
+    pub(super) fn new(wait_timeout_secs: u64, memory_warn_mb: Option<u64>) -> Self {
+        Self {
+            wait_timeout_secs,
+            memory_warn_mb,
+            timing: WaitLoopTiming::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct WaitExecutionOptions {
+    pub(super) behavior: WaitBehavior,
+    pub(super) output_mode: SessionWaitOutputMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WaitReconciliationOutcome {
+    pub(crate) result_became_available: bool,
+    pub(crate) synthetic: bool,
+}


### PR DESCRIPTION
## Summary
- Add FORBIDDEN directive against `2>/dev/null` to all 4 caller hint emission sites (run_cmd_daemon, plan_cmd_daemon, session wait retry/next)
- Extract wait types to `session_cmds_daemon_wait_types.rs` to stay under 8K token monolith limit
- Add contract test assertions verifying the new directive exists in all hints
- Version bump to 0.1.802

Closes #1622

## Test plan
- [x] All 5 caller_hints_tests pass (including new stderr suppression assertions)
- [x] `cargo test` passes
- [x] `just pre-commit` passes (monolith check under 8K after type extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>