### PR TITLE
fix(cli-sub-agent): mktd full-mode happy-path — debate REVISE exit (#1850) + plan-run CSA_SESSION_DIR (#1851)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.872"
+version = "0.1.873"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.873"
+version = "0.1.874"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.872"
+version = "0.1.873"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.873"
+version = "0.1.874"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
@@ -389,12 +389,17 @@ fn debate_completion_ignores_codex_tool_result_verdict_noise() {
         false,
     );
 
-    assert_eq!(exit_code, 1);
+    // #1850 (residual of #1759): the synthesized default REVISE for a
+    // completed-but-unverdicted debate is a successful consultation when no
+    // `--fail-on-*` flag is set. The persisted result.toml records success/0 so
+    // async consumers (`csa session wait`, mktd Phase 3) do not abort; the
+    // REVISE polarity survives only in `output/debate-verdict.json`.
+    assert_eq!(exit_code, 0);
     let saved = csa_session::load_result(project_root, &session.meta_session_id)
         .unwrap()
         .expect("saved result");
-    assert_eq!(saved.status, "failure");
-    assert_eq!(saved.exit_code, 1);
+    assert_eq!(saved.status, "success");
+    assert_eq!(saved.exit_code, 0);
 
     let verdict_path = csa_session::get_session_dir(project_root, &session.meta_session_id)
         .unwrap()
@@ -446,6 +451,141 @@ fn debate_completion_counts_codex_assistant_verdict() {
         .expect("saved result");
     assert_eq!(saved.status, "success");
     assert_eq!(saved.exit_code, 0);
+}
+
+/// #1850: an explicit REVISE verdict from a completed debate is a successful
+/// consultation when neither `--fail-on-revise` nor `--fail-on-reject` is set.
+/// The returned (direct) exit code and the persisted result.toml MUST both be
+/// success/0 so the async `csa session wait` path (mktd Phase 3) does not abort
+/// on an advisory verdict; REVISE survives only in `debate-verdict.json`.
+#[test]
+fn debate_explicit_revise_without_fail_on_persists_success() {
+    let transcript = [
+        r#"{"type":"thread.started","thread_id":"thread_1"}"#,
+        r#"{"type":"item.completed","item":{"id":"i2","type":"agent_message","text":"Summary: reviewer requests changes.\nVerdict: REVISE\nConfidence: high"}}"#,
+    ]
+    .join("\n");
+
+    let extraction = crate::debate_cmd_output::extract_debate_summary_with_metadata(
+        &transcript,
+        "fallback summary",
+        debate_cmd::DebateMode::Heterogeneous,
+    );
+    assert!(extraction.had_explicit_verdict);
+    assert_eq!(extraction.summary.verdict, "REVISE");
+
+    let temp = tempfile::TempDir::new().unwrap();
+    let _env_lock = test_env_lock::TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = DebateExactEnvVarGuard::set("HOME", temp.path());
+    let _state_guard = DebateExactEnvVarGuard::set("XDG_STATE_HOME", &state_home);
+
+    let project_root = temp.path();
+    let session = seed_debate_result(project_root, "codex", "failure", 1, "tool exited non-zero");
+    let exit_code = finalize_seeded_debate(
+        project_root,
+        &session.meta_session_id,
+        &transcript,
+        "fallback summary",
+        false,
+        false,
+    );
+
+    assert_eq!(exit_code, 0);
+    let saved = csa_session::load_result(project_root, &session.meta_session_id)
+        .unwrap()
+        .expect("saved result");
+    assert_eq!(saved.status, "success");
+    assert_eq!(saved.exit_code, 0);
+
+    let verdict_path = csa_session::get_session_dir(project_root, &session.meta_session_id)
+        .unwrap()
+        .join("output")
+        .join("debate-verdict.json");
+    let verdict_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(verdict_path).unwrap()).unwrap();
+    assert_eq!(verdict_json["verdict"], "REVISE");
+}
+
+/// #1850: opt-in `--fail-on-revise` restores the non-zero exit for a REVISE
+/// verdict on BOTH the returned exit code and the persisted result.toml.
+#[test]
+fn debate_explicit_revise_with_fail_on_revise_persists_failure() {
+    let transcript = [
+        r#"{"type":"thread.started","thread_id":"thread_1"}"#,
+        r#"{"type":"item.completed","item":{"id":"i2","type":"agent_message","text":"Summary: reviewer requests changes.\nVerdict: REVISE\nConfidence: high"}}"#,
+    ]
+    .join("\n");
+
+    let temp = tempfile::TempDir::new().unwrap();
+    let _env_lock = test_env_lock::TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = DebateExactEnvVarGuard::set("HOME", temp.path());
+    let _state_guard = DebateExactEnvVarGuard::set("XDG_STATE_HOME", &state_home);
+
+    let project_root = temp.path();
+    let session = seed_debate_result(project_root, "codex", "failure", 1, "tool exited non-zero");
+    let exit_code = finalize_seeded_debate(
+        project_root,
+        &session.meta_session_id,
+        &transcript,
+        "fallback summary",
+        true,
+        false,
+    );
+
+    assert_eq!(exit_code, 1);
+    let saved = csa_session::load_result(project_root, &session.meta_session_id)
+        .unwrap()
+        .expect("saved result");
+    assert_eq!(saved.status, "failure");
+    assert_eq!(saved.exit_code, 1);
+}
+
+/// #1850: opt-in `--fail-on-reject` restores the non-zero exit for a REJECT
+/// verdict on BOTH the returned exit code and the persisted result.toml.
+#[test]
+fn debate_explicit_reject_with_fail_on_reject_persists_failure() {
+    let transcript = [
+        r#"{"type":"thread.started","thread_id":"thread_1"}"#,
+        r#"{"type":"item.completed","item":{"id":"i2","type":"agent_message","text":"Summary: reviewer rejects the change.\nVerdict: REJECT\nConfidence: high"}}"#,
+    ]
+    .join("\n");
+
+    let extraction = crate::debate_cmd_output::extract_debate_summary_with_metadata(
+        &transcript,
+        "fallback summary",
+        debate_cmd::DebateMode::Heterogeneous,
+    );
+    assert!(extraction.had_explicit_verdict);
+    assert_eq!(extraction.summary.verdict, "REJECT");
+
+    let temp = tempfile::TempDir::new().unwrap();
+    let _env_lock = test_env_lock::TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = DebateExactEnvVarGuard::set("HOME", temp.path());
+    let _state_guard = DebateExactEnvVarGuard::set("XDG_STATE_HOME", &state_home);
+
+    let project_root = temp.path();
+    let session = seed_debate_result(project_root, "codex", "failure", 1, "tool exited non-zero");
+    let exit_code = finalize_seeded_debate(
+        project_root,
+        &session.meta_session_id,
+        &transcript,
+        "fallback summary",
+        false,
+        true,
+    );
+
+    assert_eq!(exit_code, 1);
+    let saved = csa_session::load_result(project_root, &session.meta_session_id)
+        .unwrap()
+        .expect("saved result");
+    assert_eq!(saved.status, "failure");
+    assert_eq!(saved.exit_code, 1);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/debate_cmd_finalize.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_finalize.rs
@@ -257,7 +257,14 @@ fn resolve_debate_session_exit_code(
     if artifact_exit_code == crate::verdict_exit_code::INFRASTRUCTURE_FAILURE_EXIT_CODE {
         return artifact_exit_code;
     }
-    if !completed_debate_with_verdict {
+    // A completed debate that produced a recognized verdict — whether parsed
+    // explicitly from the assistant turn or the default REVISE synthesized for a
+    // completed-but-unverdicted run — is a successful consultation. Its polarity
+    // is conveyed solely through `output/debate-verdict.json`; only the opt-in
+    // `--fail-on-*` flags turn an unfavorable verdict into a non-zero exit
+    // (#1850, residual of #1759). An UNAVAILABLE/unknown outcome (all tier
+    // models failed) is NOT a verdict, so it keeps the artifact exit code.
+    if !completed_debate_with_verdict && !debate_token_is_recognized_verdict(summary) {
         return artifact_exit_code;
     }
     if fail_on_revise && debate_token_matches(summary, "REVISE") {
@@ -267,6 +274,16 @@ fn resolve_debate_session_exit_code(
         return 1;
     }
     0
+}
+
+/// A debate summary token is a recognized verdict when it names one of the three
+/// adjudication outcomes (APPROVE/REVISE/REJECT). UNAVAILABLE and other tokens
+/// returned when the debate could not conclude are deliberately excluded so the
+/// all-tier-failure path keeps its infrastructure-failure exit code.
+fn debate_token_is_recognized_verdict(summary: &DebateSummary) -> bool {
+    debate_token_matches(summary, "APPROVE")
+        || debate_token_matches(summary, "REVISE")
+        || debate_token_matches(summary, "REJECT")
 }
 
 fn debate_token_matches(summary: &DebateSummary, expected: &str) -> bool {

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -176,7 +176,45 @@ pub(crate) async fn dispatch_plan_run(
         unreachable!("plan daemon spawn returned without exiting");
     }
 
-    plan_cmd::handle_plan_run(plan_args).await?;
+    // Foreground path (nested invocation, `--foreground`, `--resume`, or
+    // `--chunked`): unlike the daemon-child path, nothing here has wired a
+    // session identity into `startup_env`, so `spawn_bash` would omit
+    // CSA_SESSION_DIR / CSA_SESSION_ID from every workflow bash step. A
+    // top-level `--foreground` or `--resume` mktd run then dies in its Save
+    // step on `${CSA_SESSION_DIR:?...}` (#1851). `--dry-run` only prints the
+    // compiled plan and runs no bash steps, so it needs no session scratch dir
+    // and must stay side-effect free.
+    let mut plan_args = plan_args;
+    let foreground_session = if plan_args.dry_run {
+        None
+    } else {
+        let project_root = determine_project_root(plan_args.cd.as_deref())?;
+        let established = establish_foreground_plan_session(
+            &plan_args.startup_env,
+            &project_root,
+            &describe_plan_run(&plan_args),
+        )?;
+        plan_args.startup_env = established.startup_env;
+        established
+            .minted_session_id
+            .map(|session_id| (project_root, session_id))
+    };
+
+    let run_result = plan_cmd::handle_plan_run(plan_args).await;
+
+    // Retire only a session this path minted; an inherited (nested) session is
+    // owned by the parent and must outlive this call.
+    if let Some((project_root, session_id)) = foreground_session
+        && let Err(err) = retire_plan_session(&project_root, &session_id)
+    {
+        warn!(
+            session_id = %session_id,
+            error = %err,
+            "Failed to retire foreground plan session",
+        );
+    }
+    run_result?;
+
     crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
         input.sa_mode_active,
         current_depth,
@@ -373,6 +411,68 @@ fn inject_plan_daemon_session_into_startup_env(
     Ok(())
 }
 
+/// Result of ensuring the foreground `csa plan run` path has a session identity
+/// to thread into its workflow bash steps.
+///
+/// `minted_session_id` is `Some` only when this path created a brand-new
+/// placeholder plan session (the top-level `--foreground` / `--resume` case);
+/// the caller is then responsible for retiring it once the run completes. When
+/// the startup snapshot already carried a session (a nested invocation), the
+/// existing identity is reused untouched and `minted_session_id` is `None`.
+struct ForegroundPlanSession {
+    startup_env: StartupSubtreeEnv,
+    minted_session_id: Option<String>,
+}
+
+/// Guarantee the foreground plan run carries a session identity (id + dir) in
+/// `startup_env` so `spawn_bash` exports CSA_SESSION_ID / CSA_SESSION_DIR to
+/// every workflow bash step (#1851). The daemon-child path already does this via
+/// [`inject_plan_daemon_session_into_startup_env`]; the foreground path had no
+/// equivalent, leaving bash steps without CSA_SESSION_DIR.
+///
+/// Three cases, cheapest first:
+/// - both id and dir already present (nested invocation whose parent exported
+///   the full contract): reuse untouched, mint nothing.
+/// - id present but dir missing: derive the canonical dir from the id without
+///   creating a new session.
+/// - neither present (top-level `--foreground` / `--resume`): mint a fresh
+///   placeholder plan session and report its id for later retirement.
+fn establish_foreground_plan_session(
+    startup_env: &StartupSubtreeEnv,
+    project_root: &Path,
+    description: &str,
+) -> Result<ForegroundPlanSession> {
+    if startup_env.session_id().is_some() && startup_env.session_dir().is_some() {
+        return Ok(ForegroundPlanSession {
+            startup_env: startup_env.clone(),
+            minted_session_id: None,
+        });
+    }
+
+    if let Some(session_id) = startup_env.session_id() {
+        let session_dir = csa_session::get_session_dir(project_root, session_id)?;
+        let startup_env = startup_env
+            .clone()
+            .with_current_session(session_id, session_dir.display().to_string());
+        return Ok(ForegroundPlanSession {
+            startup_env,
+            minted_session_id: None,
+        });
+    }
+
+    let session_id = csa_session::new_session_id();
+    let session_root = csa_session::get_session_root(project_root)?;
+    let session_dir = session_root.join("sessions").join(&session_id);
+    persist_placeholder_plan_session(project_root, &session_dir, &session_id, description)?;
+    let startup_env = startup_env
+        .clone()
+        .with_current_session(&session_id, session_dir.display().to_string());
+    Ok(ForegroundPlanSession {
+        startup_env,
+        minted_session_id: Some(session_id),
+    })
+}
+
 fn describe_plan_run(args: &PlanRunArgs) -> String {
     if let Some(name) = &args.pattern {
         format!("plan: {name}")
@@ -513,102 +613,9 @@ fn nested_session_env_present(startup_env: &StartupSubtreeEnv) -> bool {
     })
 }
 
-/// Build daemon-child args from the parent's argv.
-///
-/// `argv` looks like `["csa", ...global, "plan", "run", ...rest]`. We strip
-/// everything up through `plan run`, drop the `--foreground` opt-out (the
-/// child is the actual worker, not a re-spawn that should opt out again),
-/// and forward the remainder. The daemon spawner re-injects
-/// `--daemon-child --session-id <ID>` between `run` and the rest.
-///
-/// Filter contract: `--foreground` is the ONLY token stripped here, and
-/// only because (a) clap parsed it as a top-level boolean flag with no
-/// value-position semantics, and (b) it's a parent-only opt-out the daemon
-/// child must not see. The filter stops at the first `--` so any literal
-/// `--foreground` that appears AFTER a `--` positional separator (e.g. a
-/// future workflow argument that happens to share the spelling) is left
-/// untouched. DO NOT add other flag strips here without preserving this
-/// `--`-aware behavior — naive `*a != "--xxx"` filters break value-position
-/// usage and `--`-escaped positionals.
-fn build_forwarded_plan_args(all_args: &[String]) -> Vec<String> {
-    let plan_pos = all_args.iter().position(|a| a == "plan");
-    let Some(plan_pos) = plan_pos else {
-        return Vec::new();
-    };
-    // Skip `plan` and the immediately-following `run` verb.
-    let after_plan = plan_pos + 1;
-    let after_run = all_args
-        .iter()
-        .enumerate()
-        .skip(after_plan)
-        .find(|(_, a)| *a == "run")
-        .map(|(idx, _)| idx + 1)
-        .unwrap_or(after_plan);
-
-    let mut forwarded = Vec::with_capacity(all_args.len().saturating_sub(after_run));
-    let mut past_double_dash = false;
-    for token in all_args.iter().skip(after_run) {
-        if past_double_dash {
-            forwarded.push(token.clone());
-            continue;
-        }
-        if token == "--" {
-            past_double_dash = true;
-            forwarded.push(token.clone());
-            continue;
-        }
-        if token == "--foreground" {
-            continue;
-        }
-        forwarded.push(token.clone());
-    }
-    forwarded
-}
-
-/// Build daemon-child forwarded args for the `--issue` path.
-///
-/// Starts from the normal [`build_forwarded_plan_args`] output, drops the
-/// already-resolved `--issue <N>` / `--issue=<N>` token(s), and appends the
-/// fetched issue body as `--var FEATURE_INPUT=<body>`. This lets the daemon
-/// child consume the pre-fetched body instead of re-running `gh issue view`,
-/// so the issue is fetched exactly once (in the parent).
-///
-/// Like [`build_forwarded_plan_args`], the `--issue` strip is `--`-aware: a
-/// literal `--issue`/`--issue=` token appearing AFTER a `--` positional
-/// separator is a workflow argument and is preserved intact.
-fn forwarded_args_with_feature_input(feature_input: &str) -> Vec<String> {
-    let argv: Vec<String> = std::env::args().collect();
-    let base = build_forwarded_plan_args(&argv);
-    let mut forwarded = Vec::with_capacity(base.len() + 2);
-    let mut post_double_dash = Vec::new();
-    let mut tokens = base.into_iter();
-    let mut past_double_dash = false;
-    while let Some(token) = tokens.next() {
-        if past_double_dash {
-            post_double_dash.push(token);
-            continue;
-        }
-        match token.as_str() {
-            "--" => {
-                past_double_dash = true;
-            }
-            // Space form `--issue <N>`: drop the flag and its value token.
-            "--issue" => {
-                tokens.next();
-            }
-            // Equals form `--issue=<N>`: drop the single token.
-            t if t.starts_with("--issue=") => {}
-            _ => forwarded.push(token),
-        }
-    }
-    forwarded.push("--var".to_string());
-    forwarded.push(format!("{FEATURE_INPUT_VAR}={feature_input}"));
-    if past_double_dash {
-        forwarded.push("--".to_string());
-        forwarded.extend(post_double_dash);
-    }
-    forwarded
-}
+#[path = "plan_cmd_daemon_forwarding.rs"]
+mod forwarding;
+pub(crate) use forwarding::{build_forwarded_plan_args, forwarded_args_with_feature_input};
 
 #[cfg(test)]
 #[path = "plan_cmd_daemon_tests.rs"]

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_forwarding.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_forwarding.rs
@@ -1,0 +1,105 @@
+//! Daemon-child argv forwarding for `csa plan run`.
+//!
+//! Split out of `plan_cmd_daemon.rs` to stay under the monolith token budget.
+//! These helpers transform the parent process argv into the token list handed
+//! to the daemon child; the daemon spawner re-injects
+//! `--daemon-child --session-id <ID>` itself.
+
+use crate::plan_cmd::FEATURE_INPUT_VAR;
+
+/// Build daemon-child args from the parent's argv.
+///
+/// `argv` looks like `["csa", ...global, "plan", "run", ...rest]`. We strip
+/// everything up through `plan run`, drop the `--foreground` opt-out (the
+/// child is the actual worker, not a re-spawn that should opt out again),
+/// and forward the remainder. The daemon spawner re-injects
+/// `--daemon-child --session-id <ID>` between `run` and the rest.
+///
+/// Filter contract: `--foreground` is the ONLY token stripped here, and
+/// only because (a) clap parsed it as a top-level boolean flag with no
+/// value-position semantics, and (b) it's a parent-only opt-out the daemon
+/// child must not see. The filter stops at the first `--` so any literal
+/// `--foreground` that appears AFTER a `--` positional separator (e.g. a
+/// future workflow argument that happens to share the spelling) is left
+/// untouched. DO NOT add other flag strips here without preserving this
+/// `--`-aware behavior — naive `*a != "--xxx"` filters break value-position
+/// usage and `--`-escaped positionals.
+pub(crate) fn build_forwarded_plan_args(all_args: &[String]) -> Vec<String> {
+    let plan_pos = all_args.iter().position(|a| a == "plan");
+    let Some(plan_pos) = plan_pos else {
+        return Vec::new();
+    };
+    // Skip `plan` and the immediately-following `run` verb.
+    let after_plan = plan_pos + 1;
+    let after_run = all_args
+        .iter()
+        .enumerate()
+        .skip(after_plan)
+        .find(|(_, a)| *a == "run")
+        .map(|(idx, _)| idx + 1)
+        .unwrap_or(after_plan);
+
+    let mut forwarded = Vec::with_capacity(all_args.len().saturating_sub(after_run));
+    let mut past_double_dash = false;
+    for token in all_args.iter().skip(after_run) {
+        if past_double_dash {
+            forwarded.push(token.clone());
+            continue;
+        }
+        if token == "--" {
+            past_double_dash = true;
+            forwarded.push(token.clone());
+            continue;
+        }
+        if token == "--foreground" {
+            continue;
+        }
+        forwarded.push(token.clone());
+    }
+    forwarded
+}
+
+/// Build daemon-child forwarded args for the `--issue` path.
+///
+/// Starts from the normal [`build_forwarded_plan_args`] output, drops the
+/// already-resolved `--issue <N>` / `--issue=<N>` token(s), and appends the
+/// fetched issue body as `--var FEATURE_INPUT=<body>`. This lets the daemon
+/// child consume the pre-fetched body instead of re-running `gh issue view`,
+/// so the issue is fetched exactly once (in the parent).
+///
+/// Like [`build_forwarded_plan_args`], the `--issue` strip is `--`-aware: a
+/// literal `--issue`/`--issue=` token appearing AFTER a `--` positional
+/// separator is a workflow argument and is preserved intact.
+pub(crate) fn forwarded_args_with_feature_input(feature_input: &str) -> Vec<String> {
+    let argv: Vec<String> = std::env::args().collect();
+    let base = build_forwarded_plan_args(&argv);
+    let mut forwarded = Vec::with_capacity(base.len() + 2);
+    let mut post_double_dash = Vec::new();
+    let mut tokens = base.into_iter();
+    let mut past_double_dash = false;
+    while let Some(token) = tokens.next() {
+        if past_double_dash {
+            post_double_dash.push(token);
+            continue;
+        }
+        match token.as_str() {
+            "--" => {
+                past_double_dash = true;
+            }
+            // Space form `--issue <N>`: drop the flag and its value token.
+            "--issue" => {
+                tokens.next();
+            }
+            // Equals form `--issue=<N>`: drop the single token.
+            t if t.starts_with("--issue=") => {}
+            _ => forwarded.push(token),
+        }
+    }
+    forwarded.push("--var".to_string());
+    forwarded.push(format!("{FEATURE_INPUT_VAR}={feature_input}"));
+    if past_double_dash {
+        forwarded.push("--".to_string());
+        forwarded.extend(post_double_dash);
+    }
+    forwarded
+}

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
@@ -70,6 +70,112 @@ fn daemon_child_injects_preassigned_session_into_startup_env() {
 }
 
 #[test]
+fn establish_foreground_plan_session_mints_session_when_absent() {
+    // #1851: a top-level `--foreground` / `--resume` plan run carries no session
+    // identity in its startup snapshot. Establishing the foreground session MUST
+    // mint one so spawn_bash exports CSA_SESSION_DIR / CSA_SESSION_ID to every
+    // workflow bash step (the mktd Save step reads `${CSA_SESSION_DIR:?...}`).
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("state home should be created");
+    let _state_guard = crate::test_env_lock::ScopedTestEnvVar::set("XDG_STATE_HOME", &state_home);
+
+    let startup_env = crate::startup_env::StartupSubtreeEnv::default();
+    let established =
+        establish_foreground_plan_session(&startup_env, temp.path(), "plan: workflow.toml")
+            .expect("foreground session should establish");
+
+    let minted = established
+        .minted_session_id
+        .as_deref()
+        .expect("a fresh foreground run must mint a session");
+    assert_eq!(established.startup_env.session_id(), Some(minted));
+    assert!(
+        established.startup_env.session_dir().is_some(),
+        "minted session must carry a session dir"
+    );
+
+    // Assert via the exact channel spawn_bash uses to build the bash-step env
+    // (`apply_startup_child_contract_env` -> `to_csa_child_contract_env_vars`).
+    let contract: std::collections::HashMap<String, String> = established
+        .startup_env
+        .to_csa_child_contract_env_vars()
+        .into_iter()
+        .collect();
+    assert!(
+        contract.contains_key(csa_core::env::CSA_SESSION_DIR_ENV_KEY),
+        "workflow bash steps must receive CSA_SESSION_DIR"
+    );
+    assert!(
+        contract.contains_key(csa_core::env::CSA_SESSION_ID_ENV_KEY),
+        "workflow bash steps must receive CSA_SESSION_ID"
+    );
+}
+
+#[test]
+fn establish_foreground_plan_session_derives_dir_from_inherited_id() {
+    // A nested foreground invocation whose parent exported CSA_SESSION_ID but
+    // (defensively) not CSA_SESSION_DIR: derive the canonical dir from the id
+    // without minting a new session.
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let session_id = "01INHERITEDID00000000000000";
+    let startup_env =
+        crate::startup_env::StartupSubtreeEnv::from_values(std::collections::HashMap::from([(
+            csa_core::env::CSA_SESSION_ID_ENV_KEY,
+            session_id.to_string(),
+        )]));
+
+    let established =
+        establish_foreground_plan_session(&startup_env, temp.path(), "plan: workflow.toml")
+            .expect("foreground session should establish");
+
+    assert!(established.minted_session_id.is_none());
+    assert_eq!(established.startup_env.session_id(), Some(session_id));
+    let expected_dir = csa_session::get_session_dir(temp.path(), session_id)
+        .expect("session dir should resolve")
+        .to_string_lossy()
+        .to_string();
+    assert_eq!(
+        established.startup_env.session_dir(),
+        Some(expected_dir.as_str())
+    );
+}
+
+#[test]
+fn establish_foreground_plan_session_preserves_inherited_identity() {
+    // A nested foreground invocation whose parent exported the full contract
+    // (id + dir): reuse it untouched, mint nothing.
+    let startup_env =
+        crate::startup_env::StartupSubtreeEnv::from_values(std::collections::HashMap::from([
+            (
+                csa_core::env::CSA_SESSION_ID_ENV_KEY,
+                "01PARENTID0000000000000000".to_string(),
+            ),
+            (
+                csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+                "/repo/parent-session".to_string(),
+            ),
+        ]));
+
+    let established = establish_foreground_plan_session(
+        &startup_env,
+        std::path::Path::new("/repo"),
+        "plan: workflow.toml",
+    )
+    .expect("foreground session should establish");
+
+    assert!(established.minted_session_id.is_none());
+    assert_eq!(
+        established.startup_env.session_id(),
+        Some("01PARENTID0000000000000000")
+    );
+    assert_eq!(
+        established.startup_env.session_dir(),
+        Some("/repo/parent-session")
+    );
+}
+
+#[test]
 fn forwarded_args_strip_through_plan_run() {
     let argv = vec![
         "csa".to_string(),


### PR DESCRIPTION
## Summary

Fixes two independent break points on the **mktd full-mode planning happy-path**, both surfaced in a single #1842 planning attempt. Each is a small, targeted fix; together they let `csa plan run --pattern mktd` complete end-to-end (Phase 3 debate → Phase 4 save) instead of aborting.

## #1850 — debate REVISE/REJECT no longer fails the persisted session result

`csa debate` producing a **REVISE** (or REJECT) verdict was writing `status="failure"` + `exit_code=1` into `result.toml` **even with no `--fail-on-revise` / `--fail-on-reject`** flag. The async path mktd uses (`csa debate` → `csa session wait "$SID"`) then propagated the non-zero exit → `on_fail="abort"` killed Phase 3 before the plan was ever saved — i.e. the adversarial debate could only ever rubber-stamp (APPROVE), defeating its purpose.

#1759 had decoupled the **direct** process exit from verdict polarity but not the **persisted** `result.toml` status/exit_code that `csa session wait` reads. This applies the same decoupling to the persisted path: REVISE/REJECT without the matching `--fail-on-*` flag now records `status="success"` / `exit_code=0`; the verdict is conveyed via `debate-verdict.json` only. With the flag, fail behavior is preserved on **both** the direct-exit and session-wait paths (they agree).

## #1851 — `csa plan run` bash steps now receive `CSA_SESSION_DIR`

The mktd Phase 4 Save step references `${CSA_SESSION_DIR:?...}`, but `csa plan run` `tool="bash"` steps did not have it (or the other documented context env vars) set → bare `exit 127` → `on_fail="abort"` **after** `csa todo create` but **before** `csa todo persist`, silently degrading the saved plan to raw feature text.

The documented context env vars (`CSA_SESSION_DIR`, `CSA_SESSION_ID`, `CSA_DEPTH`, `CSA_PROJECT_ROOT`) are now exported into the plan-run bash-step environment (including RESUME-continued steps), matching child-spawn semantics. A missing value yields a clear diagnostic rather than a bare 127.

## Test coverage

- #1850: REVISE + no `--fail-on-revise` → result.toml success/exit 0; REVISE + `--fail-on-revise` → failure/exit 1 (REJECT analogous where it shares the path).
- #1851: plan-run bash step receives `CSA_SESSION_DIR` (+ context vars); regression test.
- `just pre-commit` (fmt + clippy + nextest + token-budget) green.

## Out of scope

- #1848 (mid-run gemini-400 RECON failover) — the third mktd happy-path break point; separate PR (touches the sensitive failover-classification machinery + a routing-precedence design question).

Refs #1850, #1851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
