### PR TITLE
fix(csa-process,csa-acp): track child-process CPU liveness to stop quiet-gate kills (#1758)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.833"
+version = "0.1.834"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.833"
+version = "0.1.834"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -376,8 +376,8 @@ impl AcpConnection {
                             }
                             if process_tree_made_cpu_progress(process_activity.as_mut()) {
                                 let now = Instant::now();
+                                // CPU progress is a liveness signal, not an initial-response signal.
                                 *self.last_activity.borrow_mut() = now;
-                                *self.last_meaningful_activity.borrow_mut() = now;
                             }
                             let (effective_timeout, timeout_phase, last_relevant_activity) =
                                 if !saw_initial_response_event {

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -9,7 +9,10 @@ use agent_client_protocol::{
     Agent, ClientSideConnection, InitializeRequest, LoadSessionRequest, NewSessionRequest,
     PromptRequest, ProtocolVersion, SessionId, StopReason,
 };
-use csa_process::{DEFAULT_SPOOL_KEEP_ROTATED, DEFAULT_SPOOL_MAX_BYTES, SpoolRotator};
+use csa_process::{
+    DEFAULT_SPOOL_KEEP_ROTATED, DEFAULT_SPOOL_MAX_BYTES, ProcessTreeActivity, ProcessTreeStatus,
+    SpoolRotator,
+};
 use tokio::{process::Child, task::LocalSet};
 
 #[path = "connection_env.rs"]
@@ -329,6 +332,10 @@ impl AcpConnection {
             open_output_spool_file(io.output_spool, io.spool_max_bytes, io.keep_rotated_spool);
         let mut metadata = StreamingMetadata::default();
         let (mut stdout_line_buf, mut thought_line_buf) = (String::new(), String::new());
+        let mut process_activity = self.child_pid().map(ProcessTreeActivity::new);
+        if let Some(activity) = process_activity.as_mut() {
+            let _ = activity.observe();
+        }
 
         let request = PromptRequest::new(SessionId::new(session_id.to_string()), vec![text.into()]);
         enum PromptOutcome<T> {
@@ -366,6 +373,11 @@ impl AcpConnection {
                             );
                             if saw_progress_this_poll {
                                 saw_initial_response_event = true;
+                            }
+                            if process_tree_made_cpu_progress(process_activity.as_mut()) {
+                                let now = Instant::now();
+                                *self.last_activity.borrow_mut() = now;
+                                *self.last_meaningful_activity.borrow_mut() = now;
                             }
                             let (effective_timeout, timeout_phase, last_relevant_activity) =
                                 if !saw_initial_response_event {
@@ -533,6 +545,12 @@ impl AcpConnection {
     pub(crate) fn format_stderr(stderr: &str) -> String {
         format_stderr(stderr)
     }
+}
+
+fn process_tree_made_cpu_progress(process_activity: Option<&mut ProcessTreeActivity>) -> bool {
+    process_activity.is_some_and(|activity| {
+        matches!(activity.observe(), ProcessTreeStatus::AliveWithCpuProgress)
+    })
 }
 
 /// 64 KiB buffer for spool writes to reduce syscall overhead vs per-chunk flush.

--- a/crates/csa-acp/src/connection_initial_response_tests.rs
+++ b/crates/csa-acp/src/connection_initial_response_tests.rs
@@ -353,6 +353,69 @@ async fn initial_response_timeout_fires_when_stderr_also_silent() {
 }
 
 #[tokio::test]
+async fn idle_timeout_stays_alive_while_child_process_tree_consumes_cpu() {
+    let connection = build_test_connection(
+        spawn_test_child("while :; do :; done"),
+        Duration::from_millis(450),
+        PromptBehavior::Silent,
+    )
+    .await;
+
+    connection.initialize().await.expect("initialize");
+    let cwd = std::env::current_dir().expect("cwd");
+    let session_id = connection
+        .new_session(None, Some(cwd.as_path()), None)
+        .await
+        .expect("new session");
+
+    let result = connection
+        .prompt_with_io(
+            &session_id,
+            "ping",
+            Duration::from_millis(120),
+            None,
+            PromptIoOptions::default(),
+        )
+        .await
+        .expect("prompt should complete while CPU progress keeps idle timeout alive");
+
+    assert!(!result.timed_out, "busy child process tree must not be killed");
+    assert_eq!(result.exit_reason.as_deref(), Some("end_turn"));
+    connection.kill().await.expect("kill test child");
+}
+
+#[tokio::test]
+async fn idle_timeout_still_fires_for_alive_child_with_no_cpu_progress() {
+    let connection = build_test_connection(
+        spawn_test_child("sleep 5"),
+        Duration::from_secs(5),
+        PromptBehavior::Silent,
+    )
+    .await;
+
+    connection.initialize().await.expect("initialize");
+    let cwd = std::env::current_dir().expect("cwd");
+    let session_id = connection
+        .new_session(None, Some(cwd.as_path()), None)
+        .await
+        .expect("new session");
+
+    let result = connection
+        .prompt_with_io(
+            &session_id,
+            "ping",
+            Duration::from_millis(150),
+            None,
+            PromptIoOptions::default(),
+        )
+        .await
+        .expect("prompt returns timeout result");
+
+    assert!(result.timed_out, "sleeping child must remain killable");
+    assert_eq!(result.exit_reason.as_deref(), Some("idle_timeout"));
+}
+
+#[tokio::test]
 async fn initial_response_timeout_fires_when_only_protocol_notifications() {
     let connection = build_test_connection(
         spawn_test_child("sleep 5"),

--- a/crates/csa-acp/src/connection_initial_response_tests.rs
+++ b/crates/csa-acp/src/connection_initial_response_tests.rs
@@ -207,7 +207,10 @@ async fn build_test_connection(
         last_meaningful_activity,
         stderr_buf,
         std::env::current_dir().expect("cwd"),
-        AcpConnectionOptions::default(),
+        AcpConnectionOptions {
+            termination_grace_period: Duration::ZERO,
+            ..AcpConnectionOptions::default()
+        },
     )
 }
 
@@ -382,6 +385,48 @@ async fn idle_timeout_stays_alive_while_child_process_tree_consumes_cpu() {
     assert!(!result.timed_out, "busy child process tree must not be killed");
     assert_eq!(result.exit_reason.as_deref(), Some("end_turn"));
     connection.kill().await.expect("kill test child");
+}
+
+#[tokio::test]
+async fn initial_response_timeout_fires_while_child_process_tree_consumes_cpu() {
+    let connection = build_test_connection(
+        spawn_test_child(
+            "python3 -c 'import time\nend=time.monotonic()+2\nwhile time.monotonic()<end:\n pass'",
+        ),
+        Duration::from_secs(5),
+        PromptBehavior::Silent,
+    )
+    .await;
+
+    connection.initialize().await.expect("initialize");
+    let cwd = std::env::current_dir().expect("cwd");
+    let session_id = connection
+        .new_session(None, Some(cwd.as_path()), None)
+        .await
+        .expect("new session");
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(700),
+        connection.prompt_with_io(
+            &session_id,
+            "ping",
+            Duration::from_secs(5),
+            Some(Duration::from_millis(150)),
+            PromptIoOptions::default(),
+        ),
+    )
+    .await
+    .expect("CPU progress must not extend the initial-response watchdog")
+    .expect("prompt result");
+
+    assert!(
+        result.timed_out,
+        "CPU-only child process activity must trip the initial-response watchdog"
+    );
+    assert_eq!(
+        result.exit_reason.as_deref(),
+        Some("initial_response_timeout")
+    );
 }
 
 #[tokio::test]

--- a/crates/csa-acp/src/connection_initial_response_tests.rs
+++ b/crates/csa-acp/src/connection_initial_response_tests.rs
@@ -355,6 +355,7 @@ async fn initial_response_timeout_fires_when_stderr_also_silent() {
     );
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn idle_timeout_stays_alive_while_child_process_tree_consumes_cpu() {
     let connection = build_test_connection(
@@ -387,6 +388,7 @@ async fn idle_timeout_stays_alive_while_child_process_tree_consumes_cpu() {
     connection.kill().await.expect("kill test child");
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn initial_response_timeout_fires_while_child_process_tree_consumes_cpu() {
     let connection = build_test_connection(

--- a/crates/csa-process/src/lib.rs
+++ b/crates/csa-process/src/lib.rs
@@ -16,6 +16,8 @@ use idle_watchdog::{
 };
 mod persistent_rate_limit;
 use persistent_rate_limit::PersistentRateLimitTracker;
+mod process_activity;
+pub use process_activity::{ProcessTreeActivity, ProcessTreeStatus, process_tree_cpu_ticks};
 #[path = "lib_output_helpers.rs"]
 mod output_helpers;
 #[path = "lib_subprocess_helpers.rs"]

--- a/crates/csa-process/src/lib_tests_tail.rs
+++ b/crates/csa-process/src/lib_tests_tail.rs
@@ -281,17 +281,22 @@ async fn test_idle_timeout_with_live_pid_but_no_progress_kills_after_dead_timeou
     let locks_dir = tmp.path().join("locks");
     std::fs::create_dir_all(&locks_dir).expect("create locks dir");
     let lock_path = locks_dir.join("codex.lock");
-    std::fs::write(&lock_path, format!("{{\"pid\": {}}}", std::process::id())).expect("write lock");
-    // Make metadata stale so lock-file timestamp is not misclassified as progress.
-    set_file_mtime_seconds_ago(&lock_path, 120);
 
     let output_path = tmp.path().join("output.log");
     std::fs::write(&output_path, "").expect("seed output");
     set_file_mtime_seconds_ago(&output_path, 120);
 
     let mut cmd = Command::new("bash");
-    cmd.args(["-c", "sleep 30"]);
+    let session_path = tmp.path().display().to_string();
+    cmd.args(["-c", "sleep 30", "codex", &session_path]);
     let child = spawn_tool(cmd, None).await.expect("spawn");
+    std::fs::write(
+        &lock_path,
+        format!("{{\"pid\": {}}}", child.id().unwrap_or(0)),
+    )
+    .expect("write lock");
+    // Make metadata stale so lock-file timestamp is not misclassified as progress.
+    set_file_mtime_seconds_ago(&lock_path, 120);
     let start = Instant::now();
     let result = wait_and_capture_with_idle_timeout(
         child,
@@ -314,6 +319,50 @@ async fn test_idle_timeout_with_live_pid_but_no_progress_kills_after_dead_timeou
     assert!(
         elapsed < Duration::from_secs(15),
         "should terminate after idle+liveness_dead window, elapsed={elapsed:?}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_idle_timeout_with_busy_process_tree_does_not_kill_for_silence() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let locks_dir = tmp.path().join("locks");
+    std::fs::create_dir_all(&locks_dir).expect("create locks dir");
+    let lock_path = locks_dir.join("codex.lock");
+
+    let output_path = tmp.path().join("output.log");
+    std::fs::write(&output_path, "").expect("seed output");
+    set_file_mtime_seconds_ago(&output_path, 120);
+
+    let mut cmd = Command::new("bash");
+    let session_path = tmp.path().display().to_string();
+    cmd.args(["-c", "while :; do :; done", "codex", &session_path]);
+    let child = spawn_tool(cmd, None).await.expect("spawn");
+    std::fs::write(
+        &lock_path,
+        format!("{{\"pid\": {}}}", child.id().unwrap_or(0)),
+    )
+    .expect("write lock");
+    set_file_mtime_seconds_ago(&lock_path, 120);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(4),
+        wait_and_capture_with_idle_timeout(
+            child,
+            StreamMode::BufferOnly,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_millis(100),
+            Some(&output_path),
+            SpawnOptions::default(),
+            None,
+        ),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "busy process tree should stay alive past idle+liveness_dead despite ACP/output silence"
     );
 }
 

--- a/crates/csa-process/src/lib_tests_tail.rs
+++ b/crates/csa-process/src/lib_tests_tail.rs
@@ -322,7 +322,7 @@ async fn test_idle_timeout_with_live_pid_but_no_progress_kills_after_dead_timeou
     );
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_idle_timeout_with_busy_process_tree_does_not_kill_for_silence() {
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/csa-process/src/process_activity.rs
+++ b/crates/csa-process/src/process_activity.rs
@@ -1,0 +1,176 @@
+use std::collections::{HashMap, HashSet};
+
+/// Runtime state of a process tree sampled for quiet-session liveness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessTreeStatus {
+    /// No live process remains in the monitored process tree.
+    Dead,
+    /// At least one process is alive, but CPU counters did not advance since the previous sample.
+    AliveIdle,
+    /// At least one process is alive and cumulative CPU counters advanced since the previous sample.
+    AliveWithCpuProgress,
+}
+
+/// Tracks CPU progress for a spawned tool process and its descendants.
+///
+/// The first observation establishes the baseline. A later observation reports
+/// [`ProcessTreeStatus::AliveWithCpuProgress`] only when cumulative user+system
+/// CPU ticks for the process tree increased.
+#[derive(Debug, Clone, Copy)]
+pub struct ProcessTreeActivity {
+    root_pid: u32,
+    last_cpu_ticks: Option<u64>,
+}
+
+impl ProcessTreeActivity {
+    pub fn new(root_pid: u32) -> Self {
+        Self {
+            root_pid,
+            last_cpu_ticks: None,
+        }
+    }
+
+    pub fn observe(&mut self) -> ProcessTreeStatus {
+        let Some(cpu_ticks) = process_tree_cpu_ticks(self.root_pid) else {
+            self.last_cpu_ticks = None;
+            return ProcessTreeStatus::Dead;
+        };
+
+        let status = match self.last_cpu_ticks {
+            Some(previous) if cpu_ticks > previous => ProcessTreeStatus::AliveWithCpuProgress,
+            _ => ProcessTreeStatus::AliveIdle,
+        };
+        self.last_cpu_ticks = Some(cpu_ticks);
+        status
+    }
+}
+
+/// Return cumulative user+system CPU ticks for the live process tree rooted at `root_pid`.
+pub fn process_tree_cpu_ticks(root_pid: u32) -> Option<u64> {
+    platform_process_tree_cpu_ticks(root_pid)
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy)]
+struct ProcStat {
+    pid: u32,
+    ppid: u32,
+    pgrp: i32,
+    state: char,
+    cpu_ticks: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn platform_process_tree_cpu_ticks(root_pid: u32) -> Option<u64> {
+    let stats = read_all_proc_stats();
+    let root = stats.iter().find(|stat| stat.pid == root_pid).copied();
+    let root_pgrp = root.and_then(|stat| (stat.pgrp == root_pid as i32).then_some(stat.pgrp));
+    let parents: HashMap<u32, u32> = stats.iter().map(|stat| (stat.pid, stat.ppid)).collect();
+
+    let mut saw_live_process = false;
+    let total = stats
+        .iter()
+        .filter(|stat| process_belongs_to_tree(**stat, root_pid, root_pgrp, &parents))
+        .filter(|stat| !matches!(stat.state, 'Z' | 'X'))
+        .inspect(|_| saw_live_process = true)
+        .map(|stat| stat.cpu_ticks)
+        .sum::<u64>();
+
+    saw_live_process.then_some(total)
+}
+
+#[cfg(target_os = "linux")]
+fn process_belongs_to_tree(
+    stat: ProcStat,
+    root_pid: u32,
+    root_pgrp: Option<i32>,
+    parents: &HashMap<u32, u32>,
+) -> bool {
+    stat.pid == root_pid
+        || root_pgrp.is_some_and(|pgrp| stat.pgrp == pgrp)
+        || is_descendant_of(stat.pid, root_pid, parents)
+}
+
+#[cfg(target_os = "linux")]
+fn is_descendant_of(pid: u32, root_pid: u32, parents: &HashMap<u32, u32>) -> bool {
+    let mut current = pid;
+    let mut seen = HashSet::new();
+    while let Some(parent) = parents.get(&current).copied() {
+        if parent == root_pid {
+            return true;
+        }
+        if parent == 0 || !seen.insert(current) {
+            return false;
+        }
+        current = parent;
+    }
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn read_all_proc_stats() -> Vec<ProcStat> {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
+            read_proc_stat(pid)
+        })
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn read_proc_stat(pid: u32) -> Option<ProcStat> {
+    let content = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let close_paren = content.rfind(')')?;
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    let state = parts.next()?.chars().next()?;
+    let ppid = parts.next()?.parse::<u32>().ok()?;
+    let pgrp = parts.next()?.parse::<i32>().ok()?;
+    for _ in 0..8 {
+        parts.next()?;
+    }
+    let utime = parts.next()?.parse::<u64>().ok()?;
+    let stime = parts.next()?.parse::<u64>().ok()?;
+
+    Some(ProcStat {
+        pid,
+        ppid,
+        pgrp,
+        state,
+        cpu_ticks: utime.saturating_add(stime),
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn platform_process_tree_cpu_ticks(root_pid: u32) -> Option<u64> {
+    process_is_alive(root_pid).then_some(0)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_is_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        // SAFETY: `kill(pid, 0)` probes existence/permission without sending a signal.
+        let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if ret == 0 {
+            return true;
+        }
+        let errno = std::io::Error::last_os_error().raw_os_error();
+        errno == Some(libc::EPERM)
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+#[cfg(test)]
+#[path = "process_activity_tests.rs"]
+mod tests;

--- a/crates/csa-process/src/process_activity_tests.rs
+++ b/crates/csa-process/src/process_activity_tests.rs
@@ -1,0 +1,56 @@
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use super::{ProcessTreeActivity, ProcessTreeStatus};
+
+#[cfg(target_os = "linux")]
+#[test]
+fn process_tree_activity_reports_cpu_progress_for_busy_child() {
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg("while :; do :; done")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn busy child");
+    let mut activity = ProcessTreeActivity::new(child.id());
+
+    assert_eq!(activity.observe(), ProcessTreeStatus::AliveIdle);
+    std::thread::sleep(Duration::from_millis(80));
+    assert_eq!(activity.observe(), ProcessTreeStatus::AliveWithCpuProgress);
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn process_tree_activity_keeps_sleeping_child_idle() {
+    let mut child = Command::new("sleep")
+        .arg("5")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sleeping child");
+    let mut activity = ProcessTreeActivity::new(child.id());
+
+    assert_eq!(activity.observe(), ProcessTreeStatus::AliveIdle);
+    std::thread::sleep(Duration::from_millis(80));
+    assert_eq!(activity.observe(), ProcessTreeStatus::AliveIdle);
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn process_tree_activity_reports_dead_after_child_exits() {
+    let mut child = Command::new("true").spawn().expect("spawn short child");
+    let pid = child.id();
+    child.wait().expect("wait short child");
+
+    let mut activity = ProcessTreeActivity::new(pid);
+    assert_eq!(activity.observe(), ProcessTreeStatus::Dead);
+}

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -3,6 +3,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
+use crate::process_tree_cpu_ticks;
+
 #[path = "tool_liveness_fatal_error.rs"]
 mod fatal_error;
 use fatal_error::has_fatal_error_signal;
@@ -38,6 +40,7 @@ struct ProcessMetadata {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct LivenessSignals {
     pub pid_alive: bool,
+    pub cpu_progress: bool,
     pub output_growth: bool,
     pub session_write: bool,
     pub stderr_activity: bool,
@@ -49,7 +52,7 @@ impl LivenessSignals {
         // Treat only stream/log growth as concrete progress. Generic
         // "recent file write" is retained as a coarse liveness signal but is
         // too noisy for idle-timeout extension (lock files, snapshots, etc.).
-        self.output_growth || self.stderr_activity
+        self.cpu_progress || self.output_growth || self.stderr_activity
     }
 
     pub(crate) fn has_any_signal(self) -> bool {
@@ -63,6 +66,7 @@ struct LivenessSnapshot {
     observed_spool_bytes_written: Option<u64>,
     acp_events_size: Option<u64>,
     stderr_log_size: Option<u64>,
+    process_cpu_ticks: Option<u64>,
 }
 
 /// Filesystem-only liveness probe for a running tool session.
@@ -82,6 +86,7 @@ impl ToolLiveness {
 
         let signals = LivenessSignals {
             pid_alive: has_live_pid_signal(session_dir) || daemon_pid_alive,
+            cpu_progress: has_process_cpu_progress_signal(session_dir, &mut snapshot),
             output_growth: has_output_growth_signal(session_dir, &mut snapshot),
             session_write: has_recent_session_write_signal(session_dir, now),
             stderr_activity: has_stderr_activity_signal(session_dir, &mut snapshot),
@@ -457,6 +462,22 @@ fn has_stderr_activity_signal(session_dir: &Path, snapshot: &mut LivenessSnapsho
     stderr_growth
 }
 
+fn has_process_cpu_progress_signal(session_dir: &Path, snapshot: &mut LivenessSnapshot) -> bool {
+    let Some(pid) = find_session_pid(session_dir) else {
+        snapshot.process_cpu_ticks = None;
+        return false;
+    };
+    let Some(current_ticks) = process_tree_cpu_ticks(pid) else {
+        snapshot.process_cpu_ticks = None;
+        return false;
+    };
+
+    let progressed =
+        matches!(snapshot.process_cpu_ticks, Some(previous) if current_ticks > previous);
+    snapshot.process_cpu_ticks = Some(current_ticks);
+    progressed
+}
+
 fn detect_growth(path: &Path, previous_size: Option<u64>) -> (bool, Option<u64>) {
     let current_size = fs::metadata(path).ok().map(|meta| meta.len());
     let growth = match (previous_size, current_size) {
@@ -495,6 +516,7 @@ fn load_snapshot(session_dir: &Path) -> LivenessSnapshot {
             "observed_spool_bytes_written" => snapshot.observed_spool_bytes_written = parsed,
             "acp_events_size" => snapshot.acp_events_size = parsed,
             "stderr_log_size" => snapshot.stderr_log_size = parsed,
+            "process_cpu_ticks" => snapshot.process_cpu_ticks = parsed,
             _ => {}
         }
     }
@@ -514,6 +536,9 @@ fn save_snapshot(session_dir: &Path, snapshot: &LivenessSnapshot) {
     }
     if let Some(value) = snapshot.stderr_log_size {
         lines.push(format!("stderr_log_size={value}"));
+    }
+    if let Some(value) = snapshot.process_cpu_ticks {
+        lines.push(format!("process_cpu_ticks={value}"));
     }
     if lines.is_empty() {
         return;


### PR DESCRIPTION
Fixes #1758.

## Problem

A `csa run` WRITE session (codex, `--sa-mode false`) was killed at ~13 minutes **while
its child `just pre-commit` gate was actively running** (a long, mostly-silent
all-features clippy + nextest), leaving the completed work **staged but uncommitted** and
the session marked `status=failure exit=1`. This happened even with `--no-error-marker-scan`
(not #1745) and even with `--no-idle-timeout` set.

Root cause: the liveness check declared the session dead based on **ACP-output cadence**
(time since last ACP event). During a long quiet child phase (compiling, running 5000+
tests with no per-test ACP output), no ACP events arrived past the dead-timeout window, so
the session was killed — even though the child subprocess tree (`just`→`cargo`→`nextest`)
was alive and consuming CPU. This blocked committing on slow Rust repos via CSA.

## Fix

1. **Liveness tracks child-process CPU progress, not just ACP cadence** (`43b05a25`,
   scope `csa-process`). A new `process_activity` module samples the child process tree's
   CPU (utime+stime). While the tree is alive AND making CPU progress, the session counts
   as live — wired into both the legacy `csa-process` watchdogs (`tool_liveness.rs`) and
   ACP prompt execution (`csa-acp/connection.rs`). A live-but-no-CPU (wedged) or dead child
   remains killable per the existing dead-timeout policy — genuinely-hung sessions are
   still reaped.
2. **Preserve the initial-response watchdog** (`adbe49f1`, scope `csa-acp`). CPU progress
   refreshes only `last_activity` (the normal idle/dead timer), NOT `last_meaningful_activity`
   — the latter stays reserved for eligible ACP content / stderr, which drives the
   `initial_response_timeout`. So a backend that never emits its first eligible response is
   still caught by the initial-response watchdog even when it is burning CPU.
3. **Platform-gate the CPU-liveness tests to Linux** (`69b29dda`, scope `csa-process`/`csa-acp`).
   CPU-progress sampling is Linux-only (`/proc`); the new CPU-dependent tests are
   `#[cfg(target_os = "linux")]` so the macOS workspace test job stays green. Non-Linux
   compiles and gracefully degrades to the prior ACP-cadence liveness.

## Tests

- A quiet-but-CPU-busy child is NOT killed for ACP silence past the dead-timeout (Linux).
- A wedged (zero-CPU) / dead child IS still detected and killed — no regression in
  dead-detection.
- CPU progress does NOT reset the initial-response deadline (the watchdog still fires for a
  backend that has emitted no eligible response).

## Scope

- ONLY the idle/liveness kill detection + CPU-progress signal + the no-regression
  dead-detection guardrail + Linux test gating.
- Does not touch verdict logic (#1761/#1764), the `csa run` finalizer (#1757), or the
  `post_exec_gate` (#1767).

## Related

- #1711 — daemon lifecycle (phase-active on failure). Same family; the phase-active cleanup
  remains tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
