### PR TITLE
fix(cli-sub-agent): align csa doctor Enabled line with runtime tool gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.838"
+version = "0.1.839"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.838"
+version = "0.1.839"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/doctor.rs
+++ b/crates/cli-sub-agent/src/doctor.rs
@@ -61,6 +61,7 @@ struct ToolTransportDoctorStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ToolStatus {
     name: &'static str,
+    config_enabled: bool,
     availability: ToolAvailabilityState,
     binary_name: String,
     version: Option<String>,
@@ -69,8 +70,12 @@ struct ToolStatus {
 }
 
 impl ToolStatus {
-    fn is_ready(&self) -> bool {
+    fn binary_available(&self) -> bool {
         matches!(self.availability, ToolAvailabilityState::Installed)
+    }
+
+    fn is_ready(&self) -> bool {
+        self.config_enabled && self.binary_available()
     }
 }
 

--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -50,6 +50,16 @@ fn project_config_with_claude_code_transport(transport: TransportKind) -> Projec
     project_config_with_tool_transport("claude-code", transport)
 }
 
+fn project_config_with_disabled_tool(tool_name: &str, transport: TransportKind) -> ProjectConfig {
+    let mut config = project_config_with_tool_transport(tool_name, transport);
+    config
+        .tools
+        .get_mut(tool_name)
+        .expect("tool config should exist")
+        .enabled = false;
+    config
+}
+
 fn write_project_config(project_root: &Path, contents: &str) {
     let config_dir = project_root.join(".csa");
     std::fs::create_dir_all(&config_dir).expect("create config dir");
@@ -137,6 +147,8 @@ fn test_check_tool_status_nonexistent() {
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let status = check_tool_status("nonexistent-tool", None);
     assert!(!status.is_ready());
+    assert!(status.config_enabled);
+    assert!(!status.binary_available());
     assert!(status.version.is_none());
 }
 
@@ -156,7 +168,44 @@ fn default_build_doctor_accepts_codex_cli_runtime() {
             "doctor should accept the default codex CLI transport"
         );
         assert_eq!(status.binary_name, "codex");
+        assert!(status.config_enabled);
+        assert!(status.binary_available());
         assert!(status.hint.is_none());
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn doctor_status_uses_runtime_gate_when_tool_is_disabled_but_binary_exists() {
+    with_stubbed_codex_on_path(|| {
+        let config = project_config_with_disabled_tool("codex", TransportKind::Cli);
+        let status = check_tool_status("codex", Some(&config));
+        let rendered = render_tool_status_lines(&status).join("\n");
+        let json = tool_status_json(&status);
+
+        assert!(
+            !status.is_ready(),
+            "doctor readiness must reject tools disabled in runtime config"
+        );
+        assert!(!status.config_enabled);
+        assert!(status.binary_available());
+        assert_eq!(status.availability, ToolAvailabilityState::Installed);
+        assert!(
+            rendered.contains("Enabled: no"),
+            "overall doctor Enabled line must match runtime gate: {rendered}"
+        );
+        assert!(
+            rendered.contains("Config enabled: no"),
+            "doctor text should show the config condition: {rendered}"
+        );
+        assert!(
+            rendered.contains("Binary available: yes"),
+            "doctor text should show the binary condition: {rendered}"
+        );
+        assert_eq!(json["enabled"], Value::Bool(false));
+        assert_eq!(json["config_enabled"], Value::Bool(false));
+        assert_eq!(json["binary_available"], Value::Bool(true));
+        assert_eq!(json["installed"], Value::Bool(true));
     });
 }
 

--- a/crates/cli-sub-agent/src/doctor_tools.rs
+++ b/crates/cli-sub-agent/src/doctor_tools.rs
@@ -7,19 +7,19 @@ use std::process::Command;
 pub(super) async fn print_tool_availability(config: Option<&ProjectConfig>) {
     let tools = PRIMARY_TOOL_NAMES;
 
-    let mut installed_count = 0;
+    let mut ready_count = 0;
     let total_count = tools.len();
 
     for tool_name in tools.iter().copied() {
         let status = check_tool_status(tool_name, config);
         if status.is_ready() {
-            installed_count += 1;
+            ready_count += 1;
         }
         print_tool_status(&status);
     }
 
     println!();
-    println!("{installed_count}/{total_count} tools ready");
+    println!("{ready_count}/{total_count} tools ready");
 }
 
 pub(super) fn check_tool_status(
@@ -27,9 +27,11 @@ pub(super) fn check_tool_status(
     config: Option<&ProjectConfig>,
 ) -> ToolStatus {
     let binary_name = tool_exe_name(tool_name, config);
+    let config_enabled = config.is_none_or(|cfg| cfg.is_tool_enabled(tool_name));
     match crate::run_helpers::tool_binary_availability(tool_name, config) {
         crate::run_helpers::ToolBinaryAvailability::Available { .. } => ToolStatus {
             name: tool_name,
+            config_enabled,
             availability: ToolAvailabilityState::Installed,
             binary_name: binary_name.clone(),
             version: check_tool_version(&binary_name),
@@ -38,6 +40,7 @@ pub(super) fn check_tool_status(
         },
         crate::run_helpers::ToolBinaryAvailability::Missing { hint, .. } => ToolStatus {
             name: tool_name,
+            config_enabled,
             availability: ToolAvailabilityState::Missing,
             binary_name,
             version: None,
@@ -66,13 +69,14 @@ fn print_tool_status(status: &ToolStatus) {
 
 pub(super) fn render_tool_status_lines(status: &ToolStatus) -> Vec<String> {
     let checkmark = if status.is_ready() { "✓" } else { "✗" };
-    let status_msg = match status.availability {
-        ToolAvailabilityState::Installed => status
-            .version
-            .as_ref()
-            .map(|version| format!("installed ({version})"))
-            .unwrap_or_else(|| "installed (version unknown)".to_string()),
+    let binary_status_msg = match status.availability {
+        ToolAvailabilityState::Installed => installed_status_msg(status),
         ToolAvailabilityState::Missing => "not found".to_string(),
+    };
+    let status_msg = if status.config_enabled {
+        binary_status_msg
+    } else {
+        format!("disabled by config; {binary_status_msg}")
     };
 
     let mut lines = vec![format!(
@@ -81,6 +85,18 @@ pub(super) fn render_tool_status_lines(status: &ToolStatus) -> Vec<String> {
         checkmark,
         status_msg
     )];
+    lines.push(format!(
+        "             Enabled: {}",
+        yes_no(status.is_ready())
+    ));
+    lines.push(format!(
+        "             Config enabled: {}",
+        yes_no(status.config_enabled)
+    ));
+    lines.push(format!(
+        "             Binary available: {}",
+        yes_no(status.binary_available())
+    ));
 
     if let Some(transport_status) = status.transport.as_ref() {
         lines.push(format!(
@@ -102,7 +118,7 @@ pub(super) fn render_tool_status_lines(status: &ToolStatus) -> Vec<String> {
         }
     }
 
-    if !status.is_ready()
+    if !status.binary_available()
         && let Some(hint) = status.hint.as_deref()
     {
         lines.push(format!(
@@ -119,7 +135,10 @@ pub(super) fn tool_status_json(status: &ToolStatus) -> serde_json::Value {
     let mut entry = serde_json::json!({
         "name": status.name,
         "binary": status.binary_name,
-        "installed": status.is_ready(),
+        "enabled": status.is_ready(),
+        "config_enabled": status.config_enabled,
+        "binary_available": status.binary_available(),
+        "installed": status.binary_available(),
         "version": status.version,
         "hint": status.hint,
     });
@@ -150,6 +169,14 @@ pub(super) fn tool_status_json(status: &ToolStatus) -> serde_json::Value {
     }
 
     entry
+}
+
+fn installed_status_msg(status: &ToolStatus) -> String {
+    status
+        .version
+        .as_ref()
+        .map(|version| format!("installed ({version})"))
+        .unwrap_or_else(|| "installed (version unknown)".to_string())
 }
 
 fn tool_exe_name(tool_name: &str, config: Option<&ProjectConfig>) -> String {


### PR DESCRIPTION
Fixes #1752.

## Problem

`csa doctor` reports tool enablement using a different check than the runtime
tool-enablement gate, causing "Enabled: true" tools to be rejected at dispatch
time (or vice versa). Wastes user dispatch tokens.

## What changed

Made `csa doctor` use the same enablement logic as the runtime gate, so the
reported status matches actual dispatch availability.

## Test plan

- [ ] `csa doctor` Enabled lines match runtime tool availability
- [ ] `just pre-commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)