### PR TITLE
feat(cli-sub-agent): signal uncommitted writer sessions (#1753)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.835"
+version = "0.1.836"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.835"
+version = "0.1.836"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -220,6 +220,10 @@ pub enum Commands {
         #[arg(long)]
         no_post_exec_gate: bool,
 
+        /// Fail if a non-SA writer run ends with uncommitted worktree changes.
+        #[arg(long)]
+        require_commit: bool,
+
         /// Path to agent-spec file (.spec or .toml) for contract-based verification
         #[arg(long, value_name = "PATH", value_parser = parse_spec_path_arg)]
         spec: Option<String>,

--- a/crates/cli-sub-agent/src/debate_cmd_dry_run.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_dry_run.rs
@@ -55,6 +55,7 @@ pub(crate) fn create_debate_dry_run_session(
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     csa_session::save_result(project_root, &session.meta_session_id, &result)?;

--- a/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
@@ -85,6 +85,7 @@ fn setup_unrelated_debate_session(
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )
@@ -134,6 +135,7 @@ fn seed_debate_result(
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )
@@ -506,6 +508,7 @@ fn debate_nonzero_with_explicit_verdict_is_reclassified_success() {
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )
@@ -588,6 +591,7 @@ fn debate_finalize_persists_categorized_fallback_chain_for_multi_skip() {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )
@@ -696,6 +700,7 @@ fn debate_finalize_persists_build_time_exclusions_without_runtime_failures() {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )
@@ -786,6 +791,7 @@ fn debate_finalize_non_success_omits_after_final_disabled_tier_spec() {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )

--- a/crates/cli-sub-agent/src/debate_cmd_round4_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_round4_tests.rs
@@ -81,6 +81,7 @@ fn debate_tier_all_fail_does_not_overwrite_unrelated_latest_session() {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )
@@ -217,6 +218,7 @@ fn debate_pre_session_all_fail_yields_unavailable() {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -610,6 +610,7 @@ fn append_debate_artifacts_to_result_updates_summary_and_artifacts() {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )

--- a/crates/cli-sub-agent/src/gc_runtime_tests.rs
+++ b/crates/cli-sub-agent/src/gc_runtime_tests.rs
@@ -152,6 +152,7 @@ fn seed_runtime_session(
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )

--- a/crates/cli-sub-agent/src/goal_loop.rs
+++ b/crates/cli-sub-agent/src/goal_loop.rs
@@ -108,6 +108,7 @@ pub(crate) struct GoalRunRequest {
     /// silent-hang scan for this run, overriding config (#1745).
     pub(crate) no_error_marker_scan: bool,
     pub(crate) no_post_exec_gate: bool,
+    pub(crate) require_commit: bool,
     pub(crate) extra_writable: Vec<PathBuf>,
     pub(crate) extra_readable: Vec<PathBuf>,
 }
@@ -175,6 +176,7 @@ pub(crate) async fn handle_run_or_goal(request: GoalRunRequest) -> Result<i32> {
         request.no_fs_sandbox,
         request.no_error_marker_scan,
         request.no_post_exec_gate,
+        request.require_commit,
         request.extra_writable,
         request.extra_readable,
     )
@@ -334,6 +336,7 @@ async fn run_goal_iteration(
         request.no_fs_sandbox,
         request.no_error_marker_scan,
         request.no_post_exec_gate,
+        request.require_commit,
         request.extra_writable.clone(),
         request.extra_readable.clone(),
     )

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -288,6 +288,7 @@ async fn run() -> Result<()> {
             no_stream_stdout,
             no_error_marker_scan,
             no_post_exec_gate,
+            require_commit,
             spec: _spec,
             tier,
             force_ignore_tier_setting,
@@ -379,6 +380,7 @@ async fn run() -> Result<()> {
                 no_fs_sandbox,
                 no_error_marker_scan,
                 no_post_exec_gate,
+                require_commit,
                 extra_writable,
                 extra_readable,
             })

--- a/crates/cli-sub-agent/src/pipeline_execute.rs
+++ b/crates/cli-sub-agent/src/pipeline_execute.rs
@@ -218,6 +218,7 @@ pub(crate) async fn execute_transport_with_signal(
                 gate_timeout: false,
                 warnings: Vec::new(),
                 raw_process_exit_code: None,
+                uncommitted_changes: None,
                 manager_fields: Default::default(),
             };
             if let Err(save_err) = save_result(project_root, &session.meta_session_id, &result) {
@@ -346,6 +347,7 @@ fn record_session_termination(
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     if let Err(e) = save_result(project_root, &session.meta_session_id, &updated_result) {

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -177,6 +177,7 @@ pub(crate) async fn process_execution_result(
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     if let Err(err) = crate::session_observability::enrich_result_from_session_dir(

--- a/crates/cli-sub-agent/src/pipeline_post_exec_fallback.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_fallback.rs
@@ -126,6 +126,7 @@ pub(crate) fn ensure_terminal_result_on_post_exec_error(
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
@@ -75,6 +75,7 @@ fn ensure_terminal_result_on_post_exec_error_keeps_existing_result() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     save_result(project_root, &session.meta_session_id, &existing).expect("write existing result");
@@ -387,6 +388,7 @@ fn codex_exec_initial_stall_summary_forces_failure_status_in_result_toml() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec_audit.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec_audit.rs
@@ -98,6 +98,7 @@ fn apply_repo_write_audit_to_result_populates_manager_sidecar_sections() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     let audit = RepoWriteAudit {
@@ -418,6 +419,7 @@ fn audit_failure_does_not_fail_execution() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
 
@@ -545,6 +547,7 @@ fn reused_session_audit_uses_per_execution_baseline_not_session_creation() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
 
@@ -651,6 +654,7 @@ fn first_execution_falls_back_to_session_creation_baseline_when_per_exec_capture
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -388,6 +388,7 @@ async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: csa_session::SessionManagerFields {
                 report: Some(
                     toml::toml! {

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -330,6 +330,7 @@ pub(crate) async fn handle_plan_run_daemon_child(
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     if let Err(save_err) = save_result(&project_root, session_id, &session_result) {

--- a/crates/cli-sub-agent/src/preflight_state_dir.rs
+++ b/crates/cli-sub-agent/src/preflight_state_dir.rs
@@ -711,6 +711,7 @@ mod tests {
                 gate_timeout: false,
                 warnings: Vec::new(),
                 raw_process_exit_code: None,
+                uncommitted_changes: None,
                 manager_fields: Default::default(),
             },
         )

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -223,6 +223,7 @@ fn exact_test_wait_result(exit_code: i32, summary: &str) -> csa_session::Session
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -134,6 +134,7 @@ pub(super) fn maybe_synthesize_missing_review_result(
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -21,6 +21,8 @@ mod policy;
 mod resume;
 #[path = "run_cmd_shell.rs"]
 mod shell;
+#[path = "run_cmd_uncommitted.rs"]
+mod uncommitted;
 
 pub(crate) use execute::handle_run;
 pub(crate) use git::{
@@ -32,6 +34,7 @@ pub(crate) use policy::{
     apply_unverifiable_commit_policy, execute_tool_calls_observed, extract_executed_shell_commands,
 };
 pub(crate) use shell::detect_no_verify_commit_commands;
+pub(crate) use uncommitted::format_uncommitted_warning;
 
 #[cfg(test)]
 pub(crate) use crate::pipeline::promote_idle_timeout_for_explicit_wall_timeout;
@@ -144,6 +147,7 @@ impl SubagentRunConfig {
             false,
             false,
             false, // no_error_marker_scan: programmatic run wrapper; defer to config (#1745)
+            false,
             false,
             Vec::new(),
             Vec::new(),

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -98,6 +98,7 @@ pub(crate) async fn handle_run(
     no_fs_sandbox: bool,
     no_error_marker_scan: bool,
     no_post_exec_gate: bool,
+    require_commit: bool,
     extra_writable: Vec<PathBuf>,
     extra_readable: Vec<PathBuf>,
 ) -> Result<i32> {
@@ -589,11 +590,18 @@ pub(crate) async fn handle_run(
         RunLoopCompletion::Exit(exit_code) => return Ok(exit_code),
         RunLoopCompletion::Completed(loop_outcome) => *loop_outcome,
     };
-    let result = loop_outcome.result;
+    let mut result = loop_outcome.result;
     let current_tool = loop_outcome.current_tool;
     let executed_session_id = loop_outcome.executed_session_id;
     let changed_paths = loop_outcome.changed_paths;
     let fork_resolution = loop_outcome.fork_resolution;
+    super::uncommitted::record_run_dirty(
+        &project_root,
+        executed_session_id.as_deref(),
+        &mut result,
+        require_commit,
+        config.as_ref(),
+    );
 
     if result.exit_code == 0 {
         apply_post_exec_gate_after_success_with_runner(

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -38,6 +38,7 @@ fn project_config_with_gate(gate: PostExecGateConfig) -> ProjectConfig {
         hooks: Default::default(),
         run: RunConfig {
             allow_base_branch_working: false,
+            writer_must_commit: false,
             post_exec_gate: gate,
         },
         execution: Default::default(),
@@ -108,6 +109,7 @@ fn write_success_result_for(project_root: &Path, session_id: &str) {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     save_result(project_root, session_id, &result).expect("write success result");

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -129,6 +129,7 @@ async fn handle_run_rejects_model_spec_tier_bypass_before_session_creation() {
         false,
         false, // no_error_marker_scan (#1745)
         false,
+        false,
         Vec::new(),
         Vec::new(),
     )
@@ -209,6 +210,7 @@ async fn handle_run_does_not_persist_result_for_non_conflict_pre_exec_error() {
         false,
         false,
         false, // no_error_marker_scan (#1745)
+        false,
         false,
         Vec::new(),
         Vec::new(),

--- a/crates/cli-sub-agent/src/run_cmd_post_gate_failure_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_gate_failure_tests.rs
@@ -22,6 +22,7 @@ fn write_success_result_for(project_root: &Path, session_id: &str) {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     save_result(project_root, session_id, &result).unwrap();

--- a/crates/cli-sub-agent/src/run_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests.rs
@@ -105,6 +105,17 @@ fn run_cli_parses_allow_fallback_flag() {
 }
 
 #[test]
+fn run_cli_parses_require_commit_flag() {
+    let cli = try_parse_cli(&["csa", "run", "--require-commit", "--sa-mode", "false", "x"])
+        .expect("--require-commit should parse");
+
+    match cli.command {
+        crate::cli::Commands::Run { require_commit, .. } => assert!(require_commit),
+        _ => panic!("expected run command"),
+    }
+}
+
+#[test]
 fn run_rejects_unknown_tool_at_clap_parse() {
     let result = try_parse_cli(&["csa", "run", "--model-spec", "unknown-tool/x/y/medium", "x"]);
     let err = match result {

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -155,6 +155,7 @@ async fn handle_run_persists_result_for_direct_tool_tier_rejection() {
         false,
         false, // no_error_marker_scan (#1745)
         false,
+        false,
         Vec::new(),
         Vec::new(),
     )

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -1,0 +1,363 @@
+//! Writer-session dirty-worktree signal for `csa run`.
+
+use std::path::Path;
+use std::process::Command;
+
+use tracing::warn;
+
+const MAX_UNCOMMITTED_FILES: usize = 20;
+const REQUIRE_COMMIT_REASON: &str =
+    "writer session ended with uncommitted changes (--require-commit set)";
+
+pub(crate) fn is_writer_session(sa_mode: bool, task_type: Option<&str>) -> bool {
+    !sa_mode && matches!(task_type, Some("run"))
+}
+
+pub(crate) fn effective_writer_must_commit(
+    cli_require_commit: bool,
+    config: Option<&csa_config::ProjectConfig>,
+) -> bool {
+    cli_require_commit || config.is_some_and(|cfg| cfg.run.writer_must_commit)
+}
+
+pub(crate) fn summarize_uncommitted_changes(
+    porcelain: &str,
+    numstat: &str,
+) -> Option<csa_session::UncommittedChanges> {
+    let paths = changed_paths_from_porcelain(porcelain);
+    if paths.is_empty() {
+        return None;
+    }
+
+    let (insertions, deletions) = parse_numstat_totals(numstat);
+    let file_count = paths.len();
+    let files = paths
+        .into_iter()
+        .take(MAX_UNCOMMITTED_FILES)
+        .collect::<Vec<_>>();
+    let truncated = file_count.saturating_sub(files.len());
+
+    Some(csa_session::UncommittedChanges {
+        file_count,
+        insertions,
+        deletions,
+        files,
+        truncated,
+    })
+}
+
+pub(crate) fn record_writer_uncommitted_changes(
+    project_root: &Path,
+    session_id: Option<&str>,
+    result: &mut csa_process::ExecutionResult,
+    sa_mode: bool,
+    require_commit: bool,
+) {
+    if !is_writer_session(sa_mode, Some("run")) {
+        return;
+    }
+    let Some(session_id) = session_id else {
+        return;
+    };
+    let Some(changes) = collect_uncommitted_changes(project_root) else {
+        return;
+    };
+
+    match csa_session::load_result(project_root, session_id) {
+        Ok(Some(mut session_result)) => {
+            apply_uncommitted_changes_to_result(
+                &mut session_result,
+                changes.clone(),
+                require_commit,
+            );
+            if let Err(err) = csa_session::save_result(project_root, session_id, &session_result) {
+                warn!(
+                    session = %session_id,
+                    error = %err,
+                    "Failed to persist writer uncommitted-changes signal"
+                );
+            }
+        }
+        Ok(None) => {
+            warn!(
+                session = %session_id,
+                "No result.toml to annotate with writer uncommitted-changes signal"
+            );
+        }
+        Err(err) => {
+            warn!(
+                session = %session_id,
+                error = %err,
+                "Failed to load result.toml for writer uncommitted-changes signal"
+            );
+        }
+    }
+
+    if require_commit {
+        result.mark_gate_failure("writer-uncommitted");
+        result.summary = REQUIRE_COMMIT_REASON.to_string();
+        if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+            result.stderr_output.push('\n');
+        }
+        result.stderr_output.push_str(REQUIRE_COMMIT_REASON);
+        result.stderr_output.push('\n');
+    }
+}
+
+pub(crate) fn record_run_dirty(
+    project_root: &Path,
+    session_id: Option<&str>,
+    result: &mut csa_process::ExecutionResult,
+    cli_require_commit: bool,
+    config: Option<&csa_config::ProjectConfig>,
+) {
+    let sa_mode = std::env::var(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1"))
+        .unwrap_or(false);
+    record_writer_uncommitted_changes(
+        project_root,
+        session_id,
+        result,
+        sa_mode,
+        effective_writer_must_commit(cli_require_commit, config),
+    );
+}
+
+pub(crate) fn apply_uncommitted_changes_to_result(
+    result: &mut csa_session::SessionResult,
+    changes: csa_session::UncommittedChanges,
+    require_commit: bool,
+) {
+    result.uncommitted_changes = Some(changes);
+    if require_commit {
+        result.exit_code = 1;
+        result.status = csa_session::SessionResult::status_from_exit_code(1);
+        result.summary = REQUIRE_COMMIT_REASON.to_string();
+    }
+}
+
+pub(crate) fn format_uncommitted_warning(changes: &csa_session::UncommittedChanges) -> String {
+    format!(
+        "⚠ writer session ended with {} uncommitted files (+{}/-{}) — work NOT committed",
+        changes.file_count, changes.insertions, changes.deletions
+    )
+}
+
+fn collect_uncommitted_changes(project_root: &Path) -> Option<csa_session::UncommittedChanges> {
+    if !super::git::is_git_worktree(project_root) {
+        return None;
+    }
+
+    let porcelain = run_git_capture(
+        project_root,
+        &[
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--no-renames",
+            "-z",
+        ],
+    )?;
+    if porcelain.is_empty() {
+        return None;
+    }
+    let numstat =
+        run_git_capture(project_root, &["diff", "--numstat", "HEAD", "--"]).unwrap_or_default();
+    summarize_uncommitted_changes(&porcelain, &numstat)
+}
+
+fn run_git_capture(project_root: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn changed_paths_from_porcelain(porcelain: &str) -> Vec<String> {
+    porcelain_entries(porcelain)
+        .into_iter()
+        .filter_map(parse_porcelain_path)
+        .collect()
+}
+
+fn porcelain_entries(porcelain: &str) -> Vec<&str> {
+    if porcelain.contains('\0') {
+        porcelain
+            .split('\0')
+            .filter(|entry| !entry.is_empty())
+            .collect()
+    } else {
+        porcelain
+            .lines()
+            .filter(|entry| !entry.is_empty())
+            .collect()
+    }
+}
+
+fn parse_porcelain_path(entry: &str) -> Option<String> {
+    let mut chars = entry.chars();
+    chars.next()?;
+    chars.next()?;
+    if chars.next()? != ' ' {
+        return None;
+    }
+    let path = entry.get(3..)?.trim();
+    (!path.is_empty()).then(|| path.to_string())
+}
+
+fn parse_numstat_totals(numstat: &str) -> (u64, u64) {
+    let mut insertions = 0u64;
+    let mut deletions = 0u64;
+
+    for line in numstat.lines() {
+        let mut columns = line.split('\t');
+        let added = columns.next().and_then(|raw| raw.parse::<u64>().ok());
+        let removed = columns.next().and_then(|raw| raw.parse::<u64>().ok());
+        if let Some(value) = added {
+            insertions = insertions.saturating_add(value);
+        }
+        if let Some(value) = removed {
+            deletions = deletions.saturating_add(value);
+        }
+    }
+
+    (insertions, deletions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writer_predicate_excludes_sa_mode_and_read_only_kinds() {
+        assert!(is_writer_session(false, Some("run")));
+        assert!(!is_writer_session(true, Some("run")));
+        assert!(!is_writer_session(false, Some("review")));
+        assert!(!is_writer_session(false, Some("debate")));
+        assert!(!is_writer_session(false, Some("recon")));
+        assert!(!is_writer_session(false, None));
+    }
+
+    #[test]
+    fn summarize_uncommitted_changes_returns_none_for_clean_status() {
+        assert!(summarize_uncommitted_changes("", "").is_none());
+    }
+
+    #[test]
+    fn summarize_uncommitted_changes_counts_files_and_numstat() {
+        let porcelain = " M crates/a.rs\0A  crates/b.rs\0?? notes/todo.md\0";
+        let numstat = "10\t2\tcrates/a.rs\n5\t0\tcrates/b.rs\n-\t-\tassets/blob.bin\n";
+
+        let changes = summarize_uncommitted_changes(porcelain, numstat)
+            .expect("dirty porcelain should produce changes");
+
+        assert_eq!(changes.file_count, 3);
+        assert_eq!(changes.insertions, 15);
+        assert_eq!(changes.deletions, 2);
+        assert_eq!(
+            changes.files,
+            vec![
+                "crates/a.rs".to_string(),
+                "crates/b.rs".to_string(),
+                "notes/todo.md".to_string()
+            ]
+        );
+        assert_eq!(changes.truncated, 0);
+    }
+
+    #[test]
+    fn summarize_uncommitted_changes_caps_file_list() {
+        let porcelain = (0..25)
+            .map(|idx| format!("?? file-{idx}.txt\0"))
+            .collect::<String>();
+
+        let changes = summarize_uncommitted_changes(&porcelain, "")
+            .expect("dirty porcelain should produce changes");
+
+        assert_eq!(changes.file_count, 25);
+        assert_eq!(changes.files.len(), MAX_UNCOMMITTED_FILES);
+        assert_eq!(changes.truncated, 5);
+    }
+
+    #[test]
+    fn apply_uncommitted_changes_warn_only_preserves_success() {
+        let mut result = session_result("success", 0);
+        let changes = csa_session::UncommittedChanges {
+            file_count: 1,
+            insertions: 2,
+            deletions: 0,
+            files: vec!["src/lib.rs".to_string()],
+            truncated: 0,
+        };
+
+        apply_uncommitted_changes_to_result(&mut result, changes, false);
+
+        assert_eq!(result.status, "success");
+        assert_eq!(result.exit_code, 0);
+        assert!(result.uncommitted_changes.is_some());
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn apply_uncommitted_changes_require_commit_flips_to_failure() {
+        let mut result = session_result("success", 0);
+        let changes = csa_session::UncommittedChanges {
+            file_count: 1,
+            insertions: 2,
+            deletions: 0,
+            files: vec!["src/lib.rs".to_string()],
+            truncated: 0,
+        };
+
+        apply_uncommitted_changes_to_result(&mut result, changes, true);
+
+        assert_eq!(result.status, "failure");
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.summary, REQUIRE_COMMIT_REASON);
+        assert!(result.uncommitted_changes.is_some());
+    }
+
+    #[test]
+    fn effective_writer_must_commit_respects_cli_and_config_precedence() {
+        assert!(!effective_writer_must_commit(false, None));
+
+        let config_true: csa_config::ProjectConfig =
+            toml::from_str("[run]\nwriter_must_commit = true\n").unwrap();
+        assert!(effective_writer_must_commit(false, Some(&config_true)));
+
+        let config_false: csa_config::ProjectConfig =
+            toml::from_str("[run]\nwriter_must_commit = false\n").unwrap();
+        assert!(effective_writer_must_commit(true, Some(&config_false)));
+    }
+
+    fn session_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
+        let now = chrono::Utc::now();
+        csa_session::SessionResult {
+            status: status.to_string(),
+            exit_code,
+            summary: "done".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: Vec::new(),
+            peak_memory_mb: None,
+            fallback_chain: None,
+            gate_timeout: false,
+            warnings: Vec::new(),
+            raw_process_exit_code: None,
+            uncommitted_changes: None,
+            manager_fields: Default::default(),
+        }
+    }
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -86,6 +86,10 @@ pub(crate) fn render_wait_result_summary(
         lines.push(format!("Failover: {failover}"));
     }
 
+    if let Some(changes) = result.uncommitted_changes.as_ref() {
+        lines.push(crate::run_cmd::format_uncommitted_warning(changes));
+    }
+
     for warning in &result.warnings {
         lines.push(format!("Warning: {warning}"));
     }
@@ -457,6 +461,7 @@ mod wait_output_tests {
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         };
 
@@ -497,12 +502,51 @@ mod wait_output_tests {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         };
 
         let summary = render_wait_result_summary(temp.path(), "01TESTWAITARTPASS", &result);
 
         assert!(summary.contains("Review verdict: PASS"));
+    }
+
+    #[test]
+    fn compact_summary_includes_writer_uncommitted_warning() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let now = Utc::now();
+        let result = csa_session::SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "done".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now + chrono::TimeDelta::seconds(65),
+            events_count: 0,
+            artifacts: Vec::new(),
+            peak_memory_mb: None,
+            fallback_chain: None,
+            gate_timeout: false,
+            warnings: Vec::new(),
+            raw_process_exit_code: None,
+            uncommitted_changes: Some(csa_session::UncommittedChanges {
+                file_count: 7,
+                insertions: 240,
+                deletions: 12,
+                files: vec!["src/lib.rs".to_string()],
+                truncated: 6,
+            }),
+            manager_fields: Default::default(),
+        };
+
+        let summary = render_wait_result_summary(temp.path(), "01TESTWAITDIRTY", &result);
+
+        assert!(summary.contains(
+            "⚠ writer session ended with 7 uncommitted files (+240/-12) — work NOT committed"
+        ));
     }
 
     #[test]
@@ -533,6 +577,7 @@ mod wait_output_tests {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         };
 
@@ -595,6 +640,7 @@ mod wait_output_tests {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         };
 

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -376,6 +376,7 @@ where
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     #[rustfmt::skip]

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -150,6 +150,7 @@ fn make_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
@@ -115,6 +115,7 @@ fn make_result(status: &str, exit_code: i32) -> SessionResult {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -77,6 +77,7 @@ fn make_result(status: &str, exit_code: i32) -> SessionResult {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     }
 }
@@ -514,6 +515,7 @@ fn late_real_result_already_exists_cleans_up_reconcile_owned_sidecar() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     })
     .unwrap();
@@ -576,6 +578,7 @@ fn retire_if_dead_with_result_preserves_pr_bot_handoff_for_real_results() {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
     )

--- a/crates/cli-sub-agent/src/session_cmds_result_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests.rs
@@ -342,6 +342,7 @@ fn build_result_json_payload_includes_review_iterations() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     let review_meta = ReviewSessionMeta {
@@ -400,6 +401,7 @@ fn build_result_json_payload_includes_result_sidecars() {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
         manager_sidecar: Some(
@@ -447,6 +449,7 @@ fn build_result_json_payload_redacts_result_sidecars() {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         },
         manager_sidecar: Some(

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -60,6 +60,7 @@ fn make_result(status: &str, exit_code: i32) -> SessionResult {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/session_guard.rs
+++ b/crates/cli-sub-agent/src/session_guard.rs
@@ -98,6 +98,7 @@ pub(crate) fn write_pre_exec_error_result(
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     if let Err(e) = save_result_with_options(

--- a/crates/cli-sub-agent/src/skill_run_cmd.rs
+++ b/crates/cli-sub-agent/src/skill_run_cmd.rs
@@ -94,6 +94,7 @@ pub(crate) async fn handle_skill_run(
         no_fs_sandbox: false,
         no_error_marker_scan: false,
         no_post_exec_gate: false,
+        require_commit: false,
         extra_writable: vec![],
         extra_readable: vec![],
     })

--- a/crates/cli-sub-agent/src/todo_errors_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_errors_cmd.rs
@@ -240,6 +240,7 @@ mod tests {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         }
     }

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -664,6 +664,8 @@ transcript_enabled = false
 transcript_redaction = true
 # result_report_spill_threshold_bytes = 10240
 # require_commit_on_mutation = true
+[run]
+# writer_must_commit = false
 [resources]
 min_free_memory_mb = 4096
 idle_timeout_seconds = 250

--- a/crates/csa-config/src/config_session.rs
+++ b/crates/csa-config/src/config_session.rs
@@ -57,13 +57,18 @@ pub struct RunConfig {
     /// flag; project-local config cannot disable the run branch guard.
     #[serde(default, alias = "allow_base_branch_commit")]
     pub allow_base_branch_working: bool,
+    /// Fail writer `csa run` sessions that end with a dirty worktree.
+    #[serde(default)]
+    pub writer_must_commit: bool,
     #[serde(default)]
     pub post_exec_gate: PostExecGateConfig,
 }
 
 impl RunConfig {
     pub fn is_default(&self) -> bool {
-        !self.allow_base_branch_working && self.post_exec_gate.is_default()
+        !self.allow_base_branch_working
+            && !self.writer_must_commit
+            && self.post_exec_gate.is_default()
     }
 }
 

--- a/crates/csa-config/src/config_tests_tail.rs
+++ b/crates/csa-config/src/config_tests_tail.rs
@@ -456,6 +456,30 @@ fn test_session_config_is_default_reflects_require_commit_on_mutation() {
 }
 
 #[test]
+fn test_run_config_default_does_not_require_writer_commit() {
+    let cfg = RunConfig::default();
+    assert!(!cfg.writer_must_commit);
+}
+
+#[test]
+fn test_run_config_deserializes_writer_must_commit() {
+    let toml_str = r#"
+writer_must_commit = true
+"#;
+    let cfg: RunConfig = toml::from_str(toml_str).unwrap();
+    assert!(cfg.writer_must_commit);
+}
+
+#[test]
+fn test_run_config_is_default_reflects_writer_must_commit() {
+    let cfg = RunConfig {
+        writer_must_commit: true,
+        ..Default::default()
+    };
+    assert!(!cfg.is_default());
+}
+
+#[test]
 fn test_session_config_deserializes_spool_settings() {
     let toml_str = r#"
 spool_max_mb = 64

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -122,6 +122,8 @@ long_poll_seconds = 240
 # Post-exec quality gate for successful `csa run` employee sessions.
 # The merged project view inherits this section unless `.csa/config.toml`
 # overrides it.
+# [run]
+# writer_must_commit = false
 # [run.post_exec_gate]
 # enabled = true
 # command = "just pre-commit"

--- a/crates/csa-executor/src/transport_fork.rs
+++ b/crates/csa-executor/src/transport_fork.rs
@@ -458,6 +458,7 @@ mod tests {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         };
         std::fs::write(

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -329,6 +329,7 @@ fn test_apply_codex_exec_initial_stall_summary_renders_reason_for_result_toml() 
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     let toml = toml::to_string_pretty(&result).expect("serialize session result");

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -74,7 +74,7 @@ pub use output_section::{
 };
 pub use process_tree_memory::{SessionTreeMemorySampler, session_tree_rss_mb};
 pub use redact::{redact_event, redact_text_content};
-pub use result::{SessionArtifact, SessionManagerFields, SessionResult};
+pub use result::{SessionArtifact, SessionManagerFields, SessionResult, UncommittedChanges};
 pub use review_artifact::{
     Finding, FindingsFile, REVIEW_VERDICT_SCHEMA_VERSION, ReviewArtifact, ReviewFinding,
     ReviewFindingFileRange, ReviewVerdictArtifact, Severity, SeveritySummary, write_findings_toml,

--- a/crates/csa-session/src/manager_result_spillover.rs
+++ b/crates/csa-session/src/manager_result_spillover.rs
@@ -335,6 +335,7 @@ mod tests {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: crate::result::SessionManagerFields {
                 report: Some(
                     toml::toml! {
@@ -360,6 +361,7 @@ mod tests {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
             ..turn_1_result
         };
@@ -482,6 +484,7 @@ mod tests {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         };
         save_result_in_with_threshold(

--- a/crates/csa-session/src/manager_tests_audit.rs
+++ b/crates/csa-session/src/manager_tests_audit.rs
@@ -19,6 +19,7 @@ fn test_save_result_persists_manager_fields_sidecar() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -68,6 +68,7 @@ fn test_load_result_view_ignores_orphaned_manager_sidecar() {
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
     };
     save_result_in(
@@ -128,6 +129,7 @@ fn test_load_result_merges_manager_sidecar_sections_into_runtime_result() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     std::fs::write(
@@ -250,6 +252,7 @@ fn test_manager_sidecar_roundtrip_preserves_full_sa_schema() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     let input_sidecar = toml::Value::Table(toml::toml! {
@@ -403,6 +406,7 @@ fn test_load_result_without_sidecar_keeps_manager_fields_empty() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     save_result_in(
@@ -443,6 +447,7 @@ fn test_save_result_with_empty_manager_fields_preserves_existing_sidecar() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {
@@ -472,6 +477,7 @@ fn test_save_result_with_empty_manager_fields_preserves_existing_sidecar() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
         ..populated_result.clone()
     };
@@ -522,6 +528,7 @@ fn test_clear_manager_sidecar_removes_existing_sidecar() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {
@@ -577,6 +584,7 @@ fn test_load_result_with_malformed_manager_sidecar_is_non_fatal() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     std::fs::write(
@@ -658,6 +666,7 @@ fn test_fallback_chain_not_retained_after_save_without_fallback() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
 

--- a/crates/csa-session/src/manager_tests_sidecar_preservation.rs
+++ b/crates/csa-session/src/manager_tests_sidecar_preservation.rs
@@ -25,6 +25,7 @@ fn test_save_result_preserves_existing_contract_result_artifact_when_output_resu
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     save_result_in(
@@ -79,6 +80,7 @@ fn sidecar_write_failure_leaves_envelope_unchanged() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {
@@ -110,6 +112,7 @@ fn sidecar_write_failure_leaves_envelope_unchanged() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {
@@ -167,6 +170,7 @@ fn sidecar_clear_failure_or_crash_leaves_envelope_consistent() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {
@@ -196,6 +200,7 @@ fn sidecar_clear_failure_or_crash_leaves_envelope_consistent() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
         ..populated_result
     };
@@ -241,6 +246,7 @@ fn sidecar_clear_happy_path_publishes_envelope_then_unlinks() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {
@@ -266,6 +272,7 @@ fn sidecar_clear_happy_path_publishes_envelope_then_unlinks() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
         ..populated_result
     };

--- a/crates/csa-session/src/manager_tests_tail.rs
+++ b/crates/csa-session/src/manager_tests_tail.rs
@@ -47,6 +47,7 @@ fn test_save_and_load_result() {
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
     };
     save_result_in(td.path(), &state.meta_session_id, &result, crate::SaveOptions::default())
@@ -101,6 +102,7 @@ fn test_save_session_and_result_preserve_legacy_symlink_root() {
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
     };
     let canonical_project = project.canonicalize().unwrap();
@@ -165,6 +167,7 @@ name = "gemini-cli"
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
     };
     save_result_in(
@@ -234,6 +237,7 @@ artifacts = [1, 2]
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
     };
     save_result_in(
@@ -298,6 +302,7 @@ name = "gemini-cli"
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
     };
     save_result_in(
@@ -325,6 +330,7 @@ name = "gemini-cli"
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
     };
     save_result_in(
@@ -388,6 +394,7 @@ done = false
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
     };
     let err = save_result_in(
@@ -423,6 +430,7 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
     };
     save_result_in(
@@ -450,6 +458,7 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
         gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
     };
     save_result_in(

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -76,6 +76,10 @@ fn is_zero(value: &u64) -> bool {
     *value == 0
 }
 
+fn is_zero_usize(value: &usize) -> bool {
+    *value == 0
+}
+
 fn is_false(value: &bool) -> bool {
     !value
 }
@@ -152,6 +156,22 @@ impl SessionManagerFields {
     }
 }
 
+/// Summary of dirty worktree state left by a writer session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UncommittedChanges {
+    /// Number of paths reported by `git status --porcelain`.
+    pub file_count: usize,
+    /// Best-effort inserted line count from `git diff --numstat HEAD`.
+    pub insertions: u64,
+    /// Best-effort deleted line count from `git diff --numstat HEAD`.
+    pub deletions: u64,
+    /// First changed paths, capped to keep `result.toml` compact.
+    pub files: Vec<String>,
+    /// Number of paths omitted from `files` due to the cap.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub truncated: usize,
+}
+
 /// Structured result of a session execution.
 /// Written to `sessions/{id}/result.toml` after each tool invocation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -211,6 +231,10 @@ pub struct SessionResult {
     /// status, so existing clean envelopes are unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_process_exit_code: Option<i32>,
+    /// Dirty worktree state observed when a non-SA writer session ended without
+    /// committing. Omitted for clean sessions and read-only session kinds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uncommitted_changes: Option<UncommittedChanges>,
     /// Manager-facing data loaded from `output/result.toml` sidecars at read time.
     /// This is intentionally read-only metadata and is never serialized back into
     /// the runtime `result.toml` envelope.
@@ -256,6 +280,7 @@ mod tests {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         };
 
@@ -291,6 +316,7 @@ mod tests {
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         };
 
@@ -303,10 +329,58 @@ mod tests {
             !toml_str.contains("events_count"),
             "Zero events_count should be omitted from serialization"
         );
+        assert!(
+            !toml_str.contains("uncommitted_changes"),
+            "Clean sessions should omit uncommitted_changes"
+        );
 
         let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
         assert!(loaded.artifacts.is_empty());
         assert_eq!(loaded.events_count, 0);
+        assert!(loaded.uncommitted_changes.is_none());
+    }
+
+    #[test]
+    fn test_session_result_uncommitted_changes_roundtrip() {
+        let now = Utc::now();
+        let result = SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "Done".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: vec![],
+            peak_memory_mb: None,
+            fallback_chain: None,
+            gate_timeout: false,
+            warnings: Vec::new(),
+            raw_process_exit_code: None,
+            uncommitted_changes: Some(UncommittedChanges {
+                file_count: 7,
+                insertions: 240,
+                deletions: 12,
+                files: vec!["src/lib.rs".to_string()],
+                truncated: 6,
+            }),
+            manager_fields: Default::default(),
+        };
+
+        let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
+        assert!(toml_str.contains("[uncommitted_changes]"));
+
+        let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
+        let changes = loaded
+            .uncommitted_changes
+            .expect("uncommitted_changes should roundtrip");
+        assert_eq!(changes.file_count, 7);
+        assert_eq!(changes.insertions, 240);
+        assert_eq!(changes.deletions, 12);
+        assert_eq!(changes.truncated, 6);
     }
 
     #[test]
@@ -380,6 +454,7 @@ artifacts = ["output/a.txt", "output/b.txt"]
             gate_timeout: false,
             warnings: Vec::new(),
             raw_process_exit_code: None,
+            uncommitted_changes: None,
             manager_fields: Default::default(),
         };
 

--- a/crates/csa-session/src/soft_fork_tests.rs
+++ b/crates/csa-session/src/soft_fork_tests.rs
@@ -29,6 +29,7 @@ fn test_soft_fork_full_parent_session() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     let result_toml = toml::to_string_pretty(&result).unwrap();
@@ -80,6 +81,7 @@ fn test_soft_fork_truncation_on_large_summary() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     std::fs::write(
@@ -145,6 +147,7 @@ fn test_soft_fork_result_only_no_output() {
         gate_timeout: false,
         warnings: Vec::new(),
         raw_process_exit_code: None,
+        uncommitted_changes: None,
         manager_fields: Default::default(),
     };
     std::fs::write(


### PR DESCRIPTION
Implements #1753 (Remedy A + opt-in enforcement). Remedy B (CSA-injected worker-side commit-before-end prompt hint) is deliberately deferred to a follow-up — broader prompt-interaction surface, own review.

## Problem

A **writer** session (`--sa-mode false`, kind ≠ recon/review/debate) that finishes with a
dirty worktree — code modified but never `git commit`-ted — was reported as `success` /
`exit 0` with no signal about the uncommitted state. The orchestrator only learned by
manually running `git status`. A `success` writer session whose work is uncommitted is one
`csa gc` / host reboot away from losing the diff — exactly the regime behind the codex
"no self-commit" friction and the host-freeze data-loss risk (#1715).

## What changed

1. **Structured result field.** At writer-session teardown (writer predicate below), CSA
   runs `git status --porcelain` in the session CWD; if dirty, it records a structured
   `[result.uncommitted_changes]` section in `result.toml` (file_count, best-effort
   insertions/deletions, capped file list with truncation indicator).
2. **`csa session wait` summary line.** A one-line warning is surfaced when the field is
   present: `⚠ writer session ended with N uncommitted files (+X/-Y) — work NOT committed`.
3. **Opt-in enforcement.** New `--require-commit` flag on `csa run` + `[run].writer_must_commit`
   config field (bool, default **false**). Precedence: CLI flag > config > built-in default.
   When effective value is TRUE and the writer worktree is dirty at session end, the verdict
   flips to **failure** (non-zero exit). Default (false) is **warn-only** — verdict unchanged.

## Maintainer decisions (resolved in this PR)

- **Opt-in verdict flip:** YES, via `--require-commit` / `[run].writer_must_commit`, default OFF
  (warn-only) so legitimate "produce files for the orchestrator to commit" flows are not broken.
- **Auto-WIP-commit:** NO — commit message quality / atomicity need LLM judgment; auto-WIP
  would pollute history.
- **Writer detection:** `sa_mode == false` AND session kind ∉ {recon, review, debate}.
  Read-only / recon / review / debate sessions are never warned about.

## Tests

- Dirty writer session → `[result.uncommitted_changes]` populated; clean → field absent.
- Recon/review/debate session → no warning even if (hypothetically) dirty.
- `writer_must_commit=true` / `--require-commit` + dirty → failure; default + dirty → success unchanged.
- CLI flag overrides config; config respected when no flag.

## Scope

- Remedy A (detect + structured field + wait summary) + opt-in `--require-commit` only.
- Remedy B (CSA-injected worker-side commit-before-end prompt hint) → follow-up.
- No auto-WIP-commit. No recon/review/debate behavior change.
- Version bumped 0.1.835 → 0.1.836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
