### PR TITLE
fix(cli-sub-agent): gate review-gate scaffolding auto-install behind CSA ownership signal (#1651)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.856"
+version = "0.1.857"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.856"
+version = "0.1.857"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/lefthook_auto_install.rs
+++ b/crates/cli-sub-agent/src/lefthook_auto_install.rs
@@ -19,6 +19,7 @@ const TIMESTAMP_FILE: &str = "hook-check-ts";
 /// - `CI` environment variable is set (any non-empty value)
 /// - `project_root` has no `.git/` directory (not a git repo / test temp dir)
 /// - `project_root` has no `lefthook.yml` (lefthook not configured here)
+/// - `project_root` has no CSA review-gate opt-in signal
 pub(crate) fn spawn_lefthook_setup_if_needed(project_root: &Path) {
     if is_ci_environment() {
         debug!("lefthook auto-install: skipping (CI environment)");
@@ -31,6 +32,13 @@ pub(crate) fn spawn_lefthook_setup_if_needed(project_root: &Path) {
     if !project_root.join("lefthook.yml").exists() {
         debug!("lefthook auto-install: skipping (no lefthook.yml)");
         return;
+    }
+    match crate::setup_cmds::review_gate_opt_in_signal(project_root) {
+        Some(signal) => debug!("lefthook auto-install: opt-in detected ({signal})"),
+        None => {
+            debug!("lefthook auto-install: skipping (repo is not CSA-managed / opted in)");
+            return;
+        }
     }
 
     let project_root = project_root.to_path_buf();
@@ -47,6 +55,14 @@ fn is_ci_environment() -> bool {
 }
 
 async fn check_and_setup_lefthook(project_root: &Path) -> anyhow::Result<()> {
+    match crate::setup_cmds::review_gate_opt_in_signal(project_root) {
+        Some(signal) => debug!("lefthook auto-install: opt-in detected ({signal})"),
+        None => {
+            debug!("lefthook auto-install: skipping (repo is not CSA-managed / opted in)");
+            return Ok(());
+        }
+    }
+
     // Locate the per-project state dir for the timestamp.
     let state_dir = csa_session::get_session_root(project_root)?;
     let ts_path = state_dir.join(TIMESTAMP_FILE);
@@ -173,7 +189,70 @@ async fn run_lefthook_install(project_root: &Path) -> anyhow::Result<()> {
 mod tests {
     use super::*;
     use std::fs;
+    use std::path::Path;
+    use std::process::Command;
     use tempfile::TempDir;
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .output()
+            .expect("git command should execute");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_git_repo(project_root: &Path) {
+        run_git(project_root, &["init"]);
+        run_git(project_root, &["config", "user.email", "test@example.com"]);
+        run_git(project_root, &["config", "user.name", "Test User"]);
+        fs::write(project_root.join("tracked.txt"), "baseline\n").expect("write baseline");
+        run_git(project_root, &["add", "tracked.txt"]);
+        run_git(project_root, &["commit", "-m", "initial"]);
+    }
+
+    fn track_file(project_root: &Path, relative_path: &str, content: &str) {
+        fs::write(project_root.join(relative_path), content).expect("write tracked file");
+        run_git(project_root, &["add", relative_path]);
+        run_git(project_root, &["commit", "-m", "track lefthook opt-in"]);
+    }
+
+    #[cfg(unix)]
+    fn install_fake_lefthook(bin_dir: &Path, log_path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::create_dir_all(bin_dir).expect("create fake bin dir");
+        let fake = bin_dir.join("lefthook");
+        fs::write(
+            &fake,
+            format!(
+                "#!/bin/sh\n\
+printf '%s\\n' \"$PWD $*\" >> '{}'\n\
+mkdir -p .git/hooks\n\
+cat > .git/hooks/pre-commit <<'HOOK'\n\
+#!/bin/sh\n\
+# lefthook test stub\n\
+HOOK\n\
+cat > .git/hooks/pre-push <<'HOOK'\n\
+#!/bin/sh\n\
+# lefthook test stub\n\
+HOOK\n",
+                log_path.display()
+            ),
+        )
+        .expect("write fake lefthook");
+        let mut perms = fs::metadata(&fake)
+            .expect("fake lefthook metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(fake, perms).expect("chmod fake lefthook");
+    }
 
     // ── rate-limit logic ──────────────────────────────────────────────────────
 
@@ -272,6 +351,65 @@ mod tests {
         fs::create_dir(dir.path().join(".git")).unwrap();
         // No lefthook.yml → must be a no-op
         spawn_lefthook_setup_if_needed(dir.path());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn auto_install_skips_untracked_lefthook_yml_without_opt_in() {
+        let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
+        let dir = TempDir::new().expect("create tempdir");
+        init_git_repo(dir.path());
+        fs::write(dir.path().join("lefthook.yml"), "pre-push:\n").expect("write untracked config");
+
+        let bin_dir = dir.path().join("bin");
+        let log_path = dir.path().join("lefthook.log");
+        install_fake_lefthook(&bin_dir, &log_path);
+        let inherited_path = std::env::var("PATH").unwrap_or_default();
+        let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+        let _path_guard = crate::test_env_lock::ScopedEnvVarRestore::set("PATH", &patched_path);
+
+        check_and_setup_lefthook(dir.path())
+            .await
+            .expect("skip should not fail");
+
+        assert!(
+            !log_path.exists(),
+            "non-opted-in repo must not invoke lefthook install"
+        );
+        assert!(
+            !dir.path().join(".git/hooks/pre-push").exists(),
+            "non-opted-in repo must not receive a pre-push hook"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn auto_install_runs_when_lefthook_yml_is_tracked() {
+        let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
+        let dir = TempDir::new().expect("create tempdir");
+        init_git_repo(dir.path());
+        track_file(dir.path(), "lefthook.yml", "pre-push:\n");
+
+        let bin_dir = dir.path().join("bin");
+        let log_path = dir.path().join("lefthook.log");
+        install_fake_lefthook(&bin_dir, &log_path);
+        let inherited_path = std::env::var("PATH").unwrap_or_default();
+        let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+        let _path_guard = crate::test_env_lock::ScopedEnvVarRestore::set("PATH", &patched_path);
+
+        check_and_setup_lefthook(dir.path())
+            .await
+            .expect("tracked lefthook.yml should install hooks");
+
+        let log = fs::read_to_string(log_path).expect("read fake lefthook log");
+        assert!(
+            log.contains("install"),
+            "tracked lefthook.yml should invoke lefthook install"
+        );
+        assert!(
+            dir.path().join(".git/hooks/pre-push").exists(),
+            "tracked lefthook.yml should preserve install behavior"
+        );
     }
 
     // ── CI detection ─────────────────────────────────────────────────────────

--- a/crates/cli-sub-agent/src/setup_cmds.rs
+++ b/crates/cli-sub-agent/src/setup_cmds.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use serde_json::Value as JsonValue;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::time::SystemTime;
 use tracing::{debug, info};
 
@@ -311,6 +312,13 @@ pub(crate) fn spawn_review_gate_setup_if_needed(
         debug!("review-gate auto-setup: skipping (no .git directory)");
         return;
     }
+    match review_gate_opt_in_signal(project_root) {
+        Some(signal) => debug!("review-gate auto-setup: opt-in detected ({signal})"),
+        None => {
+            debug!("review-gate auto-setup: skipping (repo is not CSA-managed / opted in)");
+            return;
+        }
+    }
 
     let project_root = project_root.to_path_buf();
     tokio::spawn(async move {
@@ -322,6 +330,14 @@ pub(crate) fn spawn_review_gate_setup_if_needed(
 
 /// Background async task: rate-limited auto-setup of the review gate.
 async fn check_and_setup_review_gate_bg(project_root: &Path) -> anyhow::Result<()> {
+    match review_gate_opt_in_signal(project_root) {
+        Some(signal) => debug!("review-gate auto-setup: opt-in detected ({signal})"),
+        None => {
+            debug!("review-gate auto-setup: skipping (repo is not CSA-managed / opted in)");
+            return Ok(());
+        }
+    }
+
     let state_dir = csa_session::get_session_root(project_root)?;
     let ts_path = state_dir.join(REVIEW_GATE_TIMESTAMP_FILE);
 
@@ -337,6 +353,31 @@ async fn check_and_setup_review_gate_bg(project_root: &Path) -> anyhow::Result<(
     install_review_gate(project_root, /*verbose=*/ false)?;
     info!("review-gate auto-setup: complete");
     Ok(())
+}
+
+pub(crate) fn review_gate_opt_in_signal(project_root: &Path) -> Option<&'static str> {
+    if git_path_is_tracked(project_root, "lefthook.yml") {
+        return Some("tracked lefthook.yml");
+    }
+    if git_path_is_tracked(project_root, "scripts/hooks/review-check.sh") {
+        return Some("tracked scripts/hooks/review-check.sh");
+    }
+    if project_root.join("patterns/csa-review").is_dir() {
+        return Some("patterns/csa-review/");
+    }
+    None
+}
+
+fn git_path_is_tracked(project_root: &Path, relative_path: &str) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["ls-files", "--error-unmatch", "--", relative_path])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
 }
 
 /// Returns true when the timestamp file is absent or older than CHECK_INTERVAL_SECS.
@@ -488,7 +529,7 @@ fn install_review_check_script(project_root: &Path) -> Result<()> {
 
 /// Run `lefthook install` synchronously.
 fn run_lefthook_install_sync(project_root: &Path) -> Result<()> {
-    let status = std::process::Command::new("lefthook")
+    let status = Command::new("lefthook")
         .arg("install")
         .current_dir(project_root)
         .status()
@@ -551,70 +592,4 @@ fn report_review_gate_status(project_root: &Path) -> Result<()> {
 mod review_gate_script_tests;
 
 #[cfg(test)]
-mod review_gate_tests {
-    use super::*;
-    use std::fs;
-    use tempfile::TempDir;
-
-    #[test]
-    fn idempotent_when_review_check_already_present() {
-        let input =
-            "pre-push:\n  commands:\n    review-check:\n      run: scripts/hooks/review-check.sh\n";
-        // merge_lefthook_review_check guards the idempotency check at the file level.
-        let td = TempDir::new().unwrap();
-        let lf = td.path().join("lefthook.yml");
-        fs::write(&lf, input).unwrap();
-        merge_lefthook_review_check(td.path()).unwrap();
-        let content = fs::read_to_string(&lf).unwrap();
-        // Only one review-check entry should exist.
-        assert_eq!(content.matches("review-check:").count(), 1);
-    }
-
-    #[test]
-    fn inserts_after_commands_in_existing_pre_push() {
-        let input = "pre-push:\n  commands:\n    version-check:\n      run: scripts/hooks/version-check.sh\n";
-        let result = build_merged_lefthook(input);
-        assert!(result.contains("    review-check:"), "entry inserted");
-        // review-check should appear before version-check
-        let rc_pos = result.find("    review-check:").unwrap();
-        let vc_pos = result.find("    version-check:").unwrap();
-        assert!(rc_pos < vc_pos, "review-check before version-check");
-    }
-
-    #[test]
-    fn appends_section_when_no_pre_push() {
-        let input = "pre-commit:\n  commands:\n    quality-gates:\n      run: just pre-commit\n";
-        let result = build_merged_lefthook(input);
-        assert!(result.contains("pre-push:"), "pre-push section added");
-        assert!(result.contains("review-check:"), "entry added");
-    }
-
-    #[test]
-    fn creates_minimal_lefthook_from_empty() {
-        let result = build_merged_lefthook("");
-        assert!(result.contains("pre-push:"));
-        assert!(result.contains("review-check:"));
-    }
-
-    #[test]
-    fn preserves_trailing_newline() {
-        let input = "no_tty: true\npre-push:\n  commands:\n    x:\n      run: x\n";
-        let result = build_merged_lefthook(input);
-        assert!(result.ends_with('\n'));
-    }
-
-    #[test]
-    fn needs_check_true_when_no_file() {
-        let td = TempDir::new().unwrap();
-        let ts = td.path().join(REVIEW_GATE_TIMESTAMP_FILE);
-        assert!(needs_review_gate_check(&ts).unwrap());
-    }
-
-    #[test]
-    fn needs_check_false_after_recent_write() {
-        let td = TempDir::new().unwrap();
-        let ts = td.path().join(REVIEW_GATE_TIMESTAMP_FILE);
-        fs::write(&ts, b"").unwrap();
-        assert!(!needs_review_gate_check(&ts).unwrap());
-    }
-}
+mod review_gate_tests;

--- a/crates/cli-sub-agent/src/setup_cmds/review_gate_tests.rs
+++ b/crates/cli-sub-agent/src/setup_cmds/review_gate_tests.rs
@@ -1,0 +1,190 @@
+use super::*;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_git_repo(project_root: &Path) {
+    run_git(project_root, &["init"]);
+    run_git(project_root, &["config", "user.email", "test@example.com"]);
+    run_git(project_root, &["config", "user.name", "Test User"]);
+    fs::write(project_root.join("tracked.txt"), "baseline\n").expect("write baseline");
+    run_git(project_root, &["add", "tracked.txt"]);
+    run_git(project_root, &["commit", "-m", "initial"]);
+}
+
+fn track_file(project_root: &Path, relative_path: &str, content: &str) {
+    let path = project_root.join(relative_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent directory");
+    }
+    fs::write(path, content).expect("write tracked file");
+    run_git(project_root, &["add", relative_path]);
+    run_git(project_root, &["commit", "-m", "track review gate opt-in"]);
+}
+
+#[cfg(unix)]
+fn install_fake_lefthook(bin_dir: &Path, log_path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::create_dir_all(bin_dir).expect("create fake bin dir");
+    let fake = bin_dir.join("lefthook");
+    fs::write(
+        &fake,
+        format!(
+            "#!/bin/sh\n\
+printf '%s\\n' \"$PWD $*\" >> '{}'\n\
+mkdir -p .git/hooks\n\
+cat > .git/hooks/pre-push <<'HOOK'\n\
+#!/bin/sh\n\
+# lefthook test stub\n\
+HOOK\n",
+            log_path.display()
+        ),
+    )
+    .expect("write fake lefthook");
+    let mut perms = fs::metadata(&fake)
+        .expect("fake lefthook metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(fake, perms).expect("chmod fake lefthook");
+}
+
+#[test]
+fn idempotent_when_review_check_already_present() {
+    let input =
+        "pre-push:\n  commands:\n    review-check:\n      run: scripts/hooks/review-check.sh\n";
+    let td = TempDir::new().unwrap();
+    let lf = td.path().join("lefthook.yml");
+    fs::write(&lf, input).unwrap();
+    merge_lefthook_review_check(td.path()).unwrap();
+    let content = fs::read_to_string(&lf).unwrap();
+    assert_eq!(content.matches("review-check:").count(), 1);
+}
+
+#[test]
+fn inserts_after_commands_in_existing_pre_push() {
+    let input =
+        "pre-push:\n  commands:\n    version-check:\n      run: scripts/hooks/version-check.sh\n";
+    let result = build_merged_lefthook(input);
+    assert!(result.contains("    review-check:"), "entry inserted");
+    let rc_pos = result.find("    review-check:").unwrap();
+    let vc_pos = result.find("    version-check:").unwrap();
+    assert!(rc_pos < vc_pos, "review-check before version-check");
+}
+
+#[test]
+fn appends_section_when_no_pre_push() {
+    let input = "pre-commit:\n  commands:\n    quality-gates:\n      run: just pre-commit\n";
+    let result = build_merged_lefthook(input);
+    assert!(result.contains("pre-push:"), "pre-push section added");
+    assert!(result.contains("review-check:"), "entry added");
+}
+
+#[test]
+fn creates_minimal_lefthook_from_empty() {
+    let result = build_merged_lefthook("");
+    assert!(result.contains("pre-push:"));
+    assert!(result.contains("review-check:"));
+}
+
+#[test]
+fn preserves_trailing_newline() {
+    let input = "no_tty: true\npre-push:\n  commands:\n    x:\n      run: x\n";
+    let result = build_merged_lefthook(input);
+    assert!(result.ends_with('\n'));
+}
+
+#[test]
+fn needs_check_true_when_no_file() {
+    let td = TempDir::new().unwrap();
+    let ts = td.path().join(REVIEW_GATE_TIMESTAMP_FILE);
+    assert!(needs_review_gate_check(&ts).unwrap());
+}
+
+#[test]
+fn needs_check_false_after_recent_write() {
+    let td = TempDir::new().unwrap();
+    let ts = td.path().join(REVIEW_GATE_TIMESTAMP_FILE);
+    fs::write(&ts, b"").unwrap();
+    assert!(!needs_review_gate_check(&ts).unwrap());
+}
+
+#[tokio::test]
+async fn auto_setup_skips_repo_without_review_gate_opt_in() {
+    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
+    let td = TempDir::new().expect("create tempdir");
+    init_git_repo(td.path());
+
+    check_and_setup_review_gate_bg(td.path())
+        .await
+        .expect("skip should not fail");
+
+    assert!(
+        !td.path().join("lefthook.yml").exists(),
+        "non-opted-in repo must not receive lefthook.yml"
+    );
+    assert!(
+        !td.path().join("scripts/hooks/review-check.sh").exists(),
+        "non-opted-in repo must not receive review-check.sh"
+    );
+    assert!(
+        !td.path().join(".git/hooks/pre-push").exists(),
+        "non-opted-in repo must not receive installed pre-push hook"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn auto_setup_installs_when_lefthook_yml_is_tracked() {
+    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
+    let td = TempDir::new().expect("create tempdir");
+    init_git_repo(td.path());
+    track_file(td.path(), "lefthook.yml", "pre-commit:\n");
+
+    let bin_dir = td.path().join("bin");
+    let log_path = td.path().join("lefthook.log");
+    install_fake_lefthook(&bin_dir, &log_path);
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+    let _path_guard = crate::test_env_lock::ScopedEnvVarRestore::set("PATH", &patched_path);
+
+    check_and_setup_review_gate_bg(td.path())
+        .await
+        .expect("opted-in repo should install review gate");
+
+    let lefthook_yml =
+        fs::read_to_string(td.path().join("lefthook.yml")).expect("read updated lefthook.yml");
+    assert!(
+        lefthook_yml.contains("review-check:"),
+        "opted-in repo keeps existing merge behavior"
+    );
+    assert!(
+        td.path().join("scripts/hooks/review-check.sh").exists(),
+        "opted-in repo receives review-check.sh"
+    );
+    assert!(
+        td.path().join(".git/hooks/pre-push").exists(),
+        "opted-in repo receives installed pre-push hook"
+    );
+    let lefthook_log = fs::read_to_string(log_path).expect("read fake lefthook log");
+    assert!(
+        lefthook_log.contains("install"),
+        "opted-in repo should invoke lefthook install"
+    );
+}


### PR DESCRIPTION
## Summary

`csa run` / `csa review` previously injected its review-gate scaffolding into **any** target
repository's working tree and `.git/`:

- an untracked `lefthook.yml` (`pre-push` → `review-check`),
- an untracked `scripts/hooks/review-check.sh`,
- an installed `.git/hooks/pre-push` lefthook stub (`lefthook install`).

On the CSA project itself this is part of the pipeline and expected. On an **external / forked** repo
(opened only to edit one file) it was surprising, unwanted mutation: accidental-commit risk for the
untracked scaffolding, a broken config-less `pre-push` left behind after the user cleans up the
scaffolding, and silent `.git/hooks` mutation of a third-party repo.

This PR gates the review-gate scaffolding auto-install on an **"is this a CSA-managed / opted-in repo"**
detection. A repo that did not already opt into the review gate no longer has `lefthook.yml`,
`scripts/hooks/review-check.sh`, or `.git/hooks/pre-push` written into it by a CSA session. The CSA
project's own behavior is unchanged.

Closes #1651. Same external-repo-friction theme as #1647 (preflight symlink false-positive, merged).

## Verification

- New regression tests cover both paths: a non-opted-in target repo → scaffolding install is SKIPPED;
  an opted-in target repo → scaffolding behavior unchanged.
- git pre-commit hook (lefthook fmt/clippy/nextest) ran as the commit.
- Cumulative `csa review --range main...HEAD` (tier-4-critical, codex-pinned) verdict gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
