### PR TITLE
fix(cli-sub-agent): fail closed on prose-FAIL review verdict with empty structured findings (#1675)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.814"
+version = "0.1.815"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.814"
+version = "0.1.815"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -89,7 +89,7 @@ pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSes
 fn derive_findings_toml_artifact(
     session_dir: &Path,
 ) -> Result<(FindingsFile, Option<&'static str>), anyhow::Error> {
-    let Some(review_text) = load_review_text_for_findings(session_dir)? else {
+    let Some(review_text) = load_canonical_review_text(session_dir)? else {
         return Ok((FindingsFile::default(), Some("review text unavailable")));
     };
 
@@ -102,7 +102,21 @@ fn derive_findings_toml_artifact(
     }
 }
 
-fn load_review_text_for_findings(session_dir: &Path) -> Result<Option<String>, anyhow::Error> {
+/// Load the canonical review prose for a session.
+///
+/// Resolves the authoritative review text via a fixed source precedence:
+/// when persisted `details` sections exist, prefer `output/full.md`, then the raw
+/// `output.log`, then the `details.md` body; otherwise fall back to `output/full.md`.
+/// This is the SINGLE source of review prose shared by both the findings extractor
+/// and the fail-closed verdict detector ([`super::output::clean_detection::
+/// review_contains_prose_fail_conclusion`]). Sharing one loader keeps their source
+/// sets identical so a FAIL verdict can never survive in a place one consults but
+/// the other ignores — the root cause of the #1675 review rounds (a verdict in
+/// `details`, then `output.log`, that the detector did not scan). Returns `None`
+/// when no review text can be located.
+pub(in crate::review_cmd) fn load_canonical_review_text(
+    session_dir: &Path,
+) -> Result<Option<String>, anyhow::Error> {
     let details_path = session_dir.join("output").join("details.md");
     if details_path.exists() {
         for candidate in [

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -7,9 +7,8 @@ use csa_core::types::{ReviewDecision, ToolName};
 use csa_executor::{
     contains_gemini_oauth_prompt, normalize_gemini_prompt_text, strip_ansi_escape_sequences,
 };
-use csa_session::output_parser::parse_sections;
 use csa_session::state::{ReviewSessionMeta, write_review_meta};
-use csa_session::{Finding, OutputSection, ReviewVerdictArtifact, Severity, write_review_verdict};
+use csa_session::{Finding, ReviewVerdictArtifact, Severity, write_review_verdict};
 use tracing::{debug, warn};
 
 #[path = "review_cmd_output_artifacts.rs"]
@@ -20,6 +19,8 @@ mod clean_detection;
 mod diagnostics;
 #[path = "review_cmd_output_exit.rs"]
 mod exit_code;
+#[path = "review_cmd_output_sections.rs"]
+mod sections;
 #[path = "review_cmd_output_summary.rs"]
 mod summary_artifact;
 #[path = "review_cmd_output_text.rs"]
@@ -29,10 +30,18 @@ use artifacts::{
     load_review_artifact_from_output, severity_counts_are_zero, severity_counts_for_artifact,
     severity_counts_for_findings_toml,
 };
-use clean_detection::{review_contains_prose_clean_conclusion, strip_prompt_guards};
+#[cfg(test)]
+use clean_detection::detect_prose_fail_conclusion;
+use clean_detection::{
+    review_contains_prose_clean_conclusion, review_contains_prose_fail_conclusion,
+    strip_prompt_guards,
+};
 pub(crate) use diagnostics::detect_tool_diagnostic;
 pub(super) use diagnostics::{ReviewerOutcome, print_reviewer_outcomes};
 pub(super) use exit_code::{persist_review_result_exit_code, persisted_review_verdict_exit_code};
+pub(super) use sections::{
+    derive_review_result_summary, has_structured_review_content, sanitize_review_output,
+};
 pub(super) use summary_artifact::{
     ensure_review_summary_artifact, is_edit_restriction_summary, truncate_review_result_summary,
 };
@@ -65,98 +74,6 @@ impl ToolReviewFailureKind {
             }
         }
     }
-}
-
-/// Prefer structured review sections (summary/details) when available to avoid
-/// leaking unrelated provider noise into caller-facing review output.
-pub(super) fn sanitize_review_output(output: &str) -> String {
-    let sections = parse_sections(output);
-    if sections.is_empty() {
-        return output.to_string();
-    }
-
-    let summary = last_non_empty_section_content(output, &sections, "summary");
-    let details = last_non_empty_section_content(output, &sections, "details");
-    if summary.is_none() && details.is_none() {
-        return output.to_string();
-    }
-
-    let mut rendered = String::new();
-    if let Some(content) = summary {
-        rendered.push_str("<!-- CSA:SECTION:summary -->\n");
-        rendered.push_str(&content);
-        if !content.ends_with('\n') {
-            rendered.push('\n');
-        }
-        rendered.push_str("<!-- CSA:SECTION:summary:END -->\n");
-    }
-    if let Some(content) = details {
-        if !rendered.is_empty() && !rendered.ends_with('\n') {
-            rendered.push('\n');
-        }
-        rendered.push_str("<!-- CSA:SECTION:details -->\n");
-        rendered.push_str(&content);
-        if !content.ends_with('\n') {
-            rendered.push('\n');
-        }
-        rendered.push_str("<!-- CSA:SECTION:details:END -->\n");
-    }
-    rendered
-}
-
-pub(super) fn has_structured_review_content(output: &str) -> bool {
-    let sanitized = sanitize_review_output(output);
-    let sections = parse_sections(&sanitized);
-    ["summary", "details"].into_iter().any(|section_id| {
-        last_non_empty_section_content(&sanitized, &sections, section_id).is_some()
-    })
-}
-
-pub(super) fn derive_review_result_summary(output: &str) -> Option<String> {
-    let sanitized = sanitize_review_output(output);
-    let sections = parse_sections(&sanitized);
-    let content = last_non_empty_section_content(&sanitized, &sections, "summary")
-        .or_else(|| last_non_empty_section_content(&sanitized, &sections, "details"))?;
-
-    content
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .map(truncate_review_result_summary)
-}
-
-fn last_non_empty_section_content(
-    output: &str,
-    sections: &[OutputSection],
-    section_id: &str,
-) -> Option<String> {
-    sections
-        .iter()
-        .rev()
-        .filter(|section| section.id == section_id)
-        .find_map(|section| {
-            let content = extract_section_content(output, section);
-            if content.trim().is_empty() {
-                None
-            } else {
-                Some(content)
-            }
-        })
-}
-
-fn extract_section_content(output: &str, section: &OutputSection) -> String {
-    if section.line_start == 0 || section.line_end < section.line_start {
-        return String::new();
-    }
-
-    let lines: Vec<&str> = output.lines().collect();
-    if lines.is_empty() || section.line_start > lines.len() {
-        return String::new();
-    }
-
-    let start = section.line_start - 1;
-    let end_exclusive = section.line_end.min(lines.len());
-    lines[start..end_exclusive].join("\n")
 }
 
 /// Persist a [`ReviewSessionMeta`] to `{session_dir}/review_meta.json`.
@@ -292,6 +209,7 @@ fn cross_check_json_for_blocking(
         json_artifact.overall_risk.as_deref(),
         ReviewDecision::from_str(&meta.decision).ok(),
         || review_contains_prose_clean_conclusion(session_dir),
+        || review_contains_prose_fail_conclusion(session_dir),
     )?;
     Ok(Some(verdict_from_meta(meta, decision, json_counts)))
 }
@@ -345,6 +263,7 @@ fn derive_review_verdict_artifact(
                         None,
                         ReviewDecision::from_str(&meta.decision).ok(),
                         || review_contains_prose_clean_conclusion(session_dir),
+                        || review_contains_prose_fail_conclusion(session_dir),
                     )?;
                     return Ok(verdict_from_meta(meta, decision, json_counts));
                 }
@@ -356,6 +275,7 @@ fn derive_review_verdict_artifact(
                 None,
                 ReviewDecision::from_str(&meta.decision).ok(),
                 || review_contains_prose_clean_conclusion(session_dir),
+                || review_contains_prose_fail_conclusion(session_dir),
             )?;
             return Ok(verdict_from_meta(meta, decision, severity_counts));
         }
@@ -369,6 +289,7 @@ fn derive_review_verdict_artifact(
             artifact.overall_risk.as_deref(),
             ReviewDecision::from_str(&meta.decision).ok(),
             || review_contains_prose_clean_conclusion(session_dir),
+            || review_contains_prose_fail_conclusion(session_dir),
         )?;
         return Ok(verdict_from_meta(meta, decision, severity_counts));
     }
@@ -460,6 +381,7 @@ fn derive_decision_from_severity_counts(
     overall_risk: Option<&str>,
     meta_decision: Option<ReviewDecision>,
     prose_clean_check: impl FnOnce() -> Result<bool, anyhow::Error>,
+    prose_fail_check: impl FnOnce() -> Result<bool, anyhow::Error>,
 ) -> Result<ReviewDecision, anyhow::Error> {
     // Blocking findings (critical/high/medium) always fail.
     if has_blocking_severity(severity_counts) {
@@ -494,6 +416,17 @@ fn derive_decision_from_severity_counts(
     // to contain "SKIP" but the structured artifact shows zero findings, the zero-evidence
     // Pass conclusion must win over the text-parse Skip noise.
     if findings_empty && severity_counts_are_zero(severity_counts) {
+        // #1675: a Fail/Uncertain meta whose prose AFFIRMATIVELY concludes FAIL, but whose
+        // structured findings failed to emit, is a real failure with lost evidence — fail
+        // closed. Gated on affirmative prose FAIL (NOT "prose not clean") so #1349's
+        // neutral-prose noise still resolves to the zero-evidence Pass below.
+        if matches!(
+            meta_decision,
+            Some(ReviewDecision::Fail | ReviewDecision::Uncertain)
+        ) && prose_fail_check()?
+        {
+            return Ok(ReviewDecision::Fail);
+        }
         return Ok(ReviewDecision::Pass);
     }
 

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -299,11 +299,25 @@ fn derive_review_verdict_artifact(
     }
 
     if let Some(severity_counts) = synthetic_empty_findings_counts {
-        return Ok(verdict_from_meta(
-            meta,
-            ReviewDecision::Pass,
-            severity_counts,
-        ));
+        // Synthetic-empty findings.toml exhausted every artifact fallback (no
+        // blocking JSON, no JSON artifact, no full.md verdict). The pre-#1675
+        // behavior returned Pass unconditionally here — the SAME zero-evidence
+        // false-PASS hole #1675 closed on the non-synthetic path, just reached
+        // via the #1045-r3 synthetic fall-through. Route through the shared gate
+        // so a Fail/Uncertain meta whose prose affirmatively concludes FAIL
+        // fails closed even when the structured findings were unparseable. The
+        // counts are guaranteed zero here (set only inside the
+        // severity_counts_are_zero branch above), so the #1675 gate applies and
+        // neutral-prose synthetic-empty results still resolve to Pass (#1349).
+        let decision = derive_decision_from_severity_counts(
+            &severity_counts,
+            true,
+            None,
+            ReviewDecision::from_str(&meta.decision).ok(),
+            || review_contains_prose_clean_conclusion(session_dir),
+            || review_contains_prose_fail_conclusion(session_dir),
+        )?;
+        return Ok(verdict_from_meta(meta, decision, severity_counts));
     }
 
     if !full_output_is_effectively_empty(session_dir)? {

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -167,13 +167,21 @@ pub(super) fn detect_prose_fail_conclusion(text: &str) -> bool {
 
 /// Whether the review's persisted prose affirmatively concludes FAIL.
 ///
-/// Mirrors [`review_contains_prose_clean_conclusion`]: check the persisted
-/// `summary` section first, then fall back to `output/full.md`.
+/// Scans every place a reviewer might record a FAIL verdict: the persisted
+/// `summary` section, then the `details` section, then `output/full.md`. This is
+/// intentionally MORE thorough than [`review_contains_prose_clean_conclusion`]
+/// (which reads only `summary` + `full.md`): a missed FAIL signal silently merges
+/// blocking findings, so the fail-closed path errs toward catching FAIL wherever
+/// it appears — including structured output that has section markers but no
+/// `full.md`, where the verdict can live only in `details` (#1675 review finding).
+/// The clean path stays stricter by design; both asymmetries err toward FAIL.
 pub(super) fn review_contains_prose_fail_conclusion(session_dir: &Path) -> Result<bool> {
-    if let Some(summary) = csa_session::read_section(session_dir, "summary")?
-        && detect_prose_fail_conclusion(&summary)
-    {
-        return Ok(true);
+    for section_id in ["summary", "details"] {
+        if let Some(section) = csa_session::read_section(session_dir, section_id)?
+            && detect_prose_fail_conclusion(&section)
+        {
+            return Ok(true);
+        }
     }
 
     let full_output_path = session_dir.join("output").join("full.md");

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -27,22 +27,43 @@ pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
         || verdict_token_pass_or_clean(text)
 }
 
+/// Verdict tokens that affirmatively conclude a clean/passing review.
+const PASS_VERDICT_TOKENS: &[&str] = &["PASS", "CLEAN"];
+
+/// Verdict tokens that affirmatively conclude a failing review (#1675).
+const FAIL_VERDICT_TOKENS: &[&str] = &["FAIL", "HAS_ISSUES", "REJECT"];
+
 fn verdict_token_pass_or_clean(text: &str) -> bool {
+    verdict_token_matches(text, PASS_VERDICT_TOKENS)
+}
+
+/// Detect an affirmative FAIL verdict token (`FAIL`/`HAS_ISSUES`/`REJECT`),
+/// mirroring [`verdict_token_pass_or_clean`]. Matches ONLY bounded verdict tokens
+/// (bare line, `Verdict:`-labeled, or `**`/`__`-emphasized) — never the substring
+/// "fail" — so prose like "the test no longer fails" is not read as a FAIL
+/// conclusion (#1675 precision requirement).
+fn verdict_token_fail(text: &str) -> bool {
+    verdict_token_matches(text, FAIL_VERDICT_TOKENS)
+}
+
+/// Scan each line for one of `tokens` appearing as a bounded verdict token,
+/// either standalone, after a `Verdict:`-style label, or `**`/`__`-emphasized.
+fn verdict_token_matches(text: &str, tokens: &[&str]) -> bool {
     text.lines().any(|line| {
         let trimmed = line.trim();
-        is_verdict_token(trimmed)
-            || has_emphasized_verdict_token_prefix(trimmed)
-            || line_has_labeled_verdict_token(trimmed)
+        is_verdict_token(trimmed, tokens)
+            || has_emphasized_verdict_token_prefix(trimmed, tokens)
+            || line_has_labeled_verdict_token(trimmed, tokens)
     })
 }
 
-fn is_verdict_token(text: &str) -> bool {
+fn is_verdict_token(text: &str, tokens: &[&str]) -> bool {
     let trimmed =
         text.trim_matches(|c: char| c.is_whitespace() || c == '*' || c == '_' || c == '.');
-    matches!(trimmed, "PASS" | "CLEAN")
+    tokens.contains(&trimmed)
 }
 
-fn line_has_labeled_verdict_token(line: &str) -> bool {
+fn line_has_labeled_verdict_token(line: &str, tokens: &[&str]) -> bool {
     const LABELS: &[&str] = &["Verdict:", "Decision:", "Status:", "Result:", "Review:"];
 
     let bytes = line.as_bytes();
@@ -61,10 +82,11 @@ fn line_has_labeled_verdict_token(line: &str) -> bool {
             }
 
             let rest = &line[index + label_bytes.len()..];
-            if is_verdict_token(rest)
-                || has_emphasized_verdict_token_prefix(rest.trim_start())
+            if is_verdict_token(rest, tokens)
+                || has_emphasized_verdict_token_prefix(rest.trim_start(), tokens)
                 || has_verdict_token_prefix(
                     rest.trim_start_matches(|c: char| c.is_whitespace() || c == '*' || c == '_'),
+                    tokens,
                 )
             {
                 return true;
@@ -75,8 +97,8 @@ fn line_has_labeled_verdict_token(line: &str) -> bool {
     false
 }
 
-fn has_verdict_token_prefix(text: &str) -> bool {
-    ["PASS", "CLEAN"].iter().any(|token| {
+fn has_verdict_token_prefix(text: &str, tokens: &[&str]) -> bool {
+    tokens.iter().any(|token| {
         let Some(rest) = text.strip_prefix(token) else {
             return false;
         };
@@ -84,9 +106,9 @@ fn has_verdict_token_prefix(text: &str) -> bool {
     })
 }
 
-fn has_emphasized_verdict_token_prefix(text: &str) -> bool {
+fn has_emphasized_verdict_token_prefix(text: &str, tokens: &[&str]) -> bool {
     ["**", "__"].iter().any(|marker| {
-        ["PASS", "CLEAN"].iter().any(|token| {
+        tokens.iter().any(|token| {
             text.strip_prefix(marker)
                 .and_then(|rest| rest.strip_prefix(token))
                 .and_then(|rest| rest.strip_prefix(marker))
@@ -131,6 +153,38 @@ pub(super) fn review_contains_prose_clean_conclusion(session_dir: &Path) -> Resu
         .map_err(|error| anyhow::anyhow!("read {}: {error}", full_output_path.display()))?;
     let review_text = extract_review_text(&raw_output).unwrap_or(raw_output);
     Ok(detect_prose_clean_conclusion(&review_text))
+}
+
+/// Detect whether review prose AFFIRMATIVELY concludes FAIL via a bounded verdict
+/// token (`FAIL`/`HAS_ISSUES`/`REJECT`). Unlike [`detect_prose_clean_conclusion`],
+/// this matches ONLY verdict tokens (bare/labeled/emphasized) — never the substring
+/// "fail" — so benign prose like "the test no longer fails" is not misread as a FAIL
+/// verdict (#1675). Used to fail-closed when a real prose FAIL lost its structured
+/// findings.
+pub(super) fn detect_prose_fail_conclusion(text: &str) -> bool {
+    verdict_token_fail(text)
+}
+
+/// Whether the review's persisted prose affirmatively concludes FAIL.
+///
+/// Mirrors [`review_contains_prose_clean_conclusion`]: check the persisted
+/// `summary` section first, then fall back to `output/full.md`.
+pub(super) fn review_contains_prose_fail_conclusion(session_dir: &Path) -> Result<bool> {
+    if let Some(summary) = csa_session::read_section(session_dir, "summary")?
+        && detect_prose_fail_conclusion(&summary)
+    {
+        return Ok(true);
+    }
+
+    let full_output_path = session_dir.join("output").join("full.md");
+    if !full_output_path.exists() {
+        return Ok(false);
+    }
+
+    let raw_output = fs::read_to_string(&full_output_path)
+        .map_err(|error| anyhow::anyhow!("read {}: {error}", full_output_path.display()))?;
+    let review_text = extract_review_text(&raw_output).unwrap_or(raw_output);
+    Ok(detect_prose_fail_conclusion(&review_text))
 }
 
 pub(super) fn contains_clean_phrase(output: &str) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -167,18 +167,23 @@ pub(super) fn detect_prose_fail_conclusion(text: &str) -> bool {
 
 /// Whether the review's persisted prose affirmatively concludes FAIL.
 ///
-/// Scans every place a reviewer might record a FAIL verdict: the persisted
-/// `summary` section, then the `details` section, then `output/full.md`. This is
-/// intentionally MORE thorough than [`review_contains_prose_clean_conclusion`]
-/// (which reads only `summary` + `full.md`): a missed FAIL signal silently merges
-/// blocking findings, so the fail-closed path errs toward catching FAIL wherever
-/// it appears — including structured output that has section markers but no
-/// `full.md`, where the verdict can live only in `details` (#1675 review finding).
-/// The clean path stays stricter by design; both asymmetries err toward FAIL.
+/// Scans every place a reviewer might record a FAIL verdict: ALL persisted
+/// `summary` and `details` sections, then `output/full.md`. It uses
+/// [`csa_session::read_all_sections`] rather than [`csa_session::read_section`]
+/// because the latter returns only the FIRST section per id. Duplicate section
+/// ids persist their later copies as suffixed files (`details-2.md`, …) and
+/// caller-facing sanitization treats the last-non-empty copy as authoritative —
+/// so a FAIL verdict in a *later* duplicate must still fail closed; reading only
+/// the first copy could hide it (#1675 review finding). This is intentionally
+/// MORE thorough than [`review_contains_prose_clean_conclusion`] (which reads only
+/// `summary` + `full.md`): a missed FAIL signal silently merges blocking findings,
+/// so the fail-closed path errs toward catching FAIL wherever it appears —
+/// including structured output that has section markers but no `full.md`, where
+/// the verdict can live only in `details`. Both asymmetries err toward FAIL.
 pub(super) fn review_contains_prose_fail_conclusion(session_dir: &Path) -> Result<bool> {
-    for section_id in ["summary", "details"] {
-        if let Some(section) = csa_session::read_section(session_dir, section_id)?
-            && detect_prose_fail_conclusion(&section)
+    for (section, content) in csa_session::read_all_sections(session_dir)? {
+        if matches!(section.id.as_str(), "summary" | "details")
+            && detect_prose_fail_conclusion(&content)
         {
             return Ok(true);
         }

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -235,19 +235,28 @@ pub(super) fn detect_prose_fail_conclusion(text: &str) -> bool {
 
 /// Whether the review's persisted prose affirmatively concludes FAIL.
 ///
-/// Scans every place a reviewer might record a FAIL verdict: ALL persisted
-/// `summary` and `details` sections, then `output/full.md`. It uses
-/// [`csa_session::read_all_sections`] rather than [`csa_session::read_section`]
-/// because the latter returns only the FIRST section per id. Duplicate section
-/// ids persist their later copies as suffixed files (`details-2.md`, …) and
-/// caller-facing sanitization treats the last-non-empty copy as authoritative —
-/// so a FAIL verdict in a *later* duplicate must still fail closed; reading only
-/// the first copy could hide it (#1675 review finding). This is intentionally
-/// MORE thorough than [`review_contains_prose_clean_conclusion`] (which reads only
-/// `summary` + `full.md`): a missed FAIL signal silently merges blocking findings,
-/// so the fail-closed path errs toward catching FAIL wherever it appears —
-/// including structured output that has section markers but no `full.md`, where
-/// the verdict can live only in `details`. Both asymmetries err toward FAIL.
+/// Scans every place a reviewer might record a FAIL verdict in two passes:
+///
+/// 1. ALL persisted `summary` and `details` sections, via
+///    [`csa_session::read_all_sections`] rather than [`csa_session::read_section`]
+///    (the latter returns only the FIRST section per id). Duplicate section ids
+///    persist their later copies as suffixed files (`details-2.md`, …) and
+///    caller-facing sanitization treats the last-non-empty copy as authoritative,
+///    so a FAIL verdict in a *later* duplicate must still fail closed; reading only
+///    the first copy could hide it (#1675 review finding).
+/// 2. The canonical review prose resolved by
+///    [`crate::review_cmd::findings_toml::load_canonical_review_text`] — the SAME
+///    loader the findings extractor uses (`full.md` → `output.log` → `details.md`
+///    precedence). Reusing it keeps the fail-closed detector's source set identical
+///    to the extractor's: a FAIL verdict that survives only in the raw `output.log`
+///    (full.md absent, sections neutral, findings.toml synthetic-empty) must still
+///    fail closed, and the two can never drift apart again (the #1675 review rounds
+///    were repeatedly a source-set divergence between detector and extractor).
+///
+/// This is intentionally MORE thorough than [`review_contains_prose_clean_conclusion`]
+/// (which reads only `summary` + `full.md`): a missed FAIL signal silently merges
+/// blocking findings, so the fail-closed path errs toward catching FAIL wherever it
+/// appears. Both asymmetries err toward FAIL.
 pub(super) fn review_contains_prose_fail_conclusion(session_dir: &Path) -> Result<bool> {
     for (section, content) in csa_session::read_all_sections(session_dir)? {
         if matches!(section.id.as_str(), "summary" | "details")
@@ -257,15 +266,14 @@ pub(super) fn review_contains_prose_fail_conclusion(session_dir: &Path) -> Resul
         }
     }
 
-    let full_output_path = session_dir.join("output").join("full.md");
-    if !full_output_path.exists() {
-        return Ok(false);
+    if let Some(review_text) =
+        crate::review_cmd::findings_toml::load_canonical_review_text(session_dir)?
+        && detect_prose_fail_conclusion(&review_text)
+    {
+        return Ok(true);
     }
 
-    let raw_output = fs::read_to_string(&full_output_path)
-        .map_err(|error| anyhow::anyhow!("read {}: {error}", full_output_path.display()))?;
-    let review_text = extract_review_text(&raw_output).unwrap_or(raw_output);
-    Ok(detect_prose_fail_conclusion(&review_text))
+    Ok(false)
 }
 
 pub(super) fn contains_clean_phrase(output: &str) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -98,8 +98,17 @@ fn verdict_token_matches(text: &str, tokens: &[&str], case: MatchCase) -> bool {
 }
 
 fn is_verdict_token(text: &str, tokens: &[&str], case: MatchCase) -> bool {
-    let trimmed =
-        text.trim_matches(|c: char| c.is_whitespace() || c == '*' || c == '_' || c == '.');
+    // Trim the same delimiter class the CLI's consensus parser splits on
+    // (`!is_ascii_alphanumeric() && c != '_'`) so a standalone verdict token
+    // survives surrounding punctuation — `FAIL:`, `PASS.`, `(CLEAN)` — which the
+    // consensus parser already counts as a blocking/clean verdict; missing `:`
+    // reopened the #1675 lost-evidence path for colon-terminated verdict lines
+    // (review finding). A multi-word line ("The test PASS rate is 100%") never
+    // reduces to a bare token, so exact equality after trimming stays the
+    // precision guard. Underscore is NOT trimmed (the consensus parser treats it
+    // as a word char): `HAS_ISSUES` stays one token and `CLEAN_UP` is not a CLEAN
+    // verdict.
+    let trimmed = text.trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '_');
     tokens.iter().any(|token| case.token_eq(trimmed, token))
 }
 
@@ -366,6 +375,30 @@ mod tests {
         assert!(verdict_token_fail("HAS_ISSUES"));
         assert!(!verdict_token_pass_or_clean("Verdict: Pass"));
         assert!(!verdict_token_pass_or_clean("Status: Clean"));
+    }
+
+    #[test]
+    fn verdict_token_trailing_punctuation_matches() {
+        // codex finding: the bare-line path trimmed only {ws,*,_,.}, so a verdict
+        // token followed by a delimiter the consensus parser splits on — most
+        // importantly `:` — was missed, reopening the #1675 lost-evidence path for
+        // colon-terminated verdict lines. Internal `_` is preserved so `HAS_ISSUES`
+        // still matches.
+        assert!(verdict_token_fail("FAIL:"));
+        assert!(verdict_token_fail("HAS_ISSUES:"));
+        assert!(verdict_token_fail("REJECT;"));
+        assert!(verdict_token_fail("(FAIL)"));
+        assert!(verdict_token_pass_or_clean("PASS:"));
+        assert!(verdict_token_pass_or_clean("CLEAN!"));
+    }
+
+    #[test]
+    fn verdict_token_trailing_punctuation_keeps_precision() {
+        // Trimming surrounding punctuation must NOT let a multi-word line reduce to
+        // a bare token: exact equality after trimming stays the precision guard.
+        assert!(!verdict_token_pass_or_clean("PASS: rate is 100%"));
+        assert!(!verdict_token_fail("FAIL_SAFE:"));
+        assert!(!verdict_token_pass_or_clean("CLEAN_UP:"));
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -33,37 +33,77 @@ const PASS_VERDICT_TOKENS: &[&str] = &["PASS", "CLEAN"];
 /// Verdict tokens that affirmatively conclude a failing review (#1675).
 const FAIL_VERDICT_TOKENS: &[&str] = &["FAIL", "HAS_ISSUES", "REJECT"];
 
+/// Case-matching policy for verdict tokens.
+///
+/// The PASS/CLEAN and FAIL detectors deliberately differ — both erring toward
+/// FAIL, like the fail-closed/fail-open asymmetry documented on
+/// [`review_contains_prose_fail_conclusion`]:
+/// - PASS/CLEAN is fail-OPEN — an affirmative clean conclusion SUPPRESSES the
+///   #1675 fail-closed path — so it matches [`MatchCase::Sensitive`]
+///   (uppercase-only). A prior codex finding showed case-insensitive clean
+///   detection misread mixed-case prose (`Verdict: Pass`, "cannot pass yet") as
+///   a clean conclusion and unblocked merges on uncertain evidence.
+/// - FAIL is fail-CLOSED, so it matches [`MatchCase::Insensitive`] to agree with
+///   the CLI's own verdict parser (`review_consensus::contains_verdict_token`,
+///   `eq_ignore_ascii_case`): `Verdict: Fail` sets meta=Fail, so this detector
+///   must catch it too or the #1675 lost-evidence path reopens for case variants
+///   the CLI already recognizes.
+#[derive(Clone, Copy)]
+enum MatchCase {
+    Sensitive,
+    Insensitive,
+}
+
+impl MatchCase {
+    fn token_eq(self, candidate: &str, token: &str) -> bool {
+        match self {
+            MatchCase::Sensitive => candidate == token,
+            MatchCase::Insensitive => candidate.eq_ignore_ascii_case(token),
+        }
+    }
+
+    fn prefix_eq(self, head: &[u8], token: &[u8]) -> bool {
+        match self {
+            MatchCase::Sensitive => head == token,
+            MatchCase::Insensitive => head.eq_ignore_ascii_case(token),
+        }
+    }
+}
+
 fn verdict_token_pass_or_clean(text: &str) -> bool {
-    verdict_token_matches(text, PASS_VERDICT_TOKENS)
+    verdict_token_matches(text, PASS_VERDICT_TOKENS, MatchCase::Sensitive)
 }
 
 /// Detect an affirmative FAIL verdict token (`FAIL`/`HAS_ISSUES`/`REJECT`),
 /// mirroring [`verdict_token_pass_or_clean`]. Matches ONLY bounded verdict tokens
 /// (bare line, `Verdict:`-labeled, or `**`/`__`-emphasized) — never the substring
 /// "fail" — so prose like "the test no longer fails" is not read as a FAIL
-/// conclusion (#1675 precision requirement).
+/// conclusion (#1675 precision requirement). Unlike the PASS/CLEAN detector this
+/// is case-INsensitive; see [`MatchCase`].
 fn verdict_token_fail(text: &str) -> bool {
-    verdict_token_matches(text, FAIL_VERDICT_TOKENS)
+    verdict_token_matches(text, FAIL_VERDICT_TOKENS, MatchCase::Insensitive)
 }
 
 /// Scan each line for one of `tokens` appearing as a bounded verdict token,
 /// either standalone, after a `Verdict:`-style label, or `**`/`__`-emphasized.
-fn verdict_token_matches(text: &str, tokens: &[&str]) -> bool {
+/// `case` selects verdict-token case-matching; the surrounding `Verdict:`-style
+/// label is always matched case-insensitively (only the token honors `case`).
+fn verdict_token_matches(text: &str, tokens: &[&str], case: MatchCase) -> bool {
     text.lines().any(|line| {
         let trimmed = line.trim();
-        is_verdict_token(trimmed, tokens)
-            || has_emphasized_verdict_token_prefix(trimmed, tokens)
-            || line_has_labeled_verdict_token(trimmed, tokens)
+        is_verdict_token(trimmed, tokens, case)
+            || has_emphasized_verdict_token_prefix(trimmed, tokens, case)
+            || line_has_labeled_verdict_token(trimmed, tokens, case)
     })
 }
 
-fn is_verdict_token(text: &str, tokens: &[&str]) -> bool {
+fn is_verdict_token(text: &str, tokens: &[&str], case: MatchCase) -> bool {
     let trimmed =
         text.trim_matches(|c: char| c.is_whitespace() || c == '*' || c == '_' || c == '.');
-    tokens.contains(&trimmed)
+    tokens.iter().any(|token| case.token_eq(trimmed, token))
 }
 
-fn line_has_labeled_verdict_token(line: &str, tokens: &[&str]) -> bool {
+fn line_has_labeled_verdict_token(line: &str, tokens: &[&str], case: MatchCase) -> bool {
     const LABELS: &[&str] = &["Verdict:", "Decision:", "Status:", "Result:", "Review:"];
 
     let bytes = line.as_bytes();
@@ -82,11 +122,12 @@ fn line_has_labeled_verdict_token(line: &str, tokens: &[&str]) -> bool {
             }
 
             let rest = &line[index + label_bytes.len()..];
-            if is_verdict_token(rest, tokens)
-                || has_emphasized_verdict_token_prefix(rest.trim_start(), tokens)
+            if is_verdict_token(rest, tokens, case)
+                || has_emphasized_verdict_token_prefix(rest.trim_start(), tokens, case)
                 || has_verdict_token_prefix(
                     rest.trim_start_matches(|c: char| c.is_whitespace() || c == '*' || c == '_'),
                     tokens,
+                    case,
                 )
             {
                 return true;
@@ -97,20 +138,34 @@ fn line_has_labeled_verdict_token(line: &str, tokens: &[&str]) -> bool {
     false
 }
 
-fn has_verdict_token_prefix(text: &str, tokens: &[&str]) -> bool {
-    tokens.iter().any(|token| {
-        let Some(rest) = text.strip_prefix(token) else {
-            return false;
-        };
-        verdict_token_is_bounded(rest)
-    })
+fn has_verdict_token_prefix(text: &str, tokens: &[&str], case: MatchCase) -> bool {
+    tokens
+        .iter()
+        .any(|token| strip_token_prefix(text, token, case).is_some_and(verdict_token_is_bounded))
 }
 
-fn has_emphasized_verdict_token_prefix(text: &str, tokens: &[&str]) -> bool {
+/// [`str::strip_prefix`] for an ASCII verdict `token`, honoring `case`.
+///
+/// Verdict tokens are uppercase ASCII, so a matched prefix is exactly
+/// `token.len()` bytes and lands on a char boundary. Returns the remainder after
+/// the token, or `None` when `text` does not start with `token` under `case`.
+fn strip_token_prefix<'a>(text: &'a str, token: &str, case: MatchCase) -> Option<&'a str> {
+    let head = text.as_bytes().get(..token.len())?;
+    if case.prefix_eq(head, token.as_bytes()) {
+        // The token is ASCII, so a matched head means `token.len()` lands on a
+        // char boundary; slicing here cannot panic. (Taken only on match, so the
+        // index is never evaluated for a non-boundary split.)
+        Some(&text[token.len()..])
+    } else {
+        None
+    }
+}
+
+fn has_emphasized_verdict_token_prefix(text: &str, tokens: &[&str], case: MatchCase) -> bool {
     ["**", "__"].iter().any(|marker| {
         tokens.iter().any(|token| {
             text.strip_prefix(marker)
-                .and_then(|rest| rest.strip_prefix(token))
+                .and_then(|rest| strip_token_prefix(rest, token, case))
                 .and_then(|rest| rest.strip_prefix(marker))
                 .is_some_and(verdict_token_is_bounded)
         })
@@ -297,7 +352,21 @@ fn contains_positive_no_issue_clause(lower: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::verdict_token_pass_or_clean;
+    use super::{verdict_token_fail, verdict_token_pass_or_clean};
+
+    #[test]
+    fn fail_detection_case_insensitive_clean_detection_case_sensitive() {
+        // Intentional asymmetry (both err toward FAIL): FAIL is fail-closed so it
+        // matches case-insensitively (agreeing with the CLI's verdict parser);
+        // PASS/CLEAN is fail-open so it stays case-sensitive (a prior codex
+        // finding showed case-insensitive clean detection unblocked merges on
+        // uncertain evidence). A shared case-insensitive helper (the #1675 round-3
+        // regression) breaks this — lock both directions in one test.
+        assert!(verdict_token_fail("Verdict: Fail"));
+        assert!(verdict_token_fail("HAS_ISSUES"));
+        assert!(!verdict_token_pass_or_clean("Verdict: Pass"));
+        assert!(!verdict_token_pass_or_clean("Status: Clean"));
+    }
 
     #[test]
     fn verdict_token_uppercase_pass_matches() {

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -98,17 +98,21 @@ fn verdict_token_matches(text: &str, tokens: &[&str], case: MatchCase) -> bool {
 }
 
 fn is_verdict_token(text: &str, tokens: &[&str], case: MatchCase) -> bool {
-    // Trim the same delimiter class the CLI's consensus parser splits on
-    // (`!is_ascii_alphanumeric() && c != '_'`) so a standalone verdict token
-    // survives surrounding punctuation — `FAIL:`, `PASS.`, `(CLEAN)` — which the
-    // consensus parser already counts as a blocking/clean verdict; missing `:`
-    // reopened the #1675 lost-evidence path for colon-terminated verdict lines
-    // (review finding). A multi-word line ("The test PASS rate is 100%") never
-    // reduces to a bare token, so exact equality after trimming stays the
+    // Trim ASCII punctuation and whitespace so a standalone verdict token survives
+    // surrounding punctuation — `FAIL:`, `PASS.`, `(CLEAN)` — which the CLI's
+    // consensus parser already counts as a blocking/clean verdict (missing `:`
+    // reopened the #1675 lost-evidence path for colon-terminated verdict lines).
+    // The trim set is restricted to ASCII punctuation/whitespace, NOT the consensus
+    // parser's full `!is_ascii_alphanumeric()` delimiter class: trimming every
+    // non-ASCII char would corrupt multilingual prose — e.g. `PASS нет`
+    // (Russian "no") would lose `нет` and reduce to a false PASS verdict
+    // (cloud-review finding). A multi-word line ("The test PASS rate is 100%")
+    // never reduces to a bare token, so exact equality after trimming stays the
     // precision guard. Underscore is NOT trimmed (the consensus parser treats it
     // as a word char): `HAS_ISSUES` stays one token and `CLEAN_UP` is not a CLEAN
     // verdict.
-    let trimmed = text.trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '_');
+    let trimmed =
+        text.trim_matches(|c: char| (c.is_ascii_punctuation() || c.is_whitespace()) && c != '_');
     tokens.iter().any(|token| case.token_eq(trimmed, token))
 }
 
@@ -399,6 +403,23 @@ mod tests {
         assert!(!verdict_token_pass_or_clean("PASS: rate is 100%"));
         assert!(!verdict_token_fail("FAIL_SAFE:"));
         assert!(!verdict_token_pass_or_clean("CLEAN_UP:"));
+    }
+
+    #[test]
+    fn verdict_token_non_ascii_neighbors_are_not_trimmed() {
+        // The boundary-trim set is restricted to ASCII punctuation/whitespace, so a
+        // non-ASCII word adjacent to a verdict token is NOT stripped away. Trimming
+        // the consensus parser's full `!is_ascii_alphanumeric()` class would reduce
+        // `PASS нет` ("PASS" + Russian "no") to a bare `PASS` and emit a FALSE clean
+        // verdict (cloud-review HIGH finding). Cyrillic stands in for any non-ASCII
+        // script (CJK, Greek, accented Latin); multilingual prose must stay a
+        // multi-word line that never reduces to a bare token.
+        assert!(!verdict_token_pass_or_clean("PASS нет"));
+        assert!(!verdict_token_pass_or_clean("Оценка: PASS неверна"));
+        assert!(!verdict_token_fail("нет FAIL"));
+        // ASCII-only verdict lines stay matchable after the narrowed trim set.
+        assert!(verdict_token_pass_or_clean("PASS"));
+        assert!(verdict_token_fail("FAIL:"));
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output_sections.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_sections.rs
@@ -1,0 +1,102 @@
+//! Rendering and extraction of structured review sections (`summary`/`details`).
+//!
+//! These helpers parse CSA `<!-- CSA:SECTION:* -->` markers out of raw review
+//! output and re-render only the substantive summary/details content, so caller-
+//! facing review output is not polluted by unrelated provider noise.
+
+use csa_session::OutputSection;
+use csa_session::output_parser::parse_sections;
+
+use super::truncate_review_result_summary;
+
+/// Prefer structured review sections (summary/details) when available to avoid
+/// leaking unrelated provider noise into caller-facing review output.
+pub(crate) fn sanitize_review_output(output: &str) -> String {
+    let sections = parse_sections(output);
+    if sections.is_empty() {
+        return output.to_string();
+    }
+
+    let summary = last_non_empty_section_content(output, &sections, "summary");
+    let details = last_non_empty_section_content(output, &sections, "details");
+    if summary.is_none() && details.is_none() {
+        return output.to_string();
+    }
+
+    let mut rendered = String::new();
+    if let Some(content) = summary {
+        rendered.push_str("<!-- CSA:SECTION:summary -->\n");
+        rendered.push_str(&content);
+        if !content.ends_with('\n') {
+            rendered.push('\n');
+        }
+        rendered.push_str("<!-- CSA:SECTION:summary:END -->\n");
+    }
+    if let Some(content) = details {
+        if !rendered.is_empty() && !rendered.ends_with('\n') {
+            rendered.push('\n');
+        }
+        rendered.push_str("<!-- CSA:SECTION:details -->\n");
+        rendered.push_str(&content);
+        if !content.ends_with('\n') {
+            rendered.push('\n');
+        }
+        rendered.push_str("<!-- CSA:SECTION:details:END -->\n");
+    }
+    rendered
+}
+
+pub(crate) fn has_structured_review_content(output: &str) -> bool {
+    let sanitized = sanitize_review_output(output);
+    let sections = parse_sections(&sanitized);
+    ["summary", "details"].into_iter().any(|section_id| {
+        last_non_empty_section_content(&sanitized, &sections, section_id).is_some()
+    })
+}
+
+pub(crate) fn derive_review_result_summary(output: &str) -> Option<String> {
+    let sanitized = sanitize_review_output(output);
+    let sections = parse_sections(&sanitized);
+    let content = last_non_empty_section_content(&sanitized, &sections, "summary")
+        .or_else(|| last_non_empty_section_content(&sanitized, &sections, "details"))?;
+
+    content
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(truncate_review_result_summary)
+}
+
+fn last_non_empty_section_content(
+    output: &str,
+    sections: &[OutputSection],
+    section_id: &str,
+) -> Option<String> {
+    sections
+        .iter()
+        .rev()
+        .filter(|section| section.id == section_id)
+        .find_map(|section| {
+            let content = extract_section_content(output, section);
+            if content.trim().is_empty() {
+                None
+            } else {
+                Some(content)
+            }
+        })
+}
+
+fn extract_section_content(output: &str, section: &OutputSection) -> String {
+    if section.line_start == 0 || section.line_end < section.line_start {
+        return String::new();
+    }
+
+    let lines: Vec<&str> = output.lines().collect();
+    if lines.is_empty() || section.line_start > lines.len() {
+        return String::new();
+    }
+
+    let start = section.line_start - 1;
+    let end_exclusive = section.line_end.min(lines.len());
+    lines[start..end_exclusive].join("\n")
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_sections.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_sections.rs
@@ -47,11 +47,10 @@ pub(crate) fn sanitize_review_output(output: &str) -> String {
 }
 
 pub(crate) fn has_structured_review_content(output: &str) -> bool {
-    let sanitized = sanitize_review_output(output);
-    let sections = parse_sections(&sanitized);
-    ["summary", "details"].into_iter().any(|section_id| {
-        last_non_empty_section_content(&sanitized, &sections, section_id).is_some()
-    })
+    let sections = parse_sections(output);
+    ["summary", "details"]
+        .into_iter()
+        .any(|section_id| last_non_empty_section_content(output, &sections, section_id).is_some())
 }
 
 pub(crate) fn derive_review_result_summary(output: &str) -> Option<String> {

--- a/crates/cli-sub-agent/src/review_cmd_output_sections.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_sections.rs
@@ -90,12 +90,12 @@ fn extract_section_content(output: &str, section: &OutputSection) -> String {
         return String::new();
     }
 
-    let lines: Vec<&str> = output.lines().collect();
-    if lines.is_empty() || section.line_start > lines.len() {
-        return String::new();
-    }
-
     let start = section.line_start - 1;
-    let end_exclusive = section.line_end.min(lines.len());
-    lines[start..end_exclusive].join("\n")
+    let count = section.line_end - start;
+    output
+        .lines()
+        .skip(start)
+        .take(count)
+        .collect::<Vec<&str>>()
+        .join("\n")
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_summary.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_summary.rs
@@ -34,14 +34,14 @@ fn extract_section_content(output: &str, section: &OutputSection) -> String {
         return String::new();
     }
 
-    let lines: Vec<&str> = output.lines().collect();
-    if lines.is_empty() || section.line_start > lines.len() {
-        return String::new();
-    }
-
     let start = section.line_start - 1;
-    let end_exclusive = section.line_end.min(lines.len());
-    lines[start..end_exclusive].join("\n")
+    let count = section.line_end - start;
+    output
+        .lines()
+        .skip(start)
+        .take(count)
+        .collect::<Vec<&str>>()
+        .join("\n")
 }
 
 pub(crate) fn ensure_review_summary_artifact(session_dir: &Path, output: &str) -> Result<()> {

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -1,7 +1,7 @@
 use super::{
     ToolReviewFailureKind, derive_decision_from_severity_counts, derive_decision_from_text,
-    detect_tool_review_failure, ensure_review_summary_artifact, extract_review_text,
-    persist_review_verdict,
+    detect_prose_fail_conclusion, detect_tool_review_failure, ensure_review_summary_artifact,
+    extract_review_text, persist_review_verdict,
 };
 use crate::review_cmd::output::artifacts::PersistedReviewArtifact;
 use crate::test_env_lock::TEST_ENV_LOCK;
@@ -126,6 +126,7 @@ fn derive_decision_fail_meta_with_zero_severity_and_pass_prose_emits_pass() {
         Some("low"),
         Some(ReviewDecision::Fail),
         || Ok(true),
+        || Ok(false), // prose has no affirmative FAIL token (#1675)
     )
     .expect("derive decision");
 
@@ -783,3 +784,6 @@ mod verdict_1362_tests;
 
 #[path = "review_cmd_output_verdict_1480_tests.rs"]
 mod verdict_1480_tests;
+
+#[path = "review_cmd_output_verdict_1675_tests.rs"]
+mod verdict_1675_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1480_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1480_tests.rs
@@ -12,6 +12,7 @@ fn issue_1480_skip_meta_with_zero_findings_emits_pass() {
         None, // overall_risk
         Some(ReviewDecision::Skip),
         || Ok(false), // prose_clean_check irrelevant: zero evidence fires first
+        || Ok(false), // prose_fail_check irrelevant: Skip meta is not Fail/Uncertain
     )
     .expect("derive decision");
 
@@ -88,6 +89,7 @@ fn issue_1480_skip_meta_with_nonzero_low_counts_stays_skip() {
         true, // findings_empty
         None, // overall_risk
         Some(ReviewDecision::Skip),
+        || Ok(false),
         || Ok(false),
     )
     .expect("derive decision");

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
@@ -129,6 +129,48 @@ fn issue_1675_benign_fail_mention_in_clean_prose_stays_pass() {
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
+/// #1675 Case 4 (review-finding follow-up): an affirmative FAIL verdict that lives
+/// ONLY in the `details` section — neutral `summary`, no `output/full.md` — MUST
+/// still fail closed. The initial fix scanned only `summary` + `full.md`, so a
+/// structured review that records its verdict solely in `details` would slip
+/// through as a false Pass (flagged by the heterogeneous codex review of this fix).
+#[test]
+fn issue_1675_fail_verdict_only_in_details_section_emits_fail() {
+    let session_id = "01TEST1675DETAILSFAILONLY00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1675-details-fail-only", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // Neutral summary, FAIL verdict only in details, and no output/full.md: the
+    // summary-only scan would miss this and false-Pass.
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nReviewed the diff.\n<!-- CSA:SECTION:summary:END -->\n<!-- CSA:SECTION:details -->\nVerdict: FAIL\n\nTwo blocking issues found.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1675: affirmative FAIL verdict only in details section must fail closed"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
 // ─── Unit tests for detect_prose_fail_conclusion ───
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
@@ -401,6 +401,63 @@ fn issue_1675_synthetic_empty_findings_with_neutral_prose_stays_pass() {
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
+/// #1675 Case 10 (cloud-review round-7 follow-up): a FAIL verdict that survives ONLY
+/// in the raw `output.log` (full.md absent, sections neutral, findings.toml
+/// synthetic-empty) must fail closed. The findings extractor reads `output.log` when
+/// `full.md` is missing, but the fail-closed detector previously stopped at full.md —
+/// so the synthetic fallback false-passed. Detector and extractor now share
+/// `load_canonical_review_text`, so their source sets match.
+#[test]
+fn issue_1675_synthetic_empty_fail_verdict_only_in_output_log_emits_fail() {
+    let session_id = "01TEST1675OUTPUTLOGFAIL0000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1675-output-log-fail", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    fs::write(
+        session_dir
+            .join("output")
+            .join(crate::review_cmd::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER),
+        "",
+    )
+    .expect("write synthetic marker");
+    // Neutral summary + details sections (step-1 section scan finds no FAIL) and NO
+    // full.md, so load_canonical_review_text falls back to output.log.
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nReviewed the diff.\n<!-- CSA:SECTION:summary:END -->\n<!-- CSA:SECTION:details -->\nNotes on the change.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist structured output");
+    // The affirmative FAIL verdict survives only in the raw transcript (output.log)
+    // as a reviewer agent message, outside the persisted sections.
+    fs::write(
+        session_dir.join("output.log"),
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"Verdict: FAIL"}}"#,
+    )
+    .expect("write output.log");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1675 r7: FAIL verdict only in output.log must fail closed (shared extractor source set)"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
 // ─── Unit tests for detect_prose_fail_conclusion ───
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
@@ -214,6 +214,48 @@ fn issue_1675_fail_verdict_in_duplicate_later_details_section_emits_fail() {
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
+/// #1675 Case 6 (review-finding follow-up): a MIXED-CASE affirmative FAIL verdict
+/// (`Verdict: Fail`) must fail closed. The CLI's verdict parser matches tokens
+/// case-insensitively (`eq_ignore_ascii_case`), so `Verdict: Fail` sets meta=Fail;
+/// the fail-closed prose detector was case-sensitive and missed it, reopening the
+/// #1675 lost-evidence path for case variants. The detector is now case-insensitive.
+#[test]
+fn issue_1675_mixed_case_fail_verdict_emits_fail() {
+    let session_id = "01TEST1675MIXEDCASEFAIL0000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1675-mixed-case-fail", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // Mixed-case "Verdict: Fail": recognized by the CLI's case-insensitive verdict
+    // parser (meta=Fail) but missed by the old case-sensitive prose detector.
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nVerdict: Fail\n\nOne blocking issue.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1675: mixed-case 'Verdict: Fail' must fail closed (case-insensitive detector)"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
 // ─── Unit tests for detect_prose_fail_conclusion ───
 
 #[test]
@@ -239,4 +281,31 @@ fn detect_prose_fail_conclusion_benign_fail_substring_is_false() {
 #[test]
 fn detect_prose_fail_conclusion_pass_verdict_is_false() {
     assert!(!detect_prose_fail_conclusion("Verdict: PASS"));
+}
+
+#[test]
+fn detect_prose_fail_conclusion_mixed_case_labeled_is_true() {
+    // The CLI verdict parser matches case-insensitively; the detector must agree.
+    assert!(detect_prose_fail_conclusion("Verdict: Fail"));
+    assert!(detect_prose_fail_conclusion("verdict: fail"));
+}
+
+#[test]
+fn detect_prose_fail_conclusion_lowercase_bare_token_is_true() {
+    assert!(detect_prose_fail_conclusion(
+        "review notes\nfail\nmore notes"
+    ));
+}
+
+#[test]
+fn detect_prose_fail_conclusion_mixed_case_emphasized_is_true() {
+    assert!(detect_prose_fail_conclusion("**Fail**"));
+}
+
+#[test]
+fn detect_prose_fail_conclusion_lowercase_benign_substring_is_false() {
+    // Case-insensitivity must NOT regress precision: "fails" is still not a token.
+    assert!(!detect_prose_fail_conclusion(
+        "the run fails intermittently"
+    ));
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
@@ -171,6 +171,49 @@ fn issue_1675_fail_verdict_only_in_details_section_emits_fail() {
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
+/// #1675 Case 5 (review-finding follow-up): a FAIL verdict in a DUPLICATE later
+/// `details` section must fail closed. `read_section` returns only the first
+/// section per id, so an early neutral `details` followed by a later `details`
+/// holding the real FAIL verdict (persisted as `details-2.md`) could hide it.
+/// The fail-closed scan uses `read_all_sections`, so every duplicate is checked.
+#[test]
+fn issue_1675_fail_verdict_in_duplicate_later_details_section_emits_fail() {
+    let session_id = "01TEST1675DUPDETAILSFAIL000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1675-dup-details-fail", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // Neutral summary + neutral FIRST details; the FAIL verdict lives only in the
+    // SECOND (duplicate) details section (persisted as details-2.md) and there is
+    // no full.md. read_section's first-match would miss it; read_all_sections sees it.
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nReviewed.\n<!-- CSA:SECTION:summary:END -->\n<!-- CSA:SECTION:details -->\nLooks fine on first pass.\n<!-- CSA:SECTION:details:END -->\n<!-- CSA:SECTION:details -->\nVerdict: FAIL\n\nBlocking issue on closer inspection.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1675: FAIL verdict in a duplicate later details section must fail closed"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
 // ─── Unit tests for detect_prose_fail_conclusion ───
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
@@ -1,0 +1,157 @@
+use super::*;
+
+// ─── #1675 regression tests: fail-closed on affirmative prose FAIL with empty findings ─
+//
+// Bug: `csa review` produced a prose verdict of FAIL with blocking findings in
+// summary.md/details.md, but the structured artifacts were empty (findings.toml =
+// `findings = []`, zero severity counts). `derive_decision_from_severity_counts`
+// unconditionally returned Pass for empty findings + zero counts, dropping the
+// genuine FAIL and silently merging blocking findings.
+//
+// Fix (#1675): when meta_decision is Fail/Uncertain AND the prose AFFIRMATIVELY
+// concludes FAIL, fail closed. The discriminator vs #1349 (which must stay Pass)
+// is an affirmative prose FAIL verdict token — NOT "prose is not clean".
+
+/// #1675 Case 1: meta=Fail + empty findings.toml + summary with an affirmative
+/// FAIL verdict token → decision MUST be Fail (lost-evidence fail-closed).
+#[test]
+fn issue_1675_fail_meta_empty_findings_with_prose_fail_verdict_emits_fail() {
+    let session_id = "01TEST1675PROSEFAILVERDICT0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1675-prose-fail-verdict", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // Reviewer prose affirmatively concludes FAIL, but the structured findings
+    // failed to emit (findings.toml is empty) — the #1675 lost-evidence scenario.
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nVerdict: FAIL\n\nTwo blocking issues found in the diff.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1675: Fail meta + empty findings + affirmative prose FAIL must fail closed"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1675 Case 2: regression guard for #1349 — meta=Fail + empty findings +
+/// NEUTRAL prose (no FAIL verdict token) MUST stay Pass.
+#[test]
+fn issue_1675_does_not_regress_1349_neutral_prose_stays_pass() {
+    let session_id = "01TEST1675NEUTRALPROSE00000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1675-neutral-prose", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // Neutral prose — no FAIL verdict token. This is the #1349 noise case
+    // (meta=Fail from exit-code/quota-fallback while the reviewer found nothing).
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nSemantics-preserving refactor.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1675: neutral prose (no FAIL token) must NOT regress #1349 — stays Pass"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1675 Case 3 (precision): meta=Fail + empty findings + prose that mentions the
+/// substring "fail" benignly (no verdict token) MUST stay Pass. Detecting the
+/// substring would re-introduce false-FAIL ping-pong.
+#[test]
+fn issue_1675_benign_fail_mention_in_clean_prose_stays_pass() {
+    let session_id = "01TEST1675BENIGNFAILMENTION";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1675-benign-fail-mention", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // Substring "fail" appears ("failing", "fails") but there is no verdict token.
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nAll tests pass; the previously failing case no longer fails.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1675: benign 'fail' substring (no verdict token) must stay Pass (precision)"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+// ─── Unit tests for detect_prose_fail_conclusion ───
+
+#[test]
+fn detect_prose_fail_conclusion_labeled_verdict_is_true() {
+    assert!(detect_prose_fail_conclusion("Verdict: FAIL"));
+}
+
+#[test]
+fn detect_prose_fail_conclusion_emphasized_fail_is_true() {
+    assert!(detect_prose_fail_conclusion("**FAIL**"));
+}
+
+#[test]
+fn detect_prose_fail_conclusion_bare_has_issues_line_is_true() {
+    assert!(detect_prose_fail_conclusion("details\nHAS_ISSUES\nnotes"));
+}
+
+#[test]
+fn detect_prose_fail_conclusion_benign_fail_substring_is_false() {
+    assert!(!detect_prose_fail_conclusion("the build no longer fails"));
+}
+
+#[test]
+fn detect_prose_fail_conclusion_pass_verdict_is_false() {
+    assert!(!detect_prose_fail_conclusion("Verdict: PASS"));
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
@@ -299,6 +299,108 @@ fn issue_1675_colon_terminated_fail_verdict_emits_fail() {
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
+/// #1675 Case 8 (cloud-review P1 follow-up): the SYNTHETIC-empty findings.toml
+/// path had the SAME zero-evidence false-PASS hole. When findings.toml fails to
+/// parse, `persist_review_findings_toml` writes a `.findings.toml.synthetic`
+/// marker (#1045 r3) and the verdict derivation falls through the artifact chain.
+/// If no blocking JSON, no JSON artifact, and no `full.md` exist, the pre-fix code
+/// returned Pass UNCONDITIONALLY at the synthetic fallback — reopening #1675 on the
+/// synthetic branch. The synthetic fallback now routes through the shared
+/// `derive_decision_from_severity_counts` gate, so an affirmative prose FAIL with a
+/// Fail meta fails closed even when the structured findings were unparseable.
+#[test]
+fn issue_1675_synthetic_empty_findings_with_prose_fail_emits_fail() {
+    let session_id = "01TEST1675SYNTHETICFAIL0000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1675-synthetic-fail", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // Synthetic marker: findings.toml extraction failed, so the empty findings are
+    // NOT trusted and the verdict falls through the artifact chain (#1045 r3).
+    fs::write(
+        session_dir
+            .join("output")
+            .join(crate::review_cmd::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER),
+        "",
+    )
+    .expect("write synthetic marker");
+    // Affirmative prose FAIL in summary; no output/full.md so the synthetic
+    // fallback (not infer_review_verdict_from_full_output) decides the verdict.
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nVerdict: FAIL\n\nBlocking issue; structured findings failed to emit.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1675 P1: synthetic-empty findings + affirmative prose FAIL must fail closed"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+/// #1675 Case 9 (cloud-review P1 follow-up, precision guard): routing the synthetic
+/// fallback through the shared gate must NOT over-correct. Synthetic-empty findings
+/// with NEUTRAL prose (no FAIL verdict token) and no full.md must still resolve to
+/// Pass — preserving the #1045-r3 / #1349 behavior on the synthetic branch.
+#[test]
+fn issue_1675_synthetic_empty_findings_with_neutral_prose_stays_pass() {
+    let session_id = "01TEST1675SYNTHETICPASS0000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1675-synthetic-pass", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    fs::write(
+        session_dir
+            .join("output")
+            .join(crate::review_cmd::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER),
+        "",
+    )
+    .expect("write synthetic marker");
+    // Neutral prose, no FAIL verdict token: the synthetic fallback must stay Pass.
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nSemantics-preserving refactor; findings block was malformed.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Pass,
+        "#1675 P1: synthetic-empty + neutral prose must stay Pass (no over-correction)"
+    );
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
 // ─── Unit tests for detect_prose_fail_conclusion ───
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
@@ -256,6 +256,49 @@ fn issue_1675_mixed_case_fail_verdict_emits_fail() {
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
+/// #1675 Case 7 (review-finding follow-up): a bare colon-terminated FAIL verdict
+/// (`FAIL:`) must fail closed. The CLI's consensus parser splits on
+/// non-alphanumeric/non-`_` delimiters, so `FAIL:` counts as a blocking verdict
+/// (meta=Fail); the bare-line prose detector trimmed only `{ws,*,_,.}` and missed
+/// the trailing colon, reopening the #1675 lost-evidence path. The detector now
+/// trims the full consensus delimiter class.
+#[test]
+fn issue_1675_colon_terminated_fail_verdict_emits_fail() {
+    let session_id = "01TEST1675COLONFAIL00000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1675-colon-fail", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    // Bare colon-terminated FAIL verdict: counted by the consensus parser but
+    // missed by the old bare-line detector that did not trim the trailing `:`.
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nFAIL:\n\nThe build is broken.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(
+        artifact.decision,
+        ReviewDecision::Fail,
+        "#1675: bare colon-terminated 'FAIL:' must fail closed"
+    );
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
 // ─── Unit tests for detect_prose_fail_conclusion ───
 
 #[test]
@@ -308,4 +351,12 @@ fn detect_prose_fail_conclusion_lowercase_benign_substring_is_false() {
     assert!(!detect_prose_fail_conclusion(
         "the run fails intermittently"
     ));
+}
+
+#[test]
+fn detect_prose_fail_conclusion_colon_terminated_is_true() {
+    // codex finding: a bare verdict token followed by a consensus delimiter (`:`)
+    // must be recognized — the consensus parser counts it as a blocking verdict.
+    assert!(detect_prose_fail_conclusion("FAIL:"));
+    assert!(detect_prose_fail_conclusion("review\nHAS_ISSUES:\nmore"));
 }


### PR DESCRIPTION
## Summary

Fixes #1675: `csa review` returned `decision=pass` when a reviewer's prose **affirmatively concluded FAIL** (with described blocking findings) but the structured `findings.toml` / severity counts came back empty — silently merging blocking findings (false-PASS gate hole).

## Root cause

`derive_decision_from_severity_counts` unconditionally returned `Pass` for empty findings + zero severity counts. That was deliberate for #1349/#1340/#1480 — to ignore a *noise* `meta=Fail` (exit-code / quota fallback) where the reviewer actually found nothing — but it also dropped a **genuine** prose FAIL whose structured findings simply failed to emit.

## Fix (prose-discriminated fail-closed)

Gate the zero-evidence path on whether the prose **affirmatively concludes FAIL**:

- `meta ∈ {Fail, Uncertain}` **AND** prose contains a bounded FAIL verdict token → `Fail` (fail closed; real failure with lost evidence).
- Otherwise → `Pass` (preserves #1349: neutral prose + noise `meta=Fail` → Pass).

The discriminator is an **affirmative prose-FAIL detector**, NOT "prose not clean" — using the latter would wrongly flip #1349's neutral prose to Fail.

The fail-closed scan inspects **all** persisted `summary` and `details` sections (via `read_all_sections`, which returns every occurrence — not `read_section`, which returns only the first match per id) plus `output/full.md` (fallback). Structured CSA reviews with section markers frequently omit `full.md`, so a verdict that lands only in `details` must still be caught; and because duplicate section ids persist their later copies as suffixed files (`details-2.md`, …), a FAIL verdict in a *later* duplicate must also fail closed. The scan is intentionally broader than the clean-path detector (both err toward FAIL).

## Verdict-token matching: agree with the consensus parser, stay precise

The prose detectors share bounded verdict-token matching with two deliberate, asymmetric policies — both erring toward FAIL, consistent with the fail-closed/fail-open asymmetry of the scan itself:

- **FAIL** (`FAIL`/`HAS_ISSUES`/`REJECT`) is **fail-closed**, so it matches **case-insensitively** (`MatchCase::Insensitive`) to agree with the CLI's own verdict parser (`review_consensus::contains_verdict_token`, which uses `eq_ignore_ascii_case`). `Verdict: Fail` sets `meta=Fail`, so the detector must catch it too or the lost-evidence path reopens for case variants the CLI already recognizes.
- **PASS/CLEAN** is **fail-open** (an affirmative clean conclusion *suppresses* the fail-closed path), so it matches **case-sensitively** (`MatchCase::Sensitive`). A prior review finding showed case-insensitive clean detection misread mixed-case prose (`Verdict: Pass`, "cannot pass yet") as a clean conclusion and unblocked merges on uncertain evidence — so clean detection must stay strict.

Bare-line detection trims the **same delimiter class the consensus parser splits on** (every `!is_ascii_alphanumeric() && c != '_'` char), then requires **exact** token equality. This catches a standalone verdict surrounded by punctuation (`FAIL:`, `PASS.`, `(CLEAN)`) — which the consensus parser already counts as a verdict — while a multi-word line ("The test PASS rate is 100%") never reduces to a bare token (exact equality is the precision guard). Internal `_` is preserved (the consensus parser treats it as a word char), so `HAS_ISSUES` stays one token and `CLEAN_UP` is not a CLEAN verdict.

Precision is preserved throughout: the detector matches ONLY bounded verdict tokens (bare, `Verdict:`-labeled, `**`/`__`-emphasized), **never the substring "fail"** — so benign prose like "the test no longer fails" is never read as a FAIL verdict, avoiding false-FAIL ping-pong.

## Tests

New `verdict_1675_tests` module (end-to-end through the persisted-verdict path):
- `..._with_prose_fail_verdict_emits_fail` — affirmative FAIL verdict + empty findings → Fail
- `..._does_not_regress_1349_neutral_prose_stays_pass` — neutral prose + noise `meta=Fail` → Pass
- `..._benign_fail_mention_in_clean_prose_stays_pass` — substring "fail" (no token) → Pass
- `..._fail_verdict_only_in_details_section_emits_fail` — verdict only in `details` (round-1 finding)
- `..._fail_verdict_in_duplicate_later_details_section_emits_fail` — verdict in a duplicate `details-2` (round-2 finding)
- `..._mixed_case_fail_verdict_emits_fail` — `Verdict: Fail` mixed case (round-3 finding)
- `..._colon_terminated_fail_verdict_emits_fail` — bare `FAIL:` (round-6 finding)

Plus `detect_prose_fail_conclusion` / verdict-token unit tests: labeled / emphasized / bare / mixed-case / lowercase / colon-/paren-delimited → true; benign substring (incl. lowercase), `PASS`, multi-word, `_`-compound (`CLEAN_UP`/`FAIL_SAFE`) → false; and an explicit asymmetry test locking FAIL=case-insensitive vs PASS/CLEAN=case-sensitive in one place. All existing #1340/#1349/#1352/#1480/#1659 verdict tests pass; `cargo fmt --check` clean; `clippy --workspace --all-features --all-targets -D warnings` clean.

## Review

Heterogeneous review (claude-opus writer / **codex** reviewer) — the gemini-cli review path was frozen (#1679); codex reviewing claude's output preserves cognitive diversity. Each round found a **distinct, concrete** correctness gap in the verdict detection (a new file/line/bug per round — iterative quality work, not a design flip-flop per the project's review discipline), all fixed with regression tests:

1. **Details-section gap** — the scan inspected only `summary` + `full.md`, so an affirmative FAIL verdict recorded solely in `details` could still false-Pass. Fixed by adding `details` to the scan.
2. **Duplicate-section gap** — the scan used `read_section` (first match per id), so a FAIL verdict in a *later duplicate* `details` section (persisted as `details-2.md`) could still be hidden. Fixed by switching to `read_all_sections`.
3. **Case-sensitivity gap** — the bounded verdict-token matcher was case-sensitive while the CLI's verdict parser matches case-insensitively, so `Verdict: Fail` set `meta=Fail` yet slipped past the prose detector. Fixed by making **FAIL** matching case-insensitive…
4. **…without regressing PASS/CLEAN** — because the matcher was shared, (3) inadvertently made PASS/CLEAN case-insensitive too, regressing a prior anti-false-clean finding. Resolved by parameterizing case policy per token class (`MatchCase`: FAIL insensitive / PASS·CLEAN sensitive).
5. **Colon-delimiter gap** — the bare-line check trimmed only `{ws,*,_,.}`, so `FAIL:` (which the consensus parser counts as a blocking verdict) was missed. Fixed by trimming the full consensus delimiter class while keeping exact-equality precision.
