### PR TITLE
fix(cli-sub-agent): add --cd flag to csa merge subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.837"
+version = "0.1.838"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.837"
+version = "0.1.838"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -500,6 +500,10 @@ pub struct MergeArgs {
     #[arg(value_name = "PR_NUMBER", value_parser = clap::value_parser!(u64).range(1..))]
     pub pr_number: u64,
 
+    /// Working directory (defaults to CWD)
+    #[arg(long)]
+    pub cd: Option<String>,
+
     /// Base branch to check out and pull after merge (defaults to PR base or main)
     #[arg(long, value_name = "BRANCH")]
     pub base: Option<String>,

--- a/crates/cli-sub-agent/src/merge_cmd.rs
+++ b/crates/cli-sub-agent/src/merge_cmd.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::process::{Command, Output};
 
 use anyhow::{Context, Result};
@@ -8,24 +9,26 @@ const DEFAULT_BRANCH_FALLBACK: &str = "main";
 
 pub(crate) fn handle_merge(args: MergeArgs) -> Result<()> {
     let pr_number = args.pr_number;
-    let base_branch = args
-        .base
-        .unwrap_or_else(|| detect_pr_base_branch(pr_number).unwrap_or_else(warn_base_fallback));
+    let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
+    let base_branch = args.base.unwrap_or_else(|| {
+        detect_pr_base_branch(&project_root, pr_number).unwrap_or_else(warn_base_fallback)
+    });
 
     let pr_number_arg = pr_number.to_string();
     run_checked(
+        &project_root,
         "gh",
         &["pr", "merge", "--merge", &pr_number_arg],
         "merge pull request",
     )?;
 
-    sync_base_branch_best_effort(&base_branch);
+    sync_base_branch_best_effort(&project_root, &base_branch);
 
     println!("Merged PR #{pr_number}; synced base branch `{base_branch}` if possible.");
     Ok(())
 }
 
-fn detect_pr_base_branch(pr_number: u64) -> Option<String> {
+fn detect_pr_base_branch(project_root: &Path, pr_number: u64) -> Option<String> {
     let pr_number_arg = pr_number.to_string();
     let output = Command::new("gh")
         .args([
@@ -37,6 +40,7 @@ fn detect_pr_base_branch(pr_number: u64) -> Option<String> {
             "-q",
             ".baseRefName",
         ])
+        .current_dir(project_root)
         .output();
 
     match output {
@@ -69,20 +73,31 @@ fn warn_base_fallback() -> String {
     DEFAULT_BRANCH_FALLBACK.to_string()
 }
 
-fn sync_base_branch_best_effort(base_branch: &str) {
-    if let Err(err) = run_checked("git", &["checkout", base_branch], "checkout base branch") {
+fn sync_base_branch_best_effort(project_root: &Path, base_branch: &str) {
+    if let Err(err) = run_checked(
+        project_root,
+        "git",
+        &["checkout", base_branch],
+        "checkout base branch",
+    ) {
         eprintln!("WARNING: merge succeeded, but post-merge checkout failed:\n{err:#}");
         return;
     }
 
-    if let Err(err) = run_checked("git", &["pull", "origin", base_branch], "pull base branch") {
+    if let Err(err) = run_checked(
+        project_root,
+        "git",
+        &["pull", "origin", base_branch],
+        "pull base branch",
+    ) {
         eprintln!("WARNING: merge succeeded, but post-merge pull failed:\n{err:#}");
     }
 }
 
-fn run_checked(program: &str, args: &[&str], action: &str) -> Result<()> {
+fn run_checked(project_root: &Path, program: &str, args: &[&str], action: &str) -> Result<()> {
     let output = Command::new(program)
         .args(args)
+        .current_dir(project_root)
         .output()
         .with_context(|| format!("failed to run `{}`", shell_command(program, args)))?;
 
@@ -135,6 +150,7 @@ mod tests {
             Commands::Merge(args) => {
                 assert_eq!(args.pr_number, 1626);
                 assert_eq!(args.base, None);
+                assert_eq!(args.cd, None);
             }
             _ => panic!("expected merge command"),
         }
@@ -148,6 +164,20 @@ mod tests {
             Commands::Merge(args) => {
                 assert_eq!(args.pr_number, 1626);
                 assert_eq!(args.base.as_deref(), Some("dev"));
+                assert_eq!(args.cd, None);
+            }
+            _ => panic!("expected merge command"),
+        }
+    }
+
+    #[test]
+    fn parses_merge_args_with_cd() {
+        let cli = Cli::parse_from(["csa", "merge", "1626", "--cd", "/tmp/repo"]);
+
+        match cli.command {
+            Commands::Merge(args) => {
+                assert_eq!(args.pr_number, 1626);
+                assert_eq!(args.cd.as_deref(), Some("/tmp/repo"));
             }
             _ => panic!("expected merge command"),
         }


### PR DESCRIPTION
Fixes #1733.

## Problem

`csa merge` does not accept the `--cd` flag, unlike `csa run`, `csa review`,
`csa debate`, and `csa session wait` which all support it. This forces callers
to `cd` into the repo directory before running `csa merge`, breaking consistency
with the rest of the CLI surface.

## What changed

Added `--cd <path>` flag to the `MergeArgs` struct and applied it in the merge
command handler, following the same pattern used by other subcommands.

## Test plan

- [ ] `csa merge --cd /path/to/repo <PR>` works from any directory
- [ ] `csa merge <PR>` (without --cd) still works as before
- [ ] `just pre-commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
