### PR TITLE
fix(pr-bot): Final Merge on cloud_bot=false + fail-closed reporting (#1779); UTC epoch time filter (#1692)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.846"
+version = "0.1.847"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.846"
+version = "0.1.847"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -1984,7 +1984,7 @@ bash "${REBASE_SCRIPT}"
 
 ## Step 6a: Merge Without Bot
 
-> **Layer**: 0 (Orchestrator) -- merge command, no code analysis.
+> **Layer**: 0 (Orchestrator) -- merge rationale, no code analysis.
 
 Tool: bash
 
@@ -2071,37 +2071,14 @@ else
 fi
 gh pr comment "${PR_NUM}" --repo "${REPO}" --body "${COMMENT_BODY}"
 
-MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
-DELETE_BRANCH_FLAG=""
-if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
-  DELETE_BRANCH_FLAG="--delete-branch"
-fi
-# shellcheck disable=SC2086
-gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
-
-# --- Inline post-merge checkout (defense-in-depth for #1401) ---
-_SYNC_BRANCH="${DEFAULT_BRANCH:-}"
-if [ -z "${_SYNC_BRANCH}" ]; then
-  _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
-fi
-if [ -n "${_SYNC_BRANCH}" ]; then
-  git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
-fi
-
-# Write pr-bot completion marker (deterministic gate for pre-merge hook).
-MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"
-MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG}"
-mkdir -p "${MARKER_DIR}"
-touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
-
-MERGE_COMPLETED=true
-echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
-echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
+echo "CSA_VAR:MERGE_REASON=${MERGE_REASON}"
+echo "CSA_VAR:MERGE_WITHOUT_BOT_REASON_KIND=${MERGE_WITHOUT_BOT_REASON_KIND}"
+echo '<!-- CSA:NEXT_STEP cmd="merge rationale recorded; proceed to Final Merge" required=true -->'
 ```
 
 ## ENDIF
 
-## IF !(${BOT_UNAVAILABLE})
+## IF !(${BOT_UNAVAILABLE}) || (!(${CLOUD_BOT}) || ((${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && !(${FALLBACK_REVIEW_HAS_ISSUES})))
 
 ## IF ${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED})
 
@@ -2147,13 +2124,18 @@ fi
 CSA_SKIP_REVIEW_CHECK=1 \
 CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12 pre-merge push" \
   git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+MERGED_PR_VERIFY_REF="$(gh pr view "${WORKFLOW_BRANCH}-clean" --repo "${REPO}" --json number -q .number 2>/dev/null || true)"
+if [ -z "${MERGED_PR_VERIFY_REF}" ]; then
+  echo "ERROR: Could not resolve clean-branch PR for ${WORKFLOW_BRANCH}-clean before final merge." >&2
+  exit 1
+fi
 MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
 DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
   DELETE_BRANCH_FLAG="--delete-branch"
 fi
 # shellcheck disable=SC2086
-gh pr merge "${WORKFLOW_BRANCH}-clean" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
+gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
 
 # --- Inline post-merge checkout (defense-in-depth for #1401) ---
 _SYNC_BRANCH="${DEFAULT_BRANCH:-}"
@@ -2172,6 +2154,7 @@ touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
 MERGE_COMPLETED=true
 echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
+echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```
 
@@ -2202,6 +2185,7 @@ fi
 CSA_SKIP_REVIEW_CHECK=1 \
 CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12b pre-merge push" \
   git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+MERGED_PR_VERIFY_REF="${PR_NUM}"
 MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
 DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
@@ -2227,6 +2211,7 @@ touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
 MERGE_COMPLETED=true
 echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
+echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```
 
@@ -2236,20 +2221,29 @@ echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" requ
 
 ## ENDIF
 
-## IF ${MERGE_COMPLETED}
-
 ## Step 13: Post-Merge Default Branch Checkout
 
-> **Layer**: 0 (Orchestrator) -- best-effort checkout after successful merge.
+> **Layer**: 0 (Orchestrator) -- merged-state guard plus best-effort checkout.
 
 Tool: bash
+OnFail: abort
 
-After `gh pr merge` succeeds, leave the working tree on the dynamically
-detected default branch and pull its latest remote state. This step is
-best-effort: checkout or pull failure warns but does not change the successful
-merge outcome.
+Verify the PR is actually merged before reporting success. Then leave the
+working tree on the dynamically detected default branch and pull its latest
+remote state. Checkout or pull failure warns but does not change the successful
+merge outcome after the GitHub PR state is `MERGED`.
 
 ```bash
+VERIFY_PR_REF="${MERGED_PR_VERIFY_REF:-${PR_NUM}}"
+PR_STATE="$(gh pr view "${VERIFY_PR_REF}" --repo "${REPO}" --json state -q .state 2>/dev/null || true)"
+if [ "${PR_STATE}" != "MERGED" ]; then
+  if [ -z "${PR_STATE}" ]; then
+    PR_STATE="UNKNOWN"
+  fi
+  echo "ERROR: Final Merge was skipped or failed and PR ${VERIFY_PR_REF} is still ${PR_STATE} -- refusing to report success." >&2
+  exit 1
+fi
+
 set +e
 SYNC_REMOTE="${REMOTE_NAME:-origin}"
 SYNC_DEFAULT_BRANCH="${DEFAULT_BRANCH:-}"
@@ -2262,21 +2256,22 @@ if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
 fi
 if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
   echo "WARNING: post-merge checkout skipped: could not determine default branch." >&2
+  echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
   exit 0
 fi
 if ! git checkout "${SYNC_DEFAULT_BRANCH}"; then
   echo "WARNING: post-merge checkout of ${SYNC_DEFAULT_BRANCH} failed; leaving current branch unchanged." >&2
+  echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
   exit 0
 fi
 if ! git pull --ff-only "${SYNC_REMOTE}" "${SYNC_DEFAULT_BRANCH}"; then
   echo "WARNING: post-merge pull of ${SYNC_REMOTE}/${SYNC_DEFAULT_BRANCH} failed; merge already completed." >&2
+  echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
   exit 0
 fi
 git log --oneline -1
 echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
 ```
-
-## ENDIF
 
 ## Post-Merge Extensions
 

--- a/patterns/pr-bot/scripts/pr-bot-wait.sh
+++ b/patterns/pr-bot/scripts/pr-bot-wait.sh
@@ -118,9 +118,15 @@ repo_from_origin() {
 }
 
 REPO="$(repo_from_origin)"
+# PUSH_TIME is the push commit's author/commit time as epoch seconds (UTC,
+# offset-independent). GitHub API timestamps (.submitted_at / .created_at) are
+# UTC ISO8601 with a `Z` suffix; comparing them as raw strings against a
+# local-offset ISO8601 string mis-orders mixed-offset instants and can mask a
+# genuinely-new finding (#1692). Normalizing both sides to epoch seconds makes
+# the comparison numeric and timezone-safe.
 PUSH_TIME=""
 if [ -n "${PUSH_SHA}" ]; then
-  PUSH_TIME="$(git show -s --format=%cI "${PUSH_SHA}")"
+  PUSH_TIME="$(git show -s --format=%ct "${PUSH_SHA}")"
 fi
 
 if [ -z "${BOT_NAME}" ]; then
@@ -147,7 +153,7 @@ review_filter() {
     jq -c --arg login "${BOT_LOGIN}" --arg push_time "${PUSH_TIME}" --arg push_sha "${PUSH_SHA}" --arg window_start "${WINDOW_START}" '
       [ .[] | .[]
         | select((.user.login // "") == $login)
-        | select($push_time == "" or (.submitted_at // "") > $push_time)
+        | select($push_time == "" or ((.submitted_at // "" | fromdateiso8601? // 0) > ($push_time | tonumber)))
         | select(
             $push_sha == ""
             or (.commit_id // "") == $push_sha
@@ -161,7 +167,7 @@ review_filter() {
     jq -c --arg push_time "${PUSH_TIME}" --arg push_sha "${PUSH_SHA}" --arg window_start "${WINDOW_START}" '
       [ .[] | .[]
         | select((.user.type // "") == "Bot" or ((.user.login // "") | test("\\[bot\\]$")))
-        | select($push_time == "" or (.submitted_at // "") > $push_time)
+        | select($push_time == "" or ((.submitted_at // "" | fromdateiso8601? // 0) > ($push_time | tonumber)))
         | select(
             $push_sha == ""
             or (.commit_id // "") == $push_sha
@@ -197,7 +203,7 @@ while [ "${elapsed}" -le "${TIMEOUT_SEC}" ]; do
       printf '%s\n' "${comments_json}" | jq -c --arg login "${BOT_LOGIN}" --arg push_time "${PUSH_TIME}" '
         [ .[] | .[]
           | select((.user.login // "") == $login)
-          | select($push_time == "" or (.created_at // "") > $push_time)
+          | select($push_time == "" or ((.created_at // "" | fromdateiso8601? // 0) > ($push_time | tonumber)))
         ]
         | sort_by(.created_at)
         | last // empty
@@ -206,7 +212,7 @@ while [ "${elapsed}" -le "${TIMEOUT_SEC}" ]; do
       printf '%s\n' "${comments_json}" | jq -c --arg push_time "${PUSH_TIME}" '
         [ .[] | .[]
           | select((.user.type // "") == "Bot" or ((.user.login // "") | test("\\[bot\\]$")))
-          | select($push_time == "" or (.created_at // "") > $push_time)
+          | select($push_time == "" or ((.created_at // "" | fromdateiso8601? // 0) > ($push_time | tonumber)))
         ]
         | sort_by(.created_at)
         | last // empty

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -222,6 +222,9 @@ name = "MARKER_REPO_SLUG"
 name = "MAX_REVIEW_ROUNDS"
 
 [[workflow.variables]]
+name = "MERGED_PR_VERIFY_REF"
+
+[[workflow.variables]]
 name = "MERGE_COMPLETED"
 
 [[workflow.variables]]
@@ -385,6 +388,9 @@ name = "VERDICT_COUNT"
 
 [[workflow.variables]]
 name = "VERDICT_MARKER"
+
+[[workflow.variables]]
+name = "VERIFY_PR_REF"
 
 [[workflow.variables]]
 name = "WAIT_BASE_TS"
@@ -2472,7 +2478,7 @@ id = 20
 title = "Step 6a: Merge Without Bot"
 tool = "bash"
 prompt = '''
-> **Layer**: 0 (Orchestrator) -- merge command, no code analysis.
+> **Layer**: 0 (Orchestrator) -- merge rationale, no code analysis.
 
 
 Cloud bot explicitly disabled (cloud_bot=false). Local fallback review passed
@@ -2558,32 +2564,9 @@ else
 fi
 gh pr comment "${PR_NUM}" --repo "${REPO}" --body "${COMMENT_BODY}"
 
-MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
-DELETE_BRANCH_FLAG=""
-if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
-  DELETE_BRANCH_FLAG="--delete-branch"
-fi
-# shellcheck disable=SC2086
-gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
-
-# --- Inline post-merge checkout (defense-in-depth for #1401) ---
-_SYNC_BRANCH="${DEFAULT_BRANCH:-}"
-if [ -z "${_SYNC_BRANCH}" ]; then
-  _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
-fi
-if [ -n "${_SYNC_BRANCH}" ]; then
-  git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
-fi
-
-# Write pr-bot completion marker (deterministic gate for pre-merge hook).
-MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"
-MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG}"
-mkdir -p "${MARKER_DIR}"
-touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
-
-MERGE_COMPLETED=true
-echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
-echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
+echo "CSA_VAR:MERGE_REASON=${MERGE_REASON}"
+echo "CSA_VAR:MERGE_WITHOUT_BOT_REASON_KIND=${MERGE_WITHOUT_BOT_REASON_KIND}"
+echo '<!-- CSA:NEXT_STEP cmd="merge rationale recorded; proceed to Final Merge" required=true -->'
 ```'''
 on_fail = "abort"
 condition = "(!(${MERGE_COMPLETED})) && (!(${CLOUD_BOT}) || ((${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && !(${FALLBACK_REVIEW_HAS_ISSUES})))"
@@ -2607,7 +2590,7 @@ CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push clean branch for PR" \
 gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${CLEAN_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}"
 ```'''
 on_fail = "abort"
-condition = "(!(${MERGE_COMPLETED})) && ((!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED})))"
+condition = "(!(${MERGE_COMPLETED})) && ((!(${BOT_UNAVAILABLE}) || (!(${CLOUD_BOT}) || ((${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && !(${FALLBACK_REVIEW_HAS_ISSUES})))) && (${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED})))"
 
 [[workflow.steps]]
 id = 22
@@ -2635,13 +2618,18 @@ fi
 CSA_SKIP_REVIEW_CHECK=1 \
 CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12 pre-merge push" \
   git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+MERGED_PR_VERIFY_REF="$(gh pr view "${WORKFLOW_BRANCH}-clean" --repo "${REPO}" --json number -q .number 2>/dev/null || true)"
+if [ -z "${MERGED_PR_VERIFY_REF}" ]; then
+  echo "ERROR: Could not resolve clean-branch PR for ${WORKFLOW_BRANCH}-clean before final merge." >&2
+  exit 1
+fi
 MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
 DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
   DELETE_BRANCH_FLAG="--delete-branch"
 fi
 # shellcheck disable=SC2086
-gh pr merge "${WORKFLOW_BRANCH}-clean" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
+gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
 
 # --- Inline post-merge checkout (defense-in-depth for #1401) ---
 _SYNC_BRANCH="${DEFAULT_BRANCH:-}"
@@ -2660,10 +2648,11 @@ touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
 MERGE_COMPLETED=true
 echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
+echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```'''
 on_fail = "abort"
-condition = "(!(${MERGE_COMPLETED})) && ((!(${BOT_UNAVAILABLE})) && (${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED})))"
+condition = "(!(${MERGE_COMPLETED})) && ((!(${BOT_UNAVAILABLE}) || (!(${CLOUD_BOT}) || ((${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && !(${FALLBACK_REVIEW_HAS_ISSUES})))) && (${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED})))"
 
 [[workflow.steps]]
 id = 23
@@ -2691,6 +2680,7 @@ fi
 CSA_SKIP_REVIEW_CHECK=1 \
 CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12b pre-merge push" \
   git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+MERGED_PR_VERIFY_REF="${PR_NUM}"
 MERGE_STRATEGY=$(csa config get pr_review.merge_strategy --default merge)
 DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
@@ -2716,25 +2706,36 @@ touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
 MERGE_COMPLETED=true
 echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
+echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```'''
 on_fail = "abort"
-condition = "(!(${MERGE_COMPLETED})) && ((!(${BOT_UNAVAILABLE})) && (!(${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED}))))"
+condition = "(!(${MERGE_COMPLETED})) && ((!(${BOT_UNAVAILABLE}) || (!(${CLOUD_BOT}) || ((${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && !(${FALLBACK_REVIEW_HAS_ISSUES})))) && (!(${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED}))))"
 
 [[workflow.steps]]
 id = 24
 title = "Post-Merge Default Branch Checkout"
 tool = "bash"
 prompt = '''
-> **Layer**: 0 (Orchestrator) -- best-effort checkout after successful merge.
+> **Layer**: 0 (Orchestrator) -- merged-state guard plus best-effort checkout.
 
 
-After `gh pr merge` succeeds, leave the working tree on the dynamically
-detected default branch and pull its latest remote state. This step is
-best-effort: checkout or pull failure warns but does not change the successful
-merge outcome.
+Verify the PR is actually merged before reporting success. Then leave the
+working tree on the dynamically detected default branch and pull its latest
+remote state. Checkout or pull failure warns but does not change the successful
+merge outcome after the GitHub PR state is `MERGED`.
 
 ```bash
+VERIFY_PR_REF="${MERGED_PR_VERIFY_REF:-${PR_NUM}}"
+PR_STATE="$(gh pr view "${VERIFY_PR_REF}" --repo "${REPO}" --json state -q .state 2>/dev/null || true)"
+if [ "${PR_STATE}" != "MERGED" ]; then
+  if [ -z "${PR_STATE}" ]; then
+    PR_STATE="UNKNOWN"
+  fi
+  echo "ERROR: Final Merge was skipped or failed and PR ${VERIFY_PR_REF} is still ${PR_STATE} -- refusing to report success." >&2
+  exit 1
+fi
+
 set +e
 SYNC_REMOTE="${REMOTE_NAME:-origin}"
 SYNC_DEFAULT_BRANCH="${DEFAULT_BRANCH:-}"
@@ -2747,21 +2748,23 @@ if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
 fi
 if [ -z "${SYNC_DEFAULT_BRANCH}" ]; then
   echo "WARNING: post-merge checkout skipped: could not determine default branch." >&2
+  echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
   exit 0
 fi
 if ! git checkout "${SYNC_DEFAULT_BRANCH}"; then
   echo "WARNING: post-merge checkout of ${SYNC_DEFAULT_BRANCH} failed; leaving current branch unchanged." >&2
+  echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
   exit 0
 fi
 if ! git pull --ff-only "${SYNC_REMOTE}" "${SYNC_DEFAULT_BRANCH}"; then
   echo "WARNING: post-merge pull of ${SYNC_REMOTE}/${SYNC_DEFAULT_BRANCH} failed; merge already completed." >&2
+  echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
   exit 0
 fi
 git log --oneline -1
 echo '<!-- CSA:NEXT_STEP cmd="pipeline complete — PR merged" required=false -->'
 ```'''
 on_fail = "abort"
-condition = "${MERGE_COMPLETED}"
 
 [[workflow.steps]]
 id = 25


### PR DESCRIPTION
## Summary

Two independent pr-bot reliability fixes (one commit per issue).

### #1779 — Final Merge SKIPPED with `cloud_bot=false`, yet reports success

With `[pr_review] cloud_bot = false`, `csa plan run --pattern pr-bot` printed
`pipeline complete — PR merged` and exited `status=success`, but the Final Merge
steps were SKIPPED ("condition not met") and the PR was left **OPEN** — a silent
false-success that is dangerous in headless pipelines that trust the exit code.

- The Final Merge gating condition now honors the local-review-clean signal that
  already drives the merge-rationale comment, so the merge actually runs under the
  config's documented "local review is the merge gate" policy.
- Fail-closed reporting: the pipeline verifies the PR reached `MERGED` state before
  emitting the "PR merged" / success signal; a skipped-merge-with-open-PR now aborts
  non-zero instead of reporting success.

### #1692 — `pr-bot-wait.sh` `%cI` local-offset vs GitHub UTC `Z` time filter

`pr-bot-wait.sh` derived the push cutoff with `git show -s --format=%cI` (local TZ
offset) and compared it lexicographically against GitHub's UTC `Z` timestamps. Mixed
offsets mis-order under string comparison, producing false `{"status":"replied"}` and
risking masking a genuinely-new finding posted shortly after a stale comment.

- Comparisons are now timezone-normalized (epoch seconds via `%ct` +
  `fromdateiso8601`), so review/comment freshness is computed correctly regardless of
  the host's local commit timezone. The `commit_id == push_sha` review-path guard is
  preserved.

Both fixes keep `patterns/pr-bot/PATTERN.md` and `patterns/pr-bot/workflow.toml` in
sync (rule 027).

Closes #1779
Closes #1692
