### PR TITLE
fix(cli-sub-agent): enforce worktree writer lock (#1672)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.865"
+version = "0.1.866"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.865"
+version = "0.1.866"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -41,6 +41,8 @@ mod session_exec_prompt_guard;
 mod session_exec_tool_state;
 #[path = "pipeline_session_exec_write_guard.rs"]
 mod session_exec_write_guard;
+#[path = "pipeline_session_exec_write_lock.rs"]
+mod session_exec_write_lock;
 #[path = "pipeline_session_exec_state_preflight.rs"]
 mod state_preflight;
 use self::session_exec_pre_exec::{
@@ -111,12 +113,19 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     )
     .await?;
     let session_dir = get_session_dir(project_root, &session.meta_session_id)?;
-    // New-session cleanup guard: delete the orphan directory on pre-exec failure.
     let mut cleanup_guard = if session_arg.is_none() {
         Some(SessionCleanupGuard::new(session_dir.clone()))
     } else {
         None
     };
+    let _worktree_write_lock = session_exec_write_lock::acquire_or_persist_failure(
+        project_root,
+        &mut session,
+        executor.tool_name(),
+        task_type,
+        readonly_project_root,
+        &mut cleanup_guard,
+    )?;
     let (_log_writer, _log_guard) = match csa_executor::create_session_log_writer(&session_dir) {
         Ok(pair) => pair,
         Err(e) => {

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -1,0 +1,153 @@
+use super::session_exec_pre_exec::persist_pipeline_pre_exec_failure;
+use crate::session_guard::SessionCleanupGuard;
+use anyhow::{Context, Result};
+use csa_lock::WorktreeWriteLock;
+use csa_session::MetaSessionState;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub(super) fn acquire_or_persist_failure(
+    project_root: &Path,
+    session: &mut MetaSessionState,
+    tool_name: &str,
+    task_type: Option<&str>,
+    readonly_project_root: bool,
+    cleanup_guard: &mut Option<SessionCleanupGuard>,
+) -> Result<Option<WorktreeWriteLock>> {
+    acquire_if_needed(project_root, session, task_type, readonly_project_root).map_err(|err| {
+        persist_pipeline_pre_exec_failure(
+            project_root,
+            session,
+            tool_name,
+            err,
+            cleanup_guard,
+            None,
+        )
+    })
+}
+
+pub(super) fn acquire_if_needed(
+    project_root: &Path,
+    session: &MetaSessionState,
+    task_type: Option<&str>,
+    readonly_project_root: bool,
+) -> Result<Option<WorktreeWriteLock>> {
+    if !is_write_session(task_type, readonly_project_root) {
+        return Ok(None);
+    }
+
+    let worktree_root = resolve_worktree_lock_root(project_root)?;
+    let ancestor_session_ids = collect_lineage_session_ids(project_root, session)?;
+    csa_lock::acquire_worktree_write_lock(
+        &worktree_root,
+        &session.meta_session_id,
+        &ancestor_session_ids,
+    )
+    .map(Some)
+}
+
+fn is_write_session(task_type: Option<&str>, readonly_project_root: bool) -> bool {
+    matches!(task_type, Some("run")) && !readonly_project_root
+}
+
+fn resolve_worktree_lock_root(project_root: &Path) -> Result<PathBuf> {
+    if let Some(toplevel) = git_rev_parse_path(project_root, "--show-toplevel") {
+        return canonicalize_lock_root(&toplevel, "git worktree toplevel");
+    }
+
+    if let Some(common_dir) = git_rev_parse_path(project_root, "--git-common-dir") {
+        return canonicalize_lock_root(&common_dir, "git common dir");
+    }
+
+    canonicalize_lock_root(project_root, "project root")
+}
+
+fn canonicalize_lock_root(path: &Path, label: &str) -> Result<PathBuf> {
+    path.canonicalize()
+        .with_context(|| format!("failed to canonicalize {label} '{}'", path.display()))
+}
+
+fn git_rev_parse_path(project_root: &Path, arg: &str) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .arg("rev-parse")
+        .arg(arg)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        Some(project_root.join(path))
+    }
+}
+
+fn collect_lineage_session_ids(
+    project_root: &Path,
+    session: &MetaSessionState,
+) -> Result<Vec<String>> {
+    let mut ids = Vec::new();
+    let mut seen = HashSet::new();
+    push_lineage(
+        project_root,
+        session.genealogy.parent_session_id.as_deref(),
+        &mut ids,
+        &mut seen,
+    )?;
+    push_lineage(
+        project_root,
+        session.genealogy.fork_source(),
+        &mut ids,
+        &mut seen,
+    )?;
+    Ok(ids)
+}
+
+fn push_lineage(
+    project_root: &Path,
+    first_session_id: Option<&str>,
+    ids: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) -> Result<()> {
+    let mut current = first_session_id.map(ToString::to_string);
+    while let Some(session_id) = current {
+        if !seen.insert(session_id.clone()) {
+            break;
+        }
+        ids.push(session_id.clone());
+        let state = csa_session::load_session(project_root, &session_id)
+            .with_context(|| format!("failed to load ancestor session {session_id}"))?;
+        current = state
+            .genealogy
+            .parent_session_id
+            .clone()
+            .or_else(|| state.genealogy.fork_of_session_id.clone());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_lock_predicate_only_matches_writable_run_sessions() {
+        assert!(is_write_session(Some("run"), false));
+        assert!(!is_write_session(Some("run"), true));
+        assert!(!is_write_session(Some("reviewer_sub_session"), false));
+        assert!(!is_write_session(Some("debate"), false));
+        assert!(!is_write_session(None, false));
+    }
+}

--- a/crates/cli-sub-agent/src/pipeline_tests_locking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_locking.rs
@@ -81,3 +81,141 @@ async fn execute_with_session_and_meta_does_not_persist_runtime_binary_when_lock
         "lock loser must not overwrite the winner's runtime_binary"
     );
 }
+
+#[tokio::test]
+async fn run_writer_fails_fast_when_worktree_write_lock_is_held() {
+    let temp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    let project_root = temp.path();
+
+    let _holder = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
+        .expect("holder worktree write lock should succeed");
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: csa_executor::CodexRuntimeMetadata::from_transport(
+            csa_executor::CodexTransport::Acp,
+        ),
+    };
+
+    let execution = execute_with_session_and_meta(
+        &executor,
+        &ToolName::Codex,
+        "write prompt",
+        csa_core::types::OutputFormat::Json,
+        None,
+        false,
+        None,
+        None,
+        project_root,
+        None,
+        None,
+        None,
+        Some("run"),
+        None,
+        None,
+        csa_process::StreamMode::BufferOnly,
+        DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        false,
+        &[],
+        &[],
+        false,
+        false,
+        &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
+    )
+    .await;
+    let err = match execution {
+        Ok(_) => panic!("held worktree write lock must reject non-lineage run writer"),
+        Err(err) => err,
+    };
+    let err = err.to_string();
+
+    assert!(
+        err.contains("concurrent write session blocked"),
+        "unexpected error: {err}"
+    );
+    assert!(err.contains("01HOLDER"), "missing holder session id: {err}");
+    assert!(
+        err.contains(&project_root.display().to_string()),
+        "missing worktree path: {err}"
+    );
+    assert!(
+        err.contains("sequentially"),
+        "missing serialize guidance: {err}"
+    );
+}
+
+#[tokio::test]
+async fn debate_session_is_not_blocked_by_worktree_write_lock() {
+    let temp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    let project_root = temp.path();
+
+    let session =
+        csa_session::create_session(project_root, Some("debate-target"), None, Some("codex"))
+            .unwrap();
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id).unwrap();
+    let _session_lock = csa_lock::acquire_lock(&session_dir, "codex", "active debate").unwrap();
+    let _worktree_lock = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
+        .expect("holder worktree write lock should succeed");
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: csa_executor::CodexRuntimeMetadata::from_transport(
+            csa_executor::CodexTransport::Acp,
+        ),
+    };
+
+    let execution = execute_with_session_and_meta(
+        &executor,
+        &ToolName::Codex,
+        "debate prompt",
+        csa_core::types::OutputFormat::Json,
+        Some(session.meta_session_id.clone()),
+        false,
+        None,
+        None,
+        project_root,
+        None,
+        None,
+        None,
+        Some("debate"),
+        None,
+        None,
+        csa_process::StreamMode::BufferOnly,
+        DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        false,
+        &[],
+        &[],
+        false,
+        false,
+        &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
+    )
+    .await;
+    let err = match execution {
+        Ok(_) => panic!("held per-session lock must still reject the resume attempt"),
+        Err(err) => err,
+    };
+    let err = err.to_string();
+
+    assert!(
+        err.contains("Failed to acquire lock for session"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !err.contains("concurrent write session blocked"),
+        "debate must not be blocked by worktree write lock: {err}"
+    );
+}

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -1,7 +1,7 @@
 use super::handle_run;
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_config::{ProjectConfig, ProjectMeta, ResourcesConfig, TierStrategy, ToolConfig};
-use csa_core::types::OutputFormat;
+use csa_core::types::{OutputFormat, ToolArg, ToolName};
 use std::collections::HashMap;
 use std::path::Path;
 use tempfile::tempdir;
@@ -247,6 +247,91 @@ async fn handle_run_no_preflight_skips_ai_config_check() {
             .to_string()
             .contains("No tool specified and no tier-based or auto-selectable tool available"),
         "unexpected error: {routing_err:#}"
+    );
+}
+
+#[tokio::test]
+async fn handle_run_fails_fast_when_worktree_write_lock_is_held() {
+    let project_dir = tempdir().unwrap();
+    let mut sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    sandbox.track_env(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV);
+    // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for the full test.
+    unsafe {
+        std::env::set_var(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    }
+    let config = run_config_with_tier("default", vec!["codex/openai/o4-mini/high"], &["codex"]);
+    write_project_config(project_dir.path(), &config);
+    let _holder = csa_lock::acquire_worktree_write_lock(project_dir.path(), "01HOLDER", &[])
+        .expect("holder worktree write lock should succeed");
+
+    let err = handle_run(
+        Some(ToolArg::Specific(ToolName::Codex)),
+        None,
+        None,
+        None,
+        Some("fix the repository".to_string()),
+        None,
+        None,
+        None,
+        None,
+        false,
+        None,
+        false,
+        false,
+        Some("locked worktree run".to_string()),
+        false,
+        None,
+        None,
+        false,
+        true,
+        Some(project_dir.path().display().to_string()),
+        None,
+        None,
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        None,
+        false,
+        None,
+        None,
+        None,
+        false,
+        false,
+        None,
+        0,
+        OutputFormat::Text,
+        csa_process::StreamMode::BufferOnly,
+        Some("default".to_string()),
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        Vec::new(),
+        Vec::new(),
+        crate::startup_env::StartupSubtreeEnv::default(),
+    )
+    .await
+    .expect_err("run writer should fail before tool execution when worktree lock is held");
+    let err = err.to_string();
+
+    assert!(
+        err.contains("concurrent write session blocked"),
+        "unexpected error: {err}"
+    );
+    assert!(err.contains("01HOLDER"), "missing holder session id: {err}");
+    assert!(
+        err.contains(&project_dir.path().display().to_string()),
+        "missing worktree path: {err}"
+    );
+    assert!(
+        err.contains("sequentially"),
+        "missing serialize guidance: {err}"
     );
 }
 

--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -10,6 +10,9 @@
 //! owns the fd). `Drop` calls `flock(fd, LOCK_UN)` to release.
 
 pub mod slot;
+mod worktree;
+
+pub use worktree::{WorktreeWriteLock, acquire_worktree_write_lock};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -22,11 +25,15 @@ use std::path::{Path, PathBuf};
 
 /// Diagnostic information written to lock files
 #[derive(Debug, Serialize, Deserialize)]
-struct LockDiagnostic {
+pub(crate) struct LockDiagnostic {
     pid: u32,
     tool_name: String,
     acquired_at: DateTime<Utc>,
     reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) holder_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    resource_path: Option<String>,
 }
 
 /// Session lock guard backed by `flock(2)`.
@@ -92,6 +99,16 @@ pub fn acquire_lock_at_path(
     lock_name: &str,
     reason: &str,
 ) -> Result<SessionLock> {
+    acquire_lock_at_path_with_metadata(lock_path, lock_name, reason, None, None)
+}
+
+pub(crate) fn acquire_lock_at_path_with_metadata(
+    lock_path: &Path,
+    lock_name: &str,
+    reason: &str,
+    holder_session_id: Option<&str>,
+    resource_path: Option<&Path>,
+) -> Result<SessionLock> {
     if let Some(parent) = lock_path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create locks directory: {}", parent.display()))?;
@@ -125,6 +142,8 @@ pub fn acquire_lock_at_path(
             tool_name: lock_name.to_string(),
             acquired_at: Utc::now(),
             reason: reason.to_string(),
+            holder_session_id: holder_session_id.map(ToString::to_string),
+            resource_path: resource_path.map(|path| path.display().to_string()),
         };
 
         let json =
@@ -149,16 +168,35 @@ pub fn acquire_lock_at_path(
             .context("Failed to read lock file")?;
 
         let error_msg = if let Ok(diagnostic) = serde_json::from_str::<LockDiagnostic>(&contents) {
-            format!(
-                "Session locked by PID {} (tool: {}, reason: {}, acquired: {})",
-                diagnostic.pid, diagnostic.tool_name, diagnostic.reason, diagnostic.acquired_at
-            )
+            format_lock_diagnostic(&diagnostic)
         } else {
             "Session is locked (unable to read diagnostic info)".to_string()
         };
 
         Err(anyhow::anyhow!(error_msg))
     }
+}
+
+fn format_lock_diagnostic(diagnostic: &LockDiagnostic) -> String {
+    let holder = diagnostic
+        .holder_session_id
+        .as_deref()
+        .map(|session| format!(", holder_session_id: {session}"))
+        .unwrap_or_default();
+    let resource = diagnostic
+        .resource_path
+        .as_deref()
+        .map(|path| format!(", resource_path: {path}"))
+        .unwrap_or_default();
+    format!(
+        "Session locked by PID {} (tool: {}, reason: {}, acquired: {}{}{})",
+        diagnostic.pid,
+        diagnostic.tool_name,
+        diagnostic.reason,
+        diagnostic.acquired_at,
+        holder,
+        resource
+    )
 }
 
 /// Acquire a non-blocking exclusive lock for a session and tool.
@@ -222,6 +260,16 @@ pub fn acquire_project_resource_lock(
     tool_name: &str,
     reason: &str,
 ) -> Result<SessionLock> {
+    let (lock_path, lock_name, _) =
+        project_resource_lock_path(project_root, resource_kind, tool_name)?;
+    acquire_lock_at_path(&lock_path, &lock_name, reason)
+}
+
+pub(crate) fn project_resource_lock_path(
+    project_root: &Path,
+    resource_kind: &str,
+    tool_name: &str,
+) -> Result<(PathBuf, String, PathBuf)> {
     let kind = resource_kind.trim();
     if kind.is_empty() {
         anyhow::bail!("resource kind cannot be empty");
@@ -252,7 +300,16 @@ pub fn acquire_project_resource_lock(
         .join(digest)
         .join(format!("{safe_tool}.lock"));
     let lock_name = format!("{kind}:{tool}");
-    acquire_lock_at_path(&lock_path, &lock_name, reason)
+    Ok((lock_path, lock_name, canonical))
+}
+
+pub(crate) fn read_lock_diagnostic(lock_path: &Path) -> Result<Option<LockDiagnostic>> {
+    let mut contents = String::new();
+    File::open(lock_path)
+        .with_context(|| format!("Failed to open lock file: {}", lock_path.display()))?
+        .read_to_string(&mut contents)
+        .with_context(|| format!("Failed to read lock file: {}", lock_path.display()))?;
+    Ok(serde_json::from_str::<LockDiagnostic>(&contents).ok())
 }
 
 #[cfg(test)]

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -1,0 +1,230 @@
+use crate::{
+    SessionLock, acquire_lock_at_path_with_metadata, project_resource_lock_path,
+    read_lock_diagnostic,
+};
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+/// Guard for a write-capable CSA session sharing one git worktree.
+///
+/// Direct acquisitions own an exclusive `flock(2)` via [`SessionLock`].
+/// Lineage re-entries are no-op guards used when a child session runs under
+/// an ancestor session that already owns the process-level worktree lock.
+pub struct WorktreeWriteLock {
+    inner: WorktreeWriteLockKind,
+    lock_path: PathBuf,
+}
+
+enum WorktreeWriteLockKind {
+    Acquired { _lock: SessionLock },
+    LineageReentry { holder_session_id: String },
+}
+
+impl std::fmt::Debug for WorktreeWriteLock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.inner {
+            WorktreeWriteLockKind::Acquired { .. } => f
+                .debug_struct("WorktreeWriteLock")
+                .field("mode", &"acquired")
+                .field("lock_path", &self.lock_path)
+                .finish(),
+            WorktreeWriteLockKind::LineageReentry { holder_session_id } => f
+                .debug_struct("WorktreeWriteLock")
+                .field("mode", &"lineage_reentry")
+                .field("holder_session_id", holder_session_id)
+                .field("lock_path", &self.lock_path)
+                .finish(),
+        }
+    }
+}
+
+impl WorktreeWriteLock {
+    /// Returns the lock file path for this worktree write lock.
+    pub fn lock_path(&self) -> &Path {
+        &self.lock_path
+    }
+
+    /// Returns true when this session is allowed to proceed under an ancestor's lock.
+    pub fn is_lineage_reentry(&self) -> bool {
+        matches!(self.inner, WorktreeWriteLockKind::LineageReentry { .. })
+    }
+
+    /// Returns the ancestor session id that owns the underlying flock.
+    pub fn holder_session_id(&self) -> Option<&str> {
+        match &self.inner {
+            WorktreeWriteLockKind::Acquired { .. } => None,
+            WorktreeWriteLockKind::LineageReentry { holder_session_id } => {
+                Some(holder_session_id.as_str())
+            }
+        }
+    }
+}
+
+/// Acquire a fail-fast exclusive write lock for a canonical git worktree root.
+///
+/// Lock path:
+/// `${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/worktree-write-locks/<sha256(canonical(worktree_root))>/exclusive.lock`
+///
+/// If the lock holder is one of `ancestor_session_ids`, the current session is
+/// allowed to proceed under the ancestor's flock. This prevents fork-call child
+/// sessions from self-deadlocking while still blocking unrelated write sessions.
+pub fn acquire_worktree_write_lock(
+    worktree_root: &Path,
+    session_id: &str,
+    ancestor_session_ids: &[String],
+) -> Result<WorktreeWriteLock> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        anyhow::bail!("session id cannot be empty");
+    }
+
+    let (lock_path, lock_name, canonical_root) =
+        project_resource_lock_path(worktree_root, "worktree-write", "exclusive")?;
+    let reason = format!(
+        "write session {session_id} holds worktree {}",
+        canonical_root.display()
+    );
+
+    match acquire_lock_at_path_with_metadata(
+        &lock_path,
+        &lock_name,
+        &reason,
+        Some(session_id),
+        Some(&canonical_root),
+    ) {
+        Ok(lock) => Ok(WorktreeWriteLock {
+            inner: WorktreeWriteLockKind::Acquired { _lock: lock },
+            lock_path,
+        }),
+        Err(lock_error) => {
+            let diagnostic = read_lock_diagnostic(&lock_path)?;
+            if let Some(holder_session_id) = diagnostic
+                .as_ref()
+                .and_then(|diag| diag.holder_session_id.as_ref())
+                && ancestor_session_ids
+                    .iter()
+                    .any(|ancestor| ancestor == holder_session_id)
+            {
+                return Ok(WorktreeWriteLock {
+                    inner: WorktreeWriteLockKind::LineageReentry {
+                        holder_session_id: holder_session_id.clone(),
+                    },
+                    lock_path,
+                });
+            }
+
+            let holder = diagnostic
+                .as_ref()
+                .and_then(|diag| diag.holder_session_id.as_deref())
+                .unwrap_or("unknown");
+            anyhow::bail!(
+                "concurrent write session blocked: worktree '{}' is already locked by session {}. \
+                 {}. Run write-capable CSA sessions for this repository sequentially; \
+                 wait for the holder to finish or stop it before starting another writer.",
+                canonical_root.display(),
+                holder,
+                lock_error
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use tempfile::tempdir;
+
+    fn env_test_lock() -> MutexGuard<'static, ()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set_os(key: &'static str, value: &Path) -> Self {
+            let original = std::env::var_os(key);
+            // SAFETY: test-scoped env mutation is isolated to the current test.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                // SAFETY: test-scoped env restoration is isolated to the current test.
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                // SAFETY: test-scoped env restoration is isolated to the current test.
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn test_worktree_write_lock_conflicts_for_same_worktree_root() {
+        let _env_lock = env_test_lock();
+        let state_home = tempdir().expect("state-home tempdir");
+        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+        let worktree_root = tempdir().expect("worktree tempdir");
+        let _lock1 = acquire_worktree_write_lock(worktree_root.path(), "01PARENT", &[])
+            .expect("first worktree write lock should succeed");
+
+        let err = acquire_worktree_write_lock(worktree_root.path(), "01OTHER", &[])
+            .expect_err("non-lineage writer should fail fast")
+            .to_string();
+
+        assert!(err.contains("01PARENT"), "missing holder session id: {err}");
+        assert!(
+            err.contains(&worktree_root.path().display().to_string()),
+            "missing worktree path: {err}"
+        );
+        assert!(
+            err.contains("sequentially"),
+            "missing serialize guidance: {err}"
+        );
+    }
+
+    #[test]
+    fn test_worktree_write_lock_allows_lineage_reentry() {
+        let _env_lock = env_test_lock();
+        let state_home = tempdir().expect("state-home tempdir");
+        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+        let worktree_root = tempdir().expect("worktree tempdir");
+        let _parent = acquire_worktree_write_lock(worktree_root.path(), "01PARENT", &[])
+            .expect("parent worktree write lock should succeed");
+
+        let child =
+            acquire_worktree_write_lock(worktree_root.path(), "01CHILD", &["01PARENT".to_string()])
+                .expect("child should re-enter under ancestor lock");
+
+        assert!(child.is_lineage_reentry());
+        assert_eq!(child.holder_session_id(), Some("01PARENT"));
+    }
+
+    #[test]
+    fn test_worktree_write_lock_allows_different_worktree_roots() {
+        let _env_lock = env_test_lock();
+        let state_home = tempdir().expect("state-home tempdir");
+        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+        let worktree_a = tempdir().expect("worktree a tempdir");
+        let worktree_b = tempdir().expect("worktree b tempdir");
+
+        let lock_a = acquire_worktree_write_lock(worktree_a.path(), "01A", &[]);
+        let lock_b = acquire_worktree_write_lock(worktree_b.path(), "01B", &[]);
+
+        assert!(lock_a.is_ok());
+        assert!(lock_b.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

Enforces the previously **advisory-only** "never run two concurrent `csa` write
sessions against the same repository" rule (CLAUDE.md / AGENTS.md 028/050) with a
real **per-worktree exclusive write lock**. Without enforcement, an accidental
parallel dispatch or a mis-wired workflow could let two write sessions race on the
shared `.git` (index / HEAD / refs) and working tree, silently losing one
session's commit or contaminating HEAD across branches.

### Mechanism

- A per-worktree-root exclusive write lock, keyed on the canonical resolved
  worktree root, implemented over the existing `csa-lock` `flock(2)` advisory
  primitive (kernel auto-releases on holder death — no stale-lock cleanup path
  needed). New `csa-lock::worktree` module.
- **Acquired only by write-capable `csa run` sessions.** Pure read-only sessions
  (review / debate that never commit) are deliberately **not** gated — #1672 is
  specifically write↔write clobbering; read↔write is out of scope.
- **Contention is fail-fast, not blocking.** A non-lineage write session that
  finds the worktree lock held errors immediately with the holding session ID,
  the worktree path, and guidance to serialize — rather than blocking (which
  risks hangs/deadlocks and hides the mistake).

### Fork-call fractal-child case

CSA's fork-call spawns a child session that, per rule 028 (no worktrees), shares
the **same** worktree as its parent. A naive exclusive lock would deadlock a
parent write session that suspends awaiting a fork-call write child. The lock is
therefore **lineage-aware**: if the current holder is an **ancestor** of the
acquiring session (walked via the session genealogy / parent chain), re-entry is
allowed; otherwise it fails fast.

## Test plan

- New targeted locking tests assert: (1) a non-lineage concurrent write session
  on the same worktree fails fast with the holder session ID + serialize
  guidance; (2) a fork-call lineage descendant re-enters under an ancestor
  holder; (3) read-only sessions are not blocked.
- `run_cmd` pre-exec acquire-path tests updated.
- `just fmt` + `just clippy` clean. Targeted `cargo nextest` for `csa-lock` /
  `csa-session` / the cli-sub-agent acquire path.

Version bumped 0.1.865 → 0.1.866 (feature-branch pre-commit gate requires the
workspace version to differ from main before any commit).

Closes #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
