### PR TITLE
fix(cli-sub-agent): render output/summary.md prose, not turn.completed JSON, as session-wait Summary (#1682)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.812"
+version = "0.1.813"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.812"
+version = "0.1.813"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -86,6 +86,7 @@ mod session_cmds_result_measure;
 mod session_dispatch;
 mod session_guard;
 mod session_observability;
+mod session_summary_text;
 mod setup_cmds;
 mod skill_cmds;
 mod skill_dispatch;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -80,7 +80,10 @@ fn render_wait_result_summary(
         lines.push(format!("Review verdict: {verdict}"));
     }
 
-    if let Some(summary) = compact_wait_summary_text(&result.summary) {
+    if let Some(summary) =
+        crate::session_summary_text::human_session_summary(session_dir, &result.summary)
+            .and_then(|text| compact_wait_summary_text(&text))
+    {
         lines.push(format!("Summary: {summary}"));
     }
 
@@ -108,7 +111,8 @@ fn render_wait_result_json(
         "elapsed_seconds": wait_elapsed_seconds(result),
         "tokens": tokens,
         "review_verdict": read_review_verdict_label(session_dir),
-        "summary": compact_wait_summary_text(&result.summary),
+        "summary": crate::session_summary_text::human_session_summary(session_dir, &result.summary)
+            .and_then(|text| compact_wait_summary_text(&text)),
     });
     serde_json::to_string_pretty(&value).map_err(Into::into)
 }

--- a/crates/cli-sub-agent/src/session_summary_text.rs
+++ b/crates/cli-sub-agent/src/session_summary_text.rs
@@ -1,0 +1,62 @@
+//! Human-readable session summary extraction for `csa session result` / `wait`
+//! and the MCP hub tool response (#1682).
+//!
+//! `SessionResult.summary` holds the tool's raw terminal event for some tools
+//! (notably codex, where it is a `turn.completed` JSON envelope kept for token
+//! extraction). That envelope is NOT prose and must never be shown as the human
+//! "Summary:" line. The agent's actual conclusion lives in `output/summary.md`;
+//! prefer it, and otherwise suppress machine-event envelopes.
+
+use std::path::Path;
+
+/// Resolve the human-readable summary for display.
+///
+/// Preference order:
+/// 1. `output/summary.md` (agent-/review-authored prose), when present and non-empty.
+/// 2. The raw `summary`, unless it is a JSON event envelope (see
+///    [`is_json_event_envelope`]), in which case `None` is returned so the caller
+///    omits the Summary line entirely rather than printing machine JSON.
+pub(crate) fn human_session_summary(session_dir: &Path, raw_summary: &str) -> Option<String> {
+    if let Some(markdown) = read_summary_markdown(session_dir) {
+        return Some(markdown);
+    }
+    if is_json_event_envelope(raw_summary) {
+        return None;
+    }
+    non_empty_trimmed(raw_summary)
+}
+
+fn read_summary_markdown(session_dir: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(session_dir.join("output").join("summary.md")).ok()?;
+    non_empty_trimmed(&raw)
+}
+
+/// Whether `summary` is a machine event envelope rather than human prose: it
+/// parses as JSON and carries a string `type` field (e.g. codex
+/// `{"type":"turn.completed",...}`). Such envelopes are intentionally kept on
+/// `SessionResult.summary` for token extraction but are never human summaries.
+/// Kept `pub(crate)` as a reusable predicate for callers that have no session
+/// directory to consult `output/summary.md`.
+pub(crate) fn is_json_event_envelope(summary: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(summary.trim())
+        .ok()
+        .is_some_and(|value| {
+            value
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .is_some()
+        })
+}
+
+fn non_empty_trimmed(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+#[path = "session_summary_text_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/session_summary_text_tests.rs
+++ b/crates/cli-sub-agent/src/session_summary_text_tests.rs
@@ -1,0 +1,61 @@
+use super::{human_session_summary, is_json_event_envelope};
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn prefers_summary_markdown_over_raw_event_envelope() {
+    let temp = tempdir().expect("tempdir should be created");
+    let output = temp.path().join("output");
+    fs::create_dir_all(&output).expect("output dir should be created");
+    fs::write(
+        output.join("summary.md"),
+        "PASS: no blocking findings found.\n",
+    )
+    .expect("summary.md should be written");
+    let raw = r#"{"type":"turn.completed","usage":{"input_tokens":100}}"#;
+    assert_eq!(
+        human_session_summary(temp.path(), raw).as_deref(),
+        Some("PASS: no blocking findings found.")
+    );
+}
+
+#[test]
+fn suppresses_json_event_envelope_when_no_summary_markdown() {
+    let temp = tempdir().expect("tempdir should be created");
+    let raw = r#"{"type":"turn.completed","usage":{"input_tokens":100}}"#;
+    assert_eq!(human_session_summary(temp.path(), raw), None);
+}
+
+#[test]
+fn falls_back_to_raw_prose_when_not_an_envelope() {
+    let temp = tempdir().expect("tempdir should be created");
+    assert_eq!(
+        human_session_summary(temp.path(), "  Implemented the feature.  ").as_deref(),
+        Some("Implemented the feature.")
+    );
+}
+
+#[test]
+fn empty_summary_markdown_falls_through_to_raw_prose() {
+    let temp = tempdir().expect("tempdir should be created");
+    let output = temp.path().join("output");
+    fs::create_dir_all(&output).expect("output dir should be created");
+    fs::write(output.join("summary.md"), "   \n").expect("summary.md should be written");
+    assert_eq!(
+        human_session_summary(temp.path(), "raw prose").as_deref(),
+        Some("raw prose")
+    );
+}
+
+#[test]
+fn is_json_event_envelope_detects_typed_objects_only() {
+    assert!(is_json_event_envelope(r#"{"type":"turn.completed"}"#));
+    assert!(is_json_event_envelope(
+        r#"  {"type":"item.completed","item":{}}  "#
+    ));
+    assert!(!is_json_event_envelope("PASS: no blocking findings"));
+    // No `type` field -> not treated as an event envelope.
+    assert!(!is_json_event_envelope(r#"{"usage":{"input_tokens":1}}"#));
+    assert!(!is_json_event_envelope("42"));
+    assert!(!is_json_event_envelope(""));
+}


### PR DESCRIPTION
## Summary

Fixes the `csa session wait` Summary line showing raw codex `turn.completed`
JSON instead of the agent's actual conclusion (#1682).

`SessionResult.summary` holds the machine event envelope
`{"type":"turn.completed","usage":{...}}` for codex (kept intentionally for token
extraction), and the compact `session wait` renderer printed it verbatim as the
human "Summary:" line. The real prose lives in `output/summary.md` (e.g. a review
writes `PASS: no blocking findings found in main...HEAD`).

## Change

New shared `session_summary_text` module:
- `human_session_summary(session_dir, raw)` — prefers a non-empty
  `output/summary.md`; otherwise falls back to `raw` unless it is a JSON event
  envelope (object with a string `type` field), in which case the Summary line is
  omitted instead of printing machine JSON.
- `is_json_event_envelope(raw)` — reusable predicate.

`render_wait_result_summary` (text) and `render_wait_result_json` (json) now route
through the helper. Token and review-verdict extraction still read
`result.summary` unchanged — only the human Summary display changes.

## Scope (deliberately narrow)

The `csa session result` and MCP-hub response paths share the identical bug, but
their files (`session_cmds_result.rs` 8504 tok, `mcp_server.rs` 8162 tok) are
pre-existing **>8000-token monoliths**; touching them trips the `find-monolith`
pre-commit gate and requires a structural split. To keep this behavior fix
separable from that refactor, those two paths are deferred to a focused follow-up
(see #1682 comment). This PR ships the `session wait` path — the highest-frequency
surface — plus the reusable helper the follow-up will consume.

## Tests

`session_summary_text` unit suite: summary.md preferred over envelope,
envelope-suppressed when no md, prose fallback, empty-md fallthrough, and
`is_json_event_envelope` detection (typed objects only). Full `cli-sub-agent` bin
suite green (2257 passed).

Refs #1682

🤖 Generated with [Claude Code](https://claude.com/claude-code)
