### PR TITLE
fix(csa-scheduler): preserve permanent quota normalization (#1798)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.849"
+version = "0.1.850"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.849"
+version = "0.1.850"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -474,8 +474,11 @@ async fn handle_debate_marks_unavailable_when_all_tier_models_fail() {
     std::fs::create_dir_all(&bin_dir).unwrap();
 
     {
-        let (binary, version, stderr_line) =
-            ("gemini", "gemini-cli 1.0.0", "reason: 'QUOTA_EXHAUSTED'");
+        let (binary, version, stderr_line) = (
+            "gemini",
+            "gemini-cli 1.0.0",
+            "reason: 'QUOTA_EXHAUSTED'; monthly spending cap reached",
+        );
         let path = bin_dir.join(binary);
         std::fs::write(
             &path,

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -663,7 +663,7 @@ async fn execute_review_marks_unavailable_when_all_tier_models_fail() {
     exact_test_write_executable(
         &bin_dir,
         "gemini",
-        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\nexit 1\n",
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf \"reason: 'QUOTA_EXHAUSTED'; monthly spending cap reached\\n\" >&2\nexit 1\n",
     );
     exact_test_write_executable(
         &bin_dir,
@@ -749,7 +749,7 @@ async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metad
     exact_test_write_executable(
         &bin_dir,
         "gemini",
-        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\nexit 1\n",
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf \"reason: 'QUOTA_EXHAUSTED'; monthly spending cap reached\\n\" >&2\nexit 1\n",
     );
     exact_test_write_executable(
         &bin_dir,

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
@@ -139,7 +139,7 @@ async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metad
 
     std::fs::write(
         bin_dir.join("gemini"),
-        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\nexit 1\n",
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf \"reason: 'QUOTA_EXHAUSTED'; monthly spending cap reached\\n\" >&2\nexit 1\n",
     )
     .unwrap();
     std::fs::write(
@@ -274,7 +274,7 @@ async fn execute_review_advances_tier_fallback_when_explicit_tool_and_tier() {
     std::fs::write(
         bin_dir.join("gemini"),
         format!(
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf 'gemini should not be invoked\\n' >> \"{gemini_invocation_log_str}\"\nprintf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\nexit 1\n"
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf 'gemini should not be invoked\\n' >> \"{gemini_invocation_log_str}\"\nprintf \"reason: 'QUOTA_EXHAUSTED'; monthly spending cap reached\\n\" >&2\nexit 1\n"
         ),
     )
     .unwrap();
@@ -418,7 +418,7 @@ async fn execute_review_marks_unavailable_when_all_tier_models_fail() {
 
     std::fs::write(
         bin_dir.join("gemini"),
-        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\nexit 1\n",
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf \"reason: 'QUOTA_EXHAUSTED'; monthly spending cap reached\\n\" >&2\nexit 1\n",
     )
     .unwrap();
     for binary in ["codex", "codex-acp"] {

--- a/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
@@ -502,7 +502,9 @@ fn evaluate_rate_limit_failover_continues_past_permanent_quota_to_next_provider(
     ]);
     let exec_result = ExecutionResult {
         output: String::new(),
-        stderr_output: "status RESOURCE_EXHAUSTED reason QUOTA_EXHAUSTED".to_string(),
+        stderr_output:
+            "status RESOURCE_EXHAUSTED reason QUOTA_EXHAUSTED monthly spending cap reached"
+                .to_string(),
         summary: "monthly spending cap reached".to_string(),
         exit_code: 1,
         peak_memory_mb: None,
@@ -931,7 +933,9 @@ fn evaluate_rate_limit_failover_gemini_quota_skips_antigravity_picks_codex() {
     ]);
     let exec_result = ExecutionResult {
         output: String::new(),
-        stderr_output: "status RESOURCE_EXHAUSTED reason QUOTA_EXHAUSTED".to_string(),
+        stderr_output:
+            "status RESOURCE_EXHAUSTED reason QUOTA_EXHAUSTED monthly spending cap reached"
+                .to_string(),
         summary: "daily quota for project exceeded".to_string(),
         exit_code: 1,
         peak_memory_mb: None,
@@ -979,7 +983,9 @@ fn evaluate_rate_limit_failover_chained_google_pool_exhaustion_continues_past() 
     ]);
     let exec_result = ExecutionResult {
         output: String::new(),
-        stderr_output: "status RESOURCE_EXHAUSTED reason QUOTA_EXHAUSTED".to_string(),
+        stderr_output:
+            "status RESOURCE_EXHAUSTED reason QUOTA_EXHAUSTED monthly spending cap reached"
+                .to_string(),
         summary: "Google quota pool exhausted".to_string(),
         exit_code: 1,
         peak_memory_mb: None,

--- a/crates/csa-scheduler/src/rate_limit.rs
+++ b/crates/csa-scheduler/src/rate_limit.rs
@@ -207,24 +207,6 @@ fn patterns_for_tool(tool: &str) -> &'static [FailoverPattern] {
                 quota_exhausted: false,
             },
             FailoverPattern {
-                pattern: "429_quota_exhausted",
-                reason: "HTTP 429",
-                advance_to_next_model: true,
-                quota_exhausted: false,
-            },
-            FailoverPattern {
-                pattern: "quota_exhausted",
-                reason: "HTTP 429",
-                advance_to_next_model: true,
-                quota_exhausted: false,
-            },
-            FailoverPattern {
-                pattern: "quota exhausted",
-                reason: "HTTP 429",
-                advance_to_next_model: true,
-                quota_exhausted: false,
-            },
-            FailoverPattern {
                 pattern: "monthly spending cap",
                 reason: "QUOTA_EXHAUSTED",
                 advance_to_next_model: true,
@@ -247,6 +229,24 @@ fn patterns_for_tool(tool: &str) -> &'static [FailoverPattern] {
                 reason: "QUOTA_EXHAUSTED",
                 advance_to_next_model: true,
                 quota_exhausted: true,
+            },
+            FailoverPattern {
+                pattern: "429_quota_exhausted",
+                reason: "HTTP 429",
+                advance_to_next_model: true,
+                quota_exhausted: false,
+            },
+            FailoverPattern {
+                pattern: "quota_exhausted",
+                reason: "HTTP 429",
+                advance_to_next_model: true,
+                quota_exhausted: false,
+            },
+            FailoverPattern {
+                pattern: "quota exhausted",
+                reason: "HTTP 429",
+                advance_to_next_model: true,
+                quota_exhausted: false,
             },
             FailoverPattern {
                 pattern: "quota exceeded",

--- a/crates/csa-scheduler/src/rate_limit_tests.rs
+++ b/crates/csa-scheduler/src/rate_limit_tests.rs
@@ -317,6 +317,23 @@ fn test_gemini_quota_exhausted_case_insensitive() {
 }
 
 #[test]
+fn test_gemini_quota_exhausted_with_spending_cap_is_permanent() {
+    let result = detect_rate_limit(
+        "gemini-cli",
+        "status: RESOURCE_EXHAUSTED; reason: QUOTA_EXHAUSTED; monthly spending cap reached",
+        "",
+        1,
+        None,
+    );
+    assert!(result.is_some());
+    let detected = result.unwrap();
+    assert_eq!(detected.matched_pattern, "monthly spending cap");
+    assert_eq!(detected.reason, "QUOTA_EXHAUSTED");
+    assert!(detected.advance_to_next_model);
+    assert!(detected.quota_exhausted);
+}
+
+#[test]
 fn test_persistent_429_quota_exhausted_advances_to_next_model() {
     let detected = detect_rate_limit(
         "codex",


### PR DESCRIPTION
## Summary

Fixes a quota/failover error-classification regression introduced by #1719 (`d9cc2698`,
*"treat quota auth failover as transient"*) that (a) broke 7 workspace tests — blocking the
pre-commit gate for **all** commits — and (b) caused genuine permanent Gemini quota to be
misclassified as transient.

Closes #1798. Follow-up correction to #1719 (#207 cluster).

## Root cause

The `csa-scheduler` rate-limit pattern table is **order-early-stop**. #1719 intentionally reclassified
**bare** `quota_exhausted` / `QUOTA_EXHAUSTED` markers from permanent (`QUOTA_EXHAUSTED`) to transient
(`HTTP 429`) — correct on its own — but placed the new transient bare-marker entry **before** the
permanent `monthly spending cap` entry. Consequently a real permanent reason such as
`QUOTA_EXHAUSTED; monthly spending cap reached` matched the transient entry first and was downgraded
to transient `HTTP 429`. This is a real correctness bug (permanent billing/spending-cap exhaustion
would be retried instead of marking the tool pool exhausted), not just a test-fixture issue.

The visible symptom was 7 tests leaking `HTTP 429` where they assert the canonical `QUOTA_EXHAUSTED`
permanent classification, because their fixtures used bare markers that #1719 now treats as transient.

## Changes

- **`crates/csa-scheduler/src/rate_limit.rs`**: reorder so permanent-context patterns
  (`monthly spending cap`, etc.) are matched **before** the bare transient quota markers — preserving
  #1719's bare-marker-transient intent while preventing permanent-context errors from being shadowed.
- **`crates/csa-scheduler/src/rate_limit_tests.rs`**: regression test asserting both directions
  (bare marker → transient; bare marker + spending-cap context → permanent).
- **Fixtures** (`review_cmd_exact_tests.rs`, `debate_cmd_tests_tail.rs`,
  `review_cmd_execute_tier_tests.rs`, `run_cmd_attempt_tests.rs`): permanent-asserting cases now use
  deterministic `monthly spending cap reached` permanent context. A same-tool tier-fallback fixture
  that legitimately represents a transient case was intentionally left on the bare marker (correct
  per #1719).

## Validation

- The 7 originally-failing tests pass; full `just pre-commit` (fmt + clippy + nextest) passes.
- Heterogeneous review gate (tier-4) on the CRITICAL-risk classifier change.
- No revert of #1719 semantics: bare markers remain transient; only permanent-context shadowing is
  fixed.

## Notes

- The fixtures are now hermetic w.r.t. the canonical permanent-quota classification (they assert on a
  deterministic permanent marker rather than a bare token whose meaning changed under #1719), which
  also reduces sensitivity to live OAuth state (#179).
