### PR TITLE
feat(cli-sub-agent): csa review cross-dimension blocking enumeration in one pass (#1841)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.877"
+version = "0.1.878"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.877"
+version = "0.1.878"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -161,15 +161,8 @@ pub(crate) async fn handle_review(
 
     let scope = derive_scope_for_project(&args, &project_root);
     let diff_size = diff_size::compute_review_diff_size(&project_root, &scope);
-    let large_diff_warning = diff_size.as_ref().and_then(|diff_size| {
-        diff_size::large_diff_warning(
-            diff_size,
-            diff_size::resolve_large_diff_warn_lines(config.as_ref(), &global_config),
-        )
-    });
-    if let Some(warning) = large_diff_warning {
-        diff_size::emit_large_diff_warning(warning);
-    }
+    let large_diff_warning =
+        diff_size::warn_if_large_diff(diff_size.as_ref(), config.as_ref(), &global_config);
     let mode = if args.fix {
         "review-and-fix"
     } else {
@@ -222,6 +215,8 @@ pub(crate) async fn handle_review(
         prompt.push_str("\n\n");
         prompt.push_str(summary);
     }
+
+    diff_size::append_cross_dimension_anchor(&mut prompt, diff_size.as_ref(), large_diff_warning);
 
     let detected_parent_tool = crate::run_helpers::detect_parent_tool();
     let parent_tool = crate::run_helpers::resolve_tool(detected_parent_tool, &global_config);

--- a/crates/cli-sub-agent/src/review_cmd_diff_size.rs
+++ b/crates/cli-sub-agent/src/review_cmd_diff_size.rs
@@ -7,6 +7,12 @@ use csa_session::state::{ReviewSessionMeta, write_review_meta};
 use csa_session::{ReviewDiffSize, ReviewVerdictArtifact, write_review_verdict};
 use tracing::{debug, warn};
 
+// #1841 cross-dimension breadth-first blocking enumeration lives in its own file
+// so this #1645 diff-size module stays within the per-module token budget.
+#[path = "review_cmd_enumeration_mode.rs"]
+mod enumeration_mode;
+pub(super) use enumeration_mode::append_cross_dimension_anchor;
+
 const REVIEW_DIFF_SIZE_LINE_PREFIX: &str = "Diff size:";
 const REVIEW_DIFF_SIZE_HEADER_SECTION_IDS: &[&str] = &["summary", "details"];
 
@@ -67,6 +73,28 @@ pub(super) fn large_diff_warning(
 
 pub(super) fn emit_large_diff_warning(warning: LargeDiffWarning) {
     eprintln!("{}", format_large_diff_warning(warning));
+}
+
+/// Resolve the #1645 large-diff warning for an already-sized review diff and emit
+/// it to the operator (stderr) when the diff exceeds the configured threshold.
+/// Returns the warning (when present) so the caller can still thread it into
+/// downstream review artifacts. Pure extraction of the former inline command-layer
+/// block; behavior is unchanged.
+pub(super) fn warn_if_large_diff(
+    diff_size: Option<&ReviewDiffSize>,
+    project_config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+) -> Option<LargeDiffWarning> {
+    let warning = diff_size.and_then(|diff_size| {
+        large_diff_warning(
+            diff_size,
+            resolve_large_diff_warn_lines(project_config, global_config),
+        )
+    });
+    if let Some(warning) = warning {
+        emit_large_diff_warning(warning);
+    }
+    warning
 }
 
 pub(super) fn format_large_diff_warning(warning: LargeDiffWarning) -> String {

--- a/crates/cli-sub-agent/src/review_cmd_enumeration_mode.rs
+++ b/crates/cli-sub-agent/src/review_cmd_enumeration_mode.rs
@@ -1,0 +1,158 @@
+//! Cross-dimension breadth-first blocking-enumeration mode (#1841).
+//!
+//! Derives, from the existing #1645 large-diff threshold machinery in the parent
+//! diff-size module, whether a review should attempt a breadth-first pass
+//! enumerating the top blocking finding across all standard dimensions in one
+//! round, and appends the corresponding prompt anchor when so. Kept in its own
+//! file so the parent #1645 diff-size module stays within the per-module token
+//! budget.
+
+use csa_session::ReviewDiffSize;
+
+use super::LargeDiffWarning;
+
+/// Cross-dimension breadth-first enumeration mode (#1841).
+///
+/// Selected from the existing #1645 large-diff threshold so the reviewer only
+/// attempts a breadth-first pass over all dimensions when it can attend to the
+/// whole diff at once. Large (or unmeasurable) diffs keep the pre-existing
+/// chunked/escalation path, avoiding the attention-dilution regression #1645
+/// guards against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ReviewEnumerationMode {
+    /// Small/medium diff (at or below the #1645 threshold): enumerate the top
+    /// blocking finding per standard dimension in one pass before finalizing FAIL.
+    CrossDimension,
+    /// Large diff (above the #1645 threshold), or a diff that could not be sized:
+    /// keep the existing chunked/escalation path; do NOT inject the breadth-first
+    /// enumeration anchor.
+    LargeDiffChunked,
+}
+
+impl ReviewEnumerationMode {
+    /// Whether this mode injects the cross-dimension breadth-first enumeration
+    /// anchor into the review prompt.
+    fn enumerates_cross_dimension(self) -> bool {
+        matches!(self, ReviewEnumerationMode::CrossDimension)
+    }
+}
+
+/// Resolve the cross-dimension enumeration mode from the already-computed #1645
+/// diff-size report, reusing the existing large-diff threshold machinery
+/// ([`super::large_diff_warning`]) rather than introducing a second threshold:
+///
+/// - measured and NOT large -> [`ReviewEnumerationMode::CrossDimension`]
+/// - measured and large, OR unmeasurable -> [`ReviewEnumerationMode::LargeDiffChunked`]
+///
+/// An unmeasurable diff (`diff_size == None`, e.g. the git diff failed)
+/// conservatively keeps the existing path, so a diff that could not be sized never
+/// forces breadth-first enumeration onto a potentially oversized change.
+fn resolve_review_enumeration_mode(
+    diff_size: Option<&ReviewDiffSize>,
+    large_diff_warning: Option<LargeDiffWarning>,
+) -> ReviewEnumerationMode {
+    match diff_size {
+        Some(_) if large_diff_warning.is_none() => ReviewEnumerationMode::CrossDimension,
+        _ => ReviewEnumerationMode::LargeDiffChunked,
+    }
+}
+
+/// Append the #1841 cross-dimension breadth-first blocking-enumeration anchor to
+/// the review `prompt` when the #1645 diff-size gate selects cross-dimension mode
+/// (small/medium diffs); no-op for large or unmeasurable diffs. Idempotent: a
+/// repeated call does not stack the anchor.
+pub(crate) fn append_cross_dimension_anchor(
+    prompt: &mut String,
+    diff_size: Option<&ReviewDiffSize>,
+    large_diff_warning: Option<LargeDiffWarning>,
+) {
+    let mode = resolve_review_enumeration_mode(diff_size, large_diff_warning);
+    crate::review_design_anchor::append_cross_dimension_enumeration_anchor(
+        prompt,
+        mode.enumerates_cross_dimension(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::large_diff_warning;
+    use super::*;
+
+    #[test]
+    fn enumeration_mode_cross_dimension_for_measured_small_diff() {
+        let size = ReviewDiffSize {
+            files: 1,
+            changed_lines: 40,
+            bytes: 512,
+            notes: Vec::new(),
+        };
+        let warning = large_diff_warning(&size, Some(1000));
+        assert!(
+            warning.is_none(),
+            "40 lines is below the 1000-line threshold"
+        );
+
+        let mode = resolve_review_enumeration_mode(Some(&size), warning);
+        assert_eq!(mode, ReviewEnumerationMode::CrossDimension);
+        assert!(mode.enumerates_cross_dimension());
+    }
+
+    #[test]
+    fn enumeration_mode_large_chunked_for_measured_large_diff() {
+        let size = ReviewDiffSize {
+            files: 9,
+            changed_lines: 1500,
+            bytes: 65536,
+            notes: Vec::new(),
+        };
+        let warning = large_diff_warning(&size, Some(1000));
+        assert!(
+            warning.is_some(),
+            "1500 lines is above the 1000-line threshold"
+        );
+
+        let mode = resolve_review_enumeration_mode(Some(&size), warning);
+        assert_eq!(mode, ReviewEnumerationMode::LargeDiffChunked);
+        assert!(!mode.enumerates_cross_dimension());
+    }
+
+    #[test]
+    fn enumeration_mode_chunked_when_diff_size_unmeasurable() {
+        // A diff that could not be sized must keep the existing path, not force
+        // breadth-first enumeration onto a potentially oversized change.
+        assert_eq!(
+            resolve_review_enumeration_mode(None, None),
+            ReviewEnumerationMode::LargeDiffChunked
+        );
+    }
+
+    #[test]
+    fn append_cross_dimension_anchor_gates_on_diff_size() {
+        let small = ReviewDiffSize {
+            files: 1,
+            changed_lines: 40,
+            bytes: 512,
+            notes: Vec::new(),
+        };
+        let mut enabled = String::from("base prompt");
+        append_cross_dimension_anchor(&mut enabled, Some(&small), None);
+        assert!(
+            enabled.contains("## Cross-dimension blocking enumeration"),
+            "small/medium diff must receive the enumeration anchor"
+        );
+
+        let large = ReviewDiffSize {
+            files: 9,
+            changed_lines: 1500,
+            bytes: 65536,
+            notes: Vec::new(),
+        };
+        let warning = large_diff_warning(&large, Some(1000));
+        let mut disabled = String::from("base prompt");
+        append_cross_dimension_anchor(&mut disabled, Some(&large), warning);
+        assert!(
+            !disabled.contains("## Cross-dimension blocking enumeration"),
+            "large diff must keep the existing path (no enumeration anchor)"
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/review_design_anchor.rs
+++ b/crates/cli-sub-agent/src/review_design_anchor.rs
@@ -22,6 +22,15 @@ Report confirmed siblings as sub-items of one finding labeled `class sweep: N si
 For structured artifacts, use the label in the summary or evidence text only. Do not add schema fields or change severity, verdict, consensus, or pass/fail threshold semantics; each site still needs file+line evidence.
 "#;
 
+pub(crate) const REVIEW_CROSS_DIMENSION_ENUMERATION_ANCHOR: &str = r#"## Cross-dimension blocking enumeration
+
+This diff is small/medium (at or below the #1645 large-diff threshold). Before you finalize a FAIL verdict, make ONE bounded breadth-first pass that enumerates the INDEPENDENT blocking (HIGH/CRITICAL/P1) findings currently latent ACROSS the standard dimensions (correctness, concurrency, security, contract/doc-sync, ordering, completeness). Report them TOGETHER as an enumerated list; do NOT stop at the first blocking finding. K independent defects of DIFFERENT bug-classes that are all simultaneously inspectable in this same diff should surface in ONE round, because each extra round costs a full fix -> re-review -> diff re-ingestion cycle.
+
+Bounds (do NOT exhaustively enumerate): cap the list at the single highest-severity blocking finding PER dimension (the top blocker per dimension); fold sibling sites of one finding under the bounded same-class site sweep, not here. This targets only findings ALREADY latent in the reviewed diff -- defects genuinely INTRODUCED by a later fix legitimately surface in a later round, so this does NOT promise single-round convergence.
+
+This is distinct from the bounded same-class site sweep: that sweep broadens ONE finding's bug-class across its sibling SITES (intra-dimension depth, #1797); this enumeration broadens across DIFFERENT dimensions / bug-classes (cross-dimension breadth, #1841). Apply BOTH -- sweep each confirmed blocker for siblings AND enumerate the top blocker of every other dimension.
+"#;
+
 use std::path::Path;
 
 pub(crate) fn append_design_anchor(prompt: &mut String) {
@@ -37,6 +46,26 @@ pub(crate) fn append_design_anchor(prompt: &mut String) {
     );
 }
 
+/// Append the cross-dimension breadth-first blocking-enumeration anchor (#1841)
+/// when the diff-size gate selected cross-dimension mode.
+///
+/// `enabled` is the #1645-threshold gate decision computed by
+/// `resolve_review_enumeration_mode` in the review enumeration-mode module: small/medium
+/// diffs (`true`) receive the breadth-first enumeration guidance, while large diffs
+/// (`false`) keep the existing chunked/escalation review path UNCHANGED so the
+/// reviewer's attention is not diluted across dimensions on an oversized diff (the
+/// regression #1645 guards against). Idempotent: a second call is a no-op.
+pub(crate) fn append_cross_dimension_enumeration_anchor(prompt: &mut String, enabled: bool) {
+    if !enabled {
+        return;
+    }
+    append_anchor_if_missing(
+        prompt,
+        "## Cross-dimension blocking enumeration",
+        REVIEW_CROSS_DIMENSION_ENUMERATION_ANCHOR,
+    );
+}
+
 fn append_anchor_if_missing(prompt: &mut String, heading: &str, anchor: &str) {
     if prompt.contains(heading) {
         return;
@@ -48,4 +77,76 @@ fn append_anchor_if_missing(prompt: &mut String, heading: &str, anchor: &str) {
 pub(crate) fn resolve_current_branch_via_vcs(project_root: &Path) -> Option<String> {
     let backend = csa_session::vcs_backends::create_vcs_backend(project_root);
     backend.current_branch(project_root).ok().flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Canonical review protocol embedded at compile time so this runtime anchor
+    /// and the single-source protocol cannot describe cross-dimension enumeration
+    /// differently (mirrors the #1842 dimensions drift guard).
+    const REVIEW_PROTOCOL_SRC: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../patterns/csa-review/skills/csa-review/references/review-protocol.md"
+    ));
+
+    const CROSS_DIMENSION_HEADING: &str = "## Cross-dimension blocking enumeration";
+
+    #[test]
+    fn cross_dimension_anchor_appended_only_when_enabled() {
+        let mut enabled = String::from("base prompt");
+        append_cross_dimension_enumeration_anchor(&mut enabled, true);
+        assert!(
+            enabled.contains(CROSS_DIMENSION_HEADING),
+            "small/medium diff must receive the cross-dimension enumeration anchor"
+        );
+
+        let mut disabled = String::from("base prompt");
+        append_cross_dimension_enumeration_anchor(&mut disabled, false);
+        assert!(
+            !disabled.contains(CROSS_DIMENSION_HEADING),
+            "large-diff path must stay unchanged (no enumeration anchor injected)"
+        );
+    }
+
+    #[test]
+    fn cross_dimension_anchor_is_idempotent() {
+        let mut prompt = String::new();
+        append_cross_dimension_enumeration_anchor(&mut prompt, true);
+        append_cross_dimension_enumeration_anchor(&mut prompt, true);
+        assert_eq!(
+            prompt.matches(CROSS_DIMENSION_HEADING).count(),
+            1,
+            "anchor must not stack across repeated calls"
+        );
+    }
+
+    #[test]
+    fn cross_dimension_anchor_states_cap_caveat_and_sweep_distinction() {
+        let anchor = REVIEW_CROSS_DIMENSION_ENUMERATION_ANCHOR;
+        // Explicit per-dimension cap (bounded attention budget).
+        assert!(anchor.contains("per dimension"));
+        // Independently-latent caveat: must not over-promise single-round convergence.
+        assert!(anchor.contains("does NOT promise single-round convergence"));
+        // #1797 (intra-dimension same-class) vs #1841 (cross-dimension breadth).
+        assert!(anchor.contains("#1797"));
+        assert!(anchor.contains("#1841"));
+    }
+
+    /// Protocol single-source presence/drift guard: the cross-dimension enumeration
+    /// instruction AND the #1797-vs-#1841 distinction must live in
+    /// review-protocol.md (the file the reviewer reads from disk) so the protocol
+    /// and this runtime anchor cannot silently diverge.
+    #[test]
+    fn protocol_single_source_carries_cross_dimension_enumeration() {
+        assert!(
+            REVIEW_PROTOCOL_SRC.contains("Cross-dimension blocking enumeration"),
+            "review-protocol.md must document cross-dimension blocking enumeration (#1841)"
+        );
+        assert!(
+            REVIEW_PROTOCOL_SRC.contains("#1797") && REVIEW_PROTOCOL_SRC.contains("#1841"),
+            "review-protocol.md must document the #1797 (same-class) vs #1841 (cross-dimension) distinction"
+        );
+    }
 }

--- a/patterns/csa-review/skills/csa-review/references/review-protocol.md
+++ b/patterns/csa-review/skills/csa-review/references/review-protocol.md
@@ -311,6 +311,44 @@ When executing, reason from attacker perspective and evaluate exploitability for
 
 High-impact security suspicion without concrete exploit path -> list under open_questions, not findings.
 
+## Step 3.5: Cross-Dimension Blocking Enumeration (breadth-first)
+
+Before you finalize a FAIL verdict, make ONE bounded breadth-first pass that
+enumerates the INDEPENDENT blocking (HIGH/CRITICAL/P1) findings currently latent
+ACROSS the standard dimensions (correctness, concurrency, security,
+contract/doc-sync, ordering, completeness) and report them TOGETHER as an
+enumerated list. Do NOT stop at the first blocking finding: K independent defects
+of DIFFERENT bug-classes that are all simultaneously inspectable in the SAME diff
+should surface in ONE round, because each extra round costs a full
+fix -> re-review -> diff re-ingestion cycle.
+
+Bounds (do NOT naively enumerate everything):
+
+1. **Diff-size gate.** This breadth-first enumeration is selected only for
+   small/medium diffs (at or below the existing large-diff threshold from #1645).
+   For LARGE diffs the orchestrator keeps the existing chunked/escalation review
+   path UNCHANGED — do not force cross-dimension breadth there, which would dilute
+   attention on an oversized diff (the regression #1645 guards against). The
+   orchestrator signals the selected mode by injecting (or omitting) a
+   `## Cross-dimension blocking enumeration` anchor into your prompt: when the
+   anchor is present, do the breadth-first enumeration; when it is absent, follow
+   the existing large-diff / chunked handling.
+2. **Per-dimension cap.** Report at most the single highest-severity blocking
+   finding per dimension (the top blocker per dimension) so the enumeration stays
+   within a bounded attention budget. Sibling sites of one finding stay folded
+   under the bounded same-class site sweep, not re-listed here.
+3. **Independently-latent only.** This targets defects already latent in the diff
+   under review. Findings genuinely INTRODUCED by a later fix legitimately surface
+   in a later round; this does NOT promise zero-round or single-round convergence.
+
+**Relationship to the bounded same-class site sweep.** The same-class site sweep
+(#1797) broadens ONE finding's bug-CLASS across all its sibling SITES — depth
+WITHIN a dimension. This cross-dimension blocking enumeration (#1841) broadens
+across DIFFERENT bug-classes / dimensions — breadth ACROSS dimensions. They are
+complementary, and you apply BOTH: sweep each confirmed blocker for sibling sites,
+AND enumerate the top blocker of each other dimension. Together they minimize the
+number of review rounds.
+
 ## Step 4: Generate Outputs (when review is clean)
 
 After the three-pass review, if there are **no P0 or P1 findings**, generate additional outputs:


### PR DESCRIPTION
## Summary

Implements #1841 — `csa review` now enumerates **all independent blocking findings across dimensions in one pass** (cross-dimension breadth) for small/medium diffs, instead of reporting them depth-first one-per-round. Review rounds are the dominant cost/latency lever in dev2merge (each round = a fix-writer session + a fresh review session + full diff re-ingestion at ~500:1 input:output); when K independent blocking defects are latent in one diff, one-per-round reporting multiplies that cost ~K×.

This is the **reviewer-side** complement to #1842 (writer-side guard) — together they give two-sided round reduction — and is distinct from #1797 (which sweeps the same bug-class across all *sites* within one dimension; this enumerates *different* bug-classes across *dimensions*).

Evidence: the #1819–#1822 cluster took 7 review rounds where 5 of 6 blocking findings (correctness, guard/allowlist, concurrency/TOCTOU, ordering, contract/doc-sync) were all independently latent in the round-1 diff — breadth-first enumeration would plausibly have collapsed ~7 rounds into ~3.

## Behavior

Before finalizing a FAIL verdict, the reviewer makes a bounded pass enumerating all independent blocking (HIGH/CRITICAL/P1) findings across the standard dimensions (correctness, concurrency, security, contract/doc-sync, ordering, completeness) and reports them together as an enumerated list.

Balancing constraints (no naive exhaustive enumeration):
- **Diff-size gated** — reuses the existing #1645 threshold: small/medium diffs get full cross-dimension enumeration; large diffs keep the existing chunked/escalation/`--final` path **unchanged** (no attention-dilution regression).
- **Breadth-capped** — top blocking finding per dimension, bounding the reviewer's attention budget.
- **Not zero-round convergence** — findings genuinely introduced by a *later* fix legitimately surface in a later round; this targets only the independently-latent findings.

## Test coverage (mechanism, not emergent LLM output)

- diff-size gating decision: small/medium diff selects cross-dimension enumeration mode; large diff selects the existing chunked path.
- protocol presence/drift: the breadth-first enumeration instruction is in the single-source review protocol; existing drift guard (shared with the #1842 writer guard) stays green.
- `just pre-commit` (fmt + clippy + nextest + token-budget) green; `weave compile` green for any touched pattern.

## Related

#1842 (writer-side complement), #1797 (intra-dimension same-class site sweep), #1645 (large-diff attention dilution / threshold reused here), #1726/#1762 (round-cost observability).

Refs #1841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
