### PR TITLE
fix(cli-sub-agent): acquire worktree write lock for all mutating sessions incl review --fix (#1828)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.880"
+version = "0.1.881"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.880"
+version = "0.1.881"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -126,7 +126,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         project_root,
         &mut session,
         executor.tool_name(),
-        task_type,
         readonly_project_root,
         &mut cleanup_guard,
     )?;

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -11,11 +11,10 @@ pub(super) fn acquire_or_persist_failure(
     project_root: &Path,
     session: &mut MetaSessionState,
     tool_name: &str,
-    task_type: Option<&str>,
     readonly_project_root: bool,
     cleanup_guard: &mut Option<SessionCleanupGuard>,
 ) -> Result<Option<WorktreeWriteLock>> {
-    acquire_if_needed(project_root, session, task_type, readonly_project_root).map_err(|err| {
+    acquire_if_needed(project_root, session, readonly_project_root).map_err(|err| {
         persist_pipeline_pre_exec_failure(
             project_root,
             session,
@@ -30,10 +29,9 @@ pub(super) fn acquire_or_persist_failure(
 pub(super) fn acquire_if_needed(
     project_root: &Path,
     session: &MetaSessionState,
-    task_type: Option<&str>,
     readonly_project_root: bool,
 ) -> Result<Option<WorktreeWriteLock>> {
-    if !is_write_session(task_type, readonly_project_root) {
+    if !session_mutates_worktree(readonly_project_root) {
         return Ok(None);
     }
 
@@ -47,8 +45,21 @@ pub(super) fn acquire_if_needed(
     .map(Some)
 }
 
-fn is_write_session(task_type: Option<&str>, readonly_project_root: bool) -> bool {
-    matches!(task_type, Some("run")) && !readonly_project_root
+/// Whether this session can mutate the shared git worktree and therefore must
+/// serialize against other writers via the per-worktree write lock (#1672).
+///
+/// The mutation signal is `readonly_project_root == false`: any session whose
+/// project root is NOT mounted read-only can write to the shared `.git`/working
+/// tree, regardless of its session-type classification. Keying on the session
+/// type (e.g. only `csa run`) silently excluded `csa review --fix` and
+/// `csa debate` write-modes — which set `readonly_project_root = false` yet are
+/// classified as `reviewer_sub_session`/`debate` — letting them race a
+/// concurrent writer and clobber a commit (#1828). Deriving the predicate from
+/// `readonly_project_root` also covers future write-capable session kinds
+/// automatically. Pure read-only review/debate (`readonly_project_root == true`)
+/// acquires no lock and never contends.
+fn session_mutates_worktree(readonly_project_root: bool) -> bool {
+    !readonly_project_root
 }
 
 fn resolve_worktree_lock_root(project_root: &Path) -> Result<PathBuf> {
@@ -143,11 +154,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn write_lock_predicate_only_matches_writable_run_sessions() {
-        assert!(is_write_session(Some("run"), false));
-        assert!(!is_write_session(Some("run"), true));
-        assert!(!is_write_session(Some("reviewer_sub_session"), false));
-        assert!(!is_write_session(Some("debate"), false));
-        assert!(!is_write_session(None, false));
+    fn worktree_mutation_predicate_keys_on_readonly_not_session_type() {
+        // Any writable session mutates the shared worktree and must take the
+        // lock, regardless of session-type classification (#1828). This covers
+        // `csa run` write sessions, `csa review --fix`, and `csa debate`
+        // write-modes alike — session-type coverage is asserted end-to-end in
+        // `pipeline_tests_locking`.
+        assert!(session_mutates_worktree(false));
+        // A read-only sandbox cannot mutate the worktree → no lock, no
+        // contention.
+        assert!(!session_mutates_worktree(true));
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_locking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_locking.rs
@@ -2,6 +2,103 @@ use super::*;
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use std::fs;
 
+/// Run the session pipeline far enough to exercise worktree-write-lock
+/// acquisition, varying only the knobs each lock test cares about: `task_type`
+/// (`run` / `reviewer_sub_session` / `debate`), `session_arg` (fresh vs resume),
+/// and `readonly_project_root` (the worktree-mutation signal, #1828). Every
+/// other argument is fixed to an inert test value.
+async fn run_pipeline_for_worktree_lock_test(
+    project_root: &std::path::Path,
+    task_type: Option<&str>,
+    session_arg: Option<String>,
+    readonly_project_root: bool,
+) -> anyhow::Result<crate::pipeline::SessionExecutionResult> {
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: csa_executor::CodexRuntimeMetadata::from_transport(
+            csa_executor::CodexTransport::Acp,
+        ),
+    };
+    execute_with_session_and_meta(
+        &executor,
+        &ToolName::Codex,
+        "lock-test prompt",
+        csa_core::types::OutputFormat::Json,
+        session_arg,
+        false,
+        None,
+        None,
+        project_root,
+        None,
+        None,
+        None,
+        task_type,
+        None,
+        None,
+        csa_process::StreamMode::BufferOnly,
+        DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        readonly_project_root,
+        &[],
+        &[],
+        None, // error_marker_scan_override: defer to marker/config (#1745/#1847)
+        false,
+        &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
+    )
+    .await
+}
+
+/// Assert the pipeline failed fast on the per-worktree write lock, surfacing the
+/// non-lineage holder session id `01HOLDER` and serialize guidance (#1672).
+fn assert_worktree_write_lock_blocked(
+    execution: anyhow::Result<crate::pipeline::SessionExecutionResult>,
+    project_root: &std::path::Path,
+) {
+    let err = match execution {
+        Ok(_) => panic!("held worktree write lock must reject non-lineage writer"),
+        Err(err) => err.to_string(),
+    };
+    assert!(
+        err.contains("concurrent write session blocked"),
+        "unexpected error: {err}"
+    );
+    assert!(err.contains("01HOLDER"), "missing holder session id: {err}");
+    assert!(
+        err.contains(&project_root.display().to_string()),
+        "missing worktree path: {err}"
+    );
+    assert!(
+        err.contains("sequentially"),
+        "missing serialize guidance: {err}"
+    );
+}
+
+/// Assert the pipeline got PAST the worktree-write-lock gate (no contention with
+/// the held lock) and failed only on its own per-session lock — the expected
+/// outcome for read-only sessions and in-lineage re-entries.
+fn assert_blocked_on_session_lock_not_worktree(
+    execution: anyhow::Result<crate::pipeline::SessionExecutionResult>,
+) {
+    let err = match execution {
+        Ok(_) => panic!("held per-session lock must reject the resume attempt"),
+        Err(err) => err.to_string(),
+    };
+    assert!(
+        err.contains("Failed to acquire lock for session"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        !err.contains("concurrent write session blocked"),
+        "read-only / in-lineage session must not be blocked by worktree write lock: {err}"
+    );
+}
+
 #[tokio::test]
 async fn execute_with_session_and_meta_does_not_persist_runtime_binary_when_lock_is_held() {
     let temp = tempfile::tempdir().unwrap();
@@ -90,69 +187,81 @@ async fn run_writer_fails_fast_when_worktree_write_lock_is_held() {
 
     let _holder = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
         .expect("holder worktree write lock should succeed");
-    let executor = Executor::Codex {
-        model_override: None,
-        thinking_budget: None,
-        runtime_metadata: csa_executor::CodexRuntimeMetadata::from_transport(
-            csa_executor::CodexTransport::Acp,
-        ),
-    };
 
-    let execution = execute_with_session_and_meta(
-        &executor,
-        &ToolName::Codex,
-        "write prompt",
-        csa_core::types::OutputFormat::Json,
-        None,
-        false,
-        None,
-        None,
-        project_root,
-        None,
-        None,
-        None,
-        Some("run"),
-        None,
-        None,
-        csa_process::StreamMode::BufferOnly,
-        DEFAULT_IDLE_TIMEOUT_SECONDS,
-        None,
-        None,
-        None,
-        None,
-        None,
-        false,
-        false,
-        &[],
-        &[],
-        None, // error_marker_scan_override: defer to marker/config (#1745/#1847)
-        false,
-        &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
-    )
-    .await;
-    let err = match execution {
-        Ok(_) => panic!("held worktree write lock must reject non-lineage run writer"),
-        Err(err) => err,
-    };
-    let err = err.to_string();
-
-    assert!(
-        err.contains("concurrent write session blocked"),
-        "unexpected error: {err}"
-    );
-    assert!(err.contains("01HOLDER"), "missing holder session id: {err}");
-    assert!(
-        err.contains(&project_root.display().to_string()),
-        "missing worktree path: {err}"
-    );
-    assert!(
-        err.contains("sequentially"),
-        "missing serialize guidance: {err}"
-    );
+    let execution =
+        run_pipeline_for_worktree_lock_test(project_root, Some("run"), None, false).await;
+    assert_worktree_write_lock_blocked(execution, project_root);
 }
 
 #[tokio::test]
-async fn debate_session_is_not_blocked_by_worktree_write_lock() {
+async fn review_fix_fails_fast_when_worktree_write_lock_is_held() {
+    let temp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    let project_root = temp.path();
+
+    let _holder = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
+        .expect("holder worktree write lock should succeed");
+
+    // `csa review --fix` runs as a `reviewer_sub_session` with a writable
+    // project root (`readonly_project_root == false`), so it mutates the shared
+    // worktree and must contend on the same per-worktree write lock a concurrent
+    // `csa run` writer holds (#1828) — previously it slipped past the lock.
+    let execution = run_pipeline_for_worktree_lock_test(
+        project_root,
+        Some("reviewer_sub_session"),
+        None,
+        false,
+    )
+    .await;
+    assert_worktree_write_lock_blocked(execution, project_root);
+}
+
+#[tokio::test]
+async fn debate_write_mode_fails_fast_when_worktree_write_lock_is_held() {
+    let temp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    let project_root = temp.path();
+
+    let _holder = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
+        .expect("holder worktree write lock should succeed");
+
+    // A write-mode debate (`readonly_project_root == false`) can mutate the
+    // worktree and must serialize against concurrent writers (#1828).
+    let execution =
+        run_pipeline_for_worktree_lock_test(project_root, Some("debate"), None, false).await;
+    assert_worktree_write_lock_blocked(execution, project_root);
+}
+
+#[tokio::test]
+async fn readonly_review_is_not_blocked_by_worktree_write_lock() {
+    let temp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    let project_root = temp.path();
+
+    let session =
+        csa_session::create_session(project_root, Some("review-target"), None, Some("codex"))
+            .unwrap();
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id).unwrap();
+    // Hold the per-session lock so the pipeline has a deterministic failure point
+    // AFTER the worktree-lock gate.
+    let _session_lock = csa_lock::acquire_lock(&session_dir, "codex", "active review").unwrap();
+    let _worktree_lock = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
+        .expect("holder worktree write lock should succeed");
+
+    // A read-only review (`readonly_project_root == true`) cannot mutate the
+    // worktree, acquires no worktree lock, and must not contend with the holder.
+    let execution = run_pipeline_for_worktree_lock_test(
+        project_root,
+        Some("reviewer_sub_session"),
+        Some(session.meta_session_id.clone()),
+        true,
+    )
+    .await;
+    assert_blocked_on_session_lock_not_worktree(execution);
+}
+
+#[tokio::test]
+async fn readonly_debate_is_not_blocked_by_worktree_write_lock() {
     let temp = tempfile::tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&temp).await;
     let project_root = temp.path();
@@ -164,58 +273,52 @@ async fn debate_session_is_not_blocked_by_worktree_write_lock() {
     let _session_lock = csa_lock::acquire_lock(&session_dir, "codex", "active debate").unwrap();
     let _worktree_lock = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
         .expect("holder worktree write lock should succeed");
-    let executor = Executor::Codex {
-        model_override: None,
-        thinking_budget: None,
-        runtime_metadata: csa_executor::CodexRuntimeMetadata::from_transport(
-            csa_executor::CodexTransport::Acp,
-        ),
-    };
 
-    let execution = execute_with_session_and_meta(
-        &executor,
-        &ToolName::Codex,
-        "debate prompt",
-        csa_core::types::OutputFormat::Json,
-        Some(session.meta_session_id.clone()),
-        false,
-        None,
-        None,
+    // A read-only debate (`readonly_project_root == true`) acquires no worktree
+    // lock → it is not blocked by the holder.
+    let execution = run_pipeline_for_worktree_lock_test(
         project_root,
-        None,
-        None,
-        None,
         Some("debate"),
-        None,
-        None,
-        csa_process::StreamMode::BufferOnly,
-        DEFAULT_IDLE_TIMEOUT_SECONDS,
-        None,
-        None,
-        None,
-        None,
-        None,
-        false,
-        false,
-        &[],
-        &[],
-        None, // error_marker_scan_override: defer to marker/config (#1745/#1847)
-        false,
-        &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
+        Some(session.meta_session_id.clone()),
+        true,
     )
     .await;
-    let err = match execution {
-        Ok(_) => panic!("held per-session lock must still reject the resume attempt"),
-        Err(err) => err,
-    };
-    let err = err.to_string();
+    assert_blocked_on_session_lock_not_worktree(execution);
+}
 
-    assert!(
-        err.contains("Failed to acquire lock for session"),
-        "unexpected error: {err}"
-    );
-    assert!(
-        !err.contains("concurrent write session blocked"),
-        "debate must not be blocked by worktree write lock: {err}"
-    );
+#[tokio::test]
+async fn review_fix_reenters_under_ancestor_worktree_write_lock() {
+    let temp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    let project_root = temp.path();
+
+    // Ancestor session holds the per-worktree write lock.
+    let holder =
+        csa_session::create_session(project_root, Some("holder"), None, Some("codex")).unwrap();
+    let _worktree_lock =
+        csa_lock::acquire_worktree_write_lock(project_root, &holder.meta_session_id, &[])
+            .expect("ancestor worktree write lock should succeed");
+
+    // A `--fix` child WITHIN the holder's lineage must re-enter the lock, not
+    // fail fast (#1828 reuses #1672's lineage re-entry path).
+    let child = csa_session::create_session(
+        project_root,
+        Some("fix-child"),
+        Some(&holder.meta_session_id),
+        Some("codex"),
+    )
+    .unwrap();
+    let child_dir = csa_session::get_session_dir(project_root, &child.meta_session_id).unwrap();
+    // Hold the child's per-session lock so the pipeline stops AFTER re-entering
+    // the worktree lock — proving re-entry rather than fail-fast contention.
+    let _child_session_lock = csa_lock::acquire_lock(&child_dir, "codex", "active fix").unwrap();
+
+    let execution = run_pipeline_for_worktree_lock_test(
+        project_root,
+        Some("reviewer_sub_session"),
+        Some(child.meta_session_id.clone()),
+        false,
+    )
+    .await;
+    assert_blocked_on_session_lock_not_worktree(execution);
 }


### PR DESCRIPTION
## Summary

Fixes #1828 — `csa review --fix` (and `csa debate` write-modes) mutate the worktree (`readonly_project_root = false`) but did **not** acquire the per-worktree write lock added in #1672 (PR #1827), because the lock predicate `is_write_session` excludes `reviewer_sub_session`. A `csa review --fix` running concurrently with a `csa run` write session on the same worktree could still race the shared `.git`/working tree and silently clobber a commit — the exact failure #1672 set out to prevent, reached via the `--fix` path instead of the `run` path.

## The fix

The write-lock acquisition is now keyed on the actual mutation signal — `readonly_project_root == false` — rather than the session-type classification. Any worktree-mutating session (including `csa review --fix` / `csa debate` write-modes) acquires the **same** per-worktree write lock as `csa run` write sessions, so future write-capable session kinds are covered automatically.

Preserved from #1672:
- **Fork-call lineage re-entry** — a `--fix` invoked within the lock holder's lineage re-enters without deadlock (reuses #1672's existing lineage path, no parallel mechanism).
- **Read-only unaffected** — pure read-only review/debate (`readonly_project_root == true`) acquires no lock and does not contend.
- Contention/fail-fast semantics unchanged.

## Test coverage

- `csa review --fix` ↔ concurrent `csa run` write session on the same worktree → second fails fast with the holder session ID (the #1672 contention behavior, now reached via `--fix`).
- Read-only review/debate acquires no lock and does not contend with a concurrent write session.
- Lineage re-entry: an in-lineage `--fix` re-enters without deadlock.
- Existing #1672 lock tests stay green; `just pre-commit` (fmt + clippy + nextest + token-budget) green.

## Related

#1672 / PR #1827 (per-worktree write lock this extends), #1839 (sibling lock-discipline fix on the todo-save path).

Refs #1828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
