### PR TITLE
feat(xurl): multi-keyword AND search, context snippets, combined filters (#1634)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.807"
+version = "0.1.808"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_xurl.rs
+++ b/crates/cli-sub-agent/src/cli_xurl.rs
@@ -27,18 +27,27 @@ pub enum XurlCommands {
 
     /// Recover main-agent context from recorded session transcripts.
     ///
-    /// Three exclusive modes (default is "read most recent session"):
-    /// * `--keyword TEXT` — search every recorded session for the keyword.
+    /// Modes (default is "read most recent session"):
+    /// * `--keyword "A B C"` — search every recorded session; whitespace splits
+    ///   the value into terms that must ALL appear (AND logic, not exact phrase).
     /// * `--session ULID` — render a specific session transcript as markdown.
+    /// * `--keyword TEXT --session ULID` — search within the specified session
+    ///   for the keyword(s).
     /// * `--page N` — render compact page N of the latest session
     ///   (page 0 = current, higher = older).
     Recall {
-        /// Search every recorded session for this literal text.
-        #[arg(long, conflicts_with_all = ["session", "page", "list"])]
+        /// Search recorded sessions for these terms (whitespace-separated, AND).
+        ///
+        /// Without `--session`, scans every recorded session; with `--session`,
+        /// restricts the search to that session's transcript.
+        #[arg(long, conflicts_with_all = ["page", "list"])]
         keyword: Option<String>,
 
         /// Render this session as markdown (ULID, history index, or `latest`).
-        #[arg(long, conflicts_with_all = ["keyword", "page", "list"])]
+        ///
+        /// Combined with `--keyword`, restricts the keyword search to this
+        /// session instead of scanning all recorded sessions.
+        #[arg(long, conflicts_with_all = ["page", "list"])]
         session: Option<String>,
 
         /// Render compact page N of the latest session (newest-first).

--- a/crates/cli-sub-agent/src/recall_cmd.rs
+++ b/crates/cli-sub-agent/src/recall_cmd.rs
@@ -37,9 +37,9 @@ struct RecallHistoryEntry {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct SessionRef {
-    sid: String,
-    provider: String,
+pub(super) struct SessionRef {
+    pub(super) sid: String,
+    pub(super) provider: String,
 }
 
 pub(crate) fn handle_recall(cmd: RecallCommands) -> Result<()> {
@@ -341,22 +341,31 @@ fn handle_recall_search(query: &str) -> Result<()> {
     Ok(())
 }
 
-/// Search all recorded sessions across providers for `keyword`.
+/// Search recorded sessions for whitespace-separated `keyword` terms (AND).
 ///
 /// Scope:
-/// * `all = false` — restrict matches to threads belonging to `project_root`.
-/// * `all = true` — include matches from every project (use for cross-project recall).
+/// * `session = Some(sel)` — search only within the selected session
+///   (ULID, history index, or `latest`).
+/// * `session = None`, `all = false` — restrict matches to threads belonging
+///   to the current project.
+/// * `session = None`, `all = true` — include matches from every project.
 ///
 /// `limit` caps results per provider (passed into `xurl_core::ThreadQuery::limit`).
-pub(crate) fn handle_recall_keyword(keyword: &str, all: bool, limit: usize) -> Result<()> {
-    keyword::handle_recall_keyword(keyword, all, limit)
+/// Ignored when `session` is set (single-session output has no per-provider fan-out).
+pub(crate) fn handle_recall_keyword(
+    keyword: &str,
+    session: Option<&str>,
+    all: bool,
+    limit: usize,
+) -> Result<()> {
+    keyword::handle_recall_keyword(keyword, session, all, limit)
 }
 
 fn latest_session_ref(project_root: &Path) -> Result<SessionRef> {
     resolve_session_ref("latest", project_root)
 }
 
-fn resolve_session_ref(selector: &str, project_root: &Path) -> Result<SessionRef> {
+pub(super) fn resolve_session_ref(selector: &str, project_root: &Path) -> Result<SessionRef> {
     let trimmed = selector.trim();
     if trimmed.is_empty() {
         anyhow::bail!("Session selector must not be empty");
@@ -499,7 +508,7 @@ fn resolve_session_thread(session_ref: &SessionRef) -> Result<(xurl_core::Resolv
     Ok((resolved, content))
 }
 
-fn render_session_markdown(session_ref: &SessionRef) -> Result<String> {
+pub(super) fn render_session_markdown(session_ref: &SessionRef) -> Result<String> {
     resolve_session_thread(session_ref).map(|(_, content)| content)
 }
 

--- a/crates/cli-sub-agent/src/recall_cmd_keyword.rs
+++ b/crates/cli-sub-agent/src/recall_cmd_keyword.rs
@@ -1,13 +1,33 @@
 //! Cross-session keyword search for `csa xurl recall --keyword`.
 //!
-//! Iterates every recall provider and reports threads whose transcript
-//! matches the supplied keyword.  When `all = false`, results are filtered
-//! to the current project.
+//! Supports three modes selected by the caller:
+//! 1. Cross-session AND search: split the keyword string on whitespace and
+//!    list threads whose transcript contains EVERY term.
+//! 2. In-session AND search: when a session selector is provided, restrict
+//!    the search to that session's transcript and render line context.
+//! 3. Single-keyword search: a one-term `--keyword` degrades to the original
+//!    single-keyword behavior (no extra rendering cost).
+
+use std::path::Path;
 
 use anyhow::Result;
 use tracing::debug;
 
-use super::{RECALL_PROVIDERS, provider_roots, thread_belongs_to_project, truncate_display};
+use super::{
+    RECALL_PROVIDERS, SessionRef, provider_roots, render_session_markdown, resolve_session_ref,
+    thread_belongs_to_project, truncate_display,
+};
+
+/// Width of the context snippet shown in the PREVIEW column (chars).
+const PREVIEW_WIDTH: usize = 80;
+/// Context-line radius used for in-session keyword display.
+const SEARCH_CONTEXT_LINES: usize = 2;
+/// Over-fetch factor when filtering by multiple keywords.
+///
+/// `xurl_core::ThreadQuery::limit` caps results per provider after the
+/// primary keyword matches. Some candidates will be excluded by the AND
+/// filter, so we widen the initial fetch to keep enough survivors.
+const AND_OVERFETCH_FACTOR: usize = 4;
 
 struct Hit {
     provider: xurl_core::ProviderKind,
@@ -17,7 +37,12 @@ struct Hit {
     preview: Option<String>,
 }
 
-pub(super) fn handle_recall_keyword(keyword: &str, all: bool, limit: usize) -> Result<()> {
+pub(super) fn handle_recall_keyword(
+    keyword: &str,
+    session: Option<&str>,
+    all: bool,
+    limit: usize,
+) -> Result<()> {
     let trimmed = keyword.trim();
     if trimmed.is_empty() {
         anyhow::bail!("--keyword must not be empty");
@@ -25,10 +50,18 @@ pub(super) fn handle_recall_keyword(keyword: &str, all: bool, limit: usize) -> R
     if limit == 0 {
         anyhow::bail!("--limit must be greater than 0");
     }
+    let keywords: Vec<&str> = trimmed.split_whitespace().collect();
+    if keywords.is_empty() {
+        anyhow::bail!("--keyword must contain at least one non-whitespace term");
+    }
+
+    if let Some(sel) = session {
+        return handle_in_session_search(sel, &keywords);
+    }
 
     let project_root = crate::pipeline::determine_project_root(None)?;
     let roots = provider_roots()?;
-    let mut hits = collect_hits(trimmed, all, limit, &project_root, &roots);
+    let mut hits = collect_hits(&keywords, all, limit, &project_root, &roots);
 
     if hits.is_empty() {
         let scope = if all {
@@ -36,7 +69,8 @@ pub(super) fn handle_recall_keyword(keyword: &str, all: bool, limit: usize) -> R
         } else {
             format!("project {}", project_root.display())
         };
-        println!("No matches for keyword '{trimmed}' in {scope}.");
+        let kw_display = keywords.join(" ");
+        println!("No matches for keyword '{kw_display}' in {scope}.");
         return Ok(());
     }
 
@@ -46,20 +80,29 @@ pub(super) fn handle_recall_keyword(keyword: &str, all: bool, limit: usize) -> R
 }
 
 fn collect_hits(
-    keyword: &str,
+    keywords: &[&str],
     all: bool,
     limit: usize,
-    project_root: &std::path::Path,
+    project_root: &Path,
     roots: &xurl_core::ProviderRoots,
 ) -> Vec<Hit> {
+    // `keywords` is non-empty (validated by caller); safe to split.
+    let primary = keywords[0];
+    let extras = &keywords[1..];
+    let provider_limit = if extras.is_empty() {
+        limit
+    } else {
+        limit.saturating_mul(AND_OVERFETCH_FACTOR).max(limit)
+    };
+
     let mut hits: Vec<Hit> = Vec::new();
     for &provider in RECALL_PROVIDERS {
         let query = xurl_core::ThreadQuery {
             uri: format!("{provider}://"),
             provider,
             role: None,
-            q: Some(keyword.to_string()),
-            limit,
+            q: Some(primary.to_string()),
+            limit: provider_limit,
             ignored_params: Vec::new(),
         };
         let result = match xurl_core::query_threads(&query, roots) {
@@ -77,16 +120,95 @@ fn collect_hits(
             if !all && !thread_belongs_to_project(&item.thread_source, project_root, provider) {
                 continue;
             }
+            // Render the session once when we need (a) AND-filter validation or
+            // (b) a clean snippet because the upstream preview truncated away
+            // the primary keyword.
+            let need_render_for_and = !extras.is_empty();
+            let upstream_preview = item.matched_preview.as_deref();
+            let upstream_has_keyword = upstream_preview
+                .map(|p| contains_ci(p, primary))
+                .unwrap_or(false);
+            let need_render_for_snippet = !upstream_has_keyword;
+            let rendered = if need_render_for_and || need_render_for_snippet {
+                let session_ref = SessionRef {
+                    sid: item.thread_id.clone(),
+                    provider: provider.to_string(),
+                };
+                match render_session_markdown(&session_ref) {
+                    Ok(c) => Some(c),
+                    Err(err) => {
+                        debug!(
+                            provider = %provider,
+                            sid = %item.thread_id,
+                            error = %err,
+                            "recall keyword: skip (render failed)"
+                        );
+                        if need_render_for_and {
+                            continue;
+                        }
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+            if need_render_for_and {
+                // Safe: we only reach here when render succeeded (errors `continue`).
+                let content = rendered.as_deref().unwrap_or("");
+                if !all_keywords_present(content, extras) {
+                    continue;
+                }
+            }
+            let preview = build_preview(rendered.as_deref(), upstream_preview, primary);
             hits.push(Hit {
                 provider,
                 thread_id: item.thread_id,
                 thread_source: item.thread_source,
                 updated_at: item.updated_at,
-                preview: item.matched_preview,
+                preview,
             });
         }
     }
     hits
+}
+
+/// Build a PREVIEW column entry.
+///
+/// Prefers a snippet extracted from the rendered transcript (always shows the
+/// keyword in context). Falls back to the upstream `matched_preview` snippet
+/// (truncated to the matching line, may omit the keyword for very long lines)
+/// when the rendered content is unavailable.
+fn build_preview(
+    rendered: Option<&str>,
+    upstream_preview: Option<&str>,
+    primary_keyword: &str,
+) -> Option<String> {
+    if let Some(content) = rendered
+        && let Some(snippet) = snippet_from_content(content, primary_keyword, PREVIEW_WIDTH)
+    {
+        return Some(snippet);
+    }
+    upstream_preview.and_then(|p| build_snippet(p, primary_keyword, PREVIEW_WIDTH))
+}
+
+/// Find the first non-empty line containing `keyword` (case-insensitive) and
+/// build a centered snippet of `window` chars from it.
+fn snippet_from_content(content: &str, keyword: &str, window: usize) -> Option<String> {
+    let kw_lower = keyword.to_lowercase();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.to_lowercase().contains(&kw_lower) {
+            return build_snippet(trimmed, keyword, window);
+        }
+    }
+    None
+}
+
+fn contains_ci(haystack: &str, needle: &str) -> bool {
+    haystack.to_lowercase().contains(&needle.to_lowercase())
 }
 
 fn print_hits(hits: &[Hit]) {
@@ -94,25 +216,321 @@ fn print_hits(hits: &[Hit]) {
         "{:<10} {:<36} {:<20} PREVIEW",
         "PROVIDER", "SESSION", "UPDATED"
     );
-    println!("{}", "-".repeat(100));
+    println!("{}", "-".repeat(160));
     for hit in hits {
         let updated = hit.updated_at.as_deref().unwrap_or("-");
         let updated_short: String = updated.chars().take(19).collect();
-        let preview: String = hit
-            .preview
-            .as_deref()
-            .unwrap_or("")
-            .chars()
-            .take(40)
-            .collect();
+        let preview = hit.preview.as_deref().unwrap_or("");
+        let preview_display = truncate_chars(preview, PREVIEW_WIDTH);
         println!(
             "{:<10} {:<36} {:<20} {}",
             hit.provider.to_string(),
             truncate_display(&hit.thread_id, 36),
             updated_short,
-            preview,
+            preview_display,
         );
         debug!(source = %hit.thread_source, "recall keyword hit");
     }
     println!("\nTotal matches: {}", hits.len());
+}
+
+fn handle_in_session_search(session: &str, keywords: &[&str]) -> Result<()> {
+    let project_root = crate::pipeline::determine_project_root(None)?;
+    let session_ref = resolve_session_ref(session, &project_root)?;
+    let content = render_session_markdown(&session_ref)?;
+    let lines: Vec<&str> = content.lines().collect();
+    let ranges = matching_ranges_any(&lines, keywords, SEARCH_CONTEXT_LINES);
+
+    if ranges.is_empty() {
+        let kw_display = keywords.join(" ");
+        println!(
+            "No matches for '{}' in session {}.",
+            kw_display, session_ref.sid
+        );
+        return Ok(());
+    }
+
+    println!(
+        "Matches in session {} ({})",
+        session_ref.sid, session_ref.provider
+    );
+    for (start, end) in ranges {
+        println!("\n-- lines {}-{} --", start + 1, end + 1);
+        for (idx, line) in lines.iter().enumerate().take(end + 1).skip(start) {
+            let hit = keywords.iter().any(|kw| line_contains_ci(line, kw));
+            let marker = if hit { ">" } else { " " };
+            println!("{marker} {:>5} {line}", idx + 1);
+        }
+    }
+    Ok(())
+}
+
+fn matching_ranges_any(lines: &[&str], keywords: &[&str], context: usize) -> Vec<(usize, usize)> {
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for (idx, line) in lines.iter().enumerate() {
+        if !keywords.iter().any(|kw| line_contains_ci(line, kw)) {
+            continue;
+        }
+        let start = idx.saturating_sub(context);
+        let end = (idx + context).min(lines.len().saturating_sub(1));
+        if let Some((_, prev_end)) = ranges.last_mut()
+            && start <= *prev_end + 1
+        {
+            *prev_end = (*prev_end).max(end);
+            continue;
+        }
+        ranges.push((start, end));
+    }
+    ranges
+}
+
+fn all_keywords_present(content: &str, keywords: &[&str]) -> bool {
+    let lower = content.to_lowercase();
+    keywords.iter().all(|kw| lower.contains(&kw.to_lowercase()))
+}
+
+fn line_contains_ci(line: &str, keyword: &str) -> bool {
+    contains_ci(line, keyword)
+}
+
+/// Build a fixed-width context snippet around the first occurrence of `keyword`.
+///
+/// Returns up to `window` characters of context centered on the keyword, with
+/// the matched span wrapped in square brackets. Adds leading/trailing `…`
+/// when the snippet is shorter than the source. When the keyword is absent
+/// (e.g. matched on a portion outside the upstream-truncated preview),
+/// falls back to head truncation of `source`.
+fn build_snippet(source: &str, keyword: &str, window: usize) -> Option<String> {
+    if source.is_empty() || keyword.is_empty() || window == 0 {
+        return None;
+    }
+    let source_lower = source.to_lowercase();
+    let kw_lower = keyword.to_lowercase();
+
+    let Some(kw_byte) = source_lower.find(&kw_lower) else {
+        return Some(truncate_chars(source, window));
+    };
+
+    let kw_char_start = source_lower[..kw_byte].chars().count();
+    let kw_char_len = kw_lower.chars().count();
+    let total_chars = source.chars().count();
+    let context = window.saturating_sub(kw_char_len);
+    let left_ctx = context / 2;
+    let right_ctx = context - left_ctx;
+
+    let start = kw_char_start.saturating_sub(left_ctx);
+    let end = (kw_char_start + kw_char_len + right_ctx).min(total_chars);
+
+    let mut out = String::new();
+    if start > 0 {
+        out.push('…');
+    }
+    for (i, ch) in source.chars().enumerate() {
+        if i < start {
+            continue;
+        }
+        if i >= end {
+            break;
+        }
+        if i == kw_char_start {
+            out.push('[');
+        }
+        out.push(ch);
+        if i + 1 == kw_char_start + kw_char_len {
+            out.push(']');
+        }
+    }
+    if end < total_chars {
+        out.push('…');
+    }
+    Some(out)
+}
+
+fn truncate_chars(input: &str, max_chars: usize) -> String {
+    let total = input.chars().count();
+    if total <= max_chars {
+        return input.to_string();
+    }
+    let mut out: String = input.chars().take(max_chars.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_snippet_brackets_keyword_in_short_source() {
+        let source = "the quick brown fox jumps over the lazy dog";
+        let snippet = build_snippet(source, "fox", 80).expect("snippet");
+        assert!(snippet.contains("[fox]"), "snippet={snippet}");
+        // Source fits in window; no ellipsis padding required.
+        assert!(!snippet.starts_with('…'));
+        assert!(!snippet.ends_with('…'));
+    }
+
+    #[test]
+    fn build_snippet_preserves_original_case_when_matching_case_insensitively() {
+        let source = "Module-As-Software concept anchor";
+        let snippet = build_snippet(source, "module-as-software", 80).expect("snippet");
+        assert!(
+            snippet.contains("[Module-As-Software]"),
+            "snippet={snippet}"
+        );
+    }
+
+    #[test]
+    fn build_snippet_centers_window_for_long_source() {
+        let prefix = "a".repeat(200);
+        let suffix = "b".repeat(200);
+        let source = format!("{prefix}match{suffix}");
+        let snippet = build_snippet(&source, "match", 40).expect("snippet");
+        assert!(
+            snippet.starts_with('…'),
+            "leading ellipsis missing: snippet={snippet}"
+        );
+        assert!(
+            snippet.ends_with('…'),
+            "trailing ellipsis missing: snippet={snippet}"
+        );
+        assert!(snippet.contains("[match]"), "snippet={snippet}");
+    }
+
+    #[test]
+    fn build_snippet_falls_back_when_keyword_absent_from_source() {
+        let source = "no match here";
+        let snippet = build_snippet(source, "absent", 40).expect("snippet");
+        assert!(!snippet.contains('['), "snippet={snippet}");
+        assert!(!snippet.contains(']'), "snippet={snippet}");
+    }
+
+    #[test]
+    fn build_snippet_returns_none_for_empty_inputs() {
+        assert!(build_snippet("", "x", 10).is_none());
+        assert!(build_snippet("source", "", 10).is_none());
+        assert!(build_snippet("source", "x", 0).is_none());
+    }
+
+    #[test]
+    fn build_snippet_handles_multibyte_chars() {
+        // Multi-byte (Greek) keyword surrounded by enough context to require centering.
+        let source = "abcdefghijαβkeyword-γδεklmnopqrst";
+        let snippet = build_snippet(source, "αβ", 20).expect("snippet");
+        assert!(snippet.contains("[αβ]"), "snippet={snippet}");
+    }
+
+    #[test]
+    fn all_keywords_present_returns_true_when_every_term_appears() {
+        let content = "alpha beta gamma";
+        assert!(all_keywords_present(content, &["alpha", "beta"]));
+        assert!(all_keywords_present(content, &["ALPHA", "GAMMA"]));
+    }
+
+    #[test]
+    fn all_keywords_present_returns_false_when_any_term_missing() {
+        let content = "alpha beta gamma";
+        assert!(!all_keywords_present(content, &["alpha", "delta"]));
+    }
+
+    #[test]
+    fn all_keywords_present_allows_empty_keyword_slice() {
+        assert!(all_keywords_present("anything", &[]));
+    }
+
+    #[test]
+    fn matching_ranges_any_marks_lines_that_contain_any_keyword() {
+        let lines = vec!["line 0", "alpha line 1", "line 2", "beta line 3", "line 4"];
+        let ranges = matching_ranges_any(&lines, &["alpha", "beta"], 1);
+        // alpha matches line 1, beta matches line 3 — adjacent context ranges merge.
+        assert_eq!(ranges, vec![(0, 4)]);
+    }
+
+    #[test]
+    fn matching_ranges_any_returns_empty_when_no_keyword_matches() {
+        let lines = vec!["line 0", "line 1"];
+        let ranges = matching_ranges_any(&lines, &["absent"], 1);
+        assert!(ranges.is_empty());
+    }
+
+    #[test]
+    fn matching_ranges_any_case_insensitive() {
+        let lines = vec!["nothing", "Module-As-Software here"];
+        let ranges = matching_ranges_any(&lines, &["module-as-software"], 0);
+        assert_eq!(ranges, vec![(1, 1)]);
+    }
+
+    #[test]
+    fn truncate_chars_returns_input_when_short() {
+        assert_eq!(truncate_chars("abc", 10), "abc");
+    }
+
+    #[test]
+    fn truncate_chars_appends_ellipsis_when_truncating() {
+        let out = truncate_chars("abcdefghij", 5);
+        let chars: Vec<char> = out.chars().collect();
+        assert_eq!(chars.len(), 5);
+        assert_eq!(chars.last(), Some(&'…'));
+    }
+
+    #[test]
+    fn snippet_from_content_finds_first_matching_line() {
+        let content = "header line\n\nrandom prose\nthe Module-As-Software anchor pattern\nfooter";
+        let snippet = snippet_from_content(content, "module-as-software", 80).expect("snippet");
+        assert!(
+            snippet.contains("[Module-As-Software]"),
+            "snippet={snippet}"
+        );
+    }
+
+    #[test]
+    fn snippet_from_content_skips_blank_lines() {
+        let content = "\n\n   \nfirst match: keyword here\n";
+        let snippet = snippet_from_content(content, "keyword", 40).expect("snippet");
+        assert!(snippet.contains("[keyword]"), "snippet={snippet}");
+    }
+
+    #[test]
+    fn snippet_from_content_returns_none_when_keyword_missing() {
+        let content = "nothing matches\nstill nothing\n";
+        assert!(snippet_from_content(content, "absent", 40).is_none());
+    }
+
+    #[test]
+    fn build_preview_prefers_rendered_snippet_over_upstream_truncation() {
+        let rendered = "user message line\nthe target keyword is here\n";
+        let upstream = "{\"role\":\"user\",\"content\":\"...truncated long json...\"}";
+        let preview = build_preview(Some(rendered), Some(upstream), "keyword").expect("preview");
+        assert!(preview.contains("[keyword]"), "preview={preview}");
+    }
+
+    #[test]
+    fn build_preview_falls_back_to_upstream_when_no_rendered_content() {
+        let upstream = "short line with keyword inside";
+        let preview = build_preview(None, Some(upstream), "keyword").expect("preview");
+        assert!(preview.contains("[keyword]"), "preview={preview}");
+    }
+
+    #[test]
+    fn build_preview_returns_none_when_both_sources_lack_keyword() {
+        // Both inputs lack the keyword. Rendered tries first (None), then upstream
+        // returns head-truncated source without brackets.
+        let preview = build_preview(Some("no match"), Some("no match either"), "absent");
+        assert!(
+            preview.is_some(),
+            "fallback should produce truncated preview"
+        );
+        let preview = preview.unwrap();
+        assert!(
+            !preview.contains('['),
+            "no keyword bracket: preview={preview}"
+        );
+    }
+
+    #[test]
+    fn contains_ci_matches_case_insensitively() {
+        assert!(contains_ci("HELLO world", "hello"));
+        assert!(contains_ci("foo Bar baz", "BAR"));
+        assert!(!contains_ci("foo bar", "baz"));
+    }
 }

--- a/crates/cli-sub-agent/src/xurl_cmd.rs
+++ b/crates/cli-sub-agent/src/xurl_cmd.rs
@@ -41,7 +41,7 @@ fn handle_recall(
         return recall_cmd::handle_recall_list_cmd(limit, all);
     }
     if let Some(kw) = keyword {
-        return recall_cmd::handle_recall_keyword(&kw, all, limit);
+        return recall_cmd::handle_recall_keyword(&kw, session.as_deref(), all, limit);
     }
     if let Some(sid) = session {
         return recall_cmd::handle_recall_read_cmd(&sid, page);


### PR DESCRIPTION
## Summary
- Multi-keyword AND search: `--keyword "module concept anchor"` matches entries containing ALL keywords
- Context snippet display: search results show ~80 char preview around first match
- `--keyword` + `--session` combination: filter keyword search within a specific session

Closes #1634

## Test plan
- [x] `just pre-commit` passes
- [x] CSA review PASS (tier-4-critical, antigravity-cli fallback from gemini quota exhaustion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)