### PR TITLE
fix: live-daemon wait precheck + idle-watchdog transient-marker retry (#1690, #1727)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.844"
+version = "0.1.845"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.844"
+version = "0.1.845"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -266,6 +266,11 @@ fn check_session_stale_before_wait(project_root: &Path, session_id: &str) -> any
                 let elapsed = now.signed_duration_since(session.last_accessed);
 
                 if elapsed > chrono::Duration::seconds(stale_threshold_seconds as i64) {
+                    if let Ok(session_dir) = csa_session::get_session_dir(project_root, session_id)
+                        && session_has_terminal_process(&session_dir)
+                    {
+                        return Ok(());
+                    }
                     return Err(anyhow::anyhow!(
                         "daemon not running, no recent progress ({}s > {}s threshold)",
                         elapsed.num_seconds(),

--- a/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
@@ -120,3 +120,71 @@ fn handle_session_wait_kv_warm_exit_when_daemon_alive_at_cap() {
         "live daemon at wait cap must emit KV-warm exit (0), not legacy timeout (124)"
     );
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn stale_precheck_does_not_fail_live_daemon_session() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-stale-precheck-live-daemon"),
+        None,
+        Some("codex"),
+    )
+    .expect("create");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let mut state = load_session(project, &session_id).expect("load session");
+    state.phase = SessionPhase::Active;
+    state.last_accessed = chrono::Utc::now() - chrono::Duration::seconds(7_200);
+    save_session(&state).expect("save stale active session");
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn child");
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .expect("write daemon pid");
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    let exit_code = handle_session_wait_with_hooks(
+        session_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {
+            panic!("stale precheck must not emit a synthetic completion for a live daemon");
+        },
+    )
+    .expect("wait should skip stale precheck for live daemon");
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert_eq!(
+        exit_code, 0,
+        "live daemon must not be pre-failed solely because last_accessed is stale"
+    );
+}

--- a/crates/csa-process/src/idle_watchdog.rs
+++ b/crates/csa-process/src/idle_watchdog.rs
@@ -2,14 +2,61 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use crate::ToolLiveness;
+use crate::tool_liveness::ProviderErrorKind;
 
 const LIVENESS_POLL_INTERVAL: Duration = Duration::from_secs(10);
 const FATAL_ERROR_PROGRESS_GRACE: Duration = Duration::from_secs(30);
+const TRANSIENT_PROVIDER_ERROR_RETRY_BUDGET: u8 = 1;
+const TRANSIENT_PROVIDER_ERROR_BACKOFF: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum IdleTerminationReason {
     Idle,
     FatalError,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderErrorBackoff {
+    retries_used: u8,
+    retry_after: Option<Instant>,
+}
+
+impl ProviderErrorBackoff {
+    pub(crate) fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    fn transient_retry_deadline(&mut self, now: Instant) -> Option<Instant> {
+        if let Some(retry_after) = self.retry_after
+            && now < retry_after
+        {
+            return Some(retry_after);
+        }
+
+        if self.retries_used < TRANSIENT_PROVIDER_ERROR_RETRY_BUDGET {
+            self.retries_used += 1;
+            let retry_after = now + TRANSIENT_PROVIDER_ERROR_BACKOFF;
+            self.retry_after = Some(retry_after);
+            return Some(retry_after);
+        }
+
+        None
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct IdleWatchdogState {
+    pub(crate) liveness_dead_since: Option<Instant>,
+    pub(crate) next_liveness_poll_at: Option<Instant>,
+    pub(crate) provider_error_backoff: ProviderErrorBackoff,
+}
+
+impl IdleWatchdogState {
+    pub(crate) fn reset_on_activity(&mut self) {
+        self.liveness_dead_since = None;
+        self.next_liveness_poll_at = None;
+        self.provider_error_backoff.reset();
+    }
 }
 
 pub(crate) fn idle_timeout_note(
@@ -57,6 +104,7 @@ pub(crate) fn idle_timeout_note(
 /// backend errors commonly arrive on stderr.  Detect those after the same short
 /// fatal-error grace used by the normal idle watchdog instead of waiting for the
 /// full configured initial-response timeout.
+#[cfg(test)]
 pub(crate) fn should_terminate_for_initial_response(
     last_stdout_activity: Instant,
     initial_response_timeout: Duration,
@@ -64,10 +112,32 @@ pub(crate) fn should_terminate_for_initial_response(
     next_liveness_poll_at: &mut Option<Instant>,
     error_marker_scan_enabled: bool,
 ) -> Option<IdleTerminationReason> {
+    let mut state = IdleWatchdogState {
+        next_liveness_poll_at: *next_liveness_poll_at,
+        ..IdleWatchdogState::default()
+    };
+    let termination = should_terminate_for_initial_response_with_state(
+        last_stdout_activity,
+        initial_response_timeout,
+        session_dir,
+        &mut state,
+        error_marker_scan_enabled,
+    );
+    *next_liveness_poll_at = state.next_liveness_poll_at;
+    termination
+}
+
+pub(crate) fn should_terminate_for_initial_response_with_state(
+    last_stdout_activity: Instant,
+    initial_response_timeout: Duration,
+    session_dir: Option<&Path>,
+    state: &mut IdleWatchdogState,
+    error_marker_scan_enabled: bool,
+) -> Option<IdleTerminationReason> {
     let stdout_idle_for = last_stdout_activity.elapsed();
 
     if stdout_idle_for < FATAL_ERROR_PROGRESS_GRACE {
-        *next_liveness_poll_at = None;
+        state.reset_on_activity();
         return (stdout_idle_for >= initial_response_timeout)
             .then_some(IdleTerminationReason::Idle);
     }
@@ -75,15 +145,24 @@ pub(crate) fn should_terminate_for_initial_response(
     // #1745 stopgap opt-out; proper fix = scope marker scan to backend-transport stream only (#182)
     if error_marker_scan_enabled && let Some(dir) = session_dir {
         let now = Instant::now();
-        let should_poll = next_liveness_poll_at
+        let should_poll = state
+            .next_liveness_poll_at
             .as_ref()
             .is_none_or(|next_poll| now >= *next_poll);
         if should_poll {
-            *next_liveness_poll_at = Some(now + LIVENESS_POLL_INTERVAL);
-            if ToolLiveness::probe(dir).fatal_error {
-                return Some(IdleTerminationReason::FatalError);
+            state.next_liveness_poll_at = Some(now + LIVENESS_POLL_INTERVAL);
+            let signals = ToolLiveness::probe(dir);
+            if let Some(reason) = provider_error_termination(
+                signals.provider_error,
+                now,
+                &mut state.next_liveness_poll_at,
+                &mut state.provider_error_backoff,
+            ) {
+                return Some(reason);
             }
         }
+    } else {
+        state.provider_error_backoff.reset();
     }
 
     (stdout_idle_for >= initial_response_timeout).then_some(IdleTerminationReason::Idle)
@@ -97,6 +176,7 @@ pub(crate) fn should_terminate_for_initial_response(
 /// Pure "process exists" signals (live PID only) no longer
 /// grant unlimited extensions; in that case, termination happens once
 /// `liveness_dead_timeout` elapses.
+#[cfg(test)]
 pub(crate) fn should_terminate_for_idle(
     last_activity: &mut Instant,
     idle_timeout: Duration,
@@ -106,21 +186,48 @@ pub(crate) fn should_terminate_for_idle(
     next_liveness_poll_at: &mut Option<Instant>,
     error_marker_scan_enabled: bool,
 ) -> Option<IdleTerminationReason> {
+    let mut state = IdleWatchdogState {
+        liveness_dead_since: *liveness_dead_since,
+        next_liveness_poll_at: *next_liveness_poll_at,
+        ..IdleWatchdogState::default()
+    };
+    let termination = should_terminate_for_idle_with_state(
+        last_activity,
+        idle_timeout,
+        liveness_dead_timeout,
+        session_dir,
+        &mut state,
+        error_marker_scan_enabled,
+    );
+    *liveness_dead_since = state.liveness_dead_since;
+    *next_liveness_poll_at = state.next_liveness_poll_at;
+    termination
+}
+
+pub(crate) fn should_terminate_for_idle_with_state(
+    last_activity: &mut Instant,
+    idle_timeout: Duration,
+    liveness_dead_timeout: Duration,
+    session_dir: Option<&Path>,
+    state: &mut IdleWatchdogState,
+    error_marker_scan_enabled: bool,
+) -> Option<IdleTerminationReason> {
     let idle_for = last_activity.elapsed();
     if idle_for < idle_timeout && idle_for < FATAL_ERROR_PROGRESS_GRACE {
-        *liveness_dead_since = None;
-        *next_liveness_poll_at = None;
+        state.reset_on_activity();
         return None;
     }
 
     // Legacy execute_in path has no spool/session directory context.
     // Preserve original behavior: idle-timeout means immediate termination.
     let Some(dir) = session_dir else {
+        state.provider_error_backoff.reset();
         return (idle_for >= idle_timeout).then_some(IdleTerminationReason::Idle);
     };
 
     let now = Instant::now();
-    let should_poll = next_liveness_poll_at
+    let should_poll = state
+        .next_liveness_poll_at
         .as_ref()
         .is_none_or(|next_poll| now >= *next_poll);
     if !should_poll {
@@ -131,31 +238,68 @@ pub(crate) fn should_terminate_for_idle(
     if signals.has_progress_signal() {
         // Real progress observed: reset idle/death timers and give a fresh window.
         *last_activity = now;
-        *liveness_dead_since = None;
-        *next_liveness_poll_at = Some(now + LIVENESS_POLL_INTERVAL);
+        state.liveness_dead_since = None;
+        state.next_liveness_poll_at = Some(now + LIVENESS_POLL_INTERVAL);
+        state.provider_error_backoff.reset();
         return None;
     }
 
     // #1745 stopgap opt-out; proper fix = scope marker scan to backend-transport stream only (#182)
-    if error_marker_scan_enabled && signals.fatal_error && idle_for >= FATAL_ERROR_PROGRESS_GRACE {
-        return Some(IdleTerminationReason::FatalError);
+    if error_marker_scan_enabled && idle_for >= FATAL_ERROR_PROGRESS_GRACE {
+        if let Some(reason) = provider_error_termination(
+            signals.provider_error,
+            now,
+            &mut state.next_liveness_poll_at,
+            &mut state.provider_error_backoff,
+        ) {
+            return Some(reason);
+        }
+    } else {
+        state.provider_error_backoff.reset();
     }
 
     if idle_for < idle_timeout {
-        *liveness_dead_since = None;
-        *next_liveness_poll_at = Some(now + LIVENESS_POLL_INTERVAL);
+        state.liveness_dead_since = None;
+        state.next_liveness_poll_at = Some(now + LIVENESS_POLL_INTERVAL);
         return None;
     }
 
-    let dead_since = liveness_dead_since.get_or_insert(now);
+    let dead_since = state.liveness_dead_since.get_or_insert(now);
     if dead_since.elapsed() >= liveness_dead_timeout {
         return Some(IdleTerminationReason::Idle);
     }
 
     let liveness_dead_deadline = *dead_since + liveness_dead_timeout;
-    *next_liveness_poll_at = Some((now + LIVENESS_POLL_INTERVAL).min(liveness_dead_deadline));
+    state.next_liveness_poll_at = Some((now + LIVENESS_POLL_INTERVAL).min(liveness_dead_deadline));
     None
 }
+
+fn provider_error_termination(
+    provider_error: Option<ProviderErrorKind>,
+    now: Instant,
+    next_liveness_poll_at: &mut Option<Instant>,
+    provider_error_backoff: &mut ProviderErrorBackoff,
+) -> Option<IdleTerminationReason> {
+    match provider_error {
+        Some(ProviderErrorKind::Permanent) => Some(IdleTerminationReason::FatalError),
+        Some(ProviderErrorKind::Transient) => {
+            if let Some(retry_after) = provider_error_backoff.transient_retry_deadline(now) {
+                *next_liveness_poll_at = Some(retry_after);
+                None
+            } else {
+                Some(IdleTerminationReason::FatalError)
+            }
+        }
+        None => {
+            provider_error_backoff.reset();
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "idle_watchdog_provider_error_tests.rs"]
+mod provider_error_tests;
 
 #[cfg(test)]
 mod tests {
@@ -409,11 +553,7 @@ mod tests {
     #[test]
     fn fatal_error_marker_fast_fails_before_promoted_idle_timeout() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(
-            tmp.path().join("stderr.log"),
-            "provider failed: HTTP 429 Too Many Requests\n",
-        )
-        .expect("write stderr");
+        std::fs::write(tmp.path().join("stderr.log"), "invalid_api_key\n").expect("write stderr");
 
         let mut dead_since = None;
         let mut next_poll = None;

--- a/crates/csa-process/src/idle_watchdog_provider_error_tests.rs
+++ b/crates/csa-process/src/idle_watchdog_provider_error_tests.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+#[test]
+fn transient_fatal_error_marker_retries_before_kill() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("stderr.log"),
+        "provider failed: HTTP 429 Too Many Requests\n",
+    )
+    .expect("write stderr");
+
+    let mut state = IdleWatchdogState::default();
+    let mut last_activity = Instant::now() - FATAL_ERROR_PROGRESS_GRACE - Duration::from_secs(1);
+
+    let first = should_terminate_for_idle_with_state(
+        &mut last_activity,
+        Duration::from_secs(7200),
+        Duration::from_secs(600),
+        Some(tmp.path()),
+        &mut state,
+        true,
+    );
+
+    assert_eq!(first, None);
+    assert!(state.liveness_dead_since.is_none());
+    let retry_after = state
+        .next_liveness_poll_at
+        .expect("transient marker schedules retry");
+    assert!(retry_after > Instant::now());
+
+    state.provider_error_backoff.retry_after = Some(Instant::now() - Duration::from_secs(1));
+    state.next_liveness_poll_at = Some(Instant::now() - Duration::from_secs(1));
+
+    let exhausted = should_terminate_for_idle_with_state(
+        &mut last_activity,
+        Duration::from_secs(7200),
+        Duration::from_secs(600),
+        Some(tmp.path()),
+        &mut state,
+        true,
+    );
+
+    assert_eq!(exhausted, Some(IdleTerminationReason::FatalError));
+}
+
+#[test]
+fn progress_signal_clears_transient_provider_backoff() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let locks_dir = tmp.path().join("locks");
+    std::fs::create_dir_all(&locks_dir).expect("create locks dir");
+    std::fs::write(
+        locks_dir.join("codex.lock"),
+        format!("{{\"pid\": {}}}", std::process::id()),
+    )
+    .expect("write lock");
+    std::fs::write(tmp.path().join("output.log"), "progress").expect("write output");
+    std::fs::write(
+        tmp.path().join(".liveness.snapshot"),
+        "spool_bytes_written=8\nobserved_spool_bytes_written=0",
+    )
+    .expect("seed snapshot");
+
+    let mut state = IdleWatchdogState {
+        liveness_dead_since: Some(Instant::now() - Duration::from_secs(5)),
+        next_liveness_poll_at: Some(Instant::now() - Duration::from_secs(1)),
+        provider_error_backoff: ProviderErrorBackoff {
+            retries_used: TRANSIENT_PROVIDER_ERROR_RETRY_BUDGET,
+            retry_after: Some(Instant::now() + TRANSIENT_PROVIDER_ERROR_BACKOFF),
+        },
+    };
+    let mut last_activity = Instant::now() - Duration::from_secs(10);
+
+    let terminate = should_terminate_for_idle_with_state(
+        &mut last_activity,
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+        Some(tmp.path()),
+        &mut state,
+        true,
+    );
+
+    assert_eq!(terminate, None);
+    assert_eq!(
+        state.provider_error_backoff,
+        ProviderErrorBackoff::default()
+    );
+}

--- a/crates/csa-process/src/lib.rs
+++ b/crates/csa-process/src/lib.rs
@@ -11,8 +11,11 @@ use tracing::warn;
 mod execution_result;
 pub use execution_result::{ExecutionResult, model_completed_from_terminal_reason};
 mod idle_watchdog;
+#[cfg(test)]
+use idle_watchdog::should_terminate_for_idle;
 use idle_watchdog::{
-    idle_timeout_note, should_terminate_for_idle, should_terminate_for_initial_response,
+    IdleWatchdogState, idle_timeout_note, should_terminate_for_idle_with_state,
+    should_terminate_for_initial_response_with_state,
 };
 mod persistent_rate_limit;
 use persistent_rate_limit::PersistentRateLimitTracker;

--- a/crates/csa-process/src/lib_wait_capture.rs
+++ b/crates/csa-process/src/lib_wait_capture.rs
@@ -75,8 +75,7 @@ pub async fn wait_and_capture_with_idle_timeout(
     let last_stdout_activity = last_activity;
     let mut last_heartbeat = execution_start;
     let heartbeat_interval = resolve_heartbeat_interval();
-    let mut liveness_dead_since: Option<Instant> = None;
-    let mut next_liveness_poll_at: Option<Instant> = None;
+    let mut idle_watchdog_state = IdleWatchdogState::default();
     let mut received_first_output = false;
     let mut idle_timed_out = false;
     let mut workspace_boundary_timed_out = false;
@@ -131,8 +130,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                             received_first_output = true;
                             last_activity = Instant::now();
                             last_heartbeat = last_activity;
-                            liveness_dead_since = None;
-                            next_liveness_poll_at = None;
+                            idle_watchdog_state.reset_on_activity();
                             let chunk = String::from_utf8_lossy(&stdout_buf[..n]);
                             spool_chunk(&mut spool_file, &stdout_buf[..n]);
                             if let (Some(dir), Some(spool)) = (session_dir, spool_file.as_ref()) {
@@ -179,8 +177,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                             // the initial_response_timeout.
                             last_activity = Instant::now();
                             last_heartbeat = last_activity;
-                            liveness_dead_since = None;
-                            next_liveness_poll_at = None;
+                            idle_watchdog_state.reset_on_activity();
                             let chunk = String::from_utf8_lossy(&stderr_buf[..n]);
                             spool_chunk(&mut stderr_spool_file, &stderr_buf[..n]);
                             let previous_stderr_len = stderr_output.len();
@@ -224,21 +221,20 @@ pub async fn wait_and_capture_with_idle_timeout(
                         effective_idle,
                     );
                     let idle_termination = if !received_first_output && initial_response_timeout.is_some() {
-                        should_terminate_for_initial_response(
+                        should_terminate_for_initial_response_with_state(
                             last_stdout_activity,
                             effective_idle,
                             session_dir,
-                            &mut next_liveness_poll_at,
+                            &mut idle_watchdog_state,
                             spawn_options.error_marker_scan_enabled,
                         )
                     } else {
-                        should_terminate_for_idle(
+                        should_terminate_for_idle_with_state(
                             &mut last_activity,
                             effective_idle,
                             liveness_dead_timeout,
                             session_dir,
-                            &mut liveness_dead_since,
-                            &mut next_liveness_poll_at,
+                            &mut idle_watchdog_state,
                             spawn_options.error_marker_scan_enabled,
                         )
                     };
@@ -295,8 +291,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                             received_first_output = true;
                             last_activity = Instant::now();
                             last_heartbeat = last_activity;
-                            liveness_dead_since = None;
-                            next_liveness_poll_at = None;
+                            idle_watchdog_state.reset_on_activity();
                             let chunk = String::from_utf8_lossy(&stdout_buf[..n]);
                             spool_chunk(&mut spool_file, &stdout_buf[..n]);
                             if let (Some(dir), Some(spool)) = (session_dir, spool_file.as_ref()) {
@@ -339,21 +334,20 @@ pub async fn wait_and_capture_with_idle_timeout(
                         effective_idle,
                     );
                     let idle_termination = if !received_first_output && initial_response_timeout.is_some() {
-                        should_terminate_for_initial_response(
+                        should_terminate_for_initial_response_with_state(
                             last_stdout_activity,
                             effective_idle,
                             session_dir,
-                            &mut next_liveness_poll_at,
+                            &mut idle_watchdog_state,
                             spawn_options.error_marker_scan_enabled,
                         )
                     } else {
-                        should_terminate_for_idle(
+                        should_terminate_for_idle_with_state(
                             &mut last_activity,
                             effective_idle,
                             liveness_dead_timeout,
                             session_dir,
-                            &mut liveness_dead_since,
-                            &mut next_liveness_poll_at,
+                            &mut idle_watchdog_state,
                             spawn_options.error_marker_scan_enabled,
                         )
                     };

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -7,7 +7,7 @@ use crate::process_tree_cpu_ticks;
 
 #[path = "tool_liveness_fatal_error.rs"]
 mod fatal_error;
-use fatal_error::has_fatal_error_signal;
+use fatal_error::provider_error_signal;
 #[cfg(test)]
 use fatal_error::{build_fatal_error_regex, has_fatal_error_signal_in_channels};
 const LIVENESS_RECENT_WINDOW_SECS: u64 = 30;
@@ -44,6 +44,7 @@ pub(crate) struct LivenessSignals {
     pub output_growth: bool,
     pub session_write: bool,
     pub stderr_activity: bool,
+    pub provider_error: Option<ProviderErrorKind>,
     pub fatal_error: bool,
 }
 
@@ -58,6 +59,12 @@ impl LivenessSignals {
     pub(crate) fn has_any_signal(self) -> bool {
         self.pid_alive || self.session_write || self.has_progress_signal()
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProviderErrorKind {
+    Transient,
+    Permanent,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -84,13 +91,15 @@ impl ToolLiveness {
         let mut snapshot = load_snapshot(session_dir);
         let daemon_pid_alive = Self::daemon_pid_is_alive(session_dir);
 
+        let provider_error = provider_error_signal(session_dir);
         let signals = LivenessSignals {
             pid_alive: has_live_pid_signal(session_dir) || daemon_pid_alive,
             cpu_progress: has_process_cpu_progress_signal(session_dir, &mut snapshot),
             output_growth: has_output_growth_signal(session_dir, &mut snapshot),
             session_write: has_recent_session_write_signal(session_dir, now),
             stderr_activity: has_stderr_activity_signal(session_dir, &mut snapshot),
-            fatal_error: has_fatal_error_signal(session_dir),
+            provider_error,
+            fatal_error: provider_error.is_some(),
         };
 
         save_snapshot(session_dir, &snapshot);

--- a/crates/csa-process/src/tool_liveness_fatal_error.rs
+++ b/crates/csa-process/src/tool_liveness_fatal_error.rs
@@ -8,17 +8,37 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
+use super::ProviderErrorKind;
 use super::{FATAL_ERROR_MARKERS_FILE, OUTPUT_LOG_FILE, STDERR_LOG_FILE};
 
 const FATAL_ERROR_TAIL_BYTES: u64 = 4096;
 
 #[derive(Clone)]
 struct FatalErrorRegexes {
+    permanent: FatalErrorChannelRegexes,
+    transient: FatalErrorChannelRegexes,
+}
+
+#[derive(Clone)]
+struct FatalErrorChannelRegexes {
     all_channel: Option<Regex>,
     stderr_only: Option<Regex>,
 }
 
 impl FatalErrorRegexes {
+    fn from_markers(markers: &[String]) -> Self {
+        let (transient, permanent): (Vec<_>, Vec<_>) = markers
+            .iter()
+            .cloned()
+            .partition(|marker| is_transient_provider_marker(marker));
+        Self {
+            permanent: FatalErrorChannelRegexes::from_markers(&permanent),
+            transient: FatalErrorChannelRegexes::from_markers(&transient),
+        }
+    }
+}
+
+impl FatalErrorChannelRegexes {
     fn from_markers(markers: &[String]) -> Self {
         let (stderr_only, all_channel): (Vec<_>, Vec<_>) = markers
             .iter()
@@ -40,18 +60,37 @@ impl FatalErrorRegexes {
 /// still matched EXACTLY (by the caller via `build_fatal_error_regex`), so the specific
 /// status code is preserved — this is purely a channel classifier, not a pattern source.
 fn is_broad_http_marker(marker: &str) -> bool {
-    let mut words = marker.split_whitespace();
-    let (Some(first), Some(second)) = (words.next(), words.next()) else {
-        return false;
-    };
-    if first.eq_ignore_ascii_case("http") || first.eq_ignore_ascii_case("status") {
-        return is_three_digit_status_code(second);
-    }
-    is_three_digit_status_code(first) && second.chars().next().is_some_and(char::is_alphabetic)
+    marker_http_status_code(marker).is_some()
 }
 
-fn is_three_digit_status_code(value: &str) -> bool {
-    value.len() == 3 && value.bytes().all(|byte| byte.is_ascii_digit())
+fn marker_http_status_code(marker: &str) -> Option<u16> {
+    let mut words = marker.split_whitespace();
+    let (Some(first), Some(second)) = (words.next(), words.next()) else {
+        return None;
+    };
+    if first.eq_ignore_ascii_case("http") || first.eq_ignore_ascii_case("status") {
+        return parse_three_digit_status_code(second);
+    }
+    if second.chars().next().is_some_and(char::is_alphabetic) {
+        return parse_three_digit_status_code(first);
+    }
+    None
+}
+
+fn parse_three_digit_status_code(value: &str) -> Option<u16> {
+    if value.len() != 3 || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    value.parse().ok()
+}
+
+fn is_transient_provider_marker(marker: &str) -> bool {
+    let normalized = marker.trim().to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "rate_limit_exceeded" | "rate limit exceeded" | "overloaded_error"
+    ) || marker_http_status_code(marker)
+        .is_some_and(|status| matches!(status, 408 | 429 | 500 | 502 | 503 | 504))
 }
 
 fn default_tier1_fatal_error_markers() -> Vec<String> {
@@ -110,26 +149,54 @@ fn read_fatal_error_marker_file(marker_path: &Path) -> Vec<String> {
         .unwrap_or_default()
 }
 
-pub(super) fn has_fatal_error_signal(session_dir: &Path) -> bool {
+pub(super) fn provider_error_signal(session_dir: &Path) -> Option<ProviderErrorKind> {
     let tmux_pane = capture_tmux_pane(session_dir);
-    has_fatal_error_signal_in_channels(session_dir, tmux_pane.as_deref())
+    provider_error_signal_in_channels(session_dir, tmux_pane.as_deref())
 }
 
+#[cfg(test)]
 pub(super) fn has_fatal_error_signal_in_channels(
     session_dir: &Path,
     tmux_pane: Option<&str>,
 ) -> bool {
-    let regexes = fatal_error_regexes_for_session(session_dir);
+    provider_error_signal_in_channels(session_dir, tmux_pane).is_some()
+}
 
-    read_file_tail(&session_dir.join(STDERR_LOG_FILE))
-        .ok()
-        .is_some_and(|tail| {
-            matches_fatal_error(&regexes.all_channel, &tail)
-                || matches_fatal_error(&regexes.stderr_only, &tail)
-        })
-        || read_file_tail(&session_dir.join(OUTPUT_LOG_FILE))
-            .ok()
-            .is_some_and(|tail| matches_fatal_error(&regexes.all_channel, &tail))
+fn provider_error_signal_in_channels(
+    session_dir: &Path,
+    tmux_pane: Option<&str>,
+) -> Option<ProviderErrorKind> {
+    let regexes = fatal_error_regexes_for_session(session_dir);
+    let stderr_tail = read_file_tail(&session_dir.join(STDERR_LOG_FILE)).ok();
+    let output_tail = read_file_tail(&session_dir.join(OUTPUT_LOG_FILE)).ok();
+
+    if matches_provider_error(
+        &regexes.permanent,
+        stderr_tail.as_deref(),
+        output_tail.as_deref(),
+        tmux_pane,
+    ) {
+        return Some(ProviderErrorKind::Permanent);
+    }
+    matches_provider_error(
+        &regexes.transient,
+        stderr_tail.as_deref(),
+        output_tail.as_deref(),
+        tmux_pane,
+    )
+    .then_some(ProviderErrorKind::Transient)
+}
+
+fn matches_provider_error(
+    regexes: &FatalErrorChannelRegexes,
+    stderr_tail: Option<&str>,
+    output_tail: Option<&str>,
+    tmux_pane: Option<&str>,
+) -> bool {
+    stderr_tail.is_some_and(|tail| {
+        matches_fatal_error(&regexes.all_channel, tail)
+            || matches_fatal_error(&regexes.stderr_only, tail)
+    }) || output_tail.is_some_and(|tail| matches_fatal_error(&regexes.all_channel, tail))
         || tmux_pane.is_some_and(|pane| matches_fatal_error(&regexes.all_channel, pane))
 }
 


### PR DESCRIPTION
## Summary

Two independent session/daemon lifecycle reliability fixes, located by read-only triage and
verified against the current code. (Split from a larger lifecycle cluster — the entangled #1698
resume-lock work was isolated for a focused redesign and is NOT in this PR.)

- **Closes #1690** — `csa session wait`'s stale precheck no longer pre-fails a wait while the
  daemon (and its executor child) is still alive. The precheck now consults live daemon liveness
  (PID / process-group present) before declaring a session stale, mirroring the in-loop reconcile
  logic. A session with a live daemon is never pre-failed.

- **Closes #1727** — the idle watchdog no longer hard-kills a session on a single transient
  provider 4xx/5xx marker. A bounded same-tool backoff-retry runs before escalation; only after
  the retry budget is exhausted (or on a permanent error) does it kill. The #1758 CPU-liveness
  behavior is preserved: a quiet-but-CPU-busy child still survives; dead / wedged (zero-CPU)
  sessions remain killable; genuinely permanent provider errors still fail.

## Testing

- Per-fix regression tests: live-daemon → wait not pre-failed; transient provider marker →
  retried before kill, exhausted/permanent → killed (new
  `idle_watchdog_provider_error_tests.rs`).
- `just fmt` / `just clippy` clean; the pre-commit hook gated each commit.
- Pre-PR `csa review` verdict: PASS.

## Note

These two fixes were reviewed clean across five rounds of a larger branch; the resume-resolved-id
work (#1698) that shared that branch is being redesigned separately (it needs an
acquire-once-hold-through restructuring of the resume lock path, folded with #1646). The original
WIP branch is preserved for that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
