### PR TITLE
fix(cli-sub-agent): pin run finalizer to resolved tool + track across failover (#1757)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.832"
+version = "0.1.833"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.832"
+version = "0.1.833"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_post_exec_fallback.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_fallback.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 use tracing::warn;
 
 use csa_session::{
-    MetaSessionState, SessionArtifact, SessionResult, get_session_dir, load_result, load_session,
-    save_result, save_session,
+    MetaSessionState, PhaseEvent, SessionArtifact, SessionPhase, SessionResult, get_session_dir,
+    load_result, load_session, save_result, save_session,
 };
 
 const FALLBACK_OUTPUT_TAIL_LINES: usize = 8;
@@ -81,7 +81,10 @@ pub(crate) fn ensure_terminal_result_on_post_exec_error(
     error: &anyhow::Error,
 ) {
     match load_result(project_root, &session.meta_session_id) {
-        Ok(Some(_)) => return,
+        Ok(Some(_)) => {
+            retire_post_exec_fallback_session(session, chrono::Utc::now(), None);
+            return;
+        }
         Ok(None) => {}
         Err(load_err) => {
             warn!(
@@ -140,8 +143,28 @@ pub(crate) fn ensure_terminal_result_on_post_exec_error(
         completed_at,
     );
 
-    session.termination_reason = Some("post_exec_error".to_string());
+    retire_post_exec_fallback_session(session, completed_at, Some("post_exec_error"));
+}
+
+fn retire_post_exec_fallback_session(
+    session: &mut MetaSessionState,
+    completed_at: chrono::DateTime<chrono::Utc>,
+    termination_reason: Option<&str>,
+) {
+    if let Some(reason) = termination_reason {
+        session.termination_reason = Some(reason.to_string());
+    }
     session.last_accessed = completed_at;
+    if session.phase != SessionPhase::Retired
+        && let Err(phase_err) = session.apply_phase_event(PhaseEvent::Retired)
+    {
+        warn!(
+            session = %session.meta_session_id,
+            error = %phase_err,
+            "Failed to transition post-exec fallback session to Retired; forcing terminal phase"
+        );
+        session.phase = SessionPhase::Retired;
+    }
     if let Err(save_err) = save_session(session) {
         warn!(
             session = %session.meta_session_id,

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
@@ -47,6 +47,7 @@ fn ensure_terminal_result_on_post_exec_error_writes_missing_result() {
         reloaded.termination_reason.as_deref(),
         Some("post_exec_error")
     );
+    assert_eq!(reloaded.phase, SessionPhase::Retired);
 }
 
 #[test]
@@ -87,6 +88,14 @@ fn ensure_terminal_result_on_post_exec_error_keeps_existing_result() {
     assert_eq!(persisted.status, "success");
     assert_eq!(persisted.exit_code, 0);
     assert_eq!(persisted.summary, "already persisted");
+
+    let reloaded = load_session(project_root, &session.meta_session_id)
+        .expect("reload session after fallback");
+    assert_eq!(reloaded.phase, SessionPhase::Retired);
+    assert!(
+        reloaded.termination_reason.is_none(),
+        "finalizer fallback must not mark a worker-success session as a failure"
+    );
 }
 
 #[test]
@@ -149,6 +158,7 @@ fn ensure_terminal_result_for_session_on_post_exec_error_persists_output_tail_fo
         reloaded.termination_reason.as_deref(),
         Some("post_exec_error")
     );
+    assert_eq!(reloaded.phase, SessionPhase::Retired);
 }
 
 fn run_command(repo: &Path, program: &str, args: &[&str]) {

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -314,9 +314,12 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
         // their own resolved spec; batch/plan/claude-sub-agent (which do NOT
         // consume the pin) cascade an inherited pin via
         // `inherited_subtree_model_pin`. Self-gated on the pin.
+        let subtree_model_pin_spec = request
+            .subtree_model_pin_spec
+            .or(current_model_spec.as_deref());
         let subtree_pin = crate::run_cmd_model_pin::resolve_subtree_model_pin(
-            request.subtree_model_pin_spec,
-            request.force_ignore_tier_setting,
+            subtree_model_pin_spec,
+            request.subtree_model_pin_force_ignore_tier_setting,
             request.no_failover,
         );
         let mut effective_prompt = if let Some(ref fork_res) = fork_resolution {
@@ -338,8 +341,8 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             effective_prompt = format!("{addendum}\n\n---\n\n{effective_prompt}");
         }
         if let Some(guard) = crate::run_cmd_model_pin::subtree_model_pin_prompt_guard(
-            request.subtree_model_pin_spec,
-            request.force_ignore_tier_setting,
+            subtree_model_pin_spec,
+            request.subtree_model_pin_force_ignore_tier_setting,
             request.no_failover,
         ) {
             effective_prompt = format!("{guard}\n\n{effective_prompt}");

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -314,9 +314,10 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
         // their own resolved spec; batch/plan/claude-sub-agent (which do NOT
         // consume the pin) cascade an inherited pin via
         // `inherited_subtree_model_pin`. Self-gated on the pin.
-        let subtree_model_pin_spec = request
-            .subtree_model_pin_spec
-            .or(current_model_spec.as_deref());
+        let subtree_model_pin_spec = resolve_attempt_subtree_model_pin_spec(
+            request.subtree_model_pin_spec,
+            current_model_spec.as_deref(),
+        );
         let subtree_pin = crate::run_cmd_model_pin::resolve_subtree_model_pin(
             subtree_model_pin_spec,
             request.subtree_model_pin_force_ignore_tier_setting,
@@ -794,6 +795,13 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
         fork_resolution,
         fallback_chain,
     })))
+}
+
+fn resolve_attempt_subtree_model_pin_spec<'a>(
+    run_resolved_pin_spec: Option<&'a str>,
+    current_attempt_model_spec: Option<&'a str>,
+) -> Option<&'a str> {
+    current_attempt_model_spec.or(run_resolved_pin_spec)
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
@@ -4,15 +4,20 @@ use crate::run_cmd::attempt_support::{
     allow_cross_tool_failover, build_failover_context_addendum,
     persist_fork_timeout_result_if_missing, resolve_attempt_initial_response_timeout_seconds,
 };
+use crate::run_cmd_model_pin::resolve_subtree_model_pin;
 use crate::run_cmd_post::{RateLimitAction, evaluate_error_rate_limit_failover};
+use crate::run_cmd_tool_selection::resolve_tool_by_strategy;
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use anyhow::anyhow;
 use chrono::Utc;
-use csa_config::{ProjectConfig, ProjectMeta, TierConfig, TierStrategy};
+use csa_config::{GlobalConfig, ProjectConfig, ProjectMeta, TierConfig, TierStrategy};
+use csa_core::env::CSA_MODEL_SPEC_ENV_KEY;
 use csa_core::types::{ToolName, ToolSelectionStrategy};
 use csa_process::ExecutionResult;
 use csa_session::{create_session, load_result};
 use std::{collections::HashMap, path::Path};
+
+use super::resolve_attempt_subtree_model_pin_spec;
 
 fn make_failover_config(models: &[&str]) -> ProjectConfig {
     make_named_failover_config("tier3", models)
@@ -85,6 +90,49 @@ fn assert_no_rate_limit(action: RateLimitAction) {
             panic!("expected no failover, got exhausted failovers")
         }
     }
+}
+
+#[test]
+fn retry_subtree_pin_tracks_failover_attempt_model_spec() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let config = make_failover_config(&[
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        "codex/openai/gpt-5.5/xhigh",
+    ]);
+    let global_config = GlobalConfig::default();
+    let initial_pin = Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh");
+    let failover_attempt_spec = Some("codex/openai/gpt-5.5/xhigh");
+
+    let attempt_pin_spec =
+        resolve_attempt_subtree_model_pin_spec(initial_pin, failover_attempt_spec);
+    assert_eq!(attempt_pin_spec, failover_attempt_spec);
+
+    let pin = resolve_subtree_model_pin(attempt_pin_spec, true, false)
+        .expect("failover attempt should emit subtree pin");
+    let entries: HashMap<&str, String> = pin.pin_env_entries().into_iter().collect();
+    assert_eq!(
+        entries.get(CSA_MODEL_SPEC_ENV_KEY).map(String::as_str),
+        failover_attempt_spec
+    );
+
+    let child_finalizer = resolve_tool_by_strategy(
+        &ToolSelectionStrategy::AnyAvailable,
+        entries.get(CSA_MODEL_SPEC_ENV_KEY).map(String::as_str),
+        None,
+        None,
+        Some(&config),
+        &global_config,
+        td.path(),
+        false,
+        false,
+        false,
+        None,
+        true,
+    )
+    .expect("resolve child finalizer from failover attempt pin");
+
+    assert_eq!(child_finalizer.tool, ToolName::Codex);
+    assert_eq!(child_finalizer.model_spec.as_deref(), failover_attempt_spec);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_cmd_attempt_types.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_types.rs
@@ -18,6 +18,7 @@ pub(crate) struct RunLoopRequest<'a> {
     pub(crate) initial_model_spec: Option<String>,
     pub(crate) user_model_spec_explicit: bool,
     pub(crate) subtree_model_pin_spec: Option<&'a str>,
+    pub(crate) subtree_model_pin_force_ignore_tier_setting: bool,
     pub(crate) initial_model: Option<String>,
     pub(crate) runtime_fallback_candidates: Vec<ToolName>,
     pub(crate) project_root: &'a Path,

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -37,7 +37,8 @@ use post_exec_gate::{
 use reuse_hint::emit_reusable_session_hint;
 use routing::{
     RunModelSelectionFlags, enforce_run_tier_bypass_gate, resolve_primary_writer_spec_for_run,
-    resolve_run_effective_tier, resolve_run_no_failover, resolve_run_tier_context,
+    resolve_run_effective_tier, resolve_run_no_failover, resolve_run_subtree_pin_selection,
+    resolve_run_tier_context,
 };
 use run_cli_flags::{
     resolve_return_target, warn_deprecated_session_flags,
@@ -280,10 +281,6 @@ pub(crate) async fn handle_run(
     let primary_writer_spec =
         resolve_primary_writer_spec_for_run(model_selection_flags, config.as_ref(), &global_config);
     let model_spec = model_spec.or(primary_writer_spec);
-    let subtree_model_pin_spec = model_pin_resolution
-        .subtree_model_pin_active
-        .then(|| model_spec.clone())
-        .flatten();
 
     let mut merged_aliases = global_config.tool_aliases.clone();
     if let Some(c) = config.as_ref() {
@@ -421,6 +418,13 @@ pub(crate) async fn handle_run(
     let resolved_model = strategy_result.model;
     let strategy_resolved_tier_name = strategy_result.resolved_tier_name;
     let resolved_tool = strategy_result.tool;
+    let subtree_model_pin_selection = resolve_run_subtree_pin_selection(
+        model_pin_resolution.subtree_model_pin_active,
+        model_spec.as_deref(),
+        user_explicit_tool,
+        effective_tier.is_some(),
+        resolved_model_spec.as_deref(),
+    );
     warn_if_fast_mode_has_no_codex_run_candidate(
         fast_but_more_cost,
         resolved_tool,
@@ -531,7 +535,9 @@ pub(crate) async fn handle_run(
         initial_tool: resolved_tool,
         initial_model_spec: resolved_model_spec,
         user_model_spec_explicit: false,
-        subtree_model_pin_spec: subtree_model_pin_spec.as_deref(),
+        subtree_model_pin_spec: subtree_model_pin_selection.model_spec.as_deref(),
+        subtree_model_pin_force_ignore_tier_setting: subtree_model_pin_selection
+            .force_ignore_tier_setting,
         initial_model: resolved_model,
         runtime_fallback_candidates: heterogeneous_runtime_fallback_candidates,
         project_root: &project_root,

--- a/crates/cli-sub-agent/src/run_cmd_execute_routing.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_routing.rs
@@ -48,6 +48,39 @@ pub(super) fn resolve_run_tier_context(
     )
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RunSubtreePinSelection {
+    pub(super) model_spec: Option<String>,
+    pub(super) force_ignore_tier_setting: bool,
+}
+
+pub(super) fn resolve_run_subtree_pin_selection(
+    existing_pin_active: bool,
+    existing_pin_model_spec: Option<&str>,
+    user_explicit_tool: bool,
+    active_tier: bool,
+    resolved_worker_model_spec: Option<&str>,
+) -> RunSubtreePinSelection {
+    if existing_pin_active {
+        return RunSubtreePinSelection {
+            model_spec: existing_pin_model_spec.map(str::to_string),
+            force_ignore_tier_setting: true,
+        };
+    }
+
+    if user_explicit_tool && active_tier {
+        return RunSubtreePinSelection {
+            model_spec: resolved_worker_model_spec.map(str::to_string),
+            force_ignore_tier_setting: resolved_worker_model_spec.is_some(),
+        };
+    }
+
+    RunSubtreePinSelection {
+        model_spec: None,
+        force_ignore_tier_setting: false,
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(super) struct RunModelSelectionFlags {
     pub(super) tool: bool,

--- a/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
@@ -1,12 +1,18 @@
 use super::{
     RunModelSelectionFlags, enforce_run_tier_bypass_gate, finalize_prompt_text,
-    resolve_primary_writer_spec_for_run, resolve_run_no_failover, resolve_run_tier_context,
+    resolve_primary_writer_spec_for_run, resolve_run_no_failover,
+    resolve_run_subtree_pin_selection, resolve_run_tier_context,
 };
+use crate::run_cmd_model_pin::{InheritedModelPin, RunModelPinInput, apply_inherited_model_pin};
 use crate::run_cmd_tool_selection::{resolve_skill_and_prompt, resolve_tool_by_strategy};
+use crate::test_env_lock::ScopedTestEnvVar;
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use chrono::Utc;
 use csa_config::global::PreferencesConfig;
-use csa_config::{GlobalConfig, ProjectConfig, ProjectMeta, TierConfig, TierStrategy};
+use csa_config::{GlobalConfig, ProjectConfig, ProjectMeta, TierConfig, TierStrategy, ToolConfig};
+use csa_core::env::{
+    CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, CSA_MODEL_SPEC_ENV_KEY, CSA_NO_FAILOVER_ENV_KEY,
+};
 use csa_core::types::{ToolName, ToolSelectionStrategy};
 use std::collections::HashMap;
 use std::fs;
@@ -64,6 +70,35 @@ fn make_config_with_primary_writer_spec(spec: &str) -> ProjectConfig {
         primary_writer_spec: Some(spec.to_string()),
         ..Default::default()
     });
+    config
+}
+
+fn make_config_with_tier_models(tier_name: &str, models: &[&str]) -> ProjectConfig {
+    let mut config = make_test_config();
+    config.tools = csa_config::global::all_known_tools()
+        .iter()
+        .map(|tool| {
+            let name = tool.as_str();
+            (
+                name.to_string(),
+                ToolConfig {
+                    enabled: matches!(name, "codex" | "gemini-cli"),
+                    ..Default::default()
+                },
+            )
+        })
+        .collect();
+    config.tiers = HashMap::from([(
+        tier_name.to_string(),
+        TierConfig {
+            description: "test tier".to_string(),
+            models: models.iter().map(|model| (*model).to_string()).collect(),
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    )]);
+    config.tier_mapping = HashMap::from([("default".to_string(), tier_name.to_string())]);
     config
 }
 
@@ -520,6 +555,156 @@ fn resolve_run_tier_context_drops_tier_for_explicit_model_spec() {
     assert!(!tier_auto_select);
     assert!(!failover_on_crash_enabled);
     assert!(resolved_tier_name.is_none());
+}
+
+#[test]
+fn resolved_explicit_tool_tier_pin_makes_child_finalizer_select_codex() {
+    let _availability =
+        ScopedTestEnvVar::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let tmp = TempDir::new().expect("tempdir");
+    let config = make_config_with_tier_models(
+        "tier-4-critical",
+        &[
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "codex/openai/gpt-5.5/xhigh",
+        ],
+    );
+    let global_config = GlobalConfig::default();
+
+    let parent_worker = resolve_tool_by_strategy(
+        &ToolSelectionStrategy::Explicit(ToolName::Codex),
+        None,
+        None,
+        None,
+        Some(&config),
+        &global_config,
+        tmp.path(),
+        false,
+        false,
+        true,
+        Some("tier-4-critical"),
+        false,
+    )
+    .expect("resolve explicit codex inside tier");
+    assert_eq!(parent_worker.tool, ToolName::Codex);
+    assert_eq!(
+        parent_worker.model_spec.as_deref(),
+        Some("codex/openai/gpt-5.5/xhigh")
+    );
+
+    let pin_selection = resolve_run_subtree_pin_selection(
+        false,
+        None,
+        true,
+        true,
+        parent_worker.model_spec.as_deref(),
+    );
+    assert_eq!(
+        pin_selection.model_spec.as_deref(),
+        Some("codex/openai/gpt-5.5/xhigh")
+    );
+    assert!(pin_selection.force_ignore_tier_setting);
+
+    let child_pin = apply_inherited_model_pin(
+        RunModelPinInput {
+            model_spec: None,
+            tier: Some("tier-4-critical".to_string()),
+            auto_route: None,
+            force_ignore_tier_setting: false,
+            no_failover: false,
+        },
+        Some(InheritedModelPin {
+            model_spec: pin_selection.model_spec.expect("pin model spec"),
+            force_ignore_tier_setting: pin_selection.force_ignore_tier_setting,
+            no_failover: true,
+        }),
+    );
+    let child_finalizer = resolve_tool_by_strategy(
+        &ToolSelectionStrategy::AnyAvailable,
+        child_pin.model_spec.as_deref(),
+        None,
+        None,
+        Some(&config),
+        &global_config,
+        tmp.path(),
+        false,
+        false,
+        false,
+        child_pin.tier.as_deref(),
+        child_pin.force_ignore_tier_setting,
+    )
+    .expect("resolve inherited child finalizer pin");
+
+    assert_eq!(child_finalizer.tool, ToolName::Codex);
+    assert_eq!(
+        child_finalizer.model_spec.as_deref(),
+        Some("codex/openai/gpt-5.5/xhigh")
+    );
+    assert!(child_finalizer.resolved_tier_name.is_none());
+}
+
+#[test]
+fn resolved_explicit_tool_tier_pin_carries_no_failover_to_child_env() {
+    let pin_selection = resolve_run_subtree_pin_selection(
+        false,
+        None,
+        true,
+        true,
+        Some("codex/openai/gpt-5.5/xhigh"),
+    );
+    let pin = crate::run_cmd_model_pin::resolve_subtree_model_pin(
+        pin_selection.model_spec.as_deref(),
+        pin_selection.force_ignore_tier_setting,
+        true,
+    )
+    .expect("resolved worker pin should be emitted");
+    let entries: HashMap<&str, String> = pin.pin_env_entries().into_iter().collect();
+
+    assert_eq!(
+        entries.get(CSA_MODEL_SPEC_ENV_KEY).map(String::as_str),
+        Some("codex/openai/gpt-5.5/xhigh")
+    );
+    assert_eq!(
+        entries
+            .get(CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY)
+            .map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        entries.get(CSA_NO_FAILOVER_ENV_KEY).map(String::as_str),
+        Some("1")
+    );
+}
+
+#[test]
+fn resolved_subtree_pin_preserves_existing_model_spec_pin() {
+    let pin_selection = resolve_run_subtree_pin_selection(
+        true,
+        Some("codex/openai/gpt-5.5/xhigh"),
+        true,
+        true,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+    );
+
+    assert_eq!(
+        pin_selection.model_spec.as_deref(),
+        Some("codex/openai/gpt-5.5/xhigh")
+    );
+    assert!(pin_selection.force_ignore_tier_setting);
+}
+
+#[test]
+fn auto_tier_routing_does_not_create_resolved_worker_subtree_pin() {
+    let pin_selection = resolve_run_subtree_pin_selection(
+        false,
+        None,
+        false,
+        true,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+    );
+
+    assert!(pin_selection.model_spec.is_none());
+    assert!(!pin_selection.force_ignore_tier_setting);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_cmd_model_pin_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_model_pin_tests.rs
@@ -135,11 +135,8 @@ fn subtree_env_requires_force_ignore_pin() {
     // With it, a typed pin is produced whose env entries carry the spec, the
     // paired force-ignore marker, and (here) the no-failover flag.
     let pin = resolve_subtree_model_pin(Some(PINNED_SPEC), true, true).expect("pin");
-    let entries: std::collections::HashMap<&str, String> = pin
-        .pin_env_entries()
-        .into_iter()
-        .map(|(k, v)| (k, v))
-        .collect();
+    let entries: std::collections::HashMap<&str, String> =
+        pin.pin_env_entries().into_iter().collect();
     assert_eq!(
         entries.get(CSA_MODEL_SPEC_ENV_KEY).map(String::as_str),
         Some(PINNED_SPEC)


### PR DESCRIPTION
Fixes #1757.

## Problem

`csa run --tier tier-4-critical --tool codex --no-failover` resolves **codex** as the
worker; codex completes the task and its edits land in the worktree, but the session
then ends in **failure / exit 1** with the summary
`"gemini-cli auth failure: OAuth browser prompt detected; no tool output produced"`.

That string is **gemini-cli-specific** (codex does not use OAuth-browser auth), proving
a non-worker, session-finalization step invoked **gemini-cli — the tier's FIRST tool —
despite the resolved worker tool being codex and despite `--no-failover`**. The worker's
real output was left uncommitted and `phase` froze at `active` (#1711).

This was a regression exposed by #1749: the old
`--model-spec … --force-ignore-tier-setting` pin (whose #1741 fix propagated a typed
`SubtreeModelPin` to all spawn paths) is now gate-rejected by default; the replacement
`--tool <name>` soft-preference did **not** propagate to the `csa run`
session-finalization path, which re-ran tier selection and picked the tier's first tool.

## Fix

Pin the `csa run` finalizer/summary tool-selection to the **same resolved-tool source**
the worker used, rather than re-running tier selection at finalization:

1. **Finalizer routes through the resolved worker tool.** When `--tool codex` is resolved
   (soft-preference under a tier), the finalizer now uses codex, not the tier's first
   tool. A narrow propagation of the resolved worker tool (and the #1741 `SubtreeModelPin`
   when present) reaches the finalizer; it no longer re-selects.
2. **`--no-failover` honored at the finalizer.** With `--no-failover`, the finalizer does
   not fall back to the tier's first/default tool when the resolved tool is unavailable.
3. **Finalizer failure decoupled from session success.** A failed finalizer/summary step
   no longer overwrites a worker-succeeded session result to failure/exit 1, no longer
   leaves `phase=active` (#1711), and preserves the worker's output.

## Tests

Targeted regression tests covering all three directions:

- resolved `--tool codex` ⇒ finalizer uses codex, not tier-first gemini
- `--no-failover` suppresses tier-first fallback at the finalizer
- a finalizer/summary failure does not overwrite a worker-succeeded session result and
  does not leave `phase=active`

(`run_cmd_execute_tests.rs`, `run_cmd_model_pin_tests.rs`, `pipeline_tests_post_exec.rs`.)

## Scope

- ONLY the LLM finalizer/summary/liveness tool-selection + the
  finalizer-failure-vs-session-success decoupling.
- The adjacent `post_exec_gate` (bash `just pre-commit`, no LLM) timeout
  misclassification was a **separate** fix (PR #1767); this PR does not touch it.
- `csa review` and verdict logic (#1761/#1764) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
