### PR TITLE
feat(cli-sub-agent): add TIER column to csa session list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "chrono",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "chrono",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "chrono",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "axum",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "chrono",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "chrono",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "chrono",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.840"
+version = "0.1.841"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.840"
+version = "0.1.841"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -167,7 +167,7 @@ pub(crate) fn handle_session_list(
                 // Print table header
                 if all_projects && filters.show_version {
                     println!(
-                        "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<30}  {:<12}  TOKENS",
+                        "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<18}  {:<30}  {:<12}  TOKENS",
                         "SESSION",
                         "STARTED",
                         "ELAPSED",
@@ -175,14 +175,15 @@ pub(crate) fn handle_session_list(
                         "STATUS",
                         "DESCRIPTION",
                         "TOOLS",
+                        "TIER",
                         "BRANCH",
                         "PROJECT",
                         "VERSION"
                     );
-                    println!("{}", "-".repeat(206));
+                    println!("{}", "-".repeat(226));
                 } else if all_projects {
                     println!(
-                        "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<30}  TOKENS",
+                        "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<18}  {:<30}  TOKENS",
                         "SESSION",
                         "STARTED",
                         "ELAPSED",
@@ -190,13 +191,14 @@ pub(crate) fn handle_session_list(
                         "STATUS",
                         "DESCRIPTION",
                         "TOOLS",
+                        "TIER",
                         "BRANCH",
                         "PROJECT"
                     );
-                    println!("{}", "-".repeat(192));
+                    println!("{}", "-".repeat(212));
                 } else if filters.show_version {
                     println!(
-                        "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<12}  TOKENS",
+                        "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<18}  {:<12}  TOKENS",
                         "SESSION",
                         "STARTED",
                         "ELAPSED",
@@ -204,13 +206,14 @@ pub(crate) fn handle_session_list(
                         "STATUS",
                         "DESCRIPTION",
                         "TOOLS",
+                        "TIER",
                         "BRANCH",
                         "VERSION"
                     );
-                    println!("{}", "-".repeat(176));
+                    println!("{}", "-".repeat(196));
                 } else {
                     println!(
-                        "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  TOKENS",
+                        "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<18}  TOKENS",
                         "SESSION",
                         "STARTED",
                         "ELAPSED",
@@ -218,9 +221,10 @@ pub(crate) fn handle_session_list(
                         "STATUS",
                         "DESCRIPTION",
                         "TOOLS",
+                        "TIER",
                         "BRANCH"
                     );
-                    println!("{}", "-".repeat(162));
+                    println!("{}", "-".repeat(182));
                 }
                 for session in sessions {
                     // Truncate ULID to 11 chars for readability
@@ -246,6 +250,7 @@ pub(crate) fn handle_session_list(
                             .collect::<Vec<_>>()
                             .join(", ")
                     };
+                    let tier_str = session.task_context.tier_name.as_deref().unwrap_or("-");
                     let branch_str = session.branch.as_deref().unwrap_or("-");
                     let csa_version_str = session.csa_version.as_deref().unwrap_or("-");
 
@@ -291,7 +296,7 @@ pub(crate) fn handle_session_list(
                     if all_projects && filters.show_version {
                         let project_display = truncate_with_ellipsis(&session.project_path, 30);
                         println!(
-                            "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<30}  {:<12}  {}{}{}",
+                            "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<18}  {:<30}  {:<12}  {}{}{}",
                             short_id,
                             started_str,
                             elapsed_str,
@@ -302,6 +307,7 @@ pub(crate) fn handle_session_list(
                             status_str,
                             desc_display,
                             tools_str,
+                            tier_str,
                             branch_str,
                             project_display,
                             csa_version_str,
@@ -312,7 +318,7 @@ pub(crate) fn handle_session_list(
                     } else if all_projects {
                         let project_display = truncate_with_ellipsis(&session.project_path, 30);
                         println!(
-                            "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<30}  {}{}{}",
+                            "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<18}  {:<30}  {}{}{}",
                             short_id,
                             started_str,
                             elapsed_str,
@@ -323,6 +329,7 @@ pub(crate) fn handle_session_list(
                             status_str,
                             desc_display,
                             tools_str,
+                            tier_str,
                             branch_str,
                             project_display,
                             tokens_str,
@@ -331,7 +338,7 @@ pub(crate) fn handle_session_list(
                         );
                     } else if filters.show_version {
                         println!(
-                            "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<12}  {}{}{}",
+                            "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<18}  {:<12}  {}{}{}",
                             short_id,
                             started_str,
                             elapsed_str,
@@ -342,6 +349,7 @@ pub(crate) fn handle_session_list(
                             status_str,
                             desc_display,
                             tools_str,
+                            tier_str,
                             branch_str,
                             csa_version_str,
                             tokens_str,
@@ -350,7 +358,7 @@ pub(crate) fn handle_session_list(
                         );
                     } else {
                         println!(
-                            "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {}{}{}",
+                            "{:<11}  {:<19}  {:<8}  {:<19}  {:<10}  {:<25}  {:<20}  {:<18}  {:<18}  {}{}{}",
                             short_id,
                             started_str,
                             elapsed_str,
@@ -361,6 +369,7 @@ pub(crate) fn handle_session_list(
                             status_str,
                             desc_display,
                             tools_str,
+                            tier_str,
                             branch_str,
                             tokens_str,
                             fork_suffix,

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -113,6 +113,41 @@ fn write_project_config_with_tier(project_root: &Path) {
     .expect("write config");
 }
 
+fn session_root_for_state_home(state_home: &Path, project_root: &Path) -> std::path::PathBuf {
+    let project_key = std::fs::canonicalize(project_root)
+        .unwrap_or_else(|_| project_root.to_path_buf())
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .replace('/', std::path::MAIN_SEPARATOR_STR);
+    state_home.join("cli-sub-agent").join(project_key)
+}
+
+fn write_tiered_session(state_home: &Path, project_root: &Path) {
+    let session_root = session_root_for_state_home(state_home, project_root);
+    let now = chrono::Utc::now();
+    let session = csa_session::MetaSessionState {
+        meta_session_id: csa_session::new_session_id(),
+        description: Some("Tiered session".to_string()),
+        project_path: std::fs::canonicalize(project_root)
+            .unwrap_or_else(|_| project_root.to_path_buf())
+            .to_string_lossy()
+            .to_string(),
+        branch: Some("feature/tier-column".to_string()),
+        created_at: now,
+        last_accessed: now,
+        phase: csa_session::SessionPhase::Available,
+        task_context: csa_session::TaskContext {
+            tier_name: Some("tier-4-critical".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let session_dir = session_root.join("sessions").join(&session.meta_session_id);
+    std::fs::create_dir_all(session_dir.join("input")).expect("create session input dir");
+    std::fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
+    csa_session::save_session_in(&session_root, &session).expect("save tiered session");
+}
+
 #[test]
 fn cli_help_displays_correctly() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -685,6 +720,44 @@ fn session_list_exits_zero() {
     assert!(
         combined.contains("No sessions found"),
         "empty state should report no sessions"
+    );
+}
+
+#[test]
+fn session_list_text_shows_tier_column_next_to_tools() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state_home = tmp.path().join(".local/state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project");
+    write_tiered_session(&state_home, &project);
+
+    let output = csa_cmd(tmp.path())
+        .args(["session", "list", "--cd"])
+        .arg(&project)
+        .output()
+        .expect("failed to run csa session list");
+
+    assert!(
+        output.status.success(),
+        "csa session list should exit 0\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let header = stdout.lines().next().unwrap_or_default();
+    let tools_idx = header.find("TOOLS").expect("TOOLS header");
+    let tier_idx = header.find("TIER").expect("TIER header");
+    let branch_idx = header.find("BRANCH").expect("BRANCH header");
+    assert!(
+        tools_idx < tier_idx && tier_idx < branch_idx,
+        "TIER column should be between TOOLS and BRANCH, header: {header}",
+    );
+    assert!(
+        stdout.contains("tier-4-critical"),
+        "tier name should appear in session list output: {stdout}",
     );
 }
 


### PR DESCRIPTION
Fixes #1717.

## Problem

`csa session list` shows the TOOL column but not the TIER used to dispatch
each session. Users need this to diagnose routing issues and verify dispatch.

## What changed

Added a TIER column next to the existing TOOL column in `csa session list`
output. Shows the tier name when one was used, empty otherwise.

## Review iterations

- Round 1 FAIL: HIGH finding — `unsafe std::env::set_var` in e2e test not
  safe under parallel test harness (Rust 2024). Fixed by removing the
  unsafe env mutation and using a different test approach.
- Round 2 PASS.

## Test plan

- [ ] `csa session list` shows TIER column with correct values
- [ ] Sessions without tier show empty TIER field
- [ ] `just pre-commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)