### PR TITLE
fix(cli-sub-agent): review verdict grade fidelity + fallback provenance + session-result summary (#1852)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.875"
+version = "0.1.876"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.875"
+version = "0.1.876"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -807,7 +807,13 @@ async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metad
         result.routed_to.as_deref(),
         Some("codex/openai/gpt-5.4/high")
     );
-    assert_eq!(result.primary_failure.as_deref(), Some("QUOTA_EXHAUSTED"));
+    // #1852: codex fallback SUCCEEDED, so the failed-over-from gemini quota
+    // error is provenance (kept in routed_to/result.toml), not a terminal
+    // primary_failure.
+    assert!(
+        result.primary_failure.is_none(),
+        "successful fallback must not record the failed-over-from error as primary_failure"
+    );
 
     let meta = ReviewSessionMeta {
         session_id: result.execution.meta_session_id.clone(),

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -694,9 +694,16 @@ pub(crate) async fn execute_review_with_tier_filter(
             status_reason,
             forced_decision: None,
             routed_to,
-            primary_failure: (!failures.is_empty())
-                .then(|| chain_failure_reasons(&failures))
-                .flatten(),
+            // #1852: reaching here means THIS attempt's review SUCCEEDED. The
+            // earlier `failures` are the tools we failed over FROM, not a
+            // terminal failure of the review — recording them as
+            // `primary_failure` mislabels a success-via-fallback verdict as
+            // auth/quota-unavailable and (via `requires_fail_closed_verdict`)
+            // drags the verdict toward fail-closed. The failover provenance is
+            // already preserved in the persisted `fallback_chain`, `routed_to`,
+            // and `fallback_reason`. Only the all-candidates-failed return
+            // (above) carries `chain_failure_reasons` as the terminal class.
+            primary_failure: None,
             failure_reason: None,
         });
     }

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
@@ -205,7 +205,13 @@ async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metad
         result.routed_to.as_deref(),
         Some("codex/openai/gpt-5.4/high")
     );
-    assert_eq!(result.primary_failure.as_deref(), Some("QUOTA_EXHAUSTED"));
+    // #1852: a SUCCESSFUL failover leaves `primary_failure` unset — the review
+    // succeeded, so the failed-over-from quota error is not a terminal failure.
+    // Its provenance is preserved in the persisted fallback chain below.
+    assert!(
+        result.primary_failure.is_none(),
+        "successful fallback must not record the failed-over-from error as primary_failure"
+    );
 
     let meta = ReviewSessionMeta {
         session_id: result.execution.meta_session_id.clone(),
@@ -341,9 +347,12 @@ async fn execute_review_advances_tier_fallback_when_explicit_tool_and_tier() {
     assert_ne!(result.forced_decision, Some(ReviewDecision::Unavailable));
     assert_eq!(result.executed_tool, ToolName::Codex);
     assert_eq!(result.routed_to.as_deref(), Some("codex/openai/gpt-5/high"));
-    assert_eq!(
-        result.primary_failure.as_deref(),
-        Some("codex_429_retry_exhausted")
+    // #1852: the second codex variant SUCCEEDED, so the exhausted first variant
+    // is failover provenance (kept in result.toml below), not a terminal
+    // `primary_failure`.
+    assert!(
+        result.primary_failure.is_none(),
+        "successful fallback must not record the failed-over-from error as primary_failure"
     );
 
     let codex_invocations = std::fs::read_to_string(&codex_invocation_log).unwrap();
@@ -387,9 +396,11 @@ async fn execute_review_advances_tier_fallback_when_explicit_tool_and_tier() {
         artifact.routed_to.as_deref(),
         Some("codex/openai/gpt-5/high")
     );
-    assert_eq!(
-        artifact.primary_failure.as_deref(),
-        Some("codex_429_retry_exhausted")
+    // #1852: persisted verdict mirrors the success-via-fallback provenance —
+    // routing metadata is kept, primary_failure is cleared.
+    assert!(
+        artifact.primary_failure.is_none(),
+        "persisted verdict of a successful fallback must not carry primary_failure"
     );
 
     let result_toml = std::fs::read_to_string(session_dir.join("result.toml")).unwrap();

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -41,11 +41,11 @@ pub(super) fn enforce_final_verdict_consistency(
         &prose_signals.severity_counts,
     );
 
+    let prose_grade = highest_prose_severity_grade(session_dir);
+
     let resume_to_fix = has_resume_to_fix_suggestion(session_dir)?;
     let blocking_prose =
         prose_signals.blocking_summary || has_blocking_severity(&prose_signals.severity_counts);
-    let has_empty_machine_findings =
-        findings_file.findings.is_empty() && severity_counts_are_zero(&artifact.severity_counts);
     let parsed_findings_prose = prose_signals.parsed_findings_sections;
     let unparsed_findings_prose = prose_signals.unparseable_findings_sections;
 
@@ -58,24 +58,94 @@ pub(super) fn enforce_final_verdict_consistency(
     if artifact.decision == ReviewDecision::Pass
         && (resume_to_fix || blocking_prose || parsed_findings_prose || unparsed_findings_prose)
     {
-        ensure_nonzero_fail_closed_count(&mut artifact.severity_counts);
         artifact.decision = ReviewDecision::Fail;
         artifact.verdict_legacy = "HAS_ISSUES".to_string();
     }
 
-    if artifact.decision == ReviewDecision::Fail && has_empty_machine_findings {
-        ensure_nonzero_fail_closed_count(&mut artifact.severity_counts);
+    // #1852: a Fail verdict must carry a severity count that reflects the
+    // reviewer's stated prose GRADE. The structured findings can be empty (a
+    // failed-over/degraded reviewer whose machine-readable block never
+    // persisted) or under-grade the prose (a real `[HIGH]` whose
+    // backtick-wrapped tag the structured finding parsers skip). Grade the
+    // fail-closed placeholder by the highest legible prose severity — defaulting
+    // to MEDIUM only when no grade is legible — and never downgrade an existing
+    // higher count.
+    if artifact.decision == ReviewDecision::Fail {
+        ensure_fail_closed_grade(&mut artifact.severity_counts, prose_grade);
     }
 
     Ok(())
 }
 
-fn ensure_nonzero_fail_closed_count(
+/// Ensure a fail-closed verdict's severity counts reflect the reviewer's prose
+/// GRADE. With zero counts, inject one placeholder at `prose_grade` (or MEDIUM
+/// when no grade is legible). With non-zero counts whose highest graded entry is
+/// below `prose_grade`, add the prose grade so a real `[HIGH]` is never reported
+/// as a mergeable MEDIUM (#1852). Never downgrades and never inflates a matching
+/// or already-higher existing grade.
+fn ensure_fail_closed_grade(
     severity_counts: &mut std::collections::BTreeMap<Severity, u32>,
+    prose_grade: Option<Severity>,
 ) {
     if severity_counts_are_zero(severity_counts) {
-        *severity_counts.entry(Severity::Medium).or_insert(0) += 1;
+        let severity = prose_grade.unwrap_or(Severity::Medium);
+        *severity_counts.entry(severity).or_insert(0) += 1;
+        return;
     }
+    let Some(grade) = prose_grade else {
+        return;
+    };
+    let already_at_or_above = severity_counts
+        .iter()
+        .any(|(severity, count)| *count > 0 && *severity >= grade);
+    if !already_at_or_above {
+        *severity_counts.entry(grade).or_insert(0) += 1;
+    }
+}
+
+/// Highest reviewer-assigned severity GRADE legible in the persisted review
+/// sections (`summary`/`details`), tolerant of markdown inline-code backticks
+/// around the tag (e.g. `` `[HIGH]` ``). The structured finding parsers require
+/// the bracket to start the body and therefore skip backtick-wrapped tags, so
+/// the fail-closed grader consults this to avoid under-grading a real HIGH whose
+/// machine-readable findings failed to parse (#1852). Returns `None` when no
+/// bracketed severity tag is present. Best-effort: an unreadable section index
+/// yields `None` (callers fall back to MEDIUM), never an error.
+fn highest_prose_severity_grade(session_dir: &Path) -> Option<Severity> {
+    let sections = csa_session::read_all_sections(session_dir).ok()?;
+    let mut best: Option<Severity> = None;
+    for (_, content) in sections {
+        let mut in_code_fence = false;
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("```") {
+                in_code_fence = !in_code_fence;
+                continue;
+            }
+            if in_code_fence {
+                continue;
+            }
+            for severity in bracketed_severities_in_line(trimmed) {
+                best = Some(match best {
+                    Some(current) => current.max(severity),
+                    None => severity,
+                });
+            }
+        }
+    }
+    best
+}
+
+/// Every bracketed severity label on a line, mapping `[HIGH]`/`[p1]`/... to a
+/// [`Severity`]. Scans the `[label]` delimiters directly so adjacent markdown
+/// backticks (`` `[HIGH]` ``) do not hide the tag. Non-severity brackets (e.g.
+/// `[security/correctness]`) yield nothing.
+fn bracketed_severities_in_line(line: &str) -> impl Iterator<Item = Severity> + '_ {
+    line.match_indices('[').filter_map(|(open, _)| {
+        let rest = line.get(open + 1..)?;
+        let close = rest.find(']')?;
+        crate::review_cmd::prose_findings::severity_from_label(rest.get(..close)?)
+    })
 }
 
 fn has_resume_to_fix_suggestion(session_dir: &Path) -> Result<bool, anyhow::Error> {

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -801,3 +801,6 @@ mod verdict_1761_tests;
 
 #[path = "review_cmd_output_verdict_1804_tests.rs"]
 mod verdict_1804_tests;
+
+#[path = "review_cmd_output_verdict_1852_tests.rs"]
+mod verdict_1852_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1852_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1852_tests.rs
@@ -1,0 +1,203 @@
+//! Regression tests for #1852 Defect 1: a fail-closed review verdict must
+//! record a severity count that matches the reviewer's stated prose GRADE.
+//!
+//! The triggering session reported canonical prose `` `[HIGH]` `` yet persisted
+//! `severity_counts` of `medium=1, high=0` — a merge footgun, because a real
+//! HIGH was downgraded to a mergeable MEDIUM. The structured finding parsers
+//! skip backtick-wrapped severity tags, so the fail-closed grader must scan the
+//! persisted sections backtick-robustly and grade up to (never down from) the
+//! highest legible prose severity, defaulting to MEDIUM only when none is
+//! legible.
+
+use super::*;
+
+fn medium_count(artifact: &ReviewVerdictArtifact) -> u32 {
+    artifact
+        .severity_counts
+        .get(&Severity::Medium)
+        .copied()
+        .unwrap_or(0)
+}
+
+fn high_count(artifact: &ReviewVerdictArtifact) -> u32 {
+    artifact
+        .severity_counts
+        .get(&Severity::High)
+        .copied()
+        .unwrap_or(0)
+}
+
+#[test]
+fn issue_1852_fail_closed_grade_reflects_backtick_high_prose() {
+    let session_id = "01TEST1852BACKTICKHIGH000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1852-backtick-high", session_id);
+
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:details -->
+1. `[HIGH]` Untracked-file line counting can block prompt assembly on special files.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let mut artifact = ReviewVerdictArtifact::from_parts(
+        session_id,
+        ReviewDecision::Fail,
+        "HAS_ISSUES",
+        &[],
+        Vec::new(),
+    );
+    enforce_final_verdict_consistency(&session_dir, &mut artifact)
+        .expect("enforce final verdict consistency");
+
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(
+        high_count(&artifact),
+        1,
+        "backtick-wrapped [HIGH] prose must grade the fail-closed placeholder as High"
+    );
+    assert_eq!(
+        medium_count(&artifact),
+        0,
+        "a HIGH-graded finding must not be recorded as a mergeable MEDIUM (#1852)"
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1852_fail_closed_escalates_up_on_structured_under_grade() {
+    let session_id = "01TEST1852UNDERGRADE00000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1852-under-grade", session_id);
+
+    // Structured machine findings say MEDIUM; canonical prose grades the same
+    // class of issue as HIGH via a backtick-wrapped tag the parsers miss.
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "[[findings]]\nid = \"1852-structured-medium\"\nseverity = \"medium\"\ndescription = \"pre-existing structured medium finding\"\n",
+    )
+    .expect("write structured medium findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:details -->
+1. `[HIGH]` Untracked-file line counting can block prompt assembly on special files.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let mut artifact = ReviewVerdictArtifact::from_parts(
+        session_id,
+        ReviewDecision::Fail,
+        "HAS_ISSUES",
+        &[],
+        Vec::new(),
+    );
+    enforce_final_verdict_consistency(&session_dir, &mut artifact)
+        .expect("enforce final verdict consistency");
+
+    assert_eq!(
+        high_count(&artifact),
+        1,
+        "prose-vs-structured grade mismatch must fail closed UP to High"
+    );
+    assert_eq!(
+        medium_count(&artifact),
+        1,
+        "escalating UP must not erase the lower structured grade"
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1852_existing_high_count_is_not_inflated() {
+    let session_id = "01TEST1852NOINFLATE000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1852-no-inflate", session_id);
+
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "[[findings]]\nid = \"1852-structured-high\"\nseverity = \"high\"\ndescription = \"pre-existing structured high finding\"\n",
+    )
+    .expect("write structured high findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:details -->
+1. `[HIGH]` Untracked-file line counting can block prompt assembly on special files.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let mut artifact = ReviewVerdictArtifact::from_parts(
+        session_id,
+        ReviewDecision::Fail,
+        "HAS_ISSUES",
+        &[],
+        Vec::new(),
+    );
+    enforce_final_verdict_consistency(&session_dir, &mut artifact)
+        .expect("enforce final verdict consistency");
+
+    assert_eq!(
+        high_count(&artifact),
+        1,
+        "a structured High already matching the prose grade must not be double-counted"
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1852_fail_closed_without_legible_grade_defaults_to_medium() {
+    let session_id = "01TEST1852NOGRADEMEDIUM00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1852-no-grade-medium", session_id);
+
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+    // Prose has a non-severity bracket but no legible severity grade.
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:details -->
+The reviewer flagged a `[correctness]` concern but assigned no severity grade.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let mut artifact = ReviewVerdictArtifact::from_parts(
+        session_id,
+        ReviewDecision::Fail,
+        "HAS_ISSUES",
+        &[],
+        Vec::new(),
+    );
+    enforce_final_verdict_consistency(&session_dir, &mut artifact)
+        .expect("enforce final verdict consistency");
+
+    assert_eq!(
+        medium_count(&artifact),
+        1,
+        "an ungraded fail-closed verdict must keep the MEDIUM placeholder fallback"
+    );
+    assert_eq!(
+        high_count(&artifact),
+        0,
+        "no legible HIGH grade must not synthesize a HIGH count"
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -278,6 +278,10 @@ fn display_result_text(
     if let Some(summary) =
         crate::session_summary_text::human_session_summary(session_dir, &envelope.summary)
     {
+        // #1852: enrich a bare failing verdict (e.g. "FAIL") with the
+        // highest-severity finding's grade + title so the one-line Summary
+        // explains why the review failed, not merely that it did.
+        let summary = crate::session_summary_text::enrich_review_summary(session_dir, &summary);
         println!("Summary: {summary}");
     }
     if !envelope.artifacts.is_empty() {

--- a/crates/cli-sub-agent/src/session_summary_text.rs
+++ b/crates/cli-sub-agent/src/session_summary_text.rs
@@ -9,6 +9,12 @@
 
 use std::path::Path;
 
+use csa_session::Severity;
+
+/// Headline title cap so an over-long finding description never blows out the
+/// single-line `Summary:` field.
+const REVIEW_HEADLINE_MAX_CHARS: usize = 160;
+
 /// Resolve the human-readable summary for display.
 ///
 /// Preference order:
@@ -55,6 +61,164 @@ fn non_empty_trimmed(value: &str) -> Option<String> {
     } else {
         Some(trimmed.to_string())
     }
+}
+
+/// Enrich a bare failing review verdict with its highest-severity finding's
+/// grade and title (#1852).
+///
+/// `csa session result` renders a review verdict as a single `Summary:` line.
+/// For a blocking verdict the reviewer's persisted summary is frequently just
+/// the bare token (`FAIL`), which tells the reader *that* the review failed but
+/// not *why*. When `base` is such a bare failing verdict, surface the top
+/// finding as `"FAIL — [HIGH] <title>"`. Any other summary (real agent prose, a
+/// passing verdict, or a failing verdict with no legible finding) is returned
+/// unchanged — passing verdicts are intentionally never enriched so a
+/// converged-clean session cannot resurrect a stale earlier-round finding.
+pub(crate) fn enrich_review_summary(session_dir: &Path, base: &str) -> String {
+    if !is_bare_fail_verdict(base) {
+        return base.to_string();
+    }
+    match top_review_finding_headline(session_dir) {
+        Some(headline) => format!("{base} — {headline}"),
+        None => base.to_string(),
+    }
+}
+
+/// Whether `summary` is exactly a bare blocking review verdict token. Only the
+/// whole-string match counts: a verdict followed by prose already explains
+/// itself and must not be mangled.
+fn is_bare_fail_verdict(summary: &str) -> bool {
+    matches!(
+        summary.trim().to_ascii_uppercase().as_str(),
+        "FAIL" | "HAS_ISSUES"
+    )
+}
+
+/// `[SEVERITY] title` for the highest-severity finding legible in the persisted
+/// review sections, or `None` when none is present. Backtick-tolerant so a
+/// markdown-wrapped `` `[HIGH]` `` tag is still recognized (#1852). Ties on
+/// severity keep the first finding in section order.
+fn top_review_finding_headline(session_dir: &Path) -> Option<String> {
+    let sections = csa_session::read_all_sections(session_dir).ok()?;
+    let mut best: Option<(Severity, String)> = None;
+    for (_, content) in sections {
+        let mut in_code_fence = false;
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("```") {
+                in_code_fence = !in_code_fence;
+                continue;
+            }
+            if in_code_fence {
+                continue;
+            }
+            let Some((severity, title)) = graded_finding_headline(trimmed) else {
+                continue;
+            };
+            let replace = match &best {
+                Some((best_severity, _)) => &severity > best_severity,
+                None => true,
+            };
+            if replace {
+                best = Some((severity, title));
+            }
+        }
+    }
+    best.map(|(severity, title)| format!("[{}] {}", severity_label(&severity), title))
+}
+
+/// Parse a single finding line that leads with a bracketed severity tag,
+/// returning its [`Severity`] and cleaned title. Tolerates a list marker
+/// (`1. `, `- `), markdown inline-code backticks, and a leading category tag
+/// (`[HIGH][correctness] ...`). Returns `None` for any line that does not lead
+/// with a `[severity]` tag.
+fn graded_finding_headline(line: &str) -> Option<(Severity, String)> {
+    let without_marker = strip_list_marker(line.trim());
+    let normalized = without_marker.replace('`', "");
+    let body = normalized.trim_start();
+    if !body.starts_with('[') {
+        return None;
+    }
+
+    let mut severity: Option<Severity> = None;
+    let mut cursor = body;
+    while let Some(after_open) = cursor.strip_prefix('[') {
+        let Some(close) = after_open.find(']') else {
+            break;
+        };
+        let label = after_open.get(..close)?;
+        if severity.is_none() {
+            severity = severity_from_label(label);
+        }
+        cursor = after_open.get(close + 1..)?.trim_start();
+    }
+    let severity = severity?;
+
+    let title = cursor
+        .trim_start_matches([':', '-', '—'])
+        .trim()
+        .trim_end_matches('.')
+        .trim();
+    if title.is_empty() {
+        return None;
+    }
+    Some((severity, clip(title, REVIEW_HEADLINE_MAX_CHARS)))
+}
+
+/// Strip a leading ordered/unordered list marker (`12. `, `3) `, `- `, `* `,
+/// `+ `) so the finding body can be parsed uniformly.
+fn strip_list_marker(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    if let Some(rest) = strip_numeric_list_marker(trimmed) {
+        return rest;
+    }
+    for marker in ["- ", "* ", "+ "] {
+        if let Some(rest) = trimmed.strip_prefix(marker) {
+            return rest.trim_start();
+        }
+    }
+    trimmed
+}
+
+fn strip_numeric_list_marker(line: &str) -> Option<&str> {
+    let non_digit = line.find(|c: char| !c.is_ascii_digit())?;
+    if non_digit == 0 {
+        return None;
+    }
+    let after_digits = line.get(non_digit..)?;
+    let rest = after_digits
+        .strip_prefix(". ")
+        .or_else(|| after_digits.strip_prefix(") "))?;
+    Some(rest.trim_start())
+}
+
+fn severity_from_label(label: &str) -> Option<Severity> {
+    match label.trim().to_ascii_lowercase().as_str() {
+        "critical" | "p0" => Some(Severity::Critical),
+        "high" | "p1" => Some(Severity::High),
+        "medium" | "p2" => Some(Severity::Medium),
+        "low" | "info" | "p3" | "p4" => Some(Severity::Low),
+        _ => None,
+    }
+}
+
+fn severity_label(severity: &Severity) -> &'static str {
+    match severity {
+        Severity::Critical => "CRITICAL",
+        Severity::High => "HIGH",
+        Severity::Medium => "MEDIUM",
+        Severity::Low => "LOW",
+    }
+}
+
+/// Truncate `text` to at most `max` characters, appending an ellipsis when cut,
+/// counting by `char` so a multibyte boundary is never split.
+fn clip(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let truncated: String = text.chars().take(max.saturating_sub(1)).collect();
+    format!("{}…", truncated.trim_end())
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/session_summary_text_tests.rs
+++ b/crates/cli-sub-agent/src/session_summary_text_tests.rs
@@ -1,4 +1,4 @@
-use super::{human_session_summary, is_json_event_envelope};
+use super::{enrich_review_summary, human_session_summary, is_json_event_envelope};
 use std::fs;
 use tempfile::tempdir;
 
@@ -75,6 +75,69 @@ fn empty_summary_markdown_falls_through_to_raw_prose() {
     assert_eq!(
         human_session_summary(temp.path(), "raw prose").as_deref(),
         Some("raw prose")
+    );
+}
+
+#[test]
+fn enriches_bare_fail_verdict_with_backtick_high_finding() {
+    let temp = tempdir().expect("tempdir should be created");
+    csa_session::persist_structured_output(
+        temp.path(),
+        "<!-- CSA:SECTION:details -->\n1. `[HIGH]` Untracked-file line counting can block prompt assembly on special files.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist structured output");
+
+    assert_eq!(
+        enrich_review_summary(temp.path(), "FAIL"),
+        "FAIL — [HIGH] Untracked-file line counting can block prompt assembly on special files"
+    );
+}
+
+#[test]
+fn enriches_with_highest_severity_finding_when_multiple() {
+    let temp = tempdir().expect("tempdir should be created");
+    csa_session::persist_structured_output(
+        temp.path(),
+        "<!-- CSA:SECTION:details -->\n1. `[MEDIUM]` minor nit in logging.\n2. `[CRITICAL][correctness]` data loss on crash.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist structured output");
+
+    assert_eq!(
+        enrich_review_summary(temp.path(), "FAIL"),
+        "FAIL — [CRITICAL] data loss on crash"
+    );
+}
+
+#[test]
+fn does_not_enrich_passing_verdict_even_with_stale_findings() {
+    let temp = tempdir().expect("tempdir should be created");
+    csa_session::persist_structured_output(
+        temp.path(),
+        "<!-- CSA:SECTION:details -->\n1. `[HIGH]` historical finding from an earlier fix round.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist structured output");
+
+    assert_eq!(enrich_review_summary(temp.path(), "PASS"), "PASS");
+}
+
+#[test]
+fn fails_open_to_bare_verdict_when_no_legible_finding() {
+    let temp = tempdir().expect("tempdir should be created");
+    csa_session::persist_structured_output(
+        temp.path(),
+        "<!-- CSA:SECTION:details -->\nNo machine-readable findings were emitted by the reviewer.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist structured output");
+
+    assert_eq!(enrich_review_summary(temp.path(), "FAIL"), "FAIL");
+}
+
+#[test]
+fn leaves_non_verdict_prose_summary_unchanged() {
+    let temp = tempdir().expect("tempdir should be created");
+    assert_eq!(
+        enrich_review_summary(temp.path(), "Implemented the feature and added tests."),
+        "Implemented the feature and added tests."
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #1852 — three related review-verdict / session-result **reporting-fidelity** defects, all surfaced in a single codex-fallback review session (gemini OAuth dead → failover gemini-cli → codex; codex succeeded and produced exactly one `[HIGH]` prose finding). None changes review *decision* logic; each makes the structured/summary outputs faithfully reflect the canonical prose verdict.

## #1852 defect 1 — severity-GRADE downgrade (merge footgun)

A prose `[HIGH]` finding was recorded as `severity_counts.medium=1, high=0` in `review-verdict.json`. Presence parity (#1804/#1806: findings → `decision=fail`) held, but **grade** parity was broken — a real HIGH was under-graded to MEDIUM. An orchestrator on a severity-tiered merge policy ("only HIGH/CRITICAL block; MEDIUM → aggregate + merge") that trusts `severity_counts` would have wrongly merged. `severity_counts` now reflects the canonical prose grade on all paths (including the auth/fallback path); a prose-vs-structured grade mismatch **fails closed UP** to the higher grade, never silently downgrades. Same class as #1696, one level deeper (grade, not presence).

## #1852 defect 2 — `primary_failure=auth_unavailable` despite successful fallback

gemini-cli auth errored, but the codex fallback **succeeded** (sidecar `status=success`, `exit_code=0`) — yet the verdict stamped `primary_failure="auth_unavailable"`. That is misleading provenance: the review completed via codex; the failover is already recorded in `fallback_chain`. When a fallback tool completes the review successfully, `primary_failure` is no longer set to the failed-over-from tool's error class. When **all** candidates fail (no successful fallback), `primary_failure` still reflects the terminal failure class (regression guard — not blanket-cleared).

## #1852 defect 3 — `csa session result` Summary surfaced bare `FAIL`

The `Summary:` line showed a bare `FAIL` with no finding text — the actual finding lived only in `output/details.md`, forcing the orchestrator to read raw artifacts (cf #1726). The Summary now surfaces the top (highest-severity) finding's severity + title, e.g. `FAIL — [HIGH] Untracked-file line counting can block prompt assembly on special files`, and fails open to the bare verdict when no finding text is available.

## Test coverage

- defect 1: prose `[HIGH]` parsed on the fallback path → `severity_counts.high>=1`; constructed grade mismatch → fail-closed UP; presence parity (#1804) regression guard.
- defect 2: gemini auth-fail → codex fallback success → `primary_failure` cleared; all-candidates-fail → terminal failure still reported.
- defect 3: one-HIGH-finding result → Summary includes severity+title; no-findings PASS unaffected.
- `just pre-commit` (fmt + clippy + nextest + token-budget) green.

## Related

#1696 (severity_counts 0/0/0/0 vs findings), #1804 / #1806 (presence parity + fail-closed guard), #1764 (verdict-consumer divergence), #1832 (review quota/failover opacity), #1726 (post-exec detail not surfaced structurally). Discovered while dogfooding #1842 (review-aware writer guard) round-3 cumulative review.

Refs #1852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
