### PR TITLE
fix(csa-todo): stop attesting placeholder TODO.md so draft plans don't false-report [PLAN TAMPERED] (#1669)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.813"
+version = "0.1.814"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.813"
+version = "0.1.814"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_plan_context.rs
+++ b/crates/cli-sub-agent/src/pipeline_plan_context.rs
@@ -254,6 +254,10 @@ mod tests {
         let plan = manager
             .create("Protected plan", Some("feat/tamper"))
             .expect("plan");
+        // Establish a real attestation baseline (what `csa todo save` does); only a
+        // post-attestation edit is tamper. A freshly created, un-attested draft is
+        // `Missing` and is loaded normally (#1669), not refused.
+        manager.attest(&plan.timestamp).expect("attest");
         std::fs::write(plan.todo_md_path(), "# Tampered\n").expect("tamper");
 
         assert!(load_plan_context_for_branch(&manager, "feat/tamper").is_none());

--- a/crates/cli-sub-agent/src/todo_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_cmd.rs
@@ -10,8 +10,7 @@ use csa_todo::{
 use std::path::Path;
 use tracing::warn;
 
-const PLAN_TAMPERED_WARNING: &str =
-    "[PLAN TAMPERED] Plan content does not match stored attestation hash";
+const PLAN_TAMPERED_WARNING: &str = "[PLAN TAMPERED] Plan content does not match stored attestation hash. If you edited the plan intentionally, run `csa todo attest` to re-attest.";
 
 /// Auto-detect current git branch. Returns None on detached HEAD or error.
 fn detect_current_branch(project_root: &Path) -> Option<String> {
@@ -694,99 +693,5 @@ fn truncate(s: &str, max_len: usize) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoManager};
-    use tempfile::tempdir;
-
-    // --- truncate tests ---
-
-    #[test]
-    fn truncate_short_string_unchanged() {
-        assert_eq!(truncate("hello", 10), "hello");
-    }
-
-    #[test]
-    fn truncate_exact_length_unchanged() {
-        assert_eq!(truncate("hello", 5), "hello");
-    }
-
-    #[test]
-    fn truncate_long_string_adds_ellipsis() {
-        let result = truncate("hello world", 6);
-        assert!(result.ends_with('\u{2026}'));
-        assert_eq!(result.chars().count(), 6);
-    }
-
-    #[test]
-    fn truncate_preserves_multibyte_boundaries() {
-        // 6 CJK characters
-        let cjk = "\u{4f60}\u{597d}\u{4e16}\u{754c}\u{6d4b}\u{8bd5}";
-        let result = truncate(cjk, 4);
-        assert!(result.ends_with('\u{2026}'));
-        assert_eq!(result.chars().count(), 4);
-    }
-
-    #[test]
-    fn truncate_single_char_max() {
-        let result = truncate("abcdef", 1);
-        assert_eq!(result, "\u{2026}");
-    }
-
-    #[test]
-    fn render_spec_document_includes_summary_and_criteria() {
-        let spec = SpecDocument {
-            schema_version: 1,
-            plan_ulid: "01JABCDEF0123456789ABCDEFG".to_string(),
-            summary: "Validate spec display.".to_string(),
-            criteria: vec![
-                SpecCriterion {
-                    kind: CriterionKind::Scenario,
-                    id: "scenario-show".to_string(),
-                    description: "show --spec renders criteria".to_string(),
-                    status: CriterionStatus::Pending,
-                },
-                SpecCriterion {
-                    kind: CriterionKind::Check,
-                    id: "check-failure".to_string(),
-                    description: "failed criteria are labeled".to_string(),
-                    status: CriterionStatus::Failed,
-                },
-            ],
-        };
-
-        let rendered = render_spec_document(&spec);
-
-        assert!(rendered.contains("Plan ULID: 01JABCDEF0123456789ABCDEFG"));
-        assert!(rendered.contains("Summary: Validate spec display."));
-        assert!(
-            rendered.contains("- [pending] scenario scenario-show: show --spec renders criteria")
-        );
-        assert!(rendered.contains("- [failed] check check-failure: failed criteria are labeled"));
-    }
-
-    #[test]
-    fn plan_attestation_warning_reports_mismatch() {
-        let dir = tempdir().expect("tempdir");
-        let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
-        let plan = manager.create("Warn on tamper", None).expect("plan");
-        std::fs::write(plan.todo_md_path(), "# Tampered\n").expect("tamper");
-
-        assert_eq!(
-            plan_attestation_warning(&manager, &plan.timestamp).expect("warning"),
-            Some(PLAN_TAMPERED_WARNING)
-        );
-    }
-
-    // --- resolve_timestamp tests ---
-
-    // resolve_timestamp with Some returns the string directly
-    #[test]
-    fn resolve_timestamp_with_some_returns_value() {
-        // We cannot call resolve_timestamp directly because it needs a TodoManager,
-        // but we can test the logic: when timestamp is Some, it just returns it.
-        let ts: Option<&str> = Some("20250101T120000");
-        let result = ts.map(String::from).unwrap();
-        assert_eq!(result, "20250101T120000");
-    }
-}
+#[path = "todo_cmd_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/todo_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/todo_cmd_tests.rs
@@ -1,0 +1,112 @@
+use super::*;
+use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoManager};
+use tempfile::tempdir;
+
+// --- truncate tests ---
+
+#[test]
+fn truncate_short_string_unchanged() {
+    assert_eq!(truncate("hello", 10), "hello");
+}
+
+#[test]
+fn truncate_exact_length_unchanged() {
+    assert_eq!(truncate("hello", 5), "hello");
+}
+
+#[test]
+fn truncate_long_string_adds_ellipsis() {
+    let result = truncate("hello world", 6);
+    assert!(result.ends_with('\u{2026}'));
+    assert_eq!(result.chars().count(), 6);
+}
+
+#[test]
+fn truncate_preserves_multibyte_boundaries() {
+    // 6 CJK characters
+    let cjk = "\u{4f60}\u{597d}\u{4e16}\u{754c}\u{6d4b}\u{8bd5}";
+    let result = truncate(cjk, 4);
+    assert!(result.ends_with('\u{2026}'));
+    assert_eq!(result.chars().count(), 4);
+}
+
+#[test]
+fn truncate_single_char_max() {
+    let result = truncate("abcdef", 1);
+    assert_eq!(result, "\u{2026}");
+}
+
+#[test]
+fn render_spec_document_includes_summary_and_criteria() {
+    let spec = SpecDocument {
+        schema_version: 1,
+        plan_ulid: "01JABCDEF0123456789ABCDEFG".to_string(),
+        summary: "Validate spec display.".to_string(),
+        criteria: vec![
+            SpecCriterion {
+                kind: CriterionKind::Scenario,
+                id: "scenario-show".to_string(),
+                description: "show --spec renders criteria".to_string(),
+                status: CriterionStatus::Pending,
+            },
+            SpecCriterion {
+                kind: CriterionKind::Check,
+                id: "check-failure".to_string(),
+                description: "failed criteria are labeled".to_string(),
+                status: CriterionStatus::Failed,
+            },
+        ],
+    };
+
+    let rendered = render_spec_document(&spec);
+
+    assert!(rendered.contains("Plan ULID: 01JABCDEF0123456789ABCDEFG"));
+    assert!(rendered.contains("Summary: Validate spec display."));
+    assert!(rendered.contains("- [pending] scenario scenario-show: show --spec renders criteria"));
+    assert!(rendered.contains("- [failed] check check-failure: failed criteria are labeled"));
+}
+
+#[test]
+fn plan_attestation_warning_reports_mismatch() {
+    let dir = tempdir().expect("tempdir");
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+    let plan = manager.create("Warn on tamper", None).expect("plan");
+    // Establish an attestation baseline (what `csa todo save` does); only a
+    // post-attestation edit is tamper. A freshly created plan is un-attested
+    // (`Missing`) and must NOT warn (#1669).
+    manager.attest(&plan.timestamp).expect("attest");
+    std::fs::write(plan.todo_md_path(), "# Tampered\n").expect("tamper");
+
+    assert_eq!(
+        plan_attestation_warning(&manager, &plan.timestamp).expect("warning"),
+        Some(PLAN_TAMPERED_WARNING)
+    );
+}
+
+#[test]
+fn plan_attestation_warning_silent_for_unattested_draft() {
+    // #1669: a freshly created, un-attested plan whose TODO.md is written
+    // directly (the mktd workflow) reports `Missing`, so no `[PLAN TAMPERED]`
+    // banner is emitted — preventing cry-wolf that trains operators to ignore it.
+    let dir = tempdir().expect("tempdir");
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+    let plan = manager.create("Unattested draft", None).expect("plan");
+    std::fs::write(plan.todo_md_path(), "# real plan content\n").expect("write");
+
+    assert_eq!(
+        plan_attestation_warning(&manager, &plan.timestamp).expect("warning"),
+        None
+    );
+}
+
+// --- resolve_timestamp tests ---
+
+// resolve_timestamp with Some returns the string directly
+#[test]
+fn resolve_timestamp_with_some_returns_value() {
+    // We cannot call resolve_timestamp directly because it needs a TodoManager,
+    // but we can test the logic: when timestamp is Some, it just returns it.
+    let ts: Option<&str> = Some("20250101T120000");
+    let result = ts.map(String::from).unwrap();
+    assert_eq!(result, "20250101T120000");
+}

--- a/crates/csa-todo/src/lib.rs
+++ b/crates/csa-todo/src/lib.rs
@@ -519,10 +519,11 @@ impl TodoManager {
             return Err(e.context("Failed to write TODO.md (rolled back plan directory)"));
         }
 
-        if let Err(e) = self.write_attestation_for_content(&plan, initial_content.as_bytes()) {
-            let _ = std::fs::remove_dir_all(&plan.todo_dir);
-            return Err(e.context("Failed to write TODO attestation (rolled back plan directory)"));
-        }
+        // #1669: do NOT attest the placeholder here. It is always overwritten by
+        // the real plan (the mktd workflow writes TODO.md directly, then
+        // `csa todo save` attests). Attesting the throwaway placeholder would make
+        // every not-yet-finalized plan report a false `Mismatch` ("[PLAN TAMPERED]");
+        // leaving it unset reports the benign `Missing` until real content is attested.
 
         Ok(plan)
     }

--- a/crates/csa-todo/src/lib_tests.rs
+++ b/crates/csa-todo/src/lib_tests.rs
@@ -39,22 +39,60 @@ fn test_create_plan() {
 }
 
 #[test]
-fn test_create_plan_writes_valid_attestation() {
+fn test_create_plan_leaves_attestation_unset() {
+    // #1669: create writes only placeholder TODO.md and intentionally does NOT
+    // attest it (the placeholder is always overwritten with the real plan). A
+    // freshly created plan therefore reports `Missing` (un-attested, benign),
+    // never a false `Mismatch`/`[PLAN TAMPERED]`.
     let dir = tempdir().unwrap();
     let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
 
-    let plan = manager.create("Attested Plan", None).unwrap();
+    let plan = manager.create("Unattested Plan", None).unwrap();
 
-    assert!(plan.attestation_path().exists());
+    assert!(plan.todo_md_path().exists());
+    assert!(!plan.attestation_path().exists());
+    assert_eq!(
+        manager.verify_attestation(&plan.timestamp).unwrap(),
+        TodoAttestationStatus::Missing
+    );
+}
+
+#[test]
+fn test_direct_write_then_attest_is_valid_not_tampered() {
+    // #1669 regression: mimics the mktd workflow Step 13 — create a plan, write
+    // the real TODO.md directly (bypassing the csa todo API), then attest (what
+    // `csa todo save` does). The un-attested intermediate state must be `Missing`,
+    // after attest it must be `Valid`, and only a genuine post-attestation edit
+    // may report `Mismatch` — never the benign draft state.
+    let dir = tempdir().unwrap();
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+
+    let plan = manager.create("Repro 1669", None).unwrap();
+
+    // Direct write bypassing the csa todo API (the workflow's `printf > TODO.md`).
+    std::fs::write(
+        plan.todo_md_path(),
+        "# TODO: Repro 1669\n\n## Tasks\n\n- [ ] real task\n  DONE WHEN: shipped\n",
+    )
+    .unwrap();
+    assert_eq!(
+        manager.verify_attestation(&plan.timestamp).unwrap(),
+        TodoAttestationStatus::Missing,
+        "un-attested draft must be Missing, not a false [PLAN TAMPERED]"
+    );
+
+    manager.attest(&plan.timestamp).unwrap();
     assert_eq!(
         manager.verify_attestation(&plan.timestamp).unwrap(),
         TodoAttestationStatus::Valid
     );
 
-    let attestation: TodoAttestation =
-        toml::from_str(&std::fs::read_to_string(plan.attestation_path()).unwrap()).unwrap();
-    let content = std::fs::read(plan.todo_md_path()).unwrap();
-    assert_eq!(attestation.hash, hash_todo_content(&content));
+    // A genuine post-attestation edit must still surface as tampering.
+    std::fs::write(plan.todo_md_path(), "# tampered\n").unwrap();
+    assert!(matches!(
+        manager.verify_attestation(&plan.timestamp).unwrap(),
+        TodoAttestationStatus::Mismatch { .. }
+    ));
 }
 
 #[test]
@@ -243,6 +281,8 @@ fn test_verify_attestation_detects_manual_tamper() {
     let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
 
     let plan = manager.create("Tamper Test", None).unwrap();
+    // Establish a real attestation baseline (what `csa todo save` does), then tamper.
+    manager.attest(&plan.timestamp).unwrap();
     std::fs::write(plan.todo_md_path(), "# Tampered\n").unwrap();
 
     match manager.verify_attestation(&plan.timestamp).unwrap() {
@@ -260,6 +300,8 @@ fn test_attest_repairs_manual_tamper() {
     let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
 
     let plan = manager.create("Repair Test", None).unwrap();
+    // Attest a baseline first; only a post-attestation edit counts as tamper.
+    manager.attest(&plan.timestamp).unwrap();
     let edited = "# Legitimate manual edit\n";
     std::fs::write(plan.todo_md_path(), edited).unwrap();
 


### PR DESCRIPTION
## Summary

Fixes the `[PLAN TAMPERED]` banner that `csa todo show` printed for **every**
freshly-generated dev2merge/mktd plan, even pristine, never-tampered drafts (#1669).

## Root cause

`TodoManager::create` wrote a SHA-256 attestation over the **throwaway placeholder**
TODO.md (`# TODO: <title>\n\n## Goal\n\n## Tasks\n\n- [ ] \n`). That placeholder is
always overwritten with the real plan — the mktd workflow (Step 13) writes TODO.md
directly via `printf >`, then `csa todo save` re-attests. So any plan whose content
was written before a subsequent attest reported `Mismatch` → `[PLAN TAMPERED]`, which:

1. trained operators to ignore the banner, destroying the signal value of a *genuine*
   tamper warning; and
2. in `pipeline_plan_context`, **silently dropped** the plan's spec/criteria from
   pipeline context (a `Mismatch` plan is refused).

Disk forensics on a real isonomia-ce plan confirmed it: the stored `.attestation`
`attested_at` was pinned to create time (µs after metadata) with the placeholder hash,
never refreshed against the 11 KB final TODO.md.

## Fix

Root cause: `create_inner` no longer attests the placeholder. A freshly created,
not-yet-finalized plan now reports `Missing` (benign — no banner, loaded normally),
while a genuine post-attestation edit still reports `Mismatch`. `ensure_attestation`
(run by `csa todo save`), `attest`, and `write_todo_md` remain the points that
establish/refresh the real attestation.

Verified end to end with the installed build: `csa todo create` → direct `printf >`
write → `csa todo save` now yields a clean `Valid` with no banner; the old buggy
artifacts had the placeholder hash with create-time `attested_at`.

- **csa-todo**: remove the placeholder attestation in `create_inner`; the two
  manual-tamper tests attest a baseline first (tamper is only meaningful after a real
  attestation exists); add lifecycle + un-attested-draft regression tests.
- **cli-sub-agent**: extend the `[PLAN TAMPERED]` banner with a `csa todo attest`
  remediation hint (issue suggestion #2); fix the pipeline tamper test to attest a
  baseline first. Extract `todo_cmd.rs`'s inline test module to `todo_cmd_tests.rs` —
  `todo_cmd.rs` was a pre-existing **8877-token monolith** and touching it would
  otherwise trip the token-budget gate; the extraction follows the established
  `#[path = "*_tests.rs"]` convention and drops `todo_cmd.rs` to **7766** tokens.

## Tests

`csa-todo` lib suite green (170 passed) including new `#1669` regression tests;
`cli-sub-agent` bin suite green. New coverage: `test_create_plan_leaves_attestation_unset`,
`test_direct_write_then_attest_is_valid_not_tampered`,
`plan_attestation_warning_silent_for_unattested_draft`.

Fixes #1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)
