### PR TITLE
fix(mktd): plan-session hygiene cluster — gate skip, artifact routing, source-check exclusion, atomic per-task persist (#1819 #1820 #1821 #1822)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.869"
+version = "0.1.870"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.869"
+version = "0.1.870"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_todo.rs
+++ b/crates/cli-sub-agent/src/cli_todo.rs
@@ -42,6 +42,32 @@ pub enum TodoCommands {
         cd: Option<String>,
     },
 
+    /// Atomically persist generated TODO/spec artifacts and commit the plan
+    Persist {
+        /// Timestamp of the TODO plan
+        #[arg(short, long)]
+        timestamp: String,
+
+        /// File containing final TODO.md content
+        #[arg(long)]
+        todo_file: String,
+
+        /// File containing final spec.toml content
+        #[arg(long)]
+        spec_file: String,
+
+        /// File containing final epic-plan.toml content
+        #[arg(long)]
+        epic_plan_file: Option<String>,
+
+        /// Commit message
+        message: Option<String>,
+
+        /// Working directory
+        #[arg(long)]
+        cd: Option<String>,
+    },
+
     /// Recompute and store the TODO.md attestation hash
     Attest {
         /// Timestamp of the TODO plan (default: latest)

--- a/crates/cli-sub-agent/src/executor_csa_guard.rs
+++ b/crates/cli-sub-agent/src/executor_csa_guard.rs
@@ -14,6 +14,7 @@ const CSA_SKILL_MODE_EXECUTOR: &str = "executor";
 const EXECUTOR_SAFE_CSA_COMMAND_PREFIXES: &[&[&str]] = &[
     &["todo", "create"],
     &["todo", "save"],
+    &["todo", "persist"],
     &["todo", "attest"],
     &["todo", "ref", "add"],
     &["todo", "ref", "list"],
@@ -171,6 +172,9 @@ mod tests {
         for prefix in [
             &["todo", "create"][..],
             &["todo", "save"][..],
+            // Regression (#1822 round-3): `csa todo persist` must be allowed in
+            // executor mode so mktd Step 13 can persist generated plans.
+            &["todo", "persist"][..],
             &["todo", "ref", "add"][..],
             &["todo", "ref", "list"][..],
             &["todo", "ref", "show"][..],

--- a/crates/cli-sub-agent/src/executor_csa_guard.rs
+++ b/crates/cli-sub-agent/src/executor_csa_guard.rs
@@ -119,6 +119,7 @@ fn todo_prefix(cmd: &TodoCommands) -> Vec<&'static str> {
     match cmd {
         TodoCommands::Create { .. } => vec!["todo", "create"],
         TodoCommands::Save { .. } => vec!["todo", "save"],
+        TodoCommands::Persist { .. } => vec!["todo", "persist"],
         TodoCommands::Attest { .. } => vec!["todo", "attest"],
         TodoCommands::List { .. } => vec!["todo", "list"],
         TodoCommands::Find { .. } => vec!["todo", "find"],

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -109,8 +109,10 @@ mod test_session_sandbox;
 mod tier_model_fallback;
 mod tiers_cmd;
 mod todo_cmd;
+mod todo_dispatch_cmd;
 mod todo_epic_cmd;
 mod todo_errors_cmd;
+mod todo_persist_cmd;
 mod todo_ref_cmd;
 mod tool_version;
 mod triage_cmd;
@@ -125,7 +127,7 @@ include!("review_round10_exact_tests.rs");
 include!("debate_cmd_exact_tests.rs");
 use cli::{
     Cli, Commands, ConfigCommands, DoctorSubcommand, McpHubCommands, SetupCommands, TiersCommands,
-    TodoCommands, TodoRefCommands, validate_command_args,
+    validate_command_args,
 };
 use csa_core::types::OutputFormat;
 #[cfg(test)]
@@ -604,118 +606,7 @@ async fn run() -> Result<()> {
                 tiers_cmd::handle_tiers_list(cd, output_format)?;
             }
         },
-        Commands::Todo { cmd } => match cmd {
-            TodoCommands::Create {
-                title,
-                branch,
-                no_branch,
-                language,
-                cd,
-            } => {
-                todo_cmd::handle_create(title, branch, no_branch, language, cd, output_format)?;
-            }
-            TodoCommands::Save {
-                timestamp,
-                message,
-                cd,
-            } => {
-                todo_cmd::handle_save(timestamp, message, cd)?;
-            }
-            TodoCommands::Attest { timestamp, cd } => todo_cmd::handle_attest(timestamp, cd)?,
-            TodoCommands::Diff {
-                timestamp,
-                revision,
-                from,
-                to,
-                cd,
-            } => {
-                todo_cmd::handle_diff(timestamp, revision, from, to, cd)?;
-            }
-            TodoCommands::History { timestamp, cd } => {
-                todo_cmd::handle_history(timestamp, cd)?;
-            }
-            TodoCommands::List { status, cd } => {
-                todo_cmd::handle_list(status, cd, output_format)?;
-            }
-            TodoCommands::Find { branch, status, cd } => {
-                todo_cmd::handle_find(branch, status, cd, output_format)?;
-            }
-            TodoCommands::Errors { branch, cd } => {
-                todo_errors_cmd::handle_errors(branch, cd)?;
-            }
-            TodoCommands::Show {
-                timestamp,
-                version,
-                path,
-                spec,
-                refs,
-                cd,
-            } => {
-                todo_cmd::handle_show(timestamp, version, path, spec, refs, cd)?;
-            }
-            TodoCommands::Update {
-                timestamp,
-                title,
-                status,
-                description,
-                cd,
-            } => {
-                todo_cmd::handle_update(timestamp, title, status, description, cd)?;
-            }
-            TodoCommands::Status {
-                timestamp,
-                status,
-                cd,
-            } => {
-                todo_cmd::handle_status(timestamp, status, cd)?;
-            }
-            TodoCommands::Dag {
-                timestamp,
-                format,
-                cd,
-            } => {
-                todo_cmd::handle_dag(timestamp, format, cd)?;
-            }
-            TodoCommands::Epic { command } => {
-                todo_epic_cmd::handle_epic_command(command)?;
-            }
-            TodoCommands::Ref { cmd } => match cmd {
-                TodoRefCommands::List {
-                    timestamp,
-                    tokens,
-                    json,
-                    cd,
-                } => {
-                    todo_cmd::handle_ref_list(timestamp, tokens, json, cd)?;
-                }
-                TodoRefCommands::Show {
-                    timestamp,
-                    name,
-                    max_tokens,
-                    cd,
-                } => {
-                    todo_cmd::handle_ref_show(timestamp, name, max_tokens, cd)?;
-                }
-                TodoRefCommands::Add {
-                    timestamp,
-                    name,
-                    content,
-                    file,
-                    cd,
-                } => {
-                    todo_cmd::handle_ref_add(timestamp, name, content, file, cd)?;
-                }
-                TodoRefCommands::ImportTranscript {
-                    timestamp,
-                    tool,
-                    session,
-                    name,
-                    cd,
-                } => {
-                    todo_cmd::handle_ref_import_transcript(timestamp, tool, session, name, cd)?;
-                }
-            },
-        },
+        Commands::Todo { cmd } => todo_dispatch_cmd::handle_todo_command(cmd, output_format)?,
         Commands::Checklist { command } => checklist_cmd::handle_checklist_command(command)?,
         Commands::Plan { cmd } => {
             plan_cmd_daemon::dispatch(

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -112,6 +112,7 @@ mod todo_cmd;
 mod todo_dispatch_cmd;
 mod todo_epic_cmd;
 mod todo_errors_cmd;
+mod todo_hooks;
 mod todo_persist_cmd;
 mod todo_ref_cmd;
 mod tool_version;

--- a/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
@@ -126,6 +126,34 @@ fn mktd_save_step_uses_session_output_artifacts_and_persist() {
                 "{name} must not write generated artifacts directly into todo state before persist: found {forbidden}"
             );
         }
+
+        // Round-5 hard-gate ordering (#1820/#1822): the artifact validation MUST
+        // run BEFORE `csa todo persist` commits, so an invalid plan can never
+        // enter the todos git history even if a later step aborts.
+        let persist_idx = content
+            .find(r#"csa todo persist -t "${TODO_TS}""#)
+            .unwrap_or_else(|| panic!("{name} missing csa todo persist"));
+        let validate_idx = content
+            .find(r#"grep -qE '^- \[ \] .+' "${TODO_ARTIFACT}""#)
+            .unwrap_or_else(|| panic!("{name} must validate the TODO artifact before persist"));
+        assert!(
+            validate_idx < persist_idx,
+            "{name} must validate artifacts BEFORE csa todo persist (commit), not after"
+        );
+
+        for forbidden_postcommit in [
+            // Post-commit content validation is forbidden: it cannot gate the
+            // commit. These checks moved before persist (artifacts) or into
+            // `csa todo persist` itself (spec-criteria render gate).
+            r#"grep -qE '^- \[ \] .+' "${TODO_PATH}""#,
+            r#"csa todo show -t "${TODO_TS}" --spec"#,
+            "saved TODO has no non-empty checkbox tasks",
+        ] {
+            assert!(
+                !content.contains(forbidden_postcommit),
+                "{name} must not validate the persisted plan AFTER the commit: found {forbidden_postcommit}"
+            );
+        }
     }
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
@@ -85,6 +85,51 @@ fn mktd_light_mode_skips_recon_dimensions() {
 }
 
 #[test]
+fn mktd_save_step_uses_session_output_artifacts_and_persist() {
+    let workflow_path = workspace_root().join("patterns/mktd/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+    let save_step = plan
+        .steps
+        .iter()
+        .find(|step| step.id == 13)
+        .expect("missing mktd save step");
+    let pattern = std::fs::read_to_string(workspace_root().join("patterns/mktd/PATTERN.md"))
+        .expect("read mktd pattern");
+
+    for (name, content) in [
+        ("PATTERN.md", pattern.as_str()),
+        ("workflow.toml Step 13", save_step.prompt.as_str()),
+    ] {
+        for required in [
+            r#"SAVE_DIR="${CSA_SESSION_DIR:?CSA_SESSION_DIR must be set}/output/mktd-save""#,
+            r#"TODO_ARTIFACT="${SAVE_DIR}/TODO.md""#,
+            r#"SPEC_ARTIFACT="${SAVE_DIR}/spec.toml""#,
+            r#"csa todo persist -t "${TODO_TS}""#,
+            r#"--todo-file "${TODO_ARTIFACT}""#,
+            r#"--spec-file "${SPEC_ARTIFACT}""#,
+        ] {
+            assert!(
+                content.contains(required),
+                "{name} must route mktd save artifacts through session output and todo persist: missing {required}"
+            );
+        }
+
+        for forbidden in [
+            r#"> "${TODO_PATH}""#,
+            r#"> "${SPEC_PATH}""#,
+            r#"> "${EPIC_PATH}""#,
+            "csa todo save -t",
+        ] {
+            assert!(
+                !content.contains(forbidden),
+                "{name} must not write generated artifacts directly into todo state before persist: found {forbidden}"
+            );
+        }
+    }
+}
+
+#[test]
 fn pr_bot_debate_audit_reads_step12_output_and_prompt_has_comment_context() {
     let workflow_path = workspace_root().join("patterns/pr-bot/workflow.toml");
     let workflow = std::fs::read_to_string(&workflow_path).unwrap();

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -636,6 +636,7 @@ pub(crate) async fn handle_run(
                 changed_paths: changed_paths.as_deref(),
                 extra_env: post_exec_gate_env,
                 no_post_exec_gate,
+                planning_only: skill.as_deref() == Some("mktd"),
             },
             execute_post_exec_gate_command,
         )

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -165,6 +165,45 @@ fn git_worktree_has_status_changes(project_root: &Path) -> Result<bool> {
     Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
 }
 
+/// Whether the project worktree has dirty TRACKED changes (unstaged or staged
+/// modifications to files git already tracks).
+///
+/// Untracked files are intentionally excluded: a correct planning-only run
+/// (e.g. `--skill mktd`) writes its artifacts to the session output directory
+/// outside the repo tree (#1820), so a genuine plan-only run leaves the tracked
+/// tree clean. Keying on tracked changes avoids false-positives on generated /
+/// session-output scratch that would regress #1819's plan-only gate skip.
+///
+/// Fails closed: a git command that runs but reports a non-zero / unknown state
+/// is treated as dirty so the caller runs the verification gate rather than
+/// skipping on an unknown state (rule 009). Only an outright git-spawn failure
+/// propagates as an error.
+fn project_worktree_has_dirty_tracked_changes(project_root: &Path) -> Result<bool> {
+    let quiet_diff_signals_changes = |args: &[&str]| -> Result<bool> {
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .with_context(|| {
+                format!(
+                    "failed to inspect git tracked changes for post-exec gate in {}",
+                    project_root.display()
+                )
+            })?;
+        // `git diff --quiet` exits 0 when clean, 1 when differences exist, and
+        // >1 on error; any non-zero exit is treated as dirty so the caller
+        // fails closed toward running the gate rather than skipping unverified.
+        Ok(!status.success())
+    };
+
+    // Unstaged tracked modifications, then staged (index) tracked modifications.
+    Ok(quiet_diff_signals_changes(&["diff", "--quiet"])?
+        || quiet_diff_signals_changes(&["diff", "--cached", "--quiet"])?)
+}
+
 fn classify_post_exec_gate_worktree(
     project_root: &Path,
     session_id: Option<&str>,
@@ -366,7 +405,41 @@ where
         return Ok(());
     }
     if options.planning_only {
-        return Ok(());
+        // A planning-mode run (e.g. `--skill mktd`) writes its artifacts to the
+        // session output directory outside the repo tree (#1820), so a genuine
+        // plan-only run leaves the TRACKED worktree clean. The gate skip is
+        // therefore conditioned on EFFECT, not just the skill name.
+        match project_worktree_has_dirty_tracked_changes(project_root) {
+            // Clean tracked tree: a real plan-only run. Skip the code commit
+            // gate, preserving #1819's intent that such a session is not failed
+            // by `just pre-commit` / check-chinese.
+            Ok(false) => return Ok(()),
+            // Dirty tracked changes: the run unexpectedly edited tracked source.
+            // Record the anomaly and fall through to verify the edits via the
+            // configured gate instead of skipping them unverified.
+            Ok(true) => {
+                if let Some(session_id) = session_id {
+                    crate::run_cmd_post::record_post_exec_gate_planning_dirty_override(
+                        project_root,
+                        session_id,
+                    );
+                }
+            }
+            // Fail closed (rule 009): the worktree state is unknown, so never
+            // skip. Surface it as a gate failure so orchestrators reading
+            // result.toml never observe a false success, then propagate.
+            Err(err) => {
+                if let Some(session_id) = session_id {
+                    crate::run_cmd_post::overwrite_result_as_post_exec_gate_failure(
+                        project_root,
+                        session_id,
+                        &format!("could not inspect worktree for planning-mode gate: {err}"),
+                        false,
+                    );
+                }
+                return Err(err);
+            }
+        }
     }
 
     let gate_outcome = match maybe_run_post_exec_gate_with_runner(

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -56,6 +56,7 @@ pub(super) struct PostExecGateApplyOptions<'a> {
     pub(super) changed_paths: Option<&'a [String]>,
     pub(super) extra_env: Option<HashMap<String, String>>,
     pub(super) no_post_exec_gate: bool,
+    pub(super) planning_only: bool,
 }
 
 fn is_post_exec_gate_exempt_prompt(prompt_text: &str) -> bool {
@@ -362,6 +363,9 @@ where
         if let Some(session_id) = session_id {
             crate::run_cmd_post::record_post_exec_gate_skipped_by_flag(project_root, session_id);
         }
+        return Ok(());
+    }
+    if options.planning_only {
         return Ok(());
     }
 

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -571,16 +571,71 @@ async fn post_exec_gate_timeout_dirty_is_fatal() {
 }
 
 #[tokio::test]
-async fn post_exec_gate_skips_planning_only_session_without_overwriting_success() {
+async fn post_exec_gate_runs_planning_only_session_when_tracked_source_is_dirty() {
     let project_dir = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     init_clean_git_repo(project_dir.path());
     let session_id = create_session_at_current_head(project_dir.path());
+    // A planning-mode (`--skill mktd`) run is expected to leave the tracked tree
+    // clean; here it unexpectedly dirties tracked source. The gate MUST run to
+    // verify the edit rather than being skipped by skill name alone (review
+    // round 9 regression guard for #1819).
     std::fs::write(
         project_dir.path().join("tracked.txt"),
-        "planning artifact\n",
+        "unexpected source edit\n",
     )
     .unwrap();
+    write_success_result_for(project_dir.path(), &session_id);
+
+    let calls = Arc::new(Mutex::new(0usize));
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    apply_post_exec_gate_after_success_with_runner(
+        project_dir.path(),
+        "Produce an mktd plan",
+        Some(&session_id),
+        Some(&config),
+        planning_post_exec_options(),
+        {
+            let calls = Arc::clone(&calls);
+            move |_command, _cwd, _timeout_seconds, _extra_env| {
+                let calls = Arc::clone(&calls);
+                Box::pin(async move {
+                    *calls.lock().unwrap() += 1;
+                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                })
+            }
+        },
+    )
+    .await
+    .expect("planning-only run with dirty tracked source should run the gate");
+
+    assert_eq!(
+        *calls.lock().unwrap(),
+        1,
+        "dirty tracked source must trigger the gate even in planning mode"
+    );
+    let result = persisted_result(project_dir.path(), &session_id);
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("left dirty tracked changes")),
+        "planning-dirty override warning should be persisted: {:?}",
+        result.warnings
+    );
+}
+
+#[tokio::test]
+async fn post_exec_gate_skips_planning_only_session_when_tracked_tree_is_clean() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    init_clean_git_repo(project_dir.path());
+    let session_id = create_session_at_current_head(project_dir.path());
+    // Genuine plan-only run: artifacts go to session output, the tracked tree
+    // stays clean. #1819's intent — such a run must NOT be failed by the code
+    // commit gate (`just pre-commit` / check-chinese).
     write_success_result_for(project_dir.path(), &session_id);
 
     let config = project_config_with_gate(PostExecGateConfig::default());
@@ -592,17 +647,22 @@ async fn post_exec_gate_skips_planning_only_session_without_overwriting_success(
         planning_post_exec_options(),
         |_command, _cwd, _timeout_seconds, _extra_env| {
             Box::pin(async move {
-                panic!("runner must not execute for planning-only sessions");
+                panic!("runner must not execute for a clean planning-only session");
             })
         },
     )
     .await
-    .expect("planning-only session should not run code gate");
+    .expect("clean planning-only session should not run code gate");
 
     let result = persisted_result(project_dir.path(), &session_id);
     assert_eq!(result.status, "success");
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.summary, "task completed");
+    assert!(
+        result.warnings.is_empty(),
+        "clean planning-only run must not record an override warning: {:?}",
+        result.warnings
+    );
 }
 
 #[tokio::test]

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -132,6 +132,16 @@ fn post_exec_options(no_post_exec_gate: bool) -> PostExecGateApplyOptions<'stati
         changed_paths: None,
         extra_env: None,
         no_post_exec_gate,
+        planning_only: false,
+    }
+}
+
+fn planning_post_exec_options() -> PostExecGateApplyOptions<'static> {
+    PostExecGateApplyOptions {
+        changed_paths: None,
+        extra_env: None,
+        no_post_exec_gate: false,
+        planning_only: true,
     }
 }
 
@@ -558,6 +568,41 @@ async fn post_exec_gate_timeout_dirty_is_fatal() {
         result.summary,
         "timeout left dirty/uncommitted work unverified"
     );
+}
+
+#[tokio::test]
+async fn post_exec_gate_skips_planning_only_session_without_overwriting_success() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    init_clean_git_repo(project_dir.path());
+    let session_id = create_session_at_current_head(project_dir.path());
+    std::fs::write(
+        project_dir.path().join("tracked.txt"),
+        "planning artifact\n",
+    )
+    .unwrap();
+    write_success_result_for(project_dir.path(), &session_id);
+
+    let config = project_config_with_gate(PostExecGateConfig::default());
+    apply_post_exec_gate_after_success_with_runner(
+        project_dir.path(),
+        "Produce an mktd plan",
+        Some(&session_id),
+        Some(&config),
+        planning_post_exec_options(),
+        |_command, _cwd, _timeout_seconds, _extra_env| {
+            Box::pin(async move {
+                panic!("runner must not execute for planning-only sessions");
+            })
+        },
+    )
+    .await
+    .expect("planning-only session should not run code gate");
+
+    let result = persisted_result(project_dir.path(), &session_id);
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.summary, "task completed");
 }
 
 #[tokio::test]

--- a/crates/cli-sub-agent/src/run_cmd_post.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post.rs
@@ -222,6 +222,23 @@ pub(crate) fn record_post_exec_gate_skipped_by_flag(project_root: &Path, session
     );
 }
 
+/// Record that a planning-mode run (e.g. `--skill mktd`) unexpectedly left dirty
+/// tracked changes, so the post-exec gate is being run to verify them instead of
+/// being skipped by the planning-only fast path. Surfaces the anomaly both in
+/// logs and on the persisted result for audit.
+pub(crate) fn record_post_exec_gate_planning_dirty_override(project_root: &Path, session_id: &str) {
+    warn!(
+        session = %session_id,
+        "planning-mode run left dirty tracked changes; running post-exec gate to verify them"
+    );
+    record_post_exec_gate_success_warning(
+        project_root,
+        session_id,
+        false,
+        "planning-mode run left dirty tracked changes; post-exec gate run to verify them",
+    );
+}
+
 fn record_post_exec_gate_success_warning(
     project_root: &Path,
     session_id: &str,

--- a/crates/cli-sub-agent/src/todo_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_cmd.rs
@@ -124,10 +124,21 @@ pub(crate) fn handle_save(
     match csa_todo::git::save(manager.todos_dir(), &ts, &commit_msg)? {
         Some(hash) => {
             eprintln!("Saved {ts} ({hash})");
+            // DEFERRED (#1839): `csa todo save` still commits OUTSIDE the TODO
+            // write lock, so its hook version is a post-commit recompute that
+            // can race a concurrent writer. A correct fix must first move this
+            // commit under the lock (the scope of #1839); until then, preserve
+            // the existing recompute behavior EXACTLY — just supply it to the
+            // now-parameterized hook helper instead of letting the helper
+            // recompute internally.
+            let version = csa_todo::git::list_versions(manager.todos_dir(), &ts)
+                .map(|versions| versions.len())
+                .unwrap_or(1);
             crate::todo_hooks::emit_todo_save_hook(
                 &project_root,
                 manager.todos_dir(),
                 &ts,
+                version,
                 &commit_msg,
             );
         }

--- a/crates/cli-sub-agent/src/todo_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_cmd.rs
@@ -124,38 +124,12 @@ pub(crate) fn handle_save(
     match csa_todo::git::save(manager.todos_dir(), &ts, &commit_msg)? {
         Some(hash) => {
             eprintln!("Saved {ts} ({hash})");
-
-            // TodoSave hook: fires after successful save (best-effort)
-            let hooks_config = load_hooks_config(
-                csa_session::get_session_root(&project_root)
-                    .ok()
-                    .map(|r| r.join("hooks.toml"))
-                    .as_deref(),
-                global_hooks_path().as_deref(),
-                None,
+            crate::todo_hooks::emit_todo_save_hook(
+                &project_root,
+                manager.todos_dir(),
+                &ts,
+                &commit_msg,
             );
-            let version = csa_todo::git::list_versions(manager.todos_dir(), &ts)
-                .map(|v| v.len())
-                .unwrap_or(1);
-            let mut hook_vars = std::collections::HashMap::new();
-            hook_vars.insert("plan_id".to_string(), ts.clone());
-            hook_vars.insert(
-                "plan_dir".to_string(),
-                manager.todos_dir().join(&ts).display().to_string(),
-            );
-            hook_vars.insert(
-                "todo_root".to_string(),
-                manager.todos_dir().display().to_string(),
-            );
-            hook_vars.insert(
-                "project_root".to_string(),
-                project_root.display().to_string(),
-            );
-            hook_vars.insert("version".to_string(), version.to_string());
-            hook_vars.insert("message".to_string(), commit_msg);
-            if let Err(e) = run_hooks_for_event(HookEvent::TodoSave, &hooks_config, &hook_vars) {
-                warn!("TodoSave hook failed: {}", e);
-            }
         }
         None => eprintln!("No changes to save for plan '{ts}'."),
     }

--- a/crates/cli-sub-agent/src/todo_dispatch_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_dispatch_cmd.rs
@@ -1,0 +1,122 @@
+use anyhow::Result;
+use csa_core::types::OutputFormat;
+
+use crate::cli::{TodoCommands, TodoRefCommands};
+
+pub(crate) fn handle_todo_command(cmd: TodoCommands, output_format: OutputFormat) -> Result<()> {
+    match cmd {
+        TodoCommands::Create {
+            title,
+            branch,
+            no_branch,
+            language,
+            cd,
+        } => {
+            crate::todo_cmd::handle_create(title, branch, no_branch, language, cd, output_format)?;
+        }
+        TodoCommands::Save {
+            timestamp,
+            message,
+            cd,
+        } => {
+            crate::todo_cmd::handle_save(timestamp, message, cd)?;
+        }
+        cmd @ TodoCommands::Persist { .. } => crate::todo_persist_cmd::handle_command(cmd)?,
+        TodoCommands::Attest { timestamp, cd } => crate::todo_cmd::handle_attest(timestamp, cd)?,
+        TodoCommands::Diff {
+            timestamp,
+            revision,
+            from,
+            to,
+            cd,
+        } => {
+            crate::todo_cmd::handle_diff(timestamp, revision, from, to, cd)?;
+        }
+        TodoCommands::History { timestamp, cd } => {
+            crate::todo_cmd::handle_history(timestamp, cd)?;
+        }
+        TodoCommands::List { status, cd } => {
+            crate::todo_cmd::handle_list(status, cd, output_format)?;
+        }
+        TodoCommands::Find { branch, status, cd } => {
+            crate::todo_cmd::handle_find(branch, status, cd, output_format)?;
+        }
+        TodoCommands::Errors { branch, cd } => {
+            crate::todo_errors_cmd::handle_errors(branch, cd)?;
+        }
+        TodoCommands::Show {
+            timestamp,
+            version,
+            path,
+            spec,
+            refs,
+            cd,
+        } => {
+            crate::todo_cmd::handle_show(timestamp, version, path, spec, refs, cd)?;
+        }
+        TodoCommands::Update {
+            timestamp,
+            title,
+            status,
+            description,
+            cd,
+        } => {
+            crate::todo_cmd::handle_update(timestamp, title, status, description, cd)?;
+        }
+        TodoCommands::Status {
+            timestamp,
+            status,
+            cd,
+        } => {
+            crate::todo_cmd::handle_status(timestamp, status, cd)?;
+        }
+        TodoCommands::Dag {
+            timestamp,
+            format,
+            cd,
+        } => {
+            crate::todo_cmd::handle_dag(timestamp, format, cd)?;
+        }
+        TodoCommands::Epic { command } => {
+            crate::todo_epic_cmd::handle_epic_command(command)?;
+        }
+        TodoCommands::Ref { cmd } => match cmd {
+            TodoRefCommands::List {
+                timestamp,
+                tokens,
+                json,
+                cd,
+            } => {
+                crate::todo_cmd::handle_ref_list(timestamp, tokens, json, cd)?;
+            }
+            TodoRefCommands::Show {
+                timestamp,
+                name,
+                max_tokens,
+                cd,
+            } => {
+                crate::todo_cmd::handle_ref_show(timestamp, name, max_tokens, cd)?;
+            }
+            TodoRefCommands::Add {
+                timestamp,
+                name,
+                content,
+                file,
+                cd,
+            } => {
+                crate::todo_cmd::handle_ref_add(timestamp, name, content, file, cd)?;
+            }
+            TodoRefCommands::ImportTranscript {
+                timestamp,
+                tool,
+                session,
+                name,
+                cd,
+            } => {
+                crate::todo_cmd::handle_ref_import_transcript(timestamp, tool, session, name, cd)?;
+            }
+        },
+    }
+
+    Ok(())
+}

--- a/crates/cli-sub-agent/src/todo_hooks.rs
+++ b/crates/cli-sub-agent/src/todo_hooks.rs
@@ -3,10 +3,22 @@ use std::collections::HashMap;
 use std::path::Path;
 use tracing::warn;
 
+/// Fire the `TodoSave` hook for a completed save/persist.
+///
+/// `version` is the saved-version count for THIS save and MUST be supplied by
+/// the caller (the value `docs/hooks.md` documents as "Number of saved versions
+/// after this save"). The caller is responsible for computing it at the correct
+/// moment: `csa todo persist` computes it INSIDE the held write lock (right
+/// after its commit) so a concurrent TODO writer that commits another version
+/// after the lock is released cannot make this hook report the later count
+/// (#1822 round-6 concurrency finding). This helper deliberately does NOT
+/// recompute `version` from mutable git history, because doing so after the
+/// lock is released reintroduces exactly that race.
 pub(crate) fn emit_todo_save_hook(
     project_root: &Path,
     todo_root: &Path,
     plan_id: &str,
+    version: usize,
     message: &str,
 ) {
     let hooks_config = load_hooks_config(
@@ -17,9 +29,6 @@ pub(crate) fn emit_todo_save_hook(
         global_hooks_path().as_deref(),
         None,
     );
-    let version = csa_todo::git::list_versions(todo_root, plan_id)
-        .map(|versions| versions.len())
-        .unwrap_or(1);
     let mut hook_vars = HashMap::new();
     hook_vars.insert("plan_id".to_string(), plan_id.to_string());
     hook_vars.insert(

--- a/crates/cli-sub-agent/src/todo_hooks.rs
+++ b/crates/cli-sub-agent/src/todo_hooks.rs
@@ -1,0 +1,39 @@
+use csa_hooks::{HookEvent, global_hooks_path, load_hooks_config, run_hooks_for_event};
+use std::collections::HashMap;
+use std::path::Path;
+use tracing::warn;
+
+pub(crate) fn emit_todo_save_hook(
+    project_root: &Path,
+    todo_root: &Path,
+    plan_id: &str,
+    message: &str,
+) {
+    let hooks_config = load_hooks_config(
+        csa_session::get_session_root(project_root)
+            .ok()
+            .map(|r| r.join("hooks.toml"))
+            .as_deref(),
+        global_hooks_path().as_deref(),
+        None,
+    );
+    let version = csa_todo::git::list_versions(todo_root, plan_id)
+        .map(|versions| versions.len())
+        .unwrap_or(1);
+    let mut hook_vars = HashMap::new();
+    hook_vars.insert("plan_id".to_string(), plan_id.to_string());
+    hook_vars.insert(
+        "plan_dir".to_string(),
+        todo_root.join(plan_id).display().to_string(),
+    );
+    hook_vars.insert("todo_root".to_string(), todo_root.display().to_string());
+    hook_vars.insert(
+        "project_root".to_string(),
+        project_root.display().to_string(),
+    );
+    hook_vars.insert("version".to_string(), version.to_string());
+    hook_vars.insert("message".to_string(), message.to_string());
+    if let Err(e) = run_hooks_for_event(HookEvent::TodoSave, &hooks_config, &hook_vars) {
+        warn!("TodoSave hook failed: {}", e);
+    }
+}

--- a/crates/cli-sub-agent/src/todo_persist_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_persist_cmd.rs
@@ -46,30 +46,44 @@ pub(crate) fn handle_persist(
         })
         .transpose()?;
 
-    // Serialize the file writes, the git commit, and the hook-trigger decision
-    // inside ONE hold of the TODO write lock: persist_generated_plan_with runs
-    // the commit closure under the held lock, so a concurrent TODO writer cannot
-    // overwrite the freshly written files between the write and the commit
-    // (TOCTOU lost-update / wrong-snapshot hook). The closure computes the
-    // commit message from the loaded plan, stages + commits, and returns the
-    // commit hash; the TodoSave hook fires from that hash AFTER the lock is
-    // released, so an arbitrary user hook command cannot deadlock on the lock.
+    // Serialize the file writes, the git commit, the saved-version count, and
+    // the hook-trigger decision inside ONE hold of the TODO write lock:
+    // persist_generated_plan_with runs the commit closure under the held lock,
+    // so a concurrent TODO writer cannot overwrite the freshly written files
+    // between the write and the commit (TOCTOU lost-update / wrong-snapshot
+    // hook). The closure computes the commit message from the loaded plan,
+    // stages + commits, counts this commit's saved versions, and returns the
+    // commit hash + version; the TodoSave hook fires from those captured values
+    // AFTER the lock is released, so an arbitrary user hook command cannot
+    // deadlock on the lock, yet the version still reflects exactly this save
+    // (not a count a concurrent writer bumped post-release).
     let todos_dir = manager.todos_dir();
-    let (persisted, (commit_msg, commit_hash)) = manager.persist_generated_plan_with(
+    let (persisted, (commit_msg, commit_hash, version)) = manager.persist_generated_plan_with(
         &timestamp,
         GeneratedPlanPersistRequest {
             todo_content: &todo_content,
             spec: &spec,
             epic_plan: epic_plan.as_ref(),
         },
-        |result| -> Result<(String, Option<String>)> {
+        |result| -> Result<(String, Option<String>, usize)> {
             let commit_msg = message
                 .clone()
                 .unwrap_or_else(|| format!("persist: {}", result.plan.metadata.title));
             csa_todo::git::ensure_git_init(todos_dir)?;
             let file_refs: Vec<&str> = result.changed_files.iter().map(String::as_str).collect();
             let hash = csa_todo::git::save_files(todos_dir, &timestamp, &file_refs, &commit_msg)?;
-            Ok((commit_msg, hash))
+            // Compute the saved-version count for THIS save while the write lock
+            // is STILL held (right after the commit above), so the TodoSave hook
+            // reports exactly this commit's version. Recomputing it after the
+            // lock releases (the old behavior) let a concurrent TODO writer
+            // commit another version first, making the hook report the later
+            // count — the #1822 round-6 concurrency finding. Best-effort default
+            // of 1 mirrors the prior hook behavior: the commit already succeeded,
+            // so an informational version count must not fail the persist.
+            let version = csa_todo::git::list_versions(todos_dir, &timestamp)
+                .map(|versions| versions.len())
+                .unwrap_or(1);
+            Ok((commit_msg, hash, version))
         },
     )?;
 
@@ -80,6 +94,7 @@ pub(crate) fn handle_persist(
                 &project_root,
                 manager.todos_dir(),
                 &timestamp,
+                version,
                 &commit_msg,
             );
         }

--- a/crates/cli-sub-agent/src/todo_persist_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_persist_cmd.rs
@@ -46,20 +46,34 @@ pub(crate) fn handle_persist(
         })
         .transpose()?;
 
-    let persisted = manager.persist_generated_plan(
+    // Serialize the file writes, the git commit, and the hook-trigger decision
+    // inside ONE hold of the TODO write lock: persist_generated_plan_with runs
+    // the commit closure under the held lock, so a concurrent TODO writer cannot
+    // overwrite the freshly written files between the write and the commit
+    // (TOCTOU lost-update / wrong-snapshot hook). The closure computes the
+    // commit message from the loaded plan, stages + commits, and returns the
+    // commit hash; the TodoSave hook fires from that hash AFTER the lock is
+    // released, so an arbitrary user hook command cannot deadlock on the lock.
+    let todos_dir = manager.todos_dir();
+    let (persisted, (commit_msg, commit_hash)) = manager.persist_generated_plan_with(
         &timestamp,
         GeneratedPlanPersistRequest {
             todo_content: &todo_content,
             spec: &spec,
             epic_plan: epic_plan.as_ref(),
         },
+        |result| -> Result<(String, Option<String>)> {
+            let commit_msg = message
+                .clone()
+                .unwrap_or_else(|| format!("persist: {}", result.plan.metadata.title));
+            csa_todo::git::ensure_git_init(todos_dir)?;
+            let file_refs: Vec<&str> = result.changed_files.iter().map(String::as_str).collect();
+            let hash = csa_todo::git::save_files(todos_dir, &timestamp, &file_refs, &commit_msg)?;
+            Ok((commit_msg, hash))
+        },
     )?;
 
-    csa_todo::git::ensure_git_init(manager.todos_dir())?;
-    let file_refs: Vec<&str> = persisted.changed_files.iter().map(String::as_str).collect();
-    let commit_msg =
-        message.unwrap_or_else(|| format!("persist: {}", persisted.plan.metadata.title));
-    match csa_todo::git::save_files(manager.todos_dir(), &timestamp, &file_refs, &commit_msg)? {
+    match commit_hash {
         Some(hash) => {
             eprintln!("Persisted plan '{timestamp}' ({hash})");
             crate::todo_hooks::emit_todo_save_hook(

--- a/crates/cli-sub-agent/src/todo_persist_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_persist_cmd.rs
@@ -1,0 +1,73 @@
+use anyhow::Result;
+use csa_todo::{EpicPlan, GeneratedPlanPersistRequest, SpecDocument, TodoManager};
+
+use crate::cli::TodoCommands;
+
+pub(crate) fn handle_command(cmd: TodoCommands) -> Result<()> {
+    let TodoCommands::Persist {
+        timestamp,
+        todo_file,
+        spec_file,
+        epic_plan_file,
+        message,
+        cd,
+    } = cmd
+    else {
+        unreachable!("todo_persist_cmd only handles TodoCommands::Persist")
+    };
+
+    handle_persist(timestamp, todo_file, spec_file, epic_plan_file, message, cd)
+}
+
+pub(crate) fn handle_persist(
+    timestamp: String,
+    todo_file: String,
+    spec_file: String,
+    epic_plan_file: Option<String>,
+    message: Option<String>,
+    cd: Option<String>,
+) -> Result<()> {
+    let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+    let manager = TodoManager::new(&project_root)?;
+
+    let todo_content = std::fs::read_to_string(&todo_file)
+        .map_err(|e| anyhow::anyhow!("failed to read TODO file '{}': {}", todo_file, e))?;
+    let spec_content = std::fs::read_to_string(&spec_file)
+        .map_err(|e| anyhow::anyhow!("failed to read spec file '{}': {}", spec_file, e))?;
+    let spec: SpecDocument = toml::from_str(&spec_content)
+        .map_err(|e| anyhow::anyhow!("failed to parse spec file '{}': {}", spec_file, e))?;
+    let epic_plan: Option<EpicPlan> = epic_plan_file
+        .as_deref()
+        .map(|path| {
+            let content = std::fs::read_to_string(path)
+                .map_err(|e| anyhow::anyhow!("failed to read epic plan file '{}': {}", path, e))?;
+            toml::from_str(&content)
+                .map_err(|e| anyhow::anyhow!("failed to parse epic plan file '{}': {}", path, e))
+        })
+        .transpose()?;
+
+    let persisted = manager.persist_generated_plan(
+        &timestamp,
+        GeneratedPlanPersistRequest {
+            todo_content: &todo_content,
+            spec: &spec,
+            epic_plan: epic_plan.as_ref(),
+        },
+    )?;
+
+    csa_todo::git::ensure_git_init(manager.todos_dir())?;
+    let file_refs: Vec<&str> = persisted.changed_files.iter().map(String::as_str).collect();
+    let commit_msg =
+        message.unwrap_or_else(|| format!("persist: {}", persisted.plan.metadata.title));
+    match csa_todo::git::save_files(manager.todos_dir(), &timestamp, &file_refs, &commit_msg)? {
+        Some(hash) => eprintln!("Persisted plan '{timestamp}' ({hash})"),
+        None => eprintln!("Persisted plan '{timestamp}' (no git changes)"),
+    }
+    println!("{}", persisted.plan.todo_md_path().display());
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "todo_persist_cmd_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/todo_persist_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_persist_cmd.rs
@@ -60,7 +60,15 @@ pub(crate) fn handle_persist(
     let commit_msg =
         message.unwrap_or_else(|| format!("persist: {}", persisted.plan.metadata.title));
     match csa_todo::git::save_files(manager.todos_dir(), &timestamp, &file_refs, &commit_msg)? {
-        Some(hash) => eprintln!("Persisted plan '{timestamp}' ({hash})"),
+        Some(hash) => {
+            eprintln!("Persisted plan '{timestamp}' ({hash})");
+            crate::todo_hooks::emit_todo_save_hook(
+                &project_root,
+                manager.todos_dir(),
+                &timestamp,
+                &commit_msg,
+            );
+        }
         None => eprintln!("Persisted plan '{timestamp}' (no git changes)"),
     }
     println!("{}", persisted.plan.todo_md_path().display());

--- a/crates/cli-sub-agent/src/todo_persist_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/todo_persist_cmd_tests.rs
@@ -1,0 +1,71 @@
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoManager};
+use tempfile::tempdir;
+
+#[test]
+fn handle_persist_reads_artifacts_and_commits_generated_plan() {
+    let project_dir = tempdir().expect("project tempdir");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let manager = TodoManager::new(project_dir.path()).expect("todo manager");
+    csa_todo::git::ensure_git_init(manager.todos_dir()).expect("init todos git");
+    let plan = manager
+        .create("Persist generated plan", Some("fix/persist-generated-plan"))
+        .expect("create plan");
+    csa_todo::git::save(manager.todos_dir(), &plan.timestamp, "create plan")
+        .expect("save initial plan")
+        .expect("initial plan should commit");
+
+    let artifact_dir = project_dir.path().join("session-output");
+    std::fs::create_dir_all(&artifact_dir).expect("create artifact dir");
+    let todo_file = artifact_dir.join("TODO.md");
+    let spec_file = artifact_dir.join("spec.toml");
+    std::fs::write(
+        &todo_file,
+        "# Persisted plan\n\n## Tasks\n\n- [ ] Use csa todo persist.\n  DONE WHEN: csa todo show renders this saved task.\n",
+    )
+    .expect("write TODO artifact");
+    let spec = SpecDocument {
+        schema_version: 1,
+        plan_ulid: plan.timestamp.clone(),
+        summary: "Persist generated plan artifacts.".to_string(),
+        criteria: vec![SpecCriterion {
+            kind: CriterionKind::Check,
+            id: "check-persist".to_string(),
+            description: "Generated TODO/spec files are committed through csa todo persist."
+                .to_string(),
+            status: CriterionStatus::Pending,
+        }],
+    };
+    std::fs::write(
+        &spec_file,
+        toml::to_string_pretty(&spec).expect("serialize spec"),
+    )
+    .expect("write spec artifact");
+
+    handle_persist(
+        plan.timestamp.clone(),
+        todo_file.display().to_string(),
+        spec_file.display().to_string(),
+        None,
+        Some("finalize generated plan".to_string()),
+        Some(project_dir.path().display().to_string()),
+    )
+    .expect("persist generated plan");
+
+    let saved_todo = std::fs::read_to_string(plan.todo_md_path()).expect("read persisted TODO.md");
+    assert!(saved_todo.contains("Use csa todo persist."));
+    assert_eq!(
+        manager.load_spec(&plan.timestamp).expect("load spec"),
+        Some(spec)
+    );
+    let status = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(manager.todos_dir())
+        .output()
+        .expect("git status");
+    assert!(
+        String::from_utf8_lossy(&status.stdout).trim().is_empty(),
+        "todos git status should be clean after handle_persist"
+    );
+}

--- a/crates/cli-sub-agent/src/todo_persist_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/todo_persist_cmd_tests.rs
@@ -69,3 +69,70 @@ fn handle_persist_reads_artifacts_and_commits_generated_plan() {
         "todos git status should be clean after handle_persist"
     );
 }
+
+#[test]
+fn handle_persist_fires_todo_save_hook_after_commit_once() -> anyhow::Result<()> {
+    let project_dir = tempdir()?;
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let manager = TodoManager::new(project_dir.path())?;
+    csa_todo::git::ensure_git_init(manager.todos_dir())?;
+    let plan = manager.create("Persist hook plan", Some("fix/persist-hook-plan"))?;
+    csa_todo::git::save(manager.todos_dir(), &plan.timestamp, "create plan")?
+        .ok_or_else(|| anyhow::anyhow!("initial plan should commit"))?;
+
+    let session_root = csa_session::get_session_root(project_dir.path())?;
+    std::fs::create_dir_all(&session_root)?;
+    let hook_log = project_dir.path().join("todo-save-hook.log");
+    std::fs::write(
+        session_root.join("hooks.toml"),
+        format!(
+            r#"[todo_save]
+enabled = true
+command = "test -z \"$(git -C {{todo_root}} status --porcelain)\" && printf '%s|%s|%s\\n' {{plan_id}} {{version}} {{message}} >> {}"
+timeout_secs = 5
+"#,
+            hook_log.display()
+        ),
+    )?;
+
+    let artifact_dir = project_dir.path().join("session-output");
+    std::fs::create_dir_all(&artifact_dir)?;
+    let todo_file = artifact_dir.join("TODO.md");
+    let spec_file = artifact_dir.join("spec.toml");
+    std::fs::write(
+        &todo_file,
+        "# Persisted hook plan\n\n## Tasks\n\n- [ ] Fire TodoSave from persist.\n  DONE WHEN: the todo_save hook runs after commit.\n",
+    )?;
+    let spec = SpecDocument {
+        schema_version: 1,
+        plan_ulid: plan.timestamp.clone(),
+        summary: "Persist generated plan hook regression.".to_string(),
+        criteria: vec![SpecCriterion {
+            kind: CriterionKind::Check,
+            id: "check-persist-hook".to_string(),
+            description: "csa todo persist fires todo_save once after a successful commit."
+                .to_string(),
+            status: CriterionStatus::Pending,
+        }],
+    };
+    std::fs::write(&spec_file, toml::to_string_pretty(&spec)?)?;
+
+    handle_persist(
+        plan.timestamp.clone(),
+        todo_file.display().to_string(),
+        spec_file.display().to_string(),
+        None,
+        Some("finalize generated plan".to_string()),
+        Some(project_dir.path().display().to_string()),
+    )?;
+
+    let hook_output = std::fs::read_to_string(&hook_log)?;
+    let lines: Vec<&str> = hook_output.lines().collect();
+    assert_eq!(lines.len(), 1, "todo_save hook should run exactly once");
+    assert_eq!(
+        lines[0],
+        format!("{}|2|finalize generated plan", plan.timestamp)
+    );
+
+    Ok(())
+}

--- a/crates/cli-sub-agent/src/todo_persist_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/todo_persist_cmd_tests.rs
@@ -136,3 +136,81 @@ timeout_secs = 5
 
     Ok(())
 }
+
+fn git_head(dir: &std::path::Path) -> anyhow::Result<String> {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output()?;
+    anyhow::ensure!(out.status.success(), "git rev-parse HEAD failed");
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Round-5 regression: a generated TODO that lacks a `DONE WHEN` clause must be
+/// rejected fail-closed by `csa todo persist` BEFORE it commits, so no invalid
+/// plan can enter the todos git history (the hard-gate contract). Proven by
+/// asserting the todos repo HEAD is unchanged and the work tree stays clean.
+#[test]
+fn handle_persist_rejects_invalid_plan_without_committing() -> anyhow::Result<()> {
+    let project_dir = tempdir()?;
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let manager = TodoManager::new(project_dir.path())?;
+    csa_todo::git::ensure_git_init(manager.todos_dir())?;
+    let plan = manager.create("Reject invalid plan", Some("fix/reject-invalid-plan"))?;
+    // Commit the freshly created template plan so HEAD is well-defined.
+    csa_todo::git::save(manager.todos_dir(), &plan.timestamp, "create plan")?
+        .ok_or_else(|| anyhow::anyhow!("initial plan should commit"))?;
+    let head_before = git_head(manager.todos_dir())?;
+
+    let artifact_dir = project_dir.path().join("session-output");
+    std::fs::create_dir_all(&artifact_dir)?;
+    let todo_file = artifact_dir.join("TODO.md");
+    let spec_file = artifact_dir.join("spec.toml");
+    // Invalid: a real checkbox task but NO `DONE WHEN` completion clause.
+    std::fs::write(
+        &todo_file,
+        "# Invalid plan\n\n## Tasks\n\n- [ ] Task without completion criteria.\n",
+    )?;
+    let spec = SpecDocument {
+        schema_version: 1,
+        plan_ulid: plan.timestamp.clone(),
+        summary: "Invalid plan missing DONE WHEN.".to_string(),
+        criteria: vec![SpecCriterion {
+            kind: CriterionKind::Check,
+            id: "check-invalid".to_string(),
+            description: "Persist must reject this before committing.".to_string(),
+            status: CriterionStatus::Pending,
+        }],
+    };
+    std::fs::write(&spec_file, toml::to_string_pretty(&spec)?)?;
+
+    let result = handle_persist(
+        plan.timestamp.clone(),
+        todo_file.display().to_string(),
+        spec_file.display().to_string(),
+        None,
+        Some("finalize invalid plan".to_string()),
+        Some(project_dir.path().display().to_string()),
+    );
+    assert!(
+        result.is_err(),
+        "persist must reject a generated TODO with no DONE WHEN clause"
+    );
+
+    // The rejected plan must NOT have produced a new commit in the todos repo.
+    assert_eq!(
+        head_before,
+        git_head(manager.todos_dir())?,
+        "no new todos-git commit may exist for the rejected invalid plan"
+    );
+    // And no half-written, uncommitted plan files may be left behind.
+    let status = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(manager.todos_dir())
+        .output()?;
+    assert!(
+        String::from_utf8_lossy(&status.stdout).trim().is_empty(),
+        "todos git status must stay clean when persist rejects invalid content"
+    );
+    Ok(())
+}

--- a/crates/csa-todo/src/generated_plan.rs
+++ b/crates/csa-todo/src/generated_plan.rs
@@ -1,0 +1,77 @@
+use anyhow::{Context, Result};
+use chrono::Utc;
+
+use crate::{
+    ATTESTATION_FILE, EPIC_PLAN_FILE, EpicPlan, METADATA_FILE, SPEC_FILE, SpecDocument,
+    TODO_MD_FILE, TodoManager, TodoPlan, atomic_write, validate_timestamp,
+};
+
+/// Generated plan content to persist for a TODO plan.
+pub struct GeneratedPlanPersistRequest<'a> {
+    pub todo_content: &'a str,
+    pub spec: &'a SpecDocument,
+    pub epic_plan: Option<&'a EpicPlan>,
+}
+
+/// Result of persisting generated plan content.
+pub struct GeneratedPlanPersistResult {
+    pub plan: TodoPlan,
+    pub changed_files: Vec<String>,
+}
+
+impl TodoManager {
+    /// Persist generated TODO/spec artifacts for an existing plan.
+    ///
+    /// Validates all structured inputs before mutating files, then writes each
+    /// file through temp-file + rename while holding the TODO write lock.
+    pub fn persist_generated_plan(
+        &self,
+        timestamp: &str,
+        request: GeneratedPlanPersistRequest<'_>,
+    ) -> Result<GeneratedPlanPersistResult> {
+        self.with_write_lock(|| {
+            validate_timestamp(timestamp)?;
+            if request.spec.plan_ulid != timestamp {
+                anyhow::bail!(
+                    "spec plan_ulid '{}' does not match TODO plan '{}'",
+                    request.spec.plan_ulid,
+                    timestamp
+                );
+            }
+            if let Some(epic_plan) = request.epic_plan {
+                epic_plan.validate()?;
+            }
+
+            let mut plan = self.load_inner(timestamp)?;
+            let spec_content =
+                toml::to_string_pretty(request.spec).context("Failed to serialize spec")?;
+            let epic_content = request
+                .epic_plan
+                .map(toml::to_string_pretty)
+                .transpose()
+                .context("Failed to serialize epic plan")?;
+
+            atomic_write(&plan.todo_md_path(), request.todo_content.as_bytes())?;
+            self.write_attestation_for_content(&plan, request.todo_content.as_bytes())?;
+            plan.metadata.updated_at = Utc::now();
+            self.write_metadata(&plan)?;
+            atomic_write(&self.spec_path(timestamp), spec_content.as_bytes())?;
+
+            let mut changed_files = vec![
+                format!("{timestamp}/{TODO_MD_FILE}"),
+                format!("{timestamp}/{ATTESTATION_FILE}"),
+                format!("{timestamp}/{METADATA_FILE}"),
+                format!("{timestamp}/{SPEC_FILE}"),
+            ];
+            if let Some(content) = epic_content {
+                atomic_write(&self.epic_plan_path(timestamp), content.as_bytes())?;
+                changed_files.push(format!("{timestamp}/{EPIC_PLAN_FILE}"));
+            }
+
+            Ok(GeneratedPlanPersistResult {
+                plan,
+                changed_files,
+            })
+        })
+    }
+}

--- a/crates/csa-todo/src/generated_plan.rs
+++ b/crates/csa-todo/src/generated_plan.rs
@@ -128,22 +128,59 @@ impl TodoManager {
 /// persisted TODO plan must satisfy, evaluated BEFORE any file write or commit:
 ///
 /// - at least one non-empty open checkbox task (`- [ ] <text>`),
-/// - a `DONE WHEN` completion clause, and
+/// - **every** open checkbox task carries its OWN mechanically-verifiable
+///   `DONE WHEN:` completion clause (AGENTS.md Meta 005), and
 /// - at least one spec criterion (so `csa todo show --spec` renders a non-empty
 ///   criteria list — the struct-level equivalent of the workflow's former
 ///   post-commit render check).
 ///
+/// The `DONE WHEN:` check is **per-task**, not a single global mention: a plan
+/// is rejected when ANY open task block lacks a clause, even if another task
+/// carries one. The clause requires the colon followed by non-empty criteria
+/// text, so a bare keyword mention in a subject (e.g.
+/// `- [ ] Document DONE WHEN policy.`) does NOT satisfy the gate, and a clause
+/// that lives on a *completed* (`- [x]`) task line cannot satisfy a sibling open
+/// task. Completed tasks are exempt; only open tasks require a clause.
+///
 /// Returns an error so the caller's commit step never runs on invalid content.
 fn validate_generated_plan_content(todo_content: &str, spec: &SpecDocument) -> Result<()> {
-    let has_checkbox_task = todo_content.lines().any(|line| {
-        line.strip_prefix("- [ ] ")
-            .is_some_and(|rest| !rest.is_empty())
-    });
-    if !has_checkbox_task {
+    let lines: Vec<&str> = todo_content.lines().collect();
+    let mut open_task_count = 0usize;
+    let mut missing_clause: Vec<&str> = Vec::new();
+
+    let mut i = 0;
+    while i < lines.len() {
+        let Some(subject) = open_task_subject(lines[i]) else {
+            i += 1;
+            continue;
+        };
+        open_task_count += 1;
+        // The task owns its checkbox line plus every following line up to — but
+        // not including — the next checkbox (open OR completed) or section
+        // heading. This isolates each open task's clause from its neighbours so
+        // one task's `DONE WHEN:` can never cover another's gap.
+        let start = i;
+        i += 1;
+        while i < lines.len() && !is_task_block_boundary(lines[i]) {
+            i += 1;
+        }
+        let has_clause = lines[start..i]
+            .iter()
+            .any(|line| done_when_criteria(line).is_some());
+        if !has_clause {
+            missing_clause.push(subject);
+        }
+    }
+
+    if open_task_count == 0 {
         anyhow::bail!("generated TODO has no non-empty checkbox task (`- [ ] <task>`)");
     }
-    if !todo_content.contains("DONE WHEN") {
-        anyhow::bail!("generated TODO has no `DONE WHEN` completion clause");
+    if !missing_clause.is_empty() {
+        anyhow::bail!(
+            "generated TODO has open task(s) without a mechanically-verifiable `DONE WHEN:` \
+             completion clause: {}",
+            missing_clause.join("; ")
+        );
     }
     if spec.criteria.is_empty() {
         anyhow::bail!(
@@ -151,6 +188,34 @@ fn validate_generated_plan_content(todo_content: &str, spec: &SpecDocument) -> R
         );
     }
     Ok(())
+}
+
+/// The subject text of an OPEN checkbox line (`- [ ] <subject>`), or `None` when
+/// the line is not a non-empty open checkbox. Matches the column-0, unordered
+/// `- [ ]` task format the mktd plan template renders and the workflow gate
+/// checks (`^- \[ \] .+`).
+fn open_task_subject(line: &str) -> Option<&str> {
+    line.strip_prefix("- [ ] ").filter(|rest| !rest.is_empty())
+}
+
+/// True when `line` opens a new task-block boundary: any checkbox marker (open
+/// or completed) or a Markdown section heading. Used to delimit one open task's
+/// owned lines from the next.
+fn is_task_block_boundary(line: &str) -> bool {
+    line.starts_with("- [ ]")
+        || line.starts_with("- [x]")
+        || line.starts_with("- [X]")
+        || line.starts_with('#')
+}
+
+/// The non-empty criteria text following a `DONE WHEN:` clause on `line`, or
+/// `None` when the line has no clause or only empty/whitespace text after the
+/// colon. The required colon means a bare keyword mention (e.g.
+/// `... DONE WHEN policy.`) is deliberately NOT treated as a clause.
+fn done_when_criteria(line: &str) -> Option<&str> {
+    line.split_once("DONE WHEN:")
+        .map(|(_, rest)| rest.trim())
+        .filter(|rest| !rest.is_empty())
 }
 
 #[cfg(test)]
@@ -191,6 +256,66 @@ mod tests {
         assert!(
             validate_generated_plan_content("# Plan\n\n- [ ] do thing\n  DONE WHEN: y\n", &spec)
                 .is_ok()
+        );
+    }
+
+    /// Round-8 (#1822) regression: the `DONE WHEN:` gate is PER-TASK, not a
+    /// single global mention. Proves the two reviewer-named false-pass cases are
+    /// rejected (a bare subject mention without a clause; a multi-task plan where
+    /// only one open task carries a clause) while every genuinely-valid clause
+    /// placement still passes.
+    #[test]
+    fn validate_generated_plan_content_requires_per_task_done_when() {
+        let spec = sample_spec("01JABCDEF0123456789ABCDEFG");
+
+        // REJECT: the only open task merely MENTIONS the keywords in its subject
+        // with no `DONE WHEN:` clause (no colon, no criteria).
+        assert!(
+            validate_generated_plan_content("# Plan\n\n- [ ] Document DONE WHEN policy.\n", &spec)
+                .is_err(),
+            "a subject that only mentions the keywords (no clause) must be rejected"
+        );
+
+        // REJECT: multi-task plan where one open task has a clause but another
+        // does not — the global check would wrongly pass on the first clause.
+        let mixed =
+            "# Plan\n\n## Tasks\n\n- [ ] Task one.\n  DONE WHEN: one is done.\n\n- [ ] Task two.\n";
+        assert!(
+            validate_generated_plan_content(mixed, &spec).is_err(),
+            "any open task lacking a clause must reject the plan, even if a sibling has one"
+        );
+
+        // REJECT: a `DONE WHEN:` clause living on a COMPLETED task line must not
+        // satisfy a sibling OPEN task that has no clause of its own.
+        let clause_on_completed = "# Plan\n\n- [x] Done. DONE WHEN: only this completed line carries a clause.\n- [ ] Open task without its own clause.\n";
+        assert!(
+            validate_generated_plan_content(clause_on_completed, &spec).is_err(),
+            "a clause on a completed task must not cover an open task's gap"
+        );
+
+        // ACCEPT: every open task has a clause on an indented FOLLOWING line.
+        let following_line = "# Plan\n\n- [ ] Task one.\n  DONE WHEN: one is done.\n\n- [ ] Task two.\n  DONE WHEN: two is done.\n";
+        assert!(
+            validate_generated_plan_content(following_line, &spec).is_ok(),
+            "following-line clauses on every open task must be accepted"
+        );
+
+        // ACCEPT: the clause sits on the checkbox SUBJECT line itself.
+        assert!(
+            validate_generated_plan_content(
+                "# Plan\n\n- [ ] Implement X. DONE WHEN: tests pass.\n",
+                &spec
+            )
+            .is_ok(),
+            "a clause on the checkbox subject line must be accepted"
+        );
+
+        // ACCEPT: completed tasks without clauses are exempt; the lone open task
+        // carries its own clause.
+        let with_completed = "# Plan\n\n- [x] Already done, no clause needed.\n- [ ] Still open.\n  DONE WHEN: it is mechanically verifiable.\n";
+        assert!(
+            validate_generated_plan_content(with_completed, &spec).is_ok(),
+            "completed tasks are exempt; only open tasks require a clause"
         );
     }
 

--- a/crates/csa-todo/src/generated_plan.rs
+++ b/crates/csa-todo/src/generated_plan.rs
@@ -24,11 +24,47 @@ impl TodoManager {
     ///
     /// Validates all structured inputs before mutating files, then writes each
     /// file through temp-file + rename while holding the TODO write lock.
+    ///
+    /// Convenience wrapper over [`persist_generated_plan_with`](Self::persist_generated_plan_with)
+    /// for callers that only need the file writes and have no publish step to
+    /// run under the same lock.
     pub fn persist_generated_plan(
         &self,
         timestamp: &str,
         request: GeneratedPlanPersistRequest<'_>,
     ) -> Result<GeneratedPlanPersistResult> {
+        let (result, ()) = self.persist_generated_plan_with(timestamp, request, |_| Ok(()))?;
+        Ok(result)
+    }
+
+    /// Persist generated TODO/spec artifacts AND run a caller `publish` step
+    /// atomically, all under a single hold of the TODO write lock.
+    ///
+    /// The file-write phase is identical to
+    /// [`persist_generated_plan`](Self::persist_generated_plan), but `publish`
+    /// is invoked *before the write lock is released*, right after the atomic
+    /// file writes succeed. This makes the file write and the caller's publish
+    /// step (e.g. git stage + commit + the hook-trigger decision) one critical
+    /// section: a concurrent TODO writer cannot interleave between the write and
+    /// the commit and cause this call to publish the wrong snapshot (TOCTOU
+    /// lost-update / corrupted audit history).
+    ///
+    /// `publish` receives the persist result (loaded plan + the list of changed
+    /// files) and returns any caller-defined value (e.g. the commit hash). The
+    /// write lock is released only after `publish` returns, on both the success
+    /// and error paths (the lock guard in the write-lock helper drops on scope
+    /// exit regardless of outcome).
+    ///
+    /// `publish` MUST NOT itself attempt to acquire the TODO write lock (e.g. by
+    /// spawning `csa todo save`/`persist`), or it will deadlock against the held
+    /// lock. Run any such side effect (e.g. firing the `TodoSave` hook) from the
+    /// returned value, after this method returns.
+    pub fn persist_generated_plan_with<T>(
+        &self,
+        timestamp: &str,
+        request: GeneratedPlanPersistRequest<'_>,
+        publish: impl FnOnce(&GeneratedPlanPersistResult) -> Result<T>,
+    ) -> Result<(GeneratedPlanPersistResult, T)> {
         self.with_write_lock(|| {
             validate_timestamp(timestamp)?;
             if request.spec.plan_ulid != timestamp {
@@ -68,10 +104,88 @@ impl TodoManager {
                 changed_files.push(format!("{timestamp}/{EPIC_PLAN_FILE}"));
             }
 
-            Ok(GeneratedPlanPersistResult {
+            let result = GeneratedPlanPersistResult {
                 plan,
                 changed_files,
-            })
+            };
+            // Run the caller's publish step (commit + hook-trigger decision)
+            // BEFORE releasing the write lock, so the commit captures exactly
+            // the content just written above.
+            let published = publish(&result)?;
+            Ok((result, published))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LOCK_FILE;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn sample_spec(plan_ulid: &str) -> SpecDocument {
+        SpecDocument {
+            schema_version: 1,
+            plan_ulid: plan_ulid.to_string(),
+            summary: "lock-scope probe".to_string(),
+            criteria: Vec::new(),
+        }
+    }
+
+    /// Proves the publish closure runs INSIDE the held TODO write lock: a second,
+    /// independent acquisition of the same lock must fail while the closure runs.
+    /// flock(2) treats distinct open file descriptions as separate holders even
+    /// within one process, so the non-blocking probe is denied while the outer
+    /// lock is held. Linux-gated because the cross-fd flock semantics this relies
+    /// on are guaranteed there.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn persist_generated_plan_with_runs_publish_under_write_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+        let plan = manager
+            .create("Lock scope probe", Some("fix/lock-scope-probe"))
+            .expect("create plan");
+        let spec = sample_spec(&plan.timestamp);
+        let lock_path = manager.todos_dir().join(LOCK_FILE);
+        let publish_ran = AtomicBool::new(false);
+
+        let (result, lock_was_held) = manager
+            .persist_generated_plan_with(
+                &plan.timestamp,
+                GeneratedPlanPersistRequest {
+                    todo_content:
+                        "# Lock scope probe\n\n## Tasks\n\n- [ ] Probe lock.\n  DONE WHEN: probed.\n",
+                    spec: &spec,
+                    epic_plan: None,
+                },
+                |res| {
+                    publish_ran.store(true, Ordering::SeqCst);
+                    // The file write must have already happened before publish.
+                    let on_disk = std::fs::read_to_string(res.plan.todo_md_path())?;
+                    assert!(
+                        on_disk.contains("Lock scope probe"),
+                        "publish must see the freshly written TODO content"
+                    );
+                    // A competing write-lock acquisition must be denied here.
+                    let probe_file = std::fs::OpenOptions::new().write(true).open(&lock_path)?;
+                    let mut probe = fd_lock::RwLock::new(probe_file);
+                    Ok(probe.try_write().is_err())
+                },
+            )
+            .expect("persist generated plan with publish");
+
+        assert!(
+            publish_ran.load(Ordering::SeqCst),
+            "publish closure must be invoked"
+        );
+        assert!(
+            lock_was_held,
+            "the write lock must be held while the publish/commit step runs"
+        );
+        assert!(
+            result.changed_files.iter().any(|f| f.ends_with("TODO.md")),
+            "changed files must include the persisted TODO.md"
+        );
     }
 }

--- a/crates/csa-todo/src/generated_plan.rs
+++ b/crates/csa-todo/src/generated_plan.rs
@@ -77,6 +77,13 @@ impl TodoManager {
             if let Some(epic_plan) = request.epic_plan {
                 epic_plan.validate()?;
             }
+            // Fail-closed gate (#1820/#1822 hard-gate contract): reject generated
+            // content that violates the plan's hard invariants BEFORE any file
+            // write or commit. The mktd workflow validates the rendered artifacts
+            // before calling persist, but this guards EVERY caller (e.g. a direct
+            // `csa todo persist`) so an invalid plan can never enter the todos git
+            // history via the `publish` commit closure below.
+            validate_generated_plan_content(request.todo_content, request.spec)?;
 
             let mut plan = self.load_inner(timestamp)?;
             let spec_content =
@@ -117,10 +124,39 @@ impl TodoManager {
     }
 }
 
+/// Reject generated plan content that violates the hard invariants every
+/// persisted TODO plan must satisfy, evaluated BEFORE any file write or commit:
+///
+/// - at least one non-empty open checkbox task (`- [ ] <text>`),
+/// - a `DONE WHEN` completion clause, and
+/// - at least one spec criterion (so `csa todo show --spec` renders a non-empty
+///   criteria list — the struct-level equivalent of the workflow's former
+///   post-commit render check).
+///
+/// Returns an error so the caller's commit step never runs on invalid content.
+fn validate_generated_plan_content(todo_content: &str, spec: &SpecDocument) -> Result<()> {
+    let has_checkbox_task = todo_content.lines().any(|line| {
+        line.strip_prefix("- [ ] ")
+            .is_some_and(|rest| !rest.is_empty())
+    });
+    if !has_checkbox_task {
+        anyhow::bail!("generated TODO has no non-empty checkbox task (`- [ ] <task>`)");
+    }
+    if !todo_content.contains("DONE WHEN") {
+        anyhow::bail!("generated TODO has no `DONE WHEN` completion clause");
+    }
+    if spec.criteria.is_empty() {
+        anyhow::bail!(
+            "generated spec has no criteria; `csa todo show --spec` would render an empty plan"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::LOCK_FILE;
+    use crate::{CriterionKind, CriterionStatus, LOCK_FILE, SpecCriterion};
     use std::sync::atomic::{AtomicBool, Ordering};
 
     fn sample_spec(plan_ulid: &str) -> SpecDocument {
@@ -128,8 +164,34 @@ mod tests {
             schema_version: 1,
             plan_ulid: plan_ulid.to_string(),
             summary: "lock-scope probe".to_string(),
-            criteria: Vec::new(),
+            criteria: vec![SpecCriterion {
+                kind: CriterionKind::Check,
+                id: "check-lock-scope".to_string(),
+                description: "Publish runs under the held write lock.".to_string(),
+                status: CriterionStatus::Pending,
+            }],
         }
+    }
+
+    #[test]
+    fn validate_generated_plan_content_rejects_missing_invariants() {
+        let spec = sample_spec("01JABCDEF0123456789ABCDEFG");
+        // No checkbox task → rejected.
+        assert!(validate_generated_plan_content("# Plan\n\nDONE WHEN: x\n", &spec).is_err());
+        // No `DONE WHEN` clause → rejected.
+        assert!(validate_generated_plan_content("# Plan\n\n- [ ] do thing\n", &spec).is_err());
+        // No spec criteria → rejected (would render an empty plan).
+        let mut empty = sample_spec("01JABCDEF0123456789ABCDEFG");
+        empty.criteria.clear();
+        assert!(
+            validate_generated_plan_content("# Plan\n\n- [ ] do thing\n  DONE WHEN: y\n", &empty)
+                .is_err()
+        );
+        // All invariants satisfied → accepted.
+        assert!(
+            validate_generated_plan_content("# Plan\n\n- [ ] do thing\n  DONE WHEN: y\n", &spec)
+                .is_ok()
+        );
     }
 
     /// Proves the publish closure runs INSIDE the held TODO write lock: a second,

--- a/crates/csa-todo/src/generated_plan.rs
+++ b/crates/csa-todo/src/generated_plan.rs
@@ -250,4 +250,78 @@ mod tests {
             "changed files must include the persisted TODO.md"
         );
     }
+
+    /// Round-6 (#1822) regression: the TodoSave hook version for `csa todo
+    /// persist` is computed INSIDE the held write lock (right after the commit)
+    /// and returned from the publish step, so a concurrent TODO writer that
+    /// commits another version AFTER the lock releases cannot change the version
+    /// this save reports. Proven by capturing the publish-returned version, then
+    /// committing a later version and showing a fresh recompute observes the
+    /// bumped count while the captured under-lock value is unchanged. Linux-gated
+    /// to match the sibling lock-probe test.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn persist_generated_plan_with_returns_version_computed_under_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+        crate::git::ensure_git_init(manager.todos_dir()).expect("init todos git");
+        let plan = manager
+            .create("Version under lock", Some("fix/version-under-lock"))
+            .expect("create plan");
+        let spec = sample_spec(&plan.timestamp);
+        // First committed version of TODO.md (the freshly created template).
+        crate::git::save(manager.todos_dir(), &plan.timestamp, "create plan")
+            .expect("save initial")
+            .expect("initial commit");
+
+        let todos_dir = manager.todos_dir().to_path_buf();
+        let ts = plan.timestamp.clone();
+        let (_result, captured_version) = manager
+            .persist_generated_plan_with(
+                &plan.timestamp,
+                GeneratedPlanPersistRequest {
+                    todo_content:
+                        "# Version under lock\n\n## Tasks\n\n- [ ] Probe version.\n  DONE WHEN: probed.\n",
+                    spec: &spec,
+                    epic_plan: None,
+                },
+                // Mirror the production persist closure: commit, then count THIS
+                // save's versions while the write lock is still held.
+                |result| -> Result<usize> {
+                    let files: Vec<&str> =
+                        result.changed_files.iter().map(String::as_str).collect();
+                    crate::git::save_files(&todos_dir, &ts, &files, "persist probe")?;
+                    Ok(crate::git::list_versions(&todos_dir, &ts)?.len())
+                },
+            )
+            .expect("persist with publish");
+
+        // create + persist == the 2nd committed TODO.md version.
+        assert_eq!(captured_version, 2, "version captured inside the held lock");
+
+        // Simulate a concurrent writer winning the lock right after release and
+        // committing another TODO.md version. A post-release recompute would now
+        // observe 3; the captured under-lock value must remain 2.
+        std::fs::write(
+            plan.todo_md_path(),
+            "# Version under lock\n\n## Tasks\n\n- [ ] Probe version again.\n  DONE WHEN: re-probed.\n",
+        )
+        .expect("write later version");
+        crate::git::save(manager.todos_dir(), &plan.timestamp, "concurrent save")
+            .expect("save later")
+            .expect("later commit");
+        let post_release_recompute =
+            crate::git::list_versions(manager.todos_dir(), &plan.timestamp)
+                .expect("list versions")
+                .len();
+
+        assert_eq!(
+            post_release_recompute, 3,
+            "a later concurrent save bumps a fresh recompute"
+        );
+        assert_ne!(
+            captured_version, post_release_recompute,
+            "the under-lock version must not equal a post-release recompute"
+        );
+    }
 }

--- a/crates/csa-todo/src/lib.rs
+++ b/crates/csa-todo/src/lib.rs
@@ -31,10 +31,12 @@ const EPIC_PLAN_FILE: &str = "epic-plan.toml";
 const LOCK_FILE: &str = ".lock";
 
 pub use epic_plan::{EpicMeta, EpicPlan, ScaleSignals, Story, StoryStatus};
+pub use generated_plan::{GeneratedPlanPersistRequest, GeneratedPlanPersistResult};
 pub use reference::{ReferenceFile, ReferenceIndex, ReferenceSource};
 pub use spec::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument};
 
 pub mod epic_plan;
+mod generated_plan;
 pub mod reference;
 mod spec;
 

--- a/crates/csa-todo/tests/spec_lifecycle.rs
+++ b/crates/csa-todo/tests/spec_lifecycle.rs
@@ -1,4 +1,7 @@
-use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, TodoManager};
+use csa_todo::{
+    CriterionKind, CriterionStatus, GeneratedPlanPersistRequest, SpecCriterion, SpecDocument,
+    TodoManager,
+};
 
 fn sample_spec(plan_ulid: &str) -> SpecDocument {
     SpecDocument {
@@ -59,4 +62,62 @@ fn spec_lifecycle_roundtrips_through_todo_manager_storage() {
 
     let loaded = manager.load_spec(&plan.timestamp).unwrap();
     assert_eq!(loaded, Some(spec));
+}
+
+#[test]
+fn generated_plan_persist_survives_later_simulated_gate_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let manager = TodoManager::with_base_dir(dir.path().to_path_buf());
+    csa_todo::git::ensure_git_init(manager.todos_dir()).expect("init todos git");
+    let plan = manager
+        .create("Generated plan persistence", Some("fix/generated-plan"))
+        .expect("create plan");
+    csa_todo::git::save(manager.todos_dir(), &plan.timestamp, "create plan")
+        .expect("save initial plan")
+        .expect("initial plan should commit");
+
+    let todo_content = "# Generated plan\n\n## Tasks\n\n- [ ] Persist generated plan.\n  DONE WHEN: csa todo show renders this task.\n";
+    let spec = sample_spec(&plan.timestamp);
+    let persisted = manager
+        .persist_generated_plan(
+            &plan.timestamp,
+            GeneratedPlanPersistRequest {
+                todo_content,
+                spec: &spec,
+                epic_plan: None,
+            },
+        )
+        .expect("persist generated plan");
+    let file_refs: Vec<&str> = persisted.changed_files.iter().map(String::as_str).collect();
+    csa_todo::git::save_files(
+        manager.todos_dir(),
+        &plan.timestamp,
+        &file_refs,
+        "finalize generated plan",
+    )
+    .expect("save generated plan")
+    .expect("generated plan should commit");
+
+    let simulated_post_exec_gate = Err::<(), _>(anyhow::anyhow!("post-exec gate failed"));
+    assert!(simulated_post_exec_gate.is_err());
+
+    let saved_todo =
+        std::fs::read_to_string(plan.todo_md_path()).expect("TODO.md should remain persisted");
+    assert!(saved_todo.contains("Persist generated plan."));
+    assert_eq!(
+        manager
+            .load_spec(&plan.timestamp)
+            .expect("load persisted spec"),
+        Some(spec)
+    );
+
+    let status = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(manager.todos_dir())
+        .output()
+        .expect("git status");
+    assert!(
+        String::from_utf8_lossy(&status.stdout).trim().is_empty(),
+        "todos git status should be clean after atomic save"
+    );
 }

--- a/justfile
+++ b/justfile
@@ -246,7 +246,7 @@ pre-commit:
 # Requires: ripgrep (rg)
 check-chinese:
     @echo "Checking for Chinese characters..."
-    @! rg "\p{Script=Han}" . --vimgrep --glob '!target/**' --glob '!.git/**' --glob '!**/i18n/*.ftl' --glob '!skills/mktd/**' --glob '!tests/fixtures/**' --glob '!.claude/rules/**' --glob '!.agents/**' --glob '!CLAUDE.md' --glob '!GEMINI.md'
+    @! ./scripts/check-chinese.sh
 
 # Format code and re-stage only .rs files that were already staged before fmt.
 # Abort first when any staged Rust file also has unstaged hunks.

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -719,7 +719,24 @@ printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_ARTIFACT}" || { echo "write spec artif
 # `csa todo show --spec` render gate — so NO content validation runs after the
 # commit.
 grep -qE '^- \[ \] .+' "${TODO_ARTIFACT}" || { echo "TODO artifact has no non-empty checkbox tasks" >&2; exit 1; }
-grep -q 'DONE WHEN:' "${TODO_ARTIFACT}" || { echo "TODO artifact has no DONE WHEN clauses" >&2; exit 1; }
+# Per-task gate: EVERY open checkbox task must carry its OWN mechanically
+# verifiable `DONE WHEN:` clause (AGENTS.md Meta 005). A single global match is
+# insufficient — a bare keyword mention in a subject, or one task's clause, must
+# not cover another open task's gap. `csa todo persist` re-applies the same
+# per-task check fail-closed under the write lock (defense-in-depth).
+awk '
+function flush() { if (in_open == 1 && has_clause == 0) bad = 1; in_open = 0; has_clause = 0 }
+function scan(text,   pos, rest) {
+  pos = index(text, "DONE WHEN:")
+  if (pos > 0) { rest = substr(text, pos + 10); sub(/^[ \t]+/, "", rest); if (length(rest) > 0) has_clause = 1 }
+}
+{
+  is_open = ($0 ~ /^- \[ \] .+/)
+  if ($0 ~ /^- \[[ xX]\]/ || $0 ~ /^#/) { flush(); if (is_open == 1) { in_open = 1; scan($0) }; next }
+  if (in_open == 1) scan($0)
+}
+END { flush(); exit (bad + 0) }
+' "${TODO_ARTIFACT}" || { echo "TODO artifact has an open task without a mechanically-verifiable DONE WHEN: clause" >&2; exit 1; }
 grep -q '^schema_version = 1$' "${SPEC_ARTIFACT}" || { echo "spec artifact missing schema_version = 1" >&2; exit 1; }
 grep -q "^plan_ulid = \"${TODO_TS}\"$" "${SPEC_ARTIFACT}" || { echo "spec artifact plan_ulid unresolved or mismatched" >&2; exit 1; }
 grep -q '^summary = "' "${SPEC_ARTIFACT}" || { echo "spec artifact missing summary" >&2; exit 1; }

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -685,34 +685,8 @@ FINAL_TODO=$(printf '%s\n' "${FINAL_TODO}" | awk '
   /^<!-- CSA:ADR:END -->$/ { in_adr=0; next }
   !in_adr { print }
 ')
-printf '%s\n' "${FINAL_TODO}" | grep -qE '^- \[ \] .+' || { echo "TODO has no non-empty checkbox tasks" >&2; exit 1; }
-printf '%s\n' "${FINAL_TODO}" | grep -q 'DONE WHEN:' || { echo "TODO has no DONE WHEN clauses" >&2; exit 1; }
 [[ -n "${STEP_8_OUTPUT:-}" ]] || { echo "STEP_8_OUTPUT is empty — Step 8 must output spec.toml content" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^schema_version = 1$' || { echo "STEP_8_OUTPUT missing schema_version = 1" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^plan_ulid = "__PLAN_ID__"$' || { echo "STEP_8_OUTPUT missing __PLAN_ID__ placeholder" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^summary = "' || { echo "STEP_8_OUTPUT missing summary" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^\[\[criteria\]\]$' || { echo "STEP_8_OUTPUT has no criteria entries" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | rg -q '^kind = "(scenario|property|check)"$' || { echo "STEP_8_OUTPUT has invalid criterion kinds" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^id = "' || { echo "STEP_8_OUTPUT missing criterion id" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^description = "' || { echo "STEP_8_OUTPUT missing criterion description" >&2; exit 1; }
-SUMMARY_LINE=$(printf '%s\n' "${STEP_8_OUTPUT}" | sed -n 's/^summary = "\(.*\)"$/\1/p' | head -n1)
-printf '%s' "${SUMMARY_LINE}" | rg -q '[\p{Han}]' || { echo "STEP_8_OUTPUT summary must be one Chinese line" >&2; exit 1; }
 RESOLVED_LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
-if printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'chinese'; then
-  TASK_COUNT=$(printf '%s\n' "${FINAL_TODO}" | grep -cE '^- \[ \] .+')
-  MIN_HAN="${TASK_COUNT}"
-  if [ "${MIN_HAN}" -lt 2 ]; then MIN_HAN=2; fi
-  if [ "${MIN_HAN}" -gt 30 ]; then MIN_HAN=30; fi
-  HAN_COUNT_DRAFT=$(printf '%s\n' "${FINAL_TODO}" | rg -o '[\p{Han}]' | wc -l | tr -d '[:space:]')
-  [[ "${HAN_COUNT_DRAFT:-0}" -ge "${MIN_HAN}" ]] || { echo "TODO language mismatch: expected Han-script content (Han chars >= ${MIN_HAN})" >&2; exit 1; }
-elif printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'han script'; then
-  TASK_COUNT=$(printf '%s\n' "${FINAL_TODO}" | grep -cE '^- \[ \] .+')
-  MIN_CJK="${TASK_COUNT}"
-  if [ "${MIN_CJK}" -lt 2 ]; then MIN_CJK=2; fi
-  if [ "${MIN_CJK}" -gt 30 ]; then MIN_CJK=30; fi
-  CJK_COUNT_DRAFT=$(printf '%s\n' "${FINAL_TODO}" | rg -o '[\p{Han}\p{Hiragana}\p{Katakana}]' | wc -l | tr -d '[:space:]')
-  [[ "${CJK_COUNT_DRAFT:-0}" -ge "${MIN_CJK}" ]] || { echo "TODO language mismatch: expected CJK-script content (CJK chars >= ${MIN_CJK})" >&2; exit 1; }
-fi
 CURRENT_BRANCH=$(git branch --show-current) || { echo "detect branch failed" >&2; exit 1; }
 LANG_ARGS=()
 if [[ -n "${RESOLVED_LANGUAGE:-}" ]]; then
@@ -737,39 +711,44 @@ SPEC_CONTENT="${STEP_8_OUTPUT//__PLAN_ID__/${TODO_TS}}"
 printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_ARTIFACT}" || { echo "write spec artifact failed" >&2; exit 1; }
 [[ -s "${TODO_ARTIFACT}" ]] || { echo "TODO artifact is empty" >&2; exit 1; }
 [[ -s "${SPEC_ARTIFACT}" ]] || { echo "spec artifact is empty" >&2; exit 1; }
-TODO_PATH=$(csa todo persist -t "${TODO_TS}" --todo-file "${TODO_ARTIFACT}" --spec-file "${SPEC_ARTIFACT}" "${EPIC_ARGS[@]}" "finalize: ${FEATURE}") || { echo "csa todo persist failed" >&2; exit 1; }
-SPEC_PATH="$(dirname "${TODO_PATH}")/spec.toml"
-[[ -s "${TODO_PATH}" ]] || { echo "saved TODO is empty" >&2; exit 1; }
-[[ -s "${SPEC_PATH}" ]] || { echo "saved spec is empty" >&2; exit 1; }
-if [[ -n "${EPIC_PLAN:-}" ]]; then
-  csa todo epic validate -t "${TODO_TS}" 2>&1 || { echo "epic-plan.toml validation failed" >&2; exit 1; }
-  echo "Epic plan saved and validated" >&2
-fi
-grep -qE '^- \[ \] .+' "${TODO_PATH}" || { echo "saved TODO has no non-empty checkbox tasks" >&2; exit 1; }
-grep -q 'DONE WHEN:' "${TODO_PATH}" || { echo "saved TODO has no DONE WHEN clauses" >&2; exit 1; }
-grep -q '^schema_version = 1$' "${SPEC_PATH}" || { echo "saved spec missing schema_version = 1" >&2; exit 1; }
-grep -q "^plan_ulid = \"${TODO_TS}\"$" "${SPEC_PATH}" || { echo "saved spec plan_ulid mismatch" >&2; exit 1; }
-grep -q '^summary = "' "${SPEC_PATH}" || { echo "saved spec missing summary" >&2; exit 1; }
-grep -q '^\[\[criteria\]\]$' "${SPEC_PATH}" || { echo "saved spec has no criteria entries" >&2; exit 1; }
+# Hard-gate: validate the RENDERED artifacts BEFORE `csa todo persist` commits
+# them. An invalid plan must NEVER reach the persist/commit step (#1820/#1822
+# hard-gate contract; round-5 ordering fix). `csa todo persist` ALSO re-checks
+# the core invariants fail-closed inside its locked commit (defense-in-depth)
+# — including the spec-criteria check that replaces the former post-commit
+# `csa todo show --spec` render gate — so NO content validation runs after the
+# commit.
+grep -qE '^- \[ \] .+' "${TODO_ARTIFACT}" || { echo "TODO artifact has no non-empty checkbox tasks" >&2; exit 1; }
+grep -q 'DONE WHEN:' "${TODO_ARTIFACT}" || { echo "TODO artifact has no DONE WHEN clauses" >&2; exit 1; }
+grep -q '^schema_version = 1$' "${SPEC_ARTIFACT}" || { echo "spec artifact missing schema_version = 1" >&2; exit 1; }
+grep -q "^plan_ulid = \"${TODO_TS}\"$" "${SPEC_ARTIFACT}" || { echo "spec artifact plan_ulid unresolved or mismatched" >&2; exit 1; }
+grep -q '^summary = "' "${SPEC_ARTIFACT}" || { echo "spec artifact missing summary" >&2; exit 1; }
+grep -q '^\[\[criteria\]\]$' "${SPEC_ARTIFACT}" || { echo "spec artifact has no criteria entries" >&2; exit 1; }
+rg -q '^kind = "(scenario|property|check)"$' "${SPEC_ARTIFACT}" || { echo "spec artifact has invalid criterion kinds" >&2; exit 1; }
+grep -q '^id = "' "${SPEC_ARTIFACT}" || { echo "spec artifact missing criterion id" >&2; exit 1; }
+grep -q '^description = "' "${SPEC_ARTIFACT}" || { echo "spec artifact missing criterion description" >&2; exit 1; }
+SUMMARY_LINE=$(sed -n 's/^summary = "\(.*\)"$/\1/p' "${SPEC_ARTIFACT}" | head -n1)
+printf '%s' "${SUMMARY_LINE}" | rg -q '[\p{Han}]' || { echo "spec artifact summary must be one Chinese line" >&2; exit 1; }
 if printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'chinese'; then
-  HAN_COUNT_SAVED=$(rg -o '[\p{Han}]' "${TODO_PATH}" | wc -l | tr -d '[:space:]')
-  [[ "${HAN_COUNT_SAVED:-0}" -ge "${MIN_HAN:-2}" ]] || { echo "saved TODO language mismatch: expected Han-script content (Han chars >= ${MIN_HAN:-2})" >&2; exit 1; }
+  TASK_COUNT=$(grep -cE '^- \[ \] .+' "${TODO_ARTIFACT}")
+  MIN_HAN="${TASK_COUNT}"
+  if [ "${MIN_HAN}" -lt 2 ]; then MIN_HAN=2; fi
+  if [ "${MIN_HAN}" -gt 30 ]; then MIN_HAN=30; fi
+  HAN_COUNT=$(rg -o '[\p{Han}]' "${TODO_ARTIFACT}" | wc -l | tr -d '[:space:]')
+  [[ "${HAN_COUNT:-0}" -ge "${MIN_HAN}" ]] || { echo "TODO artifact language mismatch: expected Han-script content (Han chars >= ${MIN_HAN})" >&2; exit 1; }
 elif printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'han script'; then
-  CJK_COUNT_SAVED=$(rg -o '[\p{Han}\p{Hiragana}\p{Katakana}]' "${TODO_PATH}" | wc -l | tr -d '[:space:]')
-  [[ "${CJK_COUNT_SAVED:-0}" -ge "${MIN_CJK:-2}" ]] || { echo "saved TODO language mismatch: expected CJK-script content (CJK chars >= ${MIN_CJK:-2})" >&2; exit 1; }
+  TASK_COUNT=$(grep -cE '^- \[ \] .+' "${TODO_ARTIFACT}")
+  MIN_CJK="${TASK_COUNT}"
+  if [ "${MIN_CJK}" -lt 2 ]; then MIN_CJK=2; fi
+  if [ "${MIN_CJK}" -gt 30 ]; then MIN_CJK=30; fi
+  CJK_COUNT=$(rg -o '[\p{Han}\p{Hiragana}\p{Katakana}]' "${TODO_ARTIFACT}" | wc -l | tr -d '[:space:]')
+  [[ "${CJK_COUNT:-0}" -ge "${MIN_CJK}" ]] || { echo "TODO artifact language mismatch: expected CJK-script content (CJK chars >= ${MIN_CJK})" >&2; exit 1; }
 fi
-# Validate language metadata consistency: if metadata.language is set,
-# verify TODO content matches (e.g., Chinese plan should have Chinese descriptions)
-if [[ -n "${RESOLVED_LANGUAGE:-}" ]]; then
-  if printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'chinese'; then
-    HAN_META_CHECK=$(rg -o '[\p{Han}]' "${TODO_PATH}" | wc -l | tr -d '[:space:]')
-    [[ "${HAN_META_CHECK:-0}" -ge 2 ]] || { echo "language metadata mismatch: plan language is ${RESOLVED_LANGUAGE} but content lacks Han characters" >&2; exit 1; }
-  fi
-fi
-SPEC_RENDERED=$(csa todo show -t "${TODO_TS}" --spec) || { echo "csa todo show --spec failed" >&2; exit 1; }
-[[ "${SPEC_RENDERED}" != "No spec found for this plan" ]] || { echo "spec.toml was not persisted" >&2; exit 1; }
-printf '%s\n' "${SPEC_RENDERED}" | grep -q '^Criteria:$' || { echo "csa todo show --spec missing criteria section" >&2; exit 1; }
-printf '%s\n' "${SPEC_RENDERED}" | grep -q '^- \[pending\] ' || { echo "csa todo show --spec did not render pending criteria" >&2; exit 1; }
+# Artifacts validated → safe to persist. `csa todo persist` writes + commits
+# atomically under one TODO write lock and re-validates the core invariants
+# (checkbox task, DONE WHEN, spec criteria, epic DAG) before committing.
+TODO_PATH=$(csa todo persist -t "${TODO_TS}" --todo-file "${TODO_ARTIFACT}" --spec-file "${SPEC_ARTIFACT}" "${EPIC_ARGS[@]}" "finalize: ${FEATURE}") || { echo "csa todo persist failed" >&2; exit 1; }
+[[ -n "${TODO_PATH:-}" ]] || { echo "csa todo persist did not return a TODO path" >&2; exit 1; }
 csa todo show -t "${TODO_TS}" --path
 ```
 

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -667,7 +667,7 @@ to `${STEP_7_OUTPUT}` (draft TODO) since threat model/debate/revise are skipped.
 Spec comes from `${STEP_8_OUTPUT}` in both modes.
 Execute ONLY the command block below.
 FORBIDDEN: custom shell snippets, heredoc (`<<EOF`, `cat <<`), branch create/switch,
-and writing intermediate files outside the TODO path.
+and writing intermediate files outside `$CSA_SESSION_DIR/output` or csa todo state.
 
 ```bash
 # Resolve TODO content: revised (full) or draft (light)
@@ -719,23 +719,32 @@ if [[ -n "${RESOLVED_LANGUAGE:-}" ]]; then
   LANG_ARGS+=("--language" "${RESOLVED_LANGUAGE}")
 fi
 TODO_TS=$(csa todo create --branch "${CURRENT_BRANCH}" "${LANG_ARGS[@]}" -- "${FEATURE}" | head -n1) || { echo "csa todo create failed" >&2; exit 1; }
-TODO_PATH=$(csa todo show -t "${TODO_TS}" --path | head -n1) || { echo "csa todo show failed" >&2; exit 1; }
-SPEC_PATH="$(dirname "${TODO_PATH}")/spec.toml"
-printf '%s\n' "${FINAL_TODO}" > "${TODO_PATH}" || { echo "write TODO failed" >&2; exit 1; }
-# Extract and save epic-plan.toml if present in FINAL_TODO
+SAVE_DIR="${CSA_SESSION_DIR:?CSA_SESSION_DIR must be set}/output/mktd-save"
+mkdir -p "${SAVE_DIR}" || { echo "create mktd save output dir failed" >&2; exit 1; }
+TODO_ARTIFACT="${SAVE_DIR}/TODO.md"
+SPEC_ARTIFACT="${SAVE_DIR}/spec.toml"
+EPIC_ARTIFACT="${SAVE_DIR}/epic-plan.toml"
+printf '%s\n' "${FINAL_TODO}" > "${TODO_ARTIFACT}" || { echo "write TODO artifact failed" >&2; exit 1; }
+# Extract epic-plan.toml if present in FINAL_TODO; csa todo persist writes it to todo state.
 EPIC_PLAN=$(printf '%s\n' "${FINAL_TODO}" | sed -n '/^```epic-plan.toml$/,/^```$/p' | sed '1d;$d')
+EPIC_ARGS=()
 if [[ -n "${EPIC_PLAN:-}" ]]; then
-  EPIC_PATH="$(dirname "${TODO_PATH}")/epic-plan.toml"
-  printf '%s\n' "${EPIC_PLAN}" > "${EPIC_PATH}" || { echo "write epic-plan.toml failed" >&2; exit 1; }
-  [[ -s "${EPIC_PATH}" ]] || { echo "saved epic-plan.toml is empty" >&2; exit 1; }
-  # Validate via csa todo epic validate
+  printf '%s\n' "${EPIC_PLAN}" > "${EPIC_ARTIFACT}" || { echo "write epic-plan.toml artifact failed" >&2; exit 1; }
+  [[ -s "${EPIC_ARTIFACT}" ]] || { echo "epic-plan.toml artifact is empty" >&2; exit 1; }
+  EPIC_ARGS+=(--epic-plan-file "${EPIC_ARTIFACT}")
+fi
+SPEC_CONTENT="${STEP_8_OUTPUT//__PLAN_ID__/${TODO_TS}}"
+printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_ARTIFACT}" || { echo "write spec artifact failed" >&2; exit 1; }
+[[ -s "${TODO_ARTIFACT}" ]] || { echo "TODO artifact is empty" >&2; exit 1; }
+[[ -s "${SPEC_ARTIFACT}" ]] || { echo "spec artifact is empty" >&2; exit 1; }
+TODO_PATH=$(csa todo persist -t "${TODO_TS}" --todo-file "${TODO_ARTIFACT}" --spec-file "${SPEC_ARTIFACT}" "${EPIC_ARGS[@]}" "finalize: ${FEATURE}") || { echo "csa todo persist failed" >&2; exit 1; }
+SPEC_PATH="$(dirname "${TODO_PATH}")/spec.toml"
+[[ -s "${TODO_PATH}" ]] || { echo "saved TODO is empty" >&2; exit 1; }
+[[ -s "${SPEC_PATH}" ]] || { echo "saved spec is empty" >&2; exit 1; }
+if [[ -n "${EPIC_PLAN:-}" ]]; then
   csa todo epic validate -t "${TODO_TS}" 2>&1 || { echo "epic-plan.toml validation failed" >&2; exit 1; }
   echo "Epic plan saved and validated" >&2
 fi
-SPEC_CONTENT="${STEP_8_OUTPUT//__PLAN_ID__/${TODO_TS}}"
-printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_PATH}" || { echo "write spec failed" >&2; exit 1; }
-[[ -s "${TODO_PATH}" ]] || { echo "saved TODO is empty" >&2; exit 1; }
-[[ -s "${SPEC_PATH}" ]] || { echo "saved spec is empty" >&2; exit 1; }
 grep -qE '^- \[ \] .+' "${TODO_PATH}" || { echo "saved TODO has no non-empty checkbox tasks" >&2; exit 1; }
 grep -q 'DONE WHEN:' "${TODO_PATH}" || { echo "saved TODO has no DONE WHEN clauses" >&2; exit 1; }
 grep -q '^schema_version = 1$' "${SPEC_PATH}" || { echo "saved spec missing schema_version = 1" >&2; exit 1; }
@@ -757,7 +766,6 @@ if [[ -n "${RESOLVED_LANGUAGE:-}" ]]; then
     [[ "${HAN_META_CHECK:-0}" -ge 2 ]] || { echo "language metadata mismatch: plan language is ${RESOLVED_LANGUAGE} but content lacks Han characters" >&2; exit 1; }
   fi
 fi
-csa todo save -t "${TODO_TS}" "finalize: ${FEATURE}" || { echo "csa todo save failed" >&2; exit 1; }
 SPEC_RENDERED=$(csa todo show -t "${TODO_TS}" --spec) || { echo "csa todo show --spec failed" >&2; exit 1; }
 [[ "${SPEC_RENDERED}" != "No spec found for this plan" ]] || { echo "spec.toml was not persisted" >&2; exit 1; }
 printf '%s\n' "${SPEC_RENDERED}" | grep -q '^Criteria:$' || { echo "csa todo show --spec missing criteria section" >&2; exit 1; }

--- a/patterns/mktd/skills/mktd/SKILL.md
+++ b/patterns/mktd/skills/mktd/SKILL.md
@@ -87,7 +87,7 @@ breaks prompt-guard propagation.
 5. **Phase 3 -- DEBATE** *(skipped in light mode)*: Run explicit `csa debate` (uses global `[debate]` config) via bash step, then normalize stdout into an evidence packet with headers: `DEBATE_EVIDENCE`, `VALID_CONCERNS`, `SUGGESTED_CHANGES`, `OVERALL_ASSESSMENT`. The red-team MUST enumerate every TODO-plan assumption and construct a counterexample scenario for each.
 6. **Phase 3.5 -- DEBATE VALIDATION** *(skipped in light mode)*: Hard-fail if required evidence headers, mapped verdict (`READY|REVISE`), raw verdict (`APPROVE|REVISE|REJECT|UNKNOWN`), or confidence are missing.
 7. **Phase 3b -- REVISE** *(skipped in light mode)*: Incorporate debate feedback and threat model findings. Concede valid points, defend sound decisions. Output the complete revised plan as text (stdout).
-8. **Phase 4 -- SAVE**: Save TODO via `csa todo create --branch <branch> --language <resolved-language>`. In full mode, writes `${STEP_12_OUTPUT}` (revised TODO); in light mode, falls back to `${STEP_7_OUTPUT}` (draft TODO). Persists `spec.toml` from `${STEP_8_OUTPUT}`, then `csa todo save`. The save step returns the TODO path as `${STEP_13_OUTPUT}` and MUST validate non-empty checkbox tasks, `DONE WHEN` clauses, and language consistency.
+8. **Phase 4 -- SAVE**: Allocate the plan slot via `csa todo create --branch <branch> --language <resolved-language>` (returns the plan timestamp). The rendered TODO is `${STEP_12_OUTPUT}` (revised plan) in full mode, falling back to `${STEP_7_OUTPUT}` (draft plan) in light mode. Render the TODO, `spec.toml` (from `${STEP_8_OUTPUT}`), and any `epic-plan.toml` to session-output artifacts under `${CSA_SESSION_DIR}/output/mktd-save/`, then **validate those rendered artifacts BEFORE committing** (non-empty checkbox tasks, `DONE WHEN` clauses, spec criteria, language consistency) so an invalid plan never reaches the commit (round-5 ordering). Commit atomically with `csa todo persist -t <timestamp> --todo-file <TODO.md> --spec-file <spec.toml> [--epic-plan-file <epic-plan.toml>] "finalize: <feature>"`, which writes and commits under one TODO write lock and re-validates the core invariants fail-closed. The persist step returns the saved TODO path as `${STEP_13_OUTPUT}`.
 9. **Phase 4.25 -- PERSIST REFERENCES**: Persist RECON findings, threat model, debate evidence, and a consolidated `design.md` reference using `${STEP_13_OUTPUT}` as the saved TODO path anchor.
 10. **Phase 4.5 -- APPROVE**: Present to user in `${STEP_2_OUTPUT}` for APPROVE / MODIFY / REJECT.
 
@@ -114,7 +114,7 @@ context via `csa todo ref show <name>` without bloating their context window.
 
 - **Uses**: `debate` (Phase 3 adversarial review)
 - **Feeds into**: `mktsk` (converts approved TODO into executable Task entries)
-- **Lifecycle**: Plans managed by `csa todo` (create, show, save, find)
+- **Lifecycle**: Plans managed by `csa todo` (create, persist, show, find)
 - **References**: RECON/debate findings persisted via `csa todo ref add` for
   progressive disclosure during plan execution
 
@@ -130,7 +130,7 @@ context via `csa todo ref show <name>` without bloating their context window.
 8. *(full mode only)* Debate evidence packet validated (includes mapped verdict, raw verdict, and confidence).
 9. *(full mode only)* Debate Findings section captures adopted vs deferred points.
 10. *(full mode only)* TODO revised to incorporate debate feedback and threat model findings.
-11. TODO saved via `csa todo create` + `csa todo save` with branch and language association.
-12. Save gate validated task completeness (`- [ ] ...`, `DONE WHEN`) and language consistency.
+11. TODO saved via `csa todo create` + `csa todo persist` (artifact-file flow) with branch and language association.
+12. Pre-persist validation gate checked the rendered artifacts for task completeness (`- [ ] ...`, `DONE WHEN`), spec criteria, and language consistency BEFORE the commit; `csa todo persist` re-validated the core invariants fail-closed under the write lock.
 13. Design document and RECON references attempted via `csa todo ref add` (stored in `~/.local/state/cli-sub-agent/`, not git-tracked).
 14. User presented with plan for approval decision in resolved language.

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -63,12 +63,6 @@ name = "SPEC_CONTENT"
 name = "SPEC_ARTIFACT"
 
 [[workflow.variables]]
-name = "SPEC_PATH"
-
-[[workflow.variables]]
-name = "SPEC_RENDERED"
-
-[[workflow.variables]]
 name = "STEP_1_OUTPUT"
 
 [[workflow.variables]]
@@ -738,34 +732,8 @@ FINAL_TODO=$(printf '%s\n' "${FINAL_TODO}" | awk '
   /^<!-- CSA:ADR:END -->$/ { in_adr=0; next }
   !in_adr { print }
 ')
-printf '%s\n' "${FINAL_TODO}" | grep -qE '^- \[ \] .+' || { echo "TODO has no non-empty checkbox tasks" >&2; exit 1; }
-printf '%s\n' "${FINAL_TODO}" | grep -q 'DONE WHEN:' || { echo "TODO has no DONE WHEN clauses" >&2; exit 1; }
 [[ -n "${STEP_8_OUTPUT:-}" ]] || { echo "STEP_8_OUTPUT is empty — Step 8 must output spec.toml content" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^schema_version = 1$' || { echo "STEP_8_OUTPUT missing schema_version = 1" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^plan_ulid = "__PLAN_ID__"$' || { echo "STEP_8_OUTPUT missing __PLAN_ID__ placeholder" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^summary = "' || { echo "STEP_8_OUTPUT missing summary" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^\[\[criteria\]\]$' || { echo "STEP_8_OUTPUT has no criteria entries" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | rg -q '^kind = "(scenario|property|check)"$' || { echo "STEP_8_OUTPUT has invalid criterion kinds" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^id = "' || { echo "STEP_8_OUTPUT missing criterion id" >&2; exit 1; }
-printf '%s\n' "${STEP_8_OUTPUT}" | grep -q '^description = "' || { echo "STEP_8_OUTPUT missing criterion description" >&2; exit 1; }
-SUMMARY_LINE=$(printf '%s\n' "${STEP_8_OUTPUT}" | sed -n 's/^summary = "\(.*\)"$/\1/p' | head -n1)
-printf '%s' "${SUMMARY_LINE}" | rg -q '[\p{Han}]' || { echo "STEP_8_OUTPUT summary must be one Chinese line" >&2; exit 1; }
 RESOLVED_LANGUAGE="${STEP_2_OUTPUT:-Chinese (Simplified)}"
-if printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'chinese'; then
-  TASK_COUNT=$(printf '%s\n' "${FINAL_TODO}" | grep -cE '^- \[ \] .+')
-  MIN_HAN="${TASK_COUNT}"
-  if [ "${MIN_HAN}" -lt 2 ]; then MIN_HAN=2; fi
-  if [ "${MIN_HAN}" -gt 30 ]; then MIN_HAN=30; fi
-  HAN_COUNT_DRAFT=$(printf '%s\n' "${FINAL_TODO}" | rg -o '[\p{Han}]' | wc -l | tr -d '[:space:]')
-  [[ "${HAN_COUNT_DRAFT:-0}" -ge "${MIN_HAN}" ]] || { echo "TODO language mismatch: expected Han-script content (Han chars >= ${MIN_HAN})" >&2; exit 1; }
-elif printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'han script'; then
-  TASK_COUNT=$(printf '%s\n' "${FINAL_TODO}" | grep -cE '^- \[ \] .+')
-  MIN_CJK="${TASK_COUNT}"
-  if [ "${MIN_CJK}" -lt 2 ]; then MIN_CJK=2; fi
-  if [ "${MIN_CJK}" -gt 30 ]; then MIN_CJK=30; fi
-  CJK_COUNT_DRAFT=$(printf '%s\n' "${FINAL_TODO}" | rg -o '[\p{Han}\p{Hiragana}\p{Katakana}]' | wc -l | tr -d '[:space:]')
-  [[ "${CJK_COUNT_DRAFT:-0}" -ge "${MIN_CJK}" ]] || { echo "TODO language mismatch: expected CJK-script content (CJK chars >= ${MIN_CJK})" >&2; exit 1; }
-fi
 CURRENT_BRANCH=$(git branch --show-current) || { echo "detect branch failed" >&2; exit 1; }
 LANG_ARGS=()
 if [[ -n "${RESOLVED_LANGUAGE:-}" ]]; then
@@ -790,31 +758,44 @@ SPEC_CONTENT="${STEP_8_OUTPUT//__PLAN_ID__/${TODO_TS}}"
 printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_ARTIFACT}" || { echo "write spec artifact failed" >&2; exit 1; }
 [[ -s "${TODO_ARTIFACT}" ]] || { echo "TODO artifact is empty" >&2; exit 1; }
 [[ -s "${SPEC_ARTIFACT}" ]] || { echo "spec artifact is empty" >&2; exit 1; }
-TODO_PATH=$(csa todo persist -t "${TODO_TS}" --todo-file "${TODO_ARTIFACT}" --spec-file "${SPEC_ARTIFACT}" "${EPIC_ARGS[@]}" "finalize: ${FEATURE}") || { echo "csa todo persist failed" >&2; exit 1; }
-SPEC_PATH="$(dirname "${TODO_PATH}")/spec.toml"
-[[ -s "${TODO_PATH}" ]] || { echo "saved TODO is empty" >&2; exit 1; }
-[[ -s "${SPEC_PATH}" ]] || { echo "saved spec is empty" >&2; exit 1; }
-if [[ -n "${EPIC_PLAN:-}" ]]; then
-  csa todo epic validate -t "${TODO_TS}" 2>&1 || { echo "epic-plan.toml validation failed" >&2; exit 1; }
-  echo "Epic plan saved and validated" >&2
-fi
-grep -qE '^- \[ \] .+' "${TODO_PATH}" || { echo "saved TODO has no non-empty checkbox tasks" >&2; exit 1; }
-grep -q 'DONE WHEN:' "${TODO_PATH}" || { echo "saved TODO has no DONE WHEN clauses" >&2; exit 1; }
-grep -q '^schema_version = 1$' "${SPEC_PATH}" || { echo "saved spec missing schema_version = 1" >&2; exit 1; }
-grep -q "^plan_ulid = \"${TODO_TS}\"$" "${SPEC_PATH}" || { echo "saved spec plan_ulid mismatch" >&2; exit 1; }
-grep -q '^summary = "' "${SPEC_PATH}" || { echo "saved spec missing summary" >&2; exit 1; }
-grep -q '^\[\[criteria\]\]$' "${SPEC_PATH}" || { echo "saved spec has no criteria entries" >&2; exit 1; }
+# Hard-gate: validate the RENDERED artifacts BEFORE `csa todo persist` commits
+# them. An invalid plan must NEVER reach the persist/commit step (#1820/#1822
+# hard-gate contract; round-5 ordering fix). `csa todo persist` ALSO re-checks
+# the core invariants fail-closed inside its locked commit (defense-in-depth)
+# — including the spec-criteria check that replaces the former post-commit
+# `csa todo show --spec` render gate — so NO content validation runs after the
+# commit.
+grep -qE '^- \[ \] .+' "${TODO_ARTIFACT}" || { echo "TODO artifact has no non-empty checkbox tasks" >&2; exit 1; }
+grep -q 'DONE WHEN:' "${TODO_ARTIFACT}" || { echo "TODO artifact has no DONE WHEN clauses" >&2; exit 1; }
+grep -q '^schema_version = 1$' "${SPEC_ARTIFACT}" || { echo "spec artifact missing schema_version = 1" >&2; exit 1; }
+grep -q "^plan_ulid = \"${TODO_TS}\"$" "${SPEC_ARTIFACT}" || { echo "spec artifact plan_ulid unresolved or mismatched" >&2; exit 1; }
+grep -q '^summary = "' "${SPEC_ARTIFACT}" || { echo "spec artifact missing summary" >&2; exit 1; }
+grep -q '^\[\[criteria\]\]$' "${SPEC_ARTIFACT}" || { echo "spec artifact has no criteria entries" >&2; exit 1; }
+rg -q '^kind = "(scenario|property|check)"$' "${SPEC_ARTIFACT}" || { echo "spec artifact has invalid criterion kinds" >&2; exit 1; }
+grep -q '^id = "' "${SPEC_ARTIFACT}" || { echo "spec artifact missing criterion id" >&2; exit 1; }
+grep -q '^description = "' "${SPEC_ARTIFACT}" || { echo "spec artifact missing criterion description" >&2; exit 1; }
+SUMMARY_LINE=$(sed -n 's/^summary = "\(.*\)"$/\1/p' "${SPEC_ARTIFACT}" | head -n1)
+printf '%s' "${SUMMARY_LINE}" | rg -q '[\p{Han}]' || { echo "spec artifact summary must be one Chinese line" >&2; exit 1; }
 if printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'chinese'; then
-  HAN_COUNT_SAVED=$(rg -o '[\p{Han}]' "${TODO_PATH}" | wc -l | tr -d '[:space:]')
-  [[ "${HAN_COUNT_SAVED:-0}" -ge "${MIN_HAN:-2}" ]] || { echo "saved TODO language mismatch: expected Han-script content (Han chars >= ${MIN_HAN:-2})" >&2; exit 1; }
+  TASK_COUNT=$(grep -cE '^- \[ \] .+' "${TODO_ARTIFACT}")
+  MIN_HAN="${TASK_COUNT}"
+  if [ "${MIN_HAN}" -lt 2 ]; then MIN_HAN=2; fi
+  if [ "${MIN_HAN}" -gt 30 ]; then MIN_HAN=30; fi
+  HAN_COUNT=$(rg -o '[\p{Han}]' "${TODO_ARTIFACT}" | wc -l | tr -d '[:space:]')
+  [[ "${HAN_COUNT:-0}" -ge "${MIN_HAN}" ]] || { echo "TODO artifact language mismatch: expected Han-script content (Han chars >= ${MIN_HAN})" >&2; exit 1; }
 elif printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'han script'; then
-  CJK_COUNT_SAVED=$(rg -o '[\p{Han}\p{Hiragana}\p{Katakana}]' "${TODO_PATH}" | wc -l | tr -d '[:space:]')
-  [[ "${CJK_COUNT_SAVED:-0}" -ge "${MIN_CJK:-2}" ]] || { echo "saved TODO language mismatch: expected CJK-script content (CJK chars >= ${MIN_CJK:-2})" >&2; exit 1; }
+  TASK_COUNT=$(grep -cE '^- \[ \] .+' "${TODO_ARTIFACT}")
+  MIN_CJK="${TASK_COUNT}"
+  if [ "${MIN_CJK}" -lt 2 ]; then MIN_CJK=2; fi
+  if [ "${MIN_CJK}" -gt 30 ]; then MIN_CJK=30; fi
+  CJK_COUNT=$(rg -o '[\p{Han}\p{Hiragana}\p{Katakana}]' "${TODO_ARTIFACT}" | wc -l | tr -d '[:space:]')
+  [[ "${CJK_COUNT:-0}" -ge "${MIN_CJK}" ]] || { echo "TODO artifact language mismatch: expected CJK-script content (CJK chars >= ${MIN_CJK})" >&2; exit 1; }
 fi
-SPEC_RENDERED=$(csa todo show -t "${TODO_TS}" --spec) || { echo "csa todo show --spec failed" >&2; exit 1; }
-[[ "${SPEC_RENDERED}" != "No spec found for this plan" ]] || { echo "spec.toml was not persisted" >&2; exit 1; }
-printf '%s\n' "${SPEC_RENDERED}" | grep -q '^Criteria:$' || { echo "csa todo show --spec missing criteria section" >&2; exit 1; }
-printf '%s\n' "${SPEC_RENDERED}" | grep -q '^- \[pending\] ' || { echo "csa todo show --spec did not render pending criteria" >&2; exit 1; }
+# Artifacts validated → safe to persist. `csa todo persist` writes + commits
+# atomically under one TODO write lock and re-validates the core invariants
+# (checkbox task, DONE WHEN, spec criteria, epic DAG) before committing.
+TODO_PATH=$(csa todo persist -t "${TODO_TS}" --todo-file "${TODO_ARTIFACT}" --spec-file "${SPEC_ARTIFACT}" "${EPIC_ARGS[@]}" "finalize: ${FEATURE}") || { echo "csa todo persist failed" >&2; exit 1; }
+[[ -n "${TODO_PATH:-}" ]] || { echo "csa todo persist did not return a TODO path" >&2; exit 1; }
 csa todo show -t "${TODO_TS}" --path
 ```'''
 on_fail = "abort"

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -766,7 +766,24 @@ printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_ARTIFACT}" || { echo "write spec artif
 # `csa todo show --spec` render gate — so NO content validation runs after the
 # commit.
 grep -qE '^- \[ \] .+' "${TODO_ARTIFACT}" || { echo "TODO artifact has no non-empty checkbox tasks" >&2; exit 1; }
-grep -q 'DONE WHEN:' "${TODO_ARTIFACT}" || { echo "TODO artifact has no DONE WHEN clauses" >&2; exit 1; }
+# Per-task gate: EVERY open checkbox task must carry its OWN mechanically
+# verifiable `DONE WHEN:` clause (AGENTS.md Meta 005). A single global match is
+# insufficient — a bare keyword mention in a subject, or one task's clause, must
+# not cover another open task's gap. `csa todo persist` re-applies the same
+# per-task check fail-closed under the write lock (defense-in-depth).
+awk '
+function flush() { if (in_open == 1 && has_clause == 0) bad = 1; in_open = 0; has_clause = 0 }
+function scan(text,   pos, rest) {
+  pos = index(text, "DONE WHEN:")
+  if (pos > 0) { rest = substr(text, pos + 10); sub(/^[ \t]+/, "", rest); if (length(rest) > 0) has_clause = 1 }
+}
+{
+  is_open = ($0 ~ /^- \[ \] .+/)
+  if ($0 ~ /^- \[[ xX]\]/ || $0 ~ /^#/) { flush(); if (is_open == 1) { in_open = 1; scan($0) }; next }
+  if (in_open == 1) scan($0)
+}
+END { flush(); exit (bad + 0) }
+' "${TODO_ARTIFACT}" || { echo "TODO artifact has an open task without a mechanically-verifiable DONE WHEN: clause" >&2; exit 1; }
 grep -q '^schema_version = 1$' "${SPEC_ARTIFACT}" || { echo "spec artifact missing schema_version = 1" >&2; exit 1; }
 grep -q "^plan_ulid = \"${TODO_TS}\"$" "${SPEC_ARTIFACT}" || { echo "spec artifact plan_ulid unresolved or mismatched" >&2; exit 1; }
 grep -q '^summary = "' "${SPEC_ARTIFACT}" || { echo "spec artifact missing summary" >&2; exit 1; }

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -24,6 +24,9 @@ name = "FINAL_TODO"
 name = "EPIC_PLAN"
 
 [[workflow.variables]]
+name = "EPIC_ARTIFACT"
+
+[[workflow.variables]]
 name = "FEATURE"
 
 [[workflow.variables]]
@@ -51,7 +54,13 @@ name = "RESOLVED_LANGUAGE"
 name = "SID"
 
 [[workflow.variables]]
+name = "SAVE_DIR"
+
+[[workflow.variables]]
 name = "SPEC_CONTENT"
+
+[[workflow.variables]]
+name = "SPEC_ARTIFACT"
 
 [[workflow.variables]]
 name = "SPEC_PATH"
@@ -103,6 +112,9 @@ name = "TASK_COUNT"
 
 [[workflow.variables]]
 name = "TODO_PATH"
+
+[[workflow.variables]]
+name = "TODO_ARTIFACT"
 
 [[workflow.variables]]
 name = "TODO_TS"
@@ -708,7 +720,7 @@ back to `${STEP_7_OUTPUT}` (draft TODO) since threat model/debate/revise are ski
 Spec comes from `${STEP_8_OUTPUT}` in both modes.
 Execute ONLY the command block below.
 FORBIDDEN: custom shell snippets, heredoc (`<<EOF`, `cat <<`), branch create/switch,
-and writing intermediate files outside the TODO path.
+and writing intermediate files outside `$CSA_SESSION_DIR/output` or csa todo state.
 
 ```bash
 # Resolve TODO content: revised (full) or draft (light)
@@ -760,23 +772,32 @@ if [[ -n "${RESOLVED_LANGUAGE:-}" ]]; then
   LANG_ARGS+=("--language" "${RESOLVED_LANGUAGE}")
 fi
 TODO_TS=$(csa todo create --branch "${CURRENT_BRANCH}" "${LANG_ARGS[@]}" -- "${FEATURE}" | head -n1) || { echo "csa todo create failed" >&2; exit 1; }
-TODO_PATH=$(csa todo show -t "${TODO_TS}" --path | head -n1) || { echo "csa todo show failed" >&2; exit 1; }
-SPEC_PATH="$(dirname "${TODO_PATH}")/spec.toml"
-printf '%s\n' "${FINAL_TODO}" > "${TODO_PATH}" || { echo "write TODO failed" >&2; exit 1; }
-# Extract and save epic-plan.toml if present in FINAL_TODO
+SAVE_DIR="${CSA_SESSION_DIR:?CSA_SESSION_DIR must be set}/output/mktd-save"
+mkdir -p "${SAVE_DIR}" || { echo "create mktd save output dir failed" >&2; exit 1; }
+TODO_ARTIFACT="${SAVE_DIR}/TODO.md"
+SPEC_ARTIFACT="${SAVE_DIR}/spec.toml"
+EPIC_ARTIFACT="${SAVE_DIR}/epic-plan.toml"
+printf '%s\n' "${FINAL_TODO}" > "${TODO_ARTIFACT}" || { echo "write TODO artifact failed" >&2; exit 1; }
+# Extract epic-plan.toml if present in FINAL_TODO; csa todo persist writes it to todo state.
 EPIC_PLAN=$(printf '%s\n' "${FINAL_TODO}" | sed -n '/^```epic-plan.toml$/,/^```$/p' | sed '1d;$d')
+EPIC_ARGS=()
 if [[ -n "${EPIC_PLAN:-}" ]]; then
-  EPIC_PATH="$(dirname "${TODO_PATH}")/epic-plan.toml"
-  printf '%s\n' "${EPIC_PLAN}" > "${EPIC_PATH}" || { echo "write epic-plan.toml failed" >&2; exit 1; }
-  [[ -s "${EPIC_PATH}" ]] || { echo "saved epic-plan.toml is empty" >&2; exit 1; }
-  # Validate via csa todo epic validate
+  printf '%s\n' "${EPIC_PLAN}" > "${EPIC_ARTIFACT}" || { echo "write epic-plan.toml artifact failed" >&2; exit 1; }
+  [[ -s "${EPIC_ARTIFACT}" ]] || { echo "epic-plan.toml artifact is empty" >&2; exit 1; }
+  EPIC_ARGS+=(--epic-plan-file "${EPIC_ARTIFACT}")
+fi
+SPEC_CONTENT="${STEP_8_OUTPUT//__PLAN_ID__/${TODO_TS}}"
+printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_ARTIFACT}" || { echo "write spec artifact failed" >&2; exit 1; }
+[[ -s "${TODO_ARTIFACT}" ]] || { echo "TODO artifact is empty" >&2; exit 1; }
+[[ -s "${SPEC_ARTIFACT}" ]] || { echo "spec artifact is empty" >&2; exit 1; }
+TODO_PATH=$(csa todo persist -t "${TODO_TS}" --todo-file "${TODO_ARTIFACT}" --spec-file "${SPEC_ARTIFACT}" "${EPIC_ARGS[@]}" "finalize: ${FEATURE}") || { echo "csa todo persist failed" >&2; exit 1; }
+SPEC_PATH="$(dirname "${TODO_PATH}")/spec.toml"
+[[ -s "${TODO_PATH}" ]] || { echo "saved TODO is empty" >&2; exit 1; }
+[[ -s "${SPEC_PATH}" ]] || { echo "saved spec is empty" >&2; exit 1; }
+if [[ -n "${EPIC_PLAN:-}" ]]; then
   csa todo epic validate -t "${TODO_TS}" 2>&1 || { echo "epic-plan.toml validation failed" >&2; exit 1; }
   echo "Epic plan saved and validated" >&2
 fi
-SPEC_CONTENT="${STEP_8_OUTPUT//__PLAN_ID__/${TODO_TS}}"
-printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_PATH}" || { echo "write spec failed" >&2; exit 1; }
-[[ -s "${TODO_PATH}" ]] || { echo "saved TODO is empty" >&2; exit 1; }
-[[ -s "${SPEC_PATH}" ]] || { echo "saved spec is empty" >&2; exit 1; }
 grep -qE '^- \[ \] .+' "${TODO_PATH}" || { echo "saved TODO has no non-empty checkbox tasks" >&2; exit 1; }
 grep -q 'DONE WHEN:' "${TODO_PATH}" || { echo "saved TODO has no DONE WHEN clauses" >&2; exit 1; }
 grep -q '^schema_version = 1$' "${SPEC_PATH}" || { echo "saved spec missing schema_version = 1" >&2; exit 1; }
@@ -790,7 +811,6 @@ elif printf '%s' "${RESOLVED_LANGUAGE}" | grep -qi 'han script'; then
   CJK_COUNT_SAVED=$(rg -o '[\p{Han}\p{Hiragana}\p{Katakana}]' "${TODO_PATH}" | wc -l | tr -d '[:space:]')
   [[ "${CJK_COUNT_SAVED:-0}" -ge "${MIN_CJK:-2}" ]] || { echo "saved TODO language mismatch: expected CJK-script content (CJK chars >= ${MIN_CJK:-2})" >&2; exit 1; }
 fi
-csa todo save -t "${TODO_TS}" "finalize: ${FEATURE}" || { echo "csa todo save failed" >&2; exit 1; }
 SPEC_RENDERED=$(csa todo show -t "${TODO_TS}" --spec) || { echo "csa todo show --spec failed" >&2; exit 1; }
 [[ "${SPEC_RENDERED}" != "No spec found for this plan" ]] || { echo "spec.toml was not persisted" >&2; exit 1; }
 printf '%s\n' "${SPEC_RENDERED}" | grep -q '^Criteria:$' || { echo "csa todo show --spec missing criteria section" >&2; exit 1; }

--- a/scripts/check-chinese.sh
+++ b/scripts/check-chinese.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rg "\p{Script=Han}" . --vimgrep \
+  --glob '!target/**' \
+  --glob '!.git/**' \
+  --glob '!output/**' \
+  --glob '!**/i18n/*.ftl' \
+  --glob '!skills/mktd/**' \
+  --glob '!tests/fixtures/**' \
+  --glob '!.claude/rules/**' \
+  --glob '!.agents/**' \
+  --glob '!CLAUDE.md' \
+  --glob '!GEMINI.md'

--- a/scripts/tests/check-chinese.sh
+++ b/scripts/tests/check-chinese.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECKER="${ROOT_DIR}/scripts/check-chinese.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/output" "${TMP_DIR}/src"
+
+printf '\346\261\211\n' > "${TMP_DIR}/output/spec.toml"
+if (cd "${TMP_DIR}" && "${CHECKER}"); then
+  echo "expected generated output Han characters to be ignored" >&2
+  exit 1
+fi
+
+printf '\346\261\211\n' > "${TMP_DIR}/src/main.rs"
+if ! (cd "${TMP_DIR}" && "${CHECKER}"); then
+  echo "expected source Han characters to be detected" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes a four-issue cluster (all split from parent #1653) sharing ONE root cause:
**mktd planning sessions were treated as code-writing sessions.** A `csa run --skill
mktd` planning run was (1) failed by the post-exec code commit gate (`just pre-commit`
→ `check-chinese`) even though it produced only a plan; (2) left plan artifacts
(`details.md`, `revised_todo.md`, `spec.toml`, `threat_model.md`) in the repo working
tree (unignored → commit-pollution risk); and (3) did not persist the produced plan to
`csa todo` atomically, so `csa todo show` still showed the prior plan and `mktsk` could
not pick the new one up.

## Changes (atomic commits, one per concern)

- **#1819 — planning sessions skip the code commit gate** (`2665704a`). `--skill mktd`
  runs are now treated as planning-only for post-exec-gate purposes, so a plan-only
  session is not failed by `just pre-commit`/`check-chinese`. Plan-production success is
  reported independently of any code-gate status.
  (`run_cmd_execute_post_exec_gate.rs`, test in `run_cmd_execute_post_exec_tests.rs`)
- **#1820 — mktd artifacts go to session output, not the repo** (`c9ca1304`). mktd SAVE
  is routed through session-output artifacts plus `csa todo persist` instead of a
  repo-root `output/` directory, leaving the working tree clean after a planning run.
  **Rule-027 sync**: `patterns/mktd/PATTERN.md` and `patterns/mktd/workflow.toml` updated
  together in this commit; test in `plan_cmd_tests_workflows.rs`.
- **#1821 — source checks exclude generated output** (`cc4e511e`). The Han-script source
  check is extracted into a reusable `scripts/check-chinese.sh` that excludes generated
  output while still catching real source violations. (`justfile`,
  `scripts/check-chinese.sh`, test `scripts/tests/check-chinese.sh`)
- **#1822 — atomic plan persistence** (`f849f80c`). New `csa todo persist` writes
  TODO/spec artifacts through `TodoManager` atomically, so a successful plan is persisted
  to `csa todo` independent of any later post-exec gate failure (no longer surviving only
  as loose `output/*.md`). Includes a monolith-split of `main.rs` into
  `todo_dispatch_cmd.rs`/`todo_persist_cmd.rs` to respect the module-size gate.
  (`csa-todo/src/generated_plan.rs`, `todo_persist_cmd.rs`, tests in
  `todo_persist_cmd_tests.rs` + `csa-todo/tests/spec_lifecycle.rs`)

## Review iterations

- **Round 2** (`00bf30ed`): restore `TodoSave` hook emission for `csa todo persist`. Round-1
  review caught that the new `handle_persist` committed plans without firing the
  `HookEvent::TodoSave` that `csa todo save` fired, silently dropping `todo_save` hooks for
  mktd-generated plans. Fixed by extracting the emission into a shared `todo_hooks` helper
  called by both `handle_save` and `handle_persist`, with a regression test.
- **Round 3** (`08f8d013`): allow `csa todo persist` through the skill-executor guard.
  Round-2 review caught that the mktd executor's `csa todo persist` invocation was rejected
  by the skill-executor command guard because `["todo","persist"]` was missing from
  `EXECUTOR_SAFE_CSA_COMMAND_PREFIXES` — the new persist path could never run inside a
  skill executor. Fixed by adding the prefix, with a guard test.
- **Round 4** (`6d6498be`): serialize the generated-plan publish under the TODO write lock.
  Round-3 review caught a TOCTOU — `handle_persist` wrote the plan under `with_write_lock`
  but **released the lock before** `ensure_git_init`/`save_files`/`TodoSave`, so a concurrent
  writer could replace the snapshot before commit (lost update / wrong-content commit,
  AGENTS Rust 017). Fixed with a new `persist_generated_plan_with<T>` that holds the write
  lock across validation + atomic writes **and** the commit closure (`csa-todo` core stays
  app-independent via a generic closure seam); the hook still fires on the in-lock commit
  hash (round-2 preserved) and the round-3 guard entry is preserved. New regression test
  proves a competing `try_write()` is **denied** while the commit runs.
- **Round 5** (`9e655c52`): validate the mktd plan **before** the persist commit. Round-4
  review caught a P1 ordering regression — the mktd workflow committed the plan via
  `csa todo persist` **before** its hard-validation block ran, so an invalid plan could
  enter todo git history even when `on_fail = "abort"` later fired (a regression from #1820's
  rewiring). Fixed in two parts: **(A)** reordered the mktd workflow so artifact validation
  (checkbox tasks, `DONE WHEN`, language) runs **before** `csa todo persist`
  (`PATTERN.md` + `workflow.toml` synced, rule 027; dropped the now-orphaned
  `SPEC_PATH`/`SPEC_RENDERED` workflow variables); **(B)** made `csa todo persist`
  fail-closed — it validates the core invariants (checkbox / `DONE WHEN` / non-empty spec
  criteria) inside the locked publish **before** `save_files` commits, so a direct CLI call
  cannot commit invalid content either. New regression test proves invalid content yields
  **no** new todos-git commit; epic-plan and light-mode paths swept (no sibling gap).
- **Round 6** (`7283a4dd`): compute the `TodoSave` persist hook `{version}` under the write
  lock. Round-5 review caught a MEDIUM concurrency finding — `emit_todo_save_hook` recomputed
  `{version}` via `list_versions().len()` **after** the lock was released, so under concurrent
  saves the persist hook could report a later version count rather than "versions after this
  save" (`docs/hooks.md:187`). Fixed by computing the version inside the round-4 publish
  closure (under the lock, right after the commit) and forwarding it to the hook. Self-sweep
  audited all six hook variables and confirmed `commit_hash` and `message` are likewise
  captured under the lock — no post-release git read remains on the persist path. The
  pre-existing `csa todo save` sibling (same helper) is deferred to **#1839**.
- **Round 7** (`ecc785f1`): sync the mktd skill entry to the `csa todo persist` contract.
  Round-6 review caught a [P2][contract] skill↔pattern drift — `patterns/mktd/skills/mktd/SKILL.md`
  still documented the obsolete `csa todo save` path (Phase 4 command + Done Criteria) while the
  executable workflow/pattern (#1820) had moved to `csa todo persist` with session-output artifacts,
  so a `/mktd` user or orchestrator following the skill could reintroduce the old save behavior and
  bypass the new hard-gate / lock-scoped commit semantics. Fixed by updating the two stale command
  sites to `csa todo persist`. A repo-wide sweep confirmed no other mktd-flow `csa todo save`
  references remain (the surviving occurrence is the genuine standalone `csa todo save` subcommand,
  not the plan-persist flow). The "SAVE" phase **label** was deliberately preserved to stay in sync
  with `workflow.toml`/`PATTERN.md` (which still title the step "Save TODO") — only the underlying
  command string changed, so no new skill↔pattern drift is introduced.
- **Round 8** (`0d3d666f`): require a per-task `DONE WHEN` clause in the generated-plan hard gate.
  Round-7 review caught a [P1][contract] gap — the round-5/6 hard gate validated `DONE WHEN`
  **globally** (`generated_plan.rs` used `contains("DONE WHEN")` — no colon; `workflow.toml` /
  `PATTERN.md` used a single global `grep`), so a plan whose subject merely mentions the words, or
  a multi-task plan where only one task carries a clause, would pass — violating AGENTS.md Meta 005
  (every open task needs a mechanically-verifiable clause). Fixed at all 3 sites with a per-task
  scan: each OPEN `- [ ]` task block must contain a `DONE WHEN:` clause with non-empty criteria
  (`- [x]` completed tasks exempt). The class-sweep also caught and closed a "clause-on-completed-task"
  loophole; a 4th redundant sibling in `dev2merge` is deferred to **#1843**. Regression tests prove
  both rejection (subject-mention, partial-clause) and acceptance (subject-line + following-line
  placements, completed-exempt). PATTERN.md↔workflow.toml synced; `weave compile` + workspace
  `clippy -D warnings` clean.
- **Round 9** (`bd108136`): run the post-exec gate when an mktd planning run dirties tracked source.
  Round-8 review caught a [P1][regression] in #1819's gate-skip — `planning_only` was set purely by
  skill name (`skill == "mktd"`), so an mktd run that accidentally edited tracked source (mktd still
  grants `Write`/`Edit`) would skip the post-exec verification gate while still reporting `success`.
  Fixed by making the skip **effect-based**: a planning-only run skips the gate ONLY when the project
  worktree has no dirty TRACKED changes (`git diff --quiet` + `--cached`; session-output artifacts
  excluded per #1820). If it left dirty tracked source, the gate runs (with a persisted warning);
  the dirty-check fails closed (runs the gate / records failure on git error, never silent-skips).
  The pre-existing test that codified the unsafe skip was flipped to assert the safe contract, and a
  companion test proves #1819's clean-tree skip is preserved. Scope confined to the `planning_only`
  path; non-mktd runs and the separate `--no-post-exec-gate` warning path are unchanged.

## Intentionally NOT changed

No review/verdict/consensus schema changes; no compat shims (pre-production). The gate
skip is scoped specifically to mktd planning runs — code-writing sessions still run their
full post-exec gate.

The pre-existing `csa todo save` (`handle_save`) path shares the same lock-release-before-commit
shape (`ensure_attestation` releases the lock, then `git::save` commits outside it) — but it
predates this diff and is left untouched here to keep the widely-used `csa todo save` path
stable and this PR focused. Filed as a separate follow-up: **#1839** (rule 052).

Note: this branch inherits a pre-existing `main`-red test unrelated to this PR —
`session_cmds::reconcile::diagnostics_tests::synthesized_failure_summary_includes_post_mortem_diagnostics`
(stale after the daemon-completion-packet precedence change in ancestor `e2b5b2c0`). It is
NOT introduced here (the test file is byte-identical to `main`, zero overlap with the TODO
persist/hook surface) and is tracked separately as **#1834**.

The round-8 per-task `DONE WHEN` class-sweep also found a 4th sibling — a redundant **global**
check at `patterns/dev2merge/workflow.toml:441`. It sits downstream of the now-per-task
`csa todo persist` validator (so it cannot see an invalid plan in practice) and was deliberately
not folded in here, to avoid expanding scope into a second pattern. Filed as **#1843** (rule 052).

## Test plan

Per-concern targeted tests added (post-exec gate skip, mktd artifact routing,
check-chinese exclusion, atomic todo persist). `just fmt` + `just clippy` clean;
pattern compiles (PATTERN.md↔workflow.toml synced); module-size gate clean.

Version bumped 0.1.869 → 0.1.870.

Closes #1819
Closes #1820
Closes #1821
Closes #1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)
