### PR TITLE
fix(cli-sub-agent): preserve committed-clean post-exec gate timeouts as success (#1757)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.831"
+version = "0.1.832"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.831"
+version = "0.1.832"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -216,6 +216,10 @@ pub enum Commands {
         #[arg(long)]
         no_error_marker_scan: bool,
 
+        /// Skip only the post-exec shell gate; external verification remains required.
+        #[arg(long)]
+        no_post_exec_gate: bool,
+
         /// Path to agent-spec file (.spec or .toml) for contract-based verification
         #[arg(long, value_name = "PATH", value_parser = parse_spec_path_arg)]
         spec: Option<String>,

--- a/crates/cli-sub-agent/src/config_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_tests.rs
@@ -146,7 +146,7 @@ fn build_project_display_toml_keeps_effective_post_exec_gate_defaults_visible() 
     assert!(rendered.contains("[run.post_exec_gate]"));
     assert!(rendered.contains("enabled = true"));
     assert!(rendered.contains("command = \"just pre-commit\""));
-    assert!(rendered.contains("timeout_seconds = 600"));
+    assert!(rendered.contains("timeout_seconds = 1800"));
     assert!(rendered.contains("skip_on_no_changes = true"));
 }
 
@@ -168,7 +168,7 @@ fn build_project_display_json_keeps_effective_post_exec_gate_defaults_visible() 
     );
     assert_eq!(
         gate.get("timeout_seconds").and_then(|value| value.as_u64()),
-        Some(600)
+        Some(1800)
     );
     assert_eq!(
         gate.get("skip_on_no_changes")

--- a/crates/cli-sub-agent/src/goal_loop.rs
+++ b/crates/cli-sub-agent/src/goal_loop.rs
@@ -107,6 +107,7 @@ pub(crate) struct GoalRunRequest {
     /// CLI `--no-error-marker-scan`: disables the #1652 fatal-error-marker
     /// silent-hang scan for this run, overriding config (#1745).
     pub(crate) no_error_marker_scan: bool,
+    pub(crate) no_post_exec_gate: bool,
     pub(crate) extra_writable: Vec<PathBuf>,
     pub(crate) extra_readable: Vec<PathBuf>,
 }
@@ -173,6 +174,7 @@ pub(crate) async fn handle_run_or_goal(request: GoalRunRequest) -> Result<i32> {
         request.force_ignore_tier_setting,
         request.no_fs_sandbox,
         request.no_error_marker_scan,
+        request.no_post_exec_gate,
         request.extra_writable,
         request.extra_readable,
     )
@@ -331,6 +333,7 @@ async fn run_goal_iteration(
         request.force_ignore_tier_setting,
         request.no_fs_sandbox,
         request.no_error_marker_scan,
+        request.no_post_exec_gate,
         request.extra_writable.clone(),
         request.extra_readable.clone(),
     )

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -196,8 +196,6 @@ async fn run() -> Result<()> {
     let text_output = matches!(output_format, OutputFormat::Text);
     let command = cli.command;
 
-    // Resolve effective min_timeout_seconds from configs (project overrides global).
-    // This is a lightweight load; config errors are ignored (fall back to compile-time default).
     let min_timeout = resolve_effective_min_timeout();
 
     if let Err(err) = validate_command_args(&command, min_timeout) {
@@ -289,6 +287,7 @@ async fn run() -> Result<()> {
             stream_stdout,
             no_stream_stdout,
             no_error_marker_scan,
+            no_post_exec_gate,
             spec: _spec,
             tier,
             force_ignore_tier_setting,
@@ -379,12 +378,11 @@ async fn run() -> Result<()> {
                 force_ignore_tier_setting,
                 no_fs_sandbox,
                 no_error_marker_scan,
+                no_post_exec_gate,
                 extra_writable,
                 extra_readable,
             })
             .await;
-            // Report errors while fd 2 is still open (guard holds stderr rotation).
-            // Dropping the guard closes fd 2, so eprintln! must happen first.
             let exit_code = report_daemon_error_or_exit_code(result, &mut daemon_guard);
             // Post-session SA mode reminder so caller sees constraint before next action.
             crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -144,6 +144,7 @@ impl SubagentRunConfig {
             false,
             false,
             false, // no_error_marker_scan: programmatic run wrapper; defer to config (#1745)
+            false,
             Vec::new(),
             Vec::new(),
         )

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -31,7 +31,9 @@ mod run_context;
 mod skill_resume;
 #[path = "run_cmd_execute_tier_guard.rs"]
 mod tier_guard;
-use post_exec_gate::{execute_post_exec_gate_command, maybe_run_post_exec_gate_with_runner};
+use post_exec_gate::{
+    apply_post_exec_gate_after_success_with_runner, execute_post_exec_gate_command,
+};
 use reuse_hint::emit_reusable_session_hint;
 use routing::{
     RunModelSelectionFlags, enforce_run_tier_bypass_gate, resolve_primary_writer_spec_for_run,
@@ -94,6 +96,7 @@ pub(crate) async fn handle_run(
     force_ignore_tier_setting: bool,
     no_fs_sandbox: bool,
     no_error_marker_scan: bool,
+    no_post_exec_gate: bool,
     extra_writable: Vec<PathBuf>,
     extra_readable: Vec<PathBuf>,
 ) -> Result<i32> {
@@ -587,28 +590,16 @@ pub(crate) async fn handle_run(
     let fork_resolution = loop_outcome.fork_resolution;
 
     if result.exit_code == 0 {
-        // Capture gate errors so we can overwrite the already-written result.toml
-        // before propagating.  Without this, result.toml shows status=success even
-        // when the gate rejected the session output (#1486).
-        if let Err(gate_err) = maybe_run_post_exec_gate_with_runner(
+        apply_post_exec_gate_after_success_with_runner(
             &project_root,
             &gate_prompt_text,
             executed_session_id.as_deref(),
             config.as_ref(),
             changed_paths.as_deref(),
+            no_post_exec_gate,
             execute_post_exec_gate_command,
         )
-        .await
-        {
-            if let Some(ref sid) = executed_session_id {
-                crate::run_cmd_post::overwrite_result_as_post_exec_gate_failure(
-                    &project_root,
-                    sid,
-                    &gate_err,
-                );
-            }
-            return Err(gate_err);
-        }
+        .await?;
     }
 
     if fork_call {

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -353,7 +353,7 @@ where
         return Ok(());
     }
 
-    match maybe_run_post_exec_gate_with_runner(
+    let gate_outcome = match maybe_run_post_exec_gate_with_runner(
         project_root,
         prompt_text,
         session_id,
@@ -361,8 +361,23 @@ where
         changed_paths,
         runner,
     )
-    .await?
+    .await
     {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            if let Some(session_id) = session_id {
+                crate::run_cmd_post::overwrite_result_as_post_exec_gate_failure(
+                    project_root,
+                    session_id,
+                    &format!("could not run the post-exec gate: {err}"),
+                    false,
+                );
+            }
+            return Err(err);
+        }
+    };
+
+    match gate_outcome {
         PostExecGateOutcome::Passed | PostExecGateOutcome::Skipped => Ok(()),
         PostExecGateOutcome::Failed(failure) if failure.is_timeout() => {
             if classify_post_exec_gate_worktree(project_root, session_id)

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -18,6 +18,35 @@ pub(super) enum PostExecGateCommandOutcome {
 pub(super) enum PostExecGateOutcome {
     Passed,
     Skipped,
+    Failed(PostExecGateFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PostExecGateFailure {
+    kind: PostExecGateFailureKind,
+    diagnostic: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PostExecGateFailureKind {
+    Exited(Option<i32>),
+    TimedOut,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PostExecGateWorktreeState {
+    CommittedClean,
+    DirtyOrUnknown,
+}
+
+impl PostExecGateFailure {
+    fn into_error(self) -> anyhow::Error {
+        anyhow::anyhow!(self.diagnostic)
+    }
+
+    fn is_timeout(&self) -> bool {
+        matches!(self.kind, PostExecGateFailureKind::TimedOut)
+    }
 }
 
 type PostExecGateFuture = Pin<Box<dyn Future<Output = Result<PostExecGateCommandOutcome>> + Send>>;
@@ -83,6 +112,31 @@ fn git_head_changed_since(project_root: &Path, start_head: Option<&str>) -> Resu
     Ok(current_head.trim() != start_head)
 }
 
+fn current_git_head(project_root: &Path) -> Result<Option<String>> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["rev-parse", "--verify", "HEAD"])
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to inspect git HEAD for post-exec gate in {}",
+                project_root.display()
+            )
+        })?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let head = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if head.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(head))
+    }
+}
+
 fn git_worktree_has_status_changes(project_root: &Path) -> Result<bool> {
     let output = std::process::Command::new("git")
         .arg("-C")
@@ -101,6 +155,32 @@ fn git_worktree_has_status_changes(project_root: &Path) -> Result<bool> {
     }
 
     Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+fn classify_post_exec_gate_worktree(
+    project_root: &Path,
+    session_id: Option<&str>,
+) -> PostExecGateWorktreeState {
+    if !crate::run_cmd::is_git_worktree(project_root) {
+        return PostExecGateWorktreeState::DirtyOrUnknown;
+    }
+
+    let Some(start_head) = session_id.and_then(|id| session_start_head(project_root, id)) else {
+        return PostExecGateWorktreeState::DirtyOrUnknown;
+    };
+
+    let Ok(Some(current_head)) = current_git_head(project_root) else {
+        return PostExecGateWorktreeState::DirtyOrUnknown;
+    };
+
+    if current_head.trim() == start_head.trim() {
+        return PostExecGateWorktreeState::DirtyOrUnknown;
+    }
+
+    match git_worktree_has_status_changes(project_root) {
+        Ok(false) => PostExecGateWorktreeState::CommittedClean,
+        Ok(true) | Err(_) => PostExecGateWorktreeState::DirtyOrUnknown,
+    }
 }
 
 fn strip_inherited_csa_env(cmd: &mut Command) {
@@ -215,32 +295,109 @@ where
     .await?
     {
         PostExecGateCommandOutcome::Exited(Some(0)) => Ok(PostExecGateOutcome::Passed),
-        PostExecGateCommandOutcome::Exited(code) => anyhow::bail!(
-            "csa: post-exec gate failed (exit={}).\n\
-             gate command: {}\n\
-             cwd: {}\n\
-             employee session: {}\n\
-             branch: {}\n\
-             next step: inspect the gate output above, fix the issue, and re-run the dispatch manually. v1 gate does NOT auto-retry.",
-            code.map_or_else(|| "signal".to_string(), |value| value.to_string()),
-            gate_config.command,
-            project_root.display(),
-            session_id.unwrap_or("(ephemeral)"),
-            branch,
-        ),
-        PostExecGateCommandOutcome::TimedOut => anyhow::bail!(
-            "csa: post-exec gate timed out after {} seconds.\n\
-             gate command: {}\n\
-             cwd: {}\n\
-             employee session: {}\n\
-             branch: {}\n\
-             next step: inspect the gate output above, fix the issue, and re-run the dispatch manually. v1 gate does NOT auto-retry.",
-            gate_config.timeout_seconds,
-            gate_config.command,
-            project_root.display(),
-            session_id.unwrap_or("(ephemeral)"),
-            branch,
-        ),
+        PostExecGateCommandOutcome::Exited(code) => {
+            Ok(PostExecGateOutcome::Failed(PostExecGateFailure {
+                kind: PostExecGateFailureKind::Exited(code),
+                diagnostic: format!(
+                    "csa: post-exec gate failed (exit={}).\n\
+                     gate command: {}\n\
+                     cwd: {}\n\
+                     employee session: {}\n\
+                     branch: {}\n\
+                     next step: inspect the gate output above, fix the issue, and re-run the dispatch manually. v1 gate does NOT auto-retry.",
+                    code.map_or_else(|| "signal".to_string(), |value| value.to_string()),
+                    gate_config.command,
+                    project_root.display(),
+                    session_id.unwrap_or("(ephemeral)"),
+                    branch,
+                ),
+            }))
+        }
+        PostExecGateCommandOutcome::TimedOut => {
+            Ok(PostExecGateOutcome::Failed(PostExecGateFailure {
+                kind: PostExecGateFailureKind::TimedOut,
+                diagnostic: format!(
+                    "csa: post-exec gate timed out after {} seconds.\n\
+                     gate command: {}\n\
+                     cwd: {}\n\
+                     employee session: {}\n\
+                     branch: {}\n\
+                     next step: inspect the gate output above, fix the issue, and re-run the dispatch manually. v1 gate does NOT auto-retry.",
+                    gate_config.timeout_seconds,
+                    gate_config.command,
+                    project_root.display(),
+                    session_id.unwrap_or("(ephemeral)"),
+                    branch,
+                ),
+            }))
+        }
+    }
+}
+
+pub(super) async fn apply_post_exec_gate_after_success_with_runner<F>(
+    project_root: &Path,
+    prompt_text: &str,
+    session_id: Option<&str>,
+    config: Option<&ProjectConfig>,
+    changed_paths: Option<&[String]>,
+    no_post_exec_gate: bool,
+    runner: F,
+) -> Result<()>
+where
+    F: FnOnce(&str, &Path, u64) -> PostExecGateFuture,
+{
+    if no_post_exec_gate {
+        if let Some(session_id) = session_id {
+            crate::run_cmd_post::record_post_exec_gate_skipped_by_flag(project_root, session_id);
+        }
+        return Ok(());
+    }
+
+    match maybe_run_post_exec_gate_with_runner(
+        project_root,
+        prompt_text,
+        session_id,
+        config,
+        changed_paths,
+        runner,
+    )
+    .await?
+    {
+        PostExecGateOutcome::Passed | PostExecGateOutcome::Skipped => Ok(()),
+        PostExecGateOutcome::Failed(failure) if failure.is_timeout() => {
+            if classify_post_exec_gate_worktree(project_root, session_id)
+                == PostExecGateWorktreeState::CommittedClean
+            {
+                if let Some(session_id) = session_id {
+                    crate::run_cmd_post::record_post_exec_gate_timeout_advisory(
+                        project_root,
+                        session_id,
+                    );
+                }
+                Ok(())
+            } else {
+                if let Some(session_id) = session_id {
+                    crate::run_cmd_post::overwrite_result_as_post_exec_gate_failure(
+                        project_root,
+                        session_id,
+                        "timeout left dirty/uncommitted work unverified",
+                        true,
+                    );
+                }
+                Err(failure.into_error())
+            }
+        }
+        PostExecGateOutcome::Failed(failure) => {
+            if let Some(session_id) = session_id {
+                crate::run_cmd_post::overwrite_result_as_post_exec_gate_failure(
+                    project_root,
+                    session_id,
+                    &format!("post-exec gate failed: {}", failure.diagnostic),
+                    false,
+                );
+            }
+            Err(failure.into_error())
+        }
     }
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -1,11 +1,14 @@
 use super::{
-    PostExecGateCommandOutcome, PostExecGateOutcome, execute_post_exec_gate_command,
+    PostExecGateCommandOutcome, PostExecGateOutcome,
+    apply_post_exec_gate_after_success_with_runner, execute_post_exec_gate_command,
     maybe_run_post_exec_gate_with_runner,
 };
+use crate::cli::{Cli, Commands};
 use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use crate::test_session_sandbox::ScopedSessionSandbox;
+use clap::Parser;
 use csa_config::{PostExecGateConfig, ProjectConfig, ProjectMeta, ResourcesConfig, RunConfig};
-use csa_session::create_session_fresh;
+use csa_session::{SessionResult, create_session_fresh, load_result, save_result};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -86,6 +89,42 @@ fn create_session_at_current_head(project_root: &Path) -> String {
     .meta_session_id
 }
 
+fn write_success_result_for(project_root: &Path, session_id: &str) {
+    let now = chrono::Utc::now();
+    let result = SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "task completed".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        fallback_chain: None,
+        gate_timeout: false,
+        warnings: Vec::new(),
+        raw_process_exit_code: None,
+        manager_fields: Default::default(),
+    };
+    save_result(project_root, session_id, &result).expect("write success result");
+}
+
+fn persisted_result(project_root: &Path, session_id: &str) -> SessionResult {
+    load_result(project_root, session_id)
+        .expect("load result")
+        .expect("result should exist")
+}
+
+fn commit_tracked_change(project_root: &Path) {
+    std::fs::write(project_root.join("tracked.txt"), "committed\n").unwrap();
+    run_git(project_root, &["add", "tracked.txt"]);
+    run_git(project_root, &["commit", "-m", "change tracked"]);
+}
+
 #[tokio::test]
 #[serial_test::serial]
 async fn execute_post_exec_gate_strips_inherited_csa_env() {
@@ -148,7 +187,7 @@ async fn post_exec_gate_passes_when_command_succeeds() {
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].0, "just pre-commit");
     assert_eq!(calls[0].1, project_dir.path());
-    assert_eq!(calls[0].2, 600);
+    assert_eq!(calls[0].2, 1800);
 }
 
 #[tokio::test]
@@ -162,7 +201,7 @@ async fn post_exec_gate_failure_returns_structured_diagnostic() {
         command: "cargo test".to_string(),
         ..Default::default()
     });
-    let err = maybe_run_post_exec_gate_with_runner(
+    let outcome = maybe_run_post_exec_gate_with_runner(
         project_dir.path(),
         "Implement the fix in tracked.txt",
         Some("01TESTPOSTEXECGATEFAIL0000000"),
@@ -173,9 +212,13 @@ async fn post_exec_gate_failure_returns_structured_diagnostic() {
         },
     )
     .await
-    .expect_err("gate failure should bubble up");
+    .expect("gate command should return a typed outcome");
 
-    let rendered = format!("{err:#}");
+    let PostExecGateOutcome::Failed(failure) = outcome else {
+        panic!("expected typed gate failure, got {outcome:?}");
+    };
+
+    let rendered = failure.diagnostic;
     assert!(rendered.contains("csa: post-exec gate failed (exit=3)."));
     assert!(rendered.contains("gate command: cargo test"));
     assert!(rendered.contains(&format!("cwd: {}", project_dir.path().display())));
@@ -307,6 +350,256 @@ async fn post_exec_gate_runs_when_changed_paths_are_non_empty() {
 
     assert_eq!(outcome, PostExecGateOutcome::Passed);
     assert_eq!(calls.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn post_exec_gate_nonzero_committed_clean_is_fatal() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    init_clean_git_repo(project_dir.path());
+    let session_id = create_session_at_current_head(project_dir.path());
+    commit_tracked_change(project_dir.path());
+    write_success_result_for(project_dir.path(), &session_id);
+
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    let err = apply_post_exec_gate_after_success_with_runner(
+        project_dir.path(),
+        "Implement and commit the fix",
+        Some(&session_id),
+        Some(&config),
+        None,
+        false,
+        |_command, _cwd, _timeout_seconds| {
+            Box::pin(async { Ok(PostExecGateCommandOutcome::Exited(Some(3))) })
+        },
+    )
+    .await
+    .expect_err("nonzero gate exit is fatal even when committed-clean");
+
+    assert!(err.to_string().contains("post-exec gate failed"));
+    let result = persisted_result(project_dir.path(), &session_id);
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(!result.gate_timeout);
+    assert!(
+        result.warnings.is_empty(),
+        "no success warning on fatal exit"
+    );
+    assert!(result.summary.contains("post-exec gate failed"));
+}
+
+#[tokio::test]
+async fn post_exec_gate_nonzero_dirty_is_fatal() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    init_clean_git_repo(project_dir.path());
+    let session_id = create_session_at_current_head(project_dir.path());
+    std::fs::write(project_dir.path().join("tracked.txt"), "dirty\n").unwrap();
+    write_success_result_for(project_dir.path(), &session_id);
+
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    apply_post_exec_gate_after_success_with_runner(
+        project_dir.path(),
+        "Modify tracked.txt",
+        Some(&session_id),
+        Some(&config),
+        None,
+        false,
+        |_command, _cwd, _timeout_seconds| {
+            Box::pin(async { Ok(PostExecGateCommandOutcome::Exited(Some(3))) })
+        },
+    )
+    .await
+    .expect_err("nonzero gate exit is fatal for dirty work");
+
+    let result = persisted_result(project_dir.path(), &session_id);
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(!result.gate_timeout);
+    assert!(result.summary.contains("post-exec gate failed"));
+}
+
+#[tokio::test]
+async fn post_exec_gate_timeout_committed_clean_is_advisory() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    init_clean_git_repo(project_dir.path());
+    let session_id = create_session_at_current_head(project_dir.path());
+    commit_tracked_change(project_dir.path());
+    write_success_result_for(project_dir.path(), &session_id);
+
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    apply_post_exec_gate_after_success_with_runner(
+        project_dir.path(),
+        "Implement and commit the fix",
+        Some(&session_id),
+        Some(&config),
+        None,
+        false,
+        |_command, _cwd, _timeout_seconds| {
+            Box::pin(async { Ok(PostExecGateCommandOutcome::TimedOut) })
+        },
+    )
+    .await
+    .expect("timeout is advisory when work is committed-clean");
+
+    let result = persisted_result(project_dir.path(), &session_id);
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+    assert!(result.gate_timeout);
+    assert!(result.summary.contains("task completed"));
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("verification incomplete")),
+        "warning should explain incomplete verification: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn post_exec_gate_timeout_dirty_is_fatal() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    init_clean_git_repo(project_dir.path());
+    let session_id = create_session_at_current_head(project_dir.path());
+    std::fs::write(project_dir.path().join("tracked.txt"), "dirty\n").unwrap();
+    write_success_result_for(project_dir.path(), &session_id);
+
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    apply_post_exec_gate_after_success_with_runner(
+        project_dir.path(),
+        "Modify tracked.txt",
+        Some(&session_id),
+        Some(&config),
+        None,
+        false,
+        |_command, _cwd, _timeout_seconds| {
+            Box::pin(async { Ok(PostExecGateCommandOutcome::TimedOut) })
+        },
+    )
+    .await
+    .expect_err("timeout is fatal when dirty work remains");
+
+    let result = persisted_result(project_dir.path(), &session_id);
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(result.gate_timeout);
+    assert_eq!(
+        result.summary,
+        "timeout left dirty/uncommitted work unverified"
+    );
+}
+
+#[tokio::test]
+async fn post_exec_gate_success_passes_both_cleanliness_states() {
+    let config = project_config_with_gate(PostExecGateConfig::default());
+
+    {
+        let clean_dir = tempdir().unwrap();
+        let _clean_sandbox = ScopedSessionSandbox::new(&clean_dir).await;
+        init_clean_git_repo(clean_dir.path());
+        let clean_session_id = create_session_at_current_head(clean_dir.path());
+        commit_tracked_change(clean_dir.path());
+        write_success_result_for(clean_dir.path(), &clean_session_id);
+
+        apply_post_exec_gate_after_success_with_runner(
+            clean_dir.path(),
+            "Implement and commit the fix",
+            Some(&clean_session_id),
+            Some(&config),
+            None,
+            false,
+            |_command, _cwd, _timeout_seconds| {
+                Box::pin(async { Ok(PostExecGateCommandOutcome::Exited(Some(0))) })
+            },
+        )
+        .await
+        .expect("successful gate passes committed-clean work");
+
+        let clean_result = persisted_result(clean_dir.path(), &clean_session_id);
+        assert_eq!(clean_result.status, "success");
+        assert_eq!(clean_result.exit_code, 0);
+        assert!(!clean_result.gate_timeout);
+        assert!(clean_result.warnings.is_empty());
+    }
+
+    {
+        let dirty_dir = tempdir().unwrap();
+        let _dirty_sandbox = ScopedSessionSandbox::new(&dirty_dir).await;
+        init_clean_git_repo(dirty_dir.path());
+        let dirty_session_id = create_session_at_current_head(dirty_dir.path());
+        std::fs::write(dirty_dir.path().join("tracked.txt"), "dirty\n").unwrap();
+        write_success_result_for(dirty_dir.path(), &dirty_session_id);
+
+        apply_post_exec_gate_after_success_with_runner(
+            dirty_dir.path(),
+            "Modify tracked.txt",
+            Some(&dirty_session_id),
+            Some(&config),
+            None,
+            false,
+            |_command, _cwd, _timeout_seconds| {
+                Box::pin(async { Ok(PostExecGateCommandOutcome::Exited(Some(0))) })
+            },
+        )
+        .await
+        .expect("successful gate passes dirty work");
+
+        let dirty_result = persisted_result(dirty_dir.path(), &dirty_session_id);
+        assert_eq!(dirty_result.status, "success");
+        assert_eq!(dirty_result.exit_code, 0);
+        assert!(!dirty_result.gate_timeout);
+        assert!(dirty_result.warnings.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn run_cli_no_post_exec_gate_skips_runner_and_persists_warning() {
+    let cli = Cli::try_parse_from(["csa", "run", "--no-post-exec-gate", "prompt"])
+        .expect("run CLI should parse --no-post-exec-gate");
+    match cli.command {
+        Commands::Run {
+            no_post_exec_gate, ..
+        } => assert!(no_post_exec_gate),
+        _ => panic!("expected run command"),
+    }
+
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    init_clean_git_repo(project_dir.path());
+    let session_id = create_session_at_current_head(project_dir.path());
+    std::fs::write(project_dir.path().join("tracked.txt"), "dirty\n").unwrap();
+    write_success_result_for(project_dir.path(), &session_id);
+
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    apply_post_exec_gate_after_success_with_runner(
+        project_dir.path(),
+        "Modify tracked.txt",
+        Some(&session_id),
+        Some(&config),
+        None,
+        true,
+        |_command, _cwd, _timeout_seconds| {
+            Box::pin(async move {
+                panic!("runner must not execute when --no-post-exec-gate is set");
+            })
+        },
+    )
+    .await
+    .expect("skip flag should preserve successful turn result");
+
+    let result = persisted_result(project_dir.path(), &session_id);
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+    assert!(!result.gate_timeout);
+    assert!(
+        result.warnings.iter().any(|warning| warning
+            == "post-exec gate skipped by --no-post-exec-gate; external verification required"),
+        "skip warning should be persisted: {:?}",
+        result.warnings
+    );
 }
 
 #[tokio::test]

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -420,6 +420,41 @@ async fn post_exec_gate_nonzero_dirty_is_fatal() {
 }
 
 #[tokio::test]
+async fn post_exec_gate_runner_error_overwrites_result_as_failure() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    init_clean_git_repo(project_dir.path());
+    let session_id = create_session_at_current_head(project_dir.path());
+    std::fs::write(project_dir.path().join("tracked.txt"), "dirty\n").unwrap();
+    write_success_result_for(project_dir.path(), &session_id);
+
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    let err = apply_post_exec_gate_after_success_with_runner(
+        project_dir.path(),
+        "Modify tracked.txt",
+        Some(&session_id),
+        Some(&config),
+        None,
+        false,
+        |_command, _cwd, _timeout_seconds| {
+            Box::pin(async { Err(anyhow::anyhow!("gate process unavailable")) })
+        },
+    )
+    .await
+    .expect_err("runner infrastructure error is fatal");
+
+    assert!(err.to_string().contains("gate process unavailable"));
+    let result = persisted_result(project_dir.path(), &session_id);
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(!result.gate_timeout);
+    assert_eq!(
+        result.summary,
+        "could not run the post-exec gate: gate process unavailable"
+    );
+}
+
+#[tokio::test]
 async fn post_exec_gate_timeout_committed_clean_is_advisory() {
     let project_dir = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -128,6 +128,7 @@ async fn handle_run_rejects_model_spec_tier_bypass_before_session_creation() {
         false,
         false,
         false, // no_error_marker_scan (#1745)
+        false,
         Vec::new(),
         Vec::new(),
     )
@@ -208,6 +209,7 @@ async fn handle_run_does_not_persist_result_for_non_conflict_pre_exec_error() {
         false,
         false,
         false, // no_error_marker_scan (#1745)
+        false,
         Vec::new(),
         Vec::new(),
     )

--- a/crates/cli-sub-agent/src/run_cmd_post.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post.rs
@@ -162,19 +162,15 @@ pub(crate) fn update_fork_genealogy(
 pub(crate) fn overwrite_result_as_post_exec_gate_failure(
     project_root: &Path,
     session_id: &str,
-    gate_err: &anyhow::Error,
+    gate_summary: &str,
+    gate_timeout: bool,
 ) {
-    let gate_summary = format!("post-exec gate failed: {gate_err:#}");
-    let is_timeout = gate_err.to_string().contains("timed out")
-        || gate_err.to_string().contains("timeout")
-        || gate_err.to_string().contains("Timeout");
-
     match load_result(project_root, session_id) {
         Ok(Some(mut result)) => {
             result.exit_code = 1;
             result.status = "failure".to_string();
-            result.summary = gate_summary;
-            result.gate_timeout = is_timeout;
+            result.summary = gate_summary.to_string();
+            result.gate_timeout = gate_timeout;
             if let Err(save_err) = save_result(project_root, session_id, &result) {
                 warn!(
                     session = %session_id,
@@ -205,6 +201,60 @@ pub(crate) fn overwrite_result_as_post_exec_gate_failure(
             error = %retire_err,
             "Failed to retire session after post-exec gate failure"
         );
+    }
+}
+
+pub(crate) fn record_post_exec_gate_timeout_advisory(project_root: &Path, session_id: &str) {
+    record_post_exec_gate_success_warning(
+        project_root,
+        session_id,
+        true,
+        "gate timed out, verification incomplete, not a gate pass",
+    );
+}
+
+pub(crate) fn record_post_exec_gate_skipped_by_flag(project_root: &Path, session_id: &str) {
+    record_post_exec_gate_success_warning(
+        project_root,
+        session_id,
+        false,
+        "post-exec gate skipped by --no-post-exec-gate; external verification required",
+    );
+}
+
+fn record_post_exec_gate_success_warning(
+    project_root: &Path,
+    session_id: &str,
+    gate_timeout: bool,
+    warning: &str,
+) {
+    match load_result(project_root, session_id) {
+        Ok(Some(mut result)) => {
+            result.gate_timeout = result.gate_timeout || gate_timeout;
+            if !result.warnings.iter().any(|existing| existing == warning) {
+                result.warnings.push(warning.to_string());
+            }
+            if let Err(save_err) = save_result(project_root, session_id, &result) {
+                warn!(
+                    session = %session_id,
+                    error = %save_err,
+                    "Failed to record post-exec gate warning"
+                );
+            }
+        }
+        Ok(None) => {
+            warn!(
+                session = %session_id,
+                "No result.toml to annotate with post-exec gate warning"
+            );
+        }
+        Err(load_err) => {
+            warn!(
+                session = %session_id,
+                error = %load_err,
+                "Failed to load result.toml for post-exec gate warning"
+            );
+        }
     }
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_post_gate_failure_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_gate_failure_tests.rs
@@ -45,8 +45,12 @@ fn overwrites_success_result_with_failure() {
         "precondition: result.toml must start as success"
     );
 
-    let gate_err = anyhow::anyhow!("just pre-commit: No justfile found (exit=1)");
-    overwrite_result_as_post_exec_gate_failure(project_root, session_id, &gate_err);
+    overwrite_result_as_post_exec_gate_failure(
+        project_root,
+        session_id,
+        "post-exec gate failed: just pre-commit: No justfile found (exit=1)",
+        false,
+    );
 
     let result = csa_session::load_result(project_root, session_id)
         .unwrap()
@@ -61,6 +65,7 @@ fn overwrites_success_result_with_failure() {
         "summary must reference gate failure, got: {}",
         result.summary
     );
+    assert!(!result.gate_timeout);
 }
 
 #[test]
@@ -68,11 +73,62 @@ fn no_panic_when_session_missing() {
     let tmp = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
     let project_root = tmp.path();
-    let gate_err = anyhow::anyhow!("gate failed");
     // Must not panic even when result.toml does not exist
     overwrite_result_as_post_exec_gate_failure(
         project_root,
         "01TESTMISSINGSESSION0000000A",
-        &gate_err,
+        "post-exec gate failed: gate failed",
+        false,
+    );
+}
+
+#[test]
+fn records_timeout_advisory_without_overwriting_success() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path();
+    let session =
+        create_session(project_root, Some("gate-test"), None, Some("claude-code")).unwrap();
+    let session_id = &session.meta_session_id;
+    write_success_result_for(project_root, session_id);
+
+    record_post_exec_gate_timeout_advisory(project_root, session_id);
+
+    let result = csa_session::load_result(project_root, session_id)
+        .unwrap()
+        .expect("result.toml should still exist");
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+    assert!(result.gate_timeout);
+    assert!(
+        result
+            .warnings
+            .contains(&"gate timed out, verification incomplete, not a gate pass".to_string())
+    );
+}
+
+#[test]
+fn records_no_post_exec_gate_skip_warning_without_timeout() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path();
+    let session =
+        create_session(project_root, Some("gate-test"), None, Some("claude-code")).unwrap();
+    let session_id = &session.meta_session_id;
+    write_success_result_for(project_root, session_id);
+
+    record_post_exec_gate_skipped_by_flag(project_root, session_id);
+
+    let result = csa_session::load_result(project_root, session_id)
+        .unwrap()
+        .expect("result.toml should still exist");
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+    assert!(!result.gate_timeout);
+    assert!(
+        result.warnings.contains(
+            &"post-exec gate skipped by --no-post-exec-gate; external verification required"
+                .to_string()
+        )
     );
 }

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -154,6 +154,7 @@ async fn handle_run_persists_result_for_direct_tool_tier_rejection() {
         false,
         false,
         false, // no_error_marker_scan (#1745)
+        false,
         Vec::new(),
         Vec::new(),
     )

--- a/crates/cli-sub-agent/src/skill_run_cmd.rs
+++ b/crates/cli-sub-agent/src/skill_run_cmd.rs
@@ -93,6 +93,7 @@ pub(crate) async fn handle_skill_run(
         force_ignore_tier_setting: false,
         no_fs_sandbox: false,
         no_error_marker_scan: false,
+        no_post_exec_gate: false,
         extra_writable: vec![],
         extra_readable: vec![],
     })

--- a/crates/csa-config/src/config_session.rs
+++ b/crates/csa-config/src/config_session.rs
@@ -12,7 +12,7 @@ fn default_post_exec_gate_command() -> String {
 }
 
 const fn default_post_exec_gate_timeout_seconds() -> u64 {
-    600
+    1800
 }
 
 /// Post-execution quality gate for successful `csa run` sessions.

--- a/crates/csa-config/src/config_tests.rs
+++ b/crates/csa-config/src/config_tests.rs
@@ -794,3 +794,21 @@ fn test_tool_config_fast_mode_absent_defaults_to_none() {
     let cfg: ToolConfig = toml::from_str("").unwrap();
     assert_eq!(cfg.fast_mode, None);
 }
+
+#[test]
+fn post_exec_gate_default_timeout_seconds_is_1800() {
+    assert_eq!(PostExecGateConfig::default().timeout_seconds, 1800);
+}
+
+#[test]
+fn post_exec_gate_timeout_seconds_toml_override_still_works() {
+    let cfg: ProjectConfig = toml::from_str(
+        r#"
+[run.post_exec_gate]
+timeout_seconds = 2400
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(cfg.run.post_exec_gate.timeout_seconds, 2400);
+}

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -125,7 +125,7 @@ long_poll_seconds = 240
 # [run.post_exec_gate]
 # enabled = true
 # command = "just pre-commit"
-# timeout_seconds = 600  # Default 600s (10 min). Increase for heavy Rust projects with long pre-commit hooks.
+# timeout_seconds = 1800  # Default 1800s (30 min). Increase for heavy Rust projects with long pre-commit hooks.
 # skip_on_no_changes = true
 
 # MCP (Model Context Protocol) servers injected into all tool sessions.


### PR DESCRIPTION
## Summary

Fixes #1757. The default post-exec gate ran `just pre-commit` with a 600s timeout after a successful `csa run` turn and collapsed **both** nonzero-exit and timeout into the same fatal path, overwriting a committed-clean successful turn to `status=failure`/`exit_code=1`. On slow repos (this repo's real `just pre-commit` exceeds 10min > 600s), every committed-clean success was falsely reported as failure — the work landed in git but the session reported exit 1.

## Root cause

- `run_cmd_execute.rs` runs the post-exec gate after an exit-0 turn; on any gate error it called `overwrite_result_as_post_exec_gate_failure`.
- `run_cmd_execute_post_exec_gate.rs` collapsed `Exited(nonzero)` and `TimedOut` into the same fatal error — an inconclusive timeout was treated identically to a real nonzero gate failure.
- `config_session.rs` defaulted `run.post_exec_gate.timeout_seconds` to 600, far below a real Rust repo's pre-commit wall-clock.

## Fix (typed-outcome classification)

Post-exec gate outcomes are now typed (`Exited(code)` / signal / `TimedOut`) and classified against the session's git cleanliness:

| Gate outcome | committed-clean | dirty/uncommitted |
| --- | --- | --- |
| `Exited(0)` | success/0 | success/0 |
| `Exited(nonzero)` or signal | **failure/1 (FATAL)** | **failure/1 (FATAL)** |
| `TimedOut` | success/0 preserved, `gate_timeout=true`, advisory warning | **failure/1 (FATAL)** |

- **committed-clean** = session-start HEAD known, current HEAD differs, and `git status --porcelain=v1 --untracked-files=all` is empty. Unknown classification **fails closed** (treated as dirty).
- Nonzero exit / signal stays **fail-closed in every state** — a real gate failure still fails the session, so no false-PASS hole is reopened (preserves the #1659 / #1675 / #1696 / #1754 gate-integrity invariants).
- A timeout is advisory **only** when the work is provably committed-clean; a timeout over a dirty/uncommitted worktree remains fatal.

## Config + escape hatch

- `run.post_exec_gate.timeout_seconds` default raised **600 → 1800**; heavy repos can raise further (e.g. 3600 if `just pre-commit` p95 nears an hour).
- New `csa run --no-post-exec-gate`: skips only this post-exec shell gate, preserves the turn result, and records a result warning (`post-exec gate skipped by --no-post-exec-gate; external verification required`). It does **not** disable commit policy, edit guards, no-op gates, or model liveness checks.

Independent of #1758 (codex's separate in-turn tool timeout).

## Tests

7 regression tests covering the full matrix — the key proof is the two nonzero-exit cases (committed-clean + dirty), which confirm a real gate failure still fails the session:

1. `post_exec_gate_nonzero_committed_clean_is_fatal`
2. `post_exec_gate_nonzero_dirty_is_fatal`
3. `post_exec_gate_timeout_committed_clean_is_advisory`
4. `post_exec_gate_timeout_dirty_is_fatal`
5. `post_exec_gate_success_passes_both_cleanliness_states`
6. config default `timeout_seconds == 1800` + TOML override
7. `--no-post-exec-gate` parses, runner not invoked, warning persisted

Design decided by tier-4 adversarial debate (session `01KT2BW7BRFPRHMHZAZCHHQC2T`, Option D refined): keep nonzero gate exits fail-closed, make timeout a typed inconclusive result, treat timeout as advisory only when the session is provably committed-clean, raise/document the configurable timeout, and add an explicit `--no-post-exec-gate` escape hatch for externally verified callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
