### PR TITLE
feat(xurl): unify recall into xurl as xurl recall (#1623)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.806"
+version = "0.1.807"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.806"
+version = "0.1.807"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_xurl.rs
+++ b/crates/cli-sub-agent/src/cli_xurl.rs
@@ -24,6 +24,40 @@ pub enum XurlCommands {
         #[arg(long)]
         json: bool,
     },
+
+    /// Recover main-agent context from recorded session transcripts.
+    ///
+    /// Three exclusive modes (default is "read most recent session"):
+    /// * `--keyword TEXT` — search every recorded session for the keyword.
+    /// * `--session ULID` — render a specific session transcript as markdown.
+    /// * `--page N` — render compact page N of the latest session
+    ///   (page 0 = current, higher = older).
+    Recall {
+        /// Search every recorded session for this literal text.
+        #[arg(long, conflicts_with_all = ["session", "page", "list"])]
+        keyword: Option<String>,
+
+        /// Render this session as markdown (ULID, history index, or `latest`).
+        #[arg(long, conflicts_with_all = ["keyword", "page", "list"])]
+        session: Option<String>,
+
+        /// Render compact page N of the latest session (newest-first).
+        /// Page 0 = current page, 1 = previous, etc.
+        #[arg(long, conflicts_with_all = ["keyword", "session", "list"])]
+        page: Option<u32>,
+
+        /// List recorded sessions instead of reading or searching.
+        #[arg(long, conflicts_with_all = ["keyword", "session", "page"])]
+        list: bool,
+
+        /// With `--list` / `--keyword`: include all projects (not just the current one).
+        #[arg(long)]
+        all: bool,
+
+        /// With `--list` / `--keyword`: cap how many results to return.
+        #[arg(long, default_value = "10")]
+        limit: usize,
+    },
 }
 
 pub fn handle_xurl(cmd: XurlCommands) -> Result<()> {
@@ -34,7 +68,36 @@ pub fn handle_xurl(cmd: XurlCommands) -> Result<()> {
             limit,
             json,
         } => handle_threads(keyword, provider, limit, json),
+        XurlCommands::Recall {
+            keyword,
+            session,
+            page,
+            list,
+            all,
+            limit,
+        } => handle_recall(keyword, session, page, list, all, limit),
     }
+}
+
+fn handle_recall(
+    keyword: Option<String>,
+    session: Option<String>,
+    page: Option<u32>,
+    list: bool,
+    all: bool,
+    limit: usize,
+) -> Result<()> {
+    if list {
+        return crate::recall_cmd::handle_recall_list_cmd(limit, all);
+    }
+    if let Some(kw) = keyword {
+        return crate::recall_cmd::handle_recall_keyword(&kw, all, limit);
+    }
+    if let Some(sid) = session {
+        return crate::recall_cmd::handle_recall_read_cmd(&sid, page);
+    }
+    // No mode flags: default to reading the latest session, optionally paginated.
+    crate::recall_cmd::handle_recall_read_cmd("latest", page)
 }
 
 const ALL_PROVIDERS: &[xurl_core::ProviderKind] = &[

--- a/crates/cli-sub-agent/src/cli_xurl.rs
+++ b/crates/cli-sub-agent/src/cli_xurl.rs
@@ -60,46 +60,6 @@ pub enum XurlCommands {
     },
 }
 
-pub fn handle_xurl(cmd: XurlCommands) -> Result<()> {
-    match cmd {
-        XurlCommands::Threads {
-            keyword,
-            provider,
-            limit,
-            json,
-        } => handle_threads(keyword, provider, limit, json),
-        XurlCommands::Recall {
-            keyword,
-            session,
-            page,
-            list,
-            all,
-            limit,
-        } => handle_recall(keyword, session, page, list, all, limit),
-    }
-}
-
-fn handle_recall(
-    keyword: Option<String>,
-    session: Option<String>,
-    page: Option<u32>,
-    list: bool,
-    all: bool,
-    limit: usize,
-) -> Result<()> {
-    if list {
-        return crate::recall_cmd::handle_recall_list_cmd(limit, all);
-    }
-    if let Some(kw) = keyword {
-        return crate::recall_cmd::handle_recall_keyword(&kw, all, limit);
-    }
-    if let Some(sid) = session {
-        return crate::recall_cmd::handle_recall_read_cmd(&sid, page);
-    }
-    // No mode flags: default to reading the latest session, optionally paginated.
-    crate::recall_cmd::handle_recall_read_cmd("latest", page)
-}
-
 const ALL_PROVIDERS: &[xurl_core::ProviderKind] = &[
     xurl_core::ProviderKind::Claude,
     xurl_core::ProviderKind::Codex,
@@ -123,7 +83,7 @@ fn parse_provider(s: &str) -> Result<xurl_core::ProviderKind> {
     }
 }
 
-fn handle_threads(
+pub fn handle_threads(
     keyword: Option<String>,
     provider: Option<String>,
     limit: usize,

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -109,6 +109,7 @@ mod tool_version;
 mod triage_cmd;
 mod verdict_exit_code;
 mod verify_cmd;
+mod xurl_cmd;
 #[cfg(test)]
 include!("review_cmd_exact_tests.rs");
 #[cfg(test)]
@@ -174,7 +175,6 @@ async fn main() {
 async fn run() -> Result<()> {
     link_bug_class_pipeline();
 
-    // Read current depth from env
     let current_depth: u32 = std::env::var("CSA_DEPTH")
         .ok()
         .and_then(|v| v.parse().ok())
@@ -740,7 +740,7 @@ async fn run() -> Result<()> {
             exit_current_process(exit_code);
         }
         Commands::Health(args) => cli::handle_health(args)?,
-        Commands::Xurl { cmd } => cli::handle_xurl(cmd)?,
+        Commands::Xurl { cmd } => xurl_cmd::handle_xurl(cmd)?,
         Commands::Recall(args) => recall_cmd::handle_recall(args.cmd)?,
         Commands::Hooks { cmd } => hooks_cmd::handle_hooks(cmd)?,
     }

--- a/crates/cli-sub-agent/src/recall_cmd.rs
+++ b/crates/cli-sub-agent/src/recall_cmd.rs
@@ -1,5 +1,7 @@
 //! recall_cmd — main-agent session history tracking and xurl-based recovery.
 
+#[path = "recall_cmd_keyword.rs"]
+mod keyword;
 #[path = "recall_cmd_pages.rs"]
 mod pages;
 
@@ -19,7 +21,7 @@ const OUTPUT_GUARD_BYTES: usize = 50 * 1024;
 const RECENT_DEDUP_WINDOW: usize = 10;
 const SEARCH_CONTEXT_LINES: usize = 2;
 
-const RECALL_PROVIDERS: &[xurl_core::ProviderKind] = &[
+pub(super) const RECALL_PROVIDERS: &[xurl_core::ProviderKind] = &[
     xurl_core::ProviderKind::Claude,
     xurl_core::ProviderKind::Codex,
     xurl_core::ProviderKind::Gemini,
@@ -41,6 +43,10 @@ struct SessionRef {
 }
 
 pub(crate) fn handle_recall(cmd: RecallCommands) -> Result<()> {
+    eprintln!(
+        "warning: `csa recall` is deprecated; use `csa xurl recall` instead. \
+         The alias will be removed in a future release."
+    );
     match cmd {
         RecallCommands::List { limit, all } => handle_recall_list(limit, all),
         RecallCommands::Read { session, page } => handle_recall_read(&session, page),
@@ -49,11 +55,19 @@ pub(crate) fn handle_recall(cmd: RecallCommands) -> Result<()> {
     }
 }
 
+pub(crate) fn handle_recall_list_cmd(limit: usize, all: bool) -> Result<()> {
+    handle_recall_list(limit, all)
+}
+
+pub(crate) fn handle_recall_read_cmd(session: &str, page: Option<u32>) -> Result<()> {
+    handle_recall_read(session, page)
+}
+
 fn recall_allowed_at_depth(depth: u32) -> bool {
     depth == 0
 }
 
-fn thread_belongs_to_project(
+pub(super) fn thread_belongs_to_project(
     thread_source: &str,
     project_root: &Path,
     provider: xurl_core::ProviderKind,
@@ -327,6 +341,17 @@ fn handle_recall_search(query: &str) -> Result<()> {
     Ok(())
 }
 
+/// Search all recorded sessions across providers for `keyword`.
+///
+/// Scope:
+/// * `all = false` — restrict matches to threads belonging to `project_root`.
+/// * `all = true` — include matches from every project (use for cross-project recall).
+///
+/// `limit` caps results per provider (passed into `xurl_core::ThreadQuery::limit`).
+pub(crate) fn handle_recall_keyword(keyword: &str, all: bool, limit: usize) -> Result<()> {
+    keyword::handle_recall_keyword(keyword, all, limit)
+}
+
 fn latest_session_ref(project_root: &Path) -> Result<SessionRef> {
     resolve_session_ref("latest", project_root)
 }
@@ -478,7 +503,7 @@ fn render_session_markdown(session_ref: &SessionRef) -> Result<String> {
     resolve_session_thread(session_ref).map(|(_, content)| content)
 }
 
-fn provider_roots() -> Result<xurl_core::ProviderRoots> {
+pub(super) fn provider_roots() -> Result<xurl_core::ProviderRoots> {
     xurl_core::ProviderRoots::from_env_or_home().context("Failed to resolve provider roots")
 }
 
@@ -588,7 +613,7 @@ fn matching_ranges(lines: &[&str], query: &str, context: usize) -> Vec<(usize, u
     ranges
 }
 
-fn truncate_display(value: &str, width: usize) -> String {
+pub(super) fn truncate_display(value: &str, width: usize) -> String {
     let mut chars = value.chars();
     let preview: String = chars.by_ref().take(width).collect();
     if chars.next().is_some() && width > 3 {
@@ -599,177 +624,5 @@ fn truncate_display(value: &str, width: usize) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn make_entry(sid: &str) -> RecallHistoryEntry {
-        RecallHistoryEntry {
-            ts: "2026-05-08T17:48:14Z".to_string(),
-            sid: sid.to_string(),
-            project: "/tmp/project".to_string(),
-            provider: "claude".to_string(),
-        }
-    }
-
-    fn make_entry_with_project_and_provider(
-        sid: &str,
-        project: &str,
-        provider: &str,
-    ) -> RecallHistoryEntry {
-        RecallHistoryEntry {
-            ts: "2026-05-08T17:48:14Z".to_string(),
-            sid: sid.to_string(),
-            project: project.to_string(),
-            provider: provider.to_string(),
-        }
-    }
-
-    #[test]
-    fn append_history_entry_writes_jsonl_line() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let history_path = temp_dir.path().join(HISTORY_FILE_NAME);
-
-        let appended = append_history_entry(&history_path, &make_entry("sid-1")).expect("append");
-        assert!(appended, "first append must write a line");
-
-        let entries = load_history_entries(&history_path).expect("load");
-        assert_eq!(entries, vec![make_entry("sid-1")]);
-    }
-
-    #[test]
-    fn append_history_entry_skips_recent_duplicate_sid() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let history_path = temp_dir.path().join(HISTORY_FILE_NAME);
-
-        append_history_entry(&history_path, &make_entry("sid-1")).expect("first append");
-        let appended =
-            append_history_entry(&history_path, &make_entry("sid-1")).expect("second append");
-
-        assert!(!appended, "duplicate sid in recent window must be skipped");
-        let entries = load_history_entries(&history_path).expect("load");
-        assert_eq!(
-            entries.len(),
-            1,
-            "duplicate append must not add a second line"
-        );
-    }
-
-    #[test]
-    fn append_history_entry_allows_duplicate_outside_recent_window() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        let history_path = temp_dir.path().join(HISTORY_FILE_NAME);
-
-        append_history_entry(&history_path, &make_entry("sid-1")).expect("first append");
-        for index in 0..RECENT_DEDUP_WINDOW {
-            let sid = format!("sid-{index}-other");
-            append_history_entry(&history_path, &make_entry(&sid)).expect("filler append");
-        }
-
-        let appended =
-            append_history_entry(&history_path, &make_entry("sid-1")).expect("late append");
-        assert!(
-            appended,
-            "sid older than the dedup window must be recorded again"
-        );
-    }
-
-    #[test]
-    fn output_guard_triggers_at_threshold() {
-        let content = "x".repeat(OUTPUT_GUARD_BYTES);
-        let message = output_guard_message("sid-1", &content).expect("guard");
-        assert!(message.contains("OUTPUT_TOO_LARGE"));
-        assert!(message.contains("csa recall read sid-1 | tail -100"));
-    }
-
-    #[test]
-    fn output_guard_allows_small_output() {
-        let content = "x".repeat(OUTPUT_GUARD_BYTES - 1);
-        assert!(output_guard_message("sid-1", &content).is_none());
-    }
-
-    #[test]
-    fn matching_ranges_merges_overlapping_context() {
-        let lines = vec!["0", "match one", "2", "match two", "4"];
-        let ranges = matching_ranges(&lines, "match", 1);
-        assert_eq!(ranges, vec![(0, 4)]);
-    }
-
-    #[test]
-    fn recall_allowed_only_at_main_agent_depth() {
-        assert!(
-            recall_allowed_at_depth(0),
-            "main agent (depth=0) must be recorded"
-        );
-        assert!(
-            !recall_allowed_at_depth(1),
-            "depth=1 child session must not be recorded"
-        );
-        assert!(
-            !recall_allowed_at_depth(5),
-            "deeply nested child (depth=5) must not be recorded"
-        );
-    }
-
-    #[test]
-    fn thread_belongs_to_matching_project_claude() {
-        let source = "/home/obj/.claude/projects/-home-obj-project-github-user-repo/abc.jsonl";
-        let root = Path::new("/home/obj/project/github/user/repo");
-        assert!(thread_belongs_to_project(
-            source,
-            root,
-            xurl_core::ProviderKind::Claude
-        ));
-    }
-
-    #[test]
-    fn thread_rejects_different_project_claude() {
-        let source = "/home/obj/.claude/projects/-home-obj-project-github-user-other/abc.jsonl";
-        let root = Path::new("/home/obj/project/github/user/repo");
-        assert!(!thread_belongs_to_project(
-            source,
-            root,
-            xurl_core::ProviderKind::Claude
-        ));
-    }
-
-    #[test]
-    fn thread_belongs_to_project_codex_always_true() {
-        let source = "/home/obj/.codex/sessions/2026/05/16/rollout-abc.jsonl";
-        let root = Path::new("/home/obj/project/github/user/repo");
-        assert!(
-            thread_belongs_to_project(source, root, xurl_core::ProviderKind::Codex),
-            "codex sessions don't encode project; always pass ownership check"
-        );
-    }
-
-    #[test]
-    fn thread_belongs_to_project_gemini_always_true() {
-        let source = "/home/obj/.gemini/history/session-abc.jsonl";
-        let root = Path::new("/home/obj/project/github/user/repo");
-        assert!(
-            thread_belongs_to_project(source, root, xurl_core::ProviderKind::Gemini),
-            "gemini sessions don't encode project; always pass ownership check"
-        );
-    }
-
-    #[test]
-    fn latest_history_entry_returns_last_from_filtered_list() {
-        let entry1 = make_entry_with_project_and_provider("sid-1", "/project/a", "claude");
-        let entry2 = make_entry_with_project_and_provider("sid-2", "/project/b", "codex");
-        let entry3 = make_entry_with_project_and_provider("sid-3", "/project/a", "gemini");
-
-        let entries = vec![&entry1, &entry2, &entry3];
-
-        let result = latest_history_entry(&entries).expect("latest");
-        assert_eq!(result.sid, "sid-3", "latest should be the last entry");
-    }
-
-    #[test]
-    fn latest_history_entry_returns_none_for_empty_list() {
-        let entries: Vec<&RecallHistoryEntry> = vec![];
-        assert!(
-            latest_history_entry(&entries).is_none(),
-            "empty list should return None"
-        );
-    }
-}
+#[path = "recall_cmd_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/recall_cmd_keyword.rs
+++ b/crates/cli-sub-agent/src/recall_cmd_keyword.rs
@@ -1,0 +1,118 @@
+//! Cross-session keyword search for `csa xurl recall --keyword`.
+//!
+//! Iterates every recall provider and reports threads whose transcript
+//! matches the supplied keyword.  When `all = false`, results are filtered
+//! to the current project.
+
+use anyhow::Result;
+use tracing::debug;
+
+use super::{RECALL_PROVIDERS, provider_roots, thread_belongs_to_project, truncate_display};
+
+struct Hit {
+    provider: xurl_core::ProviderKind,
+    thread_id: String,
+    thread_source: String,
+    updated_at: Option<String>,
+    preview: Option<String>,
+}
+
+pub(super) fn handle_recall_keyword(keyword: &str, all: bool, limit: usize) -> Result<()> {
+    let trimmed = keyword.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("--keyword must not be empty");
+    }
+    if limit == 0 {
+        anyhow::bail!("--limit must be greater than 0");
+    }
+
+    let project_root = crate::pipeline::determine_project_root(None)?;
+    let roots = provider_roots()?;
+    let mut hits = collect_hits(trimmed, all, limit, &project_root, &roots);
+
+    if hits.is_empty() {
+        let scope = if all {
+            "any project".to_string()
+        } else {
+            format!("project {}", project_root.display())
+        };
+        println!("No matches for keyword '{trimmed}' in {scope}.");
+        return Ok(());
+    }
+
+    hits.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    print_hits(&hits);
+    Ok(())
+}
+
+fn collect_hits(
+    keyword: &str,
+    all: bool,
+    limit: usize,
+    project_root: &std::path::Path,
+    roots: &xurl_core::ProviderRoots,
+) -> Vec<Hit> {
+    let mut hits: Vec<Hit> = Vec::new();
+    for &provider in RECALL_PROVIDERS {
+        let query = xurl_core::ThreadQuery {
+            uri: format!("{provider}://"),
+            provider,
+            role: None,
+            q: Some(keyword.to_string()),
+            limit,
+            ignored_params: Vec::new(),
+        };
+        let result = match xurl_core::query_threads(&query, roots) {
+            Ok(r) => r,
+            Err(err) => {
+                debug!(
+                    provider = %provider,
+                    error = %err,
+                    "recall keyword: skipping provider"
+                );
+                continue;
+            }
+        };
+        for item in result.items {
+            if !all && !thread_belongs_to_project(&item.thread_source, project_root, provider) {
+                continue;
+            }
+            hits.push(Hit {
+                provider,
+                thread_id: item.thread_id,
+                thread_source: item.thread_source,
+                updated_at: item.updated_at,
+                preview: item.matched_preview,
+            });
+        }
+    }
+    hits
+}
+
+fn print_hits(hits: &[Hit]) {
+    println!(
+        "{:<10} {:<36} {:<20} PREVIEW",
+        "PROVIDER", "SESSION", "UPDATED"
+    );
+    println!("{}", "-".repeat(100));
+    for hit in hits {
+        let updated = hit.updated_at.as_deref().unwrap_or("-");
+        let updated_short: String = updated.chars().take(19).collect();
+        let preview: String = hit
+            .preview
+            .as_deref()
+            .unwrap_or("")
+            .chars()
+            .take(40)
+            .collect();
+        println!(
+            "{:<10} {:<36} {:<20} {}",
+            hit.provider.to_string(),
+            truncate_display(&hit.thread_id, 36),
+            updated_short,
+            preview,
+        );
+        debug!(source = %hit.thread_source, "recall keyword hit");
+    }
+    println!("\nTotal matches: {}", hits.len());
+}

--- a/crates/cli-sub-agent/src/recall_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/recall_cmd_tests.rs
@@ -1,0 +1,173 @@
+use std::path::Path;
+
+use super::*;
+
+fn make_entry(sid: &str) -> RecallHistoryEntry {
+    RecallHistoryEntry {
+        ts: "2026-05-08T17:48:14Z".to_string(),
+        sid: sid.to_string(),
+        project: "/tmp/project".to_string(),
+        provider: "claude".to_string(),
+    }
+}
+
+fn make_entry_with_project_and_provider(
+    sid: &str,
+    project: &str,
+    provider: &str,
+) -> RecallHistoryEntry {
+    RecallHistoryEntry {
+        ts: "2026-05-08T17:48:14Z".to_string(),
+        sid: sid.to_string(),
+        project: project.to_string(),
+        provider: provider.to_string(),
+    }
+}
+
+#[test]
+fn append_history_entry_writes_jsonl_line() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let history_path = temp_dir.path().join(HISTORY_FILE_NAME);
+
+    let appended = append_history_entry(&history_path, &make_entry("sid-1")).expect("append");
+    assert!(appended, "first append must write a line");
+
+    let entries = load_history_entries(&history_path).expect("load");
+    assert_eq!(entries, vec![make_entry("sid-1")]);
+}
+
+#[test]
+fn append_history_entry_skips_recent_duplicate_sid() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let history_path = temp_dir.path().join(HISTORY_FILE_NAME);
+
+    append_history_entry(&history_path, &make_entry("sid-1")).expect("first append");
+    let appended =
+        append_history_entry(&history_path, &make_entry("sid-1")).expect("second append");
+
+    assert!(!appended, "duplicate sid in recent window must be skipped");
+    let entries = load_history_entries(&history_path).expect("load");
+    assert_eq!(
+        entries.len(),
+        1,
+        "duplicate append must not add a second line"
+    );
+}
+
+#[test]
+fn append_history_entry_allows_duplicate_outside_recent_window() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let history_path = temp_dir.path().join(HISTORY_FILE_NAME);
+
+    append_history_entry(&history_path, &make_entry("sid-1")).expect("first append");
+    for index in 0..RECENT_DEDUP_WINDOW {
+        let sid = format!("sid-{index}-other");
+        append_history_entry(&history_path, &make_entry(&sid)).expect("filler append");
+    }
+
+    let appended = append_history_entry(&history_path, &make_entry("sid-1")).expect("late append");
+    assert!(
+        appended,
+        "sid older than the dedup window must be recorded again"
+    );
+}
+
+#[test]
+fn output_guard_triggers_at_threshold() {
+    let content = "x".repeat(OUTPUT_GUARD_BYTES);
+    let message = output_guard_message("sid-1", &content).expect("guard");
+    assert!(message.contains("OUTPUT_TOO_LARGE"));
+    assert!(message.contains("csa recall read sid-1 | tail -100"));
+}
+
+#[test]
+fn output_guard_allows_small_output() {
+    let content = "x".repeat(OUTPUT_GUARD_BYTES - 1);
+    assert!(output_guard_message("sid-1", &content).is_none());
+}
+
+#[test]
+fn matching_ranges_merges_overlapping_context() {
+    let lines = vec!["0", "match one", "2", "match two", "4"];
+    let ranges = matching_ranges(&lines, "match", 1);
+    assert_eq!(ranges, vec![(0, 4)]);
+}
+
+#[test]
+fn recall_allowed_only_at_main_agent_depth() {
+    assert!(
+        recall_allowed_at_depth(0),
+        "main agent (depth=0) must be recorded"
+    );
+    assert!(
+        !recall_allowed_at_depth(1),
+        "depth=1 child session must not be recorded"
+    );
+    assert!(
+        !recall_allowed_at_depth(5),
+        "deeply nested child (depth=5) must not be recorded"
+    );
+}
+
+#[test]
+fn thread_belongs_to_matching_project_claude() {
+    let source = "/home/obj/.claude/projects/-home-obj-project-github-user-repo/abc.jsonl";
+    let root = Path::new("/home/obj/project/github/user/repo");
+    assert!(thread_belongs_to_project(
+        source,
+        root,
+        xurl_core::ProviderKind::Claude
+    ));
+}
+
+#[test]
+fn thread_rejects_different_project_claude() {
+    let source = "/home/obj/.claude/projects/-home-obj-project-github-user-other/abc.jsonl";
+    let root = Path::new("/home/obj/project/github/user/repo");
+    assert!(!thread_belongs_to_project(
+        source,
+        root,
+        xurl_core::ProviderKind::Claude
+    ));
+}
+
+#[test]
+fn thread_belongs_to_project_codex_always_true() {
+    let source = "/home/obj/.codex/sessions/2026/05/16/rollout-abc.jsonl";
+    let root = Path::new("/home/obj/project/github/user/repo");
+    assert!(
+        thread_belongs_to_project(source, root, xurl_core::ProviderKind::Codex),
+        "codex sessions don't encode project; always pass ownership check"
+    );
+}
+
+#[test]
+fn thread_belongs_to_project_gemini_always_true() {
+    let source = "/home/obj/.gemini/history/session-abc.jsonl";
+    let root = Path::new("/home/obj/project/github/user/repo");
+    assert!(
+        thread_belongs_to_project(source, root, xurl_core::ProviderKind::Gemini),
+        "gemini sessions don't encode project; always pass ownership check"
+    );
+}
+
+#[test]
+fn latest_history_entry_returns_last_from_filtered_list() {
+    let entry1 = make_entry_with_project_and_provider("sid-1", "/project/a", "claude");
+    let entry2 = make_entry_with_project_and_provider("sid-2", "/project/b", "codex");
+    let entry3 = make_entry_with_project_and_provider("sid-3", "/project/a", "gemini");
+
+    let entries = vec![&entry1, &entry2, &entry3];
+
+    let result = latest_history_entry(&entries).expect("latest");
+    assert_eq!(result.sid, "sid-3", "latest should be the last entry");
+}
+
+#[test]
+fn latest_history_entry_returns_none_for_empty_list() {
+    let entries: Vec<&RecallHistoryEntry> = vec![];
+    assert!(
+        latest_history_entry(&entries).is_none(),
+        "empty list should return None"
+    );
+}

--- a/crates/cli-sub-agent/src/xurl_cmd.rs
+++ b/crates/cli-sub-agent/src/xurl_cmd.rs
@@ -1,0 +1,50 @@
+//! xurl command dispatcher.
+//!
+//! `cli_xurl.rs` only defines the `XurlCommands` enum and parsing helpers; it
+//! is `#[path]`-included from integration tests (via `cli.rs`) that don't have
+//! every binary-side module in scope. The recall dispatch lives here so it can
+//! reach `crate::recall_cmd::*` without forcing those tests to declare every
+//! transitively referenced module.
+use anyhow::Result;
+
+use crate::cli::XurlCommands;
+use crate::recall_cmd;
+
+pub fn handle_xurl(cmd: XurlCommands) -> Result<()> {
+    match cmd {
+        XurlCommands::Threads {
+            keyword,
+            provider,
+            limit,
+            json,
+        } => crate::cli::handle_threads(keyword, provider, limit, json),
+        XurlCommands::Recall {
+            keyword,
+            session,
+            page,
+            list,
+            all,
+            limit,
+        } => handle_recall(keyword, session, page, list, all, limit),
+    }
+}
+
+fn handle_recall(
+    keyword: Option<String>,
+    session: Option<String>,
+    page: Option<u32>,
+    list: bool,
+    all: bool,
+    limit: usize,
+) -> Result<()> {
+    if list {
+        return recall_cmd::handle_recall_list_cmd(limit, all);
+    }
+    if let Some(kw) = keyword {
+        return recall_cmd::handle_recall_keyword(&kw, all, limit);
+    }
+    if let Some(sid) = session {
+        return recall_cmd::handle_recall_read_cmd(&sid, page);
+    }
+    recall_cmd::handle_recall_read_cmd("latest", page)
+}


### PR DESCRIPTION
## Summary
- Merge `csa recall` into `csa xurl recall` — local transcripts become another xurl provider
- New CLI surface: `csa xurl recall --keyword "..."`, `--session <ULID>`, `--page <N>`
- Cross-session search across all .jsonl transcripts in project session directory
- `csa recall` kept as deprecated alias with warning, routes to `csa xurl recall`
- Backward-compatible: existing recall behavior preserved

Closes #1623

## Test plan
- [x] `just pre-commit` passes
- [x] CSA review PASS (codex, session 01KSNRJGR36R9KW39Y9KCHTN8F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)