### PR TITLE
fix(cli-sub-agent): CLI flag-ergonomics — model-spec passthrough, tool defaults under bypass, non-candidate warning (#1691 #1703 #1791)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.848"
+version = "0.1.849"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.848"
+version = "0.1.849"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_common.rs
+++ b/crates/cli-sub-agent/src/cli_common.rs
@@ -40,13 +40,45 @@ pub(crate) fn validate_return_to(value: &str) -> std::result::Result<String, Str
 }
 
 pub(crate) fn parse_model_spec_arg(spec: &str) -> std::result::Result<String, String> {
+    let (value, warning) = parse_model_spec_arg_with_warning(spec)?;
+    if let Some(warning) = warning {
+        eprintln!("{warning}");
+    }
+    Ok(value)
+}
+
+pub(crate) fn parse_model_spec_arg_with_warning(
+    spec: &str,
+) -> std::result::Result<(String, Option<String>), String> {
     let known_tools: Vec<&'static str> = csa_config::global::all_known_tools()
         .iter()
         .map(|tool| tool.as_str())
         .collect();
-    csa_executor::ModelSpec::parse_and_validate(spec, &known_tools)
-        .map(|_| spec.to_string())
-        .map_err(|e| e.to_string())
+    let parsed = csa_executor::ModelSpec::parse(spec).map_err(|e| e.to_string())?;
+    if parsed.tool.trim().is_empty()
+        || parsed.provider.trim().is_empty()
+        || parsed.model.trim().is_empty()
+    {
+        return Err(format!(
+            "Invalid model spec '{spec}': tool/provider/model/thinking_budget segments cannot be empty"
+        ));
+    }
+
+    match parsed.validate_with_catalog(&known_tools) {
+        Ok(()) => Ok((spec.to_string(), None)),
+        Err(csa_executor::model_spec::ModelSpecValidationError::UnknownModel {
+            tool,
+            provider,
+            got,
+            ..
+        }) => Ok((
+            spec.to_string(),
+            Some(format!(
+                "warning: model '{got}' for tool '{tool}' provider '{provider}' is not recognized in CSA's built-in model registry; passing it through unchanged, but the backend may reject it"
+            )),
+        )),
+        Err(err) => Err(err.to_string()),
+    }
 }
 
 pub(crate) fn parse_spec_path_arg(spec: &str) -> std::result::Result<String, String> {
@@ -59,4 +91,39 @@ pub(crate) fn validate_ulid(value: &str) -> std::result::Result<String, String> 
     csa_session::validate_session_id(value)
         .map(|_| value.to_string())
         .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_model_spec_arg_with_warning;
+
+    #[test]
+    fn parse_model_spec_arg_warns_and_passes_unknown_model() {
+        let (value, warning) =
+            parse_model_spec_arg_with_warning("codex/openai/claude-opus-4-8/xhigh").unwrap();
+
+        assert_eq!(value, "codex/openai/claude-opus-4-8/xhigh");
+        let warning = warning.expect("unknown model should warn");
+        assert!(warning.starts_with("warning:"), "{warning}");
+        assert!(warning.contains("claude-opus-4-8"), "{warning}");
+        assert!(warning.contains("not recognized"), "{warning}");
+        assert!(warning.contains("backend may reject"), "{warning}");
+    }
+
+    #[test]
+    fn parse_model_spec_arg_still_rejects_unknown_provider() {
+        let err = parse_model_spec_arg_with_warning("codex/anthropic/gpt-5.5/xhigh")
+            .expect_err("unknown provider should remain a hard error");
+
+        assert!(err.contains("anthropic"), "{err}");
+        assert!(err.contains("openai"), "{err}");
+    }
+
+    #[test]
+    fn parse_model_spec_arg_still_rejects_empty_segments() {
+        let err = parse_model_spec_arg_with_warning("/openai/gpt-5.5/xhigh")
+            .expect_err("empty tool should remain malformed");
+
+        assert!(err.contains("segments cannot be empty"), "{err}");
+    }
 }

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -651,7 +651,7 @@ fn debate_cli_parses_fast_but_more_cost_flag() {
 }
 
 #[test]
-fn debate_rejects_unknown_codex_model_at_clap_parse() {
+fn debate_accepts_unknown_codex_model_at_clap_parse() {
     use clap::Parser;
 
     let result = crate::cli::Cli::try_parse_from([
@@ -661,13 +661,9 @@ fn debate_rejects_unknown_codex_model_at_clap_parse() {
         "codex/openai/o3/xhigh",
         "question",
     ]);
-    let err = match result {
-        Ok(_) => panic!("unknown model should fail clap parsing"),
-        Err(err) => err,
-    };
-    let msg = err.to_string();
-    assert!(msg.contains("o3"), "missing offending model: {msg}");
-    assert!(msg.contains("gpt-5.5"), "missing valid alternative: {msg}");
+    if let Err(err) = result {
+        panic!("unknown model should pass through to backend validation: {err}");
+    }
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/pipeline_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_preflight.rs
@@ -96,29 +96,30 @@ async fn execute_with_session_and_meta_fails_preflight_before_creating_session()
 }
 
 #[tokio::test]
-async fn run_invalid_model_spec_fails_before_creating_session() {
+async fn run_malformed_model_spec_fails_before_creating_session() {
     let temp = tempfile::tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&temp).await;
 
-    let result = crate::cli::Cli::try_parse_from([
-        "csa",
-        "run",
-        "--model-spec",
-        "codex/openai/o4-mini/xhigh",
-        "prompt",
-    ]);
+    let result =
+        crate::cli::Cli::try_parse_from(["csa", "run", "--model-spec", "codex/openai", "prompt"]);
     let err = match result {
-        Ok(_) => panic!("unknown model should fail clap parsing"),
+        Ok(_) => panic!("malformed model spec should fail clap parsing"),
         Err(err) => err,
     };
     let msg = err.to_string();
-    assert!(msg.contains("o4-mini"), "missing offending model: {msg}");
-    assert!(msg.contains("gpt-5.5"), "missing valid alternative: {msg}");
+    assert!(
+        msg.contains("codex/openai"),
+        "missing offending spec: {msg}"
+    );
+    assert!(
+        msg.contains("tool/provider/model/thinking_budget"),
+        "missing expected format: {msg}"
+    );
 
     let sessions = csa_session::list_sessions(temp.path(), None).unwrap();
     assert!(
         sessions.is_empty(),
-        "invalid model spec must fail before session creation"
+        "malformed model spec must fail before session creation"
     );
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_tests/model_spec_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests/model_spec_tests.rs
@@ -1,15 +1,13 @@
 #[test]
-fn review_rejects_unknown_codex_model_at_clap_parse() {
-    let err = super::parse_review_error(&[
+fn review_accepts_unknown_codex_model_at_clap_parse() {
+    let args = super::parse_review_args(&[
         "csa",
         "review",
         "--model-spec",
         "codex/openai/o3/xhigh",
         "--diff",
     ]);
-    let msg = err.to_string();
-    assert!(msg.contains("o3"), "missing offending model: {msg}");
-    assert!(msg.contains("gpt-5.5"), "missing valid alternative: {msg}");
+    assert_eq!(args.model_spec.as_deref(), Some("codex/openai/o3/xhigh"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests.rs
@@ -57,15 +57,11 @@ fn try_parse_cli(args: &[&str]) -> Result<Cli, clap::Error> {
 }
 
 #[test]
-fn run_rejects_unknown_codex_model_at_clap_parse() {
+fn run_accepts_unknown_codex_model_at_clap_parse() {
     let result = try_parse_cli(&["csa", "run", "--model-spec", "codex/openai/o3/xhigh", "x"]);
-    let err = match result {
-        Ok(_) => panic!("unknown model should fail clap parsing"),
-        Err(err) => err,
-    };
-    let msg = err.to_string();
-    assert!(msg.contains("o3"), "missing offending model: {msg}");
-    assert!(msg.contains("gpt-5.5"), "missing valid alternative: {msg}");
+    if let Err(err) = result {
+        panic!("unknown model should pass through to backend validation: {err}");
+    }
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -232,14 +232,27 @@ pub(crate) fn resolve_tool_and_model(
     }
 
     if force_ignore_tier_setting && tiers_configured && tier.is_none() && model_spec.is_none() {
+        let configured_tool_defaults = tool.and_then(|tool_name| {
+            config.map(|cfg| {
+                (
+                    cfg.tool_default_model(tool_name.as_str()).is_some(),
+                    cfg.tool_default_thinking(tool_name.as_str()).is_some(),
+                )
+            })
+        });
+        let has_configured_default_model =
+            configured_tool_defaults.is_some_and(|(has_model, _)| has_model);
+        let has_configured_default_thinking =
+            configured_tool_defaults.is_some_and(|(_, has_thinking)| has_thinking);
+
         let mut missing = Vec::new();
         if tool.is_none() {
             missing.push("--tool");
         }
-        if model.is_none() {
+        if model.is_none() && !has_configured_default_model {
             missing.push("--model");
         }
-        if thinking.is_none() {
+        if thinking.is_none() && !has_configured_default_thinking {
             missing.push("--thinking");
         }
 

--- a/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
@@ -256,6 +256,42 @@ fn resolve_tool_and_model_force_ignore_tier_allows_complete_spec() {
 }
 
 #[test]
+fn resolve_tool_and_model_force_ignore_tier_uses_tool_defaults() {
+    let _guard = assume_tier_tools_available();
+    let mut cfg = config_with_tier("tier-1", vec!["codex/openai/gpt-4/high"], &["codex"]);
+    let codex = cfg
+        .tools
+        .get_mut("codex")
+        .expect("config_with_tier should create codex tool config");
+    codex.default_model = Some("gpt-5.4".to_string());
+    codex.default_thinking = Some("xhigh".to_string());
+
+    let result = super::resolve_tool_and_model(super::RoutingRequest {
+        tool: Some(ToolName::Codex),
+        config: Some(&cfg),
+        force_ignore_tier_setting: true,
+        ..super::RoutingRequest::new(std::path::Path::new("/tmp"))
+    });
+    let (tool, model_spec, model) = result.expect("configured tool defaults should satisfy bypass");
+    assert_eq!(tool, ToolName::Codex);
+    assert_eq!(model_spec, None);
+    assert_eq!(model, None);
+
+    let executor = super::build_executor(
+        &tool,
+        model_spec.as_deref(),
+        model.as_deref(),
+        None,
+        Some(&cfg),
+        true,
+    )
+    .expect("run execution should apply configured tool defaults");
+    let debug = format!("{executor:?}");
+    assert!(debug.contains("gpt-5.4"), "default model missing: {debug}");
+    assert!(debug.contains("Xhigh"), "default thinking missing: {debug}");
+}
+
+#[test]
 fn resolve_tool_and_model_force_ignore_tier_bypassed_when_tier_provided() {
     let _guard = assume_tier_tools_available();
     let cfg = config_with_tier("tier-1", vec!["codex/openai/gpt-4/high"], &["codex"]);

--- a/crates/cli-sub-agent/src/run_helpers_tier_resolution.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_resolution.rs
@@ -139,25 +139,23 @@ pub(crate) fn resolve_preferred_tool_from_tier(
     preference_order: &[String],
     skip_specs: &[String],
 ) -> Result<TierToolResolution> {
-    let Some(tier) = config.tiers.get(tier_name) else {
+    if !config.tiers.contains_key(tier_name) {
         anyhow::bail!("Tier '{}' not found.", tier_name);
-    };
+    }
+    let available = collect_available_tier_models(tier_name, config, skip_specs);
 
     for preferred_tool in preference_order {
-        if !tier.models.iter().any(|spec| {
-            !skip_specs.iter().any(|skip| skip == spec)
-                && spec
-                    .split('/')
-                    .next()
-                    .is_some_and(|tool_name| tool_name == preferred_tool)
-        }) {
+        if let Some(warning) =
+            ignored_tier_tool_preference_warning(tier_name, preferred_tool, &available)
+        {
             let suggestions = config.suggest_compatible_alternatives(preferred_tool, tier_name);
             warn!(
                 tier = tier_name,
                 tool = preferred_tool,
                 suggestions = %suggestions,
-                "Preferred tool is not configured in tier; ignoring preference"
+                "Preferred tool is not an enabled tier candidate; ignoring preference"
             );
+            eprintln!("{warning}");
         }
     }
 
@@ -171,6 +169,41 @@ pub(crate) fn resolve_preferred_tool_from_tier(
         "Tier '{}' has no currently available tools. Ensure at least one tier tool is installed and enabled.",
         tier_name
     );
+}
+
+fn ignored_tier_tool_preference_warning(
+    tier_name: &str,
+    preferred_tool: &str,
+    available: &[TierToolResolution],
+) -> Option<String> {
+    if available
+        .iter()
+        .any(|resolution| resolution.tool.as_str() == preferred_tool)
+    {
+        return None;
+    }
+
+    let mut candidate_tools: Vec<&str> = Vec::new();
+    for resolution in available {
+        let tool = resolution.tool.as_str();
+        if !candidate_tools.contains(&tool) {
+            candidate_tools.push(tool);
+        }
+    }
+
+    let candidates = if candidate_tools.is_empty() {
+        "none".to_string()
+    } else {
+        candidate_tools.join(", ")
+    };
+    let proceeding = available
+        .first()
+        .map(|resolution| resolution.tool.as_str())
+        .unwrap_or("no available tool");
+
+    Some(format!(
+        "warning: --tool {preferred_tool} ignored - not an enabled candidate of tier '{tier_name}' (candidates: {candidates}); proceeding with {proceeding}"
+    ))
 }
 
 pub(crate) fn resolve_tool_from_tier(
@@ -198,4 +231,52 @@ pub(crate) fn resolve_tool_from_tier(
         return Some(resolution.clone());
     }
     Some(available[0].clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TierToolResolution, ignored_tier_tool_preference_warning};
+    use csa_core::types::ToolName;
+
+    #[test]
+    fn ignored_tier_tool_preference_warning_names_candidates() {
+        let warning = ignored_tier_tool_preference_warning(
+            "tier-4-critical",
+            "claude-code",
+            &[
+                TierToolResolution {
+                    tool: ToolName::GeminiCli,
+                    model_spec: "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+                },
+                TierToolResolution {
+                    tool: ToolName::Codex,
+                    model_spec: "codex/openai/gpt-5.5/xhigh".to_string(),
+                },
+            ],
+        )
+        .expect("missing preferred tool should produce warning");
+
+        assert!(warning.starts_with("warning:"), "{warning}");
+        assert!(warning.contains("--tool claude-code ignored"), "{warning}");
+        assert!(warning.contains("tier 'tier-4-critical'"), "{warning}");
+        assert!(
+            warning.contains("candidates: gemini-cli, codex"),
+            "{warning}"
+        );
+        assert!(warning.contains("proceeding with gemini-cli"), "{warning}");
+    }
+
+    #[test]
+    fn ignored_tier_tool_preference_warning_skips_available_tool() {
+        let warning = ignored_tier_tool_preference_warning(
+            "tier-4-critical",
+            "codex",
+            &[TierToolResolution {
+                tool: ToolName::Codex,
+                model_spec: "codex/openai/gpt-5.5/xhigh".to_string(),
+            }],
+        );
+
+        assert_eq!(warning, None);
+    }
 }

--- a/crates/cli-sub-agent/src/sa_mode_tests.rs
+++ b/crates/cli-sub-agent/src/sa_mode_tests.rs
@@ -117,7 +117,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_sub_agent_rejects_unknown_codex_model_at_clap_parse() {
+    fn claude_sub_agent_accepts_unknown_codex_model_at_clap_parse() {
         let result = Cli::try_parse_from([
             "csa",
             "claude-sub-agent",
@@ -125,13 +125,9 @@ mod tests {
             "codex/openai/o3/xhigh",
             "question",
         ]);
-        let err = match result {
-            Ok(_) => panic!("unknown model should fail clap parsing"),
-            Err(err) => err,
-        };
-        let msg = err.to_string();
-        assert!(msg.contains("o3"), "missing offending model: {msg}");
-        assert!(msg.contains("gpt-5.5"), "missing valid alternative: {msg}");
+        if let Err(err) = result {
+            panic!("unknown model should pass through to backend validation: {err}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three CLI flag-ergonomics fixes in the tier / tool / model resolution path (one commit each).

### #1691 — `--model-spec` hard-rejects unknown models; warn-and-passthrough instead

`csa --model-spec <spec>` hard-rejected any model not in the built-in registry, so a newly
released model (e.g. `claude-opus-4-8`) was unusable until the registry was bumped in code.
Unknown models now emit a `warning:` and are **passed through** to the backend tool (which
validates them), instead of erroring. Genuinely malformed specs still hard-error.

### #1703 — `--force-ignore-tier-setting` + `--tool` rejected configured tool defaults

With tiers configured, the documented bypass `csa run --force-ignore-tier-setting --tool <X>`
hard-rejected the presence of a configured `default_model` / `default_thinking` under
`[tools.<X>]`. When the tier setting is explicitly bypassed and a `--tool` is named, that tool's
configured defaults are now applied rather than rejected. The #1749 gate on the non-bypass path is
unchanged.

### #1791 — `--tool <X>` silently ignored when X is not an enabled tier candidate

Under a non-empty tier, `--tool <X>` is a soft preference that only reorders within the active
tier's candidate list (#1749). When `<X>` is not an enabled candidate (disabled, or not listed),
the flag was a silent no-op — the resolver ran the tier-first tool with no diagnostic. It now
emits a `warning:` naming the ignored tool and the actual candidate set, so the surprising routing
is visible.

Closes #1691
Closes #1703
Closes #1791
