### PR TITLE
fix(cli-sub-agent): allow tracked project AI config in preflight (#1647)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.854"
+version = "0.1.855"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.854"
+version = "0.1.855"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -223,6 +223,10 @@ pub enum Commands {
         #[arg(long)]
         no_error_marker_scan: bool,
 
+        /// Skip the AI-config symlink preflight for this run only.
+        #[arg(long)]
+        no_preflight: bool,
+
         /// Skip only the post-exec shell gate; external verification remains required.
         #[arg(long)]
         no_post_exec_gate: bool,

--- a/crates/cli-sub-agent/src/goal_loop.rs
+++ b/crates/cli-sub-agent/src/goal_loop.rs
@@ -110,6 +110,7 @@ pub(crate) struct GoalRunRequest {
     /// CLI `--no-error-marker-scan`: disables the #1652 fatal-error-marker
     /// silent-hang scan for this run, overriding config (#1745).
     pub(crate) no_error_marker_scan: bool,
+    pub(crate) no_preflight: bool,
     pub(crate) no_post_exec_gate: bool,
     pub(crate) require_commit: bool,
     pub(crate) extra_writable: Vec<PathBuf>,
@@ -180,6 +181,7 @@ pub(crate) async fn handle_run_or_goal(request: GoalRunRequest) -> Result<i32> {
         request.force_ignore_tier_setting,
         request.no_fs_sandbox,
         request.no_error_marker_scan,
+        request.no_preflight,
         request.no_post_exec_gate,
         request.require_commit,
         request.extra_writable,
@@ -342,6 +344,7 @@ async fn run_goal_iteration(
         request.force_ignore_tier_setting,
         request.no_fs_sandbox,
         request.no_error_marker_scan,
+        request.no_preflight,
         request.no_post_exec_gate,
         request.require_commit,
         request.extra_writable.clone(),

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -75,6 +75,7 @@ mod run_cmd_daemon;
 mod run_cmd_fork;
 mod run_cmd_model_pin;
 mod run_cmd_post;
+mod run_cmd_preflight;
 mod run_cmd_tool_selection;
 mod run_helpers;
 mod run_helpers_branch_guard;
@@ -268,6 +269,7 @@ async fn run() -> Result<()> {
             stream_stdout,
             no_stream_stdout,
             no_error_marker_scan,
+            no_preflight,
             no_post_exec_gate,
             require_commit,
             spec: _spec,
@@ -292,6 +294,14 @@ async fn run() -> Result<()> {
                 exit_current_process(exit_code);
             }
             let effective_no_daemon = no_daemon || goal.is_some();
+            run_cmd_preflight::run_before_daemon_spawn_if_needed(
+                cd.as_deref(),
+                no_preflight,
+                effective_no_daemon,
+                daemon_child,
+                session_id.is_some(),
+                session.is_some() || last || fork_from.is_some() || fork_last,
+            )?;
             let mut daemon_guard = run_cmd_daemon::check_daemon_flags(
                 "run",
                 effective_no_daemon,
@@ -362,6 +372,7 @@ async fn run() -> Result<()> {
                 force_ignore_tier_setting,
                 no_fs_sandbox,
                 no_error_marker_scan,
+                no_preflight,
                 no_post_exec_gate,
                 require_commit,
                 extra_writable,

--- a/crates/cli-sub-agent/src/preflight_symlink.rs
+++ b/crates/cli-sub-agent/src/preflight_symlink.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 use anyhow::{Result, anyhow};
 use csa_config::AiConfigSymlinkCheckConfig;
@@ -133,6 +134,16 @@ fn validate_one_path(
     }
 
     if file_type.is_file() {
+        // Rule 036 protects personal AI-config symlinks from accidental
+        // de-symlinking. That accident leaves a gitignored/untracked regular
+        // file behind, while third-party projects can legitimately commit their
+        // own CLAUDE.md/AGENTS.md. The tracked regular-file case is therefore
+        // project-owned config and must pass; untracked regular files still
+        // flag the de-symlink accident.
+        if git_tracks_path(project_root, relative_path) {
+            return None;
+        }
+
         return Some(format!(
             "{relative_path:<32} is a regular file, expected symlink"
         ));
@@ -147,6 +158,18 @@ fn validate_one_path(
     Some(format!(
         "{relative_path:<32} is not a symlink, expected symlink"
     ))
+}
+
+fn git_tracks_path(project_root: &Path, relative_path: &str) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["ls-files", "--error-unmatch", "--"])
+        .arg(relative_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
 }
 
 fn describe_symlink_target(path: &Path) -> String {
@@ -302,6 +325,42 @@ mod tests {
             ..Default::default()
         };
         let err = run_ai_config_symlink_check(d.path(), &cfg).expect_err("should fail");
+        assert!(err.to_string().contains("AGENTS.md"), "got: {err}");
+        assert!(err.to_string().contains("regular file"), "got: {err}");
+    }
+
+    #[test]
+    fn git_tracked_regular_ai_config_files_pass() {
+        let d = tempfile::tempdir().unwrap();
+        init_git_repo(d.path());
+        std::fs::write(d.path().join("AGENTS.md"), "project agents").unwrap();
+        std::fs::write(d.path().join("CLAUDE.md"), "project claude").unwrap();
+        run_git(d.path(), &["add", "AGENTS.md", "CLAUDE.md"]);
+        run_git(d.path(), &["commit", "-m", "add project ai config"]);
+
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: true,
+            ..Default::default()
+        };
+
+        run_ai_config_symlink_check(d.path(), &cfg).expect("tracked project files should pass");
+    }
+
+    #[test]
+    fn gitignored_regular_ai_config_file_is_violation() {
+        let d = tempfile::tempdir().unwrap();
+        init_git_repo(d.path());
+        std::fs::write(d.path().join(".gitignore"), "AGENTS.md\n").unwrap();
+        run_git(d.path(), &["add", ".gitignore"]);
+        run_git(d.path(), &["commit", "-m", "ignore personal ai config"]);
+        std::fs::write(d.path().join("AGENTS.md"), "desymlinked personal config").unwrap();
+
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: true,
+            ..Default::default()
+        };
+
+        let err = run_ai_config_symlink_check(d.path(), &cfg).expect_err("ignored file flags");
         assert!(err.to_string().contains("AGENTS.md"), "got: {err}");
         assert!(err.to_string().contains("regular file"), "got: {err}");
     }
@@ -547,5 +606,27 @@ mod tests {
             ..Default::default()
         };
         run_ai_config_symlink_check(d.path(), &cfg).expect("disabled should return Ok");
+    }
+
+    fn init_git_repo(project_root: &Path) {
+        run_git(project_root, &["init"]);
+        run_git(project_root, &["config", "core.excludesFile", "/dev/null"]);
+        run_git(project_root, &["config", "user.email", "test@example.com"]);
+        run_git(project_root, &["config", "user.name", "Test User"]);
+    }
+
+    fn run_git(project_root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(project_root)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/crates/cli-sub-agent/src/preflight_symlink.rs
+++ b/crates/cli-sub-agent/src/preflight_symlink.rs
@@ -161,15 +161,25 @@ fn validate_one_path(
 }
 
 fn git_tracks_path(project_root: &Path, relative_path: &str) -> bool {
-    Command::new("git")
+    let Ok(output) = Command::new("git")
         .arg("-C")
         .arg(project_root)
-        .args(["ls-files", "--error-unmatch", "--"])
+        .args(["ls-files", "--stage", "--"])
         .arg(relative_path)
-        .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
+        .output()
+    else {
+        return false;
+    };
+
+    if !output.status.success() {
+        return false;
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .any(|mode| matches!(mode, "100644" | "100755"))
 }
 
 fn describe_symlink_target(path: &Path) -> String {
@@ -344,6 +354,29 @@ mod tests {
         };
 
         run_ai_config_symlink_check(d.path(), &cfg).expect("tracked project files should pass");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn git_tracked_symlink_replaced_by_regular_ai_config_file_is_violation() {
+        let d = tempfile::tempdir().unwrap();
+        init_git_repo(d.path());
+        std::fs::write(d.path().join("project-claude.md"), "project claude").unwrap();
+        std::os::unix::fs::symlink("project-claude.md", d.path().join("CLAUDE.md")).unwrap();
+        run_git(d.path(), &["add", "CLAUDE.md"]);
+        run_git(d.path(), &["commit", "-m", "track claude symlink"]);
+
+        std::fs::remove_file(d.path().join("CLAUDE.md")).unwrap();
+        std::fs::write(d.path().join("CLAUDE.md"), "desymlinked personal config").unwrap();
+
+        let cfg = AiConfigSymlinkCheckConfig {
+            enabled: true,
+            ..Default::default()
+        };
+
+        let err = run_ai_config_symlink_check(d.path(), &cfg).expect_err("symlink mode flags");
+        assert!(err.to_string().contains("CLAUDE.md"), "got: {err}");
+        assert!(err.to_string().contains("regular file"), "got: {err}");
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -158,6 +158,7 @@ impl SubagentRunConfig {
             false, // no_error_marker_scan: programmatic run wrapper; defer to config (#1745)
             false,
             false,
+            false,
             Vec::new(),
             Vec::new(),
             self.startup_env,

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -117,6 +117,7 @@ pub(crate) async fn handle_run(
     force_ignore_tier_setting: bool,
     no_fs_sandbox: bool,
     no_error_marker_scan: bool,
+    no_preflight: bool,
     no_post_exec_gate: bool,
     require_commit: bool,
     extra_writable: Vec<PathBuf>,
@@ -192,10 +193,18 @@ pub(crate) async fn handle_run(
         is_fork = true;
     }
 
-    let Some((config, global_config)) = pipeline::load_and_validate(&project_root, current_depth)?
+    let Some((mut config, mut global_config)) =
+        pipeline::load_and_validate(&project_root, current_depth)?
     else {
         return Ok(1);
     };
+    crate::run_cmd_preflight::apply_run_preflight_override(
+        &project_root,
+        session_arg.as_deref(),
+        no_preflight,
+        &mut config,
+        &mut global_config,
+    )?;
     let caller_fork_resolution = if fork_from_caller {
         let resolved = resolve_fork_from_caller(config.as_ref());
         if resolved.is_none() {

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -198,13 +198,6 @@ pub(crate) async fn handle_run(
     else {
         return Ok(1);
     };
-    crate::run_cmd_preflight::apply_run_preflight_override(
-        &project_root,
-        session_arg.as_deref(),
-        no_preflight,
-        &mut config,
-        &mut global_config,
-    )?;
     let caller_fork_resolution = if fork_from_caller {
         let resolved = resolve_fork_from_caller(config.as_ref());
         if resolved.is_none() {
@@ -220,6 +213,13 @@ pub(crate) async fn handle_run(
     if let Some(exit_code) = evaluate_and_emit_refusal(&branch_guard, branch_state) {
         return Ok(exit_code);
     }
+    crate::run_cmd_preflight::apply_run_preflight_override(
+        &project_root,
+        session_arg.as_deref(),
+        no_preflight,
+        &mut config,
+        &mut global_config,
+    )?;
     let pre_session_hook = csa_hooks::load_global_pre_session_hook_invocation();
     let mut user_explicit_tool = tool.is_some();
     let prompt = resolve_positional_stdin_sentinel(prompt)?.or(prompt_flag);

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -74,6 +74,61 @@ fn run_config_without_routable_tools() -> ProjectConfig {
     run_config_with_tier("default", Vec::new(), &[])
 }
 
+async fn run_preflight_fixture(project_root: &Path, no_preflight: bool) -> anyhow::Result<i32> {
+    handle_run(
+        None,
+        None,
+        None,
+        None,
+        Some("inspect the repository".to_string()),
+        None,
+        None,
+        None,
+        None,
+        false,
+        None,
+        false,
+        false,
+        None,
+        false,
+        None,
+        None,
+        false,
+        true,
+        Some(project_root.display().to_string()),
+        None,
+        None,
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        None,
+        false,
+        None,
+        None,
+        None,
+        false,
+        false,
+        None,
+        0,
+        OutputFormat::Text,
+        csa_process::StreamMode::BufferOnly,
+        None,
+        false,
+        false,
+        false, // no_error_marker_scan (#1745)
+        no_preflight,
+        false,
+        false,
+        Vec::new(),
+        Vec::new(),
+        crate::startup_env::StartupSubtreeEnv::default(),
+    )
+    .await
+}
+
 #[tokio::test]
 async fn handle_run_rejects_model_spec_tier_bypass_before_session_creation() {
     let project_dir = tempdir().unwrap();
@@ -131,6 +186,7 @@ async fn handle_run_rejects_model_spec_tier_bypass_before_session_creation() {
         false, // no_error_marker_scan (#1745)
         false,
         false,
+        false,
         Vec::new(),
         Vec::new(),
         crate::startup_env::StartupSubtreeEnv::default(),
@@ -159,6 +215,36 @@ async fn handle_run_rejects_model_spec_tier_bypass_before_session_creation() {
     assert!(
         sessions.is_empty(),
         "tier bypass gate should reject before session creation"
+    );
+}
+
+#[tokio::test]
+async fn handle_run_no_preflight_skips_ai_config_check() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    let mut config = run_config_without_routable_tools();
+    config.preflight.ai_config_symlink_check.enabled = true;
+    write_project_config(project_dir.path(), &config);
+    std::fs::write(project_dir.path().join("AGENTS.md"), "not a symlink").unwrap();
+
+    let preflight_err = run_preflight_fixture(project_dir.path(), false)
+        .await
+        .expect_err("enabled preflight should reject regular AI config");
+    assert!(
+        preflight_err
+            .to_string()
+            .contains("preflight: AI-config symlink integrity check failed"),
+        "unexpected error: {preflight_err:#}"
+    );
+
+    let routing_err = run_preflight_fixture(project_dir.path(), true)
+        .await
+        .expect_err("--no-preflight should skip to routing");
+    assert!(
+        routing_err
+            .to_string()
+            .contains("No tool specified and no tier-based or auto-selectable tool available"),
+        "unexpected error: {routing_err:#}"
     );
 }
 
@@ -213,6 +299,7 @@ async fn handle_run_does_not_persist_result_for_non_conflict_pre_exec_error() {
         false,
         false,
         false, // no_error_marker_scan (#1745)
+        false,
         false,
         false,
         Vec::new(),

--- a/crates/cli-sub-agent/src/run_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/run_cmd_preflight.rs
@@ -1,0 +1,63 @@
+//! Preflight helpers for `csa run`.
+
+use anyhow::Result;
+use std::path::Path;
+
+use csa_config::{GlobalConfig, ProjectConfig};
+
+pub(crate) fn run_before_daemon_spawn_if_needed(
+    cd: Option<&str>,
+    no_preflight: bool,
+    no_daemon: bool,
+    daemon_child: bool,
+    has_session_id: bool,
+    is_resume: bool,
+) -> Result<()> {
+    if no_preflight || no_daemon || daemon_child || has_session_id || is_resume {
+        return Ok(());
+    }
+
+    let project_root = crate::pipeline::determine_project_root(cd)?;
+    let project_config = csa_config::ProjectConfig::load(&project_root)?;
+    let global_config = csa_config::GlobalConfig::load()?;
+    let preflight_config = project_config
+        .as_ref()
+        .map(|cfg| &cfg.preflight.ai_config_symlink_check)
+        .unwrap_or(&global_config.preflight.ai_config_symlink_check);
+
+    crate::preflight_symlink::run_ai_config_symlink_check(&project_root, preflight_config)
+}
+
+pub(crate) fn apply_run_preflight_override(
+    project_root: &Path,
+    session_arg: Option<&str>,
+    no_preflight: bool,
+    config: &mut Option<ProjectConfig>,
+    global_config: &mut GlobalConfig,
+) -> Result<()> {
+    if no_preflight {
+        disable_ai_config_preflight(config, global_config);
+        return Ok(());
+    }
+
+    if session_arg.is_some() {
+        return Ok(());
+    }
+
+    let preflight_config = config
+        .as_ref()
+        .map(|cfg| &cfg.preflight.ai_config_symlink_check)
+        .unwrap_or(&global_config.preflight.ai_config_symlink_check);
+    crate::preflight_symlink::run_ai_config_symlink_check(project_root, preflight_config)
+}
+
+fn disable_ai_config_preflight(
+    config: &mut Option<ProjectConfig>,
+    global_config: &mut GlobalConfig,
+) {
+    if let Some(project_config) = config {
+        project_config.preflight.ai_config_symlink_check.enabled = false;
+    } else {
+        global_config.preflight.ai_config_symlink_check.enabled = false;
+    }
+}

--- a/crates/cli-sub-agent/src/run_cmd_tests_core.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_core.rs
@@ -369,6 +369,25 @@ fn test_cli_no_error_marker_scan_flag_parses() {
 }
 
 #[test]
+fn test_cli_no_preflight_flag_parses() {
+    let cli = try_parse_cli(&["csa", "run", "--no-preflight", "prompt"]).unwrap();
+    match cli.command {
+        crate::cli::Commands::Run { no_preflight, .. } => {
+            assert!(no_preflight);
+        }
+        _ => panic!("expected Run command"),
+    }
+
+    let cli_default = try_parse_cli(&["csa", "run", "prompt"]).unwrap();
+    match cli_default.command {
+        crate::cli::Commands::Run { no_preflight, .. } => {
+            assert!(!no_preflight);
+        }
+        _ => panic!("expected Run command"),
+    }
+}
+
+#[test]
 fn test_cli_prompt_flag_parses_and_conflicts_with_positional_prompt() {
     let cli = try_parse_cli(&["csa", "run", "--prompt", "hello"]).unwrap();
     match cli.command {

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -157,6 +157,7 @@ async fn handle_run_persists_result_for_direct_tool_tier_rejection() {
         false, // no_error_marker_scan (#1745)
         false,
         false,
+        false,
         Vec::new(),
         Vec::new(),
         crate::startup_env::StartupSubtreeEnv::default(),

--- a/crates/cli-sub-agent/src/skill_run_cmd.rs
+++ b/crates/cli-sub-agent/src/skill_run_cmd.rs
@@ -95,6 +95,7 @@ pub(crate) async fn handle_skill_run(
         force_ignore_tier_setting: false,
         no_fs_sandbox: false,
         no_error_marker_scan: false,
+        no_preflight: false,
         no_post_exec_gate: false,
         require_commit: false,
         extra_writable: vec![],

--- a/crates/cli-sub-agent/tests/cli_run_branch_guard.rs
+++ b/crates/cli-sub-agent/tests/cli_run_branch_guard.rs
@@ -390,6 +390,32 @@ fn daemon_run_on_main_without_bypass_refuses_before_spawn() {
 }
 
 #[test]
+#[cfg(unix)]
+fn run_on_main_refuses_before_ai_config_preflight_auto_heal() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_git_repo(tmp.path(), "main");
+    let config_path = tmp.path().join(".csa/config.toml");
+    std::fs::create_dir_all(config_path.parent().expect("config dir")).expect("create config dir");
+    std::fs::write(
+        config_path,
+        "[preflight.ai_config_symlink_check]\nenabled = true\n",
+    )
+    .expect("write project config");
+    std::fs::create_dir(tmp.path().join(".agents")).expect("create .agents");
+    let auto_heal_target = tmp.path().join("rules-target");
+    std::os::unix::fs::symlink("../rules-target", tmp.path().join(".agents/rules-ref"))
+        .expect("create missing-target symlink");
+
+    let output = run_csa_with_missing_tool(tmp.path(), tmp.path(), &[]);
+
+    assert_branch_guard_refused(&output);
+    assert!(
+        !auto_heal_target.exists(),
+        "branch guard refusal must happen before preflight auto-heal"
+    );
+}
+
+#[test]
 fn run_on_feature_branch_allows_guard_to_later_tool_error() {
     let tmp = tempfile::tempdir().expect("tempdir");
     init_git_repo(tmp.path(), "main");


### PR DESCRIPTION
## Summary

Fixes #1647 — the preflight AI-config symlink integrity check false-positived on external repos
that ship their own **git-tracked** `CLAUDE.md` / `AGENTS.md`, blocking the common
"fork/clone a third-party repo → run `csa` on it" workflow.

Observed before this change (e.g. on `rust-skills`, which commits a real `CLAUDE.md` + `AGENTS.md`):

```
Error: preflight: AI-config symlink integrity check failed
  AGENTS.md   is a regular file, expected symlink
  CLAUDE.md   is a regular file, expected symlink
```

## Changes

- **Core fix:** a **git-tracked** regular `CLAUDE.md` / `AGENTS.md` is now treated as the project's
  own legitimate, committed instruction file and **passes** the preflight check. The check still
  **flags** a regular file that is **not git-tracked** where a symlink is expected — i.e. the
  rule-036 de-symlink accident (the symlink replaced by a gitignored regular file) is still caught,
  because that file remains untracked.
- **Escape hatch:** new `--no-preflight` flag on `csa run` to skip the AI-config symlink preflight
  for one-off external runs.
- Tests cover: tracked regular file → passes; symlink → passes; untracked/gitignored
  regular file where a symlink is expected → still flags; `--no-preflight` → skips.
- **Index-mode check (review round 2):** tracked-ness alone is insufficient — a repo that tracks
  `CLAUDE.md`/`AGENTS.md` as a *symlink* (git mode `120000`) and then has it replaced by a regular
  file is the rule-036 de-symlink accident and must still be flagged. The check now inspects the
  tracked index mode and only allows regular-file modes (`100644`/`100755`), not `120000`.
- **Branch-guard ordering (review round 2):** the no-daemon/goal preflight (which can `create_dir_all`
  via auto-heal) now runs *after* the protected-branch guard refusal, mirroring the daemon path, so no
  mutating preflight happens before a protected-branch run is refused.
- Version bump to `0.1.855`.

## Why this preserves the maintainer guard

Rule 036 is "do NOT commit AI-config; symlink it + gitignore it." The realistic accident the check
defends against is **de-symlinking** — and the resulting regular file stays gitignored/untracked, so
"untracked regular file where symlink expected → flag" still catches it. A *tracked* regular
`CLAUDE.md` can only arise in the maintainer's own repo via a forced `git add -f` (separately
forbidden by rule 036), so allowing tracked regular files does not meaningfully weaken the guard,
while eliminating the false-positive for every external repo that legitimately commits its own
AI-config.

Closes #1647

🤖 Generated with [Claude Code](https://claude.com/claude-code)
