### PR TITLE
feat(cli-sub-agent): inject review-aware writer guard into commit-producing run sessions (#1842)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.871"
+version = "0.1.872"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.871"
+version = "0.1.872"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -37,6 +37,10 @@ mod session_exec_metadata;
 mod session_exec_pre_exec;
 #[path = "pipeline_session_exec_prompt_guard.rs"]
 mod session_exec_prompt_guard;
+#[path = "pipeline_session_exec_prompt_inject.rs"]
+mod session_exec_prompt_inject;
+#[path = "pipeline_session_exec_review_guard.rs"]
+mod session_exec_review_guard;
 #[path = "pipeline_session_exec_tool_state.rs"]
 mod session_exec_tool_state;
 #[path = "pipeline_session_exec_write_guard.rs"]
@@ -363,15 +367,13 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         &mut prompt_assembly,
         startup_env.current_depth(),
     );
-    // Inject structured output section markers when enabled in config.
-    let structured_output_enabled = config.is_none_or(|cfg| cfg.session.structured_output);
-    if let Some(instructions) =
-        csa_executor::structured_output_instructions(structured_output_enabled)
-    {
-        info!("Injecting structured output instructions into prompt");
-        prompt_assembly.add_static_or_append_dynamic(instructions);
-    }
-    let effective_prompt = prompt_assembly.finish();
+    let effective_prompt = session_exec_prompt_inject::finalize_effective_prompt(
+        prompt_assembly,
+        task_type,
+        is_first_turn,
+        project_root,
+        config,
+    );
     // Resolve sandbox configuration from project config and enforcement mode.
     let liveness_dead_seconds = resolve_liveness_dead_seconds(config);
     let mut execute_options = match crate::pipeline_sandbox::resolve_sandbox_options(

--- a/crates/cli-sub-agent/src/pipeline_session_exec_prompt_inject.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_prompt_inject.rs
@@ -1,0 +1,60 @@
+//! Post-assembly prompt-block injection for `csa run` session execution.
+//!
+//! The base prompt guards are applied by the caller; this module appends the
+//! remaining order-sensitive blocks — the review-aware writer guard (#1842) and
+//! structured-output section markers — and returns the effective prompt.
+//! Extracted from `execute_with_session_and_meta_*` so the #1842 guard can be
+//! threaded in while keeping that module under the 8000-token monolith budget.
+
+use std::path::Path;
+
+use csa_config::ProjectConfig;
+use tracing::info;
+
+use crate::pipeline::prompt_cache::PromptAssembly;
+
+/// Append the review-aware writer guard and structured-output markers to an
+/// already-guarded `prompt_assembly`, then finalize and return the prompt.
+///
+/// Order is significant and mirrors the original inline sequence: the
+/// review-aware writer guard (#1842) first, then structured-output markers.
+/// The review guard is appended to the DYNAMIC prompt layer (never the cached
+/// static block) so a per-project checklist cannot poison the
+/// cross-project/mode prompt cache (#1842 constraint B); `sa_mode` is read from
+/// the same caller-injection env signal the post-exec path uses.
+pub(super) fn finalize_effective_prompt(
+    mut prompt_assembly: PromptAssembly,
+    task_type: Option<&str>,
+    is_first_turn: bool,
+    project_root: &Path,
+    config: Option<&ProjectConfig>,
+) -> String {
+    let caller_sa_mode =
+        std::env::var(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)
+            .ok()
+            .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1"))
+            .unwrap_or(false);
+    if let Some(review_guard) = super::session_exec_review_guard::build_review_writer_guard(
+        caller_sa_mode,
+        task_type,
+        is_first_turn,
+        project_root,
+    ) {
+        info!(
+            bytes = review_guard.len(),
+            "Injecting review-aware writer guard (#1842)"
+        );
+        prompt_assembly.append_dynamic_block(&review_guard);
+    }
+
+    // Inject structured output section markers when enabled in config.
+    let structured_output_enabled = config.is_none_or(|cfg| cfg.session.structured_output);
+    if let Some(instructions) =
+        csa_executor::structured_output_instructions(structured_output_enabled)
+    {
+        info!("Injecting structured output instructions into prompt");
+        prompt_assembly.add_static_or_append_dynamic(instructions);
+    }
+
+    prompt_assembly.finish()
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec_review_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_review_guard.rs
@@ -1,0 +1,414 @@
+//! Review-aware writer guard (#1842).
+//!
+//! Commit-producing `csa run --sa-mode false` writer sessions are made
+//! *review-aware*: an always-on, size-gated guard block is injected into the
+//! writer prompt so the writer self-reviews against the SAME dimensions the
+//! independent reviewer will use, before it commits. This reduces write→review
+//! rounds (the motivating cluster, PR #1844, took nine rounds; hand-adding this
+//! framing converged round nine in one).
+//!
+//! The injected guard carries the four contract elements of #1842:
+//! 1. **You-will-be-reviewed framing** — the diff WILL be adversarially reviewed
+//!    by a separate, heterogeneous CSA reviewer and the merge gate fails on ANY
+//!    blocking finding. The framing also states this does NOT replace the
+//!    independent reviewer (a self-reviewing writer shares its own blind spots).
+//! 2. **The per-dimension checklist** — extracted from the SINGLE source of truth
+//!    shared with the reviewer ([`REVIEW_PROTOCOL_SRC`], the `csa-review`
+//!    pattern's `review-protocol.md`), plus the project's `.csa/review-checklist.md`
+//!    when present (the same file the reviewer injects).
+//! 3. **A self-review-before-commit mandate** — walk each dimension against the
+//!    diff and report the per-dimension result before committing.
+//! 4. **An anti-gold-plating clause** — match the contract, do not invent scope.
+//!
+//! Design constraints (validated by prior adversarial debate, #1842):
+//! - **A (predicate scope):** injection is gated by [`is_review_aware_writer_session`],
+//!   a documented predicate distinct from the post-exec uncommitted-change detector.
+//! - **B (cache isolation):** the guard is appended through the DYNAMIC prompt
+//!   layer (`PromptAssembly::append_dynamic_block`), never the cached static
+//!   block, so a per-project checklist cannot poison the cross-project cache.
+//! - **C (bounded read):** the embedded dimensions are extracted and capped; the
+//!   project checklist reuses [`discover_review_checklist`]'s 4000-char bound.
+//! - **D (atomic write):** this guard performs NO sidecar/metadata write — it only
+//!   returns prompt text — so no write-atomicity concern applies.
+//! - **E (single dimension source):** `review-protocol.md` is the canonical source;
+//!   the dimensions live between `CSA:REVIEW_DIMENSIONS` markers and are guarded by
+//!   the drift test below so the writer guard and reviewer cannot diverge.
+
+use std::path::Path;
+
+use tracing::warn;
+
+use crate::review_context::discover_review_checklist;
+use crate::run_cmd::{is_writer_session, working_tree_changed_lines};
+
+/// Canonical review protocol shipped with the `csa-review` pattern, embedded at
+/// compile time so the writer guard and the reviewer draw the per-dimension
+/// checklist from the SAME source file (#1842 contract item 2 / constraint E).
+/// A wrong path is a compile error — the strongest possible drift guard.
+const REVIEW_PROTOCOL_SRC: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../patterns/csa-review/skills/csa-review/references/review-protocol.md"
+));
+
+/// Markers delimiting the canonical dimensions block inside [`REVIEW_PROTOCOL_SRC`].
+const DIMENSIONS_START: &str = "<!-- CSA:REVIEW_DIMENSIONS:START -->";
+const DIMENSIONS_END: &str = "<!-- CSA:REVIEW_DIMENSIONS:END -->";
+
+/// Upper bound on dimension text injected into the prompt (#1842 constraint C —
+/// mirrors `review_context::REVIEW_CHECKLIST_MAX_CHARS`).
+const MAX_INJECTED_CHARS: usize = 4000;
+
+/// Resume-session working-tree diffs at/under this changed-line count are treated
+/// as trivial and receive the brief guard instead of the full per-dimension
+/// checklist (#1842 size-gating). Fresh (first-turn) sessions always get the full
+/// guard because their eventual diff size is unknown and presumed substantial.
+const TRIVIAL_DIFF_MAX_LINES: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GuardKind {
+    Full,
+    Brief,
+}
+
+/// Predicate gating review-aware writer-guard injection (#1842 constraint A).
+///
+/// The guard targets *commit-producing writer* sessions: a `csa run` invoked
+/// with `--sa-mode false`. It is deliberately suppressed for:
+/// - SA-mode orchestrator sessions (`--sa-mode true`) — they delegate, never commit;
+/// - `review` / `debate` / `recon` and any non-`run` task type — read-only or
+///   analysis sessions with no diff to self-review.
+///
+/// This is a SEPARATE, named concept from [`is_writer_session`]'s post-exec
+/// uncommitted-change *detection*: that function answers "did this session leave
+/// a dirty tree?", whereas this answers "should the writer prompt carry the
+/// review-aware guard?". They share the same `!sa_mode && run` shape today (a
+/// `--sa-mode false` run IS the commit-producing-writer population), so this
+/// delegates rather than duplicating the boolean — but it is documented and named
+/// independently so the two can diverge later without coupling.
+///
+/// Documented caveat (not a bug): a read-only `csa run --sa-mode false` research
+/// task is indistinguishable from a writer at prompt-assembly time — no
+/// "will commit" signal exists pre-exec. Such a session receives the advisory
+/// guard harmlessly; with no diff, the self-review is a no-op.
+pub(crate) fn is_review_aware_writer_session(sa_mode: bool, task_type: Option<&str>) -> bool {
+    is_writer_session(sa_mode, task_type)
+}
+
+/// Select guard verbosity from the session's turn and existing diff size.
+fn select_guard_kind(is_first_turn: bool, changed_lines: usize) -> GuardKind {
+    if is_first_turn || changed_lines > TRIVIAL_DIFF_MAX_LINES {
+        GuardKind::Full
+    } else {
+        GuardKind::Brief
+    }
+}
+
+/// Extract the canonical dimensions block from the embedded review protocol.
+///
+/// Returns `None` (fail-open) when the markers are absent or the block is empty;
+/// the drift test guarantees they are present in committed source.
+fn extract_dimensions(protocol_src: &str) -> Option<&str> {
+    let start = protocol_src.find(DIMENSIONS_START)? + DIMENSIONS_START.len();
+    let rel_end = protocol_src.get(start..)?.find(DIMENSIONS_END)?;
+    let block = protocol_src.get(start..start + rel_end)?.trim();
+    (!block.is_empty()).then_some(block)
+}
+
+/// Truncate `s` to at most `max_bytes`, snapping back to a UTF-8 char boundary.
+/// `str::floor_char_boundary` is still nightly-only, hence the manual loop.
+fn cap_chars(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// You-will-be-reviewed framing (#1842 contract item 1).
+const REVIEWED_FRAMING: &str = "\
+YOU WILL BE REVIEWED. The diff you produce WILL be adversarially reviewed by a \
+separate, heterogeneous CSA reviewer (a different model family than you). The \
+merge gate FAILS on ANY blocking (HIGH/CRITICAL) finding, and every blocking \
+finding forces another write->review round. Self-reviewing now, against the SAME \
+dimensions the reviewer uses, is the cheapest path to a one-round merge. This \
+self-review REDUCES rounds but does NOT replace the independent reviewer: you \
+share your own blind spots, so the heterogeneous reviewer remains mandatory and \
+is never skipped or weakened.";
+
+/// Self-review-before-commit mandate (#1842 contract item 3).
+const SELF_REVIEW_MANDATE: &str = "\
+SELF-REVIEW BEFORE COMMIT (mandatory): before you run `git commit`, walk EACH \
+dimension above against your own diff and state the per-dimension result -- PASS, \
+FIXED (naming what you changed), or N/A (one-line reason). Do not commit until \
+every dimension is addressed; a dimension you cannot honestly mark PASS or N/A is \
+a blocking finding you must fix first.";
+
+/// Anti-gold-plating clause (#1842 contract item 4).
+const ANTI_GOLD_PLATING: &str = "\
+MATCH THE CONTRACT -- NO GOLD-PLATING: implement exactly what the task specifies. \
+Do NOT invent requirements, abstractions, configuration, or scope beyond the \
+stated contract. Unrequested scope (speculative generality, premature \
+abstraction, defensive handling of impossible states) is itself a review finding.";
+
+/// Brief guard for trivial resume diffs: keeps all four contract elements in
+/// condensed form but omits the full per-dimension block (#1842 size-gating).
+const BRIEF_GUARD: &str = "\
+<csa-review-aware-writer-guard kind=\"brief\">
+YOU WILL BE REVIEWED: this change WILL be checked by a separate, heterogeneous CSA \
+reviewer and the merge gate fails on any blocking (HIGH/CRITICAL) finding. Even \
+for a small diff, before you `git commit` do a quick self-review across \
+correctness, error handling, tests, security, and AGENTS.md compliance, and MATCH \
+THE CONTRACT -- NO GOLD-PLATING. The independent reviewer still runs; this does \
+not replace it.
+</csa-review-aware-writer-guard>";
+
+/// Assemble the full guard block from the dimensions and optional project checklist.
+fn render_full_guard(dimensions: &str, project_checklist: Option<&str>) -> String {
+    let mut out = String::new();
+    out.push_str("<csa-review-aware-writer-guard>\n");
+    out.push_str(REVIEWED_FRAMING);
+    out.push_str("\n\n<review-dimensions>\n");
+    out.push_str(dimensions);
+    out.push_str("\n</review-dimensions>\n");
+    if let Some(checklist) = project_checklist {
+        // Same `<review-checklist>` framing the reviewer injects (review_cmd_resolve.rs).
+        out.push_str("\n<review-checklist>\n");
+        out.push_str(checklist);
+        out.push_str("\n</review-checklist>\n");
+    }
+    out.push('\n');
+    out.push_str(SELF_REVIEW_MANDATE);
+    out.push_str("\n\n");
+    out.push_str(ANTI_GOLD_PLATING);
+    out.push_str("\n</csa-review-aware-writer-guard>");
+    out
+}
+
+/// Build the review-aware writer guard for a session, or `None` when the session
+/// is not a commit-producing writer (suppressed for SA-mode/review/debate/recon).
+///
+/// Routed by the caller through `PromptAssembly::append_dynamic_block` so the
+/// guard — including the per-project checklist — never enters the cached static
+/// prompt (#1842 constraint B). Performs NO metadata write (#1842 constraint D).
+//
+// #1762 seam: measuring average review rounds per cluster before/after this guard
+// is intentionally out of scope here and tracked separately in issue #1762.
+pub(super) fn build_review_writer_guard(
+    sa_mode: bool,
+    task_type: Option<&str>,
+    is_first_turn: bool,
+    project_root: &Path,
+) -> Option<String> {
+    if !is_review_aware_writer_session(sa_mode, task_type) {
+        return None;
+    }
+
+    // Only resume turns have a materialized diff to size-gate on; a fresh turn is
+    // presumed substantial and skips the git probe entirely.
+    let changed_lines = if is_first_turn {
+        0
+    } else {
+        working_tree_changed_lines(project_root)
+    };
+
+    match select_guard_kind(is_first_turn, changed_lines) {
+        GuardKind::Brief => Some(BRIEF_GUARD.to_string()),
+        GuardKind::Full => {
+            let Some(dimensions) = extract_dimensions(REVIEW_PROTOCOL_SRC) else {
+                warn!(
+                    "review-aware writer guard: dimensions markers missing from \
+                     review-protocol.md; emitting brief guard"
+                );
+                return Some(BRIEF_GUARD.to_string());
+            };
+            let dimensions = cap_chars(dimensions, MAX_INJECTED_CHARS);
+            // discover_review_checklist already bounds the read at 4000 chars (#1842 C).
+            let project_checklist = discover_review_checklist(project_root);
+            Some(render_full_guard(dimensions, project_checklist.as_deref()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::prompt_cache::{PromptAssembly, STATIC_END, STATIC_START};
+
+    /// Dimension names that MUST stay in sync between the reviewer protocol and
+    /// the writer guard. Changing the canonical list requires updating this array
+    /// in the same commit (rule 027 spirit) — the drift test fails otherwise.
+    const EXPECTED_DIMENSIONS: &[&str] = &[
+        "Correctness & regressions",
+        "Error handling",
+        "Test coverage",
+        "Security",
+        "AGENTS.md compliance",
+        "Spec / plan alignment",
+        "Deslop",
+        "Language-specific",
+    ];
+
+    #[test]
+    fn predicate_injects_for_writer_and_suppresses_read_only_kinds() {
+        // Inject case: commit-producing --sa-mode false run.
+        assert!(is_review_aware_writer_session(false, Some("run")));
+        // Suppress cases.
+        assert!(!is_review_aware_writer_session(true, Some("run")));
+        assert!(!is_review_aware_writer_session(false, Some("review")));
+        assert!(!is_review_aware_writer_session(false, Some("debate")));
+        assert!(!is_review_aware_writer_session(false, Some("recon")));
+        assert!(!is_review_aware_writer_session(false, None));
+    }
+
+    #[test]
+    fn dimensions_extract_from_embedded_protocol_without_drift() {
+        assert!(
+            REVIEW_PROTOCOL_SRC.contains(DIMENSIONS_START)
+                && REVIEW_PROTOCOL_SRC.contains(DIMENSIONS_END),
+            "review-protocol.md must carry the CSA:REVIEW_DIMENSIONS markers"
+        );
+        let dims = extract_dimensions(REVIEW_PROTOCOL_SRC)
+            .expect("dimensions block must be extractable from review-protocol.md");
+        assert!(!dims.is_empty());
+
+        for name in EXPECTED_DIMENSIONS {
+            assert!(
+                dims.contains(name),
+                "canonical dimension `{name}` missing from review-protocol.md \
+                 (writer guard and reviewer would diverge)"
+            );
+        }
+
+        // Bidirectional sync gate: adding or removing a dimension bullet without
+        // updating EXPECTED_DIMENSIONS fails this test.
+        let bullet_count = dims
+            .lines()
+            .filter(|line| line.trim_start().starts_with("- **"))
+            .count();
+        assert_eq!(
+            bullet_count,
+            EXPECTED_DIMENSIONS.len(),
+            "dimension bullet count drifted from EXPECTED_DIMENSIONS"
+        );
+    }
+
+    #[test]
+    fn full_guard_contains_all_four_contract_elements() {
+        let dims = extract_dimensions(REVIEW_PROTOCOL_SRC).unwrap();
+        let guard = render_full_guard(dims, None);
+
+        // 1. you-will-be-reviewed framing (+ does-not-replace-reviewer caveat).
+        assert!(guard.contains("YOU WILL BE REVIEWED"));
+        assert!(guard.contains("does NOT replace the independent reviewer"));
+        // 2. per-dimension checklist.
+        assert!(guard.contains("<review-dimensions>"));
+        assert!(guard.contains("Correctness & regressions"));
+        // 3. self-review-before-commit mandate.
+        assert!(guard.contains("SELF-REVIEW BEFORE COMMIT"));
+        // 4. anti-gold-plating clause.
+        assert!(guard.contains("NO GOLD-PLATING"));
+    }
+
+    #[test]
+    fn full_guard_embeds_project_checklist_when_present() {
+        let dims = extract_dimensions(REVIEW_PROTOCOL_SRC).unwrap();
+        let guard = render_full_guard(dims, Some("PROJECT-SPECIFIC-RULE"));
+        assert!(guard.contains("<review-checklist>"));
+        assert!(guard.contains("PROJECT-SPECIFIC-RULE"));
+    }
+
+    #[test]
+    fn size_gate_full_for_fresh_or_substantial_brief_for_trivial_resume() {
+        // Fresh session: full regardless of (zero) diff.
+        assert_eq!(select_guard_kind(true, 0), GuardKind::Full);
+        // Resume with no/trivial diff: brief.
+        assert_eq!(select_guard_kind(false, 0), GuardKind::Brief);
+        assert_eq!(
+            select_guard_kind(false, TRIVIAL_DIFF_MAX_LINES),
+            GuardKind::Brief
+        );
+        // Resume with substantial diff: full.
+        assert_eq!(
+            select_guard_kind(false, TRIVIAL_DIFF_MAX_LINES + 1),
+            GuardKind::Full
+        );
+
+        // Content contrast: full carries the dimension block, brief does not, but
+        // both keep the you-will-be-reviewed framing.
+        let dims = extract_dimensions(REVIEW_PROTOCOL_SRC).unwrap();
+        let full = render_full_guard(dims, None);
+        assert!(full.contains("<review-dimensions>"));
+        assert!(!BRIEF_GUARD.contains("<review-dimensions>"));
+        assert!(BRIEF_GUARD.contains("YOU WILL BE REVIEWED"));
+        assert!(BRIEF_GUARD.contains("NO GOLD-PLATING"));
+    }
+
+    /// #1842 constraint B: a per-project checklist injected through the dynamic
+    /// layer must NOT bleed into the cached static prompt shared across projects.
+    #[test]
+    fn per_project_checklist_does_not_bleed_into_static_cache() {
+        let dims = extract_dimensions(REVIEW_PROTOCOL_SRC).unwrap();
+        let guard_a = render_full_guard(dims, Some("PROJECT-A-CHECKLIST"));
+        let guard_b = render_full_guard(dims, Some("PROJECT-B-CHECKLIST"));
+
+        let static_region = |guard: &str| -> String {
+            let mut assembly = PromptAssembly::new("user task".to_string(), true);
+            // Cacheable, project-independent static context.
+            assembly.add_static_or_append_dynamic("SHARED-STATIC-CONTEXT");
+            // Production injection path for the guard.
+            assembly.append_dynamic_block(guard);
+            let prompt = assembly.finish();
+
+            let start = prompt.find(STATIC_START).expect("static start marker");
+            let end = prompt.find(STATIC_END).expect("static end marker");
+            // The per-project checklist must live in the dynamic tail, after the
+            // cached static block.
+            let checklist_marker = if guard.contains("PROJECT-A-CHECKLIST") {
+                "PROJECT-A-CHECKLIST"
+            } else {
+                "PROJECT-B-CHECKLIST"
+            };
+            let checklist_pos = prompt.find(checklist_marker).expect("checklist present");
+            assert!(
+                checklist_pos > end,
+                "per-project checklist leaked into the cached static block"
+            );
+            prompt[start..end].to_string()
+        };
+
+        // The cached static region must be byte-identical across projects: the
+        // only varying input (the guard's per-project checklist) never touches it.
+        assert_eq!(
+            static_region(&guard_a),
+            static_region(&guard_b),
+            "static cache differs across projects — guard poisoned the cache"
+        );
+    }
+
+    #[test]
+    fn build_guard_suppressed_for_non_writer_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(
+            build_review_writer_guard(true, Some("run"), true, temp.path()).is_none(),
+            "sa-mode orchestrator must not receive the writer guard"
+        );
+        assert!(
+            build_review_writer_guard(false, Some("review"), true, temp.path()).is_none(),
+            "review session must not receive the writer guard"
+        );
+    }
+
+    #[test]
+    fn build_guard_full_for_fresh_writer_session() {
+        let temp = tempfile::tempdir().unwrap();
+        let guard = build_review_writer_guard(false, Some("run"), true, temp.path())
+            .expect("fresh writer session must receive the full guard");
+        assert!(guard.contains("YOU WILL BE REVIEWED"));
+        assert!(guard.contains("<review-dimensions>"));
+        assert!(guard.contains("SELF-REVIEW BEFORE COMMIT"));
+        assert!(guard.contains("NO GOLD-PLATING"));
+    }
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec_review_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_review_guard.rs
@@ -413,4 +413,90 @@ mod tests {
         assert!(guard.contains("SELF-REVIEW BEFORE COMMIT"));
         assert!(guard.contains("NO GOLD-PLATING"));
     }
+
+    fn run_git(root: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .output()
+            .expect("git command should execute");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Throwaway git repo with one commit so `HEAD` exists; hooks and GPG signing
+    /// disabled to stay hermetic regardless of the host's global git config.
+    fn init_repo_with_commit() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        run_git(root, &["init", "-q"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test User"]);
+        run_git(root, &["config", "commit.gpgsign", "false"]);
+        run_git(
+            root,
+            &["config", "core.hooksPath", "/nonexistent-csa-hooks"],
+        );
+        std::fs::write(root.join("seed.txt"), "seed\n").expect("write seed");
+        run_git(root, &["add", "seed.txt"]);
+        run_git(root, &["commit", "-q", "-m", "initial"]);
+        temp
+    }
+
+    /// #1842 size-gating bug fix: a RESUME writer whose only uncommitted work is
+    /// substantial UNTRACKED files (invisible to `git diff HEAD`) must still
+    /// receive the FULL per-dimension guard, not the brief one.
+    #[test]
+    fn build_guard_full_for_resume_with_substantial_untracked_work() {
+        let temp = init_repo_with_commit();
+        let root = temp.path();
+        let body: String = (0..40).map(|i| format!("fn f{i}() {{}}\n")).collect();
+        std::fs::write(root.join("added.rs"), body).unwrap();
+
+        let guard = build_review_writer_guard(false, Some("run"), false, root)
+            .expect("resume writer with substantial untracked work must receive a guard");
+        assert!(
+            guard.contains("<review-dimensions>"),
+            "substantial untracked-only work must get the FULL guard, got: {guard}"
+        );
+    }
+
+    #[test]
+    fn build_guard_brief_for_resume_with_trivial_untracked_work() {
+        let temp = init_repo_with_commit();
+        let root = temp.path();
+        std::fs::write(root.join("tiny.txt"), "one line\n").unwrap();
+
+        let guard = build_review_writer_guard(false, Some("run"), false, root)
+            .expect("resume writer must receive a guard");
+        assert!(
+            !guard.contains("<review-dimensions>") && guard.contains("kind=\"brief\""),
+            "trivial untracked work must get the BRIEF guard, got: {guard}"
+        );
+    }
+
+    /// Ignored files must not inflate the size measure into the FULL guard.
+    #[test]
+    fn build_guard_brief_when_only_gitignored_files_present() {
+        let temp = init_repo_with_commit();
+        let root = temp.path();
+        std::fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        run_git(root, &["add", ".gitignore"]);
+        run_git(root, &["commit", "-q", "-m", "add gitignore"]);
+
+        let big: String = (0..300).map(|i| format!("log {i}\n")).collect();
+        std::fs::write(root.join("huge.log"), big).unwrap();
+
+        let guard = build_review_writer_guard(false, Some("run"), false, root)
+            .expect("resume writer must receive a guard");
+        assert!(
+            !guard.contains("<review-dimensions>") && guard.contains("kind=\"brief\""),
+            "ignored files must not trigger the FULL guard, got: {guard}"
+        );
+    }
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_review_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_review_guard.rs
@@ -27,7 +27,8 @@
 //!   layer (`PromptAssembly::append_dynamic_block`), never the cached static
 //!   block, so a per-project checklist cannot poison the cross-project cache.
 //! - **C (bounded read):** the embedded dimensions are extracted and capped; the
-//!   project checklist reuses [`discover_review_checklist`]'s 4000-char bound.
+//!   project checklist goes through [`discover_review_checklist`], which performs a
+//!   TRUE bounded read (caps bytes pulled from disk) before truncating.
 //! - **D (atomic write):** this guard performs NO sidecar/metadata write — it only
 //!   returns prompt text — so no write-atomicity concern applies.
 //! - **E (single dimension source):** `review-protocol.md` is the canonical source;
@@ -225,7 +226,8 @@ pub(super) fn build_review_writer_guard(
                 return Some(BRIEF_GUARD.to_string());
             };
             let dimensions = cap_chars(dimensions, MAX_INJECTED_CHARS);
-            // discover_review_checklist already bounds the read at 4000 chars (#1842 C).
+            // discover_review_checklist performs a bounded read (caps bytes pulled
+            // from disk) then truncates to the 4000-char budget (#1842 C).
             let project_checklist = discover_review_checklist(project_root);
             Some(render_full_guard(dimensions, project_checklist.as_deref()))
         }

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -120,13 +120,42 @@ fn has_extension(path: &Path, expected: &str) -> bool {
 /// Files exceeding this are truncated with a warning.
 const REVIEW_CHECKLIST_MAX_CHARS: usize = 4000;
 
+/// Hard cap on bytes pulled from the checklist file before truncation (#1842
+/// constraint C). A UTF-8 scalar value is at most 4 bytes, so reading
+/// `REVIEW_CHECKLIST_MAX_CHARS * 4` bytes always covers the full character budget
+/// regardless of encoding (ASCII or multibyte) while preventing an oversized or
+/// malicious checklist from being fully materialized in memory on the
+/// prompt-assembly path (a local memory-DoS guard). For any file whose content is
+/// within the character budget the bounded read returns byte-identical content to
+/// an unbounded read.
+const REVIEW_CHECKLIST_READ_LIMIT_BYTES: u64 = REVIEW_CHECKLIST_MAX_CHARS as u64 * 4;
+
+/// Read at most `limit` bytes from `path`, decoding them as UTF-8 lossily.
+///
+/// This is a TRUE bounded read: at most `limit` bytes are pulled from disk
+/// regardless of the file's on-disk size, so an arbitrarily large file can never
+/// be fully materialized in memory. A byte cut that lands mid-codepoint (e.g. the
+/// `limit`-th byte falls inside a multibyte character) is repaired by
+/// `String::from_utf8_lossy` rather than raised as a fatal error. Returns `None`
+/// (fail-open) when the file is missing or unreadable.
+fn read_bounded_utf8(path: &Path, limit: u64) -> Option<String> {
+    use std::io::Read;
+
+    let file = std::fs::File::open(path).ok()?;
+    let mut buf = Vec::new();
+    file.take(limit).read_to_end(&mut buf).ok()?;
+    Some(String::from_utf8_lossy(&buf).into_owned())
+}
+
 /// Discover project-specific review checklist from `.csa/review-checklist.md`.
 ///
-/// Returns `None` if the file does not exist or is empty.
-/// Truncates content with a warning comment if it exceeds [`REVIEW_CHECKLIST_MAX_CHARS`].
+/// Returns `None` if the file does not exist or is empty. The file is read with a
+/// bounded read ([`REVIEW_CHECKLIST_READ_LIMIT_BYTES`]) so an oversized checklist
+/// cannot be fully materialized in memory (#1842 constraint C); content is then
+/// truncated with a warning comment if it exceeds [`REVIEW_CHECKLIST_MAX_CHARS`].
 pub(crate) fn discover_review_checklist(project_root: &Path) -> Option<String> {
     let checklist_path = project_root.join(".csa").join("review-checklist.md");
-    let content = std::fs::read_to_string(&checklist_path).ok()?;
+    let content = read_bounded_utf8(&checklist_path, REVIEW_CHECKLIST_READ_LIMIT_BYTES)?;
     let trimmed = content.trim();
     if trimmed.is_empty() {
         return None;

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -138,8 +138,22 @@ const REVIEW_CHECKLIST_READ_LIMIT_BYTES: u64 = REVIEW_CHECKLIST_MAX_CHARS as u64
 /// `limit`-th byte falls inside a multibyte character) is repaired by
 /// `String::from_utf8_lossy` rather than raised as a fatal error. Returns `None`
 /// (fail-open) when the file is missing or unreadable.
+///
+/// Only regular files are opened. The sole caller ([`discover_review_checklist`])
+/// passes a worktree-supplied path (`.csa/review-checklist.md`); `File::open`
+/// follows symlinks and blocks indefinitely on a FIFO (and can hang or error on
+/// other special files), so the path is first classified with `symlink_metadata`
+/// (which does NOT follow symlinks) and anything that is not a regular file yields
+/// `None` without being opened. Mirrors `edit_restriction_guard::capture_path_state`.
 fn read_bounded_utf8(path: &Path, limit: u64) -> Option<String> {
     use std::io::Read;
+
+    // Classify WITHOUT following symlinks and WITHOUT opening: a non-regular path
+    // (symlink, FIFO, socket, device) is skipped (fail-open `None`) so a special
+    // file planted in the worktree cannot wedge prompt assembly via `File::open`.
+    if !std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_file()) {
+        return None;
+    }
 
     let file = std::fs::File::open(path).ok()?;
     let mut buf = Vec::new();

--- a/crates/cli-sub-agent/src/review_context_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_tests.rs
@@ -562,6 +562,71 @@ fn read_bounded_utf8_is_none_for_missing_file() {
     assert!(super::read_bounded_utf8(&missing, 4096).is_none());
 }
 
+/// Create a FIFO (named pipe) at `path`. Unix-only; proves the regular-file gate
+/// skips special files instead of blocking on `File::open`.
+#[cfg(unix)]
+fn make_fifo(path: &std::path::Path) {
+    use std::os::unix::ffi::OsStrExt;
+    let c_path =
+        std::ffi::CString::new(path.as_os_str().as_bytes()).expect("fifo path has no NUL byte");
+    // SAFETY: `c_path` is a valid NUL-terminated path that outlives the call; mode
+    // 0o600 is a standard FIFO permission. The return code is checked.
+    let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+    assert_eq!(
+        rc,
+        0,
+        "mkfifo({}) failed: {}",
+        path.display(),
+        std::io::Error::last_os_error()
+    );
+}
+
+#[test]
+fn read_bounded_utf8_skips_non_regular_paths() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+
+    // A regular file is still read.
+    let regular = root.join("checklist.md");
+    std::fs::write(&regular, "- [ ] item\n").unwrap();
+    assert!(
+        super::read_bounded_utf8(&regular, REVIEW_CHECKLIST_READ_LIMIT_BYTES).is_some(),
+        "regular file must still be read"
+    );
+
+    // A symlink is non-regular: it MUST yield None (skipped, not followed to its
+    // readable regular target).
+    #[cfg(unix)]
+    {
+        let link = root.join("link.md");
+        std::os::unix::fs::symlink(&regular, &link).unwrap();
+        assert!(
+            super::read_bounded_utf8(&link, REVIEW_CHECKLIST_READ_LIMIT_BYTES).is_none(),
+            "symlink must be skipped, not followed"
+        );
+    }
+
+    // A FIFO would block `File::open` forever pre-fix. Probe on a worker thread so
+    // a regression fails within a bounded timeout instead of hanging CI.
+    #[cfg(unix)]
+    {
+        let fifo = root.join("pipe.md");
+        make_fifo(&fifo);
+        let probe = fifo.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(super::read_bounded_utf8(
+                &probe,
+                REVIEW_CHECKLIST_READ_LIMIT_BYTES,
+            ));
+        });
+        let result = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("read_bounded_utf8 blocked on a FIFO — regression: regular-file gate missing");
+        assert!(result.is_none(), "FIFO must be skipped, not opened");
+    }
+}
+
 #[test]
 fn discover_review_checklist_bounds_read_of_oversized_file() {
     let temp = tempdir().unwrap();

--- a/crates/cli-sub-agent/src/review_context_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_tests.rs
@@ -533,3 +533,56 @@ fn discover_review_checklist_truncates_oversized_content() {
     assert!(checklist.contains("WARNING: review checklist truncated"));
     assert!(!checklist.starts_with('\n'));
 }
+
+#[test]
+fn read_bounded_utf8_caps_bytes_read_from_oversized_file() {
+    let temp = tempdir().unwrap();
+    let path = temp.path().join("huge.md");
+    // A > 1 MiB file: a true bounded read must NOT materialize all of it.
+    let huge = "a".repeat(2 * 1024 * 1024);
+    std::fs::write(&path, &huge).unwrap();
+
+    let content = super::read_bounded_utf8(&path, REVIEW_CHECKLIST_READ_LIMIT_BYTES)
+        .expect("readable file yields Some");
+
+    // ASCII decodes 1:1, so the decoded length equals the bytes pulled from disk:
+    // it is capped at the limit and is far smaller than the multi-MiB file.
+    assert!(
+        content.len() as u64 <= REVIEW_CHECKLIST_READ_LIMIT_BYTES,
+        "bounded read materialized {} bytes, exceeds limit {REVIEW_CHECKLIST_READ_LIMIT_BYTES}",
+        content.len()
+    );
+    assert!((content.len() as u64) < huge.len() as u64);
+}
+
+#[test]
+fn read_bounded_utf8_is_none_for_missing_file() {
+    let temp = tempdir().unwrap();
+    let missing = temp.path().join("does-not-exist.md");
+    assert!(super::read_bounded_utf8(&missing, 4096).is_none());
+}
+
+#[test]
+fn discover_review_checklist_bounds_read_of_oversized_file() {
+    let temp = tempdir().unwrap();
+    let csa_dir = temp.path().join(".csa");
+    std::fs::create_dir_all(&csa_dir).unwrap();
+
+    // > 1 MiB checklist with newlines so truncation cuts on a line boundary.
+    let line = "- [ ] a review item long enough to fill realistic space\n";
+    let huge = line.repeat((1024 * 1024 / line.len()) + 64);
+    assert!(huge.len() > 1024 * 1024);
+    std::fs::write(csa_dir.join("review-checklist.md"), &huge).unwrap();
+
+    let checklist =
+        discover_review_checklist(temp.path()).expect("oversized file still yields Some");
+
+    // The injected string is bounded to the character budget (plus the short
+    // truncation-warning comment), never the multi-MiB file size.
+    assert!(
+        checklist.len() <= REVIEW_CHECKLIST_MAX_CHARS + 128,
+        "injected checklist len {} exceeds the character budget",
+        checklist.len()
+    );
+    assert!(checklist.contains("WARNING: review checklist truncated"));
+}

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -36,7 +36,9 @@ pub(crate) use policy::{
     extract_executed_shell_commands, resolve_hook_bypass_scan_enabled,
 };
 pub(crate) use shell::detect_no_verify_commit_commands;
-pub(crate) use uncommitted::{format_uncommitted_warning, is_writer_session};
+pub(crate) use uncommitted::{
+    format_uncommitted_warning, is_writer_session, working_tree_changed_lines,
+};
 
 #[cfg(test)]
 pub(crate) use crate::pipeline::promote_idle_timeout_for_explicit_wall_timeout;

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -205,8 +205,24 @@ const MAX_LINE_SCAN_BYTES: usize = 1 << 20;
 /// `\n` bytes, stopping after [`MAX_LINE_SCAN_BYTES`]; a final line lacking a
 /// trailing newline still counts. Fail-open: any IO error (including a missing
 /// file) yields `0` so a transient read failure cannot abort the guard.
+///
+/// Only regular files are opened. `path` comes straight from an untracked
+/// worktree enumeration ([`untracked_non_ignored_lines`]), which can legitimately
+/// surface symlinks, FIFOs, sockets, or device nodes. `File::open` follows
+/// symlinks and blocks indefinitely on a FIFO (and can hang or error on other
+/// special files), so the path is first classified with `symlink_metadata` (which
+/// does NOT follow symlinks); anything that is not a regular file is skipped
+/// (counted as `0`) without ever being opened. Mirrors the classify-before-touch
+/// pattern in [`crate::edit_restriction_guard`]'s `capture_path_state`.
 fn count_file_lines(path: &Path) -> usize {
     use std::io::Read;
+
+    // Classify WITHOUT following symlinks and WITHOUT opening: only a regular file
+    // is safe to hand to `File::open` here. A stat error (missing/unreadable) or
+    // any non-regular type (symlink, FIFO, socket, device) fails open to `0`.
+    if !std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_file()) {
+        return 0;
+    }
 
     let Ok(file) = std::fs::File::open(path) else {
         return 0;
@@ -503,6 +519,71 @@ mod tests {
         assert_eq!(count_file_lines(&empty), 0);
 
         assert_eq!(count_file_lines(&temp.path().join("missing.txt")), 0);
+    }
+
+    /// Create a FIFO (named pipe) at `path`. Unix-only; used to prove the
+    /// regular-file gate skips special files instead of blocking on `File::open`.
+    #[cfg(unix)]
+    fn make_fifo(path: &Path) {
+        use std::os::unix::ffi::OsStrExt;
+        let c_path =
+            std::ffi::CString::new(path.as_os_str().as_bytes()).expect("fifo path has no NUL byte");
+        // SAFETY: `c_path` is a valid NUL-terminated path that outlives the call;
+        // mode 0o600 is a standard FIFO permission. The return code is checked.
+        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            rc,
+            0,
+            "mkfifo({}) failed: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        );
+    }
+
+    #[test]
+    fn count_file_lines_skips_non_regular_paths_without_blocking() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+
+        // (a) A regular file is still counted normally.
+        let regular = root.join("regular.rs");
+        std::fs::write(&regular, "a\nb\nc\n").unwrap();
+        assert_eq!(count_file_lines(&regular), 3);
+
+        // (b) A symlink is non-regular: it MUST be skipped (0), not FOLLOWED to its
+        // regular target (which would count 3). Proves classification uses
+        // symlink_metadata rather than following the link.
+        #[cfg(unix)]
+        {
+            let link = root.join("link.rs");
+            std::os::unix::fs::symlink(&regular, &link).unwrap();
+            assert_eq!(
+                count_file_lines(&link),
+                0,
+                "symlink must be skipped, not followed"
+            );
+        }
+
+        // (c) A FIFO makes a blocking `File::open` hang forever pre-fix. Probe on a
+        // worker thread so a regression surfaces as a bounded timeout failure
+        // instead of an indefinite CI hang.
+        #[cfg(unix)]
+        {
+            use std::sync::mpsc;
+            use std::time::Duration;
+
+            let fifo = root.join("pipe");
+            make_fifo(&fifo);
+            let probe = fifo.clone();
+            let (tx, rx) = mpsc::channel();
+            std::thread::spawn(move || {
+                let _ = tx.send(count_file_lines(&probe));
+            });
+            let counted = rx.recv_timeout(Duration::from_secs(5)).expect(
+                "count_file_lines blocked on a FIFO — regression: regular-file gate missing",
+            );
+            assert_eq!(counted, 0, "FIFO must be skipped, not opened");
+        }
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -144,16 +144,95 @@ pub(crate) fn format_uncommitted_warning(changes: &csa_session::UncommittedChang
     )
 }
 
-/// Total working-tree changed lines (insertions + deletions) relative to `HEAD`.
+/// Total working-tree change size, in lines, used by the review-aware writer
+/// guard (#1842) to size-gate prompt injection for resume sessions: tracked diff
+/// lines (insertions + deletions vs `HEAD`) PLUS the line count of untracked,
+/// non-ignored files.
+///
+/// Untracked files never appear in `git diff HEAD`, so a substantial change made
+/// entirely of new (never-staged) files would otherwise measure as zero changed
+/// lines and be mis-classified as trivial — handing the writer the *brief* guard
+/// exactly when the full per-dimension checklist matters most. Counting untracked
+/// non-ignored lines closes that gap. `.gitignore` is honored (build artifacts do
+/// not inflate the count), and git state is never mutated to measure it (no
+/// `git add`, no intent-to-add).
 ///
 /// Returns `0` when `project_root` is not a git worktree or the tree is clean.
-/// Used by the review-aware writer guard (#1842) to size-gate prompt injection
-/// for resume sessions (a substantial in-progress diff warrants the full
-/// per-dimension checklist; a trivial one does not).
+/// Any git/IO failure is non-fatal (fail-open), matching the rest of the guard.
 pub(crate) fn working_tree_changed_lines(project_root: &Path) -> usize {
-    collect_uncommitted_changes(project_root)
+    let tracked = collect_uncommitted_changes(project_root)
         .map(|changes| changes.insertions.saturating_add(changes.deletions) as usize)
-        .unwrap_or(0)
+        .unwrap_or(0);
+    tracked.saturating_add(untracked_non_ignored_lines(project_root))
+}
+
+/// Sum of line counts across untracked, non-ignored files.
+///
+/// `git ls-files --others --exclude-standard` enumerates files git is neither
+/// tracking nor ignoring, so build artifacts and `.gitignore`d paths never
+/// inflate the size measure, and the index/worktree are never mutated. `--others`
+/// excludes anything already in the index (including intent-to-add entries, which
+/// `git diff HEAD` already counts), so there is no double-counting with the
+/// tracked diff. Fail-open: returns `0` when `project_root` is not a git worktree
+/// or git fails.
+fn untracked_non_ignored_lines(project_root: &Path) -> usize {
+    if !super::git::is_git_worktree(project_root) {
+        return 0;
+    }
+    let Some(listing) = run_git_capture(
+        project_root,
+        &["ls-files", "--others", "--exclude-standard", "-z"],
+    ) else {
+        return 0;
+    };
+    listing
+        .split('\0')
+        .filter(|path| !path.is_empty())
+        .map(|rel| count_file_lines(&project_root.join(rel)))
+        .sum()
+}
+
+/// Per-file byte ceiling when counting untracked-file lines. The gate only
+/// distinguishes trivial (`<= TRIVIAL_DIFF_MAX_LINES`) from substantial, so
+/// scanning past ~1 MiB of a single file cannot change the outcome; the ceiling
+/// keeps a pathological large non-ignored file from forcing an unbounded read
+/// (bounded-read discipline, mirroring the guard's other reads).
+const MAX_LINE_SCAN_BYTES: usize = 1 << 20;
+
+/// Count newline-delimited lines in `path` with bounded memory and IO.
+///
+/// Streams the file through a fixed buffer (never loading it whole) counting
+/// `\n` bytes, stopping after [`MAX_LINE_SCAN_BYTES`]; a final line lacking a
+/// trailing newline still counts. Fail-open: any IO error (including a missing
+/// file) yields `0` so a transient read failure cannot abort the guard.
+fn count_file_lines(path: &Path) -> usize {
+    use std::io::Read;
+
+    let Ok(file) = std::fs::File::open(path) else {
+        return 0;
+    };
+    let mut reader = std::io::BufReader::new(file);
+    let mut buf = [0u8; 16 * 1024];
+    let mut newlines = 0usize;
+    let mut scanned = 0usize;
+    let mut last_byte = None;
+    while scanned < MAX_LINE_SCAN_BYTES {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                newlines += buf[..n].iter().filter(|&&b| b == b'\n').count();
+                last_byte = Some(buf[n - 1]);
+                scanned = scanned.saturating_add(n);
+            }
+            Err(_) => return 0,
+        }
+    }
+    // A non-empty file whose final scanned byte is not a newline has a trailing
+    // partial line; an empty file (`None`) or one ending in `\n` does not.
+    match last_byte {
+        Some(b) if b != b'\n' => newlines.saturating_add(1),
+        _ => newlines,
+    }
 }
 
 fn collect_uncommitted_changes(project_root: &Path) -> Option<csa_session::UncommittedChanges> {
@@ -371,5 +450,116 @@ mod tests {
             uncommitted_changes: None,
             manager_fields: Default::default(),
         }
+    }
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .output()
+            .expect("git command should execute");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// A throwaway git repo with one commit so `HEAD` exists. Hooks and GPG
+    /// signing are disabled so the test stays hermetic regardless of the host's
+    /// global git config.
+    fn init_repo_with_initial_commit() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        run_git(root, &["init", "-q"]);
+        run_git(root, &["config", "user.email", "test@example.com"]);
+        run_git(root, &["config", "user.name", "Test User"]);
+        run_git(root, &["config", "commit.gpgsign", "false"]);
+        run_git(
+            root,
+            &["config", "core.hooksPath", "/nonexistent-csa-hooks"],
+        );
+        std::fs::write(root.join("seed.txt"), "seed\n").expect("write seed");
+        run_git(root, &["add", "seed.txt"]);
+        run_git(root, &["commit", "-q", "-m", "initial"]);
+        temp
+    }
+
+    #[test]
+    fn count_file_lines_handles_trailing_newline_partial_line_and_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let with_nl = temp.path().join("with_nl.txt");
+        std::fs::write(&with_nl, "x\ny\nz\n").unwrap();
+        assert_eq!(count_file_lines(&with_nl), 3);
+
+        let no_nl = temp.path().join("no_nl.txt");
+        std::fs::write(&no_nl, "x\ny\nz").unwrap();
+        assert_eq!(count_file_lines(&no_nl), 3);
+
+        let empty = temp.path().join("empty.txt");
+        std::fs::write(&empty, "").unwrap();
+        assert_eq!(count_file_lines(&empty), 0);
+
+        assert_eq!(count_file_lines(&temp.path().join("missing.txt")), 0);
+    }
+
+    #[test]
+    fn working_tree_changed_lines_counts_untracked_non_ignored_files() {
+        let temp = init_repo_with_initial_commit();
+        let root = temp.path();
+        // Substantial NEW work composed ENTIRELY of untracked files: `git diff
+        // HEAD` sees nothing, so the pre-fix measure would have returned 0.
+        let body: String = (0..50).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(root.join("new_module.rs"), &body).unwrap();
+
+        let measured = working_tree_changed_lines(root);
+        assert!(
+            measured >= 50,
+            "untracked-file lines must count toward the size measure, got {measured}"
+        );
+    }
+
+    #[test]
+    fn working_tree_changed_lines_combines_tracked_and_untracked() {
+        let temp = init_repo_with_initial_commit();
+        let root = temp.path();
+        // Modify a tracked file (appears in `git diff HEAD`)...
+        std::fs::write(root.join("seed.txt"), "seed\nedit-a\nedit-b\n").unwrap();
+        // ...and add an untracked file (does not).
+        std::fs::write(root.join("extra.txt"), "u1\nu2\nu3\nu4\n").unwrap();
+
+        // 2 tracked insertions + 4 untracked lines = 6, all counted, none double.
+        assert_eq!(working_tree_changed_lines(root), 6);
+    }
+
+    #[test]
+    fn working_tree_changed_lines_excludes_gitignored_files() {
+        let temp = init_repo_with_initial_commit();
+        let root = temp.path();
+        // Commit `.gitignore` so it is tracked-and-clean, not itself an untracked
+        // file that would count.
+        std::fs::write(root.join(".gitignore"), "build/\n*.log\n").unwrap();
+        run_git(root, &["add", ".gitignore"]);
+        run_git(root, &["commit", "-q", "-m", "add gitignore"]);
+
+        // Large ignored content must not inflate the measure.
+        std::fs::create_dir_all(root.join("build")).unwrap();
+        let big: String = (0..500).map(|i| format!("artifact {i}\n")).collect();
+        std::fs::write(root.join("build/out.txt"), &big).unwrap();
+        std::fs::write(root.join("debug.log"), &big).unwrap();
+
+        assert_eq!(
+            working_tree_changed_lines(root),
+            0,
+            "ignored files must not inflate the writer-guard size measure"
+        );
+    }
+
+    #[test]
+    fn working_tree_changed_lines_zero_for_non_git_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        assert_eq!(working_tree_changed_lines(temp.path()), 0);
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -144,6 +144,18 @@ pub(crate) fn format_uncommitted_warning(changes: &csa_session::UncommittedChang
     )
 }
 
+/// Total working-tree changed lines (insertions + deletions) relative to `HEAD`.
+///
+/// Returns `0` when `project_root` is not a git worktree or the tree is clean.
+/// Used by the review-aware writer guard (#1842) to size-gate prompt injection
+/// for resume sessions (a substantial in-progress diff warrants the full
+/// per-dimension checklist; a trivial one does not).
+pub(crate) fn working_tree_changed_lines(project_root: &Path) -> usize {
+    collect_uncommitted_changes(project_root)
+        .map(|changes| changes.insertions.saturating_add(changes.deletions) as usize)
+        .unwrap_or(0)
+}
+
 fn collect_uncommitted_changes(project_root: &Path) -> Option<csa_session::UncommittedChanges> {
     if !super::git::is_git_worktree(project_root) {
         return None;

--- a/patterns/csa-review/skills/csa-review/references/review-protocol.md
+++ b/patterns/csa-review/skills/csa-review/references/review-protocol.md
@@ -12,6 +12,29 @@
 > Write review artifacts to `$CSA_SESSION_DIR/reviewer-{N}/` (for example:
 > `$CSA_SESSION_DIR/reviewer-{N}/review-findings.json` and `$CSA_SESSION_DIR/reviewer-{N}/review-report.md`).
 
+<!-- CSA:REVIEW_DIMENSIONS:START -->
+## Review Dimensions (canonical checklist)
+
+> SINGLE SOURCE OF TRUTH. The block between the `CSA:REVIEW_DIMENSIONS` markers is
+> consumed by BOTH the reviewer (this protocol) and the review-aware writer guard
+> injected into `csa run --sa-mode false` writer sessions (issue #1842). The writer
+> self-reviews against these exact dimensions before committing, so converging in
+> one review round means clearing this list first. A drift test in the
+> `cli-sub-agent` crate (`pipeline_session_exec_review_guard`) fails if these
+> markers or any dimension cannot be extracted, so the two consumers cannot
+> silently diverge (rule 027 spirit). Edit the dimensions here and both sides
+> update together — never duplicate this list elsewhere.
+
+- **Correctness & regressions**: logic errors, broken invariants, and behavior the task did not intend to change.
+- **Error handling**: missing or wrong error paths; no `unwrap`/`expect`/panic on fallible or untrusted input in library code.
+- **Test coverage**: new and changed behavior is tested; insufficient tests are first-class findings (`test-gap`).
+- **Security**: auth/authz bypass, crypto misuse, injection/deserialization/path-traversal/SSRF, DoS (unbounded CPU/memory/IO), and non-constant-time secret handling.
+- **AGENTS.md compliance**: discover root-to-leaf AGENTS.md for each changed path and cite the violated rule ID; MUST/FORBIDDEN/security rules escalate priority.
+- **Spec / plan alignment**: when TODO.md/spec.toml context is provided, the diff fulfills the stated intent, respects boundary constraints, and satisfies each completion criterion.
+- **Deslop (anti-redundancy)**: no narration comments, defensive over-handling, excessive nesting, redundant type annotations, duplicated logic, or premature abstraction.
+- **Language-specific**: apply the framework-aware dimensions below for the changed files' language (Rust: `unsafe` soundness with `// SAFETY:`, lifetime/ownership correctness, panic-free library paths, serde compatibility, concurrent-writer and compensating-transaction races).
+<!-- CSA:REVIEW_DIMENSIONS:END -->
+
 ## Step 1: Read Project Context
 
 First, read CLAUDE.md at the project root to understand:


### PR DESCRIPTION
## Summary

Implements #1842: a **review-aware writer guard**. Commit-producing `csa run` sessions
(invoked with `--sa-mode false`) now receive an always-on, size-gated guard injected into
the writer prompt, so the writer self-reviews against the SAME dimensions the independent
CSA reviewer will use — *before* it commits. Goal: cut write-then-review rounds.

Complements #1841 (the reviewer-side single-pass blocking enumeration); together they give
two-sided round reduction.

## The guard carries four things (feature contract)

1. **You-will-be-reviewed framing** — explicit notice that the diff WILL be adversarially
   reviewed by a separate heterogeneous CSA reviewer and that the merge gate fails on ANY
   blocking (HIGH/CRITICAL) finding.
2. **The same per-dimension review checklist** the `csa-review` pattern uses, drawn from a
   **single source of truth** shared between reviewer and writer guard, protected by a
   **drift test** (rule 027 spirit) so the two cannot silently diverge.
3. **Self-review-before-commit mandate** — the writer must walk each dimension against its
   own diff and report the per-dimension result before committing.
4. **Anti-gold-plating clause** — match the stated contract; do not invent requirements.

## Design constraints addressed (validated by prior adversarial debate)

- **(A) Writer-detection scope** — explicit, documented predicate for guard injection;
  suppressed for read-only / recon / review / debate sessions (not silently equated with the
  uncommitted-changes predicate around `run_cmd_uncommitted.rs`).
- **(B) Prompt-cache isolation** — the per-project checklist goes through the dynamic prompt
  layer (or is cache-keyed by project+mode+content-hash) so it cannot poison the static
  cache across projects/modes. Covered by a no-cross-bleed test.
- **(C) Bounded read** — the checklist source respects the same bounded-read discipline as
  `review_context.rs` (no unbounded `read_to_string` of a large file into the prompt).
- **(D) Atomic metadata write** — any new sidecar/metadata write is atomic (temp + rename)
  with fail-open readers; or none is added (stated explicitly).
- **(E) Single-source dimensions** — `review-protocol.md` is the canonical extraction source
  (there was no pre-existing `review-dimensions.md`); the shared checklist is guarded by the
  drift test.

## Caveat (preserved by design)

This reduces rounds but does **NOT** replace independent heterogeneous review — a writer
reviewing its own diff shares its own model blind spots, so the independent reviewer stays
mandatory. The injected framing says so; no logic skips or weakens the independent reviewer.

## Out of scope

- #1762 session analytics (rounds-per-cluster metric) — a clearly-marked seam/TODO only.

## Test coverage

- inject vs suppress predicate (commit-producing `--sa-mode false` only).
- drift test (writer-guard checklist ↔ `review-protocol.md` single source).
- prompt-cache no-cross-bleed across project/mode.
- size-gating (trivial diff → no/short guard; substantial diff → full guard); untracked
  non-ignored files counted toward the gate.
- non-regular-file safety: untracked-file line counting classifies paths via `symlink_metadata`
  and skips symlinks/FIFOs/special files without opening them (no `File::open` hang on a FIFO).
- assembled guard contains all four contract elements.
- `just pre-commit` (fmt + clippy + nextest + token-budget gate) green; module-size budgets respected.

## Pre-PR review iterations

Driven through cumulative `csa review` (heterogeneous: claude writes, gemini→codex reviews).
Each round surfaced a distinct concrete bug in newly-added code (iterative quality, not design
churn):

1. **Bounded read** — checklist injection was `read_to_string` + truncate of
   `.csa/review-checklist.md`; replaced with a true bounded read (DoS-safe).
2. **Size-gating untracked files** — substantial untracked-only worktree diffs were gated as
   trivial; gate now counts untracked non-ignored files.
3. **Non-regular-file DoS** — the round-2 untracked-counting path `File::open`'d every path,
   hanging indefinitely on a FIFO; now `symlink_metadata`-classified and skipped.

Verdict/observability defects observed during these rounds were filed separately as #1852
(severity-grade downgrade + fallback provenance + bare-`FAIL` summary).

Refs #1842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
