### PR TITLE
fix(cli-sub-agent): CLI flag-parity for debate and gc (#1666 #1700 #1778 #1780)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.843"
+version = "0.1.844"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.843"
+version = "0.1.844"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -498,8 +498,8 @@ pub struct DebateArgs {
     pub context: Option<String>,
 
     /// Attach a file as context for the debate (content prepended to prompt)
-    #[arg(long)]
-    pub file: Option<String>,
+    #[arg(long, value_name = "PATH")]
+    pub file: Vec<PathBuf>,
 
     /// Disable filesystem sandbox isolation (bwrap/landlock)
     #[arg(long)]

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{ArgGroup, ValueEnum};
-use csa_core::types::ToolName;
+use csa_core::types::{ToolArg, ToolName};
 
 use super::{Commands, parse_model_spec_arg, parse_spec_path_arg};
 
@@ -404,7 +404,7 @@ pub struct DebateArgs {
     /// Combine with --tier to use that tier's model/thinking for the selected tool.
     /// Combine with --force-ignore-tier-setting to bypass tiers entirely.
     #[arg(long)]
-    pub tool: Option<ToolName>,
+    pub tool: Option<ToolArg>,
 
     /// Override tool enablement from user config (use when explicitly requesting a disabled tool)
     #[arg(long)]

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -479,6 +479,12 @@ pub struct DebateArgs {
     #[arg(long)]
     pub no_stream_stdout: bool,
 
+    /// Disable the fatal-error-marker silent-hang scan for this session. Use
+    /// when debate prose legitimately contains provider error markers. The
+    /// idle-timeout and wall-clock timeout still apply. Default: scan enabled.
+    #[arg(long)]
+    pub no_error_marker_scan: bool,
+
     /// Working directory
     #[arg(long)]
     pub cd: Option<String>,

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -9,7 +9,7 @@ use crate::debate_cmd_resolve::{
     validate_debate_direct_tool_tier_restriction,
 };
 use crate::startup_env::StartupSubtreeEnv;
-use csa_core::types::OutputFormat;
+use csa_core::types::{OutputFormat, ToolArg, ToolName};
 
 #[cfg(test)]
 use crate::tier_model_fallback::TierAttemptFailure;
@@ -141,7 +141,12 @@ pub(crate) async fn handle_debate(
     // 5. Determine tool (with tier-based resolution)
     let detected_parent_tool = crate::run_helpers::detect_parent_tool();
     let parent_tool = crate::run_helpers::resolve_tool(detected_parent_tool, &global_config);
-    let explicit_tool = args.tool.or_else(|| {
+    let mut merged_tool_aliases = global_config.tool_aliases.clone();
+    if let Some(c) = config.as_ref() {
+        merged_tool_aliases.extend(c.tool_aliases.iter().map(|(k, v)| (k.clone(), v.clone())));
+    }
+    let cli_tool = resolve_debate_cli_tool(args.tool.take(), &merged_tool_aliases)?;
+    let explicit_tool = cli_tool.or_else(|| {
         args.model_spec
             .as_deref()
             .and_then(|spec| spec.split('/').next())
@@ -154,7 +159,7 @@ pub(crate) async fn handle_debate(
             cli_model_spec: args.model_spec.as_deref(),
             cli_hint_difficulty: args.hint_difficulty.as_deref(),
             cli_session: args.session.as_deref(),
-            cli_tool: args.tool,
+            cli_tool,
             config: config.as_ref(),
             frontmatter_difficulty: frontmatter_difficulty.as_deref(),
             debate_description: debate_description.as_str(),
@@ -285,6 +290,20 @@ pub(crate) async fn handle_debate(
         startup_env,
     })
     .await
+}
+
+fn resolve_debate_cli_tool(
+    tool: Option<ToolArg>,
+    tool_aliases: &std::collections::HashMap<String, String>,
+) -> Result<Option<ToolName>> {
+    match tool.unwrap_or(ToolArg::Auto).resolve_alias(tool_aliases) {
+        Ok(ToolArg::Auto | ToolArg::AnyAvailable) => Ok(None),
+        Ok(ToolArg::Specific(tool)) => Ok(Some(tool)),
+        Ok(ToolArg::Alias(alias)) => {
+            anyhow::bail!("BUG: unresolved debate --tool alias '{alias}' after alias resolution")
+        }
+        Err(err) => anyhow::bail!("{err}"),
+    }
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/debate_cmd_dry_run_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_dry_run_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::debate_cmd_output::{DebateOutputHeader, DebateSummary, format_debate_stdout_text};
-use csa_core::types::ToolName;
+use csa_core::types::{ToolArg, ToolName};
 
 #[test]
 fn format_debate_stdout_text_includes_prompt_bytes_header() {
@@ -29,6 +29,15 @@ fn debate_cli_parses_dry_run_flag() {
 #[test]
 fn debate_explicit_tool_keeps_failover_enabled_by_default() {
     let args = parse_debate_args(&["csa", "debate", "--tool", "gemini-cli", "question"]);
-    assert_eq!(args.tool, Some(ToolName::GeminiCli));
+    assert!(matches!(
+        args.tool,
+        Some(ToolArg::Specific(ToolName::GeminiCli))
+    ));
     assert!(!args.no_failover);
+}
+
+#[test]
+fn debate_cli_parses_tool_auto_as_auto_selection() {
+    let args = parse_debate_args(&["csa", "debate", "--tool", "auto", "question"]);
+    assert!(matches!(args.tool, Some(ToolArg::Auto)));
 }

--- a/crates/cli-sub-agent/src/debate_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_execute.rs
@@ -158,7 +158,7 @@ pub(crate) async fn execute_debate(request: DebateExecutionRequest<'_>) -> Resul
                 request.readonly_project_root,
                 &request.args.extra_writable,
                 &request.args.extra_readable,
-                false, // #1745: no debate flag; config decides (shared monitor).
+                request.args.no_error_marker_scan,
                 request.startup_env,
             );
 

--- a/crates/cli-sub-agent/src/debate_cmd_question.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_question.rs
@@ -3,7 +3,7 @@
 //! Extracted verbatim from `debate_cmd::handle_debate` to keep that module
 //! under the monolith gate. Resolves the debate question from
 //! `--prompt-file` / positional / `--topic` / stdin, strips difficulty
-//! frontmatter, and prepends `--context` and `--file` content.
+//! frontmatter, and prepends `--context` and repeated `--file` content.
 
 use anyhow::{Context, Result};
 
@@ -29,22 +29,27 @@ pub(super) fn build_debate_question(args: &mut DebateArgs) -> Result<(String, Op
     if let Some(ctx) = &args.context {
         question = format!("<debate-context>\n{ctx}\n</debate-context>\n\n{question}");
     }
-    if let Some(file_path) = &args.file {
+    let mut attached_files = String::new();
+    for file_path in &args.file {
+        let file_display = file_path.display();
         let metadata = std::fs::metadata(file_path)
-            .with_context(|| format!("Failed to stat --file: {file_path}"))?;
+            .with_context(|| format!("Failed to stat --file: {file_display}"))?;
         if metadata.len() > MAX_FILE_SIZE {
             anyhow::bail!(
                 "--file '{}' is too large ({} bytes, max {} bytes)",
-                file_path,
+                file_display,
                 metadata.len(),
                 MAX_FILE_SIZE
             );
         }
         let file_content = std::fs::read_to_string(file_path)
-            .with_context(|| format!("Failed to read --file: {file_path}"))?;
-        question = format!(
-            "<attached-file path=\"{file_path}\">\n{file_content}\n</attached-file>\n\n{question}"
-        );
+            .with_context(|| format!("Failed to read --file: {file_display}"))?;
+        attached_files.push_str(&format!(
+            "<attached-file path=\"{file_display}\">\n{file_content}\n</attached-file>\n\n"
+        ));
+    }
+    if !attached_files.is_empty() {
+        question = format!("{attached_files}{question}");
     }
     Ok((question, frontmatter_difficulty))
 }

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -689,6 +689,42 @@ fn parse_debate_args(argv: &[&str]) -> crate::cli::DebateArgs {
 }
 
 #[test]
+fn debate_cli_repeats_file_and_attaches_all_context_files() {
+    let temp = tempfile::tempdir().unwrap();
+    let first = temp.path().join("a.md");
+    let second = temp.path().join("b.md");
+    std::fs::write(&first, "first context").unwrap();
+    std::fs::write(&second, "second context").unwrap();
+    let first_arg = first.display().to_string();
+    let second_arg = second.display().to_string();
+
+    let mut args = parse_debate_args(&[
+        "csa",
+        "debate",
+        "--file",
+        &first_arg,
+        "--file",
+        &second_arg,
+        "question",
+    ]);
+
+    assert_eq!(args.file, vec![first.clone(), second.clone()]);
+
+    let (question, difficulty) =
+        super::question::build_debate_question(&mut args).expect("question should build");
+    assert_eq!(difficulty, None);
+    assert!(question.contains("first context"));
+    assert!(question.contains("second context"));
+    let first_index = question.find("first context").unwrap();
+    let second_index = question.find("second context").unwrap();
+    let prompt_index = question.find("question").unwrap();
+    assert!(
+        first_index < second_index && second_index < prompt_index,
+        "attached files must preserve CLI order before the prompt: {question}"
+    );
+}
+
+#[test]
 fn debate_cli_parses_global_json_format() {
     use crate::cli::{Cli, Commands};
     use clap::Parser;

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -837,6 +837,12 @@ fn debate_cli_parses_no_stream_stdout_flag() {
 }
 
 #[test]
+fn debate_cli_parses_no_error_marker_scan_flag() {
+    let args = parse_debate_args(&["csa", "debate", "--no-error-marker-scan", "question"]);
+    assert!(args.no_error_marker_scan);
+}
+
+#[test]
 fn debate_cli_defaults_no_timeout() {
     let args = parse_debate_args(&["csa", "debate", "question"]);
     assert_eq!(args.timeout, None);
@@ -844,6 +850,7 @@ fn debate_cli_defaults_no_timeout() {
     assert_eq!(args.thinking, None);
     assert!(!args.stream_stdout);
     assert!(!args.no_stream_stdout);
+    assert!(!args.no_error_marker_scan);
     assert!(!args.dry_run);
 }
 

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -40,14 +40,40 @@ const ORPHAN_SLOT_GRACE_SECS: i64 = 30;
 
 pub(crate) type RuntimeReapStats = reaper::RuntimeReapStats;
 
+pub(crate) fn handle_gc_args(
+    args: GcArgs,
+    format: OutputFormat,
+    current_session_id: Option<&str>,
+) -> Result<()> {
+    if args.global {
+        handle_gc_global(
+            args.dry_run,
+            args.max_age_days,
+            args.reap_runtime,
+            format,
+            current_session_id,
+        )
+    } else {
+        handle_gc(
+            args.dry_run,
+            args.max_age_days,
+            args.reap_runtime,
+            format,
+            current_session_id,
+            args.cd.as_deref(),
+        )
+    }
+}
+
 pub(crate) fn handle_gc(
     dry_run: bool,
     max_age_days: Option<u64>,
     reap_runtime: bool,
     format: OutputFormat,
     current_session_id: Option<&str>,
+    cd: Option<&str>,
 ) -> Result<()> {
-    let project_root = crate::pipeline::determine_project_root(None)?;
+    let project_root = crate::pipeline::determine_project_root(cd)?;
     let session_root = get_session_root(&project_root)?;
     let sessions = list_sessions(&project_root, None)?;
     let gc_config = GcConfig::load_for_project(&project_root)?;

--- a/crates/cli-sub-agent/src/gc_args.rs
+++ b/crates/cli-sub-agent/src/gc_args.rs
@@ -17,4 +17,8 @@ pub struct GcArgs {
     /// Scan all projects under ~/.local/state/cli-sub-agent/ (not just current project)
     #[arg(long)]
     pub global: bool,
+
+    /// Working directory (defaults to CWD)
+    #[arg(long)]
+    pub cd: Option<String>,
 }

--- a/crates/cli-sub-agent/src/gc_runtime_tests.rs
+++ b/crates/cli-sub-agent/src/gc_runtime_tests.rs
@@ -450,7 +450,7 @@ fn test_handle_gc_reaps_runtime_after_retiring_stale_session() {
     );
     let _cwd = CurrentDirGuard::enter(&project_root);
 
-    handle_gc(false, None, false, OutputFormat::Text, None).unwrap();
+    handle_gc(false, None, false, OutputFormat::Text, None, None).unwrap();
 
     let sessions = list_sessions(&project_root, None).unwrap();
     let session = sessions
@@ -461,6 +461,53 @@ fn test_handle_gc_reaps_runtime_after_retiring_stale_session() {
     assert!(
         !runtime_dir.exists(),
         "default csa gc must reap runtime/ once a stale session is retired"
+    );
+}
+
+#[test]
+fn test_handle_gc_honors_cd_project_root() {
+    use clap::Parser;
+
+    const TWO_MIB: u64 = 2 * 1024 * 1024;
+
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let _cwd_lock = CURRENT_DIR_LOCK.lock().expect("current dir lock");
+    let cwd_project = tmp.path().join("cwd-project");
+    let cd_project = tmp.path().join("cd-project");
+    let (_, _, cwd_runtime_dir) = seed_runtime_session(
+        &cwd_project,
+        SessionPhase::Retired,
+        chrono::Utc::now() - chrono::Duration::days(40),
+        TWO_MIB,
+        false,
+    );
+    let (_, _, cd_runtime_dir) = seed_runtime_session(
+        &cd_project,
+        SessionPhase::Retired,
+        chrono::Utc::now() - chrono::Duration::days(40),
+        TWO_MIB,
+        false,
+    );
+    let cd = cd_project.display().to_string();
+    let cli =
+        crate::cli::Cli::try_parse_from(["csa", "gc", "--cd", &cd]).expect("gc --cd should parse");
+    match cli.command {
+        crate::cli::Commands::Gc(args) => assert_eq!(args.cd.as_deref(), Some(cd.as_str())),
+        _ => panic!("expected gc command"),
+    }
+
+    let _cwd = CurrentDirGuard::enter(&cwd_project);
+
+    handle_gc(false, None, false, OutputFormat::Text, None, Some(&cd)).unwrap();
+
+    assert!(
+        cwd_runtime_dir.exists(),
+        "csa gc --cd must not use the process cwd project root"
+    );
+    assert!(
+        !cd_runtime_dir.exists(),
+        "csa gc --cd must reap runtime/ under the explicit project root"
     );
 }
 
@@ -488,7 +535,7 @@ fn test_handle_gc_respects_reap_runtime_dirs_false() {
     );
     let _cwd = CurrentDirGuard::enter(&project_root);
 
-    handle_gc(false, None, false, OutputFormat::Text, None).unwrap();
+    handle_gc(false, None, false, OutputFormat::Text, None, None).unwrap();
 
     assert!(
         runtime_dir.exists(),

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -427,30 +427,7 @@ async fn run() -> Result<()> {
         } => {
             config_cmds::handle_init(non_interactive, full, template)?;
         }
-        Commands::Gc(gc::GcArgs {
-            dry_run,
-            max_age_days,
-            reap_runtime,
-            global,
-        }) => {
-            if global {
-                gc::handle_gc_global(
-                    dry_run,
-                    max_age_days,
-                    reap_runtime,
-                    output_format,
-                    startup_env.session_id(),
-                )?;
-            } else {
-                gc::handle_gc(
-                    dry_run,
-                    max_age_days,
-                    reap_runtime,
-                    output_format,
-                    startup_env.session_id(),
-                )?;
-            }
-        }
+        Commands::Gc(args) => gc::handle_gc_args(args, output_format, startup_env.session_id())?,
         Commands::Config { cmd } => match cmd {
             ConfigCommands::Show { cd } => {
                 config_cmds::handle_config_show(cd, output_format)?;

--- a/crates/cli-sub-agent/src/mcp_server.rs
+++ b/crates/cli-sub-agent/src/mcp_server.rs
@@ -446,6 +446,7 @@ async fn handle_gc_tool(args: Value, startup_env: &StartupSubtreeEnv) -> Result<
         reap_runtime,
         crate::OutputFormat::Text,
         startup_env.session_id(),
+        None,
     )?;
 
     let msg = if dry_run {


### PR DESCRIPTION
## Summary

CLI flag-parity sweep: four small clap-argument parity fixes that mirror flags
`csa run` / `csa review` / `csa session wait` already accept. One commit per issue.

Closes #1666, #1700, #1778, #1780.

## Changes (one commit per issue)

- **#1666** — *accept auto debate tool* (995dda54): `csa debate --tool auto` now parses
  (the `--help` already advertised it); resolves via tier/auto-select like run/review.
- **#1700** — *repeat debate file context* (a925af70): `csa debate --file` is now
  repeatable (`Vec`), so multiple context files can be attached in one invocation.
- **#1778** — *expose debate error-marker opt-out* (446b6b1d): `csa debate` now accepts
  `--no-error-marker-scan` (parity with run/review); debate prose can legitimately contain
  "fatal"/"error" tokens that would otherwise trip the self-kill scan.
- **#1780** — *honor gc cd root* (949e4af9): `csa gc --cd <path>` now parses and resolves
  the project root from the given path (parity with run/review/session wait).

## Verification

- Each flag is wired through to actually take effect (not just parsed) and carries a
  focused unit test.
- `just fmt` + `just clippy` clean; pre-commit hook passed on all four commits.
- Pre-PR review (`csa review --range main...HEAD`, tier-4) verdict PASS via gemini-cli
  (session 01KT4PNEY7ZJ227H4RRRTCH15C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
