### PR TITLE
fix(cli-sub-agent): close codex-single review false-PASS via prose parsing + line-total fail-closed (#1804)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.855"
+version = "0.1.856"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.855"
+version = "0.1.856"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -283,6 +283,7 @@ pub(super) fn contains_clean_phrase(output: &str) -> bool {
         "no issues were found",
         "no blocking issues",
         "no findings",
+        "none.",
         "\u{672a}\u{53d1}\u{73b0}\u{95ee}\u{9898}",
         "\u{6ca1}\u{6709}\u{53d1}\u{73b0}\u{95ee}\u{9898}",
         "\u{65e0}\u{963b}\u{585e}\u{95ee}\u{9898}",

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -10,6 +10,8 @@ use super::artifacts::{has_blocking_severity, load_findings_toml_from_output};
 use super::prose_signals::{reconcile_counts_with_prose, review_prose_signals};
 use crate::review_cmd::prose_findings::severity_counts_from_review_findings;
 
+const PROSE_FINDINGS_UNPARSED_REASON: &str = "prose_findings_present_but_unparsed";
+
 pub(super) fn enforce_final_verdict_consistency(
     session_dir: &Path,
     artifact: &mut ReviewVerdictArtifact,
@@ -44,8 +46,18 @@ pub(super) fn enforce_final_verdict_consistency(
         prose_signals.blocking_summary || has_blocking_severity(&prose_signals.severity_counts);
     let has_empty_machine_findings =
         findings_file.findings.is_empty() && severity_counts_are_zero(&artifact.severity_counts);
+    let unparsed_actionable_prose =
+        prose_signals.actionable_prose_sections && has_empty_machine_findings;
 
-    if artifact.decision == ReviewDecision::Pass && (resume_to_fix || blocking_prose) {
+    if unparsed_actionable_prose {
+        artifact
+            .failure_reason
+            .get_or_insert_with(|| PROSE_FINDINGS_UNPARSED_REASON.to_string());
+    }
+
+    if artifact.decision == ReviewDecision::Pass
+        && (resume_to_fix || blocking_prose || unparsed_actionable_prose)
+    {
         ensure_nonzero_fail_closed_count(&mut artifact.severity_counts);
         artifact.decision = ReviewDecision::Fail;
         artifact.verdict_legacy = "HAS_ISSUES".to_string();

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -46,17 +46,17 @@ pub(super) fn enforce_final_verdict_consistency(
         prose_signals.blocking_summary || has_blocking_severity(&prose_signals.severity_counts);
     let has_empty_machine_findings =
         findings_file.findings.is_empty() && severity_counts_are_zero(&artifact.severity_counts);
-    let unparsed_actionable_prose =
-        prose_signals.actionable_prose_sections && has_empty_machine_findings;
+    let unparsed_findings_prose =
+        prose_signals.unclean_findings_sections && has_empty_machine_findings;
 
-    if unparsed_actionable_prose {
+    if unparsed_findings_prose {
         artifact
             .failure_reason
             .get_or_insert_with(|| PROSE_FINDINGS_UNPARSED_REASON.to_string());
     }
 
     if artifact.decision == ReviewDecision::Pass
-        && (resume_to_fix || blocking_prose || unparsed_actionable_prose)
+        && (resume_to_fix || blocking_prose || unparsed_findings_prose)
     {
         ensure_nonzero_fail_closed_count(&mut artifact.severity_counts);
         artifact.decision = ReviewDecision::Fail;

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -119,13 +119,21 @@ fn findings_section_body_is_unclean(
     body: &str,
     default_unlabeled_severity: Option<Severity>,
 ) -> bool {
-    let body = body.trim();
-    if body.is_empty() || contains_canonical_clean_conclusion(body) {
-        return false;
-    }
+    body.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with("```"))
+        .any(|line| {
+            !contains_canonical_clean_conclusion(line)
+                && !line_parses_as_structured_finding(line, default_unlabeled_severity.clone())
+        })
+}
 
-    let parser_input = format!("Findings\n{body}");
-    extract_review_findings_from_prose_with_default(&parser_input, default_unlabeled_severity)
+fn line_parses_as_structured_finding(
+    line: &str,
+    default_unlabeled_severity: Option<Severity>,
+) -> bool {
+    let parser_input = format!("Findings\n{line}");
+    !extract_review_findings_from_prose_with_default(&parser_input, default_unlabeled_severity)
         .is_empty()
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
@@ -23,20 +22,15 @@ pub(super) struct ReviewProseSignals {
 }
 
 pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSignals> {
-    let contents = current_round_review_prose_contents(session_dir)?;
-
-    let blocking_summary = contents
-        .iter()
-        .filter(|(section_id, _)| section_id == "summary")
-        .any(|(_, content)| contains_blocking_issue_signal(content));
+    let prose = current_round_review_prose_contents(session_dir)?;
     let mut signals = ReviewProseSignals {
         severity_counts: zero_severity_counts(),
-        blocking_summary,
+        blocking_summary: prose.blocking_summary,
         unclean_findings_sections: false,
         findings: Vec::new(),
     };
-    let default_unlabeled_severity = blocking_summary.then_some(Severity::Medium);
-    for (section_id, content) in contents {
+    let default_unlabeled_severity = prose.blocking_summary.then_some(Severity::Medium);
+    for (section_id, content) in prose.contents {
         record_review_prose_signal(
             &mut signals,
             &section_id,
@@ -48,7 +42,14 @@ pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSign
     Ok(signals)
 }
 
-fn current_round_review_prose_contents(session_dir: &Path) -> Result<Vec<(String, String)>> {
+struct CurrentRoundReviewProseContents {
+    blocking_summary: bool,
+    contents: Vec<(String, String)>,
+}
+
+fn current_round_review_prose_contents(
+    session_dir: &Path,
+) -> Result<CurrentRoundReviewProseContents> {
     let mut latest_summary = None;
     let mut latest_details = None;
 
@@ -60,30 +61,32 @@ fn current_round_review_prose_contents(session_dir: &Path) -> Result<Vec<(String
         }
     }
 
+    let blocking_summary = latest_summary
+        .as_deref()
+        .is_some_and(contains_blocking_issue_signal);
+
+    if let Some(content) =
+        crate::review_cmd::findings_toml::load_canonical_review_text(session_dir)?
+    {
+        return Ok(CurrentRoundReviewProseContents {
+            blocking_summary,
+            contents: vec![("canonical".to_string(), content)],
+        });
+    }
+
     let mut contents = Vec::new();
     if let Some(content) = latest_summary {
-        contents.push(("summary".to_string(), content));
-    } else if let Some(content) = read_legacy_section_file(session_dir, "summary")? {
         contents.push(("summary".to_string(), content));
     }
 
     if let Some(content) = latest_details {
         contents.push(("details".to_string(), content));
-    } else if let Some(content) = read_legacy_section_file(session_dir, "details")? {
-        contents.push(("details".to_string(), content));
     }
 
-    Ok(contents)
-}
-
-fn read_legacy_section_file(session_dir: &Path, section_id: &str) -> Result<Option<String>> {
-    let path = session_dir.join("output").join(format!("{section_id}.md"));
-    if !path.exists() {
-        return Ok(None);
-    }
-    let content = fs::read_to_string(&path)
-        .map_err(|error| anyhow::anyhow!("read {}: {error}", path.display()))?;
-    Ok(Some(content))
+    Ok(CurrentRoundReviewProseContents {
+        blocking_summary,
+        contents,
+    })
 }
 
 fn record_review_prose_signal(

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use anyhow::Result;
 use csa_session::{ReviewFinding, Severity};
 
+use super::clean_detection::{contains_clean_phrase, detect_prose_clean_conclusion};
 use super::text::{
     contains_blocking_issue_signal, severity_counts_from_text, zero_severity_counts,
 };
@@ -17,7 +18,7 @@ use crate::review_cmd::prose_findings::{
 pub(super) struct ReviewProseSignals {
     pub(super) severity_counts: BTreeMap<Severity, u32>,
     pub(super) blocking_summary: bool,
-    pub(super) actionable_prose_sections: bool,
+    pub(super) unclean_findings_sections: bool,
     pub(super) findings: Vec<ReviewFinding>,
 }
 
@@ -31,9 +32,12 @@ pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSign
     let mut signals = ReviewProseSignals {
         severity_counts: zero_severity_counts(),
         blocking_summary,
-        actionable_prose_sections: false,
+        unclean_findings_sections: false,
         findings: Vec::new(),
     };
+    let review_has_clean_conclusion = contents
+        .iter()
+        .any(|(_, content)| contains_canonical_clean_conclusion(content));
     let default_unlabeled_severity = blocking_summary.then_some(Severity::Medium);
     for (section_id, content) in contents {
         record_review_prose_signal(
@@ -41,6 +45,7 @@ pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSign
             &section_id,
             &content,
             default_unlabeled_severity.clone(),
+            review_has_clean_conclusion,
         );
     }
 
@@ -90,8 +95,10 @@ fn record_review_prose_signal(
     _section_id: &str,
     content: &str,
     default_unlabeled_severity: Option<Severity>,
+    review_has_clean_conclusion: bool,
 ) {
-    signals.actionable_prose_sections |= contains_actionable_review_section(content);
+    signals.unclean_findings_sections |=
+        contains_unclean_findings_section(content, review_has_clean_conclusion);
     let findings =
         extract_review_findings_from_prose_with_default(content, default_unlabeled_severity);
     let mut counts = severity_counts_from_review_findings(&findings);
@@ -100,26 +107,19 @@ fn record_review_prose_signal(
     signals.findings.extend(findings);
 }
 
-fn contains_actionable_review_section(content: &str) -> bool {
-    let mut active_section = false;
-    let mut body = Vec::new();
+fn contains_unclean_findings_section(content: &str, review_has_clean_conclusion: bool) -> bool {
+    contains_findings_section(content) && !review_has_clean_conclusion
+}
 
-    for line in content.lines() {
-        if let Some(header) = markdown_header_text(line) {
-            if active_section && section_body_is_actionable(&body) {
-                return true;
-            }
-            active_section = is_findings_header(header);
-            body.clear();
-            continue;
-        }
+fn contains_findings_section(content: &str) -> bool {
+    content
+        .lines()
+        .filter_map(markdown_header_text)
+        .any(is_findings_header)
+}
 
-        if active_section {
-            body.push(line);
-        }
-    }
-
-    active_section && section_body_is_actionable(&body)
+fn contains_canonical_clean_conclusion(content: &str) -> bool {
+    contains_clean_phrase(content) || detect_prose_clean_conclusion(content)
 }
 
 fn markdown_header_text(line: &str) -> Option<&str> {
@@ -128,59 +128,6 @@ fn markdown_header_text(line: &str) -> Option<&str> {
         return None;
     }
     Some(trimmed.trim_start_matches('#').trim())
-}
-
-fn section_body_is_actionable(lines: &[&str]) -> bool {
-    let normalized = lines
-        .iter()
-        .map(|line| normalize_actionable_section_line(line))
-        .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>();
-
-    !normalized.is_empty()
-        && normalized
-            .iter()
-            .any(|line| !is_no_actionable_section_sentinel(line))
-}
-
-fn normalize_actionable_section_line(line: &str) -> String {
-    let mut trimmed = line.trim();
-    if matches!(trimmed.as_bytes().first(), Some(b'-' | b'*')) {
-        trimmed = trimmed[1..].trim_start();
-    } else if let Some(numbered) = strip_numbered_prefix(trimmed) {
-        trimmed = numbered.trim_start();
-    }
-    trimmed
-        .trim_matches(|ch: char| ch.is_ascii_punctuation())
-        .trim()
-        .to_ascii_lowercase()
-}
-
-fn strip_numbered_prefix(line: &str) -> Option<&str> {
-    let (index, rest) = line.split_once('.')?;
-    if index.is_empty() || !index.chars().all(|ch| ch.is_ascii_digit()) {
-        return None;
-    }
-    Some(rest)
-}
-
-fn is_no_actionable_section_sentinel(line: &str) -> bool {
-    matches!(
-        line,
-        "none"
-            | "n/a"
-            | "na"
-            | "not applicable"
-            | "no findings"
-            | "no findings found"
-            | "no blocking findings"
-            | "no blocking findings found"
-            | "no actionable findings"
-            | "no actionable findings found"
-            | "no recommended actions"
-            | "no action required"
-            | "no actions required"
-    )
 }
 
 fn merge_severity_counts_add(

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -16,6 +16,7 @@ use crate::review_cmd::prose_findings::{
 pub(super) struct ReviewProseSignals {
     pub(super) severity_counts: BTreeMap<Severity, u32>,
     pub(super) blocking_summary: bool,
+    pub(super) actionable_prose_sections: bool,
     pub(super) findings: Vec<ReviewFinding>,
 }
 
@@ -29,6 +30,7 @@ pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSign
     let mut signals = ReviewProseSignals {
         severity_counts: zero_severity_counts(),
         blocking_summary,
+        actionable_prose_sections: false,
         findings: Vec::new(),
     };
     let default_unlabeled_severity = blocking_summary.then_some(Severity::Medium);
@@ -88,12 +90,102 @@ fn record_review_prose_signal(
     content: &str,
     default_unlabeled_severity: Option<Severity>,
 ) {
+    signals.actionable_prose_sections |= contains_actionable_review_section(content);
     let findings =
         extract_review_findings_from_prose_with_default(content, default_unlabeled_severity);
     let mut counts = severity_counts_from_review_findings(&findings);
     reconcile_counts_max(&mut counts, &severity_counts_from_text(content));
     merge_severity_counts_add(&mut signals.severity_counts, &counts);
     signals.findings.extend(findings);
+}
+
+fn contains_actionable_review_section(content: &str) -> bool {
+    let mut active_section = false;
+    let mut body = Vec::new();
+
+    for line in content.lines() {
+        if let Some(header) = markdown_header_text(line) {
+            if active_section && section_body_is_actionable(&body) {
+                return true;
+            }
+            active_section = is_actionable_review_section_header(header);
+            body.clear();
+            continue;
+        }
+
+        if active_section {
+            body.push(line);
+        }
+    }
+
+    active_section && section_body_is_actionable(&body)
+}
+
+fn markdown_header_text(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with('#') {
+        return None;
+    }
+    Some(trimmed.trim_start_matches('#').trim())
+}
+
+fn is_actionable_review_section_header(header: &str) -> bool {
+    header.eq_ignore_ascii_case("findings")
+        || header.eq_ignore_ascii_case("review findings")
+        || header.eq_ignore_ascii_case("recommended actions")
+}
+
+fn section_body_is_actionable(lines: &[&str]) -> bool {
+    let normalized = lines
+        .iter()
+        .map(|line| normalize_actionable_section_line(line))
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+
+    !normalized.is_empty()
+        && normalized
+            .iter()
+            .any(|line| !is_no_actionable_section_sentinel(line))
+}
+
+fn normalize_actionable_section_line(line: &str) -> String {
+    let mut trimmed = line.trim();
+    if matches!(trimmed.as_bytes().first(), Some(b'-' | b'*')) {
+        trimmed = trimmed[1..].trim_start();
+    } else if let Some(numbered) = strip_numbered_prefix(trimmed) {
+        trimmed = numbered.trim_start();
+    }
+    trimmed
+        .trim_matches(|ch: char| ch.is_ascii_punctuation())
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn strip_numbered_prefix(line: &str) -> Option<&str> {
+    let (index, rest) = line.split_once('.')?;
+    if index.is_empty() || !index.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    Some(rest)
+}
+
+fn is_no_actionable_section_sentinel(line: &str) -> bool {
+    matches!(
+        line,
+        "none"
+            | "n/a"
+            | "na"
+            | "not applicable"
+            | "no findings"
+            | "no findings found"
+            | "no blocking findings"
+            | "no blocking findings found"
+            | "no actionable findings"
+            | "no actionable findings found"
+            | "no recommended actions"
+            | "no action required"
+            | "no actions required"
+    )
 }
 
 fn merge_severity_counts_add(

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -10,7 +10,7 @@ use super::text::{
     contains_blocking_issue_signal, severity_counts_from_text, zero_severity_counts,
 };
 use crate::review_cmd::prose_findings::{
-    extract_review_findings_from_prose_with_default, is_findings_header,
+    extract_review_findings_from_prose_with_default, findings_section_bodies,
     severity_counts_from_review_findings,
 };
 
@@ -35,9 +35,6 @@ pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSign
         unclean_findings_sections: false,
         findings: Vec::new(),
     };
-    let review_has_clean_conclusion = contents
-        .iter()
-        .any(|(_, content)| contains_canonical_clean_conclusion(content));
     let default_unlabeled_severity = blocking_summary.then_some(Severity::Medium);
     for (section_id, content) in contents {
         record_review_prose_signal(
@@ -45,7 +42,6 @@ pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSign
             &section_id,
             &content,
             default_unlabeled_severity.clone(),
-            review_has_clean_conclusion,
         );
     }
 
@@ -95,10 +91,9 @@ fn record_review_prose_signal(
     _section_id: &str,
     content: &str,
     default_unlabeled_severity: Option<Severity>,
-    review_has_clean_conclusion: bool,
 ) {
     signals.unclean_findings_sections |=
-        contains_unclean_findings_section(content, review_has_clean_conclusion);
+        contains_unclean_findings_section(content, default_unlabeled_severity.clone());
     let findings =
         extract_review_findings_from_prose_with_default(content, default_unlabeled_severity);
     let mut counts = severity_counts_from_review_findings(&findings);
@@ -107,27 +102,31 @@ fn record_review_prose_signal(
     signals.findings.extend(findings);
 }
 
-fn contains_unclean_findings_section(content: &str, review_has_clean_conclusion: bool) -> bool {
-    contains_findings_section(content) && !review_has_clean_conclusion
-}
-
-fn contains_findings_section(content: &str) -> bool {
-    content
-        .lines()
-        .filter_map(markdown_header_text)
-        .any(is_findings_header)
+fn contains_unclean_findings_section(
+    content: &str,
+    default_unlabeled_severity: Option<Severity>,
+) -> bool {
+    findings_section_bodies(content).into_iter().any(|body| {
+        findings_section_body_is_unclean(body.as_str(), default_unlabeled_severity.clone())
+    })
 }
 
 fn contains_canonical_clean_conclusion(content: &str) -> bool {
     contains_clean_phrase(content) || detect_prose_clean_conclusion(content)
 }
 
-fn markdown_header_text(line: &str) -> Option<&str> {
-    let trimmed = line.trim_start();
-    if !trimmed.starts_with('#') {
-        return None;
+fn findings_section_body_is_unclean(
+    body: &str,
+    default_unlabeled_severity: Option<Severity>,
+) -> bool {
+    let body = body.trim();
+    if body.is_empty() || contains_canonical_clean_conclusion(body) {
+        return false;
     }
-    Some(trimmed.trim_start_matches('#').trim())
+
+    let parser_input = format!("Findings\n{body}");
+    extract_review_findings_from_prose_with_default(&parser_input, default_unlabeled_severity)
+        .is_empty()
 }
 
 fn merge_severity_counts_add(

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -131,8 +131,6 @@ fn markdown_header_text(line: &str) -> Option<&str> {
 
 fn is_actionable_review_section_header(header: &str) -> bool {
     header.eq_ignore_ascii_case("findings")
-        || header.eq_ignore_ascii_case("review findings")
-        || header.eq_ignore_ascii_case("recommended actions")
 }
 
 fn section_body_is_actionable(lines: &[&str]) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -9,7 +9,8 @@ use super::text::{
     contains_blocking_issue_signal, severity_counts_from_text, zero_severity_counts,
 };
 use crate::review_cmd::prose_findings::{
-    extract_review_findings_from_prose_with_default, severity_counts_from_review_findings,
+    extract_review_findings_from_prose_with_default, is_findings_header,
+    severity_counts_from_review_findings,
 };
 
 #[derive(Debug, Clone)]
@@ -108,7 +109,7 @@ fn contains_actionable_review_section(content: &str) -> bool {
             if active_section && section_body_is_actionable(&body) {
                 return true;
             }
-            active_section = is_actionable_review_section_header(header);
+            active_section = is_findings_header(header);
             body.clear();
             continue;
         }
@@ -127,10 +128,6 @@ fn markdown_header_text(line: &str) -> Option<&str> {
         return None;
     }
     Some(trimmed.trim_start_matches('#').trim())
-}
-
-fn is_actionable_review_section_header(header: &str) -> bool {
-    header.eq_ignore_ascii_case("findings")
 }
 
 fn section_body_is_actionable(lines: &[&str]) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -798,3 +798,6 @@ mod verdict_1754_tests;
 
 #[path = "review_cmd_output_verdict_1761_tests.rs"]
 mod verdict_1761_tests;
+
+#[path = "review_cmd_output_verdict_1804_tests.rs"]
+mod verdict_1804_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -167,3 +167,47 @@ None.
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+#[test]
+fn issue_1804_clean_findings_with_benign_recommended_action_stays_pass() {
+    let session_id = "01TEST1804CLEANACTION000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-clean-action", session_id);
+
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+No blocking findings found.
+
+## Recommended Actions
+
+1. Open the PR.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -13,7 +13,11 @@ fn read_verdict(session_dir: &Path) -> ReviewVerdictArtifact {
         .expect("parse verdict")
 }
 
-const SUPPORTED_FINDINGS_HEADINGS: &[&str] = &["Findings", "Review Findings"];
+const SUPPORTED_FINDINGS_HEADINGS: &[&str] = &[
+    "Findings",
+    "Review Findings",
+    "Findings (ordered by severity)",
+];
 
 const CLEAN_FINDINGS_BODIES: &[(&str, &str, &str)] = &[
     ("no-issues-found", "Review completed.", "No issues found."),
@@ -133,7 +137,7 @@ fn issue_1804_unparsed_findings_sections_fail_closed_with_reason() {
             &session_dir,
             &format!(
                 r#"<!-- CSA:SECTION:summary -->
-Review completed.
+No blocking issues.
 <!-- CSA:SECTION:summary:END -->
 
 <!-- CSA:SECTION:details -->
@@ -225,6 +229,73 @@ fn issue_1804_canonical_clean_findings_sections_stay_pass() {
             fs::remove_dir_all(project_root).expect("remove temp project root");
         }
     }
+}
+
+#[test]
+fn issue_1804_parsed_findings_section_still_fails() {
+    let session_id = "01TEST1804PARSEDHIGH000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-parsed-high", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+No blocking issues.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+1. [High] real bug remains visible in the findings section.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1804_recommended_actions_without_findings_section_stays_pass() {
+    let session_id = "01TEST1804ACTIONONLY000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-action-only", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+No blocking issues.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Recommended Actions
+
+1. Open the PR.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -1,0 +1,169 @@
+use super::*;
+use csa_session::FindingsFile;
+
+fn read_findings_toml(session_dir: &Path) -> FindingsFile {
+    let findings_path = session_dir.join("output").join("findings.toml");
+    toml::from_str(&fs::read_to_string(findings_path).expect("read findings.toml"))
+        .expect("parse findings.toml")
+}
+
+fn read_verdict(session_dir: &Path) -> ReviewVerdictArtifact {
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    serde_json::from_str(&fs::read_to_string(verdict_path).expect("read verdict"))
+        .expect("parse verdict")
+}
+
+#[test]
+fn issue_1804_codex_single_title_word_severity_findings_populate_toml_and_fail() {
+    let session_id = "01TEST1804CODEXPROSE00000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-codex-prose-findings", session_id);
+
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+Review found two blocking findings in the diff.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+1. High correctness / sandbox violation: `csa review --single` can pass despite a blocking finding.
+   - File: crates/cli-sub-agent/src/review_cmd_output.rs:214
+   - Trigger: codex emits severity as the first word of the title line.
+   - Expected: severity_counts.high is 1 and the verdict blocks.
+   - Actual: findings.toml was empty before #1804.
+   - Fix hint: parse title-leading severity labels.
+2. Medium correctness regression: `- File:` bullets are ignored.
+   - File: crates/cli-sub-agent/src/review_cmd_prose_findings.rs:154
+   - Trigger: codex emits file locations as sub-bullets.
+   - Expected: the finding receives a file range.
+   - Actual: the old parser only accepted `File:` without a list marker.
+   - Fix hint: strip unordered-list markers before matching `File:`.
+
+## Recommended Actions
+
+1. Fix the prose extractor and verdict consistency gate.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    crate::review_cmd::findings_toml::persist_review_findings_toml(&project_root, &meta);
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 2);
+    assert_eq!(findings.findings[0].severity, Severity::High);
+    assert_eq!(
+        findings.findings[0].file_ranges[0].path,
+        "crates/cli-sub-agent/src/review_cmd_output.rs"
+    );
+    assert_eq!(findings.findings[0].file_ranges[0].start, 214);
+    assert_eq!(findings.findings[1].severity, Severity::Medium);
+    assert_eq!(
+        findings.findings[1].file_ranges[0].path,
+        "crates/cli-sub-agent/src/review_cmd_prose_findings.rs"
+    );
+    assert_eq!(findings.findings[1].file_ranges[0].start, 154);
+
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1804_unparsed_actionable_findings_section_fails_closed_with_reason() {
+    let session_id = "01TEST1804UNPARSEDPROSE00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-unparsed-prose", session_id);
+
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+Review completed.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+The reviewer identified an actionable correctness problem, but the prose does not match any machine parser shape.
+
+## Recommended Actions
+
+1. Inspect the prose manually before accepting this review.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        Some("prose_findings_present_but_unparsed")
+    );
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1804_clean_findings_sentinel_stays_pass() {
+    let session_id = "01TEST1804CLEANPROSE0000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-clean-prose", session_id);
+
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+No blocking findings found.
+
+## Recommended Actions
+
+None.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -60,6 +60,22 @@ fn write_empty_findings_toml(session_dir: &Path) {
     .expect("write empty findings.toml");
 }
 
+fn write_full_review_output(session_dir: &Path, review_text: &str) {
+    let transcript = json!({
+        "type": "item.completed",
+        "item": {
+            "id": "item_1",
+            "type": "agent_message",
+            "text": review_text
+        }
+    });
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        serde_json::to_string(&transcript).expect("serialize full.md transcript"),
+    )
+    .expect("write full.md transcript");
+}
+
 #[test]
 fn issue_1804_codex_single_title_word_severity_findings_populate_toml_and_fail() {
     let session_id = "01TEST1804CODEXPROSE00000";
@@ -121,6 +137,80 @@ Review found two blocking findings in the diff.
     assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
     assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
     assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1804_full_md_only_unparsed_findings_section_fails_closed() {
+    let session_id = "01TEST1804FULLONLYFAIL";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-full-md-only-unparsed", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    write_full_review_output(
+        &session_dir,
+        r#"Verdict: PASS
+
+No blocking issues.
+
+## Findings
+
+1. High correctness regression remains unparsed because the prose lacks a severity delimiter.
+"#,
+    );
+    assert!(!session_dir.join("output").join("index.toml").exists());
+    assert!(!session_dir.join("output").join("summary.md").exists());
+    assert!(!session_dir.join("output").join("details.md").exists());
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+    let verdict = read_verdict(&session_dir);
+    assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        Some("prose_findings_present_but_unparsed")
+    );
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1804_full_md_only_clean_findings_section_stays_pass() {
+    let session_id = "01TEST1804FULLONLYPASS";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-full-md-only-clean", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    write_full_review_output(
+        &session_dir,
+        r#"Verdict: PASS
+
+## Findings
+
+No blocking issues.
+"#,
+    );
+    assert!(!session_dir.join("output").join("index.toml").exists());
+    assert!(!session_dir.join("output").join("summary.md").exists());
+    assert!(!session_dir.join("output").join("details.md").exists());
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -179,6 +179,47 @@ No blocking issues.
 }
 
 #[test]
+fn issue_1804_mixed_clean_and_unparsed_findings_section_fails_closed() {
+    let session_id = "01TEST1804MIXEDCLEAN00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-mixed-clean-unparsed", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+No blocking issues.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+No blocking issues.
+
+1. High correctness regression remains unparsed because the prose lacks a severity delimiter.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        Some("prose_findings_present_but_unparsed")
+    );
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_1804_canonical_clean_findings_sections_stay_pass() {
     for (heading_index, heading) in SUPPORTED_FINDINGS_HEADINGS.iter().enumerate() {
         for (body_index, (case_name, summary, body)) in CLEAN_FINDINGS_BODIES.iter().enumerate() {
@@ -232,6 +273,44 @@ fn issue_1804_canonical_clean_findings_sections_stay_pass() {
 }
 
 #[test]
+fn issue_1804_multiline_clean_findings_section_stays_pass() {
+    let session_id = "01TEST1804MULTICLEAN00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-multiline-clean", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+Review completed.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+No issues found.
+
+No blocking findings found.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_1804_parsed_findings_section_still_fails() {
     let session_id = "01TEST1804PARSEDHIGH000";
     let (_env_lock, project_root, session_dir) =
@@ -247,7 +326,7 @@ No blocking issues.
 <!-- CSA:SECTION:details -->
 ## Findings
 
-1. [High] real bug remains visible in the findings section.
+1. [High]: real bug remains visible in the findings section.
 <!-- CSA:SECTION:details:END -->
 "#,
     )

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -125,6 +125,52 @@ The reviewer identified an actionable correctness problem, but the prose does no
 }
 
 #[test]
+fn issue_1804_unparsed_actionable_review_findings_section_fails_closed_with_reason() {
+    let session_id = "01TEST1804REVIEWFINDING00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-review-findings-unparsed", session_id);
+
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+Review completed.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Review Findings
+
+The reviewer identified an actionable correctness problem, but the prose does not match any machine parser shape.
+
+## Recommended Actions
+
+1. Inspect the prose manually before accepting this review.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        Some("prose_findings_present_but_unparsed")
+    );
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_1804_clean_findings_sentinel_stays_pass() {
     let session_id = "01TEST1804CLEANPROSE0000";
     let (_env_lock, project_root, session_dir) =
@@ -149,6 +195,50 @@ No blocking findings found.
 ## Recommended Actions
 
 None.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1804_clean_review_findings_sentinel_stays_pass() {
+    let session_id = "01TEST1804CLEANREVIEW000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1804-clean-review-findings", session_id);
+
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Review Findings
+
+None.
+
+## Recommended Actions
+
+1. Open the PR.
 <!-- CSA:SECTION:details:END -->
 "#,
     )

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -13,6 +13,49 @@ fn read_verdict(session_dir: &Path) -> ReviewVerdictArtifact {
         .expect("parse verdict")
 }
 
+const SUPPORTED_FINDINGS_HEADINGS: &[&str] = &["Findings", "Review Findings"];
+
+const CLEAN_FINDINGS_BODIES: &[(&str, &str, &str)] = &[
+    ("no-issues-found", "Review completed.", "No issues found."),
+    (
+        "no-issues-were-found",
+        "Review completed.",
+        "No issues were found.",
+    ),
+    (
+        "no-blocking-issues",
+        "Review completed.",
+        "No blocking issues.",
+    ),
+    ("no-findings", "Review completed.", "No findings."),
+    (
+        "no-blocking-findings-found",
+        "Review completed.",
+        "No blocking findings found.",
+    ),
+    (
+        "no-actionable-findings",
+        "Review completed.",
+        "No actionable findings.",
+    ),
+    ("ship-ready", "Review completed.", "Ship-ready."),
+    ("ship-ready-spaced", "Review completed.", "Ship ready."),
+    (
+        "positive-no-issue-clause",
+        "Review completed.",
+        "No correctness issues were introduced.",
+    ),
+    ("none-with-pass-summary", "PASS", "None."),
+];
+
+fn write_empty_findings_toml(session_dir: &Path) {
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+}
+
 #[test]
 fn issue_1804_codex_single_title_word_severity_findings_populate_toml_and_fail() {
     let session_id = "01TEST1804CODEXPROSE00000";
@@ -79,183 +122,109 @@ Review found two blocking findings in the diff.
 }
 
 #[test]
-fn issue_1804_unparsed_actionable_findings_section_fails_closed_with_reason() {
-    let session_id = "01TEST1804UNPARSEDPROSE00";
-    let (_env_lock, project_root, session_dir) =
-        lock_test_session("issue-1804-unparsed-prose", session_id);
+fn issue_1804_unparsed_findings_sections_fail_closed_with_reason() {
+    for (heading_index, heading) in SUPPORTED_FINDINGS_HEADINGS.iter().enumerate() {
+        let session_id = format!("01TEST1804UNPARSED{heading_index:02}");
+        let test_name = format!("issue-1804-unparsed-heading-{heading_index}");
+        let (_env_lock, project_root, session_dir) = lock_test_session(&test_name, &session_id);
 
-    fs::write(
-        session_dir.join("output").join("findings.toml"),
-        "findings = []\n",
-    )
-    .expect("write empty findings.toml");
-    csa_session::persist_structured_output(
-        &session_dir,
-        r#"<!-- CSA:SECTION:summary -->
+        write_empty_findings_toml(&session_dir);
+        csa_session::persist_structured_output(
+            &session_dir,
+            &format!(
+                r#"<!-- CSA:SECTION:summary -->
 Review completed.
 <!-- CSA:SECTION:summary:END -->
 
 <!-- CSA:SECTION:details -->
-## Findings
+## {heading}
 
-The reviewer identified an actionable correctness problem, but the prose does not match any machine parser shape.
+1. High correctness regression remains unparsed because the prose lacks a severity delimiter.
 
 ## Recommended Actions
 
 1. Inspect the prose manually before accepting this review.
 <!-- CSA:SECTION:details:END -->
-"#,
-    )
-    .expect("persist structured output");
+"#
+            ),
+        )
+        .expect("persist structured output");
 
-    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
-    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+        let meta = make_review_meta_with_decision(&session_id, ReviewDecision::Pass, "CLEAN");
+        persist_review_verdict(&project_root, &meta, &[], Vec::new());
 
-    let verdict = read_verdict(&session_dir);
-    assert_ne!(verdict.decision, ReviewDecision::Pass);
-    assert_eq!(verdict.decision, ReviewDecision::Fail);
-    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
-    assert_eq!(
-        verdict.failure_reason.as_deref(),
-        Some("prose_findings_present_but_unparsed")
-    );
-    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+        let findings = read_findings_toml(&session_dir);
+        assert!(findings.findings.is_empty(), "{heading}");
+        let verdict = read_verdict(&session_dir);
+        assert_ne!(verdict.decision, ReviewDecision::Pass, "{heading}");
+        assert_eq!(verdict.decision, ReviewDecision::Fail, "{heading}");
+        assert_eq!(verdict.verdict_legacy, "HAS_ISSUES", "{heading}");
+        assert_eq!(
+            verdict.failure_reason.as_deref(),
+            Some("prose_findings_present_but_unparsed"),
+            "{heading}"
+        );
+        assert_eq!(
+            verdict.severity_counts.get(&Severity::Medium),
+            Some(&1),
+            "{heading}"
+        );
 
-    fs::remove_dir_all(project_root).expect("remove temp project root");
+        fs::remove_dir_all(project_root).expect("remove temp project root");
+    }
 }
 
 #[test]
-fn issue_1804_unparsed_actionable_review_findings_section_fails_closed_with_reason() {
-    let session_id = "01TEST1804REVIEWFINDING00";
-    let (_env_lock, project_root, session_dir) =
-        lock_test_session("issue-1804-review-findings-unparsed", session_id);
+fn issue_1804_canonical_clean_findings_sections_stay_pass() {
+    for (heading_index, heading) in SUPPORTED_FINDINGS_HEADINGS.iter().enumerate() {
+        for (body_index, (case_name, summary, body)) in CLEAN_FINDINGS_BODIES.iter().enumerate() {
+            let session_id = format!("01TEST1804CLEAN{heading_index:02}{body_index:02}");
+            let test_name = format!("issue-1804-clean-{heading_index}-{case_name}");
+            let (_env_lock, project_root, session_dir) = lock_test_session(&test_name, &session_id);
 
-    fs::write(
-        session_dir.join("output").join("findings.toml"),
-        "findings = []\n",
-    )
-    .expect("write empty findings.toml");
-    csa_session::persist_structured_output(
-        &session_dir,
-        r#"<!-- CSA:SECTION:summary -->
-Review completed.
+            write_empty_findings_toml(&session_dir);
+            csa_session::persist_structured_output(
+                &session_dir,
+                &format!(
+                    r#"<!-- CSA:SECTION:summary -->
+{summary}
 <!-- CSA:SECTION:summary:END -->
 
 <!-- CSA:SECTION:details -->
-## Review Findings
+## {heading}
 
-The reviewer identified an actionable correctness problem, but the prose does not match any machine parser shape.
-
-## Recommended Actions
-
-1. Inspect the prose manually before accepting this review.
-<!-- CSA:SECTION:details:END -->
-"#,
-    )
-    .expect("persist structured output");
-
-    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
-    persist_review_verdict(&project_root, &meta, &[], Vec::new());
-
-    let verdict = read_verdict(&session_dir);
-    assert_ne!(verdict.decision, ReviewDecision::Pass);
-    assert_eq!(verdict.decision, ReviewDecision::Fail);
-    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
-    assert_eq!(
-        verdict.failure_reason.as_deref(),
-        Some("prose_findings_present_but_unparsed")
-    );
-    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
-
-    fs::remove_dir_all(project_root).expect("remove temp project root");
-}
-
-#[test]
-fn issue_1804_clean_findings_sentinel_stays_pass() {
-    let session_id = "01TEST1804CLEANPROSE0000";
-    let (_env_lock, project_root, session_dir) =
-        lock_test_session("issue-1804-clean-prose", session_id);
-
-    fs::write(
-        session_dir.join("output").join("findings.toml"),
-        "findings = []\n",
-    )
-    .expect("write empty findings.toml");
-    csa_session::persist_structured_output(
-        &session_dir,
-        r#"<!-- CSA:SECTION:summary -->
-PASS
-<!-- CSA:SECTION:summary:END -->
-
-<!-- CSA:SECTION:details -->
-## Findings
-
-No blocking findings found.
-
-## Recommended Actions
-
-None.
-<!-- CSA:SECTION:details:END -->
-"#,
-    )
-    .expect("persist structured output");
-
-    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
-    persist_review_verdict(&project_root, &meta, &[], Vec::new());
-
-    let findings = read_findings_toml(&session_dir);
-    assert!(findings.findings.is_empty());
-    let verdict = read_verdict(&session_dir);
-    assert_eq!(verdict.decision, ReviewDecision::Pass);
-    assert_eq!(verdict.verdict_legacy, "CLEAN");
-    assert!(verdict.severity_counts.values().all(|count| *count == 0));
-    assert!(verdict.failure_reason.is_none());
-
-    fs::remove_dir_all(project_root).expect("remove temp project root");
-}
-
-#[test]
-fn issue_1804_clean_review_findings_sentinel_stays_pass() {
-    let session_id = "01TEST1804CLEANREVIEW000";
-    let (_env_lock, project_root, session_dir) =
-        lock_test_session("issue-1804-clean-review-findings", session_id);
-
-    fs::write(
-        session_dir.join("output").join("findings.toml"),
-        "findings = []\n",
-    )
-    .expect("write empty findings.toml");
-    csa_session::persist_structured_output(
-        &session_dir,
-        r#"<!-- CSA:SECTION:summary -->
-PASS
-<!-- CSA:SECTION:summary:END -->
-
-<!-- CSA:SECTION:details -->
-## Review Findings
-
-None.
+{body}
 
 ## Recommended Actions
 
 1. Open the PR.
 <!-- CSA:SECTION:details:END -->
-"#,
-    )
-    .expect("persist structured output");
+"#
+                ),
+            )
+            .expect("persist structured output");
 
-    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
-    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+            let meta = make_review_meta_with_decision(&session_id, ReviewDecision::Pass, "CLEAN");
+            persist_review_verdict(&project_root, &meta, &[], Vec::new());
 
-    let findings = read_findings_toml(&session_dir);
-    assert!(findings.findings.is_empty());
-    let verdict = read_verdict(&session_dir);
-    assert_eq!(verdict.decision, ReviewDecision::Pass);
-    assert_eq!(verdict.verdict_legacy, "CLEAN");
-    assert!(verdict.severity_counts.values().all(|count| *count == 0));
-    assert!(verdict.failure_reason.is_none());
+            let findings = read_findings_toml(&session_dir);
+            assert!(findings.findings.is_empty(), "{heading}: {case_name}");
+            let verdict = read_verdict(&session_dir);
+            assert_eq!(
+                verdict.decision,
+                ReviewDecision::Pass,
+                "{heading}: {case_name}"
+            );
+            assert_eq!(verdict.verdict_legacy, "CLEAN", "{heading}: {case_name}");
+            assert!(
+                verdict.severity_counts.values().all(|count| *count == 0),
+                "{heading}: {case_name}"
+            );
+            assert!(verdict.failure_reason.is_none(), "{heading}: {case_name}");
 
-    fs::remove_dir_all(project_root).expect("remove temp project root");
+            fs::remove_dir_all(project_root).expect("remove temp project root");
+        }
+    }
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -65,6 +65,61 @@ pub(in crate::review_cmd) fn extract_review_findings_from_prose_with_default(
     findings
 }
 
+pub(in crate::review_cmd) struct FindingsSectionBody {
+    body: String,
+}
+
+impl FindingsSectionBody {
+    pub(in crate::review_cmd) fn as_str(&self) -> &str {
+        &self.body
+    }
+}
+
+pub(in crate::review_cmd) fn findings_section_bodies(text: &str) -> Vec<FindingsSectionBody> {
+    let mut bodies = Vec::new();
+    let mut current = None::<String>;
+    let mut in_code_fence = false;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            if let Some(body) = current.as_mut() {
+                body.push_str(line);
+                body.push('\n');
+            }
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+
+        if !in_code_fence && is_findings_header(trimmed) {
+            if let Some(body) = current.take() {
+                bodies.push(FindingsSectionBody { body });
+            }
+            current = Some(String::new());
+            continue;
+        }
+
+        let Some(body) = current.as_mut() else {
+            continue;
+        };
+        if !in_code_fence && trimmed.starts_with('#') {
+            if let Some(body) = current.take() {
+                bodies.push(FindingsSectionBody { body });
+            }
+            continue;
+        }
+
+        body.push_str(line);
+        body.push('\n');
+    }
+
+    if let Some(body) = current {
+        bodies.push(FindingsSectionBody { body });
+    }
+
+    bodies
+}
+
 pub(in crate::review_cmd) fn severity_counts_from_review_findings(
     findings: &[ReviewFinding],
 ) -> BTreeMap<Severity, u32> {
@@ -251,6 +306,9 @@ fn non_empty_or_fallback(value: &str, fallback: &str) -> String {
 
 pub(in crate::review_cmd) fn is_findings_header(line: &str) -> bool {
     let normalized = line.trim_start_matches('#').trim();
+    let normalized = normalized
+        .split_once('(')
+        .map_or(normalized, |(heading, _)| heading.trim_end());
     normalized.eq_ignore_ascii_case("findings")
         || normalized.eq_ignore_ascii_case("review findings")
 }

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -152,19 +152,19 @@ fn parse_severity_prefixed_finding(
     allow_description_only: bool,
 ) -> Option<ParsedProseFinding> {
     let (label, rest) = body.split_once(':')?;
-    let severity = severity_from_label(label)?;
+    let severity = severity_from_label(label).or_else(|| leading_severity_from_title(label))?;
     let rest = rest.trim();
     if let Some((file_range, description)) = parse_leading_file_range(rest) {
         return Some(ParsedProseFinding {
             severity,
             file_range: Some(file_range),
-            description: non_empty_or_fallback(&description, rest),
+            description: non_empty_or_fallback(&description, body),
         });
     }
     allow_description_only.then(|| ParsedProseFinding {
         severity,
         file_range: None,
-        description: rest.to_string(),
+        description: severity_prefixed_description(label, rest),
     })
 }
 
@@ -178,11 +178,37 @@ fn parse_path_prefixed_finding(body: &str, severity: Severity) -> Option<ParsedP
 }
 
 fn parse_file_reference_line(line: &str) -> Option<ReviewFindingFileRange> {
+    let line = strip_unordered_list_prefix(line);
     let (label, rest) = line.split_once(':')?;
     if !label.trim().eq_ignore_ascii_case("file") {
         return None;
     }
     parse_leading_file_range(rest.trim()).map(|(range, _)| range)
+}
+
+fn strip_unordered_list_prefix(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    if matches!(trimmed.as_bytes().first(), Some(b'-' | b'*')) {
+        trimmed[1..].trim_start()
+    } else {
+        trimmed
+    }
+}
+
+fn leading_severity_from_title(title: &str) -> Option<Severity> {
+    let first_word = title
+        .trim_start()
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .find(|word| !word.is_empty())?;
+    severity_from_label(first_word)
+}
+
+fn severity_prefixed_description(label: &str, rest: &str) -> String {
+    if leading_severity_from_title(label).is_some() && severity_from_label(label).is_none() {
+        non_empty_or_fallback(&format!("{}: {}", label.trim(), rest), rest)
+    } else {
+        rest.to_string()
+    }
 }
 
 fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, String)> {

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -249,7 +249,7 @@ fn non_empty_or_fallback(value: &str, fallback: &str) -> String {
     }
 }
 
-fn is_findings_header(line: &str) -> bool {
+pub(in crate::review_cmd) fn is_findings_header(line: &str) -> bool {
     let normalized = line.trim_start_matches('#').trim();
     normalized.eq_ignore_ascii_case("findings")
         || normalized.eq_ignore_ascii_case("review findings")


### PR DESCRIPTION
## Summary

Fix a false-PASS / false-FAIL hole in `csa review` verdict extraction for **codex-single** reviews
(#1804, a recurrence of the #1754 class). When codex emits its review as `## Findings` prose rather
than the machine `findings.toml`, the verdict extractor previously reported `decision=pass` with
`severity 0/0/0/0` even though the prose contained HIGH/blocking findings — a silent merge-gate hole.

This PR makes the extractor:

1. **Layer 1 (strictly additive):** parse codex `## Findings` / `## Review Findings` prose into
   structured findings so genuine blocking findings raise the verdict. This alone closes the common
   false-PASS and can never produce a false-FAIL.
2. **Layer 2 (fail-closed):** when a findings heading is present, the section is *not* a clean
   conclusion, **and** the machine findings list is empty, treat the verdict as non-pass
   (fail-closed on prose/structured mismatch). This now derives **every** classification decision
   from CSA's canonical detectors — zero hand-rolled phrase/heading whitelists remain.

## Why the canonical-reuse refactor

Layer 2 went through three review rounds, each surfacing a *different* edge because the fail-closed
path re-implemented classification logic the canonical detectors already own:

- round-2: `## Recommended Actions` (part of every clean report) was treated as unparsed findings → false-FAIL → narrowed to findings headings.
- round-3: exact-match missed `## Review Findings` (the prose parser recognizes it) → false-PASS hole → shared the canonical findings-heading predicate.
- round-4 (terminal): a hand-rolled clean-phrase whitelist omitted "No issues found." (accepted by the canonical clean detector) → false-FAIL → **reuse the canonical clean detector**, delete all local classifier lists.

Fail-closed now triggers **iff** (findings-heading present) **AND** (NOT a canonical clean conclusion)
**AND** (structured findings empty), each predicate delegating to the existing canonical function
(`contains_clean_phrase` / `detect_prose_clean_conclusion`, the shared findings-heading predicate).

## Commits

- `3d6f263f` parse codex prose review findings (Layer 1)
- `74dde5ad` narrow prose fail-closed sections (round-2)
- `75564ec6` share review findings heading predicate (round-3)
- `36195048` reuse canonical clean detector in prose fail-closed (round-4, terminal)
- `751f4833` chore(release): bump version to 0.1.856

## Tests

Table-driven battery: every clean phrase accepted by the canonical clean detector, under each
supported findings heading (`## Findings`, `## Review Findings`, `## Findings (ordered by severity)`),
stays **pass** (no false-FAIL); a genuine unparsed finding under each heading with empty machine
findings goes **fail-closed**; all existing #1804 fixtures preserved.

## Verification

- git pre-commit hook (lefthook fmt/clippy/nextest) ran as each commit.
- Cumulative `csa review --range main...HEAD` (tier-4-critical, codex-pinned) verdict gate.

Closes #1804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
