### PR TITLE
fix(csa-process): scope idle fatal-marker scan to transport stream only (#1830)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.879"
+version = "0.1.880"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.879"
+version = "0.1.880"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-process/src/idle_watchdog.rs
+++ b/crates/csa-process/src/idle_watchdog.rs
@@ -142,7 +142,9 @@ pub(crate) fn should_terminate_for_initial_response_with_state(
             .then_some(IdleTerminationReason::Idle);
     }
 
-    // #1745 stopgap opt-out; proper fix = scope marker scan to backend-transport stream only (#182)
+    // #1745 opt-out kill-switch. The marker scan is now scoped to the stderr
+    // transport stream (#1830 / #182), so model/assistant output can no longer
+    // self-trip it; the opt-out is retained as a defense-in-depth backstop.
     if error_marker_scan_enabled && let Some(dir) = session_dir {
         let now = Instant::now();
         let should_poll = state
@@ -244,7 +246,9 @@ pub(crate) fn should_terminate_for_idle_with_state(
         return None;
     }
 
-    // #1745 stopgap opt-out; proper fix = scope marker scan to backend-transport stream only (#182)
+    // #1745 opt-out kill-switch. The marker scan is now scoped to the stderr
+    // transport stream (#1830 / #182), so model/assistant output can no longer
+    // self-trip it; the opt-out is retained as a defense-in-depth backstop.
     if error_marker_scan_enabled && idle_for >= FATAL_ERROR_PROGRESS_GRACE {
         if let Some(reason) = provider_error_termination(
             signals.provider_error,

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -7,14 +7,17 @@ use crate::process_tree_cpu_ticks;
 
 #[path = "tool_liveness_fatal_error.rs"]
 mod fatal_error;
-use fatal_error::provider_error_signal;
 #[cfg(test)]
-use fatal_error::{build_fatal_error_regex, has_fatal_error_signal_in_channels};
+use fatal_error::build_fatal_error_regex;
+use fatal_error::provider_error_signal;
 const LIVENESS_RECENT_WINDOW_SECS: u64 = 30;
 const LOCK_FILE_STALE_SECS: u64 = 60;
 const DAEMON_PID_FILE: &str = "daemon.pid";
 const ACP_EVENTS_LOG_FILE: &str = "output/acp-events.jsonl";
 const STDERR_LOG_FILE: &str = "stderr.log";
+// Only referenced by tests now that the fatal-marker scan is scoped to the stderr
+// transport stream (#1830); model/assistant `output.log` is no longer scanned.
+#[cfg(test)]
 const OUTPUT_LOG_FILE: &str = "output.log";
 const SNAPSHOT_FILE: &str = ".liveness.snapshot";
 const FATAL_ERROR_MARKERS_FILE: &str = ".fatal-error-markers";

--- a/crates/csa-process/src/tool_liveness_fatal_error.rs
+++ b/crates/csa-process/src/tool_liveness_fatal_error.rs
@@ -1,15 +1,11 @@
 use regex::{Regex, RegexBuilder};
 use std::fs::{self, File};
-use std::io::{ErrorKind, Read, Seek, SeekFrom};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
-use std::process::Command;
-use std::sync::{
-    OnceLock,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::OnceLock;
 
 use super::ProviderErrorKind;
-use super::{FATAL_ERROR_MARKERS_FILE, OUTPUT_LOG_FILE, STDERR_LOG_FILE};
+use super::{FATAL_ERROR_MARKERS_FILE, STDERR_LOG_FILE};
 
 const FATAL_ERROR_TAIL_BYTES: u64 = 4096;
 
@@ -149,55 +145,40 @@ fn read_fatal_error_marker_file(marker_path: &Path) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Scan only the genuine backend transport / provider-error stream for fatal markers.
+///
+/// The fatal-marker scan is scoped to `stderr.log` — the backend's real error
+/// channel. It never inspects model/assistant OUTPUT (`output.log`) or raw tmux pane
+/// text, because those carry model-authored content that can legitimately contain
+/// marker-like strings (an agent quoting `rate_limit_exceeded`, narrating `HTTP 429`,
+/// etc.); scanning them lets assistant output self-kill its own session (#1830). The
+/// failed-turn quota path in `pipeline_execute.rs` applies the same discipline by
+/// inspecting only the transport error chain.
+///
+/// Note: this scoping does NOT retire the #1847 `CSA_PATTERN_INTERNAL` interim
+/// suppression, which additionally depends on #1738 (codex provider-error stream
+/// separation).
 pub(super) fn provider_error_signal(session_dir: &Path) -> Option<ProviderErrorKind> {
-    let tmux_pane = capture_tmux_pane(session_dir);
-    provider_error_signal_in_channels(session_dir, tmux_pane.as_deref())
-}
-
-#[cfg(test)]
-pub(super) fn has_fatal_error_signal_in_channels(
-    session_dir: &Path,
-    tmux_pane: Option<&str>,
-) -> bool {
-    provider_error_signal_in_channels(session_dir, tmux_pane).is_some()
-}
-
-fn provider_error_signal_in_channels(
-    session_dir: &Path,
-    tmux_pane: Option<&str>,
-) -> Option<ProviderErrorKind> {
     let regexes = fatal_error_regexes_for_session(session_dir);
     let stderr_tail = read_file_tail(&session_dir.join(STDERR_LOG_FILE)).ok();
-    let output_tail = read_file_tail(&session_dir.join(OUTPUT_LOG_FILE)).ok();
 
-    if matches_provider_error(
-        &regexes.permanent,
-        stderr_tail.as_deref(),
-        output_tail.as_deref(),
-        tmux_pane,
-    ) {
+    if matches_provider_error(&regexes.permanent, stderr_tail.as_deref()) {
         return Some(ProviderErrorKind::Permanent);
     }
-    matches_provider_error(
-        &regexes.transient,
-        stderr_tail.as_deref(),
-        output_tail.as_deref(),
-        tmux_pane,
-    )
-    .then_some(ProviderErrorKind::Transient)
+    matches_provider_error(&regexes.transient, stderr_tail.as_deref())
+        .then_some(ProviderErrorKind::Transient)
 }
 
-fn matches_provider_error(
-    regexes: &FatalErrorChannelRegexes,
-    stderr_tail: Option<&str>,
-    output_tail: Option<&str>,
-    tmux_pane: Option<&str>,
-) -> bool {
+fn matches_provider_error(regexes: &FatalErrorChannelRegexes, stderr_tail: Option<&str>) -> bool {
+    // Both the `all_channel` and `stderr_only` marker sets match against the stderr
+    // transport stream only. The historical split (tier-1 provider markers vs broad
+    // HTTP/status markers) now differs only in source-marker classification, not in
+    // channel: model-output channels (`output.log`, tmux pane) are no longer scanned
+    // at all (#1830).
     stderr_tail.is_some_and(|tail| {
         matches_fatal_error(&regexes.all_channel, tail)
             || matches_fatal_error(&regexes.stderr_only, tail)
-    }) || output_tail.is_some_and(|tail| matches_fatal_error(&regexes.all_channel, tail))
-        || tmux_pane.is_some_and(|pane| matches_fatal_error(&regexes.all_channel, pane))
+    })
 }
 
 fn matches_fatal_error(regex: &Option<Regex>, text: &str) -> bool {
@@ -265,45 +246,4 @@ fn read_file_tail(path: &Path) -> std::io::Result<String> {
     let mut buf = Vec::with_capacity(tail_len as usize);
     file.take(tail_len).read_to_end(&mut buf)?;
     Ok(String::from_utf8_lossy(&buf).into_owned())
-}
-
-fn capture_tmux_pane(session_dir: &Path) -> Option<String> {
-    static TMUX_AVAILABLE: AtomicBool = AtomicBool::new(true);
-    if !TMUX_AVAILABLE.load(Ordering::Relaxed) {
-        return None;
-    }
-
-    let session_id = session_dir.file_name()?.to_str()?;
-    let session_name = format!("csa-{session_id}");
-
-    if let Ok(handle) = tokio::runtime::Handle::try_current()
-        && matches!(
-            handle.runtime_flavor(),
-            tokio::runtime::RuntimeFlavor::MultiThread
-        )
-    {
-        return tokio::task::block_in_place(|| {
-            capture_tmux_pane_blocking(&session_name, &TMUX_AVAILABLE)
-        });
-    }
-
-    capture_tmux_pane_blocking(&session_name, &TMUX_AVAILABLE)
-}
-
-fn capture_tmux_pane_blocking(session_name: &str, tmux_available: &AtomicBool) -> Option<String> {
-    let output = match Command::new("tmux")
-        .args(["capture-pane", "-t", session_name, "-p", "-S", "-200"])
-        .output()
-    {
-        Ok(output) => output,
-        Err(error) if error.kind() == ErrorKind::NotFound => {
-            tmux_available.store(false, Ordering::Relaxed);
-            return None;
-        }
-        Err(_) => return None,
-    };
-    if !output.status.success() {
-        return None;
-    }
-    Some(String::from_utf8_lossy(&output.stdout).into_owned())
 }

--- a/crates/csa-process/src/tool_liveness_tests.rs
+++ b/crates/csa-process/src/tool_liveness_tests.rs
@@ -328,7 +328,10 @@ fn sidecar_broad_http_marker_ignores_unconfigured_status_code() {
 }
 
 #[test]
-fn sidecar_keeps_tier1_markers_all_channel() {
+fn sidecar_tier1_markers_scoped_to_stderr() {
+    // #1830: tier-1 provider markers are scanned ONLY on the stderr transport stream.
+    // The same marker present only in model/assistant output (`output.log`) must not
+    // trip the scanner; on stderr it still fast-fails.
     let tmp = tempfile::tempdir().expect("tempdir");
     write_fatal_error_markers(
         tmp.path(),
@@ -345,9 +348,21 @@ fn sidecar_keeps_tier1_markers_all_channel() {
     )
     .expect("write output");
 
-    let signals = ToolLiveness::probe(tmp.path());
+    assert!(
+        !ToolLiveness::probe(tmp.path()).fatal_error,
+        "tier-1 marker in model output must not trip the scanner"
+    );
 
-    assert!(signals.fatal_error);
+    fs::write(
+        tmp.path().join(STDERR_LOG_FILE),
+        "provider envelope: rate_limit_exceeded\n",
+    )
+    .expect("write stderr");
+
+    assert!(
+        ToolLiveness::probe(tmp.path()).fatal_error,
+        "tier-1 marker on the stderr transport stream must still fast-fail"
+    );
 }
 
 #[test]
@@ -361,17 +376,18 @@ fn matches_custom_markers_with_non_word_edges() {
 }
 
 #[test]
-fn fatal_error_signal_scopes_tmux_pane_to_tier1_markers() {
+fn fatal_error_signal_excludes_model_output_channel() {
+    // #1830: marker-like strings present only in model/assistant output (`output.log`,
+    // and likewise the no-longer-scanned tmux pane) must NOT register as a provider
+    // error — that text is model-authored, not a genuine transport failure.
     let tmp = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        tmp.path().join(OUTPUT_LOG_FILE),
+        "agent quoted HTTP 429 while reading API docs; provider envelope: quota exceeded\n",
+    )
+    .expect("write output");
 
-    assert!(!has_fatal_error_signal_in_channels(
-        tmp.path(),
-        Some("agent quoted HTTP 429 while reading API docs")
-    ));
-    assert!(has_fatal_error_signal_in_channels(
-        tmp.path(),
-        Some("provider envelope: quota exceeded")
-    ));
+    assert!(!ToolLiveness::probe(tmp.path()).fatal_error);
 }
 
 #[test]
@@ -389,7 +405,9 @@ fn probe_detects_broad_http_marker_in_stderr_tail() {
 }
 
 #[test]
-fn probe_detects_tier1_provider_marker_in_output_log() {
+fn probe_ignores_tier1_provider_marker_in_output_log() {
+    // #1830: a tier-1 provider marker that appears only in model/assistant output is
+    // not a genuine transport error and must not trip the fatal-error scanner.
     let tmp = tempfile::tempdir().expect("tempdir");
     fs::write(
         tmp.path().join(OUTPUT_LOG_FILE),
@@ -399,7 +417,7 @@ fn probe_detects_tier1_provider_marker_in_output_log() {
 
     let signals = ToolLiveness::probe(tmp.path());
 
-    assert!(signals.fatal_error);
+    assert!(!signals.fatal_error);
 }
 
 #[test]
@@ -407,11 +425,12 @@ fn probe_uses_custom_fatal_error_marker_sidecar() {
     let tmp = tempfile::tempdir().expect("tempdir");
     write_fatal_error_markers(tmp.path(), &["custom backend died".to_string()])
         .expect("write markers");
+    // Custom sidecar markers are matched on the stderr transport stream (#1830).
     fs::write(
-        tmp.path().join(OUTPUT_LOG_FILE),
-        "agent ui shows: custom backend died\n",
+        tmp.path().join(STDERR_LOG_FILE),
+        "transport error: custom backend died\n",
     )
-    .expect("write output");
+    .expect("write stderr");
 
     let signals = ToolLiveness::probe(tmp.path());
 
@@ -424,10 +443,10 @@ fn probe_reloads_custom_fatal_error_marker_sidecar() {
     write_fatal_error_markers(tmp.path(), &["custom backend died".to_string()])
         .expect("write markers");
     fs::write(
-        tmp.path().join(OUTPUT_LOG_FILE),
-        "agent ui shows: custom backend died\n",
+        tmp.path().join(STDERR_LOG_FILE),
+        "transport error: custom backend died\n",
     )
-    .expect("write output");
+    .expect("write stderr");
 
     assert!(ToolLiveness::probe(tmp.path()).fatal_error);
 
@@ -437,10 +456,10 @@ fn probe_reloads_custom_fatal_error_marker_sidecar() {
     assert!(!ToolLiveness::probe(tmp.path()).fatal_error);
 
     fs::write(
-        tmp.path().join(OUTPUT_LOG_FILE),
-        "agent ui shows: different marker\n",
+        tmp.path().join(STDERR_LOG_FILE),
+        "transport error: different marker\n",
     )
-    .expect("rewrite output");
+    .expect("rewrite stderr");
 
     assert!(ToolLiveness::probe(tmp.path()).fatal_error);
 }


### PR DESCRIPTION
## Summary

Fixes #1830 — the idle fatal-error-marker scanner inspected model/assistant **output** (`output.log`) and tmux pane text for `all_channel` marker regexes, in addition to the genuine transport error stream (`stderr.log`). That left a residual false-match path: model-authored assistant text could trip a fatal marker and self-kill a session, even though broad HTTP markers were already stderr-only and `--no-error-marker-scan` exists.

This implements the fix already documented in-code (`idle_watchdog.rs`: "scope marker scan to backend transport stream only") and mirrors the channel-scoping discipline `pipeline_execute.rs` already applies to failed-turn permanent-quota detection (anyhow transport error chain). Supersedes the residual noted while closing #1745 / #1736.

## Behavior

The idle fatal-marker scan now inspects only the genuine transport / provider-error channel; a fatal-marker-like string appearing solely in model/assistant output (or tmux model text) no longer triggers the kill. Genuine fatal markers on the real transport/error stream still trigger it.

Safety preserved: this removes a **false-positive** source, not a safety net — idle-timeout and wall-clock `--timeout` remain the backstops for true hangs, and real transport-stream markers still fire.

## Test coverage (mechanism)

- A fatal-marker string present only in model/assistant output (`output.log` / tmux pane text) does **not** trigger the idle fatal-marker kill.
- A genuine fatal marker on the real transport/error stream **still** triggers it (regression guard against over-narrowing into a false-negative).
- Existing idle-watchdog / fatal-error tests stay green (updated where they encoded the old all-channel-reads-output behavior).
- `just pre-commit` (fmt + clippy + nextest + token-budget) green.

## Relationship to #1847

#1830 makes the scanner channel-correct for **all** sessions. It does **not** by itself retire the #1847 `CSA_PATTERN_INTERNAL` interim marker-scan suppression — that also depends on #1738 (codex provider-error stream separation). The interim is intentionally left in place here; a code/issue-ref note records that #1830 is now done.

## Related

#1711 (defect 5, where this residual was found), #1745 / #1736 (superseded false-positive history), #1738 (remaining root-cause dependency), #1847 (interim this complements), #1830.

Refs #1830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
