### PR TITLE
fix(cli-sub-agent): opaque review quota exhaustion + escape-hatch guidance (#1832)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.867"
+version = "0.1.868"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.867"
+version = "0.1.868"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -30,9 +30,9 @@ use crate::review_routing::{ReviewRoutingMetadata, persist_review_routing_artifa
 use crate::startup_env::StartupSubtreeEnv;
 use crate::tier_model_fallback::{
     TierAttemptFailure, chain_failure_reasons, classify_next_model_failure_with_elapsed,
-    fallback_reason_for_result, format_all_models_failed_reason_with_reset,
-    ordered_tier_candidates, parse_backend_reset_duration, persist_fallback_chain,
-    persist_fallback_result_fields,
+    earliest_backend_reset_window, fallback_reason_for_result,
+    format_all_models_failed_reason_with_reset, ordered_tier_candidates,
+    parse_backend_reset_duration, persist_fallback_chain, persist_fallback_result_fields,
 };
 
 use super::output::{
@@ -435,7 +435,7 @@ pub(crate) async fn execute_review_with_tier_filter(
                     let failure_reason = format_all_models_failed_reason_with_reset(
                         tier_name.as_deref(),
                         &failures,
-                        reset_windows.iter().copied().max(),
+                        earliest_backend_reset_window(&reset_windows),
                     );
                     return Ok(ReviewExecutionOutcome {
                         execution: crate::pipeline::SessionExecutionResult {
@@ -631,7 +631,7 @@ pub(crate) async fn execute_review_with_tier_filter(
                     failure_reason: format_all_models_failed_reason_with_reset(
                         tier_name.as_deref(),
                         &failures,
-                        reset_windows.iter().copied().max(),
+                        earliest_backend_reset_window(&reset_windows),
                     ),
                 });
             }

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -30,8 +30,9 @@ use crate::review_routing::{ReviewRoutingMetadata, persist_review_routing_artifa
 use crate::startup_env::StartupSubtreeEnv;
 use crate::tier_model_fallback::{
     TierAttemptFailure, chain_failure_reasons, classify_next_model_failure_with_elapsed,
-    fallback_reason_for_result, format_all_models_failed_reason, ordered_tier_candidates,
-    persist_fallback_chain, persist_fallback_result_fields,
+    fallback_reason_for_result, format_all_models_failed_reason_with_reset,
+    ordered_tier_candidates, parse_backend_reset_duration, persist_fallback_chain,
+    persist_fallback_result_fields,
 };
 
 use super::output::{
@@ -261,6 +262,7 @@ pub(crate) async fn execute_review_with_tier_filter(
         &candidates,
     );
     let mut failures = Vec::new();
+    let mut reset_windows = Vec::new();
 
     for (attempt_index, (attempt_tool, attempt_model_spec)) in candidates.iter().enumerate() {
         let attempt_started_at = std::time::Instant::now();
@@ -369,6 +371,9 @@ pub(crate) async fn execute_review_with_tier_filter(
                     let model_label = attempt_model_spec
                         .clone()
                         .unwrap_or_else(|| attempt_tool.as_str().to_string());
+                    if let Some(reset_after) = parse_backend_reset_duration(&error_text) {
+                        reset_windows.push(reset_after);
+                    }
                     failures.push(TierAttemptFailure::from_rate_limit(
                         model_label.clone(),
                         &detected,
@@ -427,8 +432,11 @@ pub(crate) async fn execute_review_with_tier_filter(
                             ),
                         );
                     }
-                    let failure_reason =
-                        format_all_models_failed_reason(tier_name.as_deref(), &failures);
+                    let failure_reason = format_all_models_failed_reason_with_reset(
+                        tier_name.as_deref(),
+                        &failures,
+                        reset_windows.iter().copied().max(),
+                    );
                     return Ok(ReviewExecutionOutcome {
                         execution: crate::pipeline::SessionExecutionResult {
                             execution: csa_process::ExecutionResult {
@@ -568,6 +576,12 @@ pub(crate) async fn execute_review_with_tier_filter(
                 .clone()
                 .unwrap_or_else(|| attempt_tool.as_str().to_string());
             let reason = failure.reason.clone();
+            if let Some(reset_after) = parse_backend_reset_duration(&format!(
+                "{}\n{}",
+                execution.execution.stderr_output, execution.execution.output
+            )) {
+                reset_windows.push(reset_after);
+            }
             failures.push(TierAttemptFailure {
                 model_spec: model_label.clone(),
                 reason: reason.clone(),
@@ -614,9 +628,10 @@ pub(crate) async fn execute_review_with_tier_filter(
                     forced_decision: Some(ReviewDecision::Unavailable),
                     routed_to: None,
                     primary_failure: chain_failure_reasons(&failures),
-                    failure_reason: format_all_models_failed_reason(
+                    failure_reason: format_all_models_failed_reason_with_reset(
                         tier_name.as_deref(),
                         &failures,
+                        reset_windows.iter().copied().max(),
                     ),
                 });
             }

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -26,7 +26,7 @@ pub(super) fn classify_review_failover_reason(
 ) -> Option<ReviewFailoverFailure> {
     if status_reason == Some("gemini_auth_prompt") {
         return Some(ReviewFailoverFailure {
-            reason: "gemini_auth_prompt".to_string(),
+            reason: "auth_unavailable".to_string(),
             quota_exhausted: None,
         });
     }

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -11,6 +11,7 @@ use crate::review_consensus::{
     CLEAN, HAS_ISSUES, SKIP, UNAVAILABLE, UNCERTAIN, parse_explicit_review_decision_token,
     parse_review_decision,
 };
+use crate::tier_model_fallback::opaque_total_exhaustion_message;
 
 use super::execute::ReviewExecutionOutcome;
 use super::output::{
@@ -96,8 +97,14 @@ pub(super) fn resolve_single_review_result(
         result.status_reason.as_deref() == Some(GEMINI_AUTH_PROMPT_STATUS_REASON);
     let forced_unavailable = matches!(result.forced_decision, Some(ReviewDecision::Unavailable));
     let tool_unavailable_reason = tool_unavailable_failure_reason(result, tool);
+    let opaque_total_exhaustion = opaque_total_exhaustion_message(
+        result.primary_failure.as_deref(),
+        result.failure_reason.as_deref(),
+    );
     let sanitized = if auth_prompt_failure {
         AUTH_PROMPT_REVIEW_UNAVAILABLE.to_string()
+    } else if let Some(message) = opaque_total_exhaustion.as_deref() {
+        format!("{message}\n")
     } else if forced_unavailable {
         format!(
             "{REVIEW_UNAVAILABLE_PREFIX}{}\n",
@@ -115,10 +122,14 @@ pub(super) fn resolve_single_review_result(
         && !forced_unavailable
         && tool_unavailable_reason.is_none()
         && is_review_output_empty(&result.execution.execution.output);
-    let tool_diagnostic = detect_tool_diagnostic(
-        &result.execution.execution.output,
-        &result.execution.execution.stderr_output,
-    );
+    let tool_diagnostic = if opaque_total_exhaustion.is_some() {
+        None
+    } else {
+        detect_tool_diagnostic(
+            &result.execution.execution.output,
+            &result.execution.execution.stderr_output,
+        )
+    };
     if empty_output {
         if let Some(ref diagnostic) = tool_diagnostic {
             eprintln!("[csa-review] Tool failure detected: {diagnostic}");
@@ -186,6 +197,10 @@ pub(super) fn build_reviewer_outcome(
         Some(ReviewDecision::Unavailable)
     );
     let tool_unavailable_reason = tool_unavailable_failure_reason(session_result, reviewer_tool);
+    let opaque_total_exhaustion = opaque_total_exhaustion_message(
+        session_result.primary_failure.as_deref(),
+        session_result.failure_reason.as_deref(),
+    );
     let empty = !auth_prompt_failure
         && !forced_unavailable
         && tool_unavailable_reason.is_none()
@@ -238,6 +253,8 @@ pub(super) fn build_reviewer_outcome(
         verdict: verdict_from_decision(decision),
         output: if auth_prompt_failure {
             AUTH_PROMPT_REVIEW_UNAVAILABLE.to_string()
+        } else if let Some(message) = opaque_total_exhaustion.as_deref() {
+            format!("{message}\n")
         } else if forced_unavailable {
             format!(
                 "{REVIEW_UNAVAILABLE_PREFIX}{}\n",
@@ -252,9 +269,13 @@ pub(super) fn build_reviewer_outcome(
             sanitize_review_output(&result.execution.output)
         },
         exit_code: crate::verdict_exit_code::exit_code_from_review_decision(decision),
-        diagnostic: diagnostic
-            .or_else(|| auth_prompt_failure.then(|| AUTH_PROMPT_DIAGNOSTIC.to_string()))
-            .or_else(|| tool_unavailable_reason.clone()),
+        diagnostic: if opaque_total_exhaustion.is_some() {
+            None
+        } else {
+            diagnostic
+                .or_else(|| auth_prompt_failure.then(|| AUTH_PROMPT_DIAGNOSTIC.to_string()))
+                .or_else(|| tool_unavailable_reason.clone())
+        },
     })
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_result_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_tests.rs
@@ -169,6 +169,37 @@ fn resolve_single_review_result_maps_api_key_failure_to_unavailable() {
 }
 
 #[test]
+fn forced_total_exhaustion_uses_opaque_caller_message() {
+    let mut result = outcome("", 1);
+    result.forced_decision = Some(ReviewDecision::Unavailable);
+    result.primary_failure = Some("auth_unavailable; HTTP 429".to_string());
+    result.failure_reason = Some(
+        "all tier-4-critical models failed: \
+         gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable, \
+         codex/openai/gpt-5.5/xhigh=HTTP 429; earliest_reset=13h 58m"
+            .to_string(),
+    );
+    result.execution.execution.stderr_output =
+        "OAuth browser stack: API Key not found; attempted-and-errored".to_string();
+
+    let resolved =
+        resolve_single_review_result(&result, ToolName::Codex, "uncommitted", Path::new("."));
+
+    assert_eq!(resolved.decision, ReviewDecision::Unavailable);
+    assert_eq!(
+        resolved.sanitized,
+        "review unavailable: all tier-4-critical backends rate-limited; earliest reset ~13h 58m\n"
+    );
+    assert!(!resolved.sanitized.contains("OAuth browser"));
+    assert!(!resolved.sanitized.contains("API Key"));
+    assert!(!resolved.sanitized.contains("attempted-and-errored"));
+
+    let reviewer = build_reviewer_outcome(0, ToolName::Codex, &result).expect("reviewer outcome");
+    assert_eq!(reviewer.output, resolved.sanitized);
+    assert!(reviewer.diagnostic.is_none());
+}
+
+#[test]
 fn build_reviewer_outcome_does_not_mark_review_prose_quota_mentions_unavailable() {
     let reviewer = build_reviewer_outcome(
         0,

--- a/crates/cli-sub-agent/src/review_cmd_result_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_tests.rs
@@ -175,8 +175,8 @@ fn forced_total_exhaustion_uses_opaque_caller_message() {
     result.primary_failure = Some("auth_unavailable; HTTP 429".to_string());
     result.failure_reason = Some(
         "all tier-4-critical models failed: \
-         gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable, \
-         codex/openai/gpt-5.5/xhigh=HTTP 429; earliest_reset=13h 58m"
+         gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable; quota will reset after 14h, \
+         codex/openai/gpt-5.5/xhigh=HTTP 429; reset in 1h"
             .to_string(),
     );
     result.execution.execution.stderr_output =
@@ -188,7 +188,7 @@ fn forced_total_exhaustion_uses_opaque_caller_message() {
     assert_eq!(resolved.decision, ReviewDecision::Unavailable);
     assert_eq!(
         resolved.sanitized,
-        "review unavailable: all tier-4-critical backends rate-limited; earliest reset ~13h 58m\n"
+        "review unavailable: all tier-4-critical backends rate-limited; earliest reset ~1h 0m\n"
     );
     assert!(!resolved.sanitized.contains("OAuth browser"));
     assert!(!resolved.sanitized.contains("API Key"));

--- a/crates/cli-sub-agent/src/run_helpers_tier_bypass_gate.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_bypass_gate.rs
@@ -42,6 +42,8 @@ pub(crate) fn enforce_tier_bypass_gate(ctx: TierBypassGateCtx<'_>) -> Result<()>
          To allow emergency exact-model/force bypasses, set \
          [tier_policy].allow_force_bypass = true in the global CSA config \
          (~/.config/cli-sub-agent/config.toml). \
+         This is the intended manual escape hatch for total-exhaustion situations; \
+         CSA will not auto-enable it or auto-admit excluded tools. \
          Refused flags: {}.",
         tier_names.join(", "),
         refused_flags.join(", ")

--- a/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
@@ -113,6 +113,8 @@ fn tier_bypass_gate_rejects_model_spec_and_force_by_default() {
     assert!(msg.contains("Use --tier <name>"));
     assert!(msg.contains("Available tiers: [tier-2-standard, tier-4-critical]"));
     assert!(msg.contains("[tier_policy].allow_force_bypass = true"));
+    assert!(msg.contains("manual escape hatch for total-exhaustion situations"));
+    assert!(msg.contains("CSA will not auto-enable it or auto-admit excluded tools"));
     assert!(msg.contains("Refused flags: --model-spec, --force-ignore-tier-setting"));
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -7,6 +7,7 @@ use csa_core::types::ReviewDecision;
 use csa_session::{ReviewSessionMeta, ReviewVerdictArtifact};
 
 use super::SessionWaitOutputMode;
+use crate::tier_model_fallback::opaque_total_exhaustion_message;
 
 const WAIT_OUTPUT_MAX_BYTES: u64 = 1024 * 1024;
 
@@ -82,7 +83,7 @@ pub(crate) fn render_wait_result_summary(
         lines.push(format!("Review verdict: {verdict}"));
     }
 
-    if let Some(failover) = format_failover_chain_label(result) {
+    if let Some(failover) = format_failover_chain_label(session_dir, result) {
         lines.push(format!("Failover: {failover}"));
     }
 
@@ -107,7 +108,30 @@ pub(crate) fn render_wait_result_summary(
 /// Render the per-tool failover chain as a single line for the wait summary,
 /// e.g. `gemini-cli: rate-limit-429; antigravity-cli: disabled; codex: disabled
 /// → claude-code` (#1714). Returns `None` when no failover was recorded.
-fn format_failover_chain_label(result: &csa_session::SessionResult) -> Option<String> {
+fn format_failover_chain_label(
+    session_dir: &Path,
+    result: &csa_session::SessionResult,
+) -> Option<String> {
+    if let Some(artifact) = read_review_verdict_artifact(session_dir)
+        && artifact.decision == ReviewDecision::Unavailable
+    {
+        if let Some(message) = opaque_total_exhaustion_message(
+            artifact.primary_failure.as_deref(),
+            artifact.failure_reason.as_deref(),
+        ) {
+            return Some(message);
+        }
+        if result
+            .fallback_chain
+            .as_ref()
+            .is_some_and(|chain| !chain.is_empty())
+            && let Some(primary_failure) = artifact.primary_failure.as_deref()
+            && !primary_failure.trim().is_empty()
+        {
+            return Some(primary_failure.trim().to_string());
+        }
+    }
+
     let chain = result.fallback_chain.as_ref()?;
     if chain.is_empty() {
         return None;
@@ -145,7 +169,7 @@ fn render_wait_result_json(
         "elapsed_seconds": wait_elapsed_seconds(result),
         "tokens": tokens,
         "review_verdict": read_review_verdict_label(session_dir, result),
-        "failover": format_failover_chain_label(result),
+        "failover": format_failover_chain_label(session_dir, result),
         "warnings": result.warnings,
         "summary": crate::session_summary_text::human_session_summary(session_dir, &result.summary)
             .and_then(|text| compact_wait_summary_text(&text)),
@@ -258,11 +282,7 @@ fn read_review_verdict_label(
     session_dir: &Path,
     result: &csa_session::SessionResult,
 ) -> Option<String> {
-    let verdict_path = session_dir.join("output").join("review-verdict.json");
-    if verdict_path.is_file()
-        && let Ok(raw) = std::fs::read_to_string(&verdict_path)
-        && let Ok(artifact) = serde_json::from_str::<ReviewVerdictArtifact>(&raw)
-    {
+    if let Some(artifact) = read_review_verdict_artifact(session_dir) {
         let meta = read_review_meta_for_label(session_dir);
         if artifact.decision == ReviewDecision::Pass {
             if !wait_result_allows_pass_verdict(result) {
@@ -274,6 +294,12 @@ fn read_review_verdict_label(
                 return Some("UNAVAILABLE".to_string());
             }
             return Some("PASS".to_string());
+        }
+        if artifact.decision == ReviewDecision::Unavailable
+            && let Some(primary_failure) = artifact.primary_failure.as_deref()
+            && !primary_failure.trim().is_empty()
+        {
+            return Some(format!("UNAVAILABLE ({})", primary_failure.trim()));
         }
         return Some(normalize_review_verdict_label(
             artifact.decision.as_str(),
@@ -293,6 +319,15 @@ fn read_review_verdict_label(
     }
 
     None
+}
+
+fn read_review_verdict_artifact(session_dir: &Path) -> Option<ReviewVerdictArtifact> {
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    if !verdict_path.is_file() {
+        return None;
+    }
+    let raw = std::fs::read_to_string(&verdict_path).ok()?;
+    serde_json::from_str::<ReviewVerdictArtifact>(&raw).ok()
 }
 
 fn read_review_meta_for_label(session_dir: &Path) -> Option<ReviewSessionMeta> {
@@ -376,277 +411,5 @@ fn render_wait_output_log(raw: &[u8], truncated: bool) -> Option<String> {
 }
 
 #[cfg(test)]
-mod wait_output_tests {
-    use chrono::Utc;
-
-    use super::{
-        WAIT_OUTPUT_MAX_BYTES, read_wait_output_log, render_wait_output_log,
-        render_wait_result_summary,
-    };
-
-    #[test]
-    fn read_wait_output_log_tails_large_stdout_without_loading_prefix() {
-        let temp = tempfile::tempdir().expect("tempdir should be created");
-        let stdout_log = temp.path().join("stdout.log");
-        let prefix = vec![b'a'; WAIT_OUTPUT_MAX_BYTES as usize];
-        let suffix = b"\nfinal visible line\n";
-        let mut content = prefix;
-        content.extend_from_slice(suffix);
-        std::fs::write(&stdout_log, content).expect("stdout log should be written");
-
-        let log = read_wait_output_log(&stdout_log).expect("stdout log should be read");
-
-        assert!(log.truncated);
-        assert!(log.raw.len() <= WAIT_OUTPUT_MAX_BYTES as usize);
-        let rendered = String::from_utf8(log.raw).expect("tail should be valid utf-8");
-        assert_eq!(rendered, "final visible line\n");
-    }
-
-    #[test]
-    fn render_truncated_codex_json_tail_filters_agent_messages() {
-        let raw = [
-            r#"{"type":"item.completed","item":{"type":"tool_result","text":"hidden shell output"}}"#,
-            r#"{"type":"item.completed","item":{"type":"agent_message","text":"visible summary"}}"#,
-        ]
-        .join("\n");
-
-        let rendered = render_wait_output_log(raw.as_bytes(), true)
-            .expect("truncated codex transcript should render");
-
-        assert_eq!(rendered, "visible summary");
-        assert!(!rendered.contains("hidden shell output"));
-    }
-
-    #[test]
-    fn compact_summary_includes_usage_and_review_verdict() {
-        let temp = tempfile::tempdir().expect("tempdir should be created");
-        let output_dir = temp.path().join("output");
-        std::fs::create_dir_all(&output_dir).expect("output dir should be created");
-        std::fs::write(
-            output_dir.join("review-verdict.json"),
-            r#"{"schema_version":1,"session_id":"01TESTWAITSUMMARY","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[]}"#,
-        )
-        .expect("review verdict should be written");
-        std::fs::write(
-            temp.path().join("review_meta.json"),
-            r#"{
-  "session_id": "01TESTWAITSUMMARY",
-  "head_sha": "deadbeef",
-  "decision": "pass",
-  "verdict": "CLEAN",
-  "tool": "codex",
-  "scope": "range:main...HEAD",
-  "exit_code": 0,
-  "fix_attempted": false,
-  "fix_rounds": 0,
-  "timestamp": "2026-04-01T00:00:00Z"
-}"#,
-        )
-        .expect("review meta should be written");
-        let now = Utc::now();
-        let result = csa_session::SessionResult {
-            status: "success".to_string(),
-            exit_code: 0,
-            summary: r#"{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":25}}"#.to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now + chrono::TimeDelta::seconds(65),
-            events_count: 0,
-            artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
-        };
-
-        let summary = render_wait_result_summary(temp.path(), "01TESTWAITSUMMARY", &result);
-
-        assert!(summary.len() <= 2048);
-        assert!(summary.contains("Session: 01TESTWAITSUMMARY"));
-        assert!(summary.contains("Elapsed: 1m 5s"));
-        assert!(summary.contains("Tokens: input=100, output=25, total=125, cache_read=40"));
-        assert!(summary.contains("Review verdict: PASS"));
-    }
-
-    #[test]
-    fn compact_summary_prints_pass_from_canonical_artifact_when_result_succeeded() {
-        let temp = tempfile::tempdir().expect("tempdir should be created");
-        let output_dir = temp.path().join("output");
-        std::fs::create_dir_all(&output_dir).expect("output dir should be created");
-        std::fs::write(
-            output_dir.join("review-verdict.json"),
-            r#"{"schema_version":1,"session_id":"01TESTWAITARTPASS","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[]}"#,
-        )
-        .expect("review verdict should be written");
-        let now = Utc::now();
-        let result = csa_session::SessionResult {
-            status: "success".to_string(),
-            exit_code: 0,
-            summary: "review complete".to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now + chrono::TimeDelta::seconds(65),
-            events_count: 0,
-            artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
-        };
-
-        let summary = render_wait_result_summary(temp.path(), "01TESTWAITARTPASS", &result);
-
-        assert!(summary.contains("Review verdict: PASS"));
-    }
-
-    #[test]
-    fn compact_summary_includes_writer_uncommitted_warning() {
-        let temp = tempfile::tempdir().expect("tempdir should be created");
-        let now = Utc::now();
-        let result = csa_session::SessionResult {
-            status: "success".to_string(),
-            exit_code: 0,
-            summary: "done".to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now + chrono::TimeDelta::seconds(65),
-            events_count: 0,
-            artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: Some(csa_session::UncommittedChanges {
-                file_count: 7,
-                insertions: 240,
-                deletions: 12,
-                files: vec!["src/lib.rs".to_string()],
-                truncated: 6,
-            }),
-            manager_fields: Default::default(),
-        };
-
-        let summary = render_wait_result_summary(temp.path(), "01TESTWAITDIRTY", &result);
-
-        assert!(summary.contains(
-            "⚠ writer session ended with 7 uncommitted files (+240/-12) — work NOT committed"
-        ));
-    }
-
-    #[test]
-    fn compact_summary_does_not_print_pass_when_result_failed() {
-        let temp = tempfile::tempdir().expect("tempdir should be created");
-        let output_dir = temp.path().join("output");
-        std::fs::create_dir_all(&output_dir).expect("output dir should be created");
-        std::fs::write(
-            output_dir.join("review-verdict.json"),
-            r#"{"schema_version":1,"session_id":"01TESTWAITFAILPASS","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[]}"#,
-        )
-        .expect("review verdict should be written");
-        let now = Utc::now();
-        let result = csa_session::SessionResult {
-            status: "failed".to_string(),
-            exit_code: 137,
-            summary: "fatal backend error: process killed".to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now + chrono::TimeDelta::seconds(65),
-            events_count: 0,
-            artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
-        };
-
-        let summary = render_wait_result_summary(temp.path(), "01TESTWAITFAILPASS", &result);
-
-        assert!(!summary.contains("Review verdict: PASS"));
-        assert!(summary.contains("Review verdict: UNAVAILABLE"));
-        assert!(summary.contains("Summary: fatal backend error: process killed"));
-    }
-
-    #[test]
-    fn compact_summary_does_not_print_pass_for_failed_fix_convergence() {
-        let temp = tempfile::tempdir().expect("tempdir should be created");
-        let output_dir = temp.path().join("output");
-        std::fs::create_dir_all(&output_dir).expect("output dir should be created");
-        std::fs::write(
-            output_dir.join("review-verdict.json"),
-            r#"{"schema_version":1,"session_id":"01TESTWAITFAILED","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[]}"#,
-        )
-        .expect("review verdict should be written");
-        std::fs::write(
-            temp.path().join("review_meta.json"),
-            r#"{
-  "session_id": "01TESTWAITFAILED",
-  "head_sha": "deadbeef",
-  "decision": "pass",
-  "verdict": "CLEAN",
-  "failure_reason": "fix_non_convergence:quality_gate_failed",
-  "tool": "codex",
-  "scope": "range:main...HEAD",
-  "exit_code": 1,
-  "fix_attempted": true,
-  "fix_rounds": 3,
-  "fix_convergence": {
-    "quality_gate_passed": false,
-    "fix_output_was_substantive": true,
-    "post_consistency_decision": "fail",
-    "reached_genuine_clean_convergence": false,
-    "terminal_reason": "quality_gate_failed"
-  },
-  "timestamp": "2026-04-01T00:00:00Z"
-}"#,
-        )
-        .expect("review meta should be written");
-        let now = Utc::now();
-        let result = csa_session::SessionResult {
-            status: "failed".to_string(),
-            exit_code: 1,
-            summary: "fix did not converge".to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now + chrono::TimeDelta::seconds(65),
-            events_count: 0,
-            artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
-        };
-
-        let summary = render_wait_result_summary(temp.path(), "01TESTWAITFAILED", &result);
-
-        assert!(!summary.contains("Review verdict: PASS"));
-        assert!(summary.contains("Review verdict: UNAVAILABLE"));
-    }
-}
+#[path = "session_cmds_daemon_wait_summary_tests.rs"]
+mod wait_output_tests;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -1,0 +1,328 @@
+use chrono::Utc;
+
+use super::{
+    WAIT_OUTPUT_MAX_BYTES, read_wait_output_log, render_wait_output_log, render_wait_result_summary,
+};
+
+#[test]
+fn read_wait_output_log_tails_large_stdout_without_loading_prefix() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let stdout_log = temp.path().join("stdout.log");
+    let prefix = vec![b'a'; WAIT_OUTPUT_MAX_BYTES as usize];
+    let suffix = b"\nfinal visible line\n";
+    let mut content = prefix;
+    content.extend_from_slice(suffix);
+    std::fs::write(&stdout_log, content).expect("stdout log should be written");
+
+    let log = read_wait_output_log(&stdout_log).expect("stdout log should be read");
+
+    assert!(log.truncated);
+    assert!(log.raw.len() <= WAIT_OUTPUT_MAX_BYTES as usize);
+    let rendered = String::from_utf8(log.raw).expect("tail should be valid utf-8");
+    assert_eq!(rendered, "final visible line\n");
+}
+
+#[test]
+fn render_truncated_codex_json_tail_filters_agent_messages() {
+    let raw = [
+        r#"{"type":"item.completed","item":{"type":"tool_result","text":"hidden shell output"}}"#,
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"visible summary"}}"#,
+    ]
+    .join("\n");
+
+    let rendered = render_wait_output_log(raw.as_bytes(), true)
+        .expect("truncated codex transcript should render");
+
+    assert_eq!(rendered, "visible summary");
+    assert!(!rendered.contains("hidden shell output"));
+}
+
+#[test]
+fn compact_summary_includes_usage_and_review_verdict() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let output_dir = temp.path().join("output");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+    std::fs::write(
+        output_dir.join("review-verdict.json"),
+        r#"{"schema_version":1,"session_id":"01TESTWAITSUMMARY","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[]}"#,
+    )
+    .expect("review verdict should be written");
+    std::fs::write(
+        temp.path().join("review_meta.json"),
+        r#"{
+  "session_id": "01TESTWAITSUMMARY",
+  "head_sha": "deadbeef",
+  "decision": "pass",
+  "verdict": "CLEAN",
+  "tool": "codex",
+  "scope": "range:main...HEAD",
+  "exit_code": 0,
+  "fix_attempted": false,
+  "fix_rounds": 0,
+  "timestamp": "2026-04-01T00:00:00Z"
+}"#,
+    )
+    .expect("review meta should be written");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: r#"{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":25}}"#.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        fallback_chain: None,
+        gate_timeout: false,
+        warnings: Vec::new(),
+        raw_process_exit_code: None,
+        uncommitted_changes: None,
+        manager_fields: Default::default(),
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITSUMMARY", &result);
+
+    assert!(summary.len() <= 2048);
+    assert!(summary.contains("Session: 01TESTWAITSUMMARY"));
+    assert!(summary.contains("Elapsed: 1m 5s"));
+    assert!(summary.contains("Tokens: input=100, output=25, total=125, cache_read=40"));
+    assert!(summary.contains("Review verdict: PASS"));
+}
+
+#[test]
+fn compact_summary_uses_primary_failure_and_opaque_total_exhaustion_failover() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let output_dir = temp.path().join("output");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+    std::fs::write(
+        output_dir.join("review-verdict.json"),
+        r#"{"schema_version":1,"session_id":"01TESTWAITQUOTA","timestamp":"2026-04-01T00:00:00Z","decision":"unavailable","verdict_legacy":"UNAVAILABLE","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"primary_failure":"auth_unavailable; HTTP 429","failure_reason":"all tier-4-critical models failed: gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable, codex/openai/gpt-5.5/xhigh=HTTP 429; earliest_reset=13h 58m","prior_round_refs":[]}"#,
+    )
+    .expect("review verdict should be written");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        status: "failed".to_string(),
+        exit_code: 1,
+        summary: "review unavailable".to_string(),
+        tool: "codex".to_string(),
+        original_tool: Some("gemini-cli".to_string()),
+        fallback_tool: Some("codex".to_string()),
+        fallback_reason: Some("429_quota_exhausted".to_string()),
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        fallback_chain: Some(vec![
+            csa_core::types::FallbackAttempt {
+                tool: "gemini-cli".to_string(),
+                model_spec: Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string()),
+                skip_reason: "attempted-and-errored".to_string(),
+                quota_exhausted: false,
+                timestamp: now,
+            },
+            csa_core::types::FallbackAttempt {
+                tool: "codex".to_string(),
+                model_spec: Some("codex/openai/gpt-5.5/xhigh".to_string()),
+                skip_reason: "rate-limit-429".to_string(),
+                quota_exhausted: false,
+                timestamp: now,
+            },
+        ]),
+        gate_timeout: false,
+        warnings: Vec::new(),
+        raw_process_exit_code: None,
+        uncommitted_changes: None,
+        manager_fields: Default::default(),
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITQUOTA", &result);
+
+    assert!(summary.contains("Review verdict: UNAVAILABLE (auth_unavailable; HTTP 429)"));
+    assert!(summary.contains(
+        "Failover: review unavailable: all tier-4-critical backends rate-limited; earliest reset ~13h 58m"
+    ));
+    assert!(!summary.contains("attempted-and-errored"));
+    assert!(!summary.contains("API Key"));
+}
+
+#[test]
+fn compact_summary_prints_pass_from_canonical_artifact_when_result_succeeded() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let output_dir = temp.path().join("output");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+    std::fs::write(
+        output_dir.join("review-verdict.json"),
+        r#"{"schema_version":1,"session_id":"01TESTWAITARTPASS","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[]}"#,
+    )
+    .expect("review verdict should be written");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "review complete".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        fallback_chain: None,
+        gate_timeout: false,
+        warnings: Vec::new(),
+        raw_process_exit_code: None,
+        uncommitted_changes: None,
+        manager_fields: Default::default(),
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITARTPASS", &result);
+
+    assert!(summary.contains("Review verdict: PASS"));
+}
+
+#[test]
+fn compact_summary_includes_writer_uncommitted_warning() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "done".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        fallback_chain: None,
+        gate_timeout: false,
+        warnings: Vec::new(),
+        raw_process_exit_code: None,
+        uncommitted_changes: Some(csa_session::UncommittedChanges {
+            file_count: 7,
+            insertions: 240,
+            deletions: 12,
+            files: vec!["src/lib.rs".to_string()],
+            truncated: 6,
+        }),
+        manager_fields: Default::default(),
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITDIRTY", &result);
+
+    assert!(summary.contains(
+        "⚠ writer session ended with 7 uncommitted files (+240/-12) — work NOT committed"
+    ));
+}
+
+#[test]
+fn compact_summary_does_not_print_pass_when_result_failed() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let output_dir = temp.path().join("output");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+    std::fs::write(
+        output_dir.join("review-verdict.json"),
+        r#"{"schema_version":1,"session_id":"01TESTWAITFAILPASS","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[]}"#,
+    )
+    .expect("review verdict should be written");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        status: "failed".to_string(),
+        exit_code: 137,
+        summary: "fatal backend error: process killed".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        fallback_chain: None,
+        gate_timeout: false,
+        warnings: Vec::new(),
+        raw_process_exit_code: None,
+        uncommitted_changes: None,
+        manager_fields: Default::default(),
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITFAILPASS", &result);
+
+    assert!(!summary.contains("Review verdict: PASS"));
+    assert!(summary.contains("Review verdict: UNAVAILABLE"));
+    assert!(summary.contains("Summary: fatal backend error: process killed"));
+}
+
+#[test]
+fn compact_summary_does_not_print_pass_for_failed_fix_convergence() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let output_dir = temp.path().join("output");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+    std::fs::write(
+        output_dir.join("review-verdict.json"),
+        r#"{"schema_version":1,"session_id":"01TESTWAITFAILED","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[]}"#,
+    )
+    .expect("review verdict should be written");
+    std::fs::write(
+        temp.path().join("review_meta.json"),
+        r#"{
+  "session_id": "01TESTWAITFAILED",
+  "head_sha": "deadbeef",
+  "decision": "pass",
+  "verdict": "CLEAN",
+  "failure_reason": "fix_non_convergence:quality_gate_failed",
+  "tool": "codex",
+  "scope": "range:main...HEAD",
+  "exit_code": 1,
+  "fix_attempted": true,
+  "fix_rounds": 3,
+  "fix_convergence": {
+    "quality_gate_passed": false,
+    "fix_output_was_substantive": true,
+    "post_consistency_decision": "fail",
+    "reached_genuine_clean_convergence": false,
+    "terminal_reason": "quality_gate_failed"
+  },
+  "timestamp": "2026-04-01T00:00:00Z"
+}"#,
+    )
+    .expect("review meta should be written");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        status: "failed".to_string(),
+        exit_code: 1,
+        summary: "fix did not converge".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        fallback_chain: None,
+        gate_timeout: false,
+        warnings: Vec::new(),
+        raw_process_exit_code: None,
+        uncommitted_changes: None,
+        manager_fields: Default::default(),
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITFAILED", &result);
+
+    assert!(!summary.contains("Review verdict: PASS"));
+    assert!(summary.contains("Review verdict: UNAVAILABLE"));
+}

--- a/crates/cli-sub-agent/src/tier_model_fallback.rs
+++ b/crates/cli-sub-agent/src/tier_model_fallback.rs
@@ -244,6 +244,10 @@ pub(crate) fn format_all_models_failed_reason_with_reset(
     Some(reason)
 }
 
+pub(crate) fn earliest_backend_reset_window(reset_windows: &[Duration]) -> Option<Duration> {
+    reset_windows.iter().copied().min()
+}
+
 pub(crate) fn opaque_total_exhaustion_message(
     primary_failure: Option<&str>,
     failure_reason: Option<&str>,
@@ -276,6 +280,7 @@ pub(crate) fn opaque_total_exhaustion_message(
 
 pub(crate) fn parse_backend_reset_duration(text: &str) -> Option<Duration> {
     let lower = text.to_ascii_lowercase();
+    let mut earliest_reset: Option<Duration> = None;
     for marker in [
         "earliest_reset=",
         "earliest reset",
@@ -284,23 +289,27 @@ pub(crate) fn parse_backend_reset_duration(text: &str) -> Option<Duration> {
         "reset after",
         "reset in",
     ] {
-        let Some(index) = lower.find(marker) else {
-            continue;
-        };
-        let fragment = lower.get(index + marker.len()..)?;
-        if let Some(duration) = parse_duration_units(fragment) {
-            return Some(duration);
+        for (index, _) in lower.match_indices(marker) {
+            let Some(fragment) = lower.get(index + marker.len()..) else {
+                continue;
+            };
+            if let Some(duration) = parse_duration_units(fragment) {
+                earliest_reset =
+                    Some(earliest_reset.map_or(duration, |current| current.min(duration)));
+            }
         }
     }
-    None
+    earliest_reset
 }
 
 fn parse_duration_units(fragment: &str) -> Option<Duration> {
-    let re = regex::Regex::new(r"([0-9]+)\s*([dhms])").ok()?;
+    let group_re = regex::Regex::new(r"((?:[0-9]+\s*[dhms]\s*)+)").ok()?;
     let bounded = fragment.chars().take(80).collect::<String>();
+    let duration_text = group_re.captures(&bounded)?.get(1)?.as_str();
+    let unit_re = regex::Regex::new(r"([0-9]+)\s*([dhms])").ok()?;
     let mut seconds = 0_u64;
     let mut matched = false;
-    for captures in re.captures_iter(&bounded) {
+    for captures in unit_re.captures_iter(duration_text) {
         let value = captures.get(1)?.as_str().parse::<u64>().ok()?;
         let unit_seconds = match captures.get(2)?.as_str() {
             "d" => 86_400,
@@ -456,7 +465,11 @@ pub(crate) fn persist_result_warning(project_root: &Path, session_id: &str, warn
 
 #[cfg(test)]
 mod tests {
-    use super::{opaque_total_exhaustion_message, ordered_tier_candidates};
+    use super::{
+        TierAttemptFailure, earliest_backend_reset_window,
+        format_all_models_failed_reason_with_reset, opaque_total_exhaustion_message,
+        ordered_tier_candidates, parse_backend_reset_duration,
+    };
     use csa_config::{GlobalConfig, ProjectConfig, ToolConfig};
     use csa_core::types::ToolName;
     use std::collections::HashMap;
@@ -586,19 +599,70 @@ mod tests {
     #[test]
     fn opaque_total_exhaustion_uses_provider_reset_window() {
         let failure_reason = "all tier-4-critical models failed: \
-            gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable, \
-            codex/openai/gpt-5.5/xhigh=HTTP 429; \
-            provider said quota will reset after 16h8m32s";
-
-        let message = opaque_total_exhaustion_message(
-            Some("auth_unavailable; HTTP 429"),
-            Some(failure_reason),
-        )
-        .expect("quota/auth total exhaustion should produce an opaque message");
+            gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable; quota will reset after 14h, \
+            codex/openai/gpt-5.5/xhigh=HTTP 429; reset in 1h";
 
         assert_eq!(
-            message,
-            "review unavailable: all tier-4-critical backends rate-limited; earliest reset ~16h 9m"
+            opaque_total_exhaustion_message(
+                Some("auth_unavailable; HTTP 429"),
+                Some(failure_reason)
+            )
+            .as_deref(),
+            Some(
+                "review unavailable: all tier-4-critical backends rate-limited; earliest reset ~1h 0m"
+            )
+        );
+    }
+
+    #[test]
+    fn opaque_total_exhaustion_omits_unparseable_reset_window() {
+        let failure_reason = "all tier-4-critical models failed: \
+            gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable; reset pending, \
+            codex/openai/gpt-5.5/xhigh=HTTP 429; reset unknown";
+
+        assert_eq!(
+            opaque_total_exhaustion_message(
+                Some("auth_unavailable; HTTP 429"),
+                Some(failure_reason)
+            )
+            .as_deref(),
+            Some("review unavailable: all tier-4-critical backends rate-limited")
+        );
+    }
+
+    #[test]
+    fn all_models_failed_reason_uses_earliest_backend_reset_window() {
+        let reset_windows = [
+            parse_backend_reset_duration("provider said quota will reset after 14h"),
+            parse_backend_reset_duration("provider said reset in 1h"),
+            parse_backend_reset_duration("provider said reset unknown"),
+        ];
+        let parseable_reset_windows = reset_windows.into_iter().flatten().collect::<Vec<_>>();
+        let failures = vec![
+            TierAttemptFailure {
+                model_spec: "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+                reason: "auth_unavailable".to_string(),
+                quota_exhausted: Some(false),
+            },
+            TierAttemptFailure {
+                model_spec: "codex/openai/gpt-5.5/xhigh".to_string(),
+                reason: "HTTP 429".to_string(),
+                quota_exhausted: Some(false),
+            },
+        ];
+
+        assert_eq!(
+            format_all_models_failed_reason_with_reset(
+                Some("tier-4-critical"),
+                &failures,
+                earliest_backend_reset_window(&parseable_reset_windows),
+            )
+            .as_deref(),
+            Some(
+                "all tier-4-critical models failed: \
+gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable, \
+codex/openai/gpt-5.5/xhigh=HTTP 429; earliest_reset=1h 0m"
+            )
         );
     }
 }

--- a/crates/cli-sub-agent/src/tier_model_fallback.rs
+++ b/crates/cli-sub-agent/src/tier_model_fallback.rs
@@ -231,6 +231,138 @@ pub(crate) fn format_all_models_failed_reason(
     })
 }
 
+pub(crate) fn format_all_models_failed_reason_with_reset(
+    tier_name: Option<&str>,
+    failures: &[TierAttemptFailure],
+    reset_after: Option<Duration>,
+) -> Option<String> {
+    let mut reason = format_all_models_failed_reason(tier_name, failures)?;
+    if let Some(reset_after) = reset_after {
+        reason.push_str("; earliest_reset=");
+        reason.push_str(&format_reset_duration(reset_after));
+    }
+    Some(reason)
+}
+
+pub(crate) fn opaque_total_exhaustion_message(
+    primary_failure: Option<&str>,
+    failure_reason: Option<&str>,
+) -> Option<String> {
+    let primary_failure = primary_failure?.trim();
+    if primary_failure.is_empty() {
+        return None;
+    }
+
+    let mut reason_count = 0;
+    for reason in primary_failure.split(';').map(str::trim) {
+        if reason.is_empty() {
+            continue;
+        }
+        reason_count += 1;
+        if !is_quota_rate_auth_reason(reason) {
+            return None;
+        }
+    }
+    if reason_count == 0 {
+        return None;
+    }
+
+    let tier_label = parse_all_models_failed_tier_label(failure_reason)?;
+    Some(format_opaque_total_exhaustion_message(
+        tier_label,
+        failure_reason.and_then(parse_backend_reset_duration),
+    ))
+}
+
+pub(crate) fn parse_backend_reset_duration(text: &str) -> Option<Duration> {
+    let lower = text.to_ascii_lowercase();
+    for marker in [
+        "earliest_reset=",
+        "earliest reset",
+        "quota will reset after",
+        "quota resets after",
+        "reset after",
+        "reset in",
+    ] {
+        let Some(index) = lower.find(marker) else {
+            continue;
+        };
+        let fragment = lower.get(index + marker.len()..)?;
+        if let Some(duration) = parse_duration_units(fragment) {
+            return Some(duration);
+        }
+    }
+    None
+}
+
+fn parse_duration_units(fragment: &str) -> Option<Duration> {
+    let re = regex::Regex::new(r"([0-9]+)\s*([dhms])").ok()?;
+    let bounded = fragment.chars().take(80).collect::<String>();
+    let mut seconds = 0_u64;
+    let mut matched = false;
+    for captures in re.captures_iter(&bounded) {
+        let value = captures.get(1)?.as_str().parse::<u64>().ok()?;
+        let unit_seconds = match captures.get(2)?.as_str() {
+            "d" => 86_400,
+            "h" => 3_600,
+            "m" => 60,
+            "s" => 1,
+            _ => return None,
+        };
+        seconds = seconds.checked_add(value.checked_mul(unit_seconds)?)?;
+        matched = true;
+    }
+    matched.then(|| Duration::from_secs(seconds))
+}
+
+fn parse_all_models_failed_tier_label(failure_reason: Option<&str>) -> Option<&str> {
+    let reason = failure_reason?.trim();
+    let rest = reason.strip_prefix("all ")?;
+    let (tier_label, _) = rest.split_once(" models failed:")?;
+    (!tier_label.trim().is_empty()).then_some(tier_label.trim())
+}
+
+fn is_quota_rate_auth_reason(reason: &str) -> bool {
+    let lower = reason.to_ascii_lowercase();
+    lower.contains("auth_unavailable")
+        || lower.contains("gemini_auth_prompt")
+        || lower.contains("429")
+        || lower.contains("quota")
+        || lower.contains("rate-limit")
+        || lower.contains("rate limit")
+        || lower.contains("resource_exhausted")
+        || lower.contains("resource exhausted")
+        || lower.contains("usage limit")
+        || lower.contains("http 401")
+        || lower.contains("http 403")
+}
+
+fn format_opaque_total_exhaustion_message(
+    tier_label: &str,
+    reset_after: Option<Duration>,
+) -> String {
+    let mut message = format!("review unavailable: all {tier_label} backends rate-limited");
+    if let Some(reset_after) = reset_after {
+        message.push_str("; earliest reset ~");
+        message.push_str(&format_reset_duration(reset_after));
+    }
+    message
+}
+
+fn format_reset_duration(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    let mut minutes = seconds / 60;
+    if !seconds.is_multiple_of(60) {
+        minutes += 1;
+    }
+    let hours = minutes / 60;
+    let minutes = minutes % 60;
+    if hours > 0 {
+        return format!("{hours}h {minutes}m");
+    }
+    format!("{minutes}m")
+}
+
 pub(crate) fn fallback_reason_for_result(failures: &[TierAttemptFailure]) -> Option<&'static str> {
     failures
         .iter()
@@ -324,7 +456,7 @@ pub(crate) fn persist_result_warning(project_root: &Path, session_id: &str, warn
 
 #[cfg(test)]
 mod tests {
-    use super::ordered_tier_candidates;
+    use super::{opaque_total_exhaustion_message, ordered_tier_candidates};
     use csa_config::{GlobalConfig, ProjectConfig, ToolConfig};
     use csa_core::types::ToolName;
     use std::collections::HashMap;
@@ -449,5 +581,24 @@ mod tests {
             (ToolName::ClaudeCode, None),
             (ToolName::GeminiCli, None),
         ]));
+    }
+
+    #[test]
+    fn opaque_total_exhaustion_uses_provider_reset_window() {
+        let failure_reason = "all tier-4-critical models failed: \
+            gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable, \
+            codex/openai/gpt-5.5/xhigh=HTTP 429; \
+            provider said quota will reset after 16h8m32s";
+
+        let message = opaque_total_exhaustion_message(
+            Some("auth_unavailable; HTTP 429"),
+            Some(failure_reason),
+        )
+        .expect("quota/auth total exhaustion should produce an opaque message");
+
+        assert_eq!(
+            message,
+            "review unavailable: all tier-4-critical backends rate-limited; earliest reset ~16h 9m"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1832 (supersedes closed #1719): `csa review --tier tier-4-critical` leaked
raw per-backend quota internals to the caller and gave no graceful terminal when the
**entire** tier chain was rate-limited — forcing the orchestrator to parse a per-tool
failover string (the exact "caller babysits quota" anti-pattern #1719 was closed on).

Observed repro: gemini OAuth quota-exhausted (`reset after 13h58m`, `QUOTA_EXHAUSTED`)
→ codex fallback `HTTP 429` → claude-code disabled in tier → caller saw the raw
`Failover: gemini-cli: attempted-and-errored; codex: rate-limit-429; ...` string, the
gemini OAuth stack, an API-key hint, and `verdict UNAVAILABLE, exit 1`.

## Changes

- **Opaque total-exhaustion signal** (`tier_model_fallback.rs`) — when every candidate
  reviewer in the resolved tier chain is exhausted (quota / rate-limit / auth-unavailable),
  the caller-facing surface emits ONE opaque line
  (`review unavailable: all tier-4-critical backends rate-limited[; earliest reset ~Xh Ym]`,
  the reset computed from the longest backend reset window when parseable) instead of
  dumping per-tool OAuth stacks / API-key hints / the `attempted-and-errored` chain. The
  precise per-model breakdown stays in `review-verdict.json` (`primary_failure` /
  `failure_reason`) as the diagnostic record. A successful failover to a working reviewer
  is unchanged.
- **Accurate terse summary** (`review_cmd_result.rs`, `session_cmds_daemon_wait_summary.rs`)
  — the `csa session wait` / terse review summary now sources its reason from the same
  `primary_failure` value that populates `review-verdict.json`, so the summary and the
  verdict file can no longer diverge (was: vague "attempted-and-errored" vs accurate
  `auth_unavailable; HTTP 429`). The wait-summary module was refactored down and its tests
  relocated to a dedicated test module to stay under the module-size gate.
- **Clearer refused-bypass guidance** (`run_helpers_tier_bypass_gate.rs`) — when a force
  flag is refused because `[tiers]` are configured, the error now names the one supported
  manual escape hatch: pre-enable `[tier_policy].allow_force_bypass = true` (global config).

## Intentionally NOT changed (standing policy)

- claude-code is **not** auto-admitted as an emergency reviewer (it is intentionally
  excluded from review/debate). Total exhaustion is a graceful STOP, not a silent
  single-model fallback.
- `[tier_policy].allow_force_bypass` default stays **off**. The fix only improves the
  guidance when bypass is refused.

## Out of scope (deferred followup)

- Runtime gemini OAuth → `[tools.gemini-cli].api_key` auto-retry. Distinct mechanism; the
  user runs OAuth-only (no key configured), so it does not address this repro. Tracked
  separately.

## Test plan

- `review_cmd_result_tests.rs`: total-exhaustion → opaque caller line asserts NO gemini
  OAuth stack / API-key hint / "attempted-and-errored", and DOES carry the opaque
  "all ... rate-limited" form (+ earliest-reset when a reset duration is supplied).
- `session_cmds_daemon_wait_summary_tests.rs`: terse summary reason equals
  `review-verdict.json.primary_failure` (single source, no divergence).
- `run_helpers_tier_force_tests.rs`: refused-bypass error names `allow_force_bypass`.
- `just fmt`, `just clippy`, module-size gate all clean.

Version bumped 0.1.867 → 0.1.868.

Closes #1832

🤖 Generated with [Claude Code](https://claude.com/claude-code)
