### PR TITLE
fix(cli-sub-agent): add review same-class site-sweep anchor (#1797)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.868"
+version = "0.1.869"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.868"
+version = "0.1.869"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -129,6 +129,30 @@ fn build_review_instruction_for_project_contains_design_preference_anchor() {
 }
 
 #[test]
+fn build_review_instruction_for_project_contains_same_class_site_sweep_anchor() {
+    let project_dir = tempdir().expect("create temp project");
+    let (instruction, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "auto",
+        ReviewMode::Standard,
+        None,
+        project_dir.path(),
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            resolved_pattern: None,
+            prior_rounds_section: None,
+            current_session_id: None,
+            full_consistency: false,
+        },
+    );
+
+    assert!(instruction.contains("Bounded same-class site sweep"));
+    assert!(instruction.contains("class sweep: N sites"));
+    assert!(instruction.contains("Do not add schema fields"));
+}
+
+#[test]
 fn build_multi_reviewer_instruction_contains_design_preference_anchor() {
     let project_dir = tempdir().unwrap();
     let prompt = crate::review_consensus::build_multi_reviewer_instruction(
@@ -141,6 +165,23 @@ fn build_multi_reviewer_instruction_contains_design_preference_anchor() {
     );
 
     assert!(prompt.contains("Design preferences vs correctness bugs"));
+}
+
+#[test]
+fn build_multi_reviewer_instruction_contains_same_class_site_sweep_anchor() {
+    let project_dir = tempdir().expect("create temp project");
+    let prompt = crate::review_consensus::build_multi_reviewer_instruction(
+        "Base prompt",
+        1,
+        ToolName::Codex,
+        project_dir.path(),
+        None,
+        None,
+    );
+
+    assert!(prompt.contains("Bounded same-class site sweep"));
+    assert!(prompt.contains("class sweep: N sites"));
+    assert!(prompt.contains("Do not add schema fields"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -372,13 +372,14 @@ fn test_build_review_instruction_no_diff_content() {
         None,
     );
     assert!(
-        result.len() < 2300,
-        "Instruction should stay bounded even with the design anchor, got {} chars",
+        result.len() < 3000,
+        "Instruction should stay bounded even with review anchors, got {} chars",
         result.len()
     );
     assert!(!result.contains("git diff"));
     assert!(!result.contains("Pass 1:"));
     assert!(result.contains("Design preferences vs correctness bugs"));
+    assert!(result.contains("Bounded same-class site sweep"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_design_anchor.rs
+++ b/crates/cli-sub-agent/src/review_design_anchor.rs
@@ -13,14 +13,36 @@ Design preferences may have multiple valid answers. If the current choice works,
 Rationale: review ping-pong on design preferences wastes iterations and does NOT converge to better code quality. A reviewer that flip-flops on the same design point across rounds is a stronger signal of design residual than of real bugs.
 "#;
 
+pub(crate) const REVIEW_SAME_CLASS_SITE_SWEEP_ANCHOR: &str = r#"## Bounded same-class site sweep
+
+When you identify a concrete defect, sweep the reviewed diff/range for sibling sites with the same defect pattern before finalizing. Check related call sites, artifacts, branches, sinks, and finalization paths.
+
+Report confirmed siblings as sub-items of one finding labeled `class sweep: N sites`; inspect at most 12 candidates, list up to 8 confirmed sites, and note `class sweep truncated` if more remain.
+
+For structured artifacts, use the label in the summary or evidence text only. Do not add schema fields or change severity, verdict, consensus, or pass/fail threshold semantics; each site still needs file+line evidence.
+"#;
+
 use std::path::Path;
 
 pub(crate) fn append_design_anchor(prompt: &mut String) {
-    if prompt.contains("## Design preferences vs correctness bugs") {
+    append_anchor_if_missing(
+        prompt,
+        "## Design preferences vs correctness bugs",
+        REVIEW_DESIGN_PREFERENCE_ANCHOR,
+    );
+    append_anchor_if_missing(
+        prompt,
+        "## Bounded same-class site sweep",
+        REVIEW_SAME_CLASS_SITE_SWEEP_ANCHOR,
+    );
+}
+
+fn append_anchor_if_missing(prompt: &mut String, heading: &str, anchor: &str) {
+    if prompt.contains(heading) {
         return;
     }
     prompt.push_str("\n\n");
-    prompt.push_str(REVIEW_DESIGN_PREFERENCE_ANCHOR);
+    prompt.push_str(anchor);
 }
 
 pub(crate) fn resolve_current_branch_via_vcs(project_root: &Path) -> Option<String> {


### PR DESCRIPTION
## Summary

Fixes #1797: `csa review` surfaced multiple instances of the **same bug-class**
one-site-per-round instead of sweeping all sibling sites and reporting them together
in a single round. Each missed sibling costs a full extra fix→re-review cycle (writer
+ reviewer + full diff re-ingestion), inflating round count on exactly the kind of
finding that is cheapest to enumerate exhaustively once understood.

Concrete evidence: the recent #1711 daemon-finalization review took 6 rounds — round 1
flagged "dead-active reconciler ignores the daemon-completion packet" at the
`wait`/`result` sinks, and round 5 flagged the **same class** at the `artifacts`/`list`
sink. A single same-class sweep would have collapsed those into one round.

## Change

- **Same-class site-sweep anchor** (`review_design_anchor.rs`) — adds bounded
  same-class sweep guidance to the reviewer prompt, alongside the existing #821
  design-preference anchor + iteration counter. On identifying a concrete defect, the
  reviewer is instructed to sweep for sibling sites of the same class within the
  reviewed range and enumerate them together as ONE `class sweep: N sites` finding
  (per-site list) before finalizing the verdict — bounded, with truncation noted if a
  cap is hit. This mirrors the project's existing anchor-sweep-on-insert discipline
  (AGENTS.md rule 053).
- The `class sweep: N sites` label is documented as a **structured-artifact text
  convention only**.

## Intentionally NOT changed

No verdict / severity / consensus / `review-verdict.json` schema semantics change. This
is purely an additive reviewer-prompt instruction + label convention (a review-quality /
efficiency improvement, not a correctness-gate change). The anchor lives in Rust code
(`review_design_anchor.rs`), not in `patterns/csa-review/`, so no PATTERN.md↔workflow.toml
sync is involved.

## Test plan

- `review_cmd_tests_iteration.rs`: new prompt-builder tests assert the constructed
  reviewer prompt (both single- and multi-reviewer) contains the same-class sweep
  instruction.
- `review_cmd_tests_tail.rs`: bounded-prompt test updated to account for the new anchor.
- `just fmt`, `just clippy` clean; module-size gate clean.

Version bumped 0.1.868 → 0.1.869.

Closes #1797

🤖 Generated with [Claude Code](https://claude.com/claude-code)
