### PR TITLE
fix(cli-sub-agent): verdict fail-closed tri-state + finding-anchor precision (#1806, #1810)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.861"
+version = "0.1.862"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.862"
+version = "0.1.863"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.861"
+version = "0.1.862"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.862"
+version = "0.1.863"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -151,17 +151,19 @@ pub(in crate::review_cmd) fn load_canonical_review_text(
                 return Ok(Some(review_text));
             }
         }
-        let structured_text = ["summary", "details"]
+        let mut latest_summary = None;
+        let mut latest_details = None;
+        for (section, content) in csa_session::read_all_sections(session_dir)? {
+            match section.id.as_str() {
+                "summary" => latest_summary = Some(content),
+                "details" => latest_details = Some(content),
+                _ => {}
+            }
+        }
+        let structured_text = [latest_summary, latest_details]
             .into_iter()
-            .filter_map(|section_id| {
-                let path = session_dir.join("output").join(format!("{section_id}.md"));
-                path.exists().then_some(path)
-            })
-            .map(|path| {
-                fs::read_to_string(&path)
-                    .map_err(|error| anyhow::anyhow!("read {}: {error}", path.display()))
-            })
-            .collect::<Result<Vec<_>, _>>()?
+            .flatten()
+            .collect::<Vec<_>>()
             .join("\n");
         return Ok((!structured_text.trim().is_empty()).then_some(structured_text));
     }

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -46,8 +46,8 @@ pub(super) fn enforce_final_verdict_consistency(
         prose_signals.blocking_summary || has_blocking_severity(&prose_signals.severity_counts);
     let has_empty_machine_findings =
         findings_file.findings.is_empty() && severity_counts_are_zero(&artifact.severity_counts);
-    let unparsed_findings_prose =
-        prose_signals.unclean_findings_sections && has_empty_machine_findings;
+    let parsed_findings_prose = prose_signals.parsed_findings_sections;
+    let unparsed_findings_prose = prose_signals.unparseable_findings_sections;
 
     if unparsed_findings_prose {
         artifact
@@ -56,7 +56,7 @@ pub(super) fn enforce_final_verdict_consistency(
     }
 
     if artifact.decision == ReviewDecision::Pass
-        && (resume_to_fix || blocking_prose || unparsed_findings_prose)
+        && (resume_to_fix || blocking_prose || parsed_findings_prose || unparsed_findings_prose)
     {
         ensure_nonzero_fail_closed_count(&mut artifact.severity_counts);
         artifact.decision = ReviewDecision::Fail;

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -9,6 +9,7 @@ use super::text::{
     contains_blocking_issue_signal, severity_counts_from_text, zero_severity_counts,
 };
 use crate::review_cmd::prose_findings::{
+    FindingsSectionParse, classify_findings_section_body,
     extract_review_findings_from_prose_with_default, findings_section_bodies,
     severity_counts_from_review_findings,
 };
@@ -17,7 +18,8 @@ use crate::review_cmd::prose_findings::{
 pub(super) struct ReviewProseSignals {
     pub(super) severity_counts: BTreeMap<Severity, u32>,
     pub(super) blocking_summary: bool,
-    pub(super) unclean_findings_sections: bool,
+    pub(super) parsed_findings_sections: bool,
+    pub(super) unparseable_findings_sections: bool,
     pub(super) findings: Vec<ReviewFinding>,
 }
 
@@ -26,7 +28,8 @@ pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSign
     let mut signals = ReviewProseSignals {
         severity_counts: zero_severity_counts(),
         blocking_summary: prose.blocking_summary,
-        unclean_findings_sections: false,
+        parsed_findings_sections: false,
+        unparseable_findings_sections: false,
         findings: Vec::new(),
     };
     let default_unlabeled_severity = prose.blocking_summary.then_some(Severity::Medium);
@@ -95,8 +98,10 @@ fn record_review_prose_signal(
     content: &str,
     default_unlabeled_severity: Option<Severity>,
 ) {
-    signals.unclean_findings_sections |=
-        contains_unclean_findings_section(content, default_unlabeled_severity.clone());
+    let (parsed_findings_sections, unparseable_findings_sections) =
+        classify_findings_sections(content, default_unlabeled_severity.clone());
+    signals.parsed_findings_sections |= parsed_findings_sections;
+    signals.unparseable_findings_sections |= unparseable_findings_sections;
     let findings =
         extract_review_findings_from_prose_with_default(content, default_unlabeled_severity);
     let mut counts = severity_counts_from_review_findings(&findings);
@@ -105,39 +110,31 @@ fn record_review_prose_signal(
     signals.findings.extend(findings);
 }
 
-fn contains_unclean_findings_section(
+fn classify_findings_sections(
     content: &str,
     default_unlabeled_severity: Option<Severity>,
-) -> bool {
-    findings_section_bodies(content).into_iter().any(|body| {
-        findings_section_body_is_unclean(body.as_str(), default_unlabeled_severity.clone())
-    })
+) -> (bool, bool) {
+    let mut parsed_findings_sections = false;
+    let mut unparseable_findings_sections = false;
+    for body in findings_section_bodies(content) {
+        if !body.is_markdown_heading() {
+            continue;
+        }
+        match classify_findings_section_body(
+            body.as_str(),
+            default_unlabeled_severity.clone(),
+            contains_canonical_clean_conclusion,
+        ) {
+            FindingsSectionParse::Clean => {}
+            FindingsSectionParse::Findings(_) => parsed_findings_sections = true,
+            FindingsSectionParse::Unparseable => unparseable_findings_sections = true,
+        }
+    }
+    (parsed_findings_sections, unparseable_findings_sections)
 }
 
 fn contains_canonical_clean_conclusion(content: &str) -> bool {
     contains_clean_phrase(content) || detect_prose_clean_conclusion(content)
-}
-
-fn findings_section_body_is_unclean(
-    body: &str,
-    default_unlabeled_severity: Option<Severity>,
-) -> bool {
-    body.lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with("```"))
-        .any(|line| {
-            !contains_canonical_clean_conclusion(line)
-                && !line_parses_as_structured_finding(line, default_unlabeled_severity.clone())
-        })
-}
-
-fn line_parses_as_structured_finding(
-    line: &str,
-    default_unlabeled_severity: Option<Severity>,
-) -> bool {
-    let parser_input = format!("Findings\n{line}");
-    !extract_review_findings_from_prose_with_default(&parser_input, default_unlabeled_severity)
-        .is_empty()
 }
 
 fn merge_severity_counts_add(

--- a/crates/cli-sub-agent/src/review_cmd_output_text.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_text.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 
 use super::artifacts::{has_blocking_severity, severity_counts_are_zero};
 use super::clean_detection::contains_clean_phrase;
+use crate::review_cmd::prose_findings::structured_bracketed_finding_severity;
 
 #[derive(Debug, Deserialize)]
 struct TranscriptEvent {
@@ -158,13 +159,19 @@ pub(super) fn zero_severity_counts() -> std::collections::BTreeMap<Severity, u32
 }
 
 pub(super) fn severity_counts_from_text(text: &str) -> std::collections::BTreeMap<Severity, u32> {
-    let marker_re =
-        Regex::new(r"(?i)\[(critical|high|medium|low|info|p[0-4])\]").expect("valid regex");
     let mut counts = zero_severity_counts();
     let mut in_findings_section = false;
+    let mut in_code_fence = false;
 
     for line in text.lines() {
         let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
         if is_findings_header(line) {
             in_findings_section = true;
             continue;
@@ -179,13 +186,7 @@ pub(super) fn severity_counts_from_text(text: &str) -> std::collections::BTreeMa
             continue;
         }
 
-        for captures in marker_re.captures_iter(line) {
-            let Some(severity) = captures
-                .get(1)
-                .and_then(|level| severity_from_label(level.as_str()))
-            else {
-                continue;
-            };
+        if let Some(severity) = structured_bracketed_finding_severity(line) {
             *counts.entry(severity).or_insert(0) += 1;
         }
     }

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1675_tests.rs
@@ -99,10 +99,10 @@ fn issue_1740_codex_inline_findings_and_blocking_summary_emit_fail() {
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
 
-/// #1740 round 2: "non-blocking issue" is a low-only signal, not a blocking
-/// summary. The low-only finding must keep the verdict non-blocking.
+/// #1740 round 2 + #1806: "non-blocking issue" is not a blocking summary,
+/// but any parsed `## Findings` entry still fails closed.
 #[test]
-fn issue_1740_non_blocking_issue_summary_with_low_only_finding_emits_pass() {
+fn issue_1740_non_blocking_issue_summary_with_low_only_finding_fails_closed() {
     let session_id = "01TEST1740NONBLOCKINGLOW00";
     let (_env_lock, project_root, session_dir) =
         lock_test_session("issue-1740-non-blocking-low", session_id);
@@ -140,11 +140,10 @@ fn issue_1740_non_blocking_issue_summary_with_low_only_finding_emits_pass() {
             .expect("parse verdict");
     assert_eq!(
         artifact.decision,
-        ReviewDecision::Pass,
-        "#1740 round 2: low-only non-blocking issue must not fail"
+        ReviewDecision::Fail,
+        "#1806: any parsed finding in a Findings section must fail closed"
     );
-    assert_ne!(artifact.decision, ReviewDecision::Fail);
-    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
     assert_eq!(
         artifact.severity_counts.get(&Severity::Low),
         Some(&1),

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -434,6 +434,135 @@ No blocking issues.
 }
 
 #[test]
+fn issue_1806_1735_codex_numbered_priority_finding_fails_closed() {
+    let session_id = "01TEST18061735P1FIND00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1806-1735-p1-finding", session_id);
+
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+1. [P1][correctness] `just fmt` can stage unstaged hunks from partially staged Rust files (`justfile:259`, confidence=0.93)
+
+## Overall Risk
+
+High
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    crate::review_cmd::findings_toml::persist_review_findings_toml(&project_root, &meta);
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].severity, Severity::High);
+    assert_eq!(findings.findings[0].file_ranges[0].path, "justfile");
+    assert_eq!(findings.findings[0].file_ranges[0].start, 259);
+
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1810_1643_codex_numbered_medium_finding_fails_closed() {
+    let session_id = "01TEST18101643MEDIUM00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1810-1643-medium-finding", session_id);
+
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+1. `[medium][correctness]` Pinned root toolchain is not installed by every cargo-running workflow (`rust-toolchain.toml:2`, confidence=0.88)
+
+## Overall Risk
+
+Medium
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    crate::review_cmd::findings_toml::persist_review_findings_toml(&project_root, &meta);
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].severity, Severity::Medium);
+    assert_eq!(
+        findings.findings[0].file_ranges[0].path,
+        "rust-toolchain.toml"
+    );
+    assert_eq!(findings.findings[0].file_ranges[0].start, 2);
+
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1806_real_clean_findings_phrase_stays_pass() {
+    let session_id = "01TEST1806REALCLEAN000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1806-real-clean-phrase", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+No correctness, regression, security, or blocking test-coverage findings.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_1804_recommended_actions_without_findings_section_stays_pass() {
     let session_id = "01TEST1804ACTIONONLY000";
     let (_env_lock, project_root, session_dir) =

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -493,7 +493,7 @@ PASS
 <!-- CSA:SECTION:details -->
 ## Findings
 
-1. `[medium][correctness]` Pinned root toolchain is not installed by every cargo-running workflow (`rust-toolchain.toml:2`, confidence=0.88)
+1. [medium][correctness] Pinned root toolchain is not installed by every cargo-running workflow (`rust-toolchain.toml:2`, confidence=0.88)
 
 ## Overall Risk
 
@@ -558,6 +558,112 @@ No correctness, regression, security, or blocking test-coverage findings.
     assert_eq!(verdict.verdict_legacy, "CLEAN");
     assert!(verdict.severity_counts.values().all(|count| *count == 0));
     assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1806_clean_meta_review_quoted_priority_syntax_stays_pass() {
+    let session_id = "01TEST1806METACLEAN000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1806-meta-clean-priority-syntax", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+The changes correctly and cleanly implement the fix for issue #1806 and #1810.
+
+- `FindingsSectionParse` correctly replaces `unclean_findings_sections` with a tri-state, enabling `parsed_findings_sections` and `unparseable_findings_sections` to properly fail the review closed when findings exist despite a `PASS` decision in the summary.
+- The `parse_bracketed_finding` logic successfully strips out and correctly parses findings with formats like `` `[P1][correctness]` `` and extracts inline file paths gracefully without panicking.
+- Updating `load_canonical_review_text` to sequentially iterate through `csa_session::read_all_sections` ensures that the most recent text block for each output section is preserved, providing stability across fix rounds.
+- The changes successfully pass compilation and all corresponding test cases introduced explicitly address the issues.
+- No regressions or anti-patterns were detected.
+
+```toml
+findings = []
+```
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1806_minimal_backtick_priority_syntax_stays_pass() {
+    let session_id = "01TEST1806BACKTICK0000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1806-backtick-priority-syntax", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+No blocking issues; the review parser documentation mentions `[P1]` as syntax.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1806_mid_sentence_priority_syntax_stays_pass() {
+    let session_id = "01TEST1806MIDSENTENCE";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1806-mid-sentence-priority-syntax", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+No blocking issues; this review only discusses [P1][correctness] as syntax.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -220,22 +220,37 @@ fn parse_finding_line(
     in_findings_section: bool,
     default_unlabeled_severity: Option<Severity>,
 ) -> Option<ParsedProseFinding> {
-    let (numbered, body) =
-        strip_numbered_prefix(line).map_or((false, line), |body| (true, body.trim_start()));
+    let (structured_entry, body) =
+        structured_finding_body(line).map_or((false, line), |body| (true, body.trim_start()));
 
-    if let Some(parsed) = parse_bracketed_finding(body) {
+    if structured_entry && let Some(parsed) = parse_bracketed_finding(body) {
         return Some(parsed);
     }
 
-    if let Some(parsed) = parse_severity_prefixed_finding(body, numbered || in_findings_section) {
+    if let Some(parsed) =
+        parse_severity_prefixed_finding(body, structured_entry || in_findings_section)
+    {
         return Some(parsed);
     }
 
     let severity = default_unlabeled_severity?;
-    if !(numbered || in_findings_section) {
+    if !(structured_entry || in_findings_section) {
         return None;
     }
     parse_path_prefixed_finding(body, severity)
+}
+
+pub(in crate::review_cmd) fn structured_bracketed_finding_severity(line: &str) -> Option<Severity> {
+    bracketed_finding_severity(structured_finding_body(line)?.trim_start())
+}
+
+fn bracketed_finding_severity(body: &str) -> Option<Severity> {
+    let (label, _) = parse_bracketed_prefix(body.trim_start())?;
+    severity_from_label(label)
+}
+
+fn structured_finding_body(line: &str) -> Option<&str> {
+    strip_numbered_prefix(line).or_else(|| strip_unordered_finding_prefix(line))
 }
 
 fn strip_numbered_prefix(line: &str) -> Option<&str> {
@@ -246,8 +261,21 @@ fn strip_numbered_prefix(line: &str) -> Option<&str> {
     Some(rest)
 }
 
+fn strip_unordered_finding_prefix(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let marker = trimmed.as_bytes().first()?;
+    if !matches!(marker, b'-' | b'*') {
+        return None;
+    }
+    let rest = &trimmed[1..];
+    rest.chars()
+        .next()
+        .is_some_and(char::is_whitespace)
+        .then_some(rest)
+}
+
 fn parse_bracketed_finding(body: &str) -> Option<ParsedProseFinding> {
-    let (label, mut rest) = parse_bracketed_prefix(body.trim_start().trim_start_matches('`'))?;
+    let (label, mut rest) = parse_bracketed_prefix(body.trim_start())?;
     let severity = severity_from_label(label)?;
     rest = rest.trim_start();
 
@@ -258,11 +286,6 @@ fn parse_bracketed_finding(body: &str) -> Option<ParsedProseFinding> {
         rest = after_category.trim_start();
     }
 
-    rest = rest
-        .trim_start()
-        .strip_prefix('`')
-        .unwrap_or(rest)
-        .trim_start();
     rest = rest
         .trim_start_matches(|ch: char| ch == ':' || ch == '-' || ch.is_whitespace())
         .trim_start();
@@ -478,9 +501,20 @@ fn findings_section_body_has_unparseable_text(
         if in_code_fence || trimmed.is_empty() {
             continue;
         }
-        if !clean_conclusion(trimmed) {
+        if clean_conclusion(trimmed) {
+            continue;
+        }
+        if line_has_unparsed_finding_like_structure(trimmed) {
             return true;
         }
     }
     false
+}
+
+fn line_has_unparsed_finding_like_structure(line: &str) -> bool {
+    let body = structured_finding_body(line).unwrap_or(line).trim_start();
+    if body.starts_with('`') {
+        return false;
+    }
+    bracketed_finding_severity(body).is_some() || leading_severity_from_title(body).is_some()
 }

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -67,23 +67,54 @@ pub(in crate::review_cmd) fn extract_review_findings_from_prose_with_default(
 
 pub(in crate::review_cmd) struct FindingsSectionBody {
     body: String,
+    is_markdown_heading: bool,
 }
 
 impl FindingsSectionBody {
     pub(in crate::review_cmd) fn as_str(&self) -> &str {
         &self.body
     }
+
+    pub(in crate::review_cmd) fn is_markdown_heading(&self) -> bool {
+        self.is_markdown_heading
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::review_cmd) enum FindingsSectionParse {
+    Clean,
+    Findings(Vec<ReviewFinding>),
+    Unparseable,
+}
+
+pub(in crate::review_cmd) fn classify_findings_section_body(
+    body: &str,
+    default_unlabeled_severity: Option<Severity>,
+    clean_conclusion: impl Fn(&str) -> bool,
+) -> FindingsSectionParse {
+    let parser_input = format!("Findings\n{body}");
+    let findings =
+        extract_review_findings_from_prose_with_default(&parser_input, default_unlabeled_severity);
+    if !findings.is_empty() {
+        return FindingsSectionParse::Findings(findings);
+    }
+
+    if findings_section_body_has_unparseable_text(body, &clean_conclusion) {
+        FindingsSectionParse::Unparseable
+    } else {
+        FindingsSectionParse::Clean
+    }
 }
 
 pub(in crate::review_cmd) fn findings_section_bodies(text: &str) -> Vec<FindingsSectionBody> {
     let mut bodies = Vec::new();
-    let mut current = None::<String>;
+    let mut current = None::<(String, bool)>;
     let mut in_code_fence = false;
 
     for line in text.lines() {
         let trimmed = line.trim();
         if trimmed.starts_with("```") {
-            if let Some(body) = current.as_mut() {
+            if let Some((body, _)) = current.as_mut() {
                 body.push_str(line);
                 body.push('\n');
             }
@@ -92,19 +123,25 @@ pub(in crate::review_cmd) fn findings_section_bodies(text: &str) -> Vec<Findings
         }
 
         if !in_code_fence && is_findings_header(trimmed) {
-            if let Some(body) = current.take() {
-                bodies.push(FindingsSectionBody { body });
+            if let Some((body, is_markdown_heading)) = current.take() {
+                bodies.push(FindingsSectionBody {
+                    body,
+                    is_markdown_heading,
+                });
             }
-            current = Some(String::new());
+            current = Some((String::new(), trimmed.starts_with('#')));
             continue;
         }
 
-        let Some(body) = current.as_mut() else {
+        let Some((body, _)) = current.as_mut() else {
             continue;
         };
         if !in_code_fence && trimmed.starts_with('#') {
-            if let Some(body) = current.take() {
-                bodies.push(FindingsSectionBody { body });
+            if let Some((body, is_markdown_heading)) = current.take() {
+                bodies.push(FindingsSectionBody {
+                    body,
+                    is_markdown_heading,
+                });
             }
             continue;
         }
@@ -113,8 +150,11 @@ pub(in crate::review_cmd) fn findings_section_bodies(text: &str) -> Vec<Findings
         body.push('\n');
     }
 
-    if let Some(body) = current {
-        bodies.push(FindingsSectionBody { body });
+    if let Some((body, is_markdown_heading)) = current {
+        bodies.push(FindingsSectionBody {
+            body,
+            is_markdown_heading,
+        });
     }
 
     bodies
@@ -183,6 +223,10 @@ fn parse_finding_line(
     let (numbered, body) =
         strip_numbered_prefix(line).map_or((false, line), |body| (true, body.trim_start()));
 
+    if let Some(parsed) = parse_bracketed_finding(body) {
+        return Some(parsed);
+    }
+
     if let Some(parsed) = parse_severity_prefixed_finding(body, numbered || in_findings_section) {
         return Some(parsed);
     }
@@ -200,6 +244,39 @@ fn strip_numbered_prefix(line: &str) -> Option<&str> {
         return None;
     }
     Some(rest)
+}
+
+fn parse_bracketed_finding(body: &str) -> Option<ParsedProseFinding> {
+    let (label, mut rest) = parse_bracketed_prefix(body.trim_start().trim_start_matches('`'))?;
+    let severity = severity_from_label(label)?;
+    rest = rest.trim_start();
+
+    if let Some((category, after_category)) = parse_bracketed_prefix(rest)
+        && severity_from_label(category).is_none()
+        && !category.contains(':')
+    {
+        rest = after_category.trim_start();
+    }
+
+    rest = rest
+        .trim_start()
+        .strip_prefix('`')
+        .unwrap_or(rest)
+        .trim_start();
+    rest = rest
+        .trim_start_matches(|ch: char| ch == ':' || ch == '-' || ch.is_whitespace())
+        .trim_start();
+    Some(ParsedProseFinding {
+        severity,
+        file_range: parse_embedded_file_range(rest),
+        description: non_empty_or_fallback(rest, body),
+    })
+}
+
+fn parse_bracketed_prefix(text: &str) -> Option<(&str, &str)> {
+    let rest = text.strip_prefix('[')?;
+    let end = rest.find(']')?;
+    Some((&rest[..end], &rest[end + 1..]))
 }
 
 fn parse_severity_prefixed_finding(
@@ -287,13 +364,36 @@ fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, Strin
     ))
 }
 
+fn parse_embedded_file_range(body: &str) -> Option<ReviewFindingFileRange> {
+    body.split(char::is_whitespace)
+        .map(|token| token.trim_matches(['`', '(', ')', '[', ']', ',', '.', ';']))
+        .find_map(|token| {
+            parse_file_line_token(token).map(|(path, start)| ReviewFindingFileRange {
+                path,
+                start,
+                end: None,
+            })
+        })
+}
+
 fn parse_file_line_token(token: &str) -> Option<(String, u32)> {
     let (path, line) = token.rsplit_once(':')?;
-    if path.is_empty() || !(path.contains('/') || path.contains('.')) {
+    if path.is_empty() || !looks_like_file_path(path) {
         return None;
     }
     let line = line.parse::<u32>().ok()?;
     Some((path.to_string(), line))
+}
+
+fn looks_like_file_path(path: &str) -> bool {
+    if path.chars().any(char::is_whitespace) {
+        return false;
+    }
+    path.contains('/')
+        || path.contains('.')
+        || path.eq_ignore_ascii_case("justfile")
+        || path == "Makefile"
+        || path == "Dockerfile"
 }
 
 fn non_empty_or_fallback(value: &str, fallback: &str) -> String {
@@ -361,5 +461,26 @@ fn line_has_blocking_review_signal(line: &str) -> bool {
         }
     }
 
+    false
+}
+
+fn findings_section_body_has_unparseable_text(
+    body: &str,
+    clean_conclusion: &impl Fn(&str) -> bool,
+) -> bool {
+    let mut in_code_fence = false;
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence || trimmed.is_empty() {
+            continue;
+        }
+        if !clean_conclusion(trimmed) {
+            return true;
+        }
+    }
     false
 }


### PR DESCRIPTION
## Summary

Closes the recurring **codex-review false-PASS** at the structured-verdict layer
(#1806 core, #1810 instance). When `details.md` carried a real blocking finding in its
`## Findings` section, `review-verdict.json` could still report `decision=pass` with
all-zero `severity_counts` and an empty `findings.toml`, so the pre-push `review-check`
hook and `csa review --check-verdict` treated the change as mergeable.

Two live instances this session (both on a binary that already included the #1804 fix):

- `## Findings` `1. [P1][correctness] ...` + `## Overall Risk High` → verdict `pass`, severity `0/0/0/0`.
- `## Findings` `1. [medium][correctness] ...` + `## Overall Risk Medium` → verdict `pass`, severity `0/0/0/0`.

## Root cause

#1804 patched several narrow re-scan sub-cases over 7 rounds but did not close the
*class*: the fail-closed guard independently re-scanned prose with brittle clean-phrase
heuristics, so any finding layout the parser did not recognize (here, codex's **numbered**
`N. [SEVERITY][category] title (loc, confidence=X)` format) extracted zero findings and the
guard concluded "clean" → `pass`.

## The fix — structural invariant, not another special-case

- **Tri-state parser**: the `## Findings` section parser now classifies the section into
  exactly one of `Clean` / `Findings(list)` / `Unparseable` (non-empty, non-clean content
  that could not be reduced to parsed findings).
- **Fail-closed guard (the #1806 core)**: the verdict/consistency guard now *consumes* the
  parser tri-state instead of re-scanning prose independently — `Clean` → `pass` allowed,
  `Findings` → `decision != pass`, **`Unparseable` → fail-closed (`decision != pass`)**.
  This closes the hole for all finding layouts, present and future.
- **Numbered-format recognition (#1810)**: the parser recognizes
  `N. [TOKEN][category] title (loc, confidence=X)` where `TOKEN` is a severity
  (`low|medium|high|critical`) or priority (`P0|P1|P2|P3`), mapped to the existing
  `FindingSeverity` so `severity_counts` are accurate.

## Round 2 — precision fix (false-FAIL on reviews that DISCUSS finding syntax)

Round 1 over-matched: it parsed bracketed-severity tokens as findings even inside markdown
code spans (backticks) or mid-sentence narrative. Caught by dogfooding — a gemini review of
this very fix returned an explicit `findings = []` + "no regressions", yet the round-1
extractor fabricated a `high=1` from the `` `[P1][correctness]` `` token (in backticks) in the
review's *description* of the parser, false-FAILing a clean review and blocking the merge.

Round 2 tightens detection precision without re-opening #1806:

- **Code-span exclusion**: bracketed tokens inside backtick-delimited inline code are
  references/examples, not findings.
- **Structured-anchor requirement**: a bracketed-severity token is a finding only when it
  anchors a numbered/bulleted finding entry (`N. [P1][cat] title (loc)`), not mid-sentence.
- **`Clean` vs `Unparseable` refinement**: a section of positive narrative with no structured
  finding entries (especially with an explicit `findings = []`) is `Clean`, not `Unparseable`.
  An explicit `findings = []` is honored as clean ONLY when no structured prose findings are
  detected (structured-findings-present + empty-list → still the #1806 disagreement → fail closed).

## Tests — both directions pinned (prevents precision/recall ping-pong)

1. #1735-r1 `[P1]` numbered content → `decision != pass` (false-PASS direction).
2. #1643-r1 `[medium]` numbered content → `decision != pass` (false-PASS direction).
3. The verbatim clean meta-review (backtick `[P1]` + `findings = []`) → `decision == pass` (false-FAIL direction).
4. NEGATIVE: a genuinely clean report → `decision == pass`.

Existing #1804 / #1362 verdict tests stay green.

Validated by dogfooding: this PR's own diff was reviewed by gemini-cli (PASS, `findings = []`)
using the fixed binary; round-2 makes that clean verdict resolve correctly through the gate.

Closes #1806. Closes #1810. Follow-up arch hardening from #1804's 7-round narrow-patch anti-pattern.
