### PR TITLE
fix(csa-executor): exclude broad system temp dirs from gemini auto include-directories (#1679)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.815"
+version = "0.1.816"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.815"
+version = "0.1.816"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/executor_arg_helpers.rs
+++ b/crates/csa-executor/src/executor_arg_helpers.rs
@@ -173,7 +173,10 @@ fn gemini_prompt_directories(prompt: &str) -> Vec<String> {
             // canonicalize (TOCTOU removal after the existence check above) fall
             // back to the raw token.
             let normalized = fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
-            if !is_broad_system_dir(&dir) && !is_broad_system_dir(&normalized) {
+            let is_raw_broad_temp = GEMINI_BROAD_SYSTEM_DIRS
+                .iter()
+                .any(|broad| dir == Path::new(broad));
+            if !is_raw_broad_temp && !is_broad_system_dir(&normalized) {
                 push_unique_directory_string(
                     &mut directories,
                     normalized.to_string_lossy().as_ref(),

--- a/crates/csa-executor/src/executor_arg_helpers.rs
+++ b/crates/csa-executor/src/executor_arg_helpers.rs
@@ -148,8 +148,37 @@ fn gemini_prompt_directories(prompt: &str) -> Vec<String> {
                 continue;
             };
 
-            let normalized = fs::canonicalize(&dir).unwrap_or(dir);
-            push_unique_directory_string(&mut directories, normalized.to_string_lossy().as_ref());
+            // #1679: never auto-promote a broad system directory found in the
+            // prompt. gemini-cli scans every include directory recursively, and
+            // two path classes break that scan into a zero-turn, idle-killed
+            // session: broad temp roots (world-unreadable subtrees like
+            // /var/tmp/systemd-private-* -> repeated EACCES stalls) and virtual
+            // filesystems (/proc, /sys, /dev, /run -> blocking devices, FIFOs,
+            // infinite recursion). is_broad_system_dir encodes the per-class
+            // match (bare temp root vs whole virtual-FS subtree).
+            //
+            // Screen BOTH the raw prompt-derived path and its canonicalized
+            // form, skipping promotion if EITHER matches:
+            //   - the raw check catches a literal `/tmp` / `/var/tmp` token even
+            //     when that root is itself a symlink whose target is outside the
+            //     denylist (e.g. macOS, where /tmp -> /private/tmp);
+            //   - the canonical check catches `..` variants (e.g. `/tmp/../tmp`)
+            //     and symlinks pointing *into* a denylist root, including -- via
+            //     the /private/* aliases -- the macOS canonical form of
+            //     `/tmp/../tmp` (which is /private/tmp).
+            // The union is strictly more conservative than either alone: a real
+            // subdirectory matches neither form and is still included. It screens
+            // against a denylist, not by resolving every symlink chain. The
+            // canonicalized form is what gets pushed; paths that fail to
+            // canonicalize (TOCTOU removal after the existence check above) fall
+            // back to the raw token.
+            let normalized = fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
+            if !is_broad_system_dir(&dir) && !is_broad_system_dir(&normalized) {
+                push_unique_directory_string(
+                    &mut directories,
+                    normalized.to_string_lossy().as_ref(),
+                );
+            }
             index = end + 1;
         } else {
             index += 1;
@@ -229,6 +258,41 @@ fn push_unique_directory_string_with_exists(
 
 fn is_filesystem_root(path: &Path) -> bool {
     path.is_absolute() && path.parent().is_none()
+}
+
+/// Broad system *temp* roots, matched at the **bare root only** (`==`) so that
+/// scratch subdirectories such as `/tmp/work/file` stay includable. The
+/// recursive-scan EACCES stall that bars promoting the bare roots is documented
+/// at the call site (`gemini_prompt_directories`, #1679).
+///
+/// The macOS canonical aliases (`/private/tmp`, `/private/var/tmp`): there
+/// `/tmp` and `/var/tmp` symlink into `/private`, so `/tmp/../tmp` canonicalizes
+/// to `/private/tmp` and `/var/tmp/../tmp` to `/private/var/tmp`; listing them
+/// lets the canonical-form check catch those variants. ONLY the two temp-root
+/// aliases are added -- never `/private/var` or any broader parent.
+const GEMINI_BROAD_SYSTEM_DIRS: &[&str] = &["/tmp", "/var/tmp", "/private/tmp", "/private/var/tmp"];
+
+/// Virtual / pseudo filesystems whose **entire subtree** is excluded. Unlike the
+/// temp roots above, any descendant may be a blocking character device, a named
+/// pipe (FIFO), or an unbounded self-referential tree (e.g. `/proc/self/fd`,
+/// `/dev/stdin`, `/sys/kernel`), so promoting one would let gemini-cli's
+/// recursive scan block or loop forever -- the #1679 freeze class, reachable via
+/// untrusted issue-body paths under `csa plan run --issue N`. Matched with
+/// `Path::starts_with`, which is **component-wise**, not a string prefix: `/dev`
+/// denies `/dev/stdin` but NOT `/devfoo`, `/run` denies `/run/foo` but NOT
+/// `/runtime` -- only true sub-paths, never prefix-sharing siblings.
+const GEMINI_BROAD_SYSTEM_SUBTREES: &[&str] = &["/run", "/proc", "/sys", "/dev"];
+
+/// True if `path` must be excluded from Gemini auto-include promotion: either it
+/// is exactly a broad temp root (`==`, so subdirectories remain includable) or
+/// it lies within a virtual/system-FS subtree (component-wise `Path::starts_with`).
+fn is_broad_system_dir(path: &Path) -> bool {
+    GEMINI_BROAD_SYSTEM_DIRS
+        .iter()
+        .any(|broad| path == Path::new(broad))
+        || GEMINI_BROAD_SYSTEM_SUBTREES
+            .iter()
+            .any(|subtree| path.starts_with(Path::new(subtree)))
 }
 
 #[cfg(test)]
@@ -338,5 +402,194 @@ mod tests {
 
         assert_eq!(directories, vec![existing]);
         assert!(!logs.contains("Skipping Gemini include directory"));
+    }
+
+    #[test]
+    fn is_broad_system_dir_matches_bare_roots_only() {
+        for broad in [
+            "/tmp",
+            "/var/tmp",
+            "/run",
+            "/proc",
+            "/sys",
+            "/dev",
+            // macOS canonical aliases of the temp roots (#1679 round-2 follow-up).
+            "/private/tmp",
+            "/private/var/tmp",
+        ] {
+            assert!(
+                is_broad_system_dir(Path::new(broad)),
+                "{broad} must be treated as a broad system dir"
+            );
+        }
+        // A trailing slash is the same directory (component-wise comparison).
+        assert!(is_broad_system_dir(Path::new("/var/tmp/")));
+        // Specific subdirectories are NOT broad and remain includable.
+        assert!(!is_broad_system_dir(Path::new("/tmp/work")));
+        assert!(!is_broad_system_dir(Path::new("/var/tmp/foo/bar")));
+        assert!(!is_broad_system_dir(Path::new("/home/user/project")));
+    }
+
+    #[test]
+    fn is_broad_system_dir_excludes_virtual_fs_subtrees() {
+        // Virtual/system filesystems are excluded as WHOLE subtrees (#1679
+        // security follow-up). Asserted at the is_broad_system_dir level so it
+        // needs neither the paths to exist nor canonicalize to succeed.
+        for excluded in [
+            "/proc",
+            "/sys",
+            "/dev",
+            "/run",
+            "/proc/self/fd",
+            "/dev/stdin",
+            "/sys/kernel",
+            "/run/foo",
+        ] {
+            assert!(
+                is_broad_system_dir(Path::new(excluded)),
+                "{excluded} must be excluded as a virtual/system FS subtree"
+            );
+        }
+    }
+
+    #[test]
+    fn is_broad_system_dir_subtree_match_is_component_wise() {
+        // Path::starts_with is component-wise, NOT a string prefix: a sibling
+        // whose name merely begins with a denied root must stay includable.
+        assert!(!is_broad_system_dir(Path::new("/devfoo")));
+        assert!(!is_broad_system_dir(Path::new("/runtime")));
+        assert!(!is_broad_system_dir(Path::new("/sysadmin")));
+        assert!(!is_broad_system_dir(Path::new("/processes")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn gemini_prompt_directories_excludes_existing_virtual_fs_path() {
+        // End-to-end: a real virtual-FS sub-path in the prompt must not be
+        // promoted. Gated on existence for portability (minimal containers).
+        if !Path::new("/proc/self").exists() {
+            return;
+        }
+        let prompt = "Inspect /proc/self for the running process.";
+        let dirs = gemini_prompt_directories(prompt);
+        assert!(
+            !dirs.iter().any(|d| Path::new(d).starts_with("/proc")),
+            "no /proc subtree path may be promoted, got: {dirs:?}"
+        );
+    }
+
+    #[test]
+    fn gemini_prompt_directories_excludes_broad_temp_roots_keeps_subdirs() {
+        // A real nested file under the system temp root: its parent is a
+        // specific subdirectory and therefore a legitimate include candidate.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let work_dir = temp.path().join("work");
+        fs::create_dir_all(&work_dir).expect("create work dir");
+        let session_file = work_dir.join("session-file.txt");
+        fs::write(&session_file, b"x").expect("write session file");
+        let canonical_work = fs::canonicalize(&work_dir).expect("canonicalize work dir");
+
+        // Mirrors the CSA atomic-commit-discipline preamble that injects bare
+        // `/tmp` and `/var/tmp` tokens into the prompt (#1679).
+        let prompt = format!(
+            "Persist scratch under /tmp and /var/tmp; read {} for context.",
+            session_file.display()
+        );
+
+        let dirs = gemini_prompt_directories(&prompt);
+
+        assert!(
+            !dirs.iter().any(|d| d == "/tmp"),
+            "bare /tmp must be excluded, got: {dirs:?}"
+        );
+        assert!(
+            !dirs.iter().any(|d| d == "/var/tmp"),
+            "bare /var/tmp must be excluded, got: {dirs:?}"
+        );
+        assert!(
+            dirs.iter().any(|d| Path::new(d) == canonical_work),
+            "specific subdir {} must still be included, got: {dirs:?}",
+            canonical_work.display()
+        );
+    }
+
+    #[test]
+    fn gemini_prompt_directories_rejects_dotdot_broad_dir_variants() {
+        // #1679 hardening: a path token whose raw form is not literally a
+        // broad root but canonicalizes to one (e.g. `/tmp/../tmp`,
+        // `/var/tmp/../tmp`) MUST NOT slip into the include set, because the
+        // canonicalized form is what gets pushed. A real subdirectory under
+        // the temp root MUST still be included.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let work_dir = temp.path().join("work");
+        fs::create_dir_all(&work_dir).expect("create work dir");
+        let canonical_work = fs::canonicalize(&work_dir).expect("canonicalize work dir");
+
+        let prompt = format!(
+            "Scan /tmp/../tmp and /var/tmp/../tmp but read {} for context.",
+            work_dir.display()
+        );
+
+        let dirs = gemini_prompt_directories(&prompt);
+
+        assert!(
+            !dirs.iter().any(|d| d == "/tmp"),
+            "`/tmp/../tmp` must not canonicalize into an included bare /tmp, got: {dirs:?}"
+        );
+        assert!(
+            !dirs.iter().any(|d| d == "/var/tmp"),
+            "`/var/tmp/../tmp` must not canonicalize into an included bare /var/tmp, got: {dirs:?}"
+        );
+        assert!(
+            dirs.iter().any(|d| Path::new(d) == canonical_work),
+            "real subdir {} must still be included, got: {dirs:?}",
+            canonical_work.display()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn gemini_prompt_directories_rejects_symlink_into_broad_root() {
+        // #1679 hardening (symlinked-path direction): a prompt token whose raw
+        // form is NOT literally a broad root but whose canonical form resolves
+        // INTO one (here a symlink pointing at /tmp) MUST NOT be promoted. This
+        // exercises the canonical-form arm of the union screen.
+        //
+        // The mirror case -- a denylist root that is *itself* a symlink to a
+        // target outside the denylist (macOS: `/tmp` -> `/private/tmp`) -- is
+        // not portably constructible on the Linux CI host (we cannot repoint
+        // `/tmp`). It is instead covered by the raw-form arm of the screen plus
+        // the `/private/*` aliases in GEMINI_BROAD_SYSTEM_DIRS, not by this test.
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let sneaky = temp.path().join("sneaky");
+        symlink("/tmp", &sneaky).expect("create symlink to /tmp");
+
+        let prompt = format!("Scan {} for context.", sneaky.display());
+        let dirs = gemini_prompt_directories(&prompt);
+
+        assert!(
+            !dirs.iter().any(|d| d == "/tmp"),
+            "a symlink resolving to /tmp must not be promoted, got: {dirs:?}"
+        );
+    }
+
+    #[test]
+    fn gemini_include_directories_keeps_project_root_and_drops_prompt_broad_dirs() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let project_path = fs::canonicalize(project.path()).expect("canonicalize project");
+
+        let prompt = "Work in /tmp and /var/tmp but commit the project.";
+        let dirs = gemini_include_directories(None, prompt, Some(project.path()));
+
+        assert!(
+            dirs.iter().any(|d| Path::new(d) == project_path),
+            "project root must still be included, got: {dirs:?}"
+        );
+        assert!(
+            !dirs.iter().any(|d| d == "/tmp" || d == "/var/tmp"),
+            "broad prompt dirs must be excluded, got: {dirs:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1679 — gemini-cli sessions froze at startup (0 turns, doubled "YOLO mode is enabled" stderr, idle until SIGTERM/143). The issue hypothesized a **double-spawn**; independent heterogeneous investigation (codex diagnosis + claude-code re-derivation against the ground-truth failed session) **refuted** that and found the real cause.

## Root cause

1. **Single spawn** (double-spawn refuted). gemini-cli argv is assembled once and handed to one spawn path. The failed session has a single gemini chat-journal file; the cgroup scope name merely appears twice in one process's forwarded banner.
2. **Doubled stderr is a logging artifact**, not a second process: child stderr is written twice — spooled (`lib_wait_capture.rs:185`) and tee-forwarded to the daemon's parent stderr (`lib_output_helpers.rs:296-297`). Cosmetic; filed separately as #1704.
3. **The freeze (root cause):** `gemini_prompt_directories` scans the prompt for absolute-path tokens and promotes each to a `--include-directories` entry (gemini/antigravity only). The lone broad-path guard excluded `/` but **not** `/tmp` / `/var/tmp`, so gemini was handed `/var/tmp`, recursively scanned root-owned `0700` `/var/tmp/systemd-private-*` subtrees, hit an EACCES storm, never finished the workspace scan → 0 turns → idle-timeout SIGTERM (143). Confirmed by EACCES-on-`/var/tmp/systemd-private-*` in the failed session's `stderr.log`.

### Why it reproduced reliably (the trigger is CSA-injected)

Not a freak user prompt — CSA injects the trigger itself. `prepend_atomic_commit_discipline_to_prompt` (`crates/cli-sub-agent/src/run_helpers_atomic_commit.rs:76`) auto-prepends a preamble whose text contains `` `/tmp/` `` and `` `/var/tmp/` ``. `trim_prompt_path_token` strips surrounding backticks/commas but **not** a trailing slash, so `` `/var/tmp/`, `` → `/var/tmp/` → `canonicalize` → bare `/var/tmp`, which passed the old guard. Every ordinary gemini `csa run` therefore carried `/tmp` + `/var/tmp` into `--include-directories`.

## Fix

`gemini_prompt_directories` (`crates/csa-executor/src/executor_arg_helpers.rs`) now screens each prompt-derived include-dir candidate against a denylist of broad system roots, split by filesystem semantics:

- **Temp roots** (`/tmp`, `/var/tmp`, and the macOS canonical aliases `/private/tmp`, `/private/var/tmp`): excluded only at the **bare root** (exact match), so legitimate subdirectories like `/tmp/work` are still promoted. The exact-match arm screens **both** the raw token and its canonicalized form, so a literal `/tmp` token is rejected even when `/tmp` is a symlink (macOS `/tmp`→`/private/tmp`), and `..`/symlink-into-root variants that canonicalize back to a temp root are rejected.
- **Virtual / system filesystems** (`/proc`, `/sys`, `/dev`, `/run`): excluded as **entire subtrees** (component-wise `Path::starts_with`) on the **canonicalized** path, because any subpath (`/proc/self/fd`, `/dev/stdin`, …) may be a blocking character device / FIFO that would hang a recursive scan. Running the subtree check on the canonical (not raw) path means a `..`-laden token such as `/sys/../home/user/project` that resolves to a legitimate directory is **not** wrongly excluded; `Path::starts_with` is component-wise, so siblings like `/devfoo` / `/runtime` are unaffected.

A real subdirectory matches neither rule, so `/tmp/work` and friends are still promoted; the project root (separate explicit-dir path) and explicit env-provided dirs are unaffected. The shared include-dir code also serves `antigravity-cli` — intended; no tool-specific branch. This matters under the project threat model because `csa plan run --issue N` injects untrusted issue bodies into the prompt.

Delivered as two commits:

- `f27094f7` — split the denylist into bare-root (temp) vs whole-subtree (virtual FS) exclusion; closes the case where bare-root exclusion of `/proc`/`/sys`/`/dev`/`/run` would still promote their subpaths into a recursive scan.
- `1265541e` — restrict the raw-path arm to the temp-root exact match and run the subtree check on the canonicalized path only, eliminating a false-positive over-exclusion of `..`-laden paths under a virtual-FS prefix.

## Tests (in-file module, `executor_arg_helpers.rs`)

Cover: every temp/virtual root matches the denylist; temp subdirs (`/tmp/work`) still promoted; virtual-FS subtrees (`/proc/self/fd`, `/dev/stdin`, …) excluded; component-wise safety (`/devfoo`, `/runtime` **not** excluded); `..`-variant and symlink-into-root rejection; project root preserved.

## Verification

- **Heterogeneous review:** implemented by claude-code, reviewed by **codex** (gpt-5.5/high) to a clean PASS on the final HEAD. **gemini-code-assist** (cloud) surfaced the subtree exclusion as `security-high` (fixed in `f27094f7`) and the raw-path false-positive as `medium` (auto-applied as `1265541e`). A residual `medium` "call `is_broad_system_dir` on both arms" DRY suggestion was **declined**: it would reintroduce the exact `/sys/../legit` false positive the prior round fixed (design circuit-break per #821/#822). gemini-cli is the tool under repair, so local review is routed off it.
- `just pre-commit` exit 0 locally; CI **Format / Clippy / Version Bump / Test (ubuntu-latest) / Pre-commit Quality Gates** all green. Known-red baselines unrelated to this change: **Test (macos-latest)** (#1642) and the "Detect monolith files" step (#1644, monolith tokenizer).
- Version bumped `0.1.815 → 0.1.816`.

References #1704 (stderr double-write), #1705 (pre-commit host memory fragility), #1703 (tier-bypass tool-defaults friction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
