### PR TITLE
fix(cli-sub-agent): fail closed on failed/unavailable review verdicts (#1716, #1710)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.819"
+version = "0.1.820"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.819"
+version = "0.1.820"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -458,6 +458,18 @@ fn diff_fingerprint_matches(
 }
 
 fn review_meta_or_artifact_is_pass(session_dir: &Path, meta: &ReviewSessionMeta) -> Result<bool> {
+    if review_meta_has_failed_reviewer_signal(meta) {
+        debug!(
+            session_id = %meta.session_id,
+            meta_decision = %meta.decision,
+            meta_verdict = %meta.verdict,
+            meta_exit_code = meta.exit_code,
+            primary_failure = meta.primary_failure.as_deref().unwrap_or(""),
+            "Rejecting review verdict because review metadata records reviewer failure"
+        );
+        return Ok(false);
+    }
+
     let meta_pass = review_meta_is_pass(meta);
     let verdict_path = session_dir.join("output").join("review-verdict.json");
     if verdict_path.exists() {
@@ -492,9 +504,23 @@ fn review_meta_or_artifact_is_pass(session_dir: &Path, meta: &ReviewSessionMeta)
 }
 
 fn review_meta_is_pass(meta: &ReviewSessionMeta) -> bool {
+    if review_meta_has_failed_reviewer_signal(meta) {
+        return false;
+    }
+
     ReviewDecision::from_str(&meta.decision).is_ok_and(|decision| {
         decision == ReviewDecision::Pass || verdict_token_is_pass(&meta.verdict)
     }) || verdict_token_is_pass(&meta.verdict)
+}
+
+fn review_meta_has_failed_reviewer_signal(meta: &ReviewSessionMeta) -> bool {
+    meta.status_reason.is_some()
+        || meta.failure_reason.is_some()
+        || (meta.exit_code != 0
+            && meta
+                .primary_failure
+                .as_deref()
+                .is_some_and(|failure| !failure.trim().is_empty()))
 }
 
 fn verdict_token_is_pass(verdict: &str) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -458,7 +458,7 @@ fn diff_fingerprint_matches(
 }
 
 fn review_meta_or_artifact_is_pass(session_dir: &Path, meta: &ReviewSessionMeta) -> Result<bool> {
-    if review_meta_has_failed_reviewer_signal(meta) {
+    if meta.requires_fail_closed_verdict() {
         debug!(
             session_id = %meta.session_id,
             meta_decision = %meta.decision,
@@ -504,23 +504,13 @@ fn review_meta_or_artifact_is_pass(session_dir: &Path, meta: &ReviewSessionMeta)
 }
 
 fn review_meta_is_pass(meta: &ReviewSessionMeta) -> bool {
-    if review_meta_has_failed_reviewer_signal(meta) {
+    if meta.requires_fail_closed_verdict() {
         return false;
     }
 
     ReviewDecision::from_str(&meta.decision).is_ok_and(|decision| {
         decision == ReviewDecision::Pass || verdict_token_is_pass(&meta.verdict)
     }) || verdict_token_is_pass(&meta.verdict)
-}
-
-fn review_meta_has_failed_reviewer_signal(meta: &ReviewSessionMeta) -> bool {
-    meta.status_reason.is_some()
-        || meta.failure_reason.is_some()
-        || (meta.exit_code != 0
-            && meta
-                .primary_failure
-                .as_deref()
-                .is_some_and(|failure| !failure.trim().is_empty()))
 }
 
 fn verdict_token_is_pass(verdict: &str) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_tests.rs
@@ -534,6 +534,37 @@ fn check_verdict_rejects_non_pass_artifact_even_when_meta_is_pass() {
 }
 
 #[test]
+fn issue_1716_check_verdict_rejects_failed_reviewer_meta_even_when_artifact_says_pass() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let temp = setup_git_repo();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    run_git(temp.path(), &["checkout", "-b", "feature"]);
+    let branch = run_git(temp.path(), &["branch", "--show-current"]);
+    let head_sha = csa_session::detect_git_head(temp.path()).unwrap();
+
+    let session_id = write_review_session(
+        temp.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        ReviewDecision::Pass,
+        "CLEAN",
+    );
+    let session_dir = csa_session::get_session_dir(temp.path(), &session_id).unwrap();
+    let mut meta = read_review_meta(&session_dir)
+        .unwrap()
+        .expect("review meta should exist");
+    meta.exit_code = 137;
+    meta.primary_failure = Some("API key not found".to_string());
+    csa_session::state::write_review_meta(&session_dir, &meta).expect("write review meta");
+
+    let args = parse_review_args(&["csa", "review", "--check-verdict"]);
+    let exit = handle_check_verdict(temp.path(), &args).unwrap();
+    assert_eq!(exit, 1);
+}
+
+#[test]
 fn check_verdict_does_not_recover_or_rewrite_corrupt_session_state() {
     let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
     let temp = TempDir::new().unwrap();

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_tests.rs
@@ -565,6 +565,41 @@ fn issue_1716_check_verdict_rejects_failed_reviewer_meta_even_when_artifact_says
 }
 
 #[test]
+fn issue_1716_check_verdict_rejects_unavailable_nonzero_with_empty_failure_metadata() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let temp = setup_git_repo();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    run_git(temp.path(), &["checkout", "-b", "feature"]);
+    let branch = run_git(temp.path(), &["branch", "--show-current"]);
+    let head_sha = csa_session::detect_git_head(temp.path()).unwrap();
+
+    let session_id = write_review_session(
+        temp.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        ReviewDecision::Pass,
+        "CLEAN",
+    );
+    let session_dir = csa_session::get_session_dir(temp.path(), &session_id).unwrap();
+    let mut meta = read_review_meta(&session_dir)
+        .unwrap()
+        .expect("review meta should exist");
+    meta.decision = ReviewDecision::Unavailable.as_str().to_string();
+    meta.verdict = "UNAVAILABLE".to_string();
+    meta.exit_code = 1;
+    meta.status_reason = None;
+    meta.primary_failure = None;
+    meta.failure_reason = None;
+    csa_session::state::write_review_meta(&session_dir, &meta).expect("write review meta");
+
+    let args = parse_review_args(&["csa", "review", "--check-verdict"]);
+    let exit = handle_check_verdict(temp.path(), &args).unwrap();
+    assert_eq!(exit, 1);
+}
+
+#[test]
 fn check_verdict_does_not_recover_or_rewrite_corrupt_session_state() {
     let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
     let temp = TempDir::new().unwrap();

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -278,6 +278,57 @@ fn persist_review_sidecars_returns_fail_exit_for_has_issues_artifact() {
 }
 
 #[test]
+fn issue_1716_sidecars_fail_closed_and_agree_when_final_reviewer_failed() {
+    let project_dir = exact_test_setup_git_repo();
+    let _state_home = test_env_lock::ScopedTestEnvVar::set(
+        "XDG_STATE_HOME",
+        project_dir.path().join("state"),
+    );
+    let session_id = "01TEST1716SIDECARAGREE000";
+    let session_dir = csa_session::get_session_dir(project_dir.path(), session_id)
+        .expect("resolve session dir");
+    std::fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
+    std::fs::write(
+        session_dir.join("output").join("full.md"),
+        "I'll inspect the diff and then produce findings.\n",
+    )
+    .expect("write setup-only output");
+
+    let mut meta = exact_test_make_review_meta(session_id, ReviewDecision::Pass, "CLEAN");
+    meta.exit_code = 137;
+    meta.primary_failure = Some("API key not found".to_string());
+
+    let persisted_exit_code = review_cmd::persist_review_sidecars_if_session_exists(
+        project_dir.path(),
+        &meta,
+        Some(session_id),
+    );
+
+    assert_eq!(persisted_exit_code, Some(1));
+    assert!(
+        !session_dir
+            .join("output")
+            .join(".findings.toml.synthetic")
+            .exists(),
+        "failed final reviewer must not get a synthetic empty-CLEAN marker"
+    );
+
+    let persisted_meta: ReviewSessionMeta =
+        serde_json::from_str(&std::fs::read_to_string(session_dir.join("review_meta.json")).unwrap())
+            .unwrap();
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json")).unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(persisted_meta.decision, ReviewDecision::Unavailable.as_str());
+    assert_eq!(persisted_meta.verdict, "UNAVAILABLE");
+    assert_eq!(artifact.decision, ReviewDecision::Unavailable);
+    assert_eq!(artifact.verdict_legacy, "UNAVAILABLE");
+    assert_eq!(persisted_meta.primary_failure, artifact.primary_failure);
+}
+
+#[test]
 fn issue_1593_clean_verdict_artifact_writes_gate_marker_despite_stale_fail_meta() {
     let project_dir = exact_test_setup_git_repo();
     exact_test_run_git(project_dir.path(), &["checkout", "-b", "fix-1593-test"]);

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -27,6 +27,25 @@ pub(super) const FINDINGS_TOML_SYNTHETIC_MARKER: &str = ".findings.toml.syntheti
 pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSessionMeta) {
     match csa_session::get_session_dir(project_root, &meta.session_id) {
         Ok(session_dir) => {
+            if meta.status_reason.is_some()
+                || meta.failure_reason.is_some()
+                || (meta.exit_code != 0
+                    && meta
+                        .primary_failure
+                        .as_deref()
+                        .is_some_and(|failure| !failure.trim().is_empty()))
+            {
+                let marker_path = session_dir
+                    .join("output")
+                    .join(FINDINGS_TOML_SYNTHETIC_MARKER);
+                let _ = fs::remove_file(&marker_path);
+                debug!(
+                    session_id = %meta.session_id,
+                    "Skipped synthetic findings.toml for failed review execution"
+                );
+                return;
+            }
+
             let (artifact, warning_reason) = match derive_findings_toml_artifact(&session_dir) {
                 Ok(artifact) => artifact,
                 Err(error) => {

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -27,14 +27,7 @@ pub(super) const FINDINGS_TOML_SYNTHETIC_MARKER: &str = ".findings.toml.syntheti
 pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSessionMeta) {
     match csa_session::get_session_dir(project_root, &meta.session_id) {
         Ok(session_dir) => {
-            if meta.status_reason.is_some()
-                || meta.failure_reason.is_some()
-                || (meta.exit_code != 0
-                    && meta
-                        .primary_failure
-                        .as_deref()
-                        .is_some_and(|failure| !failure.trim().is_empty()))
-            {
+            if meta.requires_fail_closed_verdict() {
                 let marker_path = session_dir
                     .join("output")
                     .join(FINDINGS_TOML_SYNTHETIC_MARKER);

--- a/crates/cli-sub-agent/src/review_cmd_flow.rs
+++ b/crates/cli-sub-agent/src/review_cmd_flow.rs
@@ -5,7 +5,8 @@ use csa_session::state::ReviewSessionMeta;
 use super::execute;
 use super::findings_toml::persist_review_findings_toml;
 use super::output::{
-    persist_review_meta, persist_review_verdict, persisted_review_verdict_exit_code,
+    fail_closed_review_meta, persist_review_meta, persist_review_verdict,
+    persisted_review_verdict_exit_code,
 };
 #[cfg(test)]
 use crate::review_routing::ReviewRoutingMetadata;
@@ -36,10 +37,11 @@ pub(crate) fn persist_review_sidecars_if_session_exists(
     persistable_session_id: Option<&str>,
 ) -> Option<i32> {
     let persistable_session_id = persistable_session_id?;
+    let effective_meta = fail_closed_review_meta(project_root, meta);
 
-    persist_review_meta(project_root, meta);
-    persist_review_findings_toml(project_root, meta);
-    persist_review_verdict(project_root, meta, &[], Vec::new());
+    persist_review_meta(project_root, &effective_meta);
+    persist_review_findings_toml(project_root, &effective_meta);
+    persist_review_verdict(project_root, &effective_meta, &[], Vec::new());
     let verdict_exit_code =
         persisted_review_verdict_exit_code(project_root, persistable_session_id);
     if verdict_exit_code == 0 {

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -370,9 +370,10 @@ pub(super) fn persist_multi_review_sidecars(
             timestamp: review_meta_timestamp,
             diff_fingerprint: diff_fingerprint.clone(),
         };
-        persist_review_meta(project_root, &review_meta);
-        super::findings_toml::persist_review_findings_toml(project_root, &review_meta);
-        persist_review_verdict(project_root, &review_meta, &[], Vec::new());
+        let effective_meta = super::output::fail_closed_review_meta(project_root, &review_meta);
+        persist_review_meta(project_root, &effective_meta);
+        super::findings_toml::persist_review_findings_toml(project_root, &effective_meta);
+        persist_review_verdict(project_root, &effective_meta, &[], Vec::new());
     }
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -19,6 +19,8 @@ mod clean_detection;
 mod diagnostics;
 #[path = "review_cmd_output_exit.rs"]
 mod exit_code;
+#[path = "review_cmd_output_fail_closed.rs"]
+mod fail_closed;
 #[path = "review_cmd_output_sections.rs"]
 mod sections;
 #[path = "review_cmd_output_summary.rs"]
@@ -39,6 +41,8 @@ use clean_detection::{
 pub(crate) use diagnostics::detect_tool_diagnostic;
 pub(super) use diagnostics::{ReviewerOutcome, print_reviewer_outcomes};
 pub(super) use exit_code::{persist_review_result_exit_code, persisted_review_verdict_exit_code};
+pub(super) use fail_closed::fail_closed_review_meta;
+use fail_closed::{fail_closed_review_verdict_artifact, review_meta_requires_fail_closed};
 pub(super) use sections::{
     derive_review_result_summary, has_structured_review_content, sanitize_review_output,
 };
@@ -105,7 +109,9 @@ pub(super) fn persist_review_verdict(
 ) {
     match csa_session::get_session_dir(project_root, &meta.session_id) {
         Ok(session_dir) => {
-            let mut artifact = if meta.status_reason.is_some() {
+            let mut artifact = if review_meta_requires_fail_closed(meta) {
+                fail_closed_review_verdict_artifact(meta, findings, prior_round_refs.clone())
+            } else if meta.status_reason.is_some() {
                 let mut artifact = ReviewVerdictArtifact::from_parts(
                     meta.session_id.clone(),
                     ReviewDecision::from_str(&meta.decision).unwrap_or(ReviewDecision::Uncertain),

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -42,7 +42,7 @@ pub(crate) use diagnostics::detect_tool_diagnostic;
 pub(super) use diagnostics::{ReviewerOutcome, print_reviewer_outcomes};
 pub(super) use exit_code::{persist_review_result_exit_code, persisted_review_verdict_exit_code};
 pub(super) use fail_closed::fail_closed_review_meta;
-use fail_closed::{fail_closed_review_verdict_artifact, review_meta_requires_fail_closed};
+use fail_closed::fail_closed_review_verdict_artifact;
 pub(super) use sections::{
     derive_review_result_summary, has_structured_review_content, sanitize_review_output,
 };
@@ -109,20 +109,8 @@ pub(super) fn persist_review_verdict(
 ) {
     match csa_session::get_session_dir(project_root, &meta.session_id) {
         Ok(session_dir) => {
-            let mut artifact = if review_meta_requires_fail_closed(meta) {
+            let mut artifact = if meta.requires_fail_closed_verdict() {
                 fail_closed_review_verdict_artifact(meta, findings, prior_round_refs.clone())
-            } else if meta.status_reason.is_some() {
-                let mut artifact = ReviewVerdictArtifact::from_parts(
-                    meta.session_id.clone(),
-                    ReviewDecision::from_str(&meta.decision).unwrap_or(ReviewDecision::Uncertain),
-                    meta.verdict.clone(),
-                    findings,
-                    prior_round_refs.clone(),
-                );
-                artifact.routed_to = meta.routed_to.clone();
-                artifact.primary_failure = meta.primary_failure.clone();
-                artifact.failure_reason = meta.failure_reason.clone();
-                artifact
             } else {
                 match derive_review_verdict_artifact(&session_dir, meta, findings) {
                     Ok(mut artifact) => {

--- a/crates/cli-sub-agent/src/review_cmd_output_fail_closed.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_fail_closed.rs
@@ -1,0 +1,79 @@
+use std::path::Path;
+use std::str::FromStr;
+
+use csa_core::types::ReviewDecision;
+use csa_session::state::ReviewSessionMeta;
+use csa_session::{Finding, ReviewVerdictArtifact};
+
+pub(in crate::review_cmd) fn fail_closed_review_meta(
+    project_root: &Path,
+    meta: &ReviewSessionMeta,
+) -> ReviewSessionMeta {
+    if csa_session::get_session_dir(project_root, &meta.session_id).is_err() {
+        return meta.clone();
+    }
+    if !review_meta_requires_fail_closed(meta) {
+        return meta.clone();
+    }
+
+    let mut closed = meta.clone();
+    let decision = fail_closed_decision_for_meta(meta);
+    closed.decision = decision.as_str().to_string();
+    closed.verdict = fail_closed_legacy_verdict(decision).to_string();
+    if closed.exit_code == 0 {
+        closed.exit_code = crate::verdict_exit_code::exit_code_from_review_decision(decision);
+    }
+    closed
+}
+
+pub(super) fn fail_closed_review_verdict_artifact(
+    meta: &ReviewSessionMeta,
+    findings: &[Finding],
+    prior_round_refs: Vec<String>,
+) -> ReviewVerdictArtifact {
+    let decision = fail_closed_decision_for_meta(meta);
+    let mut artifact = ReviewVerdictArtifact::from_parts(
+        meta.session_id.clone(),
+        decision,
+        fail_closed_legacy_verdict(decision),
+        findings,
+        prior_round_refs,
+    );
+    artifact.routed_to = meta.routed_to.clone();
+    artifact.primary_failure = meta.primary_failure.clone();
+    artifact.failure_reason = meta.failure_reason.clone();
+    artifact
+}
+
+pub(super) fn review_meta_requires_fail_closed(meta: &ReviewSessionMeta) -> bool {
+    if meta.status_reason.is_some() || meta.failure_reason.is_some() {
+        return true;
+    }
+
+    let has_primary_failure = meta
+        .primary_failure
+        .as_deref()
+        .is_some_and(|failure| !failure.trim().is_empty());
+    if !has_primary_failure {
+        return false;
+    }
+
+    meta.exit_code != 0
+}
+
+fn fail_closed_decision_for_meta(meta: &ReviewSessionMeta) -> ReviewDecision {
+    match ReviewDecision::from_str(&meta.decision).unwrap_or(ReviewDecision::Unavailable) {
+        ReviewDecision::Fail => ReviewDecision::Fail,
+        ReviewDecision::Uncertain => ReviewDecision::Uncertain,
+        ReviewDecision::Unavailable => ReviewDecision::Unavailable,
+        ReviewDecision::Pass | ReviewDecision::Skip => ReviewDecision::Unavailable,
+    }
+}
+
+fn fail_closed_legacy_verdict(decision: ReviewDecision) -> &'static str {
+    match decision {
+        ReviewDecision::Fail => "HAS_ISSUES",
+        ReviewDecision::Uncertain => "UNCERTAIN",
+        ReviewDecision::Unavailable | ReviewDecision::Pass | ReviewDecision::Skip => "UNAVAILABLE",
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_fail_closed.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_fail_closed.rs
@@ -12,7 +12,7 @@ pub(in crate::review_cmd) fn fail_closed_review_meta(
     if csa_session::get_session_dir(project_root, &meta.session_id).is_err() {
         return meta.clone();
     }
-    if !review_meta_requires_fail_closed(meta) {
+    if !meta.requires_fail_closed_verdict() {
         return meta.clone();
     }
 
@@ -43,22 +43,6 @@ pub(super) fn fail_closed_review_verdict_artifact(
     artifact.primary_failure = meta.primary_failure.clone();
     artifact.failure_reason = meta.failure_reason.clone();
     artifact
-}
-
-pub(super) fn review_meta_requires_fail_closed(meta: &ReviewSessionMeta) -> bool {
-    if meta.status_reason.is_some() || meta.failure_reason.is_some() {
-        return true;
-    }
-
-    let has_primary_failure = meta
-        .primary_failure
-        .as_deref()
-        .is_some_and(|failure| !failure.trim().is_empty());
-    if !has_primary_failure {
-        return false;
-    }
-
-    meta.exit_code != 0
 }
 
 fn fail_closed_decision_for_meta(meta: &ReviewSessionMeta) -> ReviewDecision {

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
@@ -114,14 +114,10 @@ fn persist_review_verdict_fail_meta_without_prose_clean_marker_emits_pass() {
 }
 
 #[test]
-fn persist_review_verdict_uncertain_meta_with_pass_prose_emits_pass_post_crash() {
-    // #1140: when an upstream crash (e.g. claude-code reviewer-1 EROFS writing
-    // /home/obj/.claude.json after the structured verdict has already been
-    // emitted) flips meta.decision to Uncertain, the synthesizer must trust
-    // the existing severity_counts (all zero) + findings.toml (empty) +
-    // explicit "Verdict: PASS" prose to recover the real verdict. Previously
-    // any Uncertain meta short-circuited the synthesizer and propagated as
-    // Uncertain regardless of the unambiguous structured signals.
+fn persist_review_verdict_uncertain_meta_with_pass_prose_fails_closed_post_crash() {
+    // R2-001: when reviewer metadata says Uncertain, the reviewer did not
+    // complete with a trustworthy pass outcome. Even explicit PASS prose cannot
+    // override the incomplete review outcome.
     let session_id = "01TESTUNCERTAINPASSCRASH000";
     let (_env_lock, project_root, session_dir) = lock_test_session(
         "persist-review-verdict-uncertain-meta-pass-prose",
@@ -154,20 +150,19 @@ fn persist_review_verdict_uncertain_meta_with_pass_prose_emits_pass_post_crash()
             .expect("parse verdict");
     assert_eq!(
         artifact.decision,
-        ReviewDecision::Pass,
-        "Uncertain meta + zero severity + empty findings + 'Verdict: PASS' prose must downgrade to Pass"
+        ReviewDecision::Uncertain,
+        "R2-001: Uncertain meta must fail closed despite PASS prose"
     );
-    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(artifact.verdict_legacy, "UNCERTAIN");
     assert!(artifact.severity_counts.values().all(|value| *value == 0));
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
 #[test]
-fn persist_review_verdict_uncertain_meta_without_pass_prose_emits_pass() {
-    // #1349: empty findings + zero counts is conclusive Pass, even for Uncertain meta
-    // with no PASS/CLEAN prose. The structured evidence (zero findings) wins over
-    // meta_decision. Prior #1140-inverse behaviour is superseded by #1349.
+fn persist_review_verdict_uncertain_meta_without_pass_prose_fails_closed() {
+    // R2-001: empty findings are not positive proof of success when the review
+    // outcome is Uncertain.
     let session_id = "01TESTUNCERTAINNOSIGNAL0000";
     let (_env_lock, project_root, session_dir) = lock_test_session(
         "persist-review-verdict-uncertain-meta-no-signal",
@@ -200,10 +195,10 @@ fn persist_review_verdict_uncertain_meta_without_pass_prose_emits_pass() {
             .expect("parse verdict");
     assert_eq!(
         artifact.decision,
-        ReviewDecision::Pass,
-        "#1349: Uncertain meta + empty findings + zero counts must yield Pass"
+        ReviewDecision::Uncertain,
+        "R2-001: Uncertain meta + empty findings must fail closed"
     );
-    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(artifact.verdict_legacy, "UNCERTAIN");
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -630,10 +630,9 @@ fn persist_review_verdict_concrete_findings_override_uncertain_token() {
 }
 
 #[test]
-fn persist_review_verdict_empty_structured_findings_uncertain_meta_emits_pass() {
-    // #1349: empty findings + zero counts is conclusive Pass, even for Uncertain meta.
-    // The prior behaviour (preserve Uncertain unless prose says PASS/CLEAN) is superseded:
-    // structured evidence (zero findings, zero counts) is authoritative.
+fn persist_review_verdict_empty_structured_findings_uncertain_meta_fails_closed() {
+    // R2-001: Uncertain reviewer outcome means the review did not complete with
+    // positive pass evidence. Empty findings alone cannot synthesize Pass.
     let session_id = "01TESTEMPTYFINDINGSUNCERTAIN";
     let (_env_lock, project_root, session_dir) = lock_test_session(
         "persist-review-verdict-empty-findings-uncertain",
@@ -666,10 +665,10 @@ fn persist_review_verdict_empty_structured_findings_uncertain_meta_emits_pass() 
             .expect("parse verdict");
     assert_eq!(
         artifact.decision,
-        ReviewDecision::Pass,
-        "#1349: empty findings + zero counts must yield Pass even for Uncertain meta"
+        ReviewDecision::Uncertain,
+        "R2-001: empty findings + zero counts must not promote Uncertain meta to Pass"
     );
-    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(artifact.verdict_legacy, "UNCERTAIN");
     assert!(artifact.severity_counts.values().all(|value| *value == 0));
 
     fs::remove_dir_all(project_root).expect("remove temp project root");

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -787,3 +787,6 @@ mod verdict_1480_tests;
 
 #[path = "review_cmd_output_verdict_1675_tests.rs"]
 mod verdict_1675_tests;
+
+#[path = "review_cmd_output_verdict_1716_tests.rs"]
+mod verdict_1716_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1045_tests.rs
@@ -456,13 +456,13 @@ fn issue_1217_synthetic_empty_toml_unstructured_full_md_preserves_meta_pass() {
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
-/// Case 10 (#1045 round 3, superseded by #1362): synthetic-empty findings.toml
-/// + NO review-findings.json + empty full.md → decision=pass.
+/// Case 10 (#1045 round 3, superseded by R2-001): synthetic-empty findings.toml
+/// + NO review-findings.json + empty full.md + Uncertain meta → fail closed.
 ///
-/// Empty findings + zero severity counts are the primary signal; missing
-/// summary/details/full output must not fall through to stale meta failure.
+/// Synthetic empty findings are not positive evidence that the reviewer
+/// completed successfully.
 #[test]
-fn issue_1045_r3_synthetic_empty_toml_missing_json_empty_full_md_emits_pass() {
+fn issue_1045_r3_synthetic_empty_toml_missing_json_empty_full_md_fails_closed() {
     let session_id = "01TEST1045R3SYNTHNOJSEMPTY0";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("issue-1045-r3-synth-no-json-empty-full", session_id);
@@ -492,10 +492,10 @@ fn issue_1045_r3_synthetic_empty_toml_missing_json_empty_full_md_emits_pass() {
             .expect("parse verdict");
     assert_eq!(
         artifact.decision,
-        ReviewDecision::Pass,
-        "#1362: synthetic-empty TOML + missing JSON + empty/missing full.md must yield Pass"
+        ReviewDecision::Uncertain,
+        "R2-001: synthetic-empty TOML + missing JSON + empty/missing full.md must fail closed"
     );
-    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(artifact.verdict_legacy, "UNCERTAIN");
     assert!(artifact.severity_counts.values().all(|value| *value == 0));
 
     fs::remove_dir_all(project_root).expect("remove temp project root");

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1340_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1340_tests.rs
@@ -1,15 +1,17 @@
 use super::*;
 
-// ─── #1340 regression tests: Unavailable meta_decision must not override empty findings ─
+// ─── #1340/R2-001 regression tests: Unavailable meta fails closed ─
 
 /// #1340 Case 1: meta.decision=unavailable (from text-parse noise) + empty
-/// findings.toml → review-verdict.json must write decision=pass.
+/// findings.toml now fails closed instead of promoting to Pass.
 ///
 /// Regression: UNAVAILABLE token in prompt-injection text caused
 /// parse_review_decision_token to return Unavailable, which then propagated
 /// through derive_decision_from_severity_counts even though findings were empty.
+/// R2-001 supersedes that recovery: unavailable reviewer outcome is incomplete
+/// reviewer evidence, so empty findings cannot synthesize a clean artifact.
 #[test]
-fn issue_1340_unavailable_meta_with_empty_findings_toml_emits_pass() {
+fn issue_1340_unavailable_meta_with_empty_findings_toml_fails_closed() {
     let session_id = "01TEST1340UNAVAILABLEFINDS0";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("issue-1340-unavailable-empty-findings", session_id);
@@ -38,19 +40,19 @@ fn issue_1340_unavailable_meta_with_empty_findings_toml_emits_pass() {
             .expect("parse verdict");
     assert_eq!(
         artifact.decision,
-        ReviewDecision::Pass,
-        "#1340: Unavailable meta + empty findings.toml must yield pass, not unavailable"
+        ReviewDecision::Unavailable,
+        "R2-001: Unavailable meta + empty findings.toml must fail closed"
     );
-    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(artifact.verdict_legacy, "UNAVAILABLE");
     assert!(artifact.severity_counts.values().all(|v| *v == 0));
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
 /// #1340 Case 2: meta.decision=unavailable + empty findings.toml + no summary section
-/// → still emits pass (zero-findings default, not text-parse dependent).
+/// → fail closed (zero-findings is not proof that unavailable reviewer ran).
 #[test]
-fn issue_1340_unavailable_meta_with_empty_findings_toml_no_summary_emits_pass() {
+fn issue_1340_unavailable_meta_with_empty_findings_toml_no_summary_fails_closed() {
     let session_id = "01TEST1340UNAVAILABLENOSUM0";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("issue-1340-unavailable-no-summary", session_id);
@@ -61,7 +63,7 @@ fn issue_1340_unavailable_meta_with_empty_findings_toml_no_summary_emits_pass() 
         "findings = []\n",
     )
     .expect("write findings.toml");
-    // No summary.md — verdict must still be Pass from zero-findings evidence alone
+    // No summary.md — unavailable meta must not be promoted by zero-findings alone.
 
     let meta =
         make_review_meta_with_decision(session_id, ReviewDecision::Unavailable, "UNAVAILABLE");
@@ -73,10 +75,10 @@ fn issue_1340_unavailable_meta_with_empty_findings_toml_no_summary_emits_pass() 
             .expect("parse verdict");
     assert_eq!(
         artifact.decision,
-        ReviewDecision::Pass,
-        "#1340: Unavailable meta + empty findings.toml (no summary) must still yield pass"
+        ReviewDecision::Unavailable,
+        "R2-001: Unavailable meta + empty findings.toml (no summary) must fail closed"
     );
-    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(artifact.verdict_legacy, "UNAVAILABLE");
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
@@ -119,9 +121,9 @@ fn issue_1340_status_reason_set_preserves_unavailable() {
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
-/// #1340 Case 4: actual fail with HIGH findings is unaffected by the fix.
+/// #1340 Case 4: unavailable meta still fails closed before findings promotion.
 #[test]
-fn issue_1340_high_finding_with_unavailable_meta_emits_fail() {
+fn issue_1340_high_finding_with_unavailable_meta_fails_closed() {
     let session_id = "01TEST1340HIGHFINDINGUNAVAIL";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("issue-1340-high-finding-unavailable-meta", session_id);
@@ -148,11 +150,10 @@ fn issue_1340_high_finding_with_unavailable_meta_emits_fail() {
             .expect("parse verdict");
     assert_eq!(
         artifact.decision,
-        ReviewDecision::Fail,
-        "#1340: HIGH finding with Unavailable meta must still yield Fail"
+        ReviewDecision::Unavailable,
+        "R2-001: HIGH finding with Unavailable meta must preserve unavailable"
     );
-    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
-    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(artifact.verdict_legacy, "UNAVAILABLE");
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1716_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1716_tests.rs
@@ -43,6 +43,49 @@ fn issue_1716_failed_final_reviewer_with_synthetic_empty_findings_is_unavailable
 }
 
 #[test]
+fn issue_1716_unavailable_nonzero_empty_failure_metadata_is_unavailable() {
+    let session_id = "01TEST1716UNAVAILABLEEMPTY00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1716-unavailable-empty-meta", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    fs::write(
+        session_dir.join("output").join(".findings.toml.synthetic"),
+        "",
+    )
+    .expect("write synthetic marker");
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        "reviewer infrastructure became unavailable before producing a verdict\n",
+    )
+    .expect("write setup-only output");
+
+    let mut meta =
+        make_review_meta_with_decision(session_id, ReviewDecision::Unavailable, "UNAVAILABLE");
+    meta.exit_code = 1;
+    meta.status_reason = None;
+    meta.primary_failure = None;
+    meta.failure_reason = None;
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Unavailable);
+    assert_eq!(artifact.verdict_legacy, "UNAVAILABLE");
+    assert_ne!(artifact.decision, ReviewDecision::Pass);
+    assert_ne!(artifact.verdict_legacy, "CLEAN");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_1716_successful_zero_findings_fallback_with_prior_failure_still_passes() {
     let session_id = "01TEST1716SUCCESSFALLBACK00";
     let (_env_lock, project_root, session_dir) =

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1716_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1716_tests.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+#[test]
+fn issue_1716_failed_final_reviewer_with_synthetic_empty_findings_is_unavailable() {
+    let session_id = "01TEST1716FAILEDREVIEWER000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1716-failed-reviewer", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write findings.toml");
+    fs::write(
+        session_dir.join("output").join(".findings.toml.synthetic"),
+        "",
+    )
+    .expect("write synthetic marker");
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        "I'll read the workflow, then check the diff before writing findings.\n",
+    )
+    .expect("write setup-only output");
+
+    let mut meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    meta.exit_code = 137;
+    meta.primary_failure = Some("API key not found".to_string());
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Unavailable);
+    assert_eq!(artifact.verdict_legacy, "UNAVAILABLE");
+    assert_eq!(
+        artifact.primary_failure.as_deref(),
+        Some("API key not found")
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1716_successful_zero_findings_fallback_with_prior_failure_still_passes() {
+    let session_id = "01TEST1716SUCCESSFALLBACK00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1716-successful-fallback", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write real findings.toml");
+
+    let mut meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    meta.exit_code = 0;
+    meta.primary_failure = Some("QUOTA_EXHAUSTED".to_string());
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(artifact.primary_failure.as_deref(), Some("QUOTA_EXHAUSTED"));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -76,7 +76,7 @@ fn render_wait_result_summary(
         lines.push(format!("Tokens: {}", tokens.render_text()));
     }
 
-    if let Some(verdict) = read_review_verdict_label(session_dir) {
+    if let Some(verdict) = read_review_verdict_label(session_dir, result) {
         lines.push(format!("Review verdict: {verdict}"));
     }
 
@@ -110,7 +110,7 @@ fn render_wait_result_json(
         "tool": wait_result_tool_label(result),
         "elapsed_seconds": wait_elapsed_seconds(result),
         "tokens": tokens,
-        "review_verdict": read_review_verdict_label(session_dir),
+        "review_verdict": read_review_verdict_label(session_dir, result),
         "summary": crate::session_summary_text::human_session_summary(session_dir, &result.summary)
             .and_then(|text| compact_wait_summary_text(&text)),
     });
@@ -218,7 +218,10 @@ fn compact_wait_summary_text(summary: &str) -> Option<String> {
     Some(compact)
 }
 
-fn read_review_verdict_label(session_dir: &Path) -> Option<String> {
+fn read_review_verdict_label(
+    session_dir: &Path,
+    result: &csa_session::SessionResult,
+) -> Option<String> {
     let verdict_path = session_dir.join("output").join("review-verdict.json");
     if verdict_path.is_file()
         && let Ok(raw) = std::fs::read_to_string(&verdict_path)
@@ -232,7 +235,7 @@ fn read_review_verdict_label(session_dir: &Path) -> Option<String> {
                     .get("verdict_legacy")
                     .and_then(serde_json::Value::as_str)
             })
-            .map(normalize_review_verdict_label);
+            .map(|value| normalize_review_verdict_label(value, result));
     }
 
     let meta_path = session_dir.join("review_meta.json");
@@ -244,14 +247,15 @@ fn read_review_verdict_label(session_dir: &Path) -> Option<String> {
             .get("decision")
             .and_then(serde_json::Value::as_str)
             .or_else(|| value.get("verdict").and_then(serde_json::Value::as_str))
-            .map(normalize_review_verdict_label);
+            .map(|value| normalize_review_verdict_label(value, result));
     }
 
     None
 }
 
-fn normalize_review_verdict_label(value: &str) -> String {
+fn normalize_review_verdict_label(value: &str, result: &csa_session::SessionResult) -> String {
     match value.trim().to_ascii_uppercase().as_str() {
+        "PASS" | "CLEAN" if result.exit_code != 0 => "UNAVAILABLE".to_string(),
         "PASS" | "CLEAN" => "PASS".to_string(),
         "FAIL" | "FAILED" | "HAS_ISSUES" => "FAIL".to_string(),
         other => other.to_string(),
@@ -396,5 +400,43 @@ mod wait_output_tests {
         assert!(summary.contains("Elapsed: 1m 5s"));
         assert!(summary.contains("Tokens: input=100, output=25, total=125, cache_read=40"));
         assert!(summary.contains("Review verdict: PASS"));
+    }
+
+    #[test]
+    fn compact_summary_does_not_print_pass_when_result_failed() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let output_dir = temp.path().join("output");
+        std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+        std::fs::write(
+            output_dir.join("review-verdict.json"),
+            r#"{"decision":"pass","verdict_legacy":"CLEAN"}"#,
+        )
+        .expect("review verdict should be written");
+        let now = Utc::now();
+        let result = csa_session::SessionResult {
+            status: "failed".to_string(),
+            exit_code: 137,
+            summary: "fatal backend error: process killed".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now + chrono::TimeDelta::seconds(65),
+            events_count: 0,
+            artifacts: Vec::new(),
+            peak_memory_mb: None,
+            fallback_chain: None,
+            gate_timeout: false,
+            warnings: Vec::new(),
+            raw_process_exit_code: None,
+            manager_fields: Default::default(),
+        };
+
+        let summary = render_wait_result_summary(temp.path(), "01TESTWAITFAILPASS", &result);
+
+        assert!(!summary.contains("Review verdict: PASS"));
+        assert!(summary.contains("Review verdict: UNAVAILABLE"));
+        assert!(summary.contains("Summary: fatal backend error: process killed"));
     }
 }

--- a/crates/csa-session/src/state.rs
+++ b/crates/csa-session/src/state.rs
@@ -2,6 +2,7 @@
 
 use crate::output_section::ReturnPacketRef;
 use chrono::{DateTime, Utc};
+use csa_core::types::ReviewDecision;
 use csa_core::vcs::{VcsIdentity, VcsKind};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -220,6 +221,11 @@ impl ReviewSessionMeta {
     /// Returns true when review metadata represents an incomplete or failed
     /// reviewer execution that must not be treated as a clean verdict.
     pub fn requires_fail_closed_verdict(&self) -> bool {
+        match self.decision.parse::<ReviewDecision>() {
+            Ok(ReviewDecision::Unavailable | ReviewDecision::Uncertain) | Err(_) => return true,
+            Ok(ReviewDecision::Pass | ReviewDecision::Fail | ReviewDecision::Skip) => {}
+        }
+
         if self.status_reason.is_some() || self.failure_reason.is_some() {
             return true;
         }

--- a/crates/csa-session/src/state.rs
+++ b/crates/csa-session/src/state.rs
@@ -216,6 +216,23 @@ pub struct ReviewSessionMeta {
     pub diff_fingerprint: Option<String>,
 }
 
+impl ReviewSessionMeta {
+    /// Returns true when review metadata represents an incomplete or failed
+    /// reviewer execution that must not be treated as a clean verdict.
+    pub fn requires_fail_closed_verdict(&self) -> bool {
+        if self.status_reason.is_some() || self.failure_reason.is_some() {
+            return true;
+        }
+
+        let has_primary_failure = self
+            .primary_failure
+            .as_deref()
+            .is_some_and(|failure| !failure.trim().is_empty());
+
+        has_primary_failure && self.exit_code != 0
+    }
+}
+
 /// Write review session metadata to the session directory.
 ///
 /// Creates or overwrites `{session_dir}/review_meta.json`.

--- a/crates/csa-session/src/state_tests_review_tail.rs
+++ b/crates/csa-session/src/state_tests_review_tail.rs
@@ -205,3 +205,57 @@ fn review_session_meta_missing_review_iterations_defaults_to_one() {
     let decoded: ReviewSessionMeta = serde_json::from_str(json).expect("parse");
     assert_eq!(decoded.review_iterations, 1);
 }
+
+fn review_meta_with_decision(decision: &str, verdict: &str, exit_code: i32) -> ReviewSessionMeta {
+    ReviewSessionMeta {
+        session_id: "SESSION1".to_string(),
+        head_sha: "aaa".to_string(),
+        decision: decision.to_string(),
+        verdict: verdict.to_string(),
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "codex".to_string(),
+        scope: "base:main".to_string(),
+        exit_code,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+    }
+}
+
+#[test]
+fn review_session_meta_fail_closes_unavailable_nonzero_with_empty_failure_metadata() {
+    let meta = review_meta_with_decision("unavailable", "UNAVAILABLE", 1);
+
+    assert!(meta.status_reason.is_none());
+    assert!(meta.primary_failure.is_none());
+    assert!(meta.failure_reason.is_none());
+    assert!(meta.requires_fail_closed_verdict());
+}
+
+#[test]
+fn review_session_meta_fail_closes_incomplete_or_unknown_decisions() {
+    for (decision, verdict) in [
+        ("unavailable", "UNAVAILABLE"),
+        ("uncertain", "UNCERTAIN"),
+        ("not-a-real-decision", "CLEAN"),
+    ] {
+        let meta = review_meta_with_decision(decision, verdict, 0);
+
+        assert!(
+            meta.requires_fail_closed_verdict(),
+            "{decision} must fail closed"
+        );
+    }
+}
+
+#[test]
+fn review_session_meta_allows_explicit_pass_zero_exit() {
+    let meta = review_meta_with_decision("pass", "CLEAN", 0);
+
+    assert!(!meta.requires_fail_closed_verdict());
+}


### PR DESCRIPTION
## Summary

Closes the false-PASS merge-gate cluster (#1716, #1710): `csa review` could report `PASS`/`CLEAN` and synthesize an empty-CLEAN merge-gate artifact when the review did **not** genuinely succeed. A verdict-trusting orchestrator (dev2merge / pr-bot / the pre-push `review-check` hook) would then merge code that was never actually reviewed.

**Fail-closed principle:** a `PASS`/`CLEAN` artifact may be synthesized **only** when the reviewer's outcome is an explicit successful pass. Any non-pass outcome — killed reviewer, total failover-chain exhaustion, `UNAVAILABLE`, `UNCERTAIN`, error, or unknown decision — MUST fail closed (decision stays error/inconclusive/UNAVAILABLE, `--check-verdict` blocks, no `.findings.toml.synthetic` empty-CLEAN marker). **Absence of failure metadata is NOT proof of success.**

## What changed

- **`f9cd8a4a` fix(cli-sub-agent): fail closed on failed review verdicts** — the core gate. A killed reviewer (`exit_code != 0` / `primary_failure` / `status_reason`) or a totally-exhausted failover chain no longer flips to a synthetic `PASS`. `normalize_review_verdict_label` demotes `PASS`/`CLEAN` to `UNAVAILABLE` when `exit_code != 0`; the synthetic empty-CLEAN `findings.toml` marker is skipped for a failed reviewer; `--check-verdict` honors the failure signal **before** trusting any artifact.
- **`b4d9198d` refactor(csa-session): share review fail-closed predicate** — consolidated the triplicated predicate into one `ReviewSessionMeta` location in `csa-session`; removed a dead branch. (L1/L2 review cleanup.)
- **`fffe6393` fix(csa-session): fail closed on unavailable review outcome** — closes R2-001 (HIGH, found by heterogeneous review): the predicate keyed only on failure-**metadata** fields, so an `UNAVAILABLE`/`UNCERTAIN`/unknown decision with **empty** metadata still synthesized a `PASS`. Now a `PASS` artifact is allowed only on an explicit-pass outcome; every non-pass decision fails closed regardless of whether failure-metadata fields are populated.

## Tests

New regression coverage: killed-reviewer-no-synthetic-PASS, exhausted-failover-no-synthetic-PASS, `--check-verdict` honors failure signal, and R2-001 (`UNAVAILABLE` + nonzero + empty-metadata → fail closed). The explicit-PASS happy path stays green (no over-correction).

## Review

Heterogeneous tier-4 review (claude-code reviewer carrying heterogeneity; gemini OAuth monthly quota exhausted). Round 2 surfaced R2-001 (fixed in `fffe6393`); re-reviewed clean.

Closes #1716
Closes #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)
