### PR TITLE
fix(cli-sub-agent): honest severity_counts (#1696) + clean review merge-able despite quota-unavailable co-reviewer (#1657)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.820"
+version = "0.1.821"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.820"
+version = "0.1.821"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -25,6 +25,8 @@ use tracing::{debug, error, warn};
 #[path = "review_cmd_output.rs"]
 mod output;
 use output::{is_worktree_submodule, persist_review_result_exit_code};
+#[path = "review_cmd_artifact_parse.rs"]
+mod artifact_parse;
 #[path = "review_cmd_bug_class.rs"]
 mod bug_class_pipeline;
 #[path = "review_cmd_check_verdict.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_artifact_parse.rs
+++ b/crates/cli-sub-agent/src/review_cmd_artifact_parse.rs
@@ -1,0 +1,47 @@
+use anyhow::{Context, Result};
+use csa_session::{Finding, SeveritySummary};
+use serde_json::Value;
+
+#[derive(Debug)]
+pub(crate) struct LossyReviewArtifactFields {
+    pub(crate) findings: Vec<Finding>,
+    pub(crate) severity_summary: SeveritySummary,
+    pub(crate) overall_risk: Option<String>,
+}
+
+pub(crate) fn parse_review_artifact_fields_lossy(
+    content: &str,
+) -> Result<LossyReviewArtifactFields> {
+    let value: Value = serde_json::from_str(content).context("parse review artifact JSON")?;
+    let findings = value
+        .get("findings")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| serde_json::from_value::<Finding>(item.clone()).ok())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let mut severity_summary = value
+        .get("severity_summary")
+        .and_then(|summary| serde_json::from_value::<SeveritySummary>(summary.clone()).ok())
+        .unwrap_or_else(|| SeveritySummary::from_findings(&findings));
+    if severity_summary_is_zero(&severity_summary) && !findings.is_empty() {
+        severity_summary = SeveritySummary::from_findings(&findings);
+    }
+    let overall_risk = value
+        .get("overall_risk")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    Ok(LossyReviewArtifactFields {
+        findings,
+        severity_summary,
+        overall_risk,
+    })
+}
+
+fn severity_summary_is_zero(summary: &SeveritySummary) -> bool {
+    summary.critical == 0 && summary.high == 0 && summary.medium == 0 && summary.low == 0
+}

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -492,8 +492,7 @@ fn review_meta_or_artifact_is_pass(
             .with_context(|| format!("failed to read {}", verdict_path.display()))?;
         let artifact: ReviewVerdictArtifact = serde_json::from_str(&raw)
             .with_context(|| format!("failed to parse {}", verdict_path.display()))?;
-        let artifact_pass = artifact.decision == ReviewDecision::Pass
-            || verdict_token_is_pass(&artifact.verdict_legacy);
+        let artifact_pass = artifact.decision == ReviewDecision::Pass;
         debug!(
             session_id = %meta.session_id,
             meta_decision = %meta.decision,
@@ -529,9 +528,7 @@ fn review_meta_is_pass(meta: &ReviewSessionMeta) -> bool {
         return false;
     }
 
-    ReviewDecision::from_str(&meta.decision).is_ok_and(|decision| {
-        decision == ReviewDecision::Pass || verdict_token_is_pass(&meta.verdict)
-    }) || verdict_token_is_pass(&meta.verdict)
+    ReviewDecision::from_str(&meta.decision).is_ok_and(|decision| decision == ReviewDecision::Pass)
 }
 
 fn verdict_token_is_pass(verdict: &str) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::str::FromStr;
@@ -5,8 +6,8 @@ use std::str::FromStr;
 use crate::cli::ReviewArgs;
 use anyhow::{Context, Result};
 use csa_core::types::ReviewDecision;
-use csa_session::ReviewVerdictArtifact;
 use csa_session::state::{MetaSessionState, ReviewSessionMeta};
+use csa_session::{ReviewVerdictArtifact, Severity};
 use tracing::debug;
 
 const REQUIRED_FULL_DIFF_SCOPE: &str = "range:main...HEAD";
@@ -16,6 +17,7 @@ pub(crate) struct ReviewVerdictMatch {
     pub session_id: String,
     pub scope: String,
     pub head_sha: String,
+    pub severity_counts: BTreeMap<Severity, u32>,
 }
 
 pub(crate) fn handle_check_verdict(project_root: &Path, args: &ReviewArgs) -> Result<i32> {
@@ -56,13 +58,8 @@ pub(crate) fn handle_check_verdict(project_root: &Path, args: &ReviewArgs) -> Re
 
     match verdict_match {
         Ok(Some(found)) => {
-            println!(
-                "Review verdict check passed: session {} has PASS/CLEAN for {} at {} ({})",
-                found.session_id,
-                branch,
-                short_sha(&found.head_sha),
-                found.scope
-            );
+            let message = format_review_verdict_pass_message(&found, &branch);
+            println!("{message}");
             Ok(0)
         }
         Ok(None) => {
@@ -141,7 +138,8 @@ pub(crate) fn check_review_verdict_for_session(
         return Ok(None);
     }
 
-    if !review_meta_or_artifact_is_pass(&session_dir, &meta)? {
+    let pass_status = review_meta_or_artifact_is_pass(&session_dir, &meta)?;
+    if !pass_status.is_pass {
         debug!(
             session_id = %resolved.session_id,
             decision = %meta.decision,
@@ -155,6 +153,7 @@ pub(crate) fn check_review_verdict_for_session(
         session_id: meta.session_id,
         scope: meta.scope,
         head_sha: meta.head_sha,
+        severity_counts: pass_status.severity_counts,
     }))
 }
 
@@ -239,8 +238,8 @@ pub(crate) fn check_review_verdict_for_target(
             );
             continue;
         }
-        let is_pass = review_meta_or_artifact_is_pass(&session_dir, &meta)?;
-        if !is_pass {
+        let pass_status = review_meta_or_artifact_is_pass(&session_dir, &meta)?;
+        if !pass_status.is_pass {
             debug!(
                 session_id = %session.meta_session_id,
                 decision = %meta.decision,
@@ -254,7 +253,7 @@ pub(crate) fn check_review_verdict_for_target(
             scope = %meta.scope,
             head_sha = %meta.head_sha,
             timestamp = %meta.timestamp,
-            is_pass,
+            is_pass = pass_status.is_pass,
             "Found matching review verdict candidate"
         );
         candidates.push(ReviewVerdictCandidate {
@@ -262,7 +261,8 @@ pub(crate) fn check_review_verdict_for_target(
             scope: meta.scope,
             head_sha: meta.head_sha,
             timestamp: meta.timestamp,
-            is_pass,
+            is_pass: pass_status.is_pass,
+            severity_counts: pass_status.severity_counts,
         });
     }
 
@@ -291,6 +291,7 @@ pub(crate) fn check_review_verdict_for_target(
         session_id: latest.session_id,
         scope: latest.scope,
         head_sha: latest.head_sha,
+        severity_counts: latest.severity_counts,
     }))
 }
 
@@ -374,7 +375,8 @@ fn check_review_verdict_marker(
         );
         return Ok(None);
     }
-    if !review_meta_or_artifact_is_pass(&session_dir, &meta)? {
+    let pass_status = review_meta_or_artifact_is_pass(&session_dir, &meta)?;
+    if !pass_status.is_pass {
         debug!(
             session_id = %marker.session_id,
             decision = %meta.decision,
@@ -394,6 +396,7 @@ fn check_review_verdict_marker(
         session_id: meta.session_id,
         scope: meta.scope,
         head_sha: meta.head_sha,
+        severity_counts: pass_status.severity_counts,
     }))
 }
 
@@ -412,6 +415,7 @@ struct ReviewVerdictCandidate {
     head_sha: String,
     timestamp: chrono::DateTime<chrono::Utc>,
     is_pass: bool,
+    severity_counts: BTreeMap<Severity, u32>,
 }
 
 fn session_branch(session: &MetaSessionState) -> Option<&str> {
@@ -457,7 +461,15 @@ fn diff_fingerprint_matches(
         .unwrap_or(true)
 }
 
-fn review_meta_or_artifact_is_pass(session_dir: &Path, meta: &ReviewSessionMeta) -> Result<bool> {
+struct ReviewVerdictPassStatus {
+    is_pass: bool,
+    severity_counts: BTreeMap<Severity, u32>,
+}
+
+fn review_meta_or_artifact_is_pass(
+    session_dir: &Path,
+    meta: &ReviewSessionMeta,
+) -> Result<ReviewVerdictPassStatus> {
     if meta.requires_fail_closed_verdict() {
         debug!(
             session_id = %meta.session_id,
@@ -467,7 +479,10 @@ fn review_meta_or_artifact_is_pass(session_dir: &Path, meta: &ReviewSessionMeta)
             primary_failure = meta.primary_failure.as_deref().unwrap_or(""),
             "Rejecting review verdict because review metadata records reviewer failure"
         );
-        return Ok(false);
+        return Ok(ReviewVerdictPassStatus {
+            is_pass: false,
+            severity_counts: zero_severity_counts(),
+        });
     }
 
     let meta_pass = review_meta_is_pass(meta);
@@ -490,7 +505,10 @@ fn review_meta_or_artifact_is_pass(session_dir: &Path, meta: &ReviewSessionMeta)
             verdict_path = %verdict_path.display(),
             "Read review verdict artifact"
         );
-        return Ok(artifact_pass);
+        return Ok(ReviewVerdictPassStatus {
+            is_pass: artifact_pass,
+            severity_counts: artifact.severity_counts,
+        });
     }
 
     debug!(
@@ -500,7 +518,10 @@ fn review_meta_or_artifact_is_pass(session_dir: &Path, meta: &ReviewSessionMeta)
         meta_pass,
         "Using review_meta.json verdict"
     );
-    Ok(meta_pass)
+    Ok(ReviewVerdictPassStatus {
+        is_pass: meta_pass,
+        severity_counts: zero_severity_counts(),
+    })
 }
 
 fn review_meta_is_pass(meta: &ReviewSessionMeta) -> bool {
@@ -522,6 +543,49 @@ fn verdict_token_is_pass(verdict: &str) -> bool {
 
 fn short_sha(sha: &str) -> &str {
     sha.get(..sha.len().min(11)).unwrap_or(sha)
+}
+
+fn format_review_verdict_pass_message(found: &ReviewVerdictMatch, branch: &str) -> String {
+    format!(
+        "Review verdict check passed{}: session {} has PASS/CLEAN for {} at {} ({})",
+        format_nonblocking_counts_suffix(&found.severity_counts),
+        found.session_id,
+        branch,
+        short_sha(&found.head_sha),
+        found.scope
+    )
+}
+
+fn format_nonblocking_counts_suffix(counts: &BTreeMap<Severity, u32>) -> String {
+    let parts = [
+        (Severity::Critical, "critical"),
+        (Severity::High, "high"),
+        (Severity::Medium, "medium"),
+        (Severity::Low, "low"),
+    ]
+    .into_iter()
+    .filter_map(|(severity, label)| {
+        let count = *counts.get(&severity).unwrap_or(&0);
+        (count > 0).then(|| format!("{count} {label}"))
+    })
+    .collect::<Vec<_>>();
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" (non-blocking findings: {})", parts.join(", "))
+    }
+}
+
+fn zero_severity_counts() -> BTreeMap<Severity, u32> {
+    [
+        (Severity::Critical, 0),
+        (Severity::High, 0),
+        (Severity::Medium, 0),
+        (Severity::Low, 0),
+    ]
+    .into_iter()
+    .collect()
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_tests.rs
@@ -4,6 +4,7 @@ use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use chrono::{TimeZone, Utc};
 use clap::Parser;
 use csa_core::vcs::{VcsIdentity, VcsKind};
+use csa_session::Finding;
 use std::process::Command;
 use tempfile::TempDir;
 
@@ -112,6 +113,50 @@ fn write_review_session_with_description(
     session.meta_session_id
 }
 
+fn write_review_session_with_findings(
+    project_root: &Path,
+    branch: &str,
+    head_sha: &str,
+    scope: &str,
+    decision: ReviewDecision,
+    legacy_verdict: &str,
+    findings: &[Finding],
+) -> String {
+    let session_id = write_review_session(
+        project_root,
+        branch,
+        head_sha,
+        scope,
+        decision,
+        legacy_verdict,
+    );
+    let session_dir = csa_session::get_session_dir(project_root, &session_id).unwrap();
+    csa_session::write_review_verdict(
+        &session_dir,
+        &ReviewVerdictArtifact::from_parts(
+            session_id.clone(),
+            decision,
+            legacy_verdict,
+            findings,
+            Vec::new(),
+        ),
+    )
+    .expect("write review verdict with findings");
+    session_id
+}
+
+fn finding_with_severity(severity: Severity, fid: &str) -> Finding {
+    Finding {
+        severity,
+        fid: fid.to_string(),
+        file: "src/lib.rs".to_string(),
+        line: Some(7),
+        rule_id: format!("rule.review.{fid}"),
+        summary: "review finding".to_string(),
+        engine: "reviewer".to_string(),
+    }
+}
+
 fn set_task_type(project_root: &Path, session_id: &str, task_type: &str) {
     let mut session = csa_session::load_session(project_root, session_id).expect("load session");
     session.task_context.task_type = Some(task_type.to_string());
@@ -214,6 +259,59 @@ fn check_verdict_finds_pass_for_current_branch_head_and_full_diff() {
     .unwrap()
     .expect("expected matching verdict");
     assert_eq!(found.session_id, session_id);
+}
+
+#[test]
+fn issue_1696_check_verdict_pass_message_surfaces_nonblocking_counts() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let temp = setup_git_repo();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    run_git(temp.path(), &["checkout", "-b", "feature"]);
+    let branch = run_git(temp.path(), &["branch", "--show-current"]);
+    let head_sha = csa_session::detect_git_head(temp.path()).unwrap();
+    let findings = vec![
+        finding_with_severity(Severity::Medium, "FID-MEDIUM"),
+        finding_with_severity(Severity::Low, "FID-LOW-1"),
+        finding_with_severity(Severity::Low, "FID-LOW-2"),
+        finding_with_severity(Severity::Low, "FID-LOW-3"),
+    ];
+    let session_id = write_review_session_with_findings(
+        temp.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        ReviewDecision::Pass,
+        "CLEAN",
+        &findings,
+    );
+
+    let found = check_review_verdict_for_target(
+        temp.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        None,
+    )
+    .unwrap()
+    .expect("expected matching verdict");
+    assert_eq!(found.session_id, session_id);
+    assert_eq!(found.severity_counts.get(&Severity::Medium), Some(&1));
+    assert_eq!(found.severity_counts.get(&Severity::Low), Some(&3));
+
+    let message = format_review_verdict_pass_message(&found, &branch);
+    assert!(
+        message.contains("PASS/CLEAN"),
+        "pass verdict must remain visible: {message}"
+    );
+    assert!(
+        message.contains("non-blocking findings: 1 medium, 3 low"),
+        "non-blocking findings must be surfaced: {message}"
+    );
+
+    let args = parse_review_args(&["csa", "review", "--check-verdict"]);
+    let exit = handle_check_verdict(temp.path(), &args).unwrap();
+    assert_eq!(exit, 0);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_tests.rs
@@ -587,6 +587,8 @@ fn check_verdict_rejects_non_pass_artifact_even_when_meta_is_pass() {
     for (decision, legacy_verdict) in [
         (ReviewDecision::Fail, "HAS_ISSUES"),
         (ReviewDecision::Uncertain, "UNCERTAIN"),
+        (ReviewDecision::Uncertain, "UNAVAILABLE"),
+        (ReviewDecision::Uncertain, "CLEAN"),
         (ReviewDecision::Skip, "SKIP"),
         (ReviewDecision::Unavailable, "UNAVAILABLE"),
     ] {

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -292,7 +292,7 @@ fn consensus_response_from_outcome(outcome: &ReviewerOutcome) -> AgentResponse {
         ),
         content: outcome.verdict.to_string(),
         weight: 1.0,
-        timed_out: outcome.verdict == UNAVAILABLE,
+        timed_out: !outcome.produced_usable_verdict(),
     }
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -49,11 +49,11 @@ pub(super) use sections::{
 pub(super) use summary_artifact::{
     ensure_review_summary_artifact, is_edit_restriction_summary, truncate_review_result_summary,
 };
-pub(super) use text::extract_review_text;
 use text::{
     derive_decision_from_text, parse_overall_risk_from_text, severity_counts_from_text,
     zero_severity_counts,
 };
+pub(super) use text::{extract_review_text, stream_started_without_terminal_event};
 
 const REVIEW_RESULT_SUMMARY_MAX_CHARS: usize = 200;
 const EDIT_RESTRICTION_SUMMARY_PREFIX: &str = "Edit restriction violated:";

--- a/crates/cli-sub-agent/src/review_cmd_output_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_artifacts.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use tracing::warn;
 
 use crate::bug_class::{CONSOLIDATED_REVIEW_ARTIFACT_FILE, SINGLE_REVIEW_ARTIFACT_FILE};
+use crate::review_cmd::artifact_parse::parse_review_artifact_fields_lossy;
 
 #[derive(Debug, Deserialize)]
 pub(super) struct PersistedReviewArtifact {
@@ -36,6 +37,18 @@ pub(super) fn load_review_artifact_from_output(
     match serde_json::from_str::<PersistedReviewArtifact>(&contents) {
         Ok(artifact) => Ok(Some(artifact)),
         Err(error) => {
+            if let Ok(fields) = parse_review_artifact_fields_lossy(&contents) {
+                warn!(
+                    path = %findings_path.display(),
+                    error = %error,
+                    "Parsed review artifact JSON lossily; ignored findings with unsupported severities"
+                );
+                return Ok(Some(PersistedReviewArtifact {
+                    findings: fields.findings,
+                    severity_summary: fields.severity_summary,
+                    overall_risk: fields.overall_risk,
+                }));
+            }
             warn!(
                 path = %findings_path.display(),
                 error = %error,

--- a/crates/cli-sub-agent/src/review_cmd_output_diagnostics.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_diagnostics.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::review_consensus::{CLEAN, HAS_ISSUES};
 
 #[derive(Debug, Clone)]
 pub(in crate::review_cmd) struct ReviewerOutcome {
@@ -9,6 +10,12 @@ pub(in crate::review_cmd) struct ReviewerOutcome {
     pub exit_code: i32,
     pub verdict: &'static str,
     pub diagnostic: Option<String>,
+}
+
+impl ReviewerOutcome {
+    pub(in crate::review_cmd) fn produced_usable_verdict(&self) -> bool {
+        matches!(self.verdict, CLEAN | HAS_ISSUES)
+    }
 }
 
 pub(in crate::review_cmd) fn print_reviewer_outcomes(outcomes: &[ReviewerOutcome]) {

--- a/crates/cli-sub-agent/src/review_cmd_output_text.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_text.rs
@@ -66,6 +66,72 @@ pub(in crate::review_cmd) fn extract_review_text(raw_output: &str) -> Option<Str
     transcript_messages.pop()
 }
 
+/// Minimal stream-event view used to detect turn completion without depending on the shape
+/// of unrelated event payloads. Reading only `type` (serde ignores all other fields) keeps
+/// detection robust against schema drift in `result`/`item`/`usage` bodies.
+#[derive(Debug, Deserialize)]
+struct StreamEventType {
+    #[serde(rename = "type")]
+    event_type: String,
+}
+
+/// Terminal stream events marking a reviewer turn that finished normally. claude-code
+/// (`--output-format stream-json`) emits a final `{"type":"result",...}`; codex emits
+/// `{"type":"turn.completed",...}`. Their presence proves the turn ran to completion,
+/// independent of the verdict it reached.
+const STREAM_TERMINAL_EVENT_TYPES: &[&str] = &["result", "turn.completed"];
+
+/// Event types that positively identify a JSON streaming transcript (claude-code / codex).
+/// Used to keep [`stream_started_without_terminal_event`] from misclassifying non-streaming
+/// output (gemini-cli / opencode plain text, rate-limit event blobs) as an incomplete stream.
+const STREAM_EVENT_TYPES: &[&str] = &[
+    // claude-code stream-json
+    "system",
+    "assistant",
+    "user",
+    "stream_event",
+    "result",
+    // codex event stream
+    "thread.started",
+    "turn.started",
+    "turn.completed",
+    "turn.failed",
+    "item.started",
+    "item.completed",
+];
+
+/// Whether a reviewer's streamed transcript began but never reached a terminal completion
+/// event — the signature of a process killed/timed-out mid-turn (OOM, SIGKILL, no-progress
+/// watchdog). Such a transcript's verdict tokens are unreliable: they are frequently scraped
+/// from the *reviewed code* (which itself contains `CLEAN`/`HAS_ISSUES`/`UNAVAILABLE` literals)
+/// rather than emitted as a deliberate verdict, so fail-closing them to `HAS_ISSUES` mislabels
+/// an infrastructure failure as a blocking review (#1657). Callers combine this with a non-zero
+/// exit code before reclassifying the reviewer as unavailable.
+///
+/// Conservative by construction: returns `false` unless the output is *recognized* as a
+/// claude-code/codex JSON stream (so plain-text gemini-cli/opencode output is never flagged),
+/// and `false` as soon as any terminal event is seen (so a completed reviewer that merely
+/// exits non-zero is never flagged).
+pub(in crate::review_cmd) fn stream_started_without_terminal_event(raw_output: &str) -> bool {
+    let mut saw_stream_event = false;
+    for line in raw_output.lines() {
+        let line = line.trim();
+        if !line.starts_with('{') {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<StreamEventType>(line) else {
+            continue;
+        };
+        if STREAM_TERMINAL_EVENT_TYPES.contains(&event.event_type.as_str()) {
+            return false;
+        }
+        if STREAM_EVENT_TYPES.contains(&event.event_type.as_str()) {
+            saw_stream_event = true;
+        }
+    }
+    saw_stream_event
+}
+
 fn looks_like_review_message(text: &str) -> bool {
     super::has_structured_review_content(text)
         || contains_verdict_token(text, "PASS")

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -15,6 +15,7 @@ use csa_session::{
 };
 use serde::Deserialize;
 
+use crate::review_cmd::artifact_parse::parse_review_artifact_fields_lossy;
 use crate::review_consensus::{
     CLEAN, HAS_ISSUES, SKIP, UNAVAILABLE, build_consolidated_artifact, write_consolidated_artifact,
 };
@@ -69,6 +70,22 @@ struct ReviewerFindingsContractArtifact {
 fn parse_reviewer_artifact(path: &Path, content: &str) -> Result<ReviewArtifact> {
     if let Ok(artifact) = serde_json::from_str::<ReviewArtifact>(content) {
         return Ok(artifact);
+    }
+
+    if let Ok(fields) = parse_review_artifact_fields_lossy(content) {
+        return Ok(ReviewArtifact {
+            severity_summary: fields.severity_summary,
+            findings: fields.findings,
+            review_mode: None,
+            schema_version: "1.0".to_string(),
+            session_id: path
+                .parent()
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                .unwrap_or("unknown-reviewer")
+                .to_string(),
+            timestamp: chrono::Utc::now(),
+        });
     }
 
     let contract: ReviewerFindingsContractArtifact = serde_json::from_str(content)
@@ -179,7 +196,7 @@ pub(super) fn write_multi_reviewer_parent_artifacts(
     write_parent_review_verdict(
         &session_dir,
         &session_id,
-        &parent_artifact,
+        &consolidated.findings,
         parent_decision,
         &parent_verdict,
     )?;
@@ -271,7 +288,7 @@ pub(super) fn write_standalone_consensus_review_artifacts(
         target.session_id.clone(),
         decision,
         verdict,
-        &artifact.findings,
+        &consolidated.findings,
         Vec::new(),
     );
     write_review_verdict(&session_dir, &verdict_artifact)
@@ -392,7 +409,7 @@ fn review_artifact_finding_to_findings_toml(finding: &Finding) -> ReviewFinding 
 fn write_parent_review_verdict(
     session_dir: &Path,
     session_id: &str,
-    artifact: &ReviewArtifact,
+    severity_count_findings: &[Finding],
     decision: ReviewDecision,
     verdict_legacy: &str,
 ) -> Result<()> {
@@ -400,7 +417,7 @@ fn write_parent_review_verdict(
         session_id.to_string(),
         decision,
         verdict_legacy.to_string(),
-        &artifact.findings,
+        severity_count_findings,
         Vec::new(),
     );
     write_review_verdict(session_dir, &verdict)

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -173,7 +173,7 @@ pub(super) fn write_multi_reviewer_parent_artifacts(
     reviewers: usize,
     outcomes: &[ReviewerOutcome],
     final_verdict: &str,
-    all_reviewers_unavailable: bool,
+    _all_reviewers_unavailable: bool,
     parent_review_meta: Option<&ReviewSessionMeta>,
 ) -> Result<()> {
     let Some((session_dir, session_id)) = resolve_parent_session_env() else {
@@ -186,7 +186,7 @@ pub(super) fn write_multi_reviewer_parent_artifacts(
     let parent_decision = parent_review_decision(
         &consolidated,
         final_verdict,
-        all_reviewers_unavailable,
+        outcomes,
         dissent_findings_persisted,
     );
     let parent_verdict = parent_legacy_verdict(parent_decision, final_verdict);
@@ -258,7 +258,7 @@ pub(super) fn write_standalone_consensus_review_artifacts(
     let decision = parent_review_decision(
         &consolidated,
         ctx.final_verdict,
-        ctx.all_reviewers_unavailable,
+        ctx.outcomes,
         dissent_findings_persisted,
     );
     let verdict = parent_legacy_verdict(decision, ctx.final_verdict);
@@ -451,11 +451,15 @@ fn parent_artifact_for_decision(
 fn parent_review_decision(
     artifact: &ReviewArtifact,
     final_verdict: &str,
-    all_reviewers_unavailable: bool,
+    outcomes: &[ReviewerOutcome],
     dissent_findings_persisted: bool,
 ) -> ReviewDecision {
-    if all_reviewers_unavailable {
-        return ReviewDecision::Unavailable;
+    let produced_decision = review_decision_from_produced_outcomes(outcomes);
+    let Some(produced_decision) = produced_decision else {
+        return ReviewDecision::Fail;
+    };
+    if produced_decision == ReviewDecision::Fail {
+        return ReviewDecision::Fail;
     }
     let consensus_decision =
         ReviewDecision::from_str(final_verdict).unwrap_or(ReviewDecision::Uncertain);
@@ -496,6 +500,20 @@ fn parent_review_decision(
         return ReviewDecision::Pass;
     }
     consensus_decision
+}
+
+fn review_decision_from_produced_outcomes(outcomes: &[ReviewerOutcome]) -> Option<ReviewDecision> {
+    let mut saw_produced = false;
+    for outcome in outcomes
+        .iter()
+        .filter(|outcome| outcome.produced_usable_verdict())
+    {
+        saw_produced = true;
+        if outcome.verdict == HAS_ISSUES {
+            return Some(ReviewDecision::Fail);
+        }
+    }
+    saw_produced.then_some(ReviewDecision::Pass)
 }
 
 fn is_blocking_severity(severity: &Severity) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -173,7 +173,7 @@ pub(super) fn write_multi_reviewer_parent_artifacts(
     reviewers: usize,
     outcomes: &[ReviewerOutcome],
     final_verdict: &str,
-    _all_reviewers_unavailable: bool,
+    all_reviewers_unavailable: bool,
     parent_review_meta: Option<&ReviewSessionMeta>,
 ) -> Result<()> {
     let Some((session_dir, session_id)) = resolve_parent_session_env() else {
@@ -187,6 +187,7 @@ pub(super) fn write_multi_reviewer_parent_artifacts(
         &consolidated,
         final_verdict,
         outcomes,
+        all_reviewers_unavailable,
         dissent_findings_persisted,
     );
     let parent_verdict = parent_legacy_verdict(parent_decision, final_verdict);
@@ -259,6 +260,7 @@ pub(super) fn write_standalone_consensus_review_artifacts(
         &consolidated,
         ctx.final_verdict,
         ctx.outcomes,
+        ctx.all_reviewers_unavailable,
         dissent_findings_persisted,
     );
     let verdict = parent_legacy_verdict(decision, ctx.final_verdict);
@@ -452,10 +454,14 @@ fn parent_review_decision(
     artifact: &ReviewArtifact,
     final_verdict: &str,
     outcomes: &[ReviewerOutcome],
+    all_reviewers_unavailable: bool,
     dissent_findings_persisted: bool,
 ) -> ReviewDecision {
     let produced_decision = review_decision_from_produced_outcomes(outcomes);
     let Some(produced_decision) = produced_decision else {
+        if all_reviewers_unavailable {
+            return ReviewDecision::Uncertain;
+        }
         return ReviewDecision::Fail;
     };
     if produced_decision == ReviewDecision::Fail {

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -460,7 +460,7 @@ fn parent_review_decision(
     let produced_decision = review_decision_from_produced_outcomes(outcomes);
     let Some(produced_decision) = produced_decision else {
         if all_reviewers_unavailable {
-            return ReviewDecision::Uncertain;
+            return ReviewDecision::Unavailable;
         }
         return ReviewDecision::Fail;
     };

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
@@ -172,7 +172,7 @@ fn issue_1657_unavailable_reviewer_plus_blocking_reviewer_fails() {
 }
 
 #[test]
-fn issue_1657_all_unavailable_reviewers_fail_closed() {
+fn issue_1657_all_unavailable_reviewers_are_uncertain_and_fail_closed() {
     let outcomes = vec![
         reviewer_outcome(0, ToolName::GeminiCli, UNAVAILABLE, Some("quota exhausted")),
         reviewer_outcome(1, ToolName::Codex, UNAVAILABLE, Some("tool unavailable")),
@@ -180,8 +180,11 @@ fn issue_1657_all_unavailable_reviewers_fail_closed() {
 
     let verdict = parent_verdict_for_outcomes(&outcomes, UNAVAILABLE, true);
 
-    assert_eq!(verdict.decision, ReviewDecision::Fail);
-    assert_eq!(verdict.verdict_legacy, crate::review_consensus::HAS_ISSUES);
+    assert_eq!(verdict.decision, ReviewDecision::Uncertain);
+    assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_ne!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, UNAVAILABLE);
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
 }
 
 #[test]
@@ -841,6 +844,7 @@ fn parent_review_decision_fails_closed_on_unbacked_has_issues_consensus() {
             &empty,
             crate::review_consensus::HAS_ISSUES,
             &fail_outcomes,
+            false,
             false
         ),
         ReviewDecision::Fail,
@@ -851,13 +855,20 @@ fn parent_review_decision_fails_closed_on_unbacked_has_issues_consensus() {
             &empty,
             crate::review_consensus::CLEAN,
             &clean_outcomes,
+            false,
             false
         ),
         ReviewDecision::Pass,
         "a clean consensus with no artifacts must not fail-closed"
     );
     assert_eq!(
-        parent_review_decision(&empty, crate::review_consensus::HAS_ISSUES, &[], true),
+        parent_review_decision(
+            &empty,
+            crate::review_consensus::HAS_ISSUES,
+            &[],
+            false,
+            true
+        ),
         ReviewDecision::Fail,
         "empty produced set must fail-closed"
     );
@@ -1127,8 +1138,11 @@ fn write_multi_reviewer_parent_artifacts_marks_all_unavailable() {
             .expect("review-verdict.json should exist"),
     )
     .expect("review verdict should parse");
-    assert_eq!(verdict.decision, ReviewDecision::Fail);
-    assert_eq!(verdict.verdict_legacy, crate::review_consensus::HAS_ISSUES);
+    assert_eq!(verdict.decision, ReviewDecision::Uncertain);
+    assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_ne!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, UNAVAILABLE);
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
 }
 
 #[test]
@@ -1273,6 +1287,7 @@ proptest! {
             &consolidated,
             crate::review_consensus::CLEAN,
             &outcomes,
+            states.iter().all(|state| matches!(state, ReviewerState::Unavailable)),
             true,
         );
         let parent_artifact = parent_artifact_for_decision(&consolidated, decision);
@@ -1290,7 +1305,7 @@ proptest! {
             );
         }
         if states.iter().all(|state| matches!(state, ReviewerState::Unavailable)) {
-            prop_assert_eq!(decision, ReviewDecision::Fail);
+            prop_assert_eq!(decision, ReviewDecision::Uncertain);
         } else if expected_blocking_ids.is_empty() {
             prop_assert!(
                 decision != ReviewDecision::Fail,

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
@@ -172,7 +172,7 @@ fn issue_1657_unavailable_reviewer_plus_blocking_reviewer_fails() {
 }
 
 #[test]
-fn issue_1657_all_unavailable_reviewers_are_uncertain_and_fail_closed() {
+fn issue_1657_all_unavailable_reviewers_are_unavailable_and_fail_closed() {
     let outcomes = vec![
         reviewer_outcome(0, ToolName::GeminiCli, UNAVAILABLE, Some("quota exhausted")),
         reviewer_outcome(1, ToolName::Codex, UNAVAILABLE, Some("tool unavailable")),
@@ -180,9 +180,14 @@ fn issue_1657_all_unavailable_reviewers_are_uncertain_and_fail_closed() {
 
     let verdict = parent_verdict_for_outcomes(&outcomes, UNAVAILABLE, true);
 
-    assert_eq!(verdict.decision, ReviewDecision::Uncertain);
+    assert_eq!(verdict.decision, ReviewDecision::Unavailable);
     assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_ne!(verdict.decision, ReviewDecision::Uncertain);
     assert_ne!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(
+        crate::verdict_exit_code::exit_code_from_review_decision(verdict.decision),
+        1
+    );
     assert_eq!(verdict.verdict_legacy, UNAVAILABLE);
     assert!(verdict.severity_counts.values().all(|count| *count == 0));
 }
@@ -1130,19 +1135,57 @@ fn write_multi_reviewer_parent_artifacts_marks_all_unavailable() {
         diagnostic: Some("reviewer timed out after 1800s".to_string()),
     }];
 
-    write_multi_reviewer_parent_artifacts(temp.path(), 1, &outcomes, UNAVAILABLE, true, None)
-        .expect("parent artifacts should be produced");
+    let parent_meta = csa_session::state::ReviewSessionMeta {
+        session_id: "01PARENTSESSION000000000000".to_string(),
+        head_sha: "abcdef1234567890".to_string(),
+        decision: ReviewDecision::Uncertain.as_str().to_string(),
+        verdict: UNAVAILABLE.to_string(),
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "consensus".to_string(),
+        scope: "range:main...HEAD".to_string(),
+        exit_code: 1,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: Some("sha256:test".to_string()),
+    };
+
+    write_multi_reviewer_parent_artifacts(
+        temp.path(),
+        1,
+        &outcomes,
+        UNAVAILABLE,
+        true,
+        Some(&parent_meta),
+    )
+    .expect("parent artifacts should be produced");
 
     let verdict: ReviewVerdictArtifact = serde_json::from_str(
         &fs::read_to_string(temp.path().join("output").join("review-verdict.json"))
             .expect("review-verdict.json should exist"),
     )
     .expect("review verdict should parse");
-    assert_eq!(verdict.decision, ReviewDecision::Uncertain);
+    assert_eq!(verdict.decision, ReviewDecision::Unavailable);
     assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_ne!(verdict.decision, ReviewDecision::Uncertain);
     assert_ne!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(
+        crate::verdict_exit_code::exit_code_from_review_decision(verdict.decision),
+        1
+    );
     assert_eq!(verdict.verdict_legacy, UNAVAILABLE);
     assert!(verdict.severity_counts.values().all(|count| *count == 0));
+
+    let written_meta: csa_session::state::ReviewSessionMeta =
+        serde_json::from_str(&fs::read_to_string(temp.path().join("review_meta.json")).unwrap())
+            .expect("review meta should parse");
+    assert_eq!(written_meta.decision, ReviewDecision::Unavailable.as_str());
+    assert_eq!(written_meta.verdict, UNAVAILABLE);
+    assert_eq!(written_meta.exit_code, 1);
 }
 
 #[test]
@@ -1305,7 +1348,7 @@ proptest! {
             );
         }
         if states.iter().all(|state| matches!(state, ReviewerState::Unavailable)) {
-            prop_assert_eq!(decision, ReviewDecision::Uncertain);
+            prop_assert_eq!(decision, ReviewDecision::Unavailable);
         } else if expected_blocking_ids.is_empty() {
             prop_assert!(
                 decision != ReviewDecision::Fail,

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
@@ -1,7 +1,8 @@
 use super::{
     MultiReviewerConsensusArtifacts, clear_multi_reviewer_artifact_dirs,
     parent_artifact_for_decision, parent_consensus_review_meta, parent_review_decision,
-    write_multi_reviewer_consensus_artifacts, write_multi_reviewer_parent_artifacts,
+    parse_reviewer_artifact, write_multi_reviewer_consensus_artifacts,
+    write_multi_reviewer_parent_artifacts, write_parent_review_verdict,
     write_standalone_consensus_review_artifacts,
 };
 use crate::review_consensus::UNAVAILABLE;
@@ -35,6 +36,19 @@ fn blocking_finding(fid: impl Into<String>) -> Finding {
     }
 }
 
+fn finding_with_severity(severity: Severity, fid: impl Into<String>) -> Finding {
+    let fid = fid.into();
+    Finding {
+        severity,
+        fid: fid.clone(),
+        file: "src/lib.rs".to_string(),
+        line: Some(7),
+        rule_id: format!("rule.review.{fid}"),
+        summary: "review finding".to_string(),
+        engine: "reviewer".to_string(),
+    }
+}
+
 fn write_parent_reviewer_artifact(
     session_dir: &std::path::Path,
     reviewer_index: usize,
@@ -56,6 +70,123 @@ fn write_parent_reviewer_artifact(
         serde_json::to_vec_pretty(&artifact).expect("artifact should serialize"),
     )
     .expect("review artifact should be written");
+}
+
+#[test]
+fn issue_1696_parent_verdict_counts_all_reviewer_findings_when_decision_passes() {
+    let temp = tempdir().expect("tempdir should be created");
+    let findings = vec![
+        finding_with_severity(Severity::Medium, "FID-MEDIUM"),
+        finding_with_severity(Severity::Low, "FID-LOW-1"),
+        finding_with_severity(Severity::Low, "FID-LOW-2"),
+        finding_with_severity(Severity::Low, "FID-LOW-3"),
+    ];
+    let consolidated = ReviewArtifact {
+        severity_summary: SeveritySummary::from_findings(&findings),
+        findings,
+        review_mode: Some("diff".to_string()),
+        schema_version: "1.0".to_string(),
+        session_id: "01PARENTSESSION000000000000".to_string(),
+        timestamp: chrono::Utc::now(),
+    };
+    let decision = ReviewDecision::Pass;
+    let parent_artifact = parent_artifact_for_decision(&consolidated, decision);
+
+    write_parent_review_verdict(
+        temp.path(),
+        "01PARENTSESSION000000000000",
+        &consolidated.findings,
+        decision,
+        crate::review_consensus::CLEAN,
+    )
+    .expect("parent review verdict should be written");
+
+    let verdict_path = temp.path().join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_slice(&fs::read(verdict_path).expect("read review verdict"))
+            .expect("review verdict should parse");
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, crate::review_consensus::CLEAN);
+    assert_eq!(artifact.severity_counts.get(&Severity::Medium), Some(&1));
+    assert_eq!(artifact.severity_counts.get(&Severity::Low), Some(&3));
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&0));
+    assert_eq!(artifact.severity_counts.get(&Severity::Critical), Some(&0));
+    assert_eq!(
+        parent_artifact.findings.len(),
+        3,
+        "the parent artifact may stay filtered while verdict counts remain descriptive"
+    );
+}
+
+#[test]
+fn issue_1696_reviewer_artifact_ignores_info_without_dropping_countable_findings() {
+    let temp = tempdir().expect("tempdir should be created");
+    let reviewer_dir = temp.path().join("reviewer-3");
+    fs::create_dir_all(&reviewer_dir).expect("reviewer dir should be created");
+    let artifact_path = reviewer_dir.join("review-findings.json");
+    let content = r#"{
+        "findings": [
+            {
+                "severity": "medium",
+                "fid": "FID-MEDIUM",
+                "file": "src/lib.rs",
+                "line": 7,
+                "rule_id": "rule.review.medium",
+                "summary": "medium finding",
+                "engine": "reviewer"
+            },
+            {
+                "severity": "low",
+                "fid": "FID-LOW-1",
+                "file": "src/lib.rs",
+                "line": 8,
+                "rule_id": "rule.review.low1",
+                "summary": "low finding",
+                "engine": "reviewer"
+            },
+            {
+                "severity": "low",
+                "fid": "FID-LOW-2",
+                "file": "src/lib.rs",
+                "line": 9,
+                "rule_id": "rule.review.low2",
+                "summary": "low finding",
+                "engine": "reviewer"
+            },
+            {
+                "severity": "low",
+                "fid": "FID-LOW-3",
+                "file": "src/lib.rs",
+                "line": 10,
+                "rule_id": "rule.review.low3",
+                "summary": "low finding",
+                "engine": "reviewer"
+            },
+            {
+                "severity": "info",
+                "fid": "FID-INFO",
+                "file": "src/lib.rs",
+                "line": 11,
+                "rule_id": "rule.review.info",
+                "summary": "informational note",
+                "engine": "reviewer"
+            }
+        ],
+        "severity_summary": {
+            "critical": 0,
+            "high": 0,
+            "medium": 1,
+            "low": 3
+        }
+    }"#;
+
+    let artifact =
+        parse_reviewer_artifact(&artifact_path, content).expect("reviewer artifact should parse");
+    assert_eq!(artifact.findings.len(), 4);
+    assert_eq!(artifact.severity_summary.medium, 1);
+    assert_eq!(artifact.severity_summary.low, 3);
+    assert_eq!(artifact.severity_summary.high, 0);
+    assert_eq!(artifact.severity_summary.critical, 0);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
@@ -23,6 +23,16 @@ enum ReviewerState {
     Unavailable,
 }
 
+impl ReviewerState {
+    fn verdict(self) -> &'static str {
+        match self {
+            Self::Pass => crate::review_consensus::CLEAN,
+            Self::Fail => crate::review_consensus::HAS_ISSUES,
+            Self::Unavailable => UNAVAILABLE,
+        }
+    }
+}
+
 fn blocking_finding(fid: impl Into<String>) -> Finding {
     let fid = fid.into();
     Finding {
@@ -70,6 +80,141 @@ fn write_parent_reviewer_artifact(
         serde_json::to_vec_pretty(&artifact).expect("artifact should serialize"),
     )
     .expect("review artifact should be written");
+}
+
+fn reviewer_outcome(
+    reviewer_index: usize,
+    tool: ToolName,
+    verdict: &'static str,
+    diagnostic: Option<&str>,
+) -> super::super::output::ReviewerOutcome {
+    super::super::output::ReviewerOutcome {
+        reviewer_index,
+        tool,
+        session_id: format!("01TESTREVIEWER{reviewer_index:012}"),
+        output: verdict.to_string(),
+        exit_code: if verdict == crate::review_consensus::CLEAN {
+            0
+        } else {
+            1
+        },
+        verdict,
+        diagnostic: diagnostic.map(str::to_string),
+    }
+}
+
+fn parent_verdict_for_outcomes(
+    outcomes: &[super::super::output::ReviewerOutcome],
+    final_verdict: &str,
+    all_reviewers_unavailable: bool,
+) -> ReviewVerdictArtifact {
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let temp = tempdir().expect("tempdir should be created");
+    let session_dir = temp.path().display().to_string();
+    let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
+    let _session_id_guard =
+        ScopedEnvVarRestore::set("CSA_SESSION_ID", "01PARENTSESSION000000000000");
+    let _daemon_session_dir_guard = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_DIR");
+    let _daemon_session_id_guard = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_ID");
+
+    write_multi_reviewer_parent_artifacts(
+        temp.path(),
+        outcomes.len(),
+        outcomes,
+        final_verdict,
+        all_reviewers_unavailable,
+        None,
+    )
+    .expect("parent artifacts should be produced");
+
+    serde_json::from_str(
+        &fs::read_to_string(temp.path().join("output").join("review-verdict.json"))
+            .expect("review-verdict.json should exist"),
+    )
+    .expect("review verdict should parse")
+}
+
+#[test]
+fn issue_1657_unavailable_reviewer_plus_clean_reviewer_passes() {
+    let outcomes = vec![
+        reviewer_outcome(0, ToolName::GeminiCli, UNAVAILABLE, Some("quota exhausted")),
+        reviewer_outcome(
+            1,
+            ToolName::ClaudeCode,
+            crate::review_consensus::CLEAN,
+            None,
+        ),
+    ];
+
+    let verdict =
+        parent_verdict_for_outcomes(&outcomes, crate::review_consensus::HAS_ISSUES, false);
+
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, crate::review_consensus::CLEAN);
+}
+
+#[test]
+fn issue_1657_unavailable_reviewer_plus_blocking_reviewer_fails() {
+    let outcomes = vec![
+        reviewer_outcome(0, ToolName::GeminiCli, UNAVAILABLE, Some("quota exhausted")),
+        reviewer_outcome(
+            1,
+            ToolName::ClaudeCode,
+            crate::review_consensus::HAS_ISSUES,
+            None,
+        ),
+    ];
+
+    let verdict = parent_verdict_for_outcomes(&outcomes, crate::review_consensus::CLEAN, false);
+
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, crate::review_consensus::HAS_ISSUES);
+}
+
+#[test]
+fn issue_1657_all_unavailable_reviewers_fail_closed() {
+    let outcomes = vec![
+        reviewer_outcome(0, ToolName::GeminiCli, UNAVAILABLE, Some("quota exhausted")),
+        reviewer_outcome(1, ToolName::Codex, UNAVAILABLE, Some("tool unavailable")),
+    ];
+
+    let verdict = parent_verdict_for_outcomes(&outcomes, UNAVAILABLE, true);
+
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, crate::review_consensus::HAS_ISSUES);
+}
+
+#[test]
+fn issue_1657_single_crashed_reviewer_without_verdict_fails_closed() {
+    let outcomes = vec![reviewer_outcome(
+        0,
+        ToolName::Codex,
+        crate::review_consensus::UNCERTAIN,
+        Some("reviewer crashed before producing a verdict"),
+    )];
+
+    let verdict = parent_verdict_for_outcomes(&outcomes, crate::review_consensus::UNCERTAIN, false);
+
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, crate::review_consensus::HAS_ISSUES);
+}
+
+#[test]
+fn issue_1657_two_clean_reviewers_pass() {
+    let outcomes = vec![
+        reviewer_outcome(0, ToolName::Codex, crate::review_consensus::CLEAN, None),
+        reviewer_outcome(
+            1,
+            ToolName::ClaudeCode,
+            crate::review_consensus::CLEAN,
+            None,
+        ),
+    ];
+
+    let verdict = parent_verdict_for_outcomes(&outcomes, crate::review_consensus::CLEAN, false);
+
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, crate::review_consensus::CLEAN);
 }
 
 #[test]
@@ -603,8 +748,8 @@ fn write_multi_reviewer_parent_artifacts_promotes_empty_findings_to_pass() {
         tool: ToolName::Codex,
         session_id: "01CHILDSESSION0000000000000".to_string(),
         output: "Reviewer wrote a clean findings artifact.".to_string(),
-        exit_code: 1,
-        verdict: crate::review_consensus::HAS_ISSUES,
+        exit_code: 0,
+        verdict: crate::review_consensus::CLEAN,
         diagnostic: None,
     }];
     let parent_meta = csa_session::state::ReviewSessionMeta {
@@ -669,11 +814,8 @@ fn write_multi_reviewer_parent_artifacts_promotes_empty_findings_to_pass() {
 
 #[test]
 fn parent_review_decision_fails_closed_on_unbacked_has_issues_consensus() {
-    // #1659: a HAS_ISSUES consensus with an empty consolidated artifact is trustworthy as
-    // PASS only when EVERY dissenting (HAS_ISSUES-voting) reviewer persisted its structured
-    // findings. The 4th arg is `dissent_findings_persisted`: when false, at least one
-    // dissenter's findings never reached disk (quota/auth failure), so the empty artifact
-    // must FAIL-CLOSED, never promote to a synthetic PASS.
+    // #1659: a produced HAS_ISSUES verdict is a real blocking vote even when
+    // the reviewer failed to persist structured findings.
     let empty = ReviewArtifact {
         severity_summary: SeveritySummary::from_findings(&[]),
         findings: Vec::new(),
@@ -682,20 +824,42 @@ fn parent_review_decision_fails_closed_on_unbacked_has_issues_consensus() {
         session_id: "01PARENTSESSION000000000000".to_string(),
         timestamp: chrono::Utc::now(),
     };
+    let fail_outcomes = [reviewer_outcome(
+        0,
+        ToolName::Codex,
+        crate::review_consensus::HAS_ISSUES,
+        None,
+    )];
+    let clean_outcomes = [reviewer_outcome(
+        0,
+        ToolName::ClaudeCode,
+        crate::review_consensus::CLEAN,
+        None,
+    )];
     assert_eq!(
-        parent_review_decision(&empty, crate::review_consensus::HAS_ISSUES, false, false),
+        parent_review_decision(
+            &empty,
+            crate::review_consensus::HAS_ISSUES,
+            &fail_outcomes,
+            false
+        ),
         ReviewDecision::Fail,
-        "#1659: unbacked HAS_ISSUES consensus must fail-closed"
+        "#1659: produced HAS_ISSUES verdict must fail"
     );
     assert_eq!(
-        parent_review_decision(&empty, crate::review_consensus::HAS_ISSUES, false, true),
-        ReviewDecision::Pass,
-        "every dissenting reviewer persisting an explicit empty artifact remains a trusted PASS"
-    );
-    assert_eq!(
-        parent_review_decision(&empty, crate::review_consensus::CLEAN, false, false),
+        parent_review_decision(
+            &empty,
+            crate::review_consensus::CLEAN,
+            &clean_outcomes,
+            false
+        ),
         ReviewDecision::Pass,
         "a clean consensus with no artifacts must not fail-closed"
+    );
+    assert_eq!(
+        parent_review_decision(&empty, crate::review_consensus::HAS_ISSUES, &[], true),
+        ReviewDecision::Fail,
+        "empty produced set must fail-closed"
     );
 }
 
@@ -963,8 +1127,8 @@ fn write_multi_reviewer_parent_artifacts_marks_all_unavailable() {
             .expect("review-verdict.json should exist"),
     )
     .expect("review verdict should parse");
-    assert_eq!(verdict.decision, ReviewDecision::Unavailable);
-    assert_eq!(verdict.verdict_legacy, UNAVAILABLE);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, crate::review_consensus::HAS_ISSUES);
 }
 
 #[test]
@@ -1100,13 +1264,15 @@ proptest! {
             reviewer_artifacts,
             "01PARENTSESSION000000000000",
         );
-        // final_verdict is always CLEAN here, so the #1659 dissent guard never fires; pass
-        // `true` (consensus treated as backed) -- this proptest exercises the
-        // blocking-findings-survive-clean-consensus path, not the fail-closed guard.
+        let outcomes: Vec<super::super::output::ReviewerOutcome> = states
+            .iter()
+            .enumerate()
+            .map(|(idx, state)| reviewer_outcome(idx, ToolName::Codex, state.verdict(), None))
+            .collect();
         let decision = parent_review_decision(
             &consolidated,
             crate::review_consensus::CLEAN,
-            states.iter().all(|state| matches!(state, ReviewerState::Unavailable)),
+            &outcomes,
             true,
         );
         let parent_artifact = parent_artifact_for_decision(&consolidated, decision);
@@ -1123,7 +1289,9 @@ proptest! {
                 "blocking finding {expected_id} must survive clean consensus text"
             );
         }
-        if expected_blocking_ids.is_empty() {
+        if states.iter().all(|state| matches!(state, ReviewerState::Unavailable)) {
+            prop_assert_eq!(decision, ReviewDecision::Fail);
+        } else if expected_blocking_ids.is_empty() {
             prop_assert!(
                 decision != ReviewDecision::Fail,
                 "clean consensus without blocking artifacts should not be promoted to failure"
@@ -1162,9 +1330,9 @@ fn write_standalone_consensus_review_artifacts_updates_carrier_session() {
             reviewer_index: 0,
             tool: ToolName::Codex,
             session_id: carrier_id.clone(),
-            output: "Reviewer 1 found issues.".to_string(),
-            exit_code: 1,
-            verdict: crate::review_consensus::HAS_ISSUES,
+            output: "Reviewer 1 was clean.".to_string(),
+            exit_code: 0,
+            verdict: crate::review_consensus::CLEAN,
             diagnostic: None,
         },
         super::super::output::ReviewerOutcome {

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -14,7 +14,7 @@ use crate::review_consensus::{
 use super::execute::ReviewExecutionOutcome;
 use super::output::{
     GEMINI_AUTH_PROMPT_STATUS_REASON, ReviewerOutcome, detect_tool_diagnostic, extract_review_text,
-    is_review_output_empty, sanitize_review_output,
+    is_review_output_empty, sanitize_review_output, stream_started_without_terminal_event,
 };
 
 const AUTH_PROMPT_REVIEW_UNAVAILABLE: &str = "Review unavailable: gemini-cli OAuth prompt detected; authentication required (no review verdict produced).\n";
@@ -44,6 +44,15 @@ fn verdict_from_decision(decision: ReviewDecision) -> &'static str {
         ReviewDecision::Uncertain => UNCERTAIN,
         ReviewDecision::Unavailable => UNAVAILABLE,
     }
+}
+
+/// Whether a reviewer subprocess was killed/timed-out mid-turn: its streamed transcript began
+/// but never reached a terminal completion event, and it exited non-zero. Such a reviewer never
+/// produced a deliberate verdict — any verdict token in its partial output is unreliable (often
+/// scraped from the reviewed code) — so it must be classified `Unavailable` (infra could not run
+/// to completion) rather than fail-closed to `HAS_ISSUES` (#1657).
+fn reviewer_killed_before_completion(raw_output: &str, exit_code: i32) -> bool {
+    exit_code != 0 && stream_started_without_terminal_event(raw_output)
 }
 
 fn explicit_review_decision_for_execution(
@@ -123,7 +132,13 @@ pub(super) fn resolve_single_review_result(
         load_summary_fallback(project_root, &result.execution.meta_session_id).as_deref(),
     );
 
-    let decision = if let Some(decision) = explicit_decision {
+    let decision = if reviewer_killed_before_completion(
+        &result.execution.execution.output,
+        result.execution.execution.exit_code,
+    ) {
+        // Reviewer killed/timed-out mid-turn: treat as infra-unavailable, not a scraped verdict.
+        ReviewDecision::Unavailable
+    } else if let Some(decision) = explicit_decision {
         decision
     } else if let Some(forced) = result.forced_decision {
         forced
@@ -184,7 +199,16 @@ pub(super) fn build_reviewer_outcome(
         result.execution.exit_code,
         None,
     );
-    let decision = if let Some(decision) = explicit_decision {
+    let decision = if reviewer_killed_before_completion(
+        &result.execution.output,
+        result.execution.exit_code,
+    ) {
+        // Reviewer killed/timed-out mid-turn (no terminal stream event + non-zero exit): the
+        // reviewer never produced a deliberate verdict, so any verdict token in its partial
+        // output is unreliable. Classify as infra-unavailable so the all-reviewers-unavailable
+        // case persists `unavailable` and a producing co-reviewer can still gate the merge (#1657).
+        ReviewDecision::Unavailable
+    } else if let Some(decision) = explicit_decision {
         decision
     } else if let Some(forced) = session_result.forced_decision {
         forced

--- a/crates/cli-sub-agent/src/review_cmd_result_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_tests.rs
@@ -304,3 +304,230 @@ fn forced_unavailable_preserves_explicit_pass_verdict() {
     assert_eq!(reviewer.verdict, CLEAN);
     assert_eq!(reviewer.exit_code, 0);
 }
+
+/// A claude-code reviewer killed mid-turn: the stream begins (system/assistant/agent_message
+/// events) but never emits the terminal `{"type":"result"}`. Its last agent message narrates the
+/// reviewed code, which itself contains a `HAS_ISSUES` literal — the exact verdict-token
+/// contamination that made the round-4 runtime review fail-close to HAS_ISSUES instead of
+/// UNAVAILABLE (#1657).
+fn killed_claude_code_review_transcript() -> String {
+    [
+        r#"{"type":"system","subtype":"init","session_id":"01TESTKILLEDCLAUDE"}"#,
+        r#"{"type":"assistant","message":{"role":"assistant","content":"reviewing"}}"#,
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"parse_review_decision returns HAS_ISSUES when a blocking token appears in the reviewed diff."}}"#,
+        r#"{"type":"stream_event","event":{"type":"content_block_delta"}}"#,
+    ]
+    .join("\n")
+}
+
+#[test]
+fn build_reviewer_outcome_reclassifies_killed_claude_code_stream_as_unavailable() {
+    // Pre-fix: extract_review_text scrapes the partial agent message's HAS_ISSUES token and the
+    // reviewer fail-closes to HAS_ISSUES. Post-fix: the stream has no terminal `result` event and
+    // exited non-zero, so it is classified UNAVAILABLE (infra could not run to completion).
+    let mut result = outcome(&killed_claude_code_review_transcript(), 1);
+    result.executed_tool = ToolName::ClaudeCode;
+
+    let reviewer =
+        build_reviewer_outcome(0, ToolName::ClaudeCode, &result).expect("reviewer outcome");
+
+    assert_eq!(reviewer.verdict, UNAVAILABLE);
+    assert_eq!(reviewer.exit_code, 1);
+}
+
+#[test]
+fn build_reviewer_outcome_preserves_completed_has_issues_verdict() {
+    // A reviewer that ran to completion (terminal `result` event present) keeps its deliberate
+    // HAS_ISSUES verdict even with a non-zero exit — the killed-stream override must not fire.
+    let mut transcript = killed_claude_code_review_transcript();
+    transcript.push('\n');
+    transcript
+        .push_str(r#"{"type":"result","subtype":"success","result":"HAS_ISSUES: blocking bug at src/foo.rs:10"}"#);
+    let mut result = outcome(&transcript, 1);
+    result.executed_tool = ToolName::ClaudeCode;
+
+    let reviewer =
+        build_reviewer_outcome(0, ToolName::ClaudeCode, &result).expect("reviewer outcome");
+
+    assert_eq!(reviewer.verdict, HAS_ISSUES);
+    assert_eq!(reviewer.exit_code, 1);
+}
+
+#[test]
+fn build_reviewer_outcome_preserves_completed_clean_verdict() {
+    let transcript = [
+        r#"{"type":"system","subtype":"init"}"#,
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"CLEAN: no blocking issues found in the diff."}}"#,
+        r#"{"type":"result","subtype":"success","result":"CLEAN: no blocking issues found in the diff."}"#,
+    ]
+    .join("\n");
+    let mut result = outcome(&transcript, 0);
+    result.executed_tool = ToolName::ClaudeCode;
+
+    let reviewer =
+        build_reviewer_outcome(0, ToolName::ClaudeCode, &result).expect("reviewer outcome");
+
+    assert_eq!(reviewer.verdict, CLEAN);
+    assert_eq!(reviewer.exit_code, 0);
+}
+
+#[test]
+fn build_reviewer_outcome_reclassifies_killed_codex_stream_as_unavailable() {
+    // codex equivalent: a stream with `turn.failed` (killed by signal) but no `turn.completed`.
+    let transcript = [
+        r#"{"type":"thread.started","thread_id":"t-kill"}"#,
+        r#"{"type":"turn.started"}"#,
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"The verdict mapping emits HAS_ISSUES for blocking findings in the reviewed code."}}"#,
+        r#"{"type":"turn.failed","error":{"message":"stream disconnected before completion: killed by signal 9"}}"#,
+    ]
+    .join("\n");
+    let result = outcome(&transcript, 1);
+
+    let reviewer = build_reviewer_outcome(0, ToolName::Codex, &result).expect("reviewer outcome");
+
+    assert_eq!(reviewer.verdict, UNAVAILABLE);
+    assert_eq!(reviewer.exit_code, 1);
+}
+
+#[test]
+fn build_reviewer_outcome_keeps_plain_text_blocking_verdict_without_stream() {
+    // Legacy plain-text reviewer output (gemini-cli / opencode) is not a JSON stream, so the
+    // killed-stream override never fires: a genuine blocking verdict is preserved, not masked.
+    let reviewer = build_reviewer_outcome(
+        0,
+        ToolName::GeminiCli,
+        &outcome(
+            "Overall risk: high\nHAS_ISSUES: a real blocking correctness bug in the patch.",
+            1,
+        ),
+    )
+    .expect("reviewer outcome");
+
+    assert_eq!(reviewer.verdict, HAS_ISSUES);
+}
+
+#[test]
+fn stream_started_without_terminal_event_flags_killed_claude_code_stream() {
+    assert!(stream_started_without_terminal_event(
+        &killed_claude_code_review_transcript()
+    ));
+}
+
+#[test]
+fn stream_started_without_terminal_event_clears_on_claude_code_result_event() {
+    let mut transcript = killed_claude_code_review_transcript();
+    transcript.push('\n');
+    transcript.push_str(r#"{"type":"result","subtype":"success","result":"CLEAN"}"#);
+    assert!(!stream_started_without_terminal_event(&transcript));
+}
+
+#[test]
+fn stream_started_without_terminal_event_clears_on_codex_turn_completed() {
+    let transcript = [
+        r#"{"type":"turn.started"}"#,
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"done"}}"#,
+        r#"{"type":"turn.completed","usage":{"input_tokens":1}}"#,
+    ]
+    .join("\n");
+    assert!(!stream_started_without_terminal_event(&transcript));
+}
+
+#[test]
+fn stream_started_without_terminal_event_ignores_non_stream_output() {
+    // Plain-text reviewer output and rate-limit event blobs are not recognized streams.
+    assert!(!stream_started_without_terminal_event(
+        "Overall risk: high\nHAS_ISSUES"
+    ));
+    assert!(!stream_started_without_terminal_event(
+        r#"{"type":"rate_limit_event","rate_limit_info":{"status":"rejected"}}"#
+    ));
+    assert!(!stream_started_without_terminal_event(""));
+}
+
+#[test]
+fn all_killed_reviewers_persist_unavailable_decision_on_disk() {
+    // End-to-end reproduction of the round-4 runtime bug: three reviewers all killed mid-turn,
+    // run through the REAL derivation (`build_reviewer_outcome`) and the parent write path, then
+    // read back from disk. Pre-fix each killed reviewer mis-derived to HAS_ISSUES, so
+    // `all_reviewers_unavailable` was false and the parent persisted `decision: "fail"`.
+    // Post-fix each derives UNAVAILABLE → the parent persists the distinct `decision: "unavailable"`.
+    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let session_dir = temp.path().display().to_string();
+    let _session_dir_guard = crate::test_env_lock::ScopedEnvVarRestore::set(
+        csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+        &session_dir,
+    );
+    let _session_id_guard = crate::test_env_lock::ScopedEnvVarRestore::set(
+        "CSA_SESSION_ID",
+        "01PARENTSESSION000000000000",
+    );
+    let _daemon_session_dir_guard =
+        crate::test_env_lock::ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_DIR");
+    let _daemon_session_id_guard =
+        crate::test_env_lock::ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_ID");
+
+    let killed = killed_claude_code_review_transcript();
+    let outcomes: Vec<_> = (0..3)
+        .map(|index| {
+            let mut result = outcome(&killed, 1);
+            result.executed_tool = ToolName::ClaudeCode;
+            build_reviewer_outcome(index, ToolName::ClaudeCode, &result).expect("reviewer outcome")
+        })
+        .collect();
+
+    assert!(
+        outcomes
+            .iter()
+            .all(|reviewer| reviewer.verdict == UNAVAILABLE),
+        "every reviewer killed mid-turn must derive UNAVAILABLE (pre-fix they fail-closed to \
+         HAS_ISSUES); got {:?}",
+        outcomes
+            .iter()
+            .map(|reviewer| reviewer.verdict)
+            .collect::<Vec<_>>()
+    );
+
+    // Mirror the runtime aggregation in review_cmd_multi.rs: `all_reviewers_unavailable` and the
+    // `final_verdict` are COMPUTED from the derived outcomes, not hardcoded — pre-fix this yields
+    // (false, HAS_ISSUES) and the disk decision below would be `fail`.
+    let all_reviewers_unavailable = !outcomes.is_empty()
+        && outcomes
+            .iter()
+            .all(|reviewer| reviewer.verdict == UNAVAILABLE);
+    let final_verdict = if all_reviewers_unavailable {
+        UNAVAILABLE
+    } else {
+        HAS_ISSUES
+    };
+
+    super::super::parent_artifacts::write_multi_reviewer_parent_artifacts(
+        temp.path(),
+        outcomes.len(),
+        &outcomes,
+        final_verdict,
+        all_reviewers_unavailable,
+        None,
+    )
+    .expect("parent artifacts should be produced");
+
+    let verdict: csa_session::review_artifact::ReviewVerdictArtifact = serde_json::from_str(
+        &fs::read_to_string(temp.path().join("output").join("review-verdict.json"))
+            .expect("review-verdict.json should exist"),
+    )
+    .expect("review verdict should parse");
+
+    // Distinguishable at rest + fail-closed: the persisted decision is the distinct `unavailable`
+    // value, never `fail`/`uncertain`, and remains non-mergeable.
+    assert_eq!(verdict.decision, ReviewDecision::Unavailable);
+    assert_ne!(verdict.decision, ReviewDecision::Fail);
+    assert_ne!(verdict.decision, ReviewDecision::Uncertain);
+    assert!(
+        !verdict.decision.is_clean(),
+        "unavailable must remain non-mergeable (fail-closed)"
+    );
+    assert_eq!(
+        crate::verdict_exit_code::exit_code_from_review_decision(verdict.decision),
+        1
+    );
+}

--- a/crates/cli-sub-agent/src/verdict_exit_code.rs
+++ b/crates/cli-sub-agent/src/verdict_exit_code.rs
@@ -57,6 +57,14 @@ mod tests {
     }
 
     #[test]
+    fn review_unavailable_maps_to_one() {
+        assert_eq!(
+            exit_code_from_review_decision(ReviewDecision::Unavailable),
+            1
+        );
+    }
+
+    #[test]
     fn debate_approve_maps_to_zero() {
         assert_eq!(exit_code_from_debate_verdict("APPROVE", None), 0);
     }

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -12,6 +12,16 @@ use agent_client_protocol::{
 use csa_process::{DEFAULT_SPOOL_KEEP_ROTATED, DEFAULT_SPOOL_MAX_BYTES, SpoolRotator};
 use tokio::{process::Child, task::LocalSet};
 
+#[path = "connection_status.rs"]
+mod connection_status;
+use connection_status::{format_stderr, process_exited_error};
+
+#[path = "connection_stream.rs"]
+mod connection_stream;
+#[cfg(test)]
+pub(crate) use connection_stream::LINE_BUF_CAP;
+use connection_stream::{collect_agent_output, stream_new_agent_messages};
+
 // Re-export spawn-related types from the dedicated module.
 #[path = "connection_spawn.rs"]
 mod connection_spawn;
@@ -24,10 +34,7 @@ pub(crate) mod connection_fork;
 pub use connection_fork::{CliForkResult, fork_session_via_cli};
 
 use crate::{
-    client::{
-        SessionEvent, SharedActivity, SharedEvents, StreamingMetadata,
-        event_counts_as_initial_response,
-    },
+    client::{SessionEvent, SharedActivity, SharedEvents, StreamingMetadata},
     error::{AcpError, AcpResult},
 };
 
@@ -130,7 +137,7 @@ impl AcpConnection {
     }
 
     pub async fn initialize(&self) -> AcpResult<()> {
-        self.ensure_process_running()?;
+        self.ensure_process_running().await?;
 
         let request = InitializeRequest::new(ProtocolVersion::LATEST);
         let result = self
@@ -149,7 +156,7 @@ impl AcpConnection {
                 let stderr = self.stderr();
                 Err(AcpError::InitializationFailed(format!(
                     "{err}{}",
-                    Self::format_stderr(&stderr)
+                    format_stderr(&stderr)
                 )))
             }
             None => {
@@ -159,7 +166,7 @@ impl AcpConnection {
                     "ACP initialize timed out after {}s{}; \
                      consider increasing [acp] init_timeout_seconds in .csa/config.toml",
                     self.init_timeout.as_secs(),
-                    Self::format_stderr(&stderr),
+                    format_stderr(&stderr),
                 )))
             }
         }
@@ -175,7 +182,7 @@ impl AcpConnection {
         working_dir: Option<&Path>,
         meta: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> AcpResult<String> {
-        self.ensure_process_running()?;
+        self.ensure_process_running().await?;
 
         let session_working_dir = working_dir.unwrap_or(self.default_working_dir.as_path());
         let mut request = NewSessionRequest::new(session_working_dir);
@@ -197,7 +204,7 @@ impl AcpConnection {
                 let stderr = self.stderr();
                 Err(AcpError::SessionFailed(format!(
                     "{err}{}",
-                    Self::format_stderr(&stderr)
+                    format_stderr(&stderr)
                 )))
             }
             None => {
@@ -207,7 +214,7 @@ impl AcpConnection {
                     "ACP session/new timed out after {}s{}; \
                      consider increasing [acp] init_timeout_seconds in .csa/config.toml",
                     self.init_timeout.as_secs(),
-                    Self::format_stderr(&stderr),
+                    format_stderr(&stderr),
                 )))
             }
         }
@@ -218,7 +225,7 @@ impl AcpConnection {
         session_id: &str,
         working_dir: Option<&Path>,
     ) -> AcpResult<String> {
-        self.ensure_process_running()?;
+        self.ensure_process_running().await?;
 
         let session_working_dir = working_dir.unwrap_or(self.default_working_dir.as_path());
         let request =
@@ -240,7 +247,7 @@ impl AcpConnection {
                 let stderr = self.stderr();
                 Err(AcpError::SessionFailed(format!(
                     "{err}{}",
-                    Self::format_stderr(&stderr)
+                    format_stderr(&stderr)
                 )))
             }
             None => {
@@ -253,7 +260,7 @@ impl AcpConnection {
                     "ACP session/load timed out after {}s{}; \
                      consider increasing [acp] init_timeout_seconds in .csa/config.toml",
                     self.init_timeout.as_secs(),
-                    Self::format_stderr(&stderr),
+                    format_stderr(&stderr),
                 )))
             }
         }
@@ -279,7 +286,7 @@ impl AcpConnection {
             )));
         }
 
-        self.ensure_process_running()?;
+        self.ensure_process_running().await?;
 
         let fork_dir = working_dir.unwrap_or(self.default_working_dir.as_path());
         let fork_result =
@@ -321,7 +328,7 @@ impl AcpConnection {
         initial_response_timeout: Option<Duration>,
         io: PromptIoOptions<'_>,
     ) -> AcpResult<PromptResult> {
-        self.ensure_process_running()?;
+        self.ensure_process_running().await?;
 
         self.events.borrow_mut().clear();
         let now = Instant::now();
@@ -444,7 +451,7 @@ impl AcpConnection {
                 metadata,
             }),
             PromptOutcome::Completed(Err(err)) => {
-                let stderr_detail = Self::format_stderr(&self.stderr());
+                let stderr_detail = format_stderr(&self.stderr());
                 Err(AcpError::PromptFailed(format!("{err}{stderr_detail}")))
             }
             PromptOutcome::IdleTimeout => {
@@ -515,41 +522,30 @@ impl AcpConnection {
     pub fn stderr(&self) -> String {
         self.stderr_buf.borrow().clone()
     }
-    fn ensure_process_running(&self) -> AcpResult<()> {
-        let mut child = self.child.borrow_mut();
-        if let Some(status) = child
+    async fn ensure_process_running(&self) -> AcpResult<()> {
+        let status = self
+            .child
+            .borrow_mut()
             .try_wait()
-            .map_err(|err| AcpError::ConnectionFailed(err.to_string()))?
-        {
-            let code = status.code().unwrap_or(-1);
-            #[cfg(unix)]
-            let signal = {
-                use std::os::unix::process::ExitStatusExt;
-                status.signal()
-            };
-            #[cfg(not(unix))]
-            let signal = None;
+            .map_err(|err| AcpError::ConnectionFailed(err.to_string()))?;
+
+        if let Some(status) = status {
+            self.drain_stderr_tail().await;
             let stderr = self.stderr();
-            return Err(AcpError::ProcessExited {
-                code,
-                signal,
-                stderr,
-            });
+            return Err(process_exited_error(status, stderr));
         }
         Ok(())
     }
 
-    /// Format captured stderr for inclusion in error messages.
-    ///
-    /// Returns an empty string when no stderr was captured, or
-    /// `"; stderr: <content>"` otherwise.
+    async fn drain_stderr_tail(&self) {
+        self.local_set
+            .run_until(tokio::time::sleep(Duration::from_millis(10)))
+            .await;
+    }
+
+    #[cfg(test)]
     pub(crate) fn format_stderr(stderr: &str) -> String {
-        let trimmed = stderr.trim();
-        if trimmed.is_empty() {
-            String::new()
-        } else {
-            format!("; stderr: {trimmed}")
-        }
+        format_stderr(stderr)
     }
 }
 
@@ -628,158 +624,6 @@ fn maybe_emit_heartbeat(
         effective_timeout.as_secs()
     );
     *last_heartbeat = now;
-}
-
-/// Maximum bytes buffered before a newline-free chunk is force-flushed.
-pub(crate) const LINE_BUF_CAP: usize = 64 * 1024;
-
-/// Flush complete lines and keep incomplete tails unless the buffer exceeds [`LINE_BUF_CAP`].
-fn flush_complete_lines(buf: &mut String, prefix: &str) {
-    while let Some(pos) = buf.find('\n') {
-        let line: String = buf.drain(..=pos).collect();
-        eprint!("{prefix}{line}");
-    }
-    if buf.len() > LINE_BUF_CAP {
-        let remainder = std::mem::take(buf);
-        eprintln!("{prefix}{remainder}");
-    }
-}
-
-/// Flush any remaining buffered content, appending a terminating newline.
-fn flush_remaining_buf(buf: &mut String, prefix: &str) {
-    if !buf.is_empty() {
-        let remainder = std::mem::take(buf);
-        eprintln!("{prefix}{remainder}");
-    }
-}
-
-fn stream_new_agent_messages(
-    events: &SharedEvents,
-    processed_event_count: &mut usize,
-    stream_stdout_to_stderr: bool,
-    output_spool: &mut Option<SpoolRotator>,
-    metadata: &mut StreamingMetadata,
-    stdout_line_buf: &mut String,
-    thought_line_buf: &mut String,
-) -> bool {
-    // Track progress against total seen events because the retained deque can evict old entries.
-    let events_ref = events.borrow();
-    metadata.sync_from_store(&events_ref);
-    if *processed_event_count >= events_ref.total_events_count() {
-        return false;
-    }
-    let retained_start = events_ref.retained_start_index();
-    let stream_start = (*processed_event_count).max(retained_start);
-    if stream_start > *processed_event_count {
-        let skipped = stream_start - *processed_event_count;
-        tracing::warn!(
-            skipped,
-            retained_start,
-            processed = *processed_event_count,
-            "ACP event ring buffer overrun: {skipped} events were evicted before being streamed to spool/stderr"
-        );
-        // Avoid splicing pre-overrun partial lines with the first retained chunk.
-        stdout_line_buf.clear();
-        thought_line_buf.clear();
-    }
-    let skip = stream_start.saturating_sub(retained_start);
-    let mut saw_initial_response_event = false;
-
-    for event in events_ref.retained_events().iter().skip(skip) {
-        saw_initial_response_event |= event_counts_as_initial_response(event);
-        match event {
-            SessionEvent::AgentMessage(chunk) => {
-                if stream_stdout_to_stderr {
-                    flush_remaining_buf(thought_line_buf, "[thought] ");
-                    stdout_line_buf.push_str(chunk);
-                    flush_complete_lines(stdout_line_buf, "[stdout] ");
-                }
-                spool_chunk(output_spool, chunk.as_bytes(), metadata);
-                metadata.append_message_text(chunk);
-            }
-            SessionEvent::AgentThought(chunk) => {
-                if stream_stdout_to_stderr {
-                    flush_remaining_buf(stdout_line_buf, "[stdout] ");
-                    thought_line_buf.push_str(chunk);
-                    flush_complete_lines(thought_line_buf, "[thought] ");
-                }
-                spool_chunk(output_spool, chunk.as_bytes(), metadata);
-                metadata.append_thought_text(chunk);
-            }
-            SessionEvent::PlanUpdate(plan) => {
-                metadata.has_plan_updates = true;
-                let msg = format!("[plan] {plan}\n");
-                if stream_stdout_to_stderr {
-                    flush_remaining_buf(stdout_line_buf, "[stdout] ");
-                    flush_remaining_buf(thought_line_buf, "[thought] ");
-                    eprint!("{msg}");
-                }
-                spool_chunk(output_spool, msg.as_bytes(), metadata);
-            }
-            SessionEvent::ToolCallStarted { title, kind, .. } => {
-                metadata.has_tool_calls = true;
-                let msg = format!("[tool:started] {title} ({kind})\n");
-                if stream_stdout_to_stderr {
-                    flush_remaining_buf(stdout_line_buf, "[stdout] ");
-                    flush_remaining_buf(thought_line_buf, "[thought] ");
-                    eprint!("{msg}");
-                }
-                spool_chunk(output_spool, msg.as_bytes(), metadata);
-            }
-            SessionEvent::ToolCallCompleted { status, .. } => {
-                let msg = format!("[tool:completed] {status}\n");
-                if stream_stdout_to_stderr {
-                    flush_remaining_buf(stdout_line_buf, "[stdout] ");
-                    flush_remaining_buf(thought_line_buf, "[thought] ");
-                    eprint!("{msg}");
-                }
-                spool_chunk(output_spool, msg.as_bytes(), metadata);
-            }
-            SessionEvent::Other(payload) => {
-                let msg = format!("[other] {payload}\n");
-                if stream_stdout_to_stderr {
-                    flush_remaining_buf(stdout_line_buf, "[stdout] ");
-                    flush_remaining_buf(thought_line_buf, "[thought] ");
-                    eprint!("{msg}");
-                }
-                spool_chunk(output_spool, msg.as_bytes(), metadata);
-            }
-        }
-    }
-
-    if stream_stdout_to_stderr {
-        flush_remaining_buf(stdout_line_buf, "[stdout] ");
-        flush_remaining_buf(thought_line_buf, "[thought] ");
-    }
-
-    *processed_event_count = events_ref.total_events_count();
-    saw_initial_response_event
-}
-
-fn spool_chunk(spool: &mut Option<SpoolRotator>, bytes: &[u8], metadata: &mut StreamingMetadata) {
-    if let Some(writer) = spool {
-        let _ = writer.write(bytes);
-        metadata.spool_bytes_written = writer.bytes_written();
-    }
-}
-
-/// Collect agent-visible output, falling back to thought text when no message text exists.
-fn collect_agent_output(metadata: &mut StreamingMetadata) -> String {
-    let message = metadata.message_text.trim();
-    if !message.is_empty() {
-        return metadata.message_text.clone();
-    }
-    let thought = metadata.thought_text.trim();
-    if !thought.is_empty() {
-        metadata.has_thought_fallback = true;
-        tracing::warn!(
-            thought_bytes = metadata.thought_text.len(),
-            "agent produced no message output; falling back to thought text"
-        );
-        // Keep the marker on its own line so CSA section markers remain parseable.
-        return format!("[thought-fallback]\n{}", metadata.thought_text);
-    }
-    String::new()
 }
 
 fn stop_reason_to_string(reason: StopReason) -> String {

--- a/crates/csa-acp/src/connection_status.rs
+++ b/crates/csa-acp/src/connection_status.rs
@@ -1,0 +1,36 @@
+use std::process::ExitStatus;
+
+use crate::error::AcpError;
+
+pub(crate) fn process_exited_error(status: ExitStatus, stderr: String) -> AcpError {
+    AcpError::ProcessExited {
+        code: status.code().unwrap_or(-1),
+        signal: exit_signal(status),
+        stderr,
+    }
+}
+
+#[cfg(unix)]
+fn exit_signal(status: ExitStatus) -> Option<i32> {
+    use std::os::unix::process::ExitStatusExt;
+
+    status.signal()
+}
+
+#[cfg(not(unix))]
+fn exit_signal(_status: ExitStatus) -> Option<i32> {
+    None
+}
+
+/// Format captured stderr for inclusion in error messages.
+///
+/// Returns an empty string when no stderr was captured, or
+/// `"; stderr: <content>"` otherwise.
+pub(crate) fn format_stderr(stderr: &str) -> String {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        format!("; stderr: {trimmed}")
+    }
+}

--- a/crates/csa-acp/src/connection_stream.rs
+++ b/crates/csa-acp/src/connection_stream.rs
@@ -1,0 +1,157 @@
+use csa_process::SpoolRotator;
+
+use crate::client::{
+    SessionEvent, SharedEvents, StreamingMetadata, event_counts_as_initial_response,
+};
+
+/// Maximum bytes buffered before a newline-free chunk is force-flushed.
+pub(crate) const LINE_BUF_CAP: usize = 64 * 1024;
+
+/// Flush complete lines and keep incomplete tails unless the buffer exceeds [`LINE_BUF_CAP`].
+fn flush_complete_lines(buf: &mut String, prefix: &str) {
+    while let Some(pos) = buf.find('\n') {
+        let line: String = buf.drain(..=pos).collect();
+        eprint!("{prefix}{line}");
+    }
+    if buf.len() > LINE_BUF_CAP {
+        let remainder = std::mem::take(buf);
+        eprintln!("{prefix}{remainder}");
+    }
+}
+
+/// Flush any remaining buffered content, appending a terminating newline.
+fn flush_remaining_buf(buf: &mut String, prefix: &str) {
+    if !buf.is_empty() {
+        let remainder = std::mem::take(buf);
+        eprintln!("{prefix}{remainder}");
+    }
+}
+
+pub(crate) fn stream_new_agent_messages(
+    events: &SharedEvents,
+    processed_event_count: &mut usize,
+    stream_stdout_to_stderr: bool,
+    output_spool: &mut Option<SpoolRotator>,
+    metadata: &mut StreamingMetadata,
+    stdout_line_buf: &mut String,
+    thought_line_buf: &mut String,
+) -> bool {
+    // Track progress against total seen events because the retained deque can evict old entries.
+    let events_ref = events.borrow();
+    metadata.sync_from_store(&events_ref);
+    if *processed_event_count >= events_ref.total_events_count() {
+        return false;
+    }
+    let retained_start = events_ref.retained_start_index();
+    let stream_start = (*processed_event_count).max(retained_start);
+    if stream_start > *processed_event_count {
+        let skipped = stream_start - *processed_event_count;
+        tracing::warn!(
+            skipped,
+            retained_start,
+            processed = *processed_event_count,
+            "ACP event ring buffer overrun: {skipped} events were evicted before being streamed to spool/stderr"
+        );
+        // Avoid splicing pre-overrun partial lines with the first retained chunk.
+        stdout_line_buf.clear();
+        thought_line_buf.clear();
+    }
+    let skip = stream_start.saturating_sub(retained_start);
+    let mut saw_initial_response_event = false;
+
+    for event in events_ref.retained_events().iter().skip(skip) {
+        saw_initial_response_event |= event_counts_as_initial_response(event);
+        match event {
+            SessionEvent::AgentMessage(chunk) => {
+                if stream_stdout_to_stderr {
+                    flush_remaining_buf(thought_line_buf, "[thought] ");
+                    stdout_line_buf.push_str(chunk);
+                    flush_complete_lines(stdout_line_buf, "[stdout] ");
+                }
+                spool_chunk(output_spool, chunk.as_bytes(), metadata);
+                metadata.append_message_text(chunk);
+            }
+            SessionEvent::AgentThought(chunk) => {
+                if stream_stdout_to_stderr {
+                    flush_remaining_buf(stdout_line_buf, "[stdout] ");
+                    thought_line_buf.push_str(chunk);
+                    flush_complete_lines(thought_line_buf, "[thought] ");
+                }
+                spool_chunk(output_spool, chunk.as_bytes(), metadata);
+                metadata.append_thought_text(chunk);
+            }
+            SessionEvent::PlanUpdate(plan) => {
+                metadata.has_plan_updates = true;
+                let msg = format!("[plan] {plan}\n");
+                if stream_stdout_to_stderr {
+                    flush_remaining_buf(stdout_line_buf, "[stdout] ");
+                    flush_remaining_buf(thought_line_buf, "[thought] ");
+                    eprint!("{msg}");
+                }
+                spool_chunk(output_spool, msg.as_bytes(), metadata);
+            }
+            SessionEvent::ToolCallStarted { title, kind, .. } => {
+                metadata.has_tool_calls = true;
+                let msg = format!("[tool:started] {title} ({kind})\n");
+                if stream_stdout_to_stderr {
+                    flush_remaining_buf(stdout_line_buf, "[stdout] ");
+                    flush_remaining_buf(thought_line_buf, "[thought] ");
+                    eprint!("{msg}");
+                }
+                spool_chunk(output_spool, msg.as_bytes(), metadata);
+            }
+            SessionEvent::ToolCallCompleted { status, .. } => {
+                let msg = format!("[tool:completed] {status}\n");
+                if stream_stdout_to_stderr {
+                    flush_remaining_buf(stdout_line_buf, "[stdout] ");
+                    flush_remaining_buf(thought_line_buf, "[thought] ");
+                    eprint!("{msg}");
+                }
+                spool_chunk(output_spool, msg.as_bytes(), metadata);
+            }
+            SessionEvent::Other(payload) => {
+                let msg = format!("[other] {payload}\n");
+                if stream_stdout_to_stderr {
+                    flush_remaining_buf(stdout_line_buf, "[stdout] ");
+                    flush_remaining_buf(thought_line_buf, "[thought] ");
+                    eprint!("{msg}");
+                }
+                spool_chunk(output_spool, msg.as_bytes(), metadata);
+            }
+        }
+    }
+
+    if stream_stdout_to_stderr {
+        flush_remaining_buf(stdout_line_buf, "[stdout] ");
+        flush_remaining_buf(thought_line_buf, "[thought] ");
+    }
+
+    *processed_event_count = events_ref.total_events_count();
+    saw_initial_response_event
+}
+
+fn spool_chunk(spool: &mut Option<SpoolRotator>, bytes: &[u8], metadata: &mut StreamingMetadata) {
+    if let Some(writer) = spool {
+        let _ = writer.write(bytes);
+        metadata.spool_bytes_written = writer.bytes_written();
+    }
+}
+
+/// Collect agent-visible output, falling back to thought text when no message text exists.
+pub(crate) fn collect_agent_output(metadata: &mut StreamingMetadata) -> String {
+    let message = metadata.message_text.trim();
+    if !message.is_empty() {
+        return metadata.message_text.clone();
+    }
+    let thought = metadata.thought_text.trim();
+    if !thought.is_empty() {
+        metadata.has_thought_fallback = true;
+        tracing::warn!(
+            thought_bytes = metadata.thought_text.len(),
+            "agent produced no message output; falling back to thought text"
+        );
+        // Keep the marker on its own line so CSA section markers remain parseable.
+        return format!("[thought-fallback]\n{}", metadata.thought_text);
+    }
+    String::new()
+}


### PR DESCRIPTION
## Summary

This branch hardens the machine-readable review merge gate. It contains the #1696 `severity_counts` fix, a gate-forced ACP-startup race fix that was required to make `just pre-commit` pass, and the #1657 fix that lets a clean review be merge-able even when a co-reviewer is quota-unavailable. All three are described below.

> Six commits in three logical groups: Group 1 = #1696 (1 commit), Group 2 = gate-forced ACP fix (1 commit), Group 3 = #1657 (4 commits — exclude-from-consensus → represent-as-uncertain → map-to-`Unavailable` → persist-runtime-`Unavailable`; the extra commits are iterative refinement of the same fix, each surfaced by a successive review round naming a distinct defect).

## Group 1 — `fix(cli-sub-agent): aggregate review severity counts` (closes #1696)

The aggregated `output/review-verdict.json` `severity_counts` was `{low:0, medium:0, high:0, critical:0}` **even when** the per-reviewer `reviewer-N/review-findings.json` documented real findings (observed: 1 MEDIUM + 3 LOW + 2 info). `decision="pass"` was itself correct (no P0/P1 blocking), but the all-zero counts were a **merge footgun**: a pipeline reading `severity_counts` to ask "are there findings to fix?" saw zero and would merge over a documented MEDIUM correctness finding.

**Fix (Option 1 from the issue):** `severity_counts` now reflects **all** findings emitted by the reviewer(s), aggregated across every `reviewer-N/review-findings.json` (sum per low/medium/high/critical bucket; `info` findings no longer zero out the totals). For the repro it becomes `{low:3, medium:1, high:0, critical:0}`.

The merge-blocking signal is the **separate `decision` field** (Pass/Fail/Skip/Uncertain) — that logic is **unchanged**. Making `severity_counts` honest does NOT make a PASS-with-non-blocking-findings start blocking: `decision` stays `pass`. `csa review --check-verdict` now surfaces the non-blocking finding counts on a PASS-with-findings verdict (e.g. `non-blocking findings: 1 medium, 3 low`); exit-code semantics unchanged.

## Group 2 — `fix(cli-sub-agent): preserve ACP startup stderr` (gate-forced)

The post-exec gate's `just test` surfaced a **timing race** (flaky test `csa-executor transport::tests::test_execute_in_classifies_pre_handshake_gemini_failure_with_child_stderr`): ACP startup checked the child's exit before the `LocalSet` stderr reader had drained the child's stderr, so a pre-handshake failure lost its `ENOENT` text and the Gemini init classifier mis-handled it.

**Fix:** `AcpConnection::ensure_process_running` is now async and drains a short stderr tail before returning `ProcessExited`, so the classifier sees the real error text. The change pushed `crates/csa-acp/src/connection.rs` over the repo's 800-line / 8K-token per-module budget, so the connection module was split into cohesive submodules (deep-module extraction, not `#[allow]`/comment-trimming): `connection_status.rs` (process-exit/status stderr formatting) and `connection_stream.rs` (event streaming, line buffering, output collection). Final token counts: `connection.rs` 7787, `connection_status.rs` 287, `connection_stream.rs` 2172 — all under budget.

This fix is bundled here (rather than a separate PR) because the flaky test blocked `just pre-commit` for the whole workspace, so #1696 could not pass its own gate without it.

## Group 3 — #1657: clean review merge-able despite a quota-unavailable co-reviewer (closes #1657)

After #1716 (PR #1725) made an UNAVAILABLE reviewer outcome fail-closed, a tier-4 review where gemini-cli was monthly-quota-exhausted recorded `decision="fail"` **even when** the claude-code reviewer ran the full review and found NO blocking issues (`severity_counts` 0/0/0/0). This wrongly blocked push/merge on a clean review purely because a co-reviewer hit quota. Reproduced in sessions `01KSXC4AQ1TVF4WRED4N3VG5P4` (claude clean, 8m, decision=fail) and `01KSXCSAFYK6HRA341HESEX9DT` (claude clean, 11.5m, decision=fail).

**Fix:** review-verdict aggregation now partitions reviewer outcomes into **PRODUCED** (ran and emitted a usable verdict) and **NON-PRODUCING** (quota-unavailable / tool-unavailable / crashed with no verdict). The aggregate `decision` is computed **only over the PRODUCED set**: ≥1 PRODUCED reviewer with no blocking findings → PASS; any PRODUCED reviewer with blocking findings → FAIL (preserves #1659). A NON-PRODUCING reviewer is **excluded from consensus** — neither a PASS nor a FAIL vote.

This is a **narrowing** of #1716, not a revert: when the PRODUCED set is **empty** (NO reviewer emitted any usable verdict), the decision still fails closed (preserves #1716/#1652/#1675 — never synthesize a PASS without positive proof).

**All-reviewers-unavailable now persists a distinct `decision`:** the empty-PRODUCED case is recorded as `decision="unavailable"` (a fifth `ReviewDecision` value alongside Pass/Fail/Skip/Uncertain), **not** as `fail`/findings and **not** as `uncertain`. This keeps the audit trail honest — "infrastructure could not review" is distinguishable from "reviewer ran and rejected" and from "reviewer ran but was low-confidence" — while still failing closed (blocks merge, nonzero `--check-verdict` exit). The four commits in this group are the iterative convergence to that contract: the in-memory `parent_review_decision` mapping was fixed first, then a runtime/integration gap was found (the written `review-verdict.json` still serialized `"fail"`), so the final commit fixes the runtime persistence path and adds an integration test that **reads back** the written `review-verdict.json` to assert `decision="unavailable"`.

## Tests

- #1696 regression: reviewer findings = 1 MEDIUM + 3 LOW + decision=pass → aggregated `severity_counts == {low:3, medium:1, high:0, critical:0}` (not all-zero) AND `decision` stays `pass`; `--check-verdict` prints the non-blocking counts.
- #1657 regression (csa-session consensus): (a) gemini unavailable + claude clean → PASS; (b) gemini unavailable + claude FAIL(blocking) → FAIL; (c) all reviewers unavailable → fail-closed with `decision="unavailable"` (distinct from `fail`); (d) single reviewer crashed with no verdict → fail-closed; (e) two reviewers both clean → PASS.
- #1657 runtime/integration: a test that drives the runtime persistence path and **reads back** the written `output/review-verdict.json` asserts the all-unavailable case serializes `decision="unavailable"` (catches the in-memory-correct / serialization-wrong gap that a pure unit test on `parent_review_decision` missed).
- Full workspace: `just pre-commit` green; #1696, #1716, and #1657 regression suites pass.

## Relation

Direct follow-up to the #1716/#1710 false-PASS merge-gate cluster (merged in #1725). Together they harden the machine-readable merge gate: #1716 makes a non-successful review fail closed; #1696 makes a successful-with-findings review report its findings honestly; #1657 makes a clean review (≥1 reviewer ran clean) merge-able even when a co-reviewer is quota-unavailable, without re-opening the fail-open holes #1716 closed. (The smooth gemini→codex failover that should avoid the unavailable-reviewer attempt entirely is tracked separately as #1714; the post-exec-gate opacity that delayed this fix is filed as #1726.)

Closes #1696
Closes #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)
