### PR TITLE
fix(cli-sub-agent): exclude quota-dead co-reviewer from consensus (#1739)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.824"
+version = "0.1.825"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.824"
+version = "0.1.825"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -1,17 +1,20 @@
 use anyhow::{Context, Result};
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::consensus::AgentResponse;
-use csa_core::types::ToolName;
+use csa_core::types::{FallbackAttempt, ToolName};
 use tokio::task::JoinSet;
 use tracing::{error, warn};
 
 use crate::cli::ReviewArgs;
+use crate::failover_trace::FailoverSkipKind;
 use crate::pipeline::resolve_effective_initial_response_timeout_for_tool;
 use crate::review_consensus::{
     CLEAN, UNAVAILABLE, agreement_level, build_multi_reviewer_instruction,
     consensus_strategy_label, consensus_verdict, parse_consensus_strategy, resolve_consensus,
 };
-use crate::review_routing::ReviewRoutingMetadata;
+use crate::review_routing::{
+    ReviewRoutingMetadata, persist_review_routing_artifact_with_fallback_chain,
+};
 
 use super::bug_class_pipeline::{
     maybe_extract_recurring_bug_class_skills, resolve_review_iterations,
@@ -205,9 +208,18 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         diff_fingerprint.clone(),
     );
 
-    let responses: Vec<AgentResponse> = outcomes
+    let consensus_outcomes = consensus_outcomes_for_final_verdict(&outcomes);
+    let excluded_from_consensus = permanent_quota_unavailable_reviewer_indices(&outcomes);
+    let excluded_fallback_chain = permanent_quota_unavailable_fallback_chain(&outcomes);
+    persist_excluded_reviewer_routing(
+        ctx.project_root,
+        &ctx.review_routing,
+        &outcomes,
+        &excluded_fallback_chain,
+    );
+    let responses: Vec<AgentResponse> = consensus_outcomes
         .iter()
-        .map(consensus_response_from_outcome)
+        .map(|outcome| consensus_response_from_outcome(outcome))
         .collect();
 
     let consensus_result = resolve_consensus(consensus_strategy, &responses);
@@ -250,12 +262,21 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         agreement * 100.0,
     );
     for outcome in &outcomes {
-        println!(
-            "- reviewer {} ({}) => {}",
-            outcome.reviewer_index + 1,
-            outcome.tool,
-            outcome.verdict
-        );
+        if excluded_from_consensus.contains(&outcome.reviewer_index) {
+            println!(
+                "- reviewer {} ({}) => {} (excluded_from_consensus: permanent quota unavailable)",
+                outcome.reviewer_index + 1,
+                outcome.tool,
+                outcome.verdict
+            );
+        } else {
+            println!(
+                "- reviewer {} ({}) => {}",
+                outcome.reviewer_index + 1,
+                outcome.tool,
+                outcome.verdict
+            );
+        }
     }
 
     let review_session_ids = outcomes
@@ -263,7 +284,7 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         .map(|outcome| outcome.session_id.clone())
         .collect::<Vec<_>>();
     maybe_extract_recurring_bug_class_skills(ctx.project_root, &review_session_ids);
-    Ok(if final_verdict == CLEAN { 0 } else { 1 })
+    Ok(multi_reviewer_exit_code(final_verdict))
 }
 
 pub(super) fn warn_if_fast_mode_has_no_codex_reviewer(
@@ -294,6 +315,89 @@ fn consensus_response_from_outcome(outcome: &ReviewerOutcome) -> AgentResponse {
         weight: 1.0,
         timed_out: !outcome.produced_usable_verdict(),
     }
+}
+
+fn consensus_outcomes_for_final_verdict(outcomes: &[ReviewerOutcome]) -> Vec<&ReviewerOutcome> {
+    let has_usable_verdict = outcomes
+        .iter()
+        .any(ReviewerOutcome::produced_usable_verdict);
+    outcomes
+        .iter()
+        .filter(|outcome| !(has_usable_verdict && outcome_has_permanent_quota_unavailable(outcome)))
+        .collect()
+}
+
+fn permanent_quota_unavailable_reviewer_indices(outcomes: &[ReviewerOutcome]) -> Vec<usize> {
+    let has_usable_verdict = outcomes
+        .iter()
+        .any(ReviewerOutcome::produced_usable_verdict);
+    if !has_usable_verdict {
+        return Vec::new();
+    }
+    outcomes
+        .iter()
+        .filter(|outcome| outcome_has_permanent_quota_unavailable(outcome))
+        .map(|outcome| outcome.reviewer_index)
+        .collect()
+}
+
+fn outcome_has_permanent_quota_unavailable(outcome: &ReviewerOutcome) -> bool {
+    permanent_quota_unavailable_fallback_attempt(outcome).is_some()
+}
+
+fn permanent_quota_unavailable_fallback_chain(
+    outcomes: &[ReviewerOutcome],
+) -> Vec<FallbackAttempt> {
+    let has_usable_verdict = outcomes
+        .iter()
+        .any(ReviewerOutcome::produced_usable_verdict);
+    if !has_usable_verdict {
+        return Vec::new();
+    }
+    outcomes
+        .iter()
+        .filter_map(permanent_quota_unavailable_fallback_attempt)
+        .collect()
+}
+
+fn permanent_quota_unavailable_fallback_attempt(
+    outcome: &ReviewerOutcome,
+) -> Option<FallbackAttempt> {
+    let diagnostic = outcome.diagnostic.as_deref()?;
+    let kind = FailoverSkipKind::classify(diagnostic);
+    (outcome.verdict == UNAVAILABLE && kind.is_quota()).then(|| FallbackAttempt {
+        tool: outcome.tool.as_str().to_string(),
+        model_spec: None,
+        skip_reason: kind.category().to_string(),
+        quota_exhausted: true,
+        timestamp: chrono::Utc::now(),
+    })
+}
+
+fn persist_excluded_reviewer_routing(
+    project_root: &Path,
+    review_routing: &ReviewRoutingMetadata,
+    outcomes: &[ReviewerOutcome],
+    fallback_chain: &[FallbackAttempt],
+) {
+    if fallback_chain.is_empty() {
+        return;
+    }
+    for outcome in outcomes
+        .iter()
+        .filter(|outcome| outcome.produced_usable_verdict())
+    {
+        persist_review_routing_artifact_with_fallback_chain(
+            project_root,
+            &outcome.session_id,
+            review_routing,
+            fallback_chain,
+        );
+    }
+}
+
+fn multi_reviewer_exit_code(final_verdict: &str) -> i32 {
+    if final_verdict == CLEAN { 0 } else { 1 }
 }
 
 pub(super) async fn collect_reviewer_outcomes(
@@ -395,140 +499,5 @@ fn synthesize_unavailable_outcomes(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::review_consensus::HAS_ISSUES;
-    use csa_core::consensus::ConsensusStrategy;
-    use proptest::prelude::*;
-
-    #[derive(Clone, Copy, Debug)]
-    enum ReviewerState {
-        Pass,
-        Fail,
-        Unavailable,
-    }
-
-    impl ReviewerState {
-        fn verdict(self) -> &'static str {
-            match self {
-                Self::Pass => CLEAN,
-                Self::Fail => HAS_ISSUES,
-                Self::Unavailable => UNAVAILABLE,
-            }
-        }
-    }
-
-    fn outcome(reviewer_index: usize, verdict: &'static str) -> ReviewerOutcome {
-        ReviewerOutcome {
-            reviewer_index,
-            tool: ToolName::Codex,
-            session_id: format!("01TESTREVIEWER{reviewer_index:012}"),
-            output: verdict.to_string(),
-            exit_code: if verdict == CLEAN { 0 } else { 1 },
-            verdict,
-            diagnostic: None,
-        }
-    }
-
-    #[test]
-    fn unavailable_outcomes_do_not_vote_against_clean_consensus() {
-        let outcomes = [outcome(0, UNAVAILABLE), outcome(1, CLEAN)];
-        let responses: Vec<AgentResponse> = outcomes
-            .iter()
-            .map(consensus_response_from_outcome)
-            .collect();
-        let consensus = resolve_consensus(ConsensusStrategy::Majority, &responses);
-
-        assert_eq!(consensus.decision.as_deref(), Some(CLEAN));
-        assert_eq!(consensus_verdict(&consensus), CLEAN);
-    }
-
-    #[test]
-    fn unavailable_outcomes_do_not_hide_has_issues_consensus() {
-        let outcomes = [outcome(0, UNAVAILABLE), outcome(1, HAS_ISSUES)];
-        let responses: Vec<AgentResponse> = outcomes
-            .iter()
-            .map(consensus_response_from_outcome)
-            .collect();
-        let consensus = resolve_consensus(ConsensusStrategy::Majority, &responses);
-
-        assert_eq!(consensus.decision.as_deref(), Some(HAS_ISSUES));
-        assert_eq!(consensus_verdict(&consensus), HAS_ISSUES);
-    }
-
-    #[tokio::test]
-    async fn collect_reviewer_outcomes_waits_after_unavailable_reviewer() {
-        let mut join_set = JoinSet::new();
-        join_set.spawn(async {
-            Ok(build_unavailable_reviewer_outcome(
-                0,
-                ToolName::GeminiCli,
-                "gemini-cli tool failure: reason: QUOTA_EXHAUSTED",
-            ))
-        });
-        join_set.spawn(async {
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            Ok(outcome(1, CLEAN))
-        });
-
-        let outcomes =
-            collect_reviewer_outcomes(&mut join_set, &[ToolName::GeminiCli, ToolName::Codex], None)
-                .await
-                .expect("collect outcomes");
-
-        assert_eq!(outcomes.len(), 2);
-        assert_eq!(outcomes[0].verdict, UNAVAILABLE);
-        assert_eq!(outcomes[1].verdict, CLEAN);
-    }
-
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(128))]
-
-        #[test]
-        fn reviewer_outcome_consensus_mapping_filters_unavailable_before_vote(
-            states in prop::collection::vec(reviewer_state_strategy(), 2..=4),
-        ) {
-            let outcomes: Vec<ReviewerOutcome> = states
-                .iter()
-                .enumerate()
-                .map(|(idx, state)| outcome(idx, state.verdict()))
-                .collect();
-            let responses: Vec<AgentResponse> = outcomes
-                .iter()
-                .map(consensus_response_from_outcome)
-                .collect();
-            let active_responses: Vec<AgentResponse> = responses
-                .iter()
-                .filter(|response| !response.timed_out)
-                .cloned()
-                .collect();
-
-            prop_assert_eq!(
-                responses.iter().filter(|response| response.timed_out).count(),
-                states.iter().filter(|state| matches!(state, ReviewerState::Unavailable)).count()
-            );
-
-            let consensus_with_unavailable =
-                resolve_consensus(ConsensusStrategy::Majority, &responses);
-            let consensus_without_unavailable =
-                resolve_consensus(ConsensusStrategy::Majority, &active_responses);
-
-            prop_assert_eq!(
-                consensus_with_unavailable.decision.as_deref(),
-                consensus_without_unavailable.decision.as_deref()
-            );
-            prop_assert_eq!(
-                consensus_verdict(&consensus_with_unavailable),
-                consensus_verdict(&consensus_without_unavailable)
-            );
-        }
-    }
-
-    fn reviewer_state_strategy() -> impl Strategy<Value = ReviewerState> {
-        prop_oneof![
-            Just(ReviewerState::Pass),
-            Just(ReviewerState::Fail),
-            Just(ReviewerState::Unavailable),
-        ]
-    }
-}
+#[path = "review_cmd_multi_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/review_cmd_multi_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi_tests.rs
@@ -1,0 +1,241 @@
+use super::*;
+use crate::review_consensus::HAS_ISSUES;
+use csa_config::ProjectProfile;
+use csa_core::consensus::ConsensusStrategy;
+use proptest::prelude::*;
+
+#[derive(Clone, Copy, Debug)]
+enum ReviewerState {
+    Pass,
+    Fail,
+    Unavailable,
+}
+
+impl ReviewerState {
+    fn verdict(self) -> &'static str {
+        match self {
+            Self::Pass => CLEAN,
+            Self::Fail => HAS_ISSUES,
+            Self::Unavailable => UNAVAILABLE,
+        }
+    }
+}
+
+fn outcome(reviewer_index: usize, verdict: &'static str) -> ReviewerOutcome {
+    outcome_with_tool(reviewer_index, ToolName::Codex, verdict, None)
+}
+
+fn outcome_with_tool(
+    reviewer_index: usize,
+    tool: ToolName,
+    verdict: &'static str,
+    diagnostic: Option<&str>,
+) -> ReviewerOutcome {
+    ReviewerOutcome {
+        reviewer_index,
+        tool,
+        session_id: format!("01TESTREVIEWER{reviewer_index:012}"),
+        output: verdict.to_string(),
+        exit_code: if verdict == CLEAN { 0 } else { 1 },
+        verdict,
+        diagnostic: diagnostic.map(str::to_string),
+    }
+}
+
+#[test]
+fn unavailable_outcomes_do_not_vote_against_clean_consensus() {
+    let outcomes = [outcome(0, UNAVAILABLE), outcome(1, CLEAN)];
+    let responses: Vec<AgentResponse> = outcomes
+        .iter()
+        .map(consensus_response_from_outcome)
+        .collect();
+    let consensus = resolve_consensus(ConsensusStrategy::Majority, &responses);
+
+    assert_eq!(consensus.decision.as_deref(), Some(CLEAN));
+    assert_eq!(consensus_verdict(&consensus), CLEAN);
+}
+
+#[test]
+fn permanent_quota_unavailable_reviewer_is_excluded_when_peer_passes() {
+    let outcomes = [
+        outcome_with_tool(
+            0,
+            ToolName::GeminiCli,
+            UNAVAILABLE,
+            Some("gemini-cli OAuth quota exhausted; monthly cap reached"),
+        ),
+        outcome_with_tool(1, ToolName::Codex, CLEAN, None),
+    ];
+
+    let consensus_outcomes = consensus_outcomes_for_final_verdict(&outcomes);
+    assert_eq!(
+        consensus_outcomes
+            .iter()
+            .map(|outcome| outcome.reviewer_index)
+            .collect::<Vec<_>>(),
+        vec![1]
+    );
+
+    let responses: Vec<AgentResponse> = consensus_outcomes
+        .iter()
+        .map(|outcome| consensus_response_from_outcome(outcome))
+        .collect();
+    let consensus = resolve_consensus(ConsensusStrategy::Majority, &responses);
+
+    assert_eq!(consensus.decision.as_deref(), Some(CLEAN));
+    assert_eq!(consensus_verdict(&consensus), CLEAN);
+    assert_eq!(multi_reviewer_exit_code(consensus_verdict(&consensus)), 0);
+
+    let fallback_chain = permanent_quota_unavailable_fallback_chain(&outcomes);
+    assert_eq!(fallback_chain.len(), 1);
+    assert_eq!(fallback_chain[0].tool, "gemini-cli");
+    assert_eq!(fallback_chain[0].skip_reason, "oauth-quota");
+    assert!(fallback_chain[0].quota_exhausted);
+}
+
+#[test]
+fn all_permanent_quota_unavailable_reviewers_still_fail_unavailable() {
+    let outcomes = [
+        outcome_with_tool(
+            0,
+            ToolName::GeminiCli,
+            UNAVAILABLE,
+            Some("gemini-cli OAuth quota exhausted; monthly cap reached"),
+        ),
+        outcome_with_tool(
+            1,
+            ToolName::ClaudeCode,
+            UNAVAILABLE,
+            Some("OAuth quota exhausted; billing monthly spending cap reached"),
+        ),
+    ];
+
+    let consensus_outcomes = consensus_outcomes_for_final_verdict(&outcomes);
+    assert_eq!(consensus_outcomes.len(), outcomes.len());
+    assert!(permanent_quota_unavailable_reviewer_indices(&outcomes).is_empty());
+    assert!(
+        outcomes
+            .iter()
+            .all(|outcome| outcome.verdict == UNAVAILABLE)
+    );
+    assert!(permanent_quota_unavailable_fallback_chain(&outcomes).is_empty());
+    assert_eq!(multi_reviewer_exit_code(UNAVAILABLE), 1);
+}
+
+#[test]
+fn review_routing_artifact_records_excluded_quota_reviewer_skip_reason() {
+    let outcomes = [
+        outcome_with_tool(
+            0,
+            ToolName::GeminiCli,
+            UNAVAILABLE,
+            Some("gemini-cli OAuth quota exhausted; monthly cap reached"),
+        ),
+        outcome_with_tool(1, ToolName::Codex, CLEAN, None),
+    ];
+    let fallback_chain = permanent_quota_unavailable_fallback_chain(&outcomes);
+    let routing = ReviewRoutingMetadata {
+        project_profile: ProjectProfile::Unknown,
+        detection_method: "auto",
+    };
+
+    let artifact = crate::review_routing::render_review_routing_artifact(&routing, &fallback_chain);
+    let parsed: serde_json::Value = serde_json::from_str(&artifact).expect("review-routing json");
+    let chain = parsed["fallback_chain"]
+        .as_array()
+        .expect("fallback_chain array");
+
+    assert_eq!(chain.len(), 1);
+    assert_eq!(chain[0]["tool"], "gemini-cli");
+    assert_eq!(chain[0]["skip_reason"], "oauth-quota");
+    assert_eq!(chain[0]["quota_exhausted"], true);
+}
+
+#[test]
+fn unavailable_outcomes_do_not_hide_has_issues_consensus() {
+    let outcomes = [outcome(0, UNAVAILABLE), outcome(1, HAS_ISSUES)];
+    let responses: Vec<AgentResponse> = outcomes
+        .iter()
+        .map(consensus_response_from_outcome)
+        .collect();
+    let consensus = resolve_consensus(ConsensusStrategy::Majority, &responses);
+
+    assert_eq!(consensus.decision.as_deref(), Some(HAS_ISSUES));
+    assert_eq!(consensus_verdict(&consensus), HAS_ISSUES);
+}
+
+#[tokio::test]
+async fn collect_reviewer_outcomes_waits_after_unavailable_reviewer() {
+    let mut join_set = JoinSet::new();
+    join_set.spawn(async {
+        Ok(build_unavailable_reviewer_outcome(
+            0,
+            ToolName::GeminiCli,
+            "gemini-cli tool failure: reason: QUOTA_EXHAUSTED",
+        ))
+    });
+    join_set.spawn(async {
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        Ok(outcome(1, CLEAN))
+    });
+
+    let outcomes =
+        collect_reviewer_outcomes(&mut join_set, &[ToolName::GeminiCli, ToolName::Codex], None)
+            .await
+            .expect("collect outcomes");
+
+    assert_eq!(outcomes.len(), 2);
+    assert_eq!(outcomes[0].verdict, UNAVAILABLE);
+    assert_eq!(outcomes[1].verdict, CLEAN);
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    #[test]
+    fn reviewer_outcome_consensus_mapping_filters_unavailable_before_vote(
+        states in prop::collection::vec(reviewer_state_strategy(), 2..=4),
+    ) {
+        let outcomes: Vec<ReviewerOutcome> = states
+            .iter()
+            .enumerate()
+            .map(|(idx, state)| outcome(idx, state.verdict()))
+            .collect();
+        let responses: Vec<AgentResponse> = outcomes
+            .iter()
+            .map(consensus_response_from_outcome)
+            .collect();
+        let active_responses: Vec<AgentResponse> = responses
+            .iter()
+            .filter(|response| !response.timed_out)
+            .cloned()
+            .collect();
+
+        prop_assert_eq!(
+            responses.iter().filter(|response| response.timed_out).count(),
+            states.iter().filter(|state| matches!(state, ReviewerState::Unavailable)).count()
+        );
+
+        let consensus_with_unavailable =
+            resolve_consensus(ConsensusStrategy::Majority, &responses);
+        let consensus_without_unavailable =
+            resolve_consensus(ConsensusStrategy::Majority, &active_responses);
+
+        prop_assert_eq!(
+            consensus_with_unavailable.decision.as_deref(),
+            consensus_without_unavailable.decision.as_deref()
+        );
+        prop_assert_eq!(
+            consensus_verdict(&consensus_with_unavailable),
+            consensus_verdict(&consensus_without_unavailable)
+        );
+    }
+}
+
+fn reviewer_state_strategy() -> impl Strategy<Value = ReviewerState> {
+    prop_oneof![
+        Just(ReviewerState::Pass),
+        Just(ReviewerState::Fail),
+        Just(ReviewerState::Unavailable),
+    ]
+}

--- a/crates/cli-sub-agent/src/review_cmd_reviewers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers.rs
@@ -54,6 +54,17 @@ fn collect_tier_reviewer_specs(
         .unwrap_or_default()
 }
 
+fn effective_review_tool_whitelist<'a>(
+    config: Option<&'a ProjectConfig>,
+    global_config: &'a GlobalConfig,
+) -> Option<&'a [String]> {
+    config
+        .and_then(|cfg| cfg.review.as_ref())
+        .map(|review| &review.tool)
+        .unwrap_or(&global_config.review.tool)
+        .whitelist()
+}
+
 fn collect_unique_tier_tools(
     tier_reviewer_specs: &[crate::run_helpers::TierToolResolution],
 ) -> Vec<ToolName> {
@@ -70,15 +81,27 @@ fn build_selected_tool_subset(
     primary_tool: ToolName,
     tier_reviewer_tools: &[ToolName],
     reviewers: usize,
+    whitelist: Option<&[String]>,
 ) -> Vec<ToolName> {
-    let mut selected = vec![primary_tool];
+    let tool_allowed =
+        |tool: ToolName| whitelist.is_none_or(|wl| wl.iter().any(|w| w == tool.as_str()));
+    let mut selected = Vec::new();
+    if tool_allowed(primary_tool) {
+        selected.push(primary_tool);
+    }
     for tool in tier_reviewer_tools {
-        if !selected.contains(tool) {
+        if tool_allowed(*tool) && !selected.contains(tool) {
             selected.push(*tool);
         }
     }
     selected.truncate(reviewers);
     selected
+}
+
+fn repeat_reviewer_pool(pool: &[ToolName], reviewer_count: usize) -> Vec<ToolName> {
+    (0..reviewer_count)
+        .map(|idx| pool[idx % pool.len()])
+        .collect()
 }
 
 pub(crate) fn resolve_auto_reviewer_selection(
@@ -100,10 +123,12 @@ pub(crate) fn resolve_auto_reviewer_selection(
         request.global_config,
     );
     let tier_reviewer_tools = collect_unique_tier_tools(&tier_reviewer_specs);
+    let whitelist = effective_review_tool_whitelist(request.config, request.global_config);
     let unique_pool = build_selected_tool_subset(
         request.primary_tool,
         &tier_reviewer_tools,
         MAX_AUTO_HETEROGENEOUS_REVIEWERS,
+        whitelist,
     );
 
     (unique_pool.len() >= 2).then_some(AutoReviewerSelection {
@@ -146,14 +171,20 @@ pub(crate) fn resolve_multi_reviewer_pool(
     let tier_reviewer_specs =
         collect_tier_reviewer_specs(resolved_tier_name, config, global_config);
     let tier_reviewer_tools = collect_unique_tier_tools(&tier_reviewer_specs);
+    let whitelist = effective_review_tool_whitelist(config, global_config);
 
     if let Some(tier_name) = resolved_tier_name {
-        let unique_reviewer_tools = validate_multi_reviewer_tier_pool(
-            tier_name,
-            reviewers,
-            primary_tool,
-            &tier_reviewer_tools,
-        )?;
+        let unique_reviewer_tools = if whitelist.is_some() {
+            build_selected_tool_subset(primary_tool, &tier_reviewer_tools, usize::MAX, whitelist)
+                .len()
+        } else {
+            validate_multi_reviewer_tier_pool(
+                tier_name,
+                reviewers,
+                primary_tool,
+                &tier_reviewer_tools,
+            )?
+        };
         if reviewers > unique_reviewer_tools {
             warn!(
                 tier = tier_name,
@@ -164,14 +195,25 @@ pub(crate) fn resolve_multi_reviewer_pool(
         }
     }
 
-    let reviewer_tools = build_reviewer_tools(
-        explicit_tool,
-        primary_tool,
-        config,
-        Some(global_config),
-        resolved_tier_name.map(|_| tier_reviewer_tools.as_slice()),
-        reviewers,
-    );
+    let reviewer_tools = if resolved_tier_name.is_some() && explicit_tool.is_none() {
+        let pool =
+            build_selected_tool_subset(primary_tool, &tier_reviewer_tools, usize::MAX, whitelist);
+        if pool.is_empty() {
+            anyhow::bail!(
+                "Review tier resolved no reviewer tools after applying [review].tool whitelist"
+            );
+        }
+        repeat_reviewer_pool(&pool, reviewers)
+    } else {
+        build_reviewer_tools(
+            explicit_tool,
+            primary_tool,
+            config,
+            Some(global_config),
+            resolved_tier_name.map(|_| tier_reviewer_tools.as_slice()),
+            reviewers,
+        )
+    };
 
     Ok(MultiReviewerPool {
         reviewer_tools,
@@ -181,12 +223,15 @@ pub(crate) fn resolve_multi_reviewer_pool(
 
 #[cfg(test)]
 mod tests {
-    use super::{AutoReviewerRequest, resolve_auto_reviewer_selection};
+    use super::{
+        AutoReviewerRequest, resolve_auto_reviewer_selection, resolve_multi_reviewer_pool,
+    };
     use crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV;
     use crate::test_env_lock::TEST_ENV_LOCK;
     use csa_config::config::TierConfig;
     use csa_config::{
-        GlobalConfig, ProjectConfig, ProjectMeta, ResourcesConfig, TierStrategy, ToolConfig,
+        GlobalConfig, ProjectConfig, ProjectMeta, ResourcesConfig, ReviewConfig, TierStrategy,
+        ToolConfig, ToolSelection,
     };
     use csa_core::types::ToolName;
     use std::collections::HashMap;
@@ -289,6 +334,18 @@ mod tests {
         }
     }
 
+    fn project_config_with_tier_and_review_tool(
+        models: &[&str],
+        tool: ToolSelection,
+    ) -> ProjectConfig {
+        let mut config = project_config_with_tier(models);
+        config.review = Some(ReviewConfig {
+            tool,
+            ..ReviewConfig::default()
+        });
+        config
+    }
+
     #[test]
     fn auto_reviewer_selection_skips_single_tool_tier() {
         let (_env_lock, _available_guard) = assume_review_tools_available();
@@ -340,6 +397,36 @@ mod tests {
         assert_eq!(
             selection.selected_tools,
             vec![ToolName::GeminiCli, ToolName::Codex, ToolName::Opencode]
+        );
+    }
+
+    #[test]
+    fn auto_range_reviewer_roster_respects_review_tool_whitelist() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier_and_review_tool(
+            &[
+                "codex/openai/gpt-5.4/high",
+                "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            ],
+            ToolSelection::Whitelist(vec!["codex".to_string()]),
+        );
+        let global = GlobalConfig::default();
+
+        let pool = resolve_multi_reviewer_pool(
+            2,
+            None,
+            ToolName::Codex,
+            Some("quality"),
+            Some(&config),
+            &global,
+        )
+        .expect("whitelisted single-tool roster should resolve");
+
+        assert_eq!(pool.reviewer_tools, vec![ToolName::Codex, ToolName::Codex]);
+        assert!(
+            pool.tier_reviewer_specs
+                .iter()
+                .all(|resolution| resolution.tool == ToolName::Codex)
         );
     }
 

--- a/crates/cli-sub-agent/src/review_routing.rs
+++ b/crates/cli-sub-agent/src/review_routing.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use csa_config::{ProjectConfig, ProjectProfile};
+use csa_core::types::FallbackAttempt;
 use tracing::{debug, warn};
 
 #[derive(Debug, Clone)]
@@ -26,6 +27,20 @@ pub(crate) fn persist_review_routing_artifact(
     meta_session_id: &str,
     review_routing: &ReviewRoutingMetadata,
 ) {
+    persist_review_routing_artifact_with_fallback_chain(
+        project_root,
+        meta_session_id,
+        review_routing,
+        &[],
+    );
+}
+
+pub(crate) fn persist_review_routing_artifact_with_fallback_chain(
+    project_root: &Path,
+    meta_session_id: &str,
+    review_routing: &ReviewRoutingMetadata,
+    fallback_chain: &[FallbackAttempt],
+) {
     let session_dir = match csa_session::get_session_dir(project_root, meta_session_id) {
         Ok(path) => path,
         Err(err) => {
@@ -48,10 +63,7 @@ pub(crate) fn persist_review_routing_artifact(
         return;
     }
 
-    let artifact = format!(
-        "{{\"project_profile\":\"{}\",\"detection_method\":\"{}\",\"schema_version\":\"1.0\"}}\n",
-        review_routing.project_profile, review_routing.detection_method
-    );
+    let artifact = render_review_routing_artifact(review_routing, fallback_chain);
     let artifact_path = output_dir.join("review-routing.json");
     if let Err(err) = std::fs::write(&artifact_path, artifact) {
         warn!(
@@ -61,4 +73,20 @@ pub(crate) fn persist_review_routing_artifact(
             "Failed to write review-routing artifact (best-effort)"
         );
     }
+}
+
+pub(crate) fn render_review_routing_artifact(
+    review_routing: &ReviewRoutingMetadata,
+    fallback_chain: &[FallbackAttempt],
+) -> String {
+    let mut artifact = serde_json::json!({
+        "project_profile": review_routing.project_profile.to_string(),
+        "detection_method": review_routing.detection_method,
+        "schema_version": "1.0",
+    });
+    if !fallback_chain.is_empty() {
+        artifact["fallback_chain"] =
+            serde_json::to_value(fallback_chain).unwrap_or_else(|_| serde_json::json!([]));
+    }
+    format!("{artifact}\n")
 }


### PR DESCRIPTION
## Summary

Fixes #1739 — during the gemini-cli monthly-OAuth-cap window, `csa review --range main...HEAD --tier tier-4-critical` (no `--single`/`--tool`/`--model-spec`) auto-selected a HETEROGENEOUS reviewer roster that pulled in the quota-dead gemini co-reviewer. codex reviewed cleanly and emitted PASS, but gemini's OAuth-cap failure flipped the session to `exit_code=1`/`failure` and the verdict to UNAVAILABLE, **masking the clean codex PASS**. With gemini permanently capped and codex the sole working reviewer, every clean review recorded UNAVAILABLE → no PR could pass the push/merge gate (a #1657-class merge-blocking regression on the daemon-completion / verdict-derivation path).

## Changes (4 layered fixes from the issue)

1. **Honor `[review].tool` as a whitelist on the `--range` auto-heterogeneous roster** — a configured `[review].tool = ["codex"]` now filters the reviewer roster (gemini is not pulled in). Empty/absent whitelist preserves current behavior.
2. **Exclude permanently quota-unavailable co-reviewers from roster + consensus** — when ≥1 reviewer yields a real verdict and another is permanently quota-unavailable (OAuth monthly cap / permanent `RESOURCE_EXHAUSTED`, via the existing rate-limit/permanent-exhaustion classifier), the unavailable reviewer is excluded; the session verdict is the surviving reviewer's verdict. UNAVAILABLE is recorded **only when ALL reviewers are unavailable** (preserves #1716 total-failure behavior).
3. **daemon-completion `exit_code` reflects the review verdict** — not a co-reviewer's quota-probe failure. A clean PASS with an excluded quota-unavailable co-reviewer finalizes `exit_code=0`/`status=success`.
4. **Structured skip reason in `review-routing.json`** — the co-reviewer exclusion reason is recorded (reusing the #1714 failover-trace machinery), closing the opacity gap (#179 / #1714).
5. **Monolith-gate split** — the `review_cmd_multi.rs` test module was moved verbatim into a sibling `review_cmd_multi_tests.rs` (wired via `#[cfg(test)] #[path = ...] mod tests;`, the existing project convention) to keep the source under the 8000-token monolith gate. Pure move, no logic change.

## Tests

- Regression: one reviewer quota-unavailable (gemini OAuth cap) + one PASS (codex) → verdict PASS, `exit_code=0`/`success`, not UNAVAILABLE.
- Regression: ALL reviewers quota-unavailable → UNAVAILABLE (preserves #1716).
- Regression: `[review].tool = ["codex"]` whitelist on a multi-tool tier `--range` roster → only codex selected.
- Regression: `review-routing.json` records the structured skip reason for the excluded co-reviewer.
- Full workspace suite green.

## Out of scope

- #1711 (phase stuck `active`) is a separate daemon-lifecycle issue, tracked independently — not addressed here.

## Review

- Pre-PR review: codex single-reviewer, pinned exactly via `--range main...HEAD --model-spec codex/openai/gpt-5.5/xhigh --force-ignore-tier-setting --no-failover --single` during the gemini-dead window (the pin avoids the very dead-co-reviewer pull this PR fixes). Verdict confirmed by reading `output/details.md`, not the verdict field alone (verdict-field-unreliable discipline during the gemini-OAuth-cap window).
- Committed on host via the documented escape hatch (#1745): the in-session edit/commit self-kills on this change because the source + pre-commit `just test` output legitimately contain the fatal-error-marker strings (quota / 429 / `RESOURCE_EXHAUSTED`) the detection code and its regression tests must reference.

## Relates

#1657, #1659, #1716, #179, #1714, #1745. Out of scope: #1711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
