### PR TITLE
fix(cli-sub-agent): scope permanent-quota detection to provider-error channel (#1736)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.821"
+version = "0.1.822"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.821"
+version = "0.1.822"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_execute.rs
+++ b/crates/cli-sub-agent/src/pipeline_execute.rs
@@ -185,11 +185,13 @@ pub(crate) async fn execute_transport_with_signal(
                 .find_map(|cause| cause.downcast_ref::<PeakMemoryContext>())
                 .and_then(|ctx| ctx.0);
             let error_summary = format!("transport: {e}");
+            // The anyhow error chain is the provider/transport error channel for
+            // a failed turn (the agent's reviewed stdout is discarded on Err), so
+            // it is the correct — and only — source for a permanent quota verdict
+            // (#1736).
             let exhaustion = crate::run_cmd_post::detect_permanent_tool_exhaustion_text(
                 executor.tool_name(),
-                &error_summary,
                 &format!("{e:#}"),
-                "",
                 1,
                 None,
             );

--- a/crates/cli-sub-agent/src/run_cmd_post_failover.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_failover.rs
@@ -54,11 +54,12 @@ pub(crate) fn detect_permanent_tool_exhaustion_result(
     exec_result: &csa_process::ExecutionResult,
     current_model_spec: Option<&str>,
 ) -> Option<csa_scheduler::RateLimitDetected> {
+    // Only stderr_output is the provider's error channel; `summary`/`output`
+    // are agent stdout (reviewed/echoed content) and must not drive a permanent
+    // quota verdict (#1736).
     detect_permanent_tool_exhaustion_text(
         tool_name_str,
-        &exec_result.summary,
         &exec_result.stderr_output,
-        &exec_result.output,
         exec_result.exit_code,
         current_model_spec,
     )
@@ -66,26 +67,30 @@ pub(crate) fn detect_permanent_tool_exhaustion_result(
 
 pub(crate) fn detect_permanent_tool_exhaustion_text(
     tool_name_str: &str,
-    summary: &str,
-    stderr: &str,
-    stdout: &str,
+    provider_error_channel: &str,
     exit_code: i32,
     current_model_spec: Option<&str>,
 ) -> Option<csa_scheduler::RateLimitDetected> {
     if exit_code == 0 {
         return None;
     }
-    let stdout_with_summary = if summary.trim().is_empty() {
-        stdout.to_string()
-    } else if stdout.trim().is_empty() {
-        summary.to_string()
-    } else {
-        format!("{summary}\n{stdout}")
-    };
+    // PERMANENT tool exhaustion self-kills the session (the caller marks a fatal
+    // gate, blocks failover, and writes `tool_exhausted: ...`). It MUST be
+    // derived only from the provider's own error channel — captured process
+    // stderr, or the anyhow error chain of a transport failure — NEVER from the
+    // agent's stdout (`output`) or the stdout-derived `summary`. A `csa review`
+    // whose reviewed diff/source/commit literally contains a quota phrase (e.g.
+    // "monthly spending cap") must not be misread as a real provider quota
+    // exhaustion (#1736). Both call sites pass the provider-error channel here:
+    // the success path passes `ExecutionResult::stderr_output`, the transport
+    // error path passes the formatted anyhow error chain. `detect_rate_limit`
+    // confirms `quota_exhausted` only from its `stderr` argument, so feeding the
+    // provider channel as stderr (and an empty stdout) yields the permanent
+    // verdict iff the provider itself reported quota exhaustion.
     csa_scheduler::detect_rate_limit(
         tool_name_str,
-        stderr,
-        &stdout_with_summary,
+        provider_error_channel,
+        "",
         exit_code,
         current_model_spec,
     )
@@ -590,3 +595,7 @@ pub(crate) fn evaluate_error_rate_limit_failover(
         }
     }
 }
+
+#[cfg(test)]
+#[path = "run_cmd_post_failover_tests.rs"]
+mod permanent_exhaustion_tests;

--- a/crates/cli-sub-agent/src/run_cmd_post_failover_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_failover_tests.rs
@@ -1,0 +1,81 @@
+use super::*;
+
+fn result_with(summary: &str, stderr: &str, stdout: &str) -> csa_process::ExecutionResult {
+    csa_process::ExecutionResult {
+        summary: summary.to_string(),
+        stderr_output: stderr.to_string(),
+        output: stdout.to_string(),
+        exit_code: 1,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn reviewed_quota_phrase_in_stdout_is_not_permanent_exhaustion() {
+    // #1736: a `csa review` of a diff that literally contains a quota phrase
+    // (e.g. this failover classifier's own source / a test fixture / a commit
+    // message) must NOT self-kill the session. The marker is in agent stdout
+    // and the stdout-derived summary only, never the provider error channel.
+    let result = result_with(
+        "+    pattern: \"monthly spending cap\",",
+        "",
+        "Reviewing diff:\n+const PATTERN: &str = \"monthly spending cap\";\n\
+         +// also matches \"usage limit\" / QUOTA_EXHAUSTED\nVerdict: PASS",
+    );
+    assert!(
+        detect_permanent_tool_exhaustion_result("codex", &result, None).is_none(),
+        "reviewed quota phrase in stdout/summary must not be permanent exhaustion"
+    );
+    assert!(
+        detect_permanent_tool_exhaustion_result("gemini-cli", &result, None).is_none(),
+        "reviewed quota phrase in stdout/summary must not be permanent exhaustion (gemini)"
+    );
+}
+
+#[test]
+fn provider_quota_error_on_stderr_is_permanent_exhaustion() {
+    // Positive: a genuine provider quota error on the stderr (provider error)
+    // channel MUST still be detected as permanent so failover handling fires.
+    let result = result_with(
+        "Verdict: PASS",
+        "Error: Usage limit exceeded for this account",
+        "Reviewing diff... Verdict: PASS",
+    );
+    let detected = detect_permanent_tool_exhaustion_result("codex", &result, None)
+        .expect("provider usage-limit error on stderr must be permanent exhaustion");
+    assert!(detected.quota_exhausted);
+    assert_eq!(detected.matched_pattern, "usage limit");
+}
+
+#[test]
+fn transport_error_chain_quota_is_permanent_exhaustion() {
+    // The error path feeds the anyhow error chain as the provider channel; a
+    // provider quota error there must still be detected.
+    let detected = detect_permanent_tool_exhaustion_text(
+        "codex",
+        "transport: ACP prompt failed: You've hit your usage limit. \
+         insufficient_quota for this account",
+        1,
+        None,
+    )
+    .expect("provider quota in transport error chain must be permanent exhaustion");
+    assert!(detected.quota_exhausted);
+}
+
+#[test]
+fn reviewed_quota_phrase_in_transport_error_summary_is_not_permanent() {
+    // A transport error whose text merely echoes reviewed content (no real
+    // provider quota framing) must not self-kill. `detect_rate_limit` requires
+    // the marker in the provider channel AND will only set quota_exhausted for
+    // genuine quota patterns — a bare unrelated failure does not match.
+    assert!(
+        detect_permanent_tool_exhaustion_text(
+            "codex",
+            "transport: turn failed while reviewing line `pattern: \"monthly\"`",
+            1,
+            None,
+        )
+        .is_none(),
+        "unrelated transport failure must not be permanent exhaustion"
+    );
+}

--- a/crates/csa-executor/src/transport_gemini_retry.rs
+++ b/crates/csa-executor/src/transport_gemini_retry.rs
@@ -88,10 +88,16 @@ pub(crate) fn detect_gemini_permanent_quota_exhaustion_result(
     if execution.exit_code == 0 {
         return None;
     }
-    detect_permanent_quota_exhaustion_pattern(&format!(
-        "{}\n{}\n{}",
-        execution.summary, execution.stderr_output, execution.output
-    ))
+    // Scan ONLY stderr — the provider's error channel. The agent's stdout
+    // (`output`) and the stdout-derived `summary` are reviewed/echoed content
+    // (e.g. a diff hunk, source line, or commit message under review may
+    // literally contain "monthly spending cap"), so matching markers there
+    // produced a false permanent-quota verdict and self-killed healthy sessions
+    // (#1736). gemini-cli emits genuine quota errors on stderr (mirrored by the
+    // fake-gemini test harness writing the failure reason with `>&2`), matching
+    // the stderr-only contract already used for codex (`is_codex_permanent_quota_result`,
+    // #1460). Transient rate-limit retry detection is unchanged.
+    detect_permanent_quota_exhaustion_pattern(&execution.stderr_output)
 }
 
 #[cfg(feature = "acp")]

--- a/crates/csa-executor/src/transport_tests_tail_retry.rs
+++ b/crates/csa-executor/src/transport_tests_tail_retry.rs
@@ -77,6 +77,53 @@ fn test_should_retry_generic_quota_exhausted_marker() {
 }
 
 #[test]
+fn test_gemini_permanent_quota_not_triggered_by_reviewed_content_in_stdout() {
+    // #1736 regression: a `csa review` whose reviewed diff/source/commit message
+    // literally contains a quota phrase (e.g. this failover classifier's own
+    // source) must NOT be misclassified as provider quota exhaustion. The marker
+    // here lives only in agent stdout (`output`) and the stdout-derived
+    // `summary`, never in the provider error channel (`stderr_output`).
+    let execution = ExecutionResult {
+        summary: "+    pattern: \"monthly spending cap\",".to_string(),
+        output: "Reviewing diff:\n+const PATTERN: &str = \"monthly spending cap\";\n\
+                  +// matches QUOTA_EXHAUSTED / RESOURCE_EXHAUSTED markers\n\
+                  Verdict: PASS"
+            .to_string(),
+        stderr_output: String::new(),
+        exit_code: 1,
+        peak_memory_mb: None,
+        ..Default::default()
+    };
+    assert_eq!(
+        detect_gemini_permanent_quota_exhaustion_result(&execution),
+        None,
+        "reviewed quota phrase in stdout/summary must not be read as provider quota exhaustion"
+    );
+}
+
+#[test]
+fn test_gemini_permanent_quota_still_detected_from_provider_stderr() {
+    // Positive: a genuine provider quota error on the stderr channel (as the
+    // gemini-cli backend emits, mirrored by the fake-gemini harness writing the
+    // failure reason with `>&2`) MUST still be detected as permanent.
+    let execution = ExecutionResult {
+        summary: "Verdict: PASS".to_string(),
+        output: "Reviewing diff... Verdict: PASS".to_string(),
+        stderr_output:
+            "reason: 'RESOURCE_EXHAUSTED'; the monthly spending cap was reached for this project"
+                .to_string(),
+        exit_code: 1,
+        peak_memory_mb: None,
+        ..Default::default()
+    };
+    assert_eq!(
+        detect_gemini_permanent_quota_exhaustion_result(&execution),
+        Some("monthly spending cap"),
+        "provider-reported monthly spending cap on stderr must still be permanent quota"
+    );
+}
+
+#[test]
 fn test_should_retry_transient_429_too_many_requests() {
     let transport = LegacyTransport::new(Executor::GeminiCli {
         model_override: None,


### PR DESCRIPTION
## Summary

Closes #1736. A `csa review` / `csa run` session was self-killed as "permanent
quota exhaustion" (`tool_exhausted: ... matched <spending-cap marker>`) whenever
the session's OWN output merely contained a quota-marker substring — e.g.
reviewing a diff, source file, test fixture, or commit message that literally
contains the spending-cap phrase, as the #1714 failover-classifier source does.
The backend quota was healthy; this false positive blocked CSA from reviewing
any quota/rate-limit-touching code (it surfaced concretely while reviewing the
#1714 branch).

## Root cause

`detect_rate_limit` (csa-scheduler) already gates the permanent `quota_exhausted`
verdict on the provider/stderr channel (the codex path has done so since #1460).
But two callers fed AGENT STDOUT content to the permanent-quota detector instead
of the provider-error channel:

- `detect_gemini_permanent_quota_exhaustion_result` (transport_gemini_retry.rs)
  scanned `summary + stderr + full agent output` — gemini was never updated by
  #1460.
- the shared self-kill chokepoint `detect_permanent_tool_exhaustion_text`
  (run_cmd_post_failover.rs) folded the stdout-derived `summary` into its scan.

## Fix

Both detectors now consult ONLY the provider-error channel: captured process
stderr (success path) or the anyhow error chain (transport-error path), matching
the stderr-only contract codex has used since #1460. Genuine provider quota
errors (usage limit, RESOURCE_EXHAUSTED, provider-reported spending cap on
stderr) are still detected and still trigger failover/exhaustion handling.

## Testing

- New regression + positive tests for both the gemini and shared paths: agent
  content / reviewed-diff containing a quota-marker substring does NOT classify
  as exhausted; a real provider-error quota line still IS detected.
- `just test`: 5285 passed.
- **Dogfood validation**: this PR's own branch — whose diff literally contains
  the spending-cap phrase — was reviewed by tier-4 codex using the fixed binary
  and PASSED without self-killing. That is the exact scenario that previously
  triggered the false positive (observed failing on the pre-fix binary during
  the #1714 review).

## Known residual (tracked follow-up, out of scope)

The codex CLI multiplexes tool-command output and provider errors onto one
captured stderr, so a quota phrase echoed by a codex tool-call onto its own
stderr could in principle still reach the provider channel. This minimal fix
deliberately avoids content-framing heuristics (they break legitimate bare-phrase
provider errors and risk under-detecting real exhaustion on a critical path). If
that residual is observed, the correct follow-up is to separate codex's
provider-error stream from tool-command output at the transport layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
