### PR TITLE
fix(cli-sub-agent): close false-PASS merge-gate hole in review consensus (#1659)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.811"
+version = "0.1.812"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.811"
+version = "0.1.812"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -76,8 +77,9 @@ fn load_multi_reviewer_artifacts(
     output_dir: &Path,
     reviewers: usize,
     outcomes: &[ReviewerOutcome],
-) -> Result<Vec<ReviewArtifact>> {
+) -> Result<(Vec<ReviewArtifact>, BTreeSet<usize>)> {
     let mut reviewer_artifacts = Vec::new();
+    let mut persisted_indices = BTreeSet::new();
     for reviewer_index in 1..=reviewers {
         let mut artifact_paths = vec![
             output_dir
@@ -105,10 +107,28 @@ fn load_multi_reviewer_artifacts(
                 .with_context(|| format!("failed to read {}", artifact_path.display()))?;
             let artifact = parse_reviewer_artifact(&artifact_path, &content)?;
             reviewer_artifacts.push(artifact);
+            persisted_indices.insert(reviewer_index);
             break;
         }
     }
-    Ok(reviewer_artifacts)
+    Ok((reviewer_artifacts, persisted_indices))
+}
+
+/// Whether every reviewer that voted `HAS_ISSUES` persisted a structured findings
+/// artifact. When false, at least one dissenting reviewer's findings never reached
+/// disk (e.g. quota/auth failure forced a non-zero exit before structured output was
+/// written), so an empty consolidated artifact does NOT prove "no issues exist" and the
+/// parent gate must fail-closed rather than promote to PASS. Crucially this is per-reviewer:
+/// one OTHER reviewer persisting an empty artifact must not mask an unpersisted dissenter
+/// (#1659).
+fn dissenting_findings_persisted(
+    outcomes: &[ReviewerOutcome],
+    persisted_indices: &BTreeSet<usize>,
+) -> bool {
+    outcomes
+        .iter()
+        .filter(|outcome| outcome.verdict == HAS_ISSUES)
+        .all(|outcome| persisted_indices.contains(&(outcome.reviewer_index + 1)))
 }
 
 pub(super) fn write_multi_reviewer_parent_artifacts(
@@ -122,15 +142,15 @@ pub(super) fn write_multi_reviewer_parent_artifacts(
     let Some((session_dir, session_id)) = resolve_parent_session_env() else {
         return Ok(());
     };
-    let reviewer_artifacts =
+    let (reviewer_artifacts, persisted_indices) =
         load_multi_reviewer_artifacts(project_root, &session_dir, reviewers, outcomes)?;
-    let any_reviewer_artifact_loaded = !reviewer_artifacts.is_empty();
+    let dissent_findings_persisted = dissenting_findings_persisted(outcomes, &persisted_indices);
     let consolidated = build_consolidated_artifact(reviewer_artifacts, &session_id);
     let parent_decision = parent_review_decision(
         &consolidated,
         final_verdict,
         all_reviewers_unavailable,
-        any_reviewer_artifact_loaded,
+        dissent_findings_persisted,
     );
     let parent_verdict = parent_legacy_verdict(parent_decision, final_verdict);
     let parent_artifact = parent_artifact_for_decision(&consolidated, parent_decision);
@@ -193,15 +213,16 @@ pub(super) fn write_standalone_consensus_review_artifacts(
     let Some((target, session_dir)) = resolve_standalone_consensus_carrier(ctx)? else {
         return Ok(None);
     };
-    let reviewer_artifacts =
+    let (reviewer_artifacts, persisted_indices) =
         load_multi_reviewer_artifacts(ctx.project_root, &session_dir, ctx.reviewers, ctx.outcomes)?;
-    let any_reviewer_artifact_loaded = !reviewer_artifacts.is_empty();
+    let dissent_findings_persisted =
+        dissenting_findings_persisted(ctx.outcomes, &persisted_indices);
     let consolidated = build_consolidated_artifact(reviewer_artifacts, &target.session_id);
     let decision = parent_review_decision(
         &consolidated,
         ctx.final_verdict,
         ctx.all_reviewers_unavailable,
-        any_reviewer_artifact_loaded,
+        dissent_findings_persisted,
     );
     let verdict = parent_legacy_verdict(decision, ctx.final_verdict);
     let artifact = parent_artifact_for_decision(&consolidated, decision);
@@ -394,7 +415,7 @@ fn parent_review_decision(
     artifact: &ReviewArtifact,
     final_verdict: &str,
     all_reviewers_unavailable: bool,
-    any_reviewer_artifact_loaded: bool,
+    dissent_findings_persisted: bool,
 ) -> ReviewDecision {
     if all_reviewers_unavailable {
         return ReviewDecision::Unavailable;
@@ -408,14 +429,16 @@ fn parent_review_decision(
     {
         return ReviewDecision::Fail;
     }
-    // #1659 false-PASS guard: a non-clean consensus with an empty consolidated artifact
-    // AND no reviewer that persisted a structured findings artifact is an UNTRUSTWORTHY
-    // "clean" signal -- the reviewers' findings never persisted (e.g. quota/auth failure
-    // forced a non-zero exit before structured output was written), so an empty/synthetic
-    // findings.toml does NOT mean "no findings exist". Fail-closed on the consensus verdict
-    // rather than promoting to PASS. A reviewer that DID persist an artifact (even an empty
-    // one) is still trusted below as a genuine "no findings" PASS, preserving #1045 et al.
-    if !any_reviewer_artifact_loaded
+    // #1659 false-PASS guard: a non-clean consensus (a reviewer voted HAS_ISSUES) whose
+    // consolidated artifact is empty is only trustworthy as PASS when EVERY dissenting
+    // reviewer persisted its structured findings. If any HAS_ISSUES voter never persisted
+    // (e.g. quota/auth failure forced a non-zero exit before structured output was written),
+    // an empty/synthetic findings.toml does NOT mean "no findings exist" -- and one OTHER
+    // reviewer's empty artifact must not mask that unpersisted dissent (#1659 round-2, codex).
+    // Fail-closed on the consensus verdict rather than promoting to PASS. When every dissenter
+    // DID persist (even an empty artifact), the explicit "no findings" is trusted as a genuine
+    // PASS, preserving the #1045/#1217 zero-findings-pass behavior.
+    if !dissent_findings_persisted
         && artifact.findings.is_empty()
         && consensus_decision == ReviewDecision::Fail
     {

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -124,9 +124,14 @@ pub(super) fn write_multi_reviewer_parent_artifacts(
     };
     let reviewer_artifacts =
         load_multi_reviewer_artifacts(project_root, &session_dir, reviewers, outcomes)?;
+    let any_reviewer_artifact_loaded = !reviewer_artifacts.is_empty();
     let consolidated = build_consolidated_artifact(reviewer_artifacts, &session_id);
-    let parent_decision =
-        parent_review_decision(&consolidated, final_verdict, all_reviewers_unavailable);
+    let parent_decision = parent_review_decision(
+        &consolidated,
+        final_verdict,
+        all_reviewers_unavailable,
+        any_reviewer_artifact_loaded,
+    );
     let parent_verdict = parent_legacy_verdict(parent_decision, final_verdict);
     let parent_artifact = parent_artifact_for_decision(&consolidated, parent_decision);
     write_consolidated_artifact(&parent_artifact, &session_dir)?;
@@ -190,11 +195,13 @@ pub(super) fn write_standalone_consensus_review_artifacts(
     };
     let reviewer_artifacts =
         load_multi_reviewer_artifacts(ctx.project_root, &session_dir, ctx.reviewers, ctx.outcomes)?;
+    let any_reviewer_artifact_loaded = !reviewer_artifacts.is_empty();
     let consolidated = build_consolidated_artifact(reviewer_artifacts, &target.session_id);
     let decision = parent_review_decision(
         &consolidated,
         ctx.final_verdict,
         ctx.all_reviewers_unavailable,
+        any_reviewer_artifact_loaded,
     );
     let verdict = parent_legacy_verdict(decision, ctx.final_verdict);
     let artifact = parent_artifact_for_decision(&consolidated, decision);
@@ -387,6 +394,7 @@ fn parent_review_decision(
     artifact: &ReviewArtifact,
     final_verdict: &str,
     all_reviewers_unavailable: bool,
+    any_reviewer_artifact_loaded: bool,
 ) -> ReviewDecision {
     if all_reviewers_unavailable {
         return ReviewDecision::Unavailable;
@@ -397,6 +405,19 @@ fn parent_review_decision(
         .findings
         .iter()
         .any(|finding| is_blocking_severity(&finding.severity))
+    {
+        return ReviewDecision::Fail;
+    }
+    // #1659 false-PASS guard: a non-clean consensus with an empty consolidated artifact
+    // AND no reviewer that persisted a structured findings artifact is an UNTRUSTWORTHY
+    // "clean" signal -- the reviewers' findings never persisted (e.g. quota/auth failure
+    // forced a non-zero exit before structured output was written), so an empty/synthetic
+    // findings.toml does NOT mean "no findings exist". Fail-closed on the consensus verdict
+    // rather than promoting to PASS. A reviewer that DID persist an artifact (even an empty
+    // one) is still trusted below as a genuine "no findings" PASS, preserving #1045 et al.
+    if !any_reviewer_artifact_loaded
+        && artifact.findings.is_empty()
+        && consensus_decision == ReviewDecision::Fail
     {
         return ReviewDecision::Fail;
     }

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
@@ -537,10 +537,11 @@ fn write_multi_reviewer_parent_artifacts_promotes_empty_findings_to_pass() {
 
 #[test]
 fn parent_review_decision_fails_closed_on_unbacked_has_issues_consensus() {
-    // #1659: a HAS_ISSUES consensus with an empty consolidated artifact AND no reviewer
-    // that persisted a structured findings artifact must FAIL-CLOSED, never PASS. This is
-    // the quota-induced false-PASS: reviewers reached HAS_ISSUES but their findings never
-    // persisted, leaving a synthetic-empty findings.toml that previously promoted to PASS.
+    // #1659: a HAS_ISSUES consensus with an empty consolidated artifact is trustworthy as
+    // PASS only when EVERY dissenting (HAS_ISSUES-voting) reviewer persisted its structured
+    // findings. The 4th arg is `dissent_findings_persisted`: when false, at least one
+    // dissenter's findings never reached disk (quota/auth failure), so the empty artifact
+    // must FAIL-CLOSED, never promote to a synthetic PASS.
     let empty = ReviewArtifact {
         severity_summary: SeveritySummary::from_findings(&[]),
         findings: Vec::new(),
@@ -557,7 +558,7 @@ fn parent_review_decision_fails_closed_on_unbacked_has_issues_consensus() {
     assert_eq!(
         parent_review_decision(&empty, crate::review_consensus::HAS_ISSUES, false, true),
         ReviewDecision::Pass,
-        "an explicitly-persisted empty reviewer artifact remains a trusted PASS"
+        "every dissenting reviewer persisting an explicit empty artifact remains a trusted PASS"
     );
     assert_eq!(
         parent_review_decision(&empty, crate::review_consensus::CLEAN, false, false),
@@ -622,6 +623,82 @@ fn write_multi_reviewer_parent_artifacts_fails_closed_without_persisted_reviewer
         verdict.decision,
         ReviewDecision::Fail,
         "#1659: HAS_ISSUES consensus with no persisted reviewer findings must fail-closed"
+    );
+}
+
+#[test]
+fn write_multi_reviewer_parent_artifacts_fails_closed_when_empty_artifact_masks_unpersisted_dissent()
+ {
+    // #1659 round-2 (codex): a single reviewer persisting an EMPTY artifact must NOT mask
+    // another reviewer that voted HAS_ISSUES but never persisted its findings. The earlier
+    // any-reviewer-loaded discriminator wrongly trusted the empty artifact and promoted to
+    // PASS; the per-dissenter check must fail-closed because the HAS_ISSUES voter (reviewer 2)
+    // left no structured findings on disk.
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let temp = tempdir().expect("tempdir should be created");
+    let session_dir = temp.path().display().to_string();
+    let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
+    let _session_id_guard =
+        ScopedEnvVarRestore::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
+    let _daemon_session_dir_guard = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_DIR");
+    let _daemon_session_id_guard = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_ID");
+
+    // Reviewer 1 (CLEAN) persists an EXPLICIT empty artifact.
+    let reviewer_dir = temp.path().join("reviewer-1");
+    fs::create_dir_all(&reviewer_dir).expect("reviewer dir should be created");
+    fs::write(
+        reviewer_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "verdict": "PASS",
+            "summary": "No blocking findings.",
+            "findings": []
+        }))
+        .expect("artifact should serialize"),
+    )
+    .expect("review artifact should be written");
+
+    // Reviewer 2 (HAS_ISSUES) persists NOTHING -- the masked dissenter (no reviewer-2 dir).
+    let outcomes = vec![
+        super::super::output::ReviewerOutcome {
+            reviewer_index: 0,
+            tool: ToolName::GeminiCli,
+            session_id: "01CLEANREVIEWER00000000000".to_string(),
+            output: "Reviewer 1 was clean.".to_string(),
+            exit_code: 0,
+            verdict: crate::review_consensus::CLEAN,
+            diagnostic: None,
+        },
+        super::super::output::ReviewerOutcome {
+            reviewer_index: 1,
+            tool: ToolName::Codex,
+            session_id: "01DISSENTREVIEWER0000000000".to_string(),
+            output: "Reviewer 2 flagged blocking issues in prose but persisted no findings."
+                .to_string(),
+            exit_code: 1,
+            verdict: crate::review_consensus::HAS_ISSUES,
+            diagnostic: None,
+        },
+    ];
+
+    write_multi_reviewer_parent_artifacts(
+        temp.path(),
+        2,
+        &outcomes,
+        crate::review_consensus::HAS_ISSUES,
+        false,
+        None,
+    )
+    .expect("parent artifacts should be produced");
+
+    let verdict: ReviewVerdictArtifact = serde_json::from_str(
+        &fs::read_to_string(temp.path().join("output").join("review-verdict.json"))
+            .expect("review-verdict.json should exist"),
+    )
+    .expect("review verdict should parse");
+    assert_eq!(
+        verdict.decision,
+        ReviewDecision::Fail,
+        "#1659 round-2: an empty artifact must not mask an unpersisted HAS_ISSUES dissenter"
     );
 }
 
@@ -786,16 +863,18 @@ proptest! {
                 }
             })
             .collect();
-        let any_reviewer_artifact_loaded = !reviewer_artifacts.is_empty();
         let consolidated = crate::review_consensus::build_consolidated_artifact(
             reviewer_artifacts,
             "01PARENTSESSION000000000000",
         );
+        // final_verdict is always CLEAN here, so the #1659 dissent guard never fires; pass
+        // `true` (consensus treated as backed) -- this proptest exercises the
+        // blocking-findings-survive-clean-consensus path, not the fail-closed guard.
         let decision = parent_review_decision(
             &consolidated,
             crate::review_consensus::CLEAN,
             states.iter().all(|state| matches!(state, ReviewerState::Unavailable)),
-            any_reviewer_artifact_loaded,
+            true,
         );
         let parent_artifact = parent_artifact_for_decision(&consolidated, decision);
 

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
@@ -536,6 +536,96 @@ fn write_multi_reviewer_parent_artifacts_promotes_empty_findings_to_pass() {
 }
 
 #[test]
+fn parent_review_decision_fails_closed_on_unbacked_has_issues_consensus() {
+    // #1659: a HAS_ISSUES consensus with an empty consolidated artifact AND no reviewer
+    // that persisted a structured findings artifact must FAIL-CLOSED, never PASS. This is
+    // the quota-induced false-PASS: reviewers reached HAS_ISSUES but their findings never
+    // persisted, leaving a synthetic-empty findings.toml that previously promoted to PASS.
+    let empty = ReviewArtifact {
+        severity_summary: SeveritySummary::from_findings(&[]),
+        findings: Vec::new(),
+        review_mode: Some("diff".to_string()),
+        schema_version: "1.0".to_string(),
+        session_id: "01PARENTSESSION000000000000".to_string(),
+        timestamp: chrono::Utc::now(),
+    };
+    assert_eq!(
+        parent_review_decision(&empty, crate::review_consensus::HAS_ISSUES, false, false),
+        ReviewDecision::Fail,
+        "#1659: unbacked HAS_ISSUES consensus must fail-closed"
+    );
+    assert_eq!(
+        parent_review_decision(&empty, crate::review_consensus::HAS_ISSUES, false, true),
+        ReviewDecision::Pass,
+        "an explicitly-persisted empty reviewer artifact remains a trusted PASS"
+    );
+    assert_eq!(
+        parent_review_decision(&empty, crate::review_consensus::CLEAN, false, false),
+        ReviewDecision::Pass,
+        "a clean consensus with no artifacts must not fail-closed"
+    );
+}
+
+#[test]
+fn write_multi_reviewer_parent_artifacts_fails_closed_without_persisted_reviewer_artifact() {
+    // #1659 end-to-end: reviewers reached HAS_ISSUES but none persisted a
+    // review-findings.json (quota/auth failure). The parent gate verdict MUST be fail,
+    // not a synthetic-empty PASS, so the merge gate cannot be silently bypassed.
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let temp = tempdir().expect("tempdir should be created");
+    let session_dir = temp.path().display().to_string();
+    let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
+    let _session_id_guard =
+        ScopedEnvVarRestore::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
+    let _daemon_session_dir_guard = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_DIR");
+    let _daemon_session_id_guard = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_ID");
+
+    // Deliberately persist NO reviewer-N/review-findings.json (the #1659 condition).
+    let outcomes = vec![
+        super::super::output::ReviewerOutcome {
+            reviewer_index: 0,
+            tool: ToolName::Codex,
+            session_id: "01CHILDSESSION0000000000000".to_string(),
+            output: "Reviewer flagged issues in prose but persisted no structured findings."
+                .to_string(),
+            exit_code: 1,
+            verdict: crate::review_consensus::HAS_ISSUES,
+            diagnostic: None,
+        },
+        super::super::output::ReviewerOutcome {
+            reviewer_index: 1,
+            tool: ToolName::GeminiCli,
+            session_id: "reviewer-2-unavailable".to_string(),
+            output: "Review unavailable: quota exhausted\n".to_string(),
+            exit_code: 1,
+            verdict: UNAVAILABLE,
+            diagnostic: Some("quota exhausted".to_string()),
+        },
+    ];
+
+    write_multi_reviewer_parent_artifacts(
+        temp.path(),
+        2,
+        &outcomes,
+        crate::review_consensus::HAS_ISSUES,
+        false,
+        None,
+    )
+    .expect("parent artifacts should be produced");
+
+    let verdict: ReviewVerdictArtifact = serde_json::from_str(
+        &fs::read_to_string(temp.path().join("output").join("review-verdict.json"))
+            .expect("review-verdict.json should exist"),
+    )
+    .expect("review verdict should parse");
+    assert_eq!(
+        verdict.decision,
+        ReviewDecision::Fail,
+        "#1659: HAS_ISSUES consensus with no persisted reviewer findings must fail-closed"
+    );
+}
+
+#[test]
 fn write_multi_reviewer_parent_artifacts_marks_all_unavailable() {
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let temp = tempdir().expect("tempdir should be created");
@@ -696,6 +786,7 @@ proptest! {
                 }
             })
             .collect();
+        let any_reviewer_artifact_loaded = !reviewer_artifacts.is_empty();
         let consolidated = crate::review_consensus::build_consolidated_artifact(
             reviewer_artifacts,
             "01PARENTSESSION000000000000",
@@ -704,6 +795,7 @@ proptest! {
             &consolidated,
             crate::review_consensus::CLEAN,
             states.iter().all(|state| matches!(state, ReviewerState::Unavailable)),
+            any_reviewer_artifact_loaded,
         );
         let parent_artifact = parent_artifact_for_decision(&consolidated, decision);
 


### PR DESCRIPTION
## Summary

Closes the CRITICAL false-PASS merge-gate hole in `csa review` multi-reviewer
consensus (#1659): a `HAS_ISSUES` consensus was silently persisted as
`decision=pass` / `CLEAN` in `review_meta.json` and `output/review-verdict.json`
whenever the consolidated reviewer artifact was empty — so `csa review
--check-verdict` (the push/merge gate) waved through a HEAD that reviewers had
actually flagged. The empty artifact arises when reviewers reach `HAS_ISSUES`
but exit non-zero before persisting their structured `review-findings.json`
(e.g. gemini quota / auth failure).

## Root cause

`parent_review_decision` ordered `findings.is_empty() -> Pass` **before** the
`consensus == Fail` check. An empty consolidated artifact short-circuited to
`Pass`, discarding the `HAS_ISSUES` consensus.

## Fix

Fail-closed when a non-clean consensus is **not backed by persisted findings**,
using **per-dissenting-reviewer accounting**:

- The consensus is trustworthy as `PASS` only when **every reviewer that voted
  `HAS_ISSUES` persisted a structured findings artifact**.
- `load_multi_reviewer_artifacts` now returns the set of reviewer indices that
  persisted; `dissenting_findings_persisted` verifies each `HAS_ISSUES` voter is
  in that set. If any dissenter is missing, the empty consolidated artifact
  cannot prove "no issues exist" → fail-closed on the consensus verdict.

The deliberate #1045/#1217 zero-findings-PASS behavior is preserved: a reviewer
that itself persists an explicit empty artifact is still a trusted `PASS`
(`promotes_empty_findings_to_pass` stays green).

### Two rounds (audit trail)

- **Round 1** (`831ed069`): introduced a global `any_reviewer_artifact_loaded`
  discriminator.
- **Round 2**: a force-codex review of round-1 found the global discriminator
  was too coarse — one reviewer's empty artifact could mask another reviewer's
  *unpersisted* `HAS_ISSUES` vote. Replaced with per-dissenter accounting (above).

## Empirical evidence

Confirmed against session `01KSRMZRZ63G9S5S0Y3EXJMCAK` (PR #1655 review): no
`review-findings.json` persisted, `findings.toml` synthetic-empty, consensus
`HAS_ISSUES`, yet `review_meta.json` `decision=pass`. The cloud bot independently
flagged real findings on the same HEAD — proving the local PASS was false.

## Tests

- `parent_review_decision_fails_closed_on_unbacked_has_issues_consensus` (unit, 3 branches)
- `write_multi_reviewer_parent_artifacts_fails_closed_without_persisted_reviewer_artifact` (end-to-end)
- `write_multi_reviewer_parent_artifacts_fails_closed_when_empty_artifact_masks_unpersisted_dissent`
  (end-to-end, round-2: empty artifact must not mask an unpersisted dissenter)
- Full `cli-sub-agent` bin suite green.

## Scope note

The **single-reviewer** synthetic-empty→Pass fallback
(`derive_review_verdict_artifact`) is intentionally out of scope — it conflicts
with the deliberate #1357/#1362/#1217 zero-evidence-Pass tests and is tracked
separately (#156 / single-reviewer decision).

Refs #1659

🤖 Generated with [Claude Code](https://claude.com/claude-code)
