### PR TITLE
fix(cli-sub-agent): scope just fmt restage to staged Rust files + reject partial staging (#1735)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.857"
+version = "0.1.858"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.858"
+version = "0.1.859"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.857"
+version = "0.1.858"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.858"
+version = "0.1.859"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/justfile
+++ b/justfile
@@ -248,12 +248,16 @@ check-chinese:
     @echo "Checking for Chinese characters..."
     @! rg "\p{Script=Han}" . --vimgrep --glob '!target/**' --glob '!.git/**' --glob '!**/i18n/*.ftl' --glob '!skills/mktd/**' --glob '!tests/fixtures/**' --glob '!.claude/rules/**' --glob '!.agents/**' --glob '!CLAUDE.md' --glob '!GEMINI.md'
 
-# Format code and auto-stage modified .rs files.
-# This allows 'just fmt' to be run immediately before commit without manual 'git add'.
+# Format code and re-stage only .rs files that were already staged before fmt.
+# This keeps pre-commit formatting scoped to the intended commit.
 fmt:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    staged="$(git diff --cached --name-only -- '*.rs')"
     cargo fmt --all
-    # Only stage tracked .rs files that were modified by fmt
-    git diff --name-only | grep '\.rs$' | xargs -r git add
+    if [ -n "$staged" ]; then
+        printf '%s\n' "$staged" | xargs -r git add --
+    fi
 
 # Run clippy for the entire workspace (strict mode).
 clippy:

--- a/justfile
+++ b/justfile
@@ -249,15 +249,37 @@ check-chinese:
     @! rg "\p{Script=Han}" . --vimgrep --glob '!target/**' --glob '!.git/**' --glob '!**/i18n/*.ftl' --glob '!skills/mktd/**' --glob '!tests/fixtures/**' --glob '!.claude/rules/**' --glob '!.agents/**' --glob '!CLAUDE.md' --glob '!GEMINI.md'
 
 # Format code and re-stage only .rs files that were already staged before fmt.
-# This keeps pre-commit formatting scoped to the intended commit.
+# Abort first when any staged Rust file also has unstaged hunks.
 fmt:
     #!/usr/bin/env bash
     set -euo pipefail
-    staged="$(git diff --cached --name-only -- '*.rs')"
-    cargo fmt --all
-    if [ -n "$staged" ]; then
-        printf '%s\n' "$staged" | xargs -r git add --
+    staged_rs=()
+    while IFS= read -r -d '' path; do
+        staged_rs+=("$path")
+    done < <(git diff --cached --name-only -z -- '*.rs')
+    unstaged_rs=()
+    while IFS= read -r -d '' path; do
+        unstaged_rs+=("$path")
+    done < <(git diff --name-only -z -- '*.rs')
+    partial=()
+    for staged in "${staged_rs[@]}"; do
+        for unstaged in "${unstaged_rs[@]}"; do
+            if [[ "$staged" == "$unstaged" ]]; then
+                partial+=("$staged")
+                break
+            fi
+        done
+    done
+    if (( ${#partial[@]} > 0 )); then
+        printf 'just fmt: refusing to format -- these Rust files are partially staged (mixed staged/unstaged hunks); stage or stash the remaining hunks first:\n' >&2
+        printf '  %q\n' "${partial[@]}" >&2
+        exit 1
     fi
+    if (( ${#staged_rs[@]} == 0 )); then
+        exit 0
+    fi
+    cargo fmt --all
+    printf '%s\0' "${staged_rs[@]}" | xargs -0 git add --
 
 # Run clippy for the entire workspace (strict mode).
 clippy:


### PR DESCRIPTION
## Summary

The repo-root `justfile` `fmt:` recipe re-staged **every** unstaged modified `.rs`
(`git diff --name-only | grep '\.rs$' | xargs -r git add`). Because `fmt` runs inside the
`pre-commit-fast` lefthook step, the first `git commit` of a multi-change working tree
vacuumed unrelated still-unstaged `.rs` into that commit — making atomic commits (rule 048)
impossible without a manual stash dance.

This PR makes `just fmt` preserve the intended commit boundary:

1. **Scope the re-stage to the already-staged `.rs` set** — snapshot
   `git diff --cached --name-only -- '*.rs'` BEFORE `cargo fmt --all`, then re-add only that
   snapshot. Unrelated wholly-unstaged `.rs` are left untouched.
2. **Refuse partially-staged Rust files** — before formatting, if any staged `.rs` is ALSO
   unstaged-modified (mixed staged/unstaged hunks, or staged-then-modified), the recipe
   aborts with a clear message instead of running `cargo fmt`. This prevents `git add <path>`
   from absorbing that file's unstaged hunks into the commit (the same boundary-widening bug
   at hunk granularity — which could otherwise publish unrelated debug code or secrets).
   NUL-delimited path handling is used for filename safety.

An empty staged `.rs` set exits cleanly (no abort, no-op). The "fmt-then-commit without a
manual `git add`" convenience is preserved for fully-staged files.

Closes #1735.

## Verification

- The change is exercised by its own commits: the pre-commit-fast hook runs the new `fmt`
  recipe AS each commit (live exercise of the fully-staged + empty-set paths).
- The three cases were reasoned through: (a) partially-staged `.rs` → abort non-zero, nothing
  staged, no `cargo fmt`; (b) fully-staged `.rs` → fmt + re-add only those; (c) empty staged
  set → exit 0 no-op.

## Note

The pre-PR `csa review` that surfaced case (a)'s gap was itself a **false-PASS** at the
structured-verdict layer (`review-verdict.json=pass` while `details.md` carried the P1) —
filed as #1810 (recurrence past #1804; root cause #1806). This PR's merge gate was therefore
driven by the prose `details.md`, not the structured verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
