### PR TITLE
fix(cli-sub-agent): clear stale reviewer artifacts before each multi-reviewer round (#1681)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.816"
+version = "0.1.817"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.816"
+version = "0.1.817"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -76,6 +76,7 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         &reviewer_tool_plan,
         &tier_reviewer_specs,
     );
+    super::parent_artifacts::clear_multi_reviewer_artifact_dirs(ctx.reviewers)?;
 
     let mut join_set = JoinSet::new();
     for (reviewer_index, reviewer_tool) in reviewer_tools.into_iter().enumerate() {

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -35,6 +36,25 @@ pub(super) struct MultiReviewerConsensusArtifacts<'a> {
 const CSA_DAEMON_SESSION_DIR_ENV_KEY: &str = "CSA_DAEMON_SESSION_DIR";
 const CSA_DAEMON_SESSION_ID_ENV_KEY: &str = "CSA_DAEMON_SESSION_ID";
 const CSA_SESSION_ID_ENV_KEY: &str = "CSA_SESSION_ID";
+
+pub(super) fn clear_multi_reviewer_artifact_dirs(reviewers: usize) -> Result<()> {
+    let Some((session_dir, _session_id)) = resolve_parent_session_env() else {
+        return Ok(());
+    };
+
+    for reviewer_index in 1..=reviewers {
+        let reviewer_dir = session_dir.join(format!("reviewer-{reviewer_index}"));
+        match fs::remove_dir_all(&reviewer_dir) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("failed to clear {}", reviewer_dir.display()));
+            }
+        }
+    }
+    Ok(())
+}
 
 #[derive(Debug, Deserialize)]
 struct ReviewerFindingsContractArtifact {

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
@@ -1,7 +1,8 @@
 use super::{
-    MultiReviewerConsensusArtifacts, parent_artifact_for_decision, parent_consensus_review_meta,
-    parent_review_decision, write_multi_reviewer_consensus_artifacts,
-    write_multi_reviewer_parent_artifacts, write_standalone_consensus_review_artifacts,
+    MultiReviewerConsensusArtifacts, clear_multi_reviewer_artifact_dirs,
+    parent_artifact_for_decision, parent_consensus_review_meta, parent_review_decision,
+    write_multi_reviewer_consensus_artifacts, write_multi_reviewer_parent_artifacts,
+    write_standalone_consensus_review_artifacts,
 };
 use crate::review_consensus::UNAVAILABLE;
 use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
@@ -699,6 +700,107 @@ fn write_multi_reviewer_parent_artifacts_fails_closed_when_empty_artifact_masks_
         verdict.decision,
         ReviewDecision::Fail,
         "#1659 round-2: an empty artifact must not mask an unpersisted HAS_ISSUES dissenter"
+    );
+}
+
+#[test]
+fn clear_multi_reviewer_artifact_dirs_removes_stale_empty_artifact_so_dissenter_fails_closed() {
+    // #1681: the parent/daemon session dir can survive across review invocations in a
+    // plan. If reviewer-1 left an empty artifact in round 1, round 2 must clear it before
+    // accepting reviewer-1 as a persisted HAS_ISSUES dissenter.
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let temp = tempdir().expect("tempdir should be created");
+    let session_dir = temp.path().display().to_string();
+    let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
+    let _session_id_guard =
+        ScopedEnvVarRestore::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
+    let _daemon_session_dir_guard = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_DIR");
+    let _daemon_session_id_guard = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_ID");
+
+    let stale_reviewer_dir = temp.path().join("reviewer-1");
+    fs::create_dir_all(&stale_reviewer_dir).expect("stale reviewer dir should be created");
+    fs::write(
+        stale_reviewer_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "verdict": "PASS",
+            "summary": "Round 1 had no findings.",
+            "findings": []
+        }))
+        .expect("stale artifact should serialize"),
+    )
+    .expect("stale artifact should be written");
+
+    let sibling_output_dir = temp.path().join("output");
+    fs::create_dir_all(&sibling_output_dir).expect("output dir should be created");
+    fs::write(
+        sibling_output_dir.join("keep.txt"),
+        "preserve sibling output",
+    )
+    .expect("sibling output marker should be written");
+    let out_of_scope_reviewer_dir = temp.path().join("reviewer-3");
+    fs::create_dir_all(&out_of_scope_reviewer_dir)
+        .expect("out-of-scope reviewer dir should be created");
+
+    clear_multi_reviewer_artifact_dirs(2).expect("stale reviewer dirs should be cleared");
+
+    assert!(
+        !temp.path().join("reviewer-1").exists(),
+        "reviewer-1 must be cleared before the new round writes"
+    );
+    assert!(
+        !temp.path().join("reviewer-2").exists(),
+        "missing reviewer-2 is treated as already clear"
+    );
+    assert!(
+        sibling_output_dir.join("keep.txt").exists(),
+        "clearing must preserve non-reviewer-N sibling artifacts"
+    );
+    assert!(
+        out_of_scope_reviewer_dir.exists(),
+        "clearing reviewers=2 must not remove reviewer-3"
+    );
+
+    let outcomes = vec![
+        super::super::output::ReviewerOutcome {
+            reviewer_index: 0,
+            tool: ToolName::Codex,
+            session_id: "01DISSENTREVIEWER0000000000".to_string(),
+            output: "Reviewer 1 flagged blocking issues but persisted no fresh artifact."
+                .to_string(),
+            exit_code: 1,
+            verdict: crate::review_consensus::HAS_ISSUES,
+            diagnostic: None,
+        },
+        super::super::output::ReviewerOutcome {
+            reviewer_index: 1,
+            tool: ToolName::GeminiCli,
+            session_id: "01CLEANREVIEWER00000000000".to_string(),
+            output: "Reviewer 2 was clean.".to_string(),
+            exit_code: 0,
+            verdict: crate::review_consensus::CLEAN,
+            diagnostic: None,
+        },
+    ];
+
+    write_multi_reviewer_parent_artifacts(
+        temp.path(),
+        2,
+        &outcomes,
+        crate::review_consensus::HAS_ISSUES,
+        false,
+        None,
+    )
+    .expect("parent artifacts should be produced");
+
+    let verdict: ReviewVerdictArtifact = serde_json::from_str(
+        &fs::read_to_string(temp.path().join("output").join("review-verdict.json"))
+            .expect("review-verdict.json should exist"),
+    )
+    .expect("review verdict should parse");
+    assert_eq!(
+        verdict.decision,
+        ReviewDecision::Fail,
+        "#1681: stale empty reviewer-N artifacts must not satisfy persisted dissent"
     );
 }
 


### PR DESCRIPTION
## Problem

The #1659 per-dissenter fail-closed guard can be silently defeated by **stale
cross-round reviewer artifacts** when a multi-reviewer `csa review` runs more
than once inside the same daemon session context (e.g. a weave/plan loop that
re-invokes `csa review`).

Root cause chain:

1. Child reviewers write their findings to
   `${CSA_PARENT_SESSION_DIR:-$CSA_SESSION_DIR}/reviewer-{N}/review-findings.json`
   (`review_consensus.rs`). The parent/daemon session dir resolved by
   `resolve_parent_session_env` (`review_cmd_parent_artifacts.rs`) **persists
   across `csa review` invocations** within the same plan.
2. `run_multi_reviewer_review` did **not** clear the previous round's
   `reviewer-N/` directories before spawning the new round's reviewers.
3. `load_multi_reviewer_artifacts` treats the mere **existence** of
   `reviewer-N/review-findings.json` as "reviewer N persisted", and
   `dissenting_findings_persisted` returns `true` once every `HAS_ISSUES`
   reviewer index is in `persisted_indices`.

Consequence: a clean round-1 artifact (`findings: []`) left on disk keeps
reviewer N in `persisted_indices` during round 2. If round 2's reviewer reaches
`HAS_ISSUES` but exits before persisting a fresh artifact, the stale empty
artifact masks the dissent and the consolidated verdict is promoted to **PASS** —
exactly the false-PASS class #1659 was meant to close.

## Fix

Clear the per-reviewer artifact directories at the **start of each
multi-reviewer round**, before spawning the round's reviewers, so any
`reviewer-N/review-findings.json` found afterward is guaranteed to have been
written by the current invocation.

- `clear_multi_reviewer_artifact_dirs` (`review_cmd_parent_artifacts.rs`)
  removes `reviewer-1 .. reviewer-N` under the parent session dir resolved the
  **same way** writers/readers resolve it (`resolve_parent_session_env`), so the
  cleared path is byte-identical to where reviewers write and the loader reads.
- Scoped strictly to the in-range `reviewer-N/` subdirectories — sibling
  artifacts (`output/`, `findings.toml`, `review-verdict.json`) and out-of-range
  reviewer dirs are never touched. `NotFound` is accepted; other IO errors fail
  with context.
- Called from `run_multi_reviewer_review` before reviewer dispatch.

### Why "clear before each round" (not round-stamping / mtime-scoping)

It is the minimal, least-invasive fix: no JSON schema change, no LLM prompt
change (round-stamping risks the model echoing the wrong round), and no flaky
`mtime` bookkeeping. Clearing strictly guarantees freshness by construction.

### `--fix` / cross-round safety

No legitimate cross-round consumer reads `reviewer-N/` after the clear point:

- Multi-reviewer mode **rejects** `--fix` (`review_cmd_multi.rs`), so the
  re-review-after-fix flow never enters this path.
- Prior-round context is loaded **before** multi-reviewer dispatch
  (`review_cmd.rs`) and passed as a rendered string; it reads the explicit
  prior-round summary TOML (`review_prior_rounds.rs`), **not** `reviewer-N/`.

## Tests

`clear_multi_reviewer_artifact_dirs_removes_stale_empty_artifact_so_dissenter_fails_closed`
(`review_cmd_parent_artifacts_tests.rs`):

- Seeds a stale `reviewer-1/review-findings.json` (clean, `findings: []`).
- Verifies `output/` and an out-of-range `reviewer-3/` **survive** the clear
  (scoping proof).
- Confirms that an unpersisted `HAS_ISSUES` dissenter yields
  `ReviewDecision::Fail` (fail-closed fires).

Red without the fix (stale empty artifact keeps reviewer 1 in
`persisted_indices` → empty consolidated promoted to `Pass`); green with it.

## Verification

- `cargo test -p cli-sub-agent review_cmd::parent_artifacts::tests` → 18/18.
- `just pre-commit` exit 0.

Closes #1681.
