### PR TITLE
fix(cli-sub-agent): tolerate empty/partial state.toml in csa session wait startup race (#1794)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.851"
+version = "0.1.852"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.851"
+version = "0.1.852"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -1,6 +1,7 @@
 use super::*;
 use chrono::Utc;
 use csa_config::GlobalConfig;
+use std::time::{Duration, Instant, SystemTime};
 
 #[path = "session_cmds_daemon_wait_completion.rs"]
 mod completion;
@@ -241,12 +242,17 @@ fn emit_wait_completion_signal(
 
 /// Check if a session is stale before starting to wait.
 /// Returns Err if the session is stale (daemon not running, no recent progress).
-fn check_session_stale_before_wait(project_root: &Path, session_id: &str) -> anyhow::Result<()> {
+fn check_session_stale_before_wait(
+    project_root: &Path,
+    session_id: &str,
+    session_dir: &Path,
+    wait_behavior: WaitBehavior,
+) -> anyhow::Result<()> {
     // Load the session to check its phase and last_accessed time.
     // Only flag truly stale sessions (Active phase, no daemon, no recent progress).
     // Sessions with an existing result.toml are NOT stale — they completed, and the
     // main polling loop will return the result correctly.
-    match csa_session::load_session(project_root, session_id) {
+    match load_session_for_stale_precheck(project_root, session_id, session_dir, wait_behavior) {
         Ok(session) => {
             // Only check Active sessions for staleness
             if matches!(session.phase, csa_session::SessionPhase::Active) {
@@ -266,9 +272,7 @@ fn check_session_stale_before_wait(project_root: &Path, session_id: &str) -> any
                 let elapsed = now.signed_duration_since(session.last_accessed);
 
                 if elapsed > chrono::Duration::seconds(stale_threshold_seconds as i64) {
-                    if let Ok(session_dir) = csa_session::get_session_dir(project_root, session_id)
-                        && session_has_terminal_process(&session_dir)
-                    {
+                    if session_has_terminal_process(session_dir) {
                         return Ok(());
                     }
                     return Err(anyhow::anyhow!(
@@ -285,6 +289,83 @@ fn check_session_stale_before_wait(project_root: &Path, session_id: &str) -> any
     }
 
     Ok(())
+}
+
+fn load_session_for_stale_precheck(
+    project_root: &Path,
+    session_id: &str,
+    session_dir: &Path,
+    wait_behavior: WaitBehavior,
+) -> anyhow::Result<csa_session::MetaSessionState> {
+    let state_path = session_dir.join("state.toml");
+    let retry_until = startup_state_retry_deadline(
+        &state_path,
+        session_dir,
+        Duration::from_secs(wait_behavior.wait_timeout_secs),
+    );
+
+    loop {
+        match csa_session::load_session(project_root, session_id) {
+            Ok(session) => return Ok(session),
+            Err(load_err) => {
+                let Some(deadline) = retry_until else {
+                    return Err(load_err);
+                };
+                if Instant::now() >= deadline || !state_load_error_can_be_initializing(&state_path)
+                {
+                    return Err(load_err);
+                }
+
+                tracing::debug!(
+                    session_id,
+                    state_path = %state_path.display(),
+                    "Session state is still initializing; retrying stale precheck load"
+                );
+                std::thread::sleep(
+                    deadline
+                        .saturating_duration_since(Instant::now())
+                        .min(wait_behavior.timing.poll_interval),
+                );
+            }
+        }
+    }
+}
+
+fn startup_state_retry_deadline(
+    state_path: &Path,
+    session_dir: &Path,
+    retry_window: Duration,
+) -> Option<Instant> {
+    if retry_window.is_zero() {
+        return None;
+    }
+
+    let modified = state_retry_modified_time(state_path, session_dir)?;
+    let age = SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or(Duration::ZERO);
+    if age > retry_window {
+        return None;
+    }
+
+    Some(Instant::now() + retry_window.saturating_sub(age))
+}
+
+fn state_retry_modified_time(state_path: &Path, session_dir: &Path) -> Option<SystemTime> {
+    match std::fs::metadata(state_path) {
+        Ok(metadata) => metadata.modified().ok(),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::metadata(session_dir).ok()?.modified().ok()
+        }
+        Err(_) => None,
+    }
+}
+
+fn state_load_error_can_be_initializing(state_path: &Path) -> bool {
+    match std::fs::read_to_string(state_path) {
+        Ok(_) => true,
+        Err(err) => err.kind() == std::io::ErrorKind::NotFound,
+    }
 }
 
 fn emit_wait_memory_warn_marker(session_id: &str, rss_mb: u64, limit_mb: u64) {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -77,9 +77,12 @@ where
     // Check if the session is Stale before entering the polling loop.
     // This prevents indefinite polling of sessions that have no live daemon process
     // and no progress for an extended period.
-    if let Err(stale_err) =
-        super::check_session_stale_before_wait(effective_root, &resolved.session_id)
-    {
+    if let Err(stale_err) = super::check_session_stale_before_wait(
+        effective_root,
+        &resolved.session_id,
+        &session_dir,
+        wait_options.behavior,
+    ) {
         eprintln!(
             "Session {} appears stale: {}",
             resolved.session_id, stale_err

--- a/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
@@ -188,3 +188,119 @@ fn stale_precheck_does_not_fail_live_daemon_session() {
         "live daemon must not be pre-failed solely because last_accessed is stale"
     );
 }
+
+#[test]
+fn wait_retries_blank_state_during_startup_precheck() {
+    assert_wait_retries_initializing_state_until_complete("\n  \n");
+}
+
+#[test]
+fn wait_retries_partial_state_missing_required_field_during_startup_precheck() {
+    assert_wait_retries_initializing_state_until_complete(
+        "project_path = \"/tmp/wait-partial-state\"\n",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wait_errors_on_malformed_state_past_startup_precheck_window() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-malformed-state-old"),
+        None,
+        Some("codex"),
+    )
+    .expect("create");
+    let session_id = session.meta_session_id;
+    let state_path = get_session_dir(project, &session_id)
+        .expect("session dir")
+        .join("state.toml");
+    std::fs::write(&state_path, "not valid toml = [\n").expect("write malformed state");
+    super::set_file_mtime_seconds_ago(&state_path, 2);
+
+    let exit_code = handle_session_wait_with_hooks(
+        session_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("malformed state must fail before reconciliation")
+        },
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {
+            panic!("malformed state must not emit completion")
+        },
+    )
+    .expect("old malformed state should be reported as a wait failure");
+
+    assert_eq!(
+        exit_code, 1,
+        "old malformed state must remain a hard wait failure"
+    );
+}
+
+fn assert_wait_retries_initializing_state_until_complete(initial_state: &str) {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-initializing-state"),
+        None,
+        Some("codex"),
+    )
+    .expect("create");
+    let session_id = session.meta_session_id;
+    save_result(project, &session_id, &make_result("success", 0)).expect("save result");
+
+    let state_path = get_session_dir(project, &session_id)
+        .expect("session dir")
+        .join("state.toml");
+    let complete_state = std::fs::read_to_string(&state_path).expect("read complete state");
+    std::fs::write(&state_path, initial_state).expect("write initializing state");
+
+    let restore_path = state_path.clone();
+    let writer = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(restore_path, complete_state).expect("restore complete state");
+    });
+
+    let exit_code = handle_session_wait_with_hooks(
+        session_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("completed result should be loaded without reconciliation")
+        },
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {},
+    )
+    .expect("wait should retry initializing state and then read completed result");
+
+    writer.join().expect("state restore thread");
+    assert_eq!(exit_code, 0);
+}


### PR DESCRIPTION
## Summary

Fixes a startup-race crash in `csa session wait`: when invoked immediately after `csa run` dispatch,
`wait` could read an empty / not-yet-complete `state.toml` (the daemon hadn't finished writing it yet)
and abort with a hard TOML parse error (`missing field meta_session_id`, exit 1) — even though the
session was alive and healthy. In an autonomous / SA orchestration loop the backgrounded
`csa session wait` is the *only* completion signal, so this crash made `wait` report failure on a
perfectly healthy session and risked the orchestrator double-dispatching.

Closes #1794.

## Root cause

`csa session wait`'s `state.toml` read treated the first parse failure as fatal. During the session
startup window the daemon may not have written (or finished writing) `state.toml`, so the reader
observed a zero-length / partial file and the serde deserialize failed on a missing required field
(`meta_session_id`). Re-running `wait` a moment later succeeded — confirming a startup race, not a
genuinely corrupt file.

## Fix

`csa session wait` now treats an empty / not-yet-complete `state.toml` during the startup window as
**"initializing"** and retries with bounded backoff rather than hard-erroring on the first parse
failure:

- A zero-length / blank or partial (missing-required-field) `state.toml` read during the bounded
  startup window is classified as *mid-initialization* and retried, not surfaced as an error.
- A parse failure that persists past the bounded startup window — i.e. a `state.toml` that is
  genuinely malformed after a complete write — still errors as before (no weakening of corruption
  detection).
- The retry reuses the existing bounded wait/backoff machinery; no unbounded spin.

## Tests

- Empty/blank `state.toml` during startup → `wait` treats it as initializing and does not crash.
- Partial `state.toml` missing a required field during startup → same tolerant retry.
- Genuinely malformed `state.toml` past the startup window → still errors (corruption detection
  preserved).

## Notes

- Scope is limited to the live-session startup-race read path. The separate *dead-session* frozen-state
  misreport is tracked in #1711 (sibling fix in the same `state.toml` area, intentionally not folded in
  here).
