### PR TITLE
feat(cli-sub-agent): bundled review/debate pattern fallback for external repos (#1649 #1688)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.853"
+version = "0.1.854"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.853"
+version = "0.1.854"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -42,7 +42,9 @@ use gate::run_pre_debate_quality_gate;
 
 #[path = "debate_cmd_readonly.rs"]
 mod readonly;
+#[cfg(test)]
 use readonly::build_debate_instruction;
+use readonly::build_debate_instruction_for_project;
 pub(crate) use readonly::with_readonly_session_env;
 
 #[path = "debate_cmd_runtime.rs"]
@@ -104,7 +106,7 @@ pub(crate) async fn handle_debate(
     let pre_session_hook = csa_hooks::load_global_pre_session_hook_invocation();
 
     // 2b. Verify debate skill is available (fail fast before any execution)
-    verify_debate_skill_available(&project_root)?;
+    let debate_pattern = verify_debate_skill_available(&project_root)?;
 
     // 2c. Run pre-debate quality gate (reuses [review] gate settings)
     //
@@ -126,8 +128,14 @@ pub(crate) async fn handle_debate(
     // debate_cmd_question::build_debate_question).
     let (question, frontmatter_difficulty) = question::build_debate_question(&mut args)?;
 
-    // 4. Build debate instruction (parameter passing — tool loads debate skill)
-    let mut prompt = build_debate_instruction(&question, args.session.is_some(), args.rounds);
+    // 4. Build debate instruction with the resolved pattern injected.
+    let mut prompt = build_debate_instruction_for_project(
+        &question,
+        args.session.is_some(),
+        args.rounds,
+        &project_root,
+        &debate_pattern,
+    );
     if let Some(guard) =
         crate::pipeline::prompt_guard::anti_recursion_guard(config.as_ref(), current_depth)
     {

--- a/crates/cli-sub-agent/src/debate_cmd_readonly.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_readonly.rs
@@ -1,4 +1,7 @@
 use std::collections::HashMap;
+use std::path::Path;
+
+use crate::pattern_resolver::ResolvedPattern;
 
 pub(crate) const CSA_READONLY_SESSION_ENV: &str = "CSA_READONLY_SESSION";
 
@@ -26,7 +29,38 @@ pub(crate) fn with_readonly_session_env(
 /// The debate tool loads the debate skill from the project's `.claude/skills/`
 /// directory and follows its instructions autonomously. We only pass parameters.
 /// An anti-recursion preamble is prepended (see GitHub issue #272).
+#[cfg(test)]
 pub(crate) fn build_debate_instruction(
+    question: &str,
+    is_continuation: bool,
+    rounds: u32,
+) -> String {
+    build_debate_parameter_instruction(question, is_continuation, rounds)
+}
+
+pub(crate) fn build_debate_instruction_for_project(
+    question: &str,
+    is_continuation: bool,
+    rounds: u32,
+    project_root: &Path,
+    pattern: &ResolvedPattern,
+) -> String {
+    let instruction = build_debate_parameter_instruction(question, is_continuation, rounds);
+    let skill_source_dir = pattern.skill_source_dir("debate");
+    let mut parts = vec![instruction];
+    parts.extend(crate::run_cmd_tool_selection::build_skill_prompt_parts(
+        crate::run_cmd_tool_selection::SkillPromptSource {
+            project_root,
+            skill_source_dir: &skill_source_dir,
+            extra_context_dir: &pattern.dir,
+            skill_md: &pattern.skill_md,
+            agent_config: pattern.agent_config(),
+        },
+    ));
+    parts.join("\n\n")
+}
+
+fn build_debate_parameter_instruction(
     question: &str,
     is_continuation: bool,
     rounds: u32,

--- a/crates/cli-sub-agent/src/debate_cmd_runtime.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_runtime.rs
@@ -11,6 +11,7 @@ use crate::debate_cmd_output::{
     DebateOutputHeader, DebateSummary, format_debate_stdout_text, render_debate_stdout_json,
 };
 use crate::debate_errors::DebateErrorKind;
+use crate::pattern_resolver::ResolvedPattern;
 
 pub(super) fn render_debate_cli_output(
     output_format: OutputFormat,
@@ -37,7 +38,7 @@ pub(super) const STILL_WORKING_BACKOFF: Duration = Duration::from_secs(5);
 ///
 /// Fails fast with actionable install guidance if the pattern is missing,
 /// preventing silent degradation where the tool runs without skill context.
-pub(super) fn verify_debate_skill_available(project_root: &Path) -> Result<()> {
+pub(super) fn verify_debate_skill_available(project_root: &Path) -> Result<ResolvedPattern> {
     match crate::pattern_resolver::resolve_pattern("debate", project_root) {
         Ok(resolved) => {
             debug!(
@@ -46,7 +47,7 @@ pub(super) fn verify_debate_skill_available(project_root: &Path) -> Result<()> {
                 skill_md_len = resolved.skill_md.len(),
                 "Debate pattern resolved"
             );
-            Ok(())
+            Ok(resolved)
         }
         Err(resolve_err) => {
             anyhow::bail!(

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::debate_cmd_output::*;
 use crate::debate_cmd_resolve::resolve_debate_tool;
 use crate::test_env_lock::TEST_ENV_LOCK;
+use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_config::global::ReviewConfig;
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_config::{ProjectMeta, ResourcesConfig, ToolConfig};
@@ -402,6 +403,60 @@ fn build_debate_instruction_continuation() {
 fn build_debate_instruction_custom_rounds() {
     let prompt = build_debate_instruction("topic", false, 5);
     assert!(prompt.contains("rounds=5"));
+}
+
+#[test]
+fn build_debate_instruction_for_project_injects_bundled_pattern_without_repo_local_pattern() {
+    let project_dir = tempfile::TempDir::new().unwrap();
+    let state_dir = tempfile::TempDir::new().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&state_dir);
+    let pattern = verify_debate_skill_available(project_dir.path()).unwrap();
+
+    let prompt = build_debate_instruction_for_project(
+        "Should we use gRPC?",
+        false,
+        3,
+        project_dir.path(),
+        &pattern,
+    );
+
+    assert!(prompt.contains("Use the debate skill. rounds=3"));
+    assert!(prompt.contains("<skill-mode>executor</skill-mode>"));
+    assert!(prompt.contains("<skill-source path=\""));
+    assert!(prompt.contains("Debate: Adversarial Multi-Tool Strategy Formulation"));
+    assert!(!project_dir.path().join(".csa").exists());
+    assert!(!project_dir.path().join("patterns").exists());
+}
+
+#[test]
+fn build_debate_instruction_for_project_injects_repo_local_pattern() {
+    let project_dir = tempfile::TempDir::new().unwrap();
+    let skill_dir = project_dir
+        .path()
+        .join("patterns")
+        .join("debate")
+        .join("skills")
+        .join("debate");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "# Repo Local Debate Protocol\nUse this local debater.",
+    )
+    .unwrap();
+    let pattern = verify_debate_skill_available(project_dir.path()).unwrap();
+
+    let prompt = build_debate_instruction_for_project(
+        "Should we use gRPC?",
+        false,
+        3,
+        project_dir.path(),
+        &pattern,
+    );
+
+    assert!(prompt.contains("Use the debate skill. rounds=3"));
+    assert!(prompt.contains("Repo Local Debate Protocol"));
+    assert!(prompt.contains(&skill_dir.display().to_string()));
+    assert!(!prompt.contains("Debate: Adversarial Multi-Tool Strategy Formulation"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -180,22 +180,12 @@ async fn still_working_backoff_waits_before_retry() {
 // --- verify_debate_skill_available tests (#140) ---
 
 #[test]
-fn verify_debate_skill_missing_returns_actionable_error() {
+fn verify_debate_skill_missing_repo_local_pattern_uses_bundled_fallback() {
     let tmp = tempfile::TempDir::new().unwrap();
-    let err = verify_debate_skill_available(tmp.path()).unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("Debate pattern not found"),
-        "should mention missing pattern: {msg}"
-    );
-    assert!(
-        msg.contains("csa skill install"),
-        "should include install guidance: {msg}"
-    );
-    assert!(
-        msg.contains("patterns/debate"),
-        "should list searched paths: {msg}"
-    );
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    assert!(verify_debate_skill_available(tmp.path()).is_ok());
+    assert!(!tmp.path().join(".csa").exists());
+    assert!(!tmp.path().join("patterns").exists());
 }
 
 #[test]
@@ -388,14 +378,13 @@ fn resolve_debate_tool_same_model_fallback_skips_unavailable_parent_binary() {
 }
 
 #[test]
-fn verify_debate_skill_no_fallback_without_skill() {
-    // Ensure no execution path silently downgrades when skill is missing.
-    // The verify function must return Err — it must NOT return Ok with a warning.
+fn verify_debate_skill_no_repo_local_pattern_uses_bundled_fallback() {
     let tmp = tempfile::TempDir::new().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
     let result = verify_debate_skill_available(tmp.path());
     assert!(
-        result.is_err(),
-        "missing skill must be a hard error, not a warning"
+        result.is_ok(),
+        "missing repo-local debate pattern should resolve via bundled fallback"
     );
 }
 

--- a/crates/cli-sub-agent/src/pattern_resolver.rs
+++ b/crates/cli-sub-agent/src/pattern_resolver.rs
@@ -184,6 +184,15 @@ impl ResolvedPattern {
     pub fn agent_config(&self) -> Option<&AgentConfig> {
         self.config.as_ref().and_then(|c| c.agent.as_ref())
     }
+
+    pub(crate) fn skill_source_dir(&self, name: &str) -> PathBuf {
+        let skill_dir = self.dir.join("skills").join(name);
+        if skill_dir.join("SKILL.md").is_file() {
+            skill_dir
+        } else {
+            self.dir.clone()
+        }
+    }
 }
 
 /// Resolve a pattern by name, searching standard paths in priority order.

--- a/crates/cli-sub-agent/src/pattern_resolver.rs
+++ b/crates/cli-sub-agent/src/pattern_resolver.rs
@@ -14,7 +14,10 @@
 
 use anyhow::{Context, Result, bail};
 use csa_config::paths;
+use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::debug;
 
 use weave::package::{self, SourceKind};
@@ -28,6 +31,8 @@ struct BundledPatternFile {
     path: &'static str,
     contents: &'static [u8],
 }
+
+static BUNDLED_WRITE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 static BUNDLED_CSA_REVIEW_FILES: &[BundledPatternFile] = &[
     BundledPatternFile {
@@ -334,13 +339,45 @@ fn write_bundled_pattern(pattern: &BundledPattern, dest_root: &Path) -> Result<(
     for file in pattern.files {
         let dest = dest_root.join(file.path);
         if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent)
+            fs::create_dir_all(parent)
                 .with_context(|| format!("failed to create {}", parent.display()))?;
         }
-        std::fs::write(&dest, file.contents)
-            .with_context(|| format!("failed to write {}", dest.display()))?;
+        atomic_write_bundled_file(&dest, file.contents)?;
     }
     Ok(())
+}
+
+/// Write bundled content via a same-directory temp file and atomic rename.
+fn atomic_write_bundled_file(dest: &Path, contents: &[u8]) -> Result<()> {
+    let parent = dest
+        .parent()
+        .with_context(|| format!("bundled file has no parent path: {}", dest.display()))?;
+    let file_name = dest
+        .file_name()
+        .with_context(|| format!("bundled file has no file name: {}", dest.display()))?;
+    let counter = BUNDLED_WRITE_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut tmp_file_name = file_name.to_os_string();
+    tmp_file_name.push(format!(".tmp.{}-{counter}", std::process::id()));
+    let tmp = parent.join(tmp_file_name);
+
+    if let Err(err) = fs::write(&tmp, contents) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err).with_context(|| format!("failed to write {}", tmp.display()));
+    }
+
+    match fs::rename(&tmp, dest) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::AlreadyExists && dest.exists() => {
+            fs::remove_file(&tmp).with_context(|| format!("failed to remove {}", tmp.display()))?;
+            Ok(())
+        }
+        Err(err) => {
+            let _ = fs::remove_file(&tmp);
+            Err(err).with_context(|| {
+                format!("failed to rename {} to {}", tmp.display(), dest.display())
+            })
+        }
+    }
 }
 
 /// Build the ordered list of directories to search for a pattern.

--- a/crates/cli-sub-agent/src/pattern_resolver.rs
+++ b/crates/cli-sub-agent/src/pattern_resolver.rs
@@ -10,6 +10,7 @@
 //! 3. Superproject root (submodule only): `.csa/patterns/<name>/`
 //! 4. Superproject root (submodule only): `patterns/<name>/`
 //! 5. `<global_store>/<pkg>/<commit>/patterns/<name>/` from lockfiles under current/superproject
+//! 6. Binary-bundled fallback for first-party review/debate patterns
 
 use anyhow::{Context, Result, bail};
 use csa_config::paths;
@@ -18,6 +19,119 @@ use tracing::debug;
 
 use weave::package::{self, SourceKind};
 use weave::parser::{AgentConfig, SkillConfig};
+
+struct BundledPattern {
+    files: &'static [BundledPatternFile],
+}
+
+struct BundledPatternFile {
+    path: &'static str,
+    contents: &'static [u8],
+}
+
+static BUNDLED_CSA_REVIEW_FILES: &[BundledPatternFile] = &[
+    BundledPatternFile {
+        path: ".skill.toml",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/csa-review/.skill.toml"
+        )),
+    },
+    BundledPatternFile {
+        path: "PATTERN.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/csa-review/PATTERN.md"
+        )),
+    },
+    BundledPatternFile {
+        path: "workflow.toml",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/csa-review/workflow.toml"
+        )),
+    },
+    BundledPatternFile {
+        path: "skills/csa-review/SKILL.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/csa-review/skills/csa-review/SKILL.md"
+        )),
+    },
+    BundledPatternFile {
+        path: "skills/csa-review/references/disagreement-escalation.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/csa-review/skills/csa-review/references/disagreement-escalation.md"
+        )),
+    },
+    BundledPatternFile {
+        path: "skills/csa-review/references/fix-workflow.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/csa-review/skills/csa-review/references/fix-workflow.md"
+        )),
+    },
+    BundledPatternFile {
+        path: "skills/csa-review/references/output-schema.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/csa-review/skills/csa-review/references/output-schema.md"
+        )),
+    },
+    BundledPatternFile {
+        path: "skills/csa-review/references/red-team-mode.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/csa-review/skills/csa-review/references/red-team-mode.md"
+        )),
+    },
+    BundledPatternFile {
+        path: "skills/csa-review/references/review-protocol.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/csa-review/skills/csa-review/references/review-protocol.md"
+        )),
+    },
+];
+
+static BUNDLED_DEBATE_FILES: &[BundledPatternFile] = &[
+    BundledPatternFile {
+        path: ".skill.toml",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/debate/.skill.toml"
+        )),
+    },
+    BundledPatternFile {
+        path: "PATTERN.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/debate/PATTERN.md"
+        )),
+    },
+    BundledPatternFile {
+        path: "workflow.toml",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/debate/workflow.toml"
+        )),
+    },
+    BundledPatternFile {
+        path: "skills/debate/SKILL.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/debate/skills/debate/SKILL.md"
+        )),
+    },
+];
+
+static BUNDLED_CSA_REVIEW_PATTERN: BundledPattern = BundledPattern {
+    files: BUNDLED_CSA_REVIEW_FILES,
+};
+static BUNDLED_DEBATE_PATTERN: BundledPattern = BundledPattern {
+    files: BUNDLED_DEBATE_FILES,
+};
 
 // ---------------------------------------------------------------------------
 // TOML value merge (top-level shallow, nested tables deep-merge)
@@ -76,6 +190,14 @@ impl ResolvedPattern {
 ///
 /// `project_root` is the working directory / project root for the CSA run.
 pub(crate) fn resolve_pattern(name: &str, project_root: &Path) -> Result<ResolvedPattern> {
+    resolve_pattern_with_materialization_root(name, project_root, None)
+}
+
+fn resolve_pattern_with_materialization_root(
+    name: &str,
+    project_root: &Path,
+    materialization_root: Option<&Path>,
+) -> Result<ResolvedPattern> {
     if name.is_empty() || name.contains('/') || name.contains('\\') || name.contains("..") {
         bail!("Invalid pattern name: '{name}' (must be a simple name, no path separators)");
     }
@@ -83,54 +205,133 @@ pub(crate) fn resolve_pattern(name: &str, project_root: &Path) -> Result<Resolve
     let candidates = search_paths(name, project_root);
 
     for dir in &candidates {
-        // Primary: skills/<name>/SKILL.md (new layout)
-        let skill_md_path = dir.join("skills").join(name).join("SKILL.md");
-        if skill_md_path.is_file() {
-            let skill_md = std::fs::read_to_string(&skill_md_path)
-                .with_context(|| format!("failed to read {}", skill_md_path.display()))?;
-
-            let config = load_skill_config(dir, name, project_root)?;
-
-            debug!(pattern_dir = %dir.display(), "Pattern resolved");
-
-            return Ok(ResolvedPattern {
-                dir: dir.clone(),
-                skill_md,
-                config,
-            });
+        if let Some(resolved) = resolve_pattern_from_dir(name, project_root, dir)? {
+            return Ok(resolved);
         }
+    }
 
-        // Fallback: PATTERN.md at pattern root (legacy weave-locked layout)
-        let pattern_md_path = dir.join("PATTERN.md");
-        if pattern_md_path.is_file() {
-            let skill_md = std::fs::read_to_string(&pattern_md_path)
-                .with_context(|| format!("failed to read {}", pattern_md_path.display()))?;
-
-            let config = load_skill_config(dir, name, project_root)?;
-
-            debug!(pattern_dir = %dir.display(), "Pattern resolved (PATTERN.md fallback)");
-
-            return Ok(ResolvedPattern {
-                dir: dir.clone(),
-                skill_md,
-                config,
-            });
+    if let Some(bundled) = bundled_pattern(name) {
+        let dir = materialize_bundled_pattern(name, bundled, materialization_root)?;
+        if let Some(resolved) = resolve_pattern_from_dir(name, project_root, &dir)? {
+            debug!(pattern_dir = %resolved.dir.display(), "Pattern resolved (bundled fallback)");
+            return Ok(resolved);
         }
+        bail!(
+            "Bundled pattern '{name}' materialized to {} but did not contain skills/{name}/SKILL.md or PATTERN.md",
+            dir.display()
+        );
     }
 
     bail!(
         "Pattern '{name}' not found. Searched:\n{}",
-        candidates
-            .iter()
-            .map(|p| {
-                format!(
-                    "  - {0}/skills/{name}/SKILL.md\n  - {0}/PATTERN.md",
-                    p.display()
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
+        format_searched_paths(name, &candidates)
     )
+}
+
+fn resolve_pattern_from_dir(
+    name: &str,
+    project_root: &Path,
+    dir: &Path,
+) -> Result<Option<ResolvedPattern>> {
+    // Primary: skills/<name>/SKILL.md (new layout)
+    let skill_md_path = dir.join("skills").join(name).join("SKILL.md");
+    if skill_md_path.is_file() {
+        let skill_md = std::fs::read_to_string(&skill_md_path)
+            .with_context(|| format!("failed to read {}", skill_md_path.display()))?;
+
+        let config = load_skill_config(dir, name, project_root)?;
+
+        debug!(pattern_dir = %dir.display(), "Pattern resolved");
+
+        return Ok(Some(ResolvedPattern {
+            dir: dir.to_path_buf(),
+            skill_md,
+            config,
+        }));
+    }
+
+    // Fallback: PATTERN.md at pattern root (legacy weave-locked layout)
+    let pattern_md_path = dir.join("PATTERN.md");
+    if pattern_md_path.is_file() {
+        let skill_md = std::fs::read_to_string(&pattern_md_path)
+            .with_context(|| format!("failed to read {}", pattern_md_path.display()))?;
+
+        let config = load_skill_config(dir, name, project_root)?;
+
+        debug!(pattern_dir = %dir.display(), "Pattern resolved (PATTERN.md fallback)");
+
+        return Ok(Some(ResolvedPattern {
+            dir: dir.to_path_buf(),
+            skill_md,
+            config,
+        }));
+    }
+
+    Ok(None)
+}
+
+fn format_searched_paths(name: &str, candidates: &[PathBuf]) -> String {
+    candidates
+        .iter()
+        .map(|p| {
+            format!(
+                "  - {0}/skills/{name}/SKILL.md\n  - {0}/PATTERN.md",
+                p.display()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn bundled_pattern(name: &str) -> Option<&'static BundledPattern> {
+    match name {
+        "csa-review" => Some(&BUNDLED_CSA_REVIEW_PATTERN),
+        "debate" => Some(&BUNDLED_DEBATE_PATTERN),
+        _ => None,
+    }
+}
+
+fn materialize_bundled_pattern(
+    name: &str,
+    pattern: &BundledPattern,
+    materialization_root: Option<&Path>,
+) -> Result<PathBuf> {
+    let dest = bundled_pattern_materialization_root(materialization_root).join(name);
+    write_bundled_pattern(pattern, &dest)
+        .with_context(|| format!("failed to materialize bundled pattern '{name}'"))?;
+    Ok(dest)
+}
+
+fn bundled_pattern_materialization_root(explicit_root: Option<&Path>) -> PathBuf {
+    if let Some(root) = explicit_root {
+        return root.to_path_buf();
+    }
+
+    for env_name in ["CSA_SESSION_DIR", "CSA_DAEMON_SESSION_DIR"] {
+        if let Some(value) = std::env::var_os(env_name)
+            && !value.is_empty()
+        {
+            return PathBuf::from(value).join("bundled-patterns");
+        }
+    }
+
+    let state_dir = paths::state_dir_write().unwrap_or_else(paths::state_dir_fallback);
+    state_dir
+        .join("bundled-patterns")
+        .join(env!("CARGO_PKG_VERSION"))
+}
+
+fn write_bundled_pattern(pattern: &BundledPattern, dest_root: &Path) -> Result<()> {
+    for file in pattern.files {
+        let dest = dest_root.join(file.path);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        std::fs::write(&dest, file.contents)
+            .with_context(|| format!("failed to write {}", dest.display()))?;
+    }
+    Ok(())
 }
 
 /// Build the ordered list of directories to search for a pattern.

--- a/crates/cli-sub-agent/src/pattern_resolver_tests.rs
+++ b/crates/cli-sub-agent/src/pattern_resolver_tests.rs
@@ -232,6 +232,93 @@ fn resolve_pattern_repo_takes_priority_over_global_store() {
 }
 
 #[test]
+fn resolve_pattern_falls_back_to_bundled_csa_review_without_repo_local_pattern() {
+    let tmp = TempDir::new().unwrap();
+    let materialized = TempDir::new().unwrap();
+
+    let resolved = resolve_pattern_with_materialization_root(
+        "csa-review",
+        tmp.path(),
+        Some(materialized.path()),
+    )
+    .unwrap();
+
+    assert!(resolved.skill_md.contains("CSA Review"));
+    assert!(resolved.dir.starts_with(materialized.path()));
+    assert!(resolved.dir.join("workflow.toml").is_file());
+    assert!(
+        resolved
+            .dir
+            .join("skills/csa-review/references/output-schema.md")
+            .is_file()
+    );
+    assert!(!tmp.path().join(".csa").exists());
+    assert!(!tmp.path().join("patterns").exists());
+}
+
+#[test]
+fn resolve_pattern_falls_back_to_bundled_debate_without_repo_local_pattern() {
+    let tmp = TempDir::new().unwrap();
+    let materialized = TempDir::new().unwrap();
+
+    let resolved =
+        resolve_pattern_with_materialization_root("debate", tmp.path(), Some(materialized.path()))
+            .unwrap();
+
+    assert!(resolved.skill_md.contains("Debate"));
+    assert!(resolved.dir.starts_with(materialized.path()));
+    assert!(resolved.dir.join("workflow.toml").is_file());
+    assert!(resolved.dir.join("skills/debate/SKILL.md").is_file());
+    assert!(!tmp.path().join(".csa").exists());
+    assert!(!tmp.path().join("patterns").exists());
+}
+
+#[test]
+fn repo_local_csa_review_overrides_bundled_pattern() {
+    let tmp = TempDir::new().unwrap();
+    let materialized = TempDir::new().unwrap();
+    make_pattern_dir(
+        tmp.path(),
+        ".csa/patterns/csa-review",
+        "csa-review",
+        "# CSA Local Review",
+        None,
+    );
+
+    let resolved = resolve_pattern_with_materialization_root(
+        "csa-review",
+        tmp.path(),
+        Some(materialized.path()),
+    )
+    .unwrap();
+
+    assert!(resolved.skill_md.contains("CSA Local Review"));
+    assert!(resolved.dir.ends_with(".csa/patterns/csa-review"));
+    assert!(!materialized.path().join("csa-review").exists());
+}
+
+#[test]
+fn repo_local_debate_overrides_bundled_pattern() {
+    let tmp = TempDir::new().unwrap();
+    let materialized = TempDir::new().unwrap();
+    make_pattern_dir(
+        tmp.path(),
+        "patterns/debate",
+        "debate",
+        "# Local Debate",
+        None,
+    );
+
+    let resolved =
+        resolve_pattern_with_materialization_root("debate", tmp.path(), Some(materialized.path()))
+            .unwrap();
+
+    assert!(resolved.skill_md.contains("Local Debate"));
+    assert!(resolved.dir.ends_with("patterns/debate"));
+    assert!(!materialized.path().join("debate").exists());
+}
+
+#[test]
 fn search_paths_include_superproject_roots_for_submodule_project_root() {
     let tmp = TempDir::new().unwrap();
     fs::create_dir(tmp.path().join(".git")).unwrap();

--- a/crates/cli-sub-agent/src/pattern_resolver_tests.rs
+++ b/crates/cli-sub-agent/src/pattern_resolver_tests.rs
@@ -95,6 +95,24 @@ fn assert_paths_exclude(paths: &[std::path::PathBuf], expected: &Path, msg: &str
     );
 }
 
+fn assert_no_bundled_temp_files(dir: &Path) {
+    for entry in fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
+            assert_no_bundled_temp_files(&path);
+            continue;
+        }
+
+        let file_name = path.file_name().unwrap().to_string_lossy();
+        assert!(
+            !file_name.contains(".tmp."),
+            "temporary bundled file was left behind: {}",
+            path.display()
+        );
+    }
+}
+
 // ------------------------------------------------------------------
 // Resolution tests
 // ------------------------------------------------------------------
@@ -271,6 +289,30 @@ fn resolve_pattern_falls_back_to_bundled_debate_without_repo_local_pattern() {
     assert!(resolved.dir.join("skills/debate/SKILL.md").is_file());
     assert!(!tmp.path().join(".csa").exists());
     assert!(!tmp.path().join("patterns").exists());
+}
+
+#[test]
+fn materialize_bundled_patterns_writes_full_files_without_temp_residue() {
+    for (name, pattern) in [
+        ("csa-review", &BUNDLED_CSA_REVIEW_PATTERN),
+        ("debate", &BUNDLED_DEBATE_PATTERN),
+    ] {
+        let materialized = TempDir::new().unwrap();
+        let dest = materialize_bundled_pattern(name, pattern, Some(materialized.path())).unwrap();
+
+        for file in pattern.files {
+            let path = dest.join(file.path);
+            let actual = fs::read(&path).unwrap();
+            assert_eq!(
+                actual,
+                file.contents,
+                "materialized bundled file content differs for {}",
+                path.display()
+            );
+        }
+
+        assert_no_bundled_temp_files(&dest);
+    }
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -144,7 +144,7 @@ pub(crate) async fn handle_review(
         args.model_spec.is_some(),
     )?;
     let pre_session_hook = csa_hooks::load_global_pre_session_hook_invocation();
-    verify_review_skill_available(&project_root, args.allow_fallback)?;
+    let review_pattern = verify_review_skill_available(&project_root, args.allow_fallback)?;
     if is_worktree_submodule(&project_root) {
         warn!(project_root = %project_root.display(),
             "Review inside git worktree submodule — may produce empty/unreliable output (issue #487)");
@@ -211,6 +211,7 @@ pub(crate) async fn handle_review(
         &project_root,
         ReviewProjectPromptOptions {
             project_config: config.as_ref(),
+            resolved_pattern: review_pattern.as_ref(),
             prior_rounds_section: prior_rounds_section.as_deref(),
             current_session_id: startup_env.session_id(),
             full_consistency: args.full_consistency,

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use tracing::{debug, info, warn};
 
 use crate::cli::{ReviewArgs, ReviewMode};
+use crate::pattern_resolver::ResolvedPattern;
 use crate::review_context::{
     ResolvedReviewContext, ResolvedReviewContextKind, discover_prior_round_assumptions,
     discover_review_checklist, render_spec_review_context,
@@ -30,7 +31,7 @@ pub(crate) use selection::{
 pub(crate) fn verify_review_skill_available(
     project_root: &Path,
     allow_fallback: bool,
-) -> Result<()> {
+) -> Result<Option<ResolvedPattern>> {
     match crate::pattern_resolver::resolve_pattern("csa-review", project_root) {
         Ok(resolved) => {
             debug!(
@@ -40,7 +41,7 @@ pub(crate) fn verify_review_skill_available(
                 skill_md_len = resolved.skill_md.len(),
                 "Review pattern resolved"
             );
-            Ok(())
+            Ok(Some(resolved))
         }
         Err(resolve_err) => {
             if allow_fallback {
@@ -48,7 +49,7 @@ pub(crate) fn verify_review_skill_available(
                     "Review pattern not found; continuing because --allow-fallback is set. \
                      Install with `weave install RyderFreeman4Logos/cli-sub-agent` for structured review protocol."
                 );
-                return Ok(());
+                return Ok(None);
             }
 
             anyhow::bail!(
@@ -445,6 +446,8 @@ pub(crate) fn build_review_instruction(
         security_mode,
         review_mode,
         context,
+        None,
+        None,
     );
     crate::review_design_anchor::append_design_anchor(&mut instruction);
     instruction
@@ -456,6 +459,8 @@ fn build_review_instruction_without_design_anchor(
     security_mode: &str,
     review_mode: ReviewMode,
     context: Option<&ResolvedReviewContext>,
+    project_root: Option<&Path>,
+    pattern: Option<&ResolvedPattern>,
 ) -> String {
     let mut instruction = format!(
         "{ANTI_RECURSION_PREAMBLE}Use the csa-review skill. scope={scope}, mode={mode}, security_mode={security_mode}, review_mode={review_mode}. Emit exactly one final verdict token: PASS, FAIL, SKIP, UNCERTAIN, or UNAVAILABLE."
@@ -472,7 +477,22 @@ fn build_review_instruction_without_design_anchor(
             instruction.push_str(&render_spec_review_context(spec));
         }
     }
-    instruction
+    if let (Some(project_root), Some(pattern)) = (project_root, pattern) {
+        let skill_source_dir = pattern.skill_source_dir("csa-review");
+        let mut parts = vec![instruction];
+        parts.extend(crate::run_cmd_tool_selection::build_skill_prompt_parts(
+            crate::run_cmd_tool_selection::SkillPromptSource {
+                project_root,
+                skill_source_dir: &skill_source_dir,
+                extra_context_dir: &pattern.dir,
+                skill_md: &pattern.skill_md,
+                agent_config: pattern.agent_config(),
+            },
+        ));
+        parts.join("\n\n")
+    } else {
+        instruction
+    }
 }
 
 pub(crate) fn build_review_instruction_for_project(
@@ -491,6 +511,8 @@ pub(crate) fn build_review_instruction_for_project(
         security_mode,
         review_mode,
         context,
+        Some(project_root),
+        options.resolved_pattern,
     );
     let consistency_scope = if options.full_consistency {
         "touched-files"
@@ -540,6 +562,7 @@ pub(crate) fn build_review_instruction_for_project(
 
 pub(crate) struct ReviewProjectPromptOptions<'a> {
     pub(crate) project_config: Option<&'a ProjectConfig>,
+    pub(crate) resolved_pattern: Option<&'a ResolvedPattern>,
     pub(crate) prior_rounds_section: Option<&'a str>,
     pub(crate) current_session_id: Option<&'a str>,
     pub(crate) full_consistency: bool,

--- a/crates/cli-sub-agent/src/review_cmd_tests_checklist.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_checklist.rs
@@ -21,6 +21,7 @@ fn build_review_instruction_for_project_injects_review_checklist() {
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
@@ -51,6 +52,7 @@ fn build_review_instruction_for_project_omits_checklist_when_missing() {
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,

--- a/crates/cli-sub-agent/src/review_cmd_tests_full_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_full_consistency.rs
@@ -34,6 +34,7 @@ fn test_build_review_instruction_no_diff_content_default() {
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
@@ -66,6 +67,7 @@ fn test_build_review_instruction_full_consistency() {
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: true,

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -118,6 +118,7 @@ fn build_review_instruction_for_project_contains_design_preference_anchor() {
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
@@ -162,6 +163,7 @@ fn count_prior_reviews_zero_omits_iteration_block() {
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
@@ -198,6 +200,7 @@ fn count_prior_reviews_one_injects_iteration_two() {
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,

--- a/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
@@ -52,6 +52,7 @@ invariant = "lock-losing resume cannot mutate metadata of winning session"
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: Some(&prior_rounds),
             current_session_id: None,
             full_consistency: false,
@@ -146,6 +147,7 @@ fn build_review_instruction_for_project_without_prior_rounds_flag_leaves_section
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -399,6 +399,7 @@ fn test_build_review_instruction_for_project_includes_rust_profile() {
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
@@ -422,6 +423,7 @@ fn test_build_review_instruction_for_project_includes_unknown_profile_for_empty_
         project_dir.path(),
         resolve::ReviewProjectPromptOptions {
             project_config: None,
+            resolved_pattern: None,
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
@@ -553,6 +555,81 @@ fn verify_review_skill_present_succeeds() {
     .unwrap();
 
     assert!(verify_review_skill_available(tmp.path(), false).is_ok());
+}
+
+#[test]
+fn build_review_instruction_for_project_injects_bundled_pattern_without_repo_local_pattern() {
+    let project_dir = tempfile::TempDir::new().unwrap();
+    let state_dir = tempfile::TempDir::new().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&state_dir);
+    let pattern = verify_review_skill_available(project_dir.path(), false)
+        .unwrap()
+        .expect("bundled pattern should resolve");
+
+    let (instruction, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            resolved_pattern: Some(&pattern),
+            prior_rounds_section: None,
+            current_session_id: None,
+            full_consistency: false,
+        },
+    );
+
+    assert!(instruction.contains("Use the csa-review skill. scope=uncommitted"));
+    assert!(instruction.contains("<skill-mode>executor</skill-mode>"));
+    assert!(instruction.contains("<skill-source path=\""));
+    assert!(instruction.contains("CSA Review: Independent Code Review Orchestration"));
+    assert!(!project_dir.path().join(".csa").exists());
+    assert!(!project_dir.path().join("patterns").exists());
+}
+
+#[test]
+fn build_review_instruction_for_project_injects_repo_local_pattern() {
+    let project_dir = tempfile::TempDir::new().unwrap();
+    let skill_dir = project_dir
+        .path()
+        .join(".csa")
+        .join("patterns")
+        .join("csa-review")
+        .join("skills")
+        .join("csa-review");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "# Repo Local Review Protocol\nUse this local reviewer.",
+    )
+    .unwrap();
+    let pattern = verify_review_skill_available(project_dir.path(), false)
+        .unwrap()
+        .expect("repo-local pattern should resolve");
+
+    let (instruction, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            resolved_pattern: Some(&pattern),
+            prior_rounds_section: None,
+            current_session_id: None,
+            full_consistency: false,
+        },
+    );
+
+    assert!(instruction.contains("Use the csa-review skill. scope=uncommitted"));
+    assert!(instruction.contains("Repo Local Review Protocol"));
+    assert!(instruction.contains(&skill_dir.display().to_string()));
+    assert!(!instruction.contains("CSA Review: Independent Code Review Orchestration"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -526,26 +526,12 @@ fn discover_review_context_for_branch_skips_when_spec_missing() {
 }
 
 #[test]
-fn verify_review_skill_missing_returns_actionable_error() {
+fn verify_review_skill_missing_repo_local_pattern_uses_bundled_fallback() {
     let tmp = tempfile::TempDir::new().unwrap();
-    let err = verify_review_skill_available(tmp.path(), false).unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("Review pattern not found"),
-        "should mention missing pattern: {msg}"
-    );
-    assert!(
-        msg.contains("weave install"),
-        "should include install guidance: {msg}"
-    );
-    assert!(
-        msg.contains("does NOT install"),
-        "should clarify skill install vs pattern install: {msg}"
-    );
-    assert!(
-        msg.contains("patterns/csa-review"),
-        "should list searched paths: {msg}"
-    );
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    assert!(verify_review_skill_available(tmp.path(), false).is_ok());
+    assert!(!tmp.path().join(".csa").exists());
+    assert!(!tmp.path().join("patterns").exists());
 }
 
 #[test]
@@ -570,20 +556,20 @@ fn verify_review_skill_present_succeeds() {
 }
 
 #[test]
-fn verify_review_skill_no_fallback_without_skill() {
-    // Ensure no execution path silently downgrades when skill is missing.
-    // The verify function must return Err — it must NOT return Ok with a warning.
+fn verify_review_skill_no_repo_local_pattern_uses_bundled_without_allow_fallback() {
     let tmp = tempfile::TempDir::new().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
     let result = verify_review_skill_available(tmp.path(), false);
     assert!(
-        result.is_err(),
-        "missing skill must be a hard error, not a warning"
+        result.is_ok(),
+        "missing repo-local review pattern should resolve via bundled fallback"
     );
 }
 
 #[test]
 fn verify_review_skill_allow_fallback_without_skill() {
     let tmp = tempfile::TempDir::new().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
     let result = verify_review_skill_available(tmp.path(), true);
     assert!(
         result.is_ok(),

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
@@ -9,6 +9,7 @@ use tracing::warn;
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::{ToolName, ToolSelectionStrategy};
 use csa_session::{MetaSessionState, SessionPhase, resolve_session_prefix};
+use weave::parser::AgentConfig;
 
 use crate::cli::ReturnTarget;
 use crate::run_helpers::{
@@ -480,6 +481,47 @@ pub(crate) struct SkillResolution {
     pub(crate) thinking: Option<String>,
 }
 
+pub(crate) struct SkillPromptSource<'a> {
+    pub(crate) project_root: &'a Path,
+    pub(crate) skill_source_dir: &'a Path,
+    pub(crate) extra_context_dir: &'a Path,
+    pub(crate) skill_md: &'a str,
+    pub(crate) agent_config: Option<&'a AgentConfig>,
+}
+
+pub(crate) fn build_skill_prompt_parts(source: SkillPromptSource<'_>) -> Vec<String> {
+    let mut parts = vec![
+        "<skill-mode>executor</skill-mode>".to_string(),
+        format!(
+            "<workspace-scope root=\"{}\">\nSTRICT SCOPE: Only read/write files under this root. If a tool returns workspace-boundary errors (for example, 'Path not in workspace'), stop and report failure instead of retrying sibling paths.\n</workspace-scope>",
+            source.project_root.display()
+        ),
+        format!(
+            "<skill-source path=\"{}\">\nResolve relative skill references from this directory.\n</skill-source>",
+            source.skill_source_dir.display()
+        ),
+        crate::skill_repo::sanitize_skill_md(source.skill_md),
+    ];
+
+    if let Some(agent) = source.agent_config {
+        for extra in &agent.extra_context {
+            let extra_path = source.extra_context_dir.join(extra);
+            match std::fs::read_to_string(&extra_path) {
+                Ok(content) => {
+                    parts.push(format!(
+                        "<context-file path=\"{extra}\">\n{content}\n</context-file>"
+                    ));
+                }
+                Err(e) => {
+                    warn!(path = %extra, error = %e, "Failed to load skill extra_context file");
+                }
+            }
+        }
+    }
+
+    parts
+}
+
 /// Resolve the skill (if any), build the prompt, and apply agent config
 /// overrides for tool/model/thinking.
 pub(crate) fn resolve_skill_and_prompt(
@@ -500,31 +542,13 @@ pub(crate) fn resolve_skill_and_prompt(
         // Skills execute inside `csa run` as the leaf executor. Inject an
         // explicit mode marker so skill docs can branch deterministically and
         // avoid orchestrator-style recursive `csa run` loops.
-        let mut parts = vec![
-            "<skill-mode>executor</skill-mode>".to_string(),
-            format!(
-                "<workspace-scope root=\"{}\">\nSTRICT SCOPE: Only read/write files under this root. If a tool returns workspace-boundary errors (for example, 'Path not in workspace'), stop and report failure instead of retrying sibling paths.\n</workspace-scope>",
-                project_root.display()
-            ),
-            sk.skill_md.clone(),
-        ];
-
-        // Load extra_context files relative to the skill directory.
-        if let Some(agent) = sk.agent_config() {
-            for extra in &agent.extra_context {
-                let extra_path = sk.dir.join(extra);
-                match std::fs::read_to_string(&extra_path) {
-                    Ok(content) => {
-                        parts.push(format!(
-                            "<context-file path=\"{extra}\">\n{content}\n</context-file>"
-                        ));
-                    }
-                    Err(e) => {
-                        warn!(path = %extra, error = %e, "Failed to load skill extra_context file");
-                    }
-                }
-            }
-        }
+        let mut parts = build_skill_prompt_parts(SkillPromptSource {
+            project_root,
+            skill_source_dir: &sk.dir,
+            extra_context_dir: &sk.dir,
+            skill_md: &sk.skill_md,
+            agent_config: sk.agent_config(),
+        });
 
         let mut difficulty = None;
         if let Some(user_prompt) = prompt {


### PR DESCRIPTION
## Summary

Makes `csa review` and `csa debate` usable on external / forked repos by falling back to a
**binary-bundled** `csa-review` / `debate` pattern when the target repo ships none, instead of
hard-failing. Repo-local patterns still take precedence.

Closes #1649.
Closes #1688.

## Problem

Pattern resolution searched **only** the target-repo paths (`<repo>/.csa/patterns/<name>/...` and
`<repo>/patterns/<name>/...`) with no fallback to a pattern shipped with the installed `csa` binary.
On any forked / third-party repo lacking a repo-local pattern, the review daemon spawned, ran ~37-70s,
died with `Error: Review pattern not found`, and `csa session wait` reported a slow *synthetic* failure
(`result.toml missing`, `Tool: unknown`). The "fork an OSS repo → `csa review` the branch before
pushing" workflow was blocked unless you first polluted the repo with a copy of cli-sub-agent's pattern
subtree.

`#1649` and `#1688` were duplicate reports of this same gap.

## Fix

- The `csa-review` and `debate` patterns are now bundled with the binary at compile time (embedded from
  the in-repo `patterns/csa-review/` + `patterns/debate/` source trees, so the embedded copy stays
  version-locked to the binary with zero drift).
- Resolution order: **repo-local paths (unchanged) → bundled fallback → not-found error**. The bundled
  copy is always present, so the missing-pattern hard-failure path is now effectively unreachable for
  review/debate — which also resolves the slow-synthetic-failure symptom for the pattern case.
- The bundled pattern is materialized to a session/cache directory; the target repo's working tree and
  `.git/` are never mutated.
- Repo-local patterns continue to override the bundled fallback (per-repo / versioned-with-project
  customization preserved).

## Scope

Pattern fallback only. The sibling external-repo frictions — preflight AI-config symlink false-positive
(#1647) and review-gate scaffolding injection into target repos (#1651) — are intentionally **not**
folded in here and are tracked separately.

## Tests

- External-repo shape (no repo-local pattern) → resolver returns the bundled pattern; review/debate
  proceed instead of hard-failing.
- Repo-local pattern present → repo-local path still used (bundled fallback not consulted).
- Coverage for both the `csa-review` and `debate` patterns.
