### PR TITLE
fix(patterns): pass --no-error-marker-scan to mktd Phase 3 debate step (#1845)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.870"
+version = "0.1.871"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.870"
+version = "0.1.871"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -560,7 +560,7 @@ trap 'rc=$?; rm -f "$PROMPT_FILE"; exit $rc' EXIT INT TERM
   printf '%s\n' "## Output Requirements"
   printf '%s\n' "Provide explicit verdict and confidence in your conclusion."
 } > "$PROMPT_FILE" || { echo "Failed to write prompt file" >&2; exit 1; }
-SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --prompt-file "$PROMPT_FILE") || { echo "csa debate failed" >&2; exit 1; }
+SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --no-error-marker-scan --prompt-file "$PROMPT_FILE") || { echo "csa debate failed" >&2; exit 1; }
 DEBATE_JSON="$(csa session wait --session "$SID" 2>&1)" || { echo "csa debate failed" >&2; exit 1; }
 [[ -n "${DEBATE_JSON:-}" ]] || { echo "empty debate json output" >&2; exit 1; }
 RAW_VERDICT="$(printf '%s\n' "${DEBATE_JSON}" | jq -r '.verdict // "UNKNOWN"' | tr '[:lower:]' '[:upper:]')"

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -609,7 +609,7 @@ trap 'rc=$?; rm -f "$PROMPT_FILE"; exit $rc' EXIT INT TERM
   printf '%s\n' "## Output Requirements"
   printf '%s\n' "Provide explicit verdict and confidence in your conclusion."
 } > "$PROMPT_FILE" || { echo "Failed to write prompt file" >&2; exit 1; }
-SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --prompt-file "$PROMPT_FILE") || { echo "csa debate failed" >&2; exit 1; }
+SID=$(csa debate --sa-mode true --rounds 3 --format json --idle-timeout 600 --no-stream-stdout --no-error-marker-scan --prompt-file "$PROMPT_FILE") || { echo "csa debate failed" >&2; exit 1; }
 DEBATE_JSON="$(csa session wait --session "$SID" 2>&1)" || { echo "csa debate failed" >&2; exit 1; }
 [[ -n "${DEBATE_JSON:-}" ]] || { echo "empty debate json output" >&2; exit 1; }
 RAW_VERDICT="$(printf '%s\n' "${DEBATE_JSON}" | jq -r '.verdict // "UNKNOWN"' | tr '[:lower:]' '[:upper:]')"


### PR DESCRIPTION
## Summary

Fixes #1845. The mktd workflow's Phase 3 "Adversarial Debate" step invoked `csa debate` **without** `--no-error-marker-scan`. When `gemini-cli` is OAuth-unavailable and the debate falls back to `codex`, the codex debate session was self-killed at ~36s by the fatal-error-marker scanner (`matched configured 4xx/5xx/provider marker and observed no output progress for 30s`, signal / exit 137). Because the step is `on_fail = "abort"`, the entire mktd run aborted, discarding all preceding PASSED steps (RECON ×4, DRAFT, Spec, Threat Model — ~25 min of work). This made mktd unusable for debate-enhanced planning in exactly the window the codex fallback exists to cover.

## Fix

- `patterns/mktd/workflow.toml`: add `--no-error-marker-scan` to the Phase 3 debate `csa debate` invocation. The flag has existed on `csa debate` since #1778 precisely to suppress this false-positive, and every canonical write/review recipe already passes it — only mktd's internal debate step was missing it.
- `patterns/mktd/PATTERN.md`: synced identically (rule 027 — PATTERN.md ↔ workflow.toml must not diverge).
- Scope deliberately confined to `patterns/mktd/*` to keep this a FAST_PATH change.

## Verification

- Pattern compiles (`weave compile` exit 0).
- Pre-PR `csa review --range main...HEAD` verdict: **PASS** (no blocking findings) on bumped HEAD `868a3da9` (re-reviewed after the version bump; first review of the fix commit was also PASS).
- Version bumped 0.1.870 → 0.1.871.

## Follow-up (separate issue, not in this PR)

A rule-052 sweep surfaced the same flag-gap across ~25 other shipped pattern steps (`csa debate` / `csa review` / `csa run` invocations that can fall back to codex). That broad audit is deliberately deferred to keep this PR FAST_PATH — and may be mooted by fixing the root false-positive (#182 provider-error stream separation / #1830 idle-scanner channel scope) rather than sprinkling the flag across every site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
