### PR TITLE
fix(csa-resource): expose ~/.claude writable for nested claude-code sandboxes (#1683)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.818"
+version = "0.1.819"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.818"
+version = "0.1.819"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -8,6 +8,8 @@ use crate::sandbox::ResourceCapability;
 
 pub const DEFAULT_SANDBOX_TMPDIR: &str = "/tmp";
 
+#[path = "isolation_plan_claude.rs"]
+mod claude_paths;
 #[path = "isolation_plan_codex.rs"]
 mod codex_paths;
 #[path = "isolation_plan_runtime_path.rs"]
@@ -317,15 +319,20 @@ impl IsolationPlanBuilder {
                 &mut self.required_writable_dirs,
             );
 
-            // claude-code may cold-start by creating ~/.claude/session-env/<uuid>
-            // during review; pre-create ~/.claude so HOME does not stay read-only.
+            // Expose the claude home (~/.claude or $CLAUDE_CONFIG_DIR) writable
+            // for every sandboxed parent so a nested claude-code CSA child can
+            // create ~/.claude/session-env/<id> instead of hitting EROFS under a
+            // read-only HOME. Mirrors the codex helper above; see
+            // isolation_plan_claude.rs for the #1683 root cause and the ~/.codex
+            // symmetry justification.
+            claude_paths::add_claude_home_for_tool(
+                tool_name,
+                &home,
+                &mut self.writable_paths,
+                &mut self.required_writable_dirs,
+            );
+
             match tool_name {
-                "claude-code" => {
-                    let claude_dir = home.join(".claude");
-                    let claude_state_file = home.join(".claude.json");
-                    add_dir_or_creatable_parent(&mut self.writable_paths, &claude_dir);
-                    self.writable_paths.push(claude_state_file);
-                }
                 "gemini-cli" => [".gemini", ".config/gemini-cli"]
                     .into_iter()
                     .map(|rel| home.join(rel))

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -495,3 +495,7 @@ mod tests;
 #[cfg(test)]
 #[path = "isolation_plan_path_tests.rs"]
 mod path_tests;
+
+#[cfg(test)]
+#[path = "isolation_plan_claude_tests.rs"]
+mod claude_tests;

--- a/crates/csa-resource/src/isolation_plan_claude.rs
+++ b/crates/csa-resource/src/isolation_plan_claude.rs
@@ -1,0 +1,123 @@
+//! Claude home (`~/.claude` / `$CLAUDE_CONFIG_DIR`) writable-mount wiring.
+//!
+//! Mirrors [`super::codex_paths::add_codex_home_for_tool`] for the codex home,
+//! and exists to fix the nested-EROFS failure in #1661 / #1665 / #1677 / #1683.
+//!
+//! ## Why every tool's sandbox exposes the claude home
+//!
+//! Every bwrap sandbox mounts the host root read-only (`--ro-bind / /`) and then
+//! re-binds specific paths read-write.  Before this module, the `~/.claude`
+//! writable bind was added ONLY in the `"claude-code"` arm of
+//! `with_tool_defaults`.  When the PARENT tool is e.g. `codex`, that arm is
+//! never entered, so the parent never exposes `~/.claude` writable.  A nested
+//! claude-code review/debate child then inherits a read-only `~/.claude` from
+//! the parent namespace, and its SessionStart hook
+//! `mkdir ~/.claude/session-env/<id>` fails with EROFS.
+//!
+//! The codebase already solves this exact class for codex:
+//! [`super::codex_paths::add_codex_home_for_tool`] exposes `~/.codex` (which
+//! holds `auth.json` credentials) writable in EVERY tool's sandbox, "to avoid
+//! read-only-fs in nested CSA sessions".  Exposing `~/.claude` writable for all
+//! tools therefore EXTENDS that already-accepted symmetry rather than opening a
+//! new class of hole: `~/.claude` is the same credential/state risk class as
+//! `~/.codex`, which peers already mount read-write.
+//!
+//! Probe asymmetry mirrors codex exactly: a fail-fast write probe is registered
+//! ONLY for the owning tool (`claude-code`); peers get a writable bind but no
+//! probe.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::codex_paths::RequiredWritableDir;
+
+/// Environment override claude-code honors to relocate its config/state dir
+/// (default `~/.claude`).  Mirrors codex's `CODEX_HOME` handling.
+const CLAUDE_CONFIG_DIR_ENV: &str = "CLAUDE_CONFIG_DIR";
+const CLAUDE_DEFAULT_HOME_REL: &str = ".claude";
+/// Legacy global config file. With the default layout it lives at
+/// `$HOME/.claude.json` — a sibling of `~/.claude`, NOT inside it — so it needs
+/// its own writable entry. Under `CLAUDE_CONFIG_DIR` the config file lives
+/// inside the (already writable) override dir, so no separate entry is needed.
+const CLAUDE_LEGACY_STATE_REL: &str = ".claude.json";
+const CLAUDE_SANDBOX_CONFIG_HINT: &str =
+    "[tools.claude-code].filesystem_sandbox.writable_paths or [filesystem_sandbox].extra_writable";
+
+/// Expose the claude home (`~/.claude` or `$CLAUDE_CONFIG_DIR`) writable so that
+/// a nested claude-code CSA child can create `~/.claude/session-env/<id>`
+/// instead of hitting EROFS under a read-only HOME.
+///
+/// - `tool_name == "claude-code"`: add the claude home writable AND register a
+///   fail-fast [`RequiredWritableDir`] probe, plus the legacy `~/.claude.json`
+///   state file (default layout only).
+/// - any other tool with claude installed: add the claude home writable WITHOUT
+///   a probe (the symmetric peer widening — see module docs).
+///
+/// The peer widening is gated on `has_claude_on_path()` so hosts without claude
+/// installed gain nothing.
+pub(super) fn add_claude_home_for_tool(
+    tool_name: &str,
+    home: &Path,
+    writable_paths: &mut Vec<PathBuf>,
+    required_writable_dirs: &mut Vec<RequiredWritableDir>,
+) {
+    let (claude_home, claude_home_source) = claude_home_dir(home);
+    if tool_name == "claude-code" {
+        if claude_home.is_absolute() {
+            super::add_dir_or_creatable_parent(writable_paths, &claude_home);
+        }
+        // Default layout keeps the global config at $HOME/.claude.json (a
+        // sibling of ~/.claude, NOT inside it), so it needs its own writable
+        // entry. Push it raw: it must stay a file, never a pre-created
+        // directory (see isolation_plan_path_tests.rs). Under CLAUDE_CONFIG_DIR
+        // the config file lives inside the override dir already covered above.
+        if !claude_config_dir_overridden() {
+            writable_paths.push(home.join(CLAUDE_LEGACY_STATE_REL));
+        }
+        required_writable_dirs.push(RequiredWritableDir {
+            path: claude_home,
+            source: claude_home_source,
+            purpose: "Claude session-env recorder and SessionStart hook scratch dir",
+            config_hint: CLAUDE_SANDBOX_CONFIG_HINT,
+            tool_label: "claude",
+        });
+    } else if claude_home.is_absolute() && has_claude_on_path() {
+        // Claude is installed — route through `add_dir_or_creatable_parent` so
+        // the directory is pre-created when it doesn't exist yet (avoids
+        // read-only-fs in nested CSA sessions spawning a claude-code child).
+        // Symmetric with the `~/.codex` peer widening in isolation_plan_codex.rs.
+        super::add_dir_or_creatable_parent(writable_paths, &claude_home);
+    }
+}
+
+/// Resolve the canonical claude home, honoring `CLAUDE_CONFIG_DIR` when set
+/// (mirrors [`super::codex_paths::codex_home_dir`]'s `CODEX_HOME` nuance).
+pub(super) fn claude_home_dir(home: &Path) -> (PathBuf, &'static str) {
+    match std::env::var_os(CLAUDE_CONFIG_DIR_ENV) {
+        Some(value) if !value.is_empty() => (PathBuf::from(value), CLAUDE_CONFIG_DIR_ENV),
+        _ => (home.join(CLAUDE_DEFAULT_HOME_REL), "HOME/.claude"),
+    }
+}
+
+/// Whether `CLAUDE_CONFIG_DIR` relocates the claude home away from the default.
+fn claude_config_dir_overridden() -> bool {
+    std::env::var_os(CLAUDE_CONFIG_DIR_ENV).is_some_and(|value| !value.is_empty())
+}
+
+/// Check whether any claude-code binary (`claude` CLI or the `claude-code-acp`
+/// ACP adapter) is on `PATH`.  Mirrors [`super::codex_paths::has_codex_on_path`].
+pub(super) fn has_claude_on_path() -> bool {
+    for binary in &["claude", "claude-code-acp"] {
+        let found = Command::new("which")
+            .arg(binary)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|s| s.success());
+        if found {
+            return true;
+        }
+    }
+    false
+}

--- a/crates/csa-resource/src/isolation_plan_claude_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_claude_tests.rs
@@ -1,0 +1,233 @@
+//! Integration tests for the claude-home writable-mount wiring
+//! (`isolation_plan_claude.rs`).
+//!
+//! Mirrors the codex-home tests in `isolation_plan_tests.rs`:
+//! - the owning `claude-code` tool gets the claude home writable AND a fail-fast
+//!   write probe (`RequiredWritableDir`);
+//! - a peer (non claude-code) tool gets the claude home writable WITHOUT a probe,
+//!   gated on claude being installed — the symmetric widening that fixes the
+//!   nested-EROFS failure in #1683 / #1661 / #161.
+//!
+//! HOME is always redirected to a temp dir so assertions never depend on the
+//! host's real `~/.claude` (see the env-dependent-test lint and the #642 lesson).
+use super::*;
+use std::ffi::OsString;
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: tests that mutate process environment hold ENV_LOCK.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: tests that mutate process environment hold ENV_LOCK.
+        unsafe { std::env::remove_var(key) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: tests that mutate process environment hold ENV_LOCK.
+        unsafe {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+}
+
+/// (a) The owning `claude-code` tool registers a fail-fast write probe for the
+/// claude home: an unwritable `CLAUDE_CONFIG_DIR` must abort the build, exactly
+/// like the codex owner probe in
+/// `test_tool_defaults_codex_rejects_unwritable_codex_home`.  This proves the
+/// probe is registered for the owner (the writable-mount half is covered by
+/// `test_claude_tool_defaults_precreate_claude_dir_for_session_env` and
+/// `test_tool_defaults_claude_code`).
+#[test]
+fn test_tool_defaults_claude_code_rejects_unwritable_claude_home() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let _home_env = ScopedEnvVar::set("HOME", &home);
+
+    let claude_home = temp.path().join("readonly-claude-home");
+    std::fs::create_dir(&claude_home).unwrap();
+    #[cfg(unix)]
+    let original_mode = {
+        use std::os::unix::fs::PermissionsExt;
+
+        let metadata = std::fs::metadata(&claude_home).unwrap();
+        let original_mode = metadata.permissions().mode();
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o500);
+        std::fs::set_permissions(&claude_home, permissions).unwrap();
+        original_mode
+    };
+    #[cfg(not(unix))]
+    {
+        let mut permissions = std::fs::metadata(&claude_home).unwrap().permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&claude_home, permissions).unwrap();
+    }
+    let _claude_home_env = ScopedEnvVar::set("CLAUDE_CONFIG_DIR", &claude_home);
+
+    let project = PathBuf::from("/tmp/project");
+    let session = PathBuf::from("/tmp/session");
+
+    let error = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_tool_defaults("claude-code", &project, &session)
+        .build()
+        .expect_err("unwritable CLAUDE_CONFIG_DIR should fail preflight");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = std::fs::metadata(&claude_home).unwrap().permissions();
+        permissions.set_mode(original_mode);
+        std::fs::set_permissions(&claude_home, permissions).unwrap();
+    }
+    #[cfg(not(unix))]
+    {
+        let mut permissions = std::fs::metadata(&claude_home).unwrap().permissions();
+        permissions.set_readonly(false);
+        std::fs::set_permissions(&claude_home, permissions).unwrap();
+    }
+
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("claude sandbox preflight failed"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("CLAUDE_CONFIG_DIR"),
+        "error should name the canonical claude home source: {message}"
+    );
+    assert!(
+        message.contains("[tools.claude-code].filesystem_sandbox.writable_paths"),
+        "error should surface the claude sandbox config hint: {message}"
+    );
+}
+
+/// (b) A peer (non claude-code) tool exposes the claude home WITHOUT a probe,
+/// gated on claude being on PATH.  Because peers register no probe, an
+/// unwritable claude home must NOT abort the build — the asymmetry mirrored from
+/// `isolation_plan_codex.rs` (peer `~/.codex` widening without a probe).
+#[test]
+fn test_peer_tool_exposes_claude_home_without_probe() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let _home_env = ScopedEnvVar::set("HOME", &home);
+    // Use the default ~/.claude layout (no override) for the peer path.
+    let _claude_home_env = ScopedEnvVar::unset("CLAUDE_CONFIG_DIR");
+
+    // Pre-create the default claude home and make it READ-ONLY.  A peer tool
+    // adds it to writable_paths (so a nested claude-code child gets a writable
+    // bind) but registers NO write probe, so the read-only mode must not abort.
+    let claude_home = home.join(".claude");
+    std::fs::create_dir(&claude_home).unwrap();
+    #[cfg(unix)]
+    let original_mode = {
+        use std::os::unix::fs::PermissionsExt;
+
+        let metadata = std::fs::metadata(&claude_home).unwrap();
+        let original_mode = metadata.permissions().mode();
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o500);
+        std::fs::set_permissions(&claude_home, permissions).unwrap();
+        original_mode
+    };
+
+    let project = PathBuf::from("/tmp/project");
+    let session = PathBuf::from("/tmp/session");
+
+    // gemini-cli is a peer to BOTH codex and claude, so neither owner probe is
+    // registered — this isolates the claude peer (no-probe) behavior.
+    let result = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_tool_defaults("gemini-cli", &project, &session)
+        .build();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = std::fs::metadata(&claude_home).unwrap().permissions();
+        permissions.set_mode(original_mode);
+        std::fs::set_permissions(&claude_home, permissions).unwrap();
+    }
+
+    let plan = result.expect("a peer tool must NOT probe an unwritable claude home");
+
+    if claude_paths::has_claude_on_path() {
+        assert!(
+            plan.writable_paths.contains(&claude_home),
+            "a peer sandbox should expose the claude home when claude is installed"
+        );
+    } else {
+        assert!(
+            !plan.writable_paths.contains(&claude_home),
+            "without claude on PATH, a peer sandbox must NOT expose the claude home"
+        );
+    }
+}
+
+/// (c) Regression for the nested-EROFS bug (#1683 / #1661): a claude-code child
+/// spawned NESTED inside a codex parent bwrap used to inherit a read-only
+/// `~/.claude` (the depth-0 claude arm only ran for the claude-code tool), so
+/// the child's SessionStart hook `mkdir ~/.claude/session-env/<id>` failed with
+/// EROFS.  A codex parent must now expose the claude home writable.
+#[test]
+fn test_codex_parent_exposes_writable_claude_home_nested_erofs_regression() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let _home_env = ScopedEnvVar::set("HOME", &home);
+    let _claude_home_env = ScopedEnvVar::unset("CLAUDE_CONFIG_DIR");
+    // Keep the codex OWNER probe hermetic (writable temp); it is not under test.
+    let codex_home = temp.path().join("codex-home");
+    std::fs::create_dir(&codex_home).unwrap();
+    let _codex_home_env = ScopedEnvVar::set("CODEX_HOME", &codex_home);
+
+    let project = PathBuf::from("/tmp/project");
+    let session = PathBuf::from("/tmp/session");
+
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_tool_defaults("codex", &project, &session)
+        .build()
+        .expect("codex parent defaults should build");
+
+    let claude_home = home.join(".claude");
+    if claude_paths::has_claude_on_path() {
+        assert!(
+            plan.writable_paths.contains(&claude_home),
+            "a codex parent must expose ~/.claude writable so a nested claude-code child avoids EROFS"
+        );
+        assert!(
+            claude_home.is_dir(),
+            "the claude home should be pre-created as a bwrap bind source"
+        );
+    } else {
+        assert!(
+            !plan.writable_paths.contains(&claude_home),
+            "without claude on PATH, a codex parent need not expose ~/.claude"
+        );
+    }
+}

--- a/crates/csa-resource/src/isolation_plan_codex.rs
+++ b/crates/csa-resource/src/isolation_plan_codex.rs
@@ -9,12 +9,22 @@ const CODEX_DEFAULT_HOME_REL: &str = ".codex";
 const CODEX_SANDBOX_CONFIG_HINT: &str =
     "[tools.codex].filesystem_sandbox.writable_paths or [filesystem_sandbox].extra_writable";
 
+/// A directory that MUST be writable before spawning a tool, validated
+/// fail-fast in `IsolationPlanBuilder::build`.
+///
+/// Shared across tool-home preflights — the codex home (`~/.codex`) and the
+/// claude home (`~/.claude`, see `isolation_plan_claude.rs`).  `tool_label`
+/// selects the wording so a single probe reports the owning tool correctly.
+/// Fields are `pub(super)` so the sibling claude helper module can construct
+/// and inspect entries.
 #[derive(Debug, Clone)]
 pub(super) struct RequiredWritableDir {
-    path: PathBuf,
-    source: &'static str,
-    purpose: &'static str,
-    config_hint: &'static str,
+    pub(super) path: PathBuf,
+    pub(super) source: &'static str,
+    pub(super) purpose: &'static str,
+    pub(super) config_hint: &'static str,
+    /// Lowercase tool identifier ("codex" / "claude") used in error wording.
+    pub(super) tool_label: &'static str,
 }
 
 pub(super) fn add_codex_home_for_tool(
@@ -33,6 +43,7 @@ pub(super) fn add_codex_home_for_tool(
             source: codex_home_source,
             purpose: "Codex rollout recorder and arg0 PATH shim",
             config_hint: CODEX_SANDBOX_CONFIG_HINT,
+            tool_label: "codex",
         });
     } else if codex_home.is_absolute() && has_codex_on_path() {
         // Codex is installed — route through `add_dir_or_creatable_parent` so
@@ -93,10 +104,11 @@ fn validate_required_writable_dir(
     writable_paths: &[PathBuf],
 ) -> anyhow::Result<()> {
     let path = &required.path;
+    let label = required.tool_label;
 
     if !path.is_absolute() {
         anyhow::bail!(
-            "codex sandbox preflight failed: required writable path {} ({}, source: {}) is not absolute. \
+            "{label} sandbox preflight failed: required writable path {} ({}, source: {}) is not absolute. \
              Sandbox config key: {}",
             path.display(),
             required.purpose,
@@ -107,7 +119,7 @@ fn validate_required_writable_dir(
 
     if !path_is_covered_by_writable_mount(path, writable_paths) {
         anyhow::bail!(
-            "codex sandbox preflight failed: required writable path {} ({}, source: {}) is missing from IsolationPlan.writable_paths. \
+            "{label} sandbox preflight failed: required writable path {} ({}, source: {}) is missing from IsolationPlan.writable_paths. \
              Sandbox config key: {}",
             path.display(),
             required.purpose,
@@ -118,7 +130,7 @@ fn validate_required_writable_dir(
 
     if super::is_sensitive_system_path(path) {
         anyhow::bail!(
-            "codex sandbox preflight failed: required writable path {} ({}, source: {}) is under a sensitive system directory. \
+            "{label} sandbox preflight failed: required writable path {} ({}, source: {}) is under a sensitive system directory. \
              Sandbox config key: {}",
             path.display(),
             required.purpose,
@@ -129,7 +141,7 @@ fn validate_required_writable_dir(
 
     if let Err(error) = fs::create_dir_all(path) {
         anyhow::bail!(
-            "codex sandbox preflight failed: required writable path {} ({}, source: {}) could not be created before spawning Codex: {}. \
+            "{label} sandbox preflight failed: required writable path {} ({}, source: {}) could not be created before spawning {label}: {}. \
              Sandbox config key: {}",
             path.display(),
             required.purpose,
@@ -143,7 +155,7 @@ fn validate_required_writable_dir(
         Ok(metadata) => metadata,
         Err(error) => {
             anyhow::bail!(
-                "codex sandbox preflight failed: required writable path {} ({}, source: {}) could not be inspected before spawning Codex: {}. \
+                "{label} sandbox preflight failed: required writable path {} ({}, source: {}) could not be inspected before spawning {label}: {}. \
                  Sandbox config key: {}",
                 path.display(),
                 required.purpose,
@@ -155,7 +167,7 @@ fn validate_required_writable_dir(
     };
     if !metadata.is_dir() {
         anyhow::bail!(
-            "codex sandbox preflight failed: required writable path {} ({}, source: {}) exists but is not a directory. \
+            "{label} sandbox preflight failed: required writable path {} ({}, source: {}) exists but is not a directory. \
              Sandbox config key: {}",
             path.display(),
             required.purpose,
@@ -168,6 +180,7 @@ fn validate_required_writable_dir(
 }
 
 fn probe_writable_dir(path: &Path, required: &RequiredWritableDir) -> anyhow::Result<()> {
+    let label = required.tool_label;
     for attempt in 0..16 {
         let probe = path.join(format!(".csa-write-probe-{}-{attempt}", std::process::id()));
         match OpenOptions::new().write(true).create_new(true).open(&probe) {
@@ -187,8 +200,8 @@ fn probe_writable_dir(path: &Path, required: &RequiredWritableDir) -> anyhow::Re
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(error) => {
                 anyhow::bail!(
-                    "codex sandbox preflight failed: required writable path {} ({}, source: {}) is not writable before spawning Codex: {}. \
-                     Sandbox config key: {}. If this is a nested CSA session, ensure the parent filesystem sandbox also exposes this same canonical Codex home path.",
+                    "{label} sandbox preflight failed: required writable path {} ({}, source: {}) is not writable before spawning {label}: {}. \
+                     Sandbox config key: {}. If this is a nested CSA session, ensure the parent filesystem sandbox also exposes this same canonical {label} home path.",
                     path.display(),
                     required.purpose,
                     required.source,
@@ -200,7 +213,7 @@ fn probe_writable_dir(path: &Path, required: &RequiredWritableDir) -> anyhow::Re
     }
 
     anyhow::bail!(
-        "codex sandbox preflight failed: could not allocate a unique write probe under {} ({}, source: {}). \
+        "{label} sandbox preflight failed: could not allocate a unique write probe under {} ({}, source: {}). \
          Sandbox config key: {}",
         path.display(),
         required.purpose,


### PR DESCRIPTION
Fixes #1683 (and the EROFS facet of #1661/#1677): nested claude-code running inside a codex parent bwrap hit EROFS on mkdir of ~/.claude/session-env/<id>, because the claude home was only exposed writable in claude-code own match arm — a codex parent never exposed it, so the nested child re-bound the parent read-only claude home.

Approach A (heterogeneous-debate decided + codex-verified): add_claude_home_for_tool, structurally mirroring add_codex_home_for_tool — expose the canonical claude home (honoring CLAUDE_CONFIG_DIR) writable for every tool, with a RequiredWritableDir probe only for the owning claude-code tool and a writable bind WITHOUT probe for peer tools when claude is on PATH. Justified by the already-accepted ~/.codex peer-widening symmetry.

Tests: owner probe-failure, peer no-probe behavior, and the codex-parent nested-EROFS regression.

Reviews: claude PASS (01KSWX29N) + codex heterogeneous PASS (01KSWY1Y).

Refs #1683 #1661 #1677 #161.