### PR TITLE
fix(pr-bot): merge-gate cluster #1656/#1671/#1702 (dedupe verdict markers, blocking-only post-fix gate, degraded-fallback rationale)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.845"
+version = "0.1.846"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.845"
+version = "0.1.846"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
@@ -423,6 +423,57 @@ async fn execute_step_bash_posts_pr_audit_trail_for_dismissed_verdict() {
 }
 
 #[tokio::test]
+async fn execute_step_bash_dedupes_identical_verdict_markers() {
+    let step = load_pr_bot_step_by_title("Step 8a: Post Debate Audit Trail Comment");
+    let tmp = tempfile::tempdir().unwrap();
+    let capture_path = install_fake_gh(tmp.path());
+    let duplicate_verdict_output = r#"VERDICT: DISMISSED
+RATIONALE: The first marker is duplicated by a later identical marker.
+VERDICT: DISMISSED
+PR_COMMENT_START
+**Local arbitration result: DISMISSED.**
+
+## Participants
+- **Author**: codex/openai/gpt-5/xhigh
+- **Arbiter**: gemini-cli/google/default/xhigh
+
+## Bot Concern
+Identical verdict markers are noisy but not ambiguous.
+
+## Debate Summary
+### Round 1
+- **Proposer** (`codex/openai/gpt-5/xhigh`): Duplicate identical verdicts should collapse.
+- **Critic** (`gemini-cli/google/default/xhigh`): Conflicting verdicts must still fail closed.
+
+## Conclusion
+The repeated identical verdict is treated as one DISMISSED verdict.
+
+CSA session ID: 01TESTDEBATESESSIONID
+PR_COMMENT_END
+"#;
+    let vars = step_15_env(tmp.path(), &capture_path, duplicate_verdict_output);
+
+    let result = execute_step(&step, &vars, tmp.path(), None, None, None).await;
+
+    assert_eq!(
+        result.exit_code, 0,
+        "error={:?} output={:?}",
+        result.error, result.output
+    );
+    assert!(
+        result
+            .output
+            .as_deref()
+            .unwrap_or("")
+            .contains("CSA_VAR:AUDIT_TRAIL_POSTED=true")
+    );
+
+    let comment = std::fs::read_to_string(&capture_path).unwrap();
+    assert!(comment.contains("Identical verdict markers are noisy but not ambiguous."));
+    assert!(comment.contains("CSA session ID: 01TESTDEBATESESSIONID"));
+}
+
+#[tokio::test]
 async fn execute_step_bash_reroutes_confirmed_verdict_without_posting_comment() {
     let step = load_pr_bot_step_by_title("Step 8a: Post Debate Audit Trail Comment");
     let tmp = tempfile::tempdir().unwrap();
@@ -495,7 +546,7 @@ CSA session ID: 01TESTDEBATESESSIONID
 }
 
 #[tokio::test]
-async fn execute_step_bash_fails_closed_on_duplicate_verdict_markers() {
+async fn execute_step_bash_fails_closed_on_conflicting_verdict_markers() {
     let step = load_pr_bot_step_by_title("Step 8a: Post Debate Audit Trail Comment");
     let tmp = tempfile::tempdir().unwrap();
     let capture_path = install_fake_gh(tmp.path());

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -1611,7 +1611,7 @@ it waits for a new current-window review before proceeding. This distinguishes
 The gate:
 1. Records push timestamp before checking
 2. Checks for an already-posted exact current-HEAD review before retriggering; otherwise polls for a new review event from `${CLOUD_BOT_LOGIN}` on the current HEAD
-3. If review event found AND has P0/P1/P2 inline comments → **abort** (user must re-run pr-bot)
+3. If review event found AND has P0/P1/HIGH/CRITICAL inline comments → **abort** (user must re-run pr-bot)
 4. If review event found AND clean → clears `BOT_HAS_ISSUES=false` so merge steps can proceed
 5. If no review event within timeout → falls back to local `csa review --range ${DEFAULT_BRANCH}...HEAD`
 
@@ -1786,19 +1786,19 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     _check_setup_message
     REVIEW_API_FAILED=true
   fi
-  # --- Check inline comments for actionable findings ---
+  # --- Check inline comments for blocking findings ---
   if [ "${BOT_CLEAN}" != "true" ]; then
     set +e
     if [ "${REUSE_EXISTING_POST_FIX_REVIEW}" = "true" ]; then
       ACTIONABLE_COUNT="$(
         gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews/${POST_FIX_REUSED_REVIEW_ID}/comments?per_page=100" \
-          | jq -r '[.[] | .[] | select((.user.login // "") == "'"${CLOUD_BOT_LOGIN}"'") | select((.body | test("(^|[^A-Za-z0-9])(P0|P1|P2|critical|high|medium)([^A-Za-z0-9]|$)"; "i"))) ] | length' \
+          | jq -r '[.[] | .[] | select((.user.login // "") == "'"${CLOUD_BOT_LOGIN}"'") | select((.body | test("(^|[^A-Za-z0-9])(P0|P1|critical|high)([^A-Za-z0-9]|$)"; "i"))) ] | length' \
           2>/dev/null
       )"
     else
       ACTIONABLE_COUNT="$(
         gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/comments" \
-          | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'") | select((.body | test("(^|[^A-Za-z0-9])(P0|P1|P2|critical|high|medium)([^A-Za-z0-9]|$)"; "i"))) ] | length' \
+          | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'") | select((.body | test("(^|[^A-Za-z0-9])(P0|P1|critical|high)([^A-Za-z0-9]|$)"; "i"))) ] | length' \
           2>/dev/null
       )"
     fi
@@ -1810,12 +1810,12 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     fi
     case "${ACTIONABLE_COUNT:-}" in
       ''|*[!0-9]*)
-        echo "ERROR: Invalid actionable comment count from GitHub API: '${ACTIONABLE_COUNT}'." >&2
+        echo "ERROR: Invalid blocking comment count from GitHub API: '${ACTIONABLE_COUNT}'." >&2
         exit 1
         ;;
     esac
     if [ "${ACTIONABLE_COUNT}" -gt 0 ]; then
-      echo "ERROR: Post-fix re-review found ${ACTIONABLE_COUNT} new actionable finding(s). Cannot merge." >&2
+      echo "ERROR: Post-fix re-review found ${ACTIONABLE_COUNT} new blocking finding(s). Cannot merge." >&2
       echo "Re-run pr-bot to start a new fix cycle."
       exit 1
     elif [ "${REVIEW_EVENT_COUNT:-0}" -eq 0 ] || [ "${REVIEW_API_FAILED:-false}" = "true" ]; then

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -83,11 +83,12 @@ canonical repository.
 Tool: bash
 
 Ensure all changes committed. Set `WORKFLOW_BRANCH`, `REMOTE_NAME`, `REPO_SLUG`, and `DEFAULT_BRANCH` once
-(both persist through clean branch switches in Step 11).
+(both persist through clean branch switches in Step 11). Declare `PR_WAS_EXISTING`
+so the Step 3 PR lookup result persists into cloud-bot trigger selection.
 
 ```bash
 # Force weave to pick up workflow variables used across steps.
-: "${WORKFLOW_BRANCH}" "${REVIEW_COMPLETED}" "${REMOTE_NAME}" "${REPO_SLUG}" "${DEFAULT_BRANCH}"
+: "${WORKFLOW_BRANCH}" "${REVIEW_COMPLETED}" "${REMOTE_NAME}" "${REPO_SLUG}" "${DEFAULT_BRANCH}" "${PR_WAS_EXISTING}"
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 WORKFLOW_BRANCH="$(git branch --show-current)"
@@ -1320,10 +1321,6 @@ Fetch the review comment body yourself:
 MUST use independent model arbitration. NEVER dismiss bot comments using only
 your own reasoning.
 
-## INCLUDE debate
-
-MUST use independent model for arbitration.
-NEVER dismiss bot comments using own reasoning alone.
 Emit structured output for the caller:
 - `VERDICT: DISMISSED|CONFIRMED`
 - `RATIONALE: ...`
@@ -1335,6 +1332,12 @@ Emit structured output for the caller:
 
 Emit each marker exactly once, in the order shown, and do not repeat the
 format description in the answer.
+
+If the finding is valid, emit `VERDICT: CONFIRMED`. If it is not a real issue,
+emit `VERDICT: DISMISSED` and include the full explanatory PR comment between
+the PR comment markers.
+
+## INCLUDE debate
 
 The workflow posts the audit trail to PR in a dedicated `gh pr comment` step
 and aborts if comment creation fails.
@@ -1742,6 +1745,95 @@ if [ "${WAIT_MARKER}" != "BOT_REPLY=received" ]; then
   fi
 fi
 
+# --- Setup message check (runs before any fallback to catch config issues) ---
+# NOTE: Similar to _check_setup_message_step5 in Step 5, but with different
+# semantics: Step 5 soft-detects (sets BOT_NEEDS_SETUP, returns 0/1);
+# this version hard-fails (exit 1) because post-fix is too late to recover.
+_check_setup_message() {
+  set +e
+  local setup_body
+  setup_body="$(
+    gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
+      | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'")] | .[0].body // ""' \
+      2>/dev/null
+  )"
+  set -e
+  if [ -n "${setup_body}" ] && echo "${setup_body}" | grep -qEi 'configur|set.?up.*(environment|repo)|environment.*(set.?up|configur|need)|unable.to.(review|access)|cannot.*(complete|access|review)|not.*configured|permission|credential'; then
+    echo "ERROR: Cloud bot responded with a setup/configuration message instead of a code review." >&2
+    echo "Bot response (truncated): $(echo "${setup_body}" | head -c 500)" >&2
+    echo "ACTION REQUIRED: Configure the cloud bot, then re-run pr-bot." >&2
+    exit 1
+  fi
+}
+
+_local_review_failure_is_degraded() {
+  local review_output
+  review_output="$(cat)"
+  if printf '%s\n' "${review_output}" | grep -Eiq 'Review verdict:[[:space:]]*(FAIL|HAS_ISSUES)|"decision"[[:space:]]*:[[:space:]]*"fail"|(^|[^A-Za-z])HAS_ISSUES([^A-Za-z]|$)'; then
+    return 1
+  fi
+  printf '%s\n' "${review_output}" | grep -Eiq 'Review verdict:[[:space:]]*UNAVAILABLE|"decision"[[:space:]]*:[[:space:]]*"unavailable"|Review unavailable:|(^|[^A-Za-z])UNAVAILABLE([^A-Za-z]|$)|tool[^[:cntrl:]]*unavailable|OAuth prompt|authentication required|MCP init degraded'
+}
+
+_allow_degraded_local_review_merge() {
+  local reason="$1"
+  echo "WARN: ${reason}" >&2
+  echo "WARN: Cloud bot produced no blocking findings; routing to merge rationale because local fallback review is unavailable/degraded." >&2
+  BOT_UNAVAILABLE=true
+  FALLBACK_REVIEW_HAS_ISSUES=false
+  BOT_HAS_ISSUES=false
+  MERGE_WITHOUT_BOT_REASON_KIND="local_review_degraded_no_blocking_findings"
+}
+
+_run_local_fallback_review() {
+  local allow_degraded_merge="${1:-false}"
+  local launch_output
+  local launch_rc
+  local sid
+  local review_result
+  local review_rc
+
+  set +e
+  launch_output="$(csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD" 2>&1)"
+  launch_rc=$?
+  set -e
+  if [ "${launch_rc}" -ne 0 ]; then
+    if [ "${allow_degraded_merge}" = "true" ] && printf '%s\n' "${launch_output}" | _local_review_failure_is_degraded; then
+      _allow_degraded_local_review_merge "Local fallback review launch failed with an unavailable/degraded reviewer (rc=${launch_rc})."
+      return 0
+    fi
+    echo "ERROR: Failed to launch local fallback review after fix (rc=${launch_rc}). Cannot merge." >&2
+    printf '%s\n' "${launch_output}" >&2
+    exit 1
+  fi
+
+  sid="$(printf '%s\n' "${launch_output}" | grep -Eo '[0-9A-HJKMNP-TV-Z]{26}' | tail -n 1 || true)"
+  if [ -z "${sid}" ]; then
+    if [ "${allow_degraded_merge}" = "true" ] && printf '%s\n' "${launch_output}" | _local_review_failure_is_degraded; then
+      _allow_degraded_local_review_merge "Local fallback review did not return a session id because the reviewer is unavailable/degraded."
+      return 0
+    fi
+    echo "ERROR: Local fallback review did not return a session id. Cannot merge." >&2
+    printf '%s\n' "${launch_output}" >&2
+    exit 1
+  fi
+
+  LOCAL_REVIEW_SESSION_ID="${sid}"
+  set +e
+  review_result="$(bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "${sid}" 2>&1)"
+  review_rc=$?
+  set -e
+  printf '%s\n' "${review_result}"
+  if [ "${review_rc}" -ne 0 ]; then
+    if [ "${allow_degraded_merge}" = "true" ] && printf '%s\n' "${review_result}" | _local_review_failure_is_degraded; then
+      _allow_degraded_local_review_merge "Local fallback review session ${sid} ended unavailable/degraded (rc=${review_rc})."
+      return 0
+    fi
+    echo "ERROR: Local fallback review found issues after fix. Cannot merge." >&2
+    exit 1
+  fi
+}
+
 if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   BOT_SETTLE_SECS="${BOT_SETTLE_SECS:-20}"
   sleep "${BOT_SETTLE_SECS}"
@@ -1760,27 +1852,6 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     set -e
     REVIEW_EVENT_COUNT="$(echo "${REVIEW_EVENT_RAW}" | awk '{s+=$1} END {print s+0}')"
   fi
-  # --- Setup message check (runs before any fallback to catch config issues) ---
-  # NOTE: Similar to _check_setup_message_step5 in Step 5, but with different
-  # semantics: Step 5 soft-detects (sets BOT_NEEDS_SETUP, returns 0/1);
-  # this version hard-fails (exit 1) because post-fix is too late to recover.
-  _check_setup_message() {
-    set +e
-    local setup_body
-    setup_body="$(
-      gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
-        | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'")] | .[0].body // ""' \
-        2>/dev/null
-    )"
-    set -e
-    if [ -n "${setup_body}" ] && echo "${setup_body}" | grep -qEi 'configur|set.?up.*(environment|repo)|environment.*(set.?up|configur|need)|unable.to.(review|access)|cannot.*(complete|access|review)|not.*configured|permission|credential'; then
-      echo "ERROR: Cloud bot responded with a setup/configuration message instead of a code review." >&2
-      echo "Bot response (truncated): $(echo "${setup_body}" | head -c 500)" >&2
-      echo "ACTION REQUIRED: Configure the cloud bot, then re-run pr-bot." >&2
-      exit 1
-    fi
-  }
-
   if [ "${REVIEW_EVENT_RC}" -ne 0 ]; then
     echo "WARN: Failed to query review events (rc=${REVIEW_EVENT_RC})." >&2
     _check_setup_message
@@ -1821,22 +1892,27 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     elif [ "${REVIEW_EVENT_COUNT:-0}" -eq 0 ] || [ "${REVIEW_API_FAILED:-false}" = "true" ]; then
       echo "WARN: No positive signal (review event or inline comments) for HEAD ${CURRENT_SHA} since ${POST_FIX_REVIEW_WINDOW_START}." >&2
       _check_setup_message
-      echo "Falling back to local review." >&2
-      SID=$(csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD")
-      if ! bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "$SID"; then
-        echo "ERROR: Local fallback review found issues after fix. Cannot merge." >&2
-        exit 1
+      allow_degraded_merge=false
+      set +e
+      nonblocking_comment_count="$(
+        gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/comments" \
+          | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'") | select((.body | test("(^|[^A-Za-z0-9])(P2|medium)([^A-Za-z0-9]|$)"; "i"))) ] | length' \
+          2>/dev/null
+      )"
+      nonblocking_count_rc=$?
+      set -e
+      if [ "${nonblocking_count_rc}" -eq 0 ] && [ "${nonblocking_comment_count:-0}" -gt 0 ] 2>/dev/null; then
+        allow_degraded_merge=true
+        echo "Detected ${nonblocking_comment_count} non-blocking MEDIUM/P2 bot comment(s); local fallback degradation may use merge-rationale path." >&2
       fi
+      echo "Falling back to local review." >&2
+      _run_local_fallback_review "${allow_degraded_merge}"
     fi
   fi
   BOT_CLEAN=true
 else
   echo "WARN: Post-fix bot wait returned timeout/no-marker. Falling back to local review."
-  SID=$(csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD")
-  if ! bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "$SID"; then
-    echo "ERROR: Local fallback review found issues after fix. Cannot merge." >&2
-    exit 1
-  fi
+  _run_local_fallback_review false
   BOT_CLEAN=true
 fi
 
@@ -1849,6 +1925,10 @@ fi
 BOT_HAS_ISSUES=false
 echo "CSA_VAR:POST_FIX_REUSED_REVIEW_ID=${POST_FIX_REUSED_REVIEW_ID}"
 echo "CSA_VAR:BOT_HAS_ISSUES=$BOT_HAS_ISSUES"
+echo "CSA_VAR:BOT_UNAVAILABLE=$BOT_UNAVAILABLE"
+echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
+echo "CSA_VAR:LOCAL_REVIEW_SESSION_ID=${LOCAL_REVIEW_SESSION_ID:-}"
+echo "CSA_VAR:MERGE_WITHOUT_BOT_REASON_KIND=${MERGE_WITHOUT_BOT_REASON_KIND:-}"
 echo "Post-fix re-review gate PASSED. Merge is now allowed."
 ```
 
@@ -1918,9 +1998,10 @@ Note: this Step 6a path now also covers the latest-comment quota fallback once
 the workflow records the quota window.
 
 **MANDATORY**: Before merging, leave a PR comment explaining the merge rationale.
-This step has two audit-trail cases:
+This step has three audit-trail cases:
 - `cloud_bot=false`: "cloud_bot=false (disabled in config); merging on local review clean"
 - `MERGE_WITHOUT_BOT_REASON_KIND=cloud_bot_quota_exhausted`: explain the cached quota window and cite the local review session ID
+- `MERGE_WITHOUT_BOT_REASON_KIND=local_review_degraded_no_blocking_findings`: explain that the cloud bot produced no blocking findings and the local fallback review was unavailable/degraded
 When `MERGE_WITHOUT_BOT_REASON_KIND=cloud_bot_quota_exhausted`, the audit trail
 must explain the cached quota window and cite the local review session ID.
 
@@ -1961,6 +2042,23 @@ elif [ "${MERGE_WITHOUT_BOT_REASON_KIND:-}" = "cloud_bot_quota_exhausted" ]; the
       "Configured cloud bot \`${CLOUD_BOT_NAME}\` is quota-exhausted (detected at \`${CLOUD_BOT_QUOTA_EXHAUSTED_AT:-unknown}\`, expected reset \`${CLOUD_BOT_QUOTA_EXPECTED_RESET_AT:-unknown}\`). Per pr-bot quota fallback, routing to the bot-unavailable + local-review-clean merge path." \
       '' \
       "**Local pre-merge review verdict**: CLEAN (session \`${LOCAL_REVIEW_SESSION_ID:-unknown}\`)" \
+      '' \
+      '**Diff scope**:' \
+      '\`\`\`' \
+      "${DIFF_SUMMARY}" \
+      '\`\`\`'
+  )"
+elif [ "${MERGE_WITHOUT_BOT_REASON_KIND:-}" = "local_review_degraded_no_blocking_findings" ]; then
+  MERGE_REASON="cloud bot reported no blocking findings; local fallback review unavailable/degraded"
+  COMMENT_BODY="$(
+    printf '%s\n' \
+      '## Merge audit trail — local fallback review degraded' \
+      '' \
+      "Configured cloud bot \`${CLOUD_BOT_NAME}\` produced no HIGH/CRITICAL/P1 blocking findings. MEDIUM/P2 comments are non-blocking follow-up by policy." \
+      '' \
+      "Local fallback review could not complete with an available reviewer, so pr-bot is proceeding through the explicit degraded-local-review rationale path instead of aborting on a non-blocking cloud review." \
+      '' \
+      "**Local fallback review session**: \`${LOCAL_REVIEW_SESSION_ID:-unavailable}\`" \
       '' \
       '**Diff scope**:' \
       '\`\`\`' \

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -1364,25 +1364,25 @@ Parse the structured debate result from Step 8.
 ```bash
 set -euo pipefail
 DEBATE_OUTPUT="${STEP_12_OUTPUT}"
-VERDICT_COUNT="$(
-  printf '%s\n' "${DEBATE_OUTPUT}" \
-    | grep -Ec '^[[:space:]]*VERDICT: (DISMISSED|CONFIRMED)[[:space:]]*$' \
-    || true
-)"
-if [ "${VERDICT_COUNT}" != "1" ]; then
-  echo "ERROR: Debate output must contain exactly one VERDICT marker." >&2
-  exit 1
-fi
 VERDICT_MARKER="$(
   printf '%s\n' "${DEBATE_OUTPUT}" \
-    | grep -E '^[[:space:]]*VERDICT: (DISMISSED|CONFIRMED)[[:space:]]*$' \
-    | tail -n 1 \
-    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+    | sed -n -E 's/^[[:space:]]*VERDICT:[[:space:]]*([^[:space:]]+)[[:space:]]*$/VERDICT: \1/p' \
+    | sort -u \
     || true
 )"
+VERDICT_COUNT="$(
+  printf '%s\n' "${VERDICT_MARKER}" \
+    | sed '/^$/d' \
+    | wc -l \
+    | tr -d '[:space:]'
+)"
 
-if [ -z "${VERDICT_MARKER}" ]; then
+if [ "${VERDICT_COUNT}" = "0" ]; then
   echo "ERROR: Debate output missing VERDICT marker." >&2
+  exit 1
+fi
+if [ "${VERDICT_COUNT}" != "1" ]; then
+  echo "ERROR: Debate output contains conflicting VERDICT markers." >&2
   exit 1
 fi
 

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -2062,7 +2062,7 @@ it waits for a new current-window review before proceeding. This distinguishes
 The gate:
 1. Records push timestamp before checking
 2. Checks for an already-posted exact current-HEAD review before retriggering; otherwise polls for a new review event from `${CLOUD_BOT_LOGIN}` on the current HEAD
-3. If review event found AND has P0/P1/P2 inline comments → **abort** (user must re-run pr-bot)
+3. If review event found AND has P0/P1/HIGH/CRITICAL inline comments → **abort** (user must re-run pr-bot)
 4. If review event found AND clean → clears `BOT_HAS_ISSUES=false` so merge steps can proceed
 5. If no review event within timeout → falls back to local `csa review --range ${DEFAULT_BRANCH}...HEAD`
 
@@ -2237,19 +2237,19 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     _check_setup_message
     REVIEW_API_FAILED=true
   fi
-  # --- Check inline comments for actionable findings ---
+  # --- Check inline comments for blocking findings ---
   if [ "${BOT_CLEAN}" != "true" ]; then
     set +e
     if [ "${REUSE_EXISTING_POST_FIX_REVIEW}" = "true" ]; then
       ACTIONABLE_COUNT="$(
         gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/reviews/${POST_FIX_REUSED_REVIEW_ID}/comments?per_page=100" \
-          | jq -r '[.[] | .[] | select((.user.login // "") == "'"${CLOUD_BOT_LOGIN}"'") | select((.body | test("(^|[^A-Za-z0-9])(P0|P1|P2|critical|high|medium)([^A-Za-z0-9]|$)"; "i"))) ] | length' \
+          | jq -r '[.[] | .[] | select((.user.login // "") == "'"${CLOUD_BOT_LOGIN}"'") | select((.body | test("(^|[^A-Za-z0-9])(P0|P1|critical|high)([^A-Za-z0-9]|$)"; "i"))) ] | length' \
           2>/dev/null
       )"
     else
       ACTIONABLE_COUNT="$(
         gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/comments" \
-          | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'") | select((.body | test("(^|[^A-Za-z0-9])(P0|P1|P2|critical|high|medium)([^A-Za-z0-9]|$)"; "i"))) ] | length' \
+          | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'") | select((.body | test("(^|[^A-Za-z0-9])(P0|P1|critical|high)([^A-Za-z0-9]|$)"; "i"))) ] | length' \
           2>/dev/null
       )"
     fi
@@ -2261,12 +2261,12 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     fi
     case "${ACTIONABLE_COUNT:-}" in
       ''|*[!0-9]*)
-        echo "ERROR: Invalid actionable comment count from GitHub API: '${ACTIONABLE_COUNT}'." >&2
+        echo "ERROR: Invalid blocking comment count from GitHub API: '${ACTIONABLE_COUNT}'." >&2
         exit 1
         ;;
     esac
     if [ "${ACTIONABLE_COUNT}" -gt 0 ]; then
-      echo "ERROR: Post-fix re-review found ${ACTIONABLE_COUNT} new actionable finding(s). Cannot merge." >&2
+      echo "ERROR: Post-fix re-review found ${ACTIONABLE_COUNT} new blocking finding(s). Cannot merge." >&2
       echo "Re-run pr-bot to start a new fix cycle."
       exit 1
     elif [ "${REVIEW_EVENT_COUNT:-0}" -eq 0 ] || [ "${REVIEW_API_FAILED:-false}" = "true" ]; then

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -363,7 +363,7 @@ name = "SID"
 name = "SOURCE_OWNER"
 
 [[workflow.variables]]
-name = "STEP_11_OUTPUT"
+name = "STEP_12_OUTPUT"
 
 [[workflow.variables]]
 name = "SYNC_DEFAULT_BRANCH"
@@ -420,6 +420,9 @@ name = "WORKFLOW_BRANCH"
 name = "_SYNC_BRANCH"
 
 [[workflow.variables]]
+name = "allow_degraded_merge"
+
+[[workflow.variables]]
 name = "attempt"
 
 [[workflow.variables]]
@@ -430,6 +433,18 @@ name = "latest_bot_comment_json"
 
 [[workflow.variables]]
 name = "latest_trigger_ts"
+
+[[workflow.variables]]
+name = "launch_output"
+
+[[workflow.variables]]
+name = "launch_rc"
+
+[[workflow.variables]]
+name = "nonblocking_comment_count"
+
+[[workflow.variables]]
+name = "nonblocking_count_rc"
 
 [[workflow.variables]]
 name = "pr_merged_at"
@@ -459,6 +474,9 @@ name = "quota_section_header"
 name = "rc"
 
 [[workflow.variables]]
+name = "reason"
+
+[[workflow.variables]]
 name = "remaining"
 
 [[workflow.variables]]
@@ -474,7 +492,19 @@ name = "reusable_current_head_review_ts"
 name = "reuse_existing_current_head_review"
 
 [[workflow.variables]]
+name = "review_output"
+
+[[workflow.variables]]
+name = "review_rc"
+
+[[workflow.variables]]
+name = "review_result"
+
+[[workflow.variables]]
 name = "setup_body"
+
+[[workflow.variables]]
+name = "sid"
 
 [[workflow.variables]]
 name = "status"
@@ -530,11 +560,12 @@ prompt = '''
 
 
 Ensure all changes committed. Set `WORKFLOW_BRANCH`, `REMOTE_NAME`, `REPO_SLUG`, and `DEFAULT_BRANCH` once
-(both persist through clean branch switches in Step 11).
+(both persist through clean branch switches in Step 11). Declare `PR_WAS_EXISTING`
+so the Step 3 PR lookup result persists into cloud-bot trigger selection.
 
 ```bash
 # Force weave to pick up workflow variables used across steps.
-: "${WORKFLOW_BRANCH}" "${REVIEW_COMPLETED}" "${REMOTE_NAME}" "${REPO_SLUG}" "${DEFAULT_BRANCH}"
+: "${WORKFLOW_BRANCH}" "${REVIEW_COMPLETED}" "${REMOTE_NAME}" "${REPO_SLUG}" "${DEFAULT_BRANCH}" "${PR_WAS_EXISTING}"
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 WORKFLOW_BRANCH="$(git branch --show-current)"
@@ -1758,6 +1789,7 @@ prompt = """
 > internally spawns Layer 2 independent models for adversarial evaluation.
 > Orchestrator receives the verdict and posts audit trail to PR.
 
+
 Arbitrate the current cloud-bot review comment for PR `${PR_NUM}` in
 `${REPO}`.
 
@@ -2193,6 +2225,95 @@ if [ "${WAIT_MARKER}" != "BOT_REPLY=received" ]; then
   fi
 fi
 
+# --- Setup message check (runs before any fallback to catch config issues) ---
+# NOTE: Similar to _check_setup_message_step5 in Step 5, but with different
+# semantics: Step 5 soft-detects (sets BOT_NEEDS_SETUP, returns 0/1);
+# this version hard-fails (exit 1) because post-fix is too late to recover.
+_check_setup_message() {
+  set +e
+  local setup_body
+  setup_body="$(
+    gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
+      | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'")] | .[0].body // ""' \
+      2>/dev/null
+  )"
+  set -e
+  if [ -n "${setup_body}" ] && echo "${setup_body}" | grep -qEi 'configur|set.?up.*(environment|repo)|environment.*(set.?up|configur|need)|unable.to.(review|access)|cannot.*(complete|access|review)|not.*configured|permission|credential'; then
+    echo "ERROR: Cloud bot responded with a setup/configuration message instead of a code review." >&2
+    echo "Bot response (truncated): $(echo "${setup_body}" | head -c 500)" >&2
+    echo "ACTION REQUIRED: Configure the cloud bot, then re-run pr-bot." >&2
+    exit 1
+  fi
+}
+
+_local_review_failure_is_degraded() {
+  local review_output
+  review_output="$(cat)"
+  if printf '%s\n' "${review_output}" | grep -Eiq 'Review verdict:[[:space:]]*(FAIL|HAS_ISSUES)|"decision"[[:space:]]*:[[:space:]]*"fail"|(^|[^A-Za-z])HAS_ISSUES([^A-Za-z]|$)'; then
+    return 1
+  fi
+  printf '%s\n' "${review_output}" | grep -Eiq 'Review verdict:[[:space:]]*UNAVAILABLE|"decision"[[:space:]]*:[[:space:]]*"unavailable"|Review unavailable:|(^|[^A-Za-z])UNAVAILABLE([^A-Za-z]|$)|tool[^[:cntrl:]]*unavailable|OAuth prompt|authentication required|MCP init degraded'
+}
+
+_allow_degraded_local_review_merge() {
+  local reason="$1"
+  echo "WARN: ${reason}" >&2
+  echo "WARN: Cloud bot produced no blocking findings; routing to merge rationale because local fallback review is unavailable/degraded." >&2
+  BOT_UNAVAILABLE=true
+  FALLBACK_REVIEW_HAS_ISSUES=false
+  BOT_HAS_ISSUES=false
+  MERGE_WITHOUT_BOT_REASON_KIND="local_review_degraded_no_blocking_findings"
+}
+
+_run_local_fallback_review() {
+  local allow_degraded_merge="${1:-false}"
+  local launch_output
+  local launch_rc
+  local sid
+  local review_result
+  local review_rc
+
+  set +e
+  launch_output="$(csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD" 2>&1)"
+  launch_rc=$?
+  set -e
+  if [ "${launch_rc}" -ne 0 ]; then
+    if [ "${allow_degraded_merge}" = "true" ] && printf '%s\n' "${launch_output}" | _local_review_failure_is_degraded; then
+      _allow_degraded_local_review_merge "Local fallback review launch failed with an unavailable/degraded reviewer (rc=${launch_rc})."
+      return 0
+    fi
+    echo "ERROR: Failed to launch local fallback review after fix (rc=${launch_rc}). Cannot merge." >&2
+    printf '%s\n' "${launch_output}" >&2
+    exit 1
+  fi
+
+  sid="$(printf '%s\n' "${launch_output}" | grep -Eo '[0-9A-HJKMNP-TV-Z]{26}' | tail -n 1 || true)"
+  if [ -z "${sid}" ]; then
+    if [ "${allow_degraded_merge}" = "true" ] && printf '%s\n' "${launch_output}" | _local_review_failure_is_degraded; then
+      _allow_degraded_local_review_merge "Local fallback review did not return a session id because the reviewer is unavailable/degraded."
+      return 0
+    fi
+    echo "ERROR: Local fallback review did not return a session id. Cannot merge." >&2
+    printf '%s\n' "${launch_output}" >&2
+    exit 1
+  fi
+
+  LOCAL_REVIEW_SESSION_ID="${sid}"
+  set +e
+  review_result="$(bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "${sid}" 2>&1)"
+  review_rc=$?
+  set -e
+  printf '%s\n' "${review_result}"
+  if [ "${review_rc}" -ne 0 ]; then
+    if [ "${allow_degraded_merge}" = "true" ] && printf '%s\n' "${review_result}" | _local_review_failure_is_degraded; then
+      _allow_degraded_local_review_merge "Local fallback review session ${sid} ended unavailable/degraded (rc=${review_rc})."
+      return 0
+    fi
+    echo "ERROR: Local fallback review found issues after fix. Cannot merge." >&2
+    exit 1
+  fi
+}
+
 if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
   BOT_SETTLE_SECS="${BOT_SETTLE_SECS:-20}"
   sleep "${BOT_SETTLE_SECS}"
@@ -2211,27 +2332,6 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     set -e
     REVIEW_EVENT_COUNT="$(echo "${REVIEW_EVENT_RAW}" | awk '{s+=$1} END {print s+0}')"
   fi
-  # --- Setup message check (runs before any fallback to catch config issues) ---
-  # NOTE: Similar to _check_setup_message_step5 in Step 5, but with different
-  # semantics: Step 5 soft-detects (sets BOT_NEEDS_SETUP, returns 0/1);
-  # this version hard-fails (exit 1) because post-fix is too late to recover.
-  _check_setup_message() {
-    set +e
-    local setup_body
-    setup_body="$(
-      gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" \
-        | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'")] | .[0].body // ""' \
-        2>/dev/null
-    )"
-    set -e
-    if [ -n "${setup_body}" ] && echo "${setup_body}" | grep -qEi 'configur|set.?up.*(environment|repo)|environment.*(set.?up|configur|need)|unable.to.(review|access)|cannot.*(complete|access|review)|not.*configured|permission|credential'; then
-      echo "ERROR: Cloud bot responded with a setup/configuration message instead of a code review." >&2
-      echo "Bot response (truncated): $(echo "${setup_body}" | head -c 500)" >&2
-      echo "ACTION REQUIRED: Configure the cloud bot, then re-run pr-bot." >&2
-      exit 1
-    fi
-  }
-
   if [ "${REVIEW_EVENT_RC}" -ne 0 ]; then
     echo "WARN: Failed to query review events (rc=${REVIEW_EVENT_RC})." >&2
     _check_setup_message
@@ -2272,22 +2372,27 @@ if [ "${WAIT_MARKER}" = "BOT_REPLY=received" ]; then
     elif [ "${REVIEW_EVENT_COUNT:-0}" -eq 0 ] || [ "${REVIEW_API_FAILED:-false}" = "true" ]; then
       echo "WARN: No positive signal (review event or inline comments) for HEAD ${CURRENT_SHA} since ${POST_FIX_REVIEW_WINDOW_START}." >&2
       _check_setup_message
-      echo "Falling back to local review." >&2
-      SID=$(csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD")
-      if ! bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "$SID"; then
-        echo "ERROR: Local fallback review found issues after fix. Cannot merge." >&2
-        exit 1
+      allow_degraded_merge=false
+      set +e
+      nonblocking_comment_count="$(
+        gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUM}/comments" \
+          | jq -r '[.[] | .[] | select(.user.login == "'"${CLOUD_BOT_LOGIN}"'") | select(.created_at >= "'"${POST_FIX_REVIEW_WINDOW_START}"'") | select((.body | test("(^|[^A-Za-z0-9])(P2|medium)([^A-Za-z0-9]|$)"; "i"))) ] | length' \
+          2>/dev/null
+      )"
+      nonblocking_count_rc=$?
+      set -e
+      if [ "${nonblocking_count_rc}" -eq 0 ] && [ "${nonblocking_comment_count:-0}" -gt 0 ] 2>/dev/null; then
+        allow_degraded_merge=true
+        echo "Detected ${nonblocking_comment_count} non-blocking MEDIUM/P2 bot comment(s); local fallback degradation may use merge-rationale path." >&2
       fi
+      echo "Falling back to local review." >&2
+      _run_local_fallback_review "${allow_degraded_merge}"
     fi
   fi
   BOT_CLEAN=true
 else
   echo "WARN: Post-fix bot wait returned timeout/no-marker. Falling back to local review."
-  SID=$(csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD")
-  if ! bash "${CSA_HELPER_DIR}/session-wait-until-done.sh" "$SID"; then
-    echo "ERROR: Local fallback review found issues after fix. Cannot merge." >&2
-    exit 1
-  fi
+  _run_local_fallback_review false
   BOT_CLEAN=true
 fi
 
@@ -2300,6 +2405,10 @@ fi
 BOT_HAS_ISSUES=false
 echo "CSA_VAR:POST_FIX_REUSED_REVIEW_ID=${POST_FIX_REUSED_REVIEW_ID}"
 echo "CSA_VAR:BOT_HAS_ISSUES=$BOT_HAS_ISSUES"
+echo "CSA_VAR:BOT_UNAVAILABLE=$BOT_UNAVAILABLE"
+echo "CSA_VAR:FALLBACK_REVIEW_HAS_ISSUES=$FALLBACK_REVIEW_HAS_ISSUES"
+echo "CSA_VAR:LOCAL_REVIEW_SESSION_ID=${LOCAL_REVIEW_SESSION_ID:-}"
+echo "CSA_VAR:MERGE_WITHOUT_BOT_REASON_KIND=${MERGE_WITHOUT_BOT_REASON_KIND:-}"
 echo "Post-fix re-review gate PASSED. Merge is now allowed."
 ```'''
 on_fail = "abort"
@@ -2376,9 +2485,10 @@ Note: this Step 6a path now also covers the latest-comment quota fallback once
 the workflow records the quota window.
 
 **MANDATORY**: Before merging, leave a PR comment explaining the merge rationale.
-This step has two audit-trail cases:
+This step has three audit-trail cases:
 - `cloud_bot=false`: "cloud_bot=false (disabled in config); merging on local review clean"
 - `MERGE_WITHOUT_BOT_REASON_KIND=cloud_bot_quota_exhausted`: explain the cached quota window and cite the local review session ID
+- `MERGE_WITHOUT_BOT_REASON_KIND=local_review_degraded_no_blocking_findings`: explain that the cloud bot produced no blocking findings and the local fallback review was unavailable/degraded
 When `MERGE_WITHOUT_BOT_REASON_KIND=cloud_bot_quota_exhausted`, the audit trail
 must explain the cached quota window and cite the local review session ID.
 
@@ -2419,6 +2529,23 @@ elif [ "${MERGE_WITHOUT_BOT_REASON_KIND:-}" = "cloud_bot_quota_exhausted" ]; the
       "Configured cloud bot \`${CLOUD_BOT_NAME}\` is quota-exhausted (detected at \`${CLOUD_BOT_QUOTA_EXHAUSTED_AT:-unknown}\`, expected reset \`${CLOUD_BOT_QUOTA_EXPECTED_RESET_AT:-unknown}\`). Per pr-bot quota fallback, routing to the bot-unavailable + local-review-clean merge path." \
       '' \
       "**Local pre-merge review verdict**: CLEAN (session \`${LOCAL_REVIEW_SESSION_ID:-unknown}\`)" \
+      '' \
+      '**Diff scope**:' \
+      '\`\`\`' \
+      "${DIFF_SUMMARY}" \
+      '\`\`\`'
+  )"
+elif [ "${MERGE_WITHOUT_BOT_REASON_KIND:-}" = "local_review_degraded_no_blocking_findings" ]; then
+  MERGE_REASON="cloud bot reported no blocking findings; local fallback review unavailable/degraded"
+  COMMENT_BODY="$(
+    printf '%s\n' \
+      '## Merge audit trail — local fallback review degraded' \
+      '' \
+      "Configured cloud bot \`${CLOUD_BOT_NAME}\` produced no HIGH/CRITICAL/P1 blocking findings. MEDIUM/P2 comments are non-blocking follow-up by policy." \
+      '' \
+      "Local fallback review could not complete with an available reviewer, so pr-bot is proceeding through the explicit degraded-local-review rationale path instead of aborting on a non-blocking cloud review." \
+      '' \
+      "**Local fallback review session**: \`${LOCAL_REVIEW_SESSION_ID:-unavailable}\`" \
       '' \
       '**Diff scope**:' \
       '\`\`\`' \

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -1818,25 +1818,25 @@ Parse the structured debate result from Step 8.
 ```bash
 set -euo pipefail
 DEBATE_OUTPUT="${STEP_12_OUTPUT}"
-VERDICT_COUNT="$(
-  printf '%s\n' "${DEBATE_OUTPUT}" \
-    | grep -Ec '^[[:space:]]*VERDICT: (DISMISSED|CONFIRMED)[[:space:]]*$' \
-    || true
-)"
-if [ "${VERDICT_COUNT}" != "1" ]; then
-  echo "ERROR: Debate output must contain exactly one VERDICT marker." >&2
-  exit 1
-fi
 VERDICT_MARKER="$(
   printf '%s\n' "${DEBATE_OUTPUT}" \
-    | grep -E '^[[:space:]]*VERDICT: (DISMISSED|CONFIRMED)[[:space:]]*$' \
-    | tail -n 1 \
-    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+    | sed -n -E 's/^[[:space:]]*VERDICT:[[:space:]]*([^[:space:]]+)[[:space:]]*$/VERDICT: \1/p' \
+    | sort -u \
     || true
 )"
+VERDICT_COUNT="$(
+  printf '%s\n' "${VERDICT_MARKER}" \
+    | sed '/^$/d' \
+    | wc -l \
+    | tr -d '[:space:]'
+)"
 
-if [ -z "${VERDICT_MARKER}" ]; then
+if [ "${VERDICT_COUNT}" = "0" ]; then
   echo "ERROR: Debate output missing VERDICT marker." >&2
+  exit 1
+fi
+if [ "${VERDICT_COUNT}" != "1" ]; then
+  echo "ERROR: Debate output contains conflicting VERDICT markers." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Three correctness fixes to the **pr-bot merge gate** (`patterns/pr-bot/workflow.toml`, with
`PATTERN.md` kept in sync per rule 027). These are `tool = "bash"` deterministic steps — exit codes
are checked programmatically, so the fixes live in the shell logic. The severity contract is
unchanged: only **HIGH / CRITICAL / P1** findings block a merge; MEDIUM aggregates to a follow-up
issue; LOW / nit are ignored.

- **Closes #1656** — Step 8a no longer aborts when arbitration emits the *same* `VERDICT:` line in
  both the summary and details sections. Identical-value VERDICT lines are deduped and treated as a
  single verdict; the gate fails only on genuinely **conflicting** verdicts (e.g. APPROVE vs REJECT).

- **Closes #1671** — the post-fix gate no longer counts MEDIUM (or LOW/nit) findings as blocking
  "actionable" comments. A COMMENTED cloud review carrying only MEDIUM/LOW findings no longer
  triggers a hard-fail / nit ping-pong. Only HIGH/CRITICAL/P1 count as blocking.

- **Closes #1702** — adds an explicit local-degraded merge-rationale branch. When cloud review is
  MEDIUM-only **and** the local review fallback is degraded / tool-unavailable, the gate now records
  a merge rationale and proceeds instead of deadlocking at the Step 6a no-rationale abort. Composes
  with #1671 (MEDIUM is non-blocking).

## Invariants preserved

- Genuinely-blocking findings (HIGH/CRITICAL/P1) and **conflicting** verdicts still abort the merge.
- The gate is not weakened beyond the documented severity policy.
- `weave compile` passes for the pr-bot pattern after each change; `PATTERN.md` ↔ `workflow.toml`
  are in sync (every `${VAR}` present in both).

## Testing

- `weave compile` (pr-bot) succeeds.
- Pre-commit hook gated each commit; pre-PR `csa review` verdict: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
