### PR TITLE
fix(patterns): make dev2merge Step 7 DONE WHEN gate per-task (#1843)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.883"
+version = "0.1.884"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.883"
+version = "0.1.884"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
@@ -295,3 +295,116 @@ fn dev2merge_plan_step_has_brief_specificity_heuristic() {
         "file:line regex must match Rust, TOML, and Markdown paths"
     );
 }
+
+// #1843 ─────────────────────────────────────────────────────────────────────
+//
+// Step 7 (`Plan with mktd`) must validate DONE WHEN *per task*, not via a single
+// global mention. This is the 4th sibling of the #1822 per-task conversion (the
+// other three: csa-todo `validate_generated_plan_content`, mktd `workflow.toml`,
+// mktd `PATTERN.md`). A global `grep -q 'DONE WHEN'` passes a multi-task plan
+// where only one open task carries a clause; the per-task awk rejects it.
+#[test]
+fn dev2merge_plan_step_done_when_gate_is_per_task() {
+    let workflow_path = workspace_root().join("patterns/dev2merge/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+    let prompt = &plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Plan with mktd")
+        .expect("missing dev2merge plan step")
+        .prompt;
+
+    assert!(
+        !prompt.contains("grep -q 'DONE WHEN'"),
+        "Step 7 must NOT use the weak global `grep -q 'DONE WHEN'` check (#1843)"
+    );
+    assert!(
+        prompt.contains("index(text, \"DONE WHEN:\")") && prompt.contains("is_open"),
+        "Step 7 must use the per-task awk DONE WHEN gate (#1843)"
+    );
+}
+
+// #1843 behavioral check: the extracted awk gate must reject any open task that
+// lacks its own `DONE WHEN:` clause — including the empty `- [ ] ` placeholder
+// `csa todo create` leaves on the branch when mktd fails before persist — and
+// accept a plan where every open task carries one. Unix-only: relies on `awk`.
+#[cfg(unix)]
+#[test]
+fn dev2merge_done_when_awk_gate_enforces_per_task() {
+    let workflow_path = workspace_root().join("patterns/dev2merge/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+    let prompt = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Plan with mktd")
+        .expect("missing dev2merge plan step")
+        .prompt
+        .clone();
+    // Extract the exact awk program bash hands to `awk` (the bytes between
+    // `awk '` and `' "${TODO_PATH}"`), so this exercises the real gate.
+    let awk_program = prompt
+        .split("awk '")
+        .nth(1)
+        .and_then(|rest| rest.split("' \"${TODO_PATH}\"").next())
+        .expect("Step 7 must invoke `awk '<program>' \"${TODO_PATH}\"`");
+
+    let run = |todo: &str| -> i32 {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+        let mut child = Command::new("awk")
+            .arg(awk_program)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("awk must be available on unix test hosts");
+        child
+            .stdin
+            .take()
+            .expect("awk stdin")
+            .write_all(todo.as_bytes())
+            .expect("write todo to awk stdin");
+        child.wait().expect("await awk").code().unwrap_or(1)
+    };
+
+    // Accept: every open task carries its own clause (following-line and same-line).
+    assert_eq!(
+        run("# Plan\n- [ ] a\n  DONE WHEN: tests pass\n- [ ] b DONE WHEN: lint clean\n"),
+        0,
+        "fully per-task plan must pass"
+    );
+    // Reject: a single open task with no clause.
+    assert_ne!(
+        run("# Plan\n- [ ] do thing\n"),
+        0,
+        "open task missing DONE WHEN must fail"
+    );
+    // Reject: multi-task plan where only one task carries a clause — the per-task
+    // gain a global `grep -q 'DONE WHEN'` would miss.
+    assert_ne!(
+        run("# Plan\n- [ ] a\n  DONE WHEN: x\n- [ ] b\n"),
+        0,
+        "partial per-task coverage must fail"
+    );
+    // Reject: a bare keyword mention in a subject is not a clause (#1822 case).
+    assert_ne!(
+        run("# Plan\n- [ ] Document DONE WHEN policy.\n"),
+        0,
+        "bare `DONE WHEN` subject mention without a colon clause must fail"
+    );
+    // Reject: a clause on a completed task must not cover a sibling open task.
+    assert_ne!(
+        run("# Plan\n- [x] done\n  DONE WHEN: x\n- [ ] open\n"),
+        0,
+        "completed-task clause must not satisfy an open task"
+    );
+    // Reject: the empty `- [ ] ` placeholder `csa todo create` writes — preserves
+    // the rejection the prior global check gave when mktd fails before persist.
+    assert_ne!(
+        run("# TODO: feature\n\n## Tasks\n\n- [ ] \n"),
+        0,
+        "empty csa-todo-create scaffold must fail (no regression vs global check)"
+    );
+}

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -343,8 +343,25 @@ TODO_PATH="$(csa todo show -t "${LATEST_TS}" --path)"
 if ! grep -qF -- '- [ ] ' "${TODO_PATH}"; then
   fail_step7_gate "TODO missing checkbox tasks."
 fi
-if ! grep -q 'DONE WHEN' "${TODO_PATH}"; then
-  fail_step7_gate "TODO missing DONE WHEN clauses."
+# Per-task DONE WHEN gate (#1843; 4th sibling of the #1822 per-task conversion).
+# Every OPEN task must carry its OWN `DONE WHEN:` clause (AGENTS.md Meta 005), not
+# a single global mention. Mirrors mktd's pre-persist awk; `is_open` matches `- [ ]`
+# (not mktd's `^- \[ \] .+`) so the empty `- [ ] ` placeholder `csa todo create`
+# leaves when mktd fails before persist is still rejected, as the prior global check did.
+if ! awk '
+function flush() { if (in_open == 1 && has_clause == 0) bad = 1; in_open = 0; has_clause = 0 }
+function scan(text,   pos, rest) {
+  pos = index(text, "DONE WHEN:")
+  if (pos > 0) { rest = substr(text, pos + 10); sub(/^[ \t]+/, "", rest); if (length(rest) > 0) has_clause = 1 }
+}
+{
+  is_open = ($0 ~ /^- \[ \]/)
+  if ($0 ~ /^- \[[ xX]\]/ || $0 ~ /^#/) { flush(); if (is_open == 1) { in_open = 1; scan($0) }; next }
+  if (in_open == 1) scan($0)
+}
+END { flush(); exit (bad + 0) }
+' "${TODO_PATH}"; then
+  fail_step7_gate "TODO has an open task without a mechanically-verifiable DONE WHEN: clause."
 fi
 if [ "${MKTD_EXIT}" -ne 0 ]; then
   echo "WARNING: mktd exited ${MKTD_EXIT}, but TODO gates passed; treating Step 7 as successful." >&2

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -438,8 +438,25 @@ TODO_PATH="$(csa todo show -t "${LATEST_TS}" --path)"
 if ! grep -qF -- '- [ ] ' "${TODO_PATH}"; then
   fail_step7_gate "TODO missing checkbox tasks."
 fi
-if ! grep -q 'DONE WHEN' "${TODO_PATH}"; then
-  fail_step7_gate "TODO missing DONE WHEN clauses."
+# Per-task DONE WHEN gate (#1843; 4th sibling of the #1822 per-task conversion).
+# Every OPEN task must carry its OWN `DONE WHEN:` clause (AGENTS.md Meta 005), not
+# a single global mention. Mirrors mktd's pre-persist awk; `is_open` matches `- [ ]`
+# (not mktd's `^- \[ \] .+`) so the empty `- [ ] ` placeholder `csa todo create`
+# leaves when mktd fails before persist is still rejected, as the prior global check did.
+if ! awk '
+function flush() { if (in_open == 1 && has_clause == 0) bad = 1; in_open = 0; has_clause = 0 }
+function scan(text,   pos, rest) {
+  pos = index(text, "DONE WHEN:")
+  if (pos > 0) { rest = substr(text, pos + 10); sub(/^[ \t]+/, "", rest); if (length(rest) > 0) has_clause = 1 }
+}
+{
+  is_open = ($0 ~ /^- \[ \]/)
+  if ($0 ~ /^- \[[ xX]\]/ || $0 ~ /^#/) { flush(); if (is_open == 1) { in_open = 1; scan($0) }; next }
+  if (in_open == 1) scan($0)
+}
+END { flush(); exit (bad + 0) }
+' "${TODO_PATH}"; then
+  fail_step7_gate "TODO has an open task without a mechanically-verifiable DONE WHEN: clause."
 fi
 if [ "${MKTD_EXIT}" -ne 0 ]; then
   echo "WARNING: mktd exited ${MKTD_EXIT}, but TODO gates passed; treating Step 7 as successful." >&2


### PR DESCRIPTION
## Summary

Fixes #1843 — `patterns/dev2merge/workflow.toml` Step 7 ("Plan with mktd") validated `DONE WHEN` with a single **global** `grep -q 'DONE WHEN'`: the plan passed if *any one* line anywhere contained `DONE WHEN`, even when most tasks lacked their own clause. This was the 4th sibling of the #1822 per-task conversion (the other three — csa-todo `validate_generated_plan_content`, mktd `workflow.toml`, mktd `PATTERN.md` — were already made per-task in #1822).

## Decision: PER-TASK (not removal) — evidence-based

The issue offered two options gated on a verifiable reachability fact: **remove** the check if it can only ever see a plan already validated by #1822's per-task `csa todo persist` gate, else **make it per-task**. The redundancy claim does **NOT** hold, so the gate is made per-task:

- Step 7 invokes mktd; mktd's `csa todo create` first writes an **empty placeholder** `todo.md` (`crates/csa-todo/src/lib.rs`, body `...- [ ] `), newest ULID, branch = current.
- If mktd fails its own artifact gate **before** `csa todo persist` (where the #1822 per-task validator lives), persist never runs.
- `csa todo list` lists Draft/uncommitted plans with no filter, so dev2merge's `LATEST_TS` resolution picks up that **unvalidated placeholder**.
- The placeholder contains `- [ ] `, so it **passes** the loose checkbox gate (`grep -qF '- [ ] '`); only the `DONE WHEN` gate rejects it. dev2merge also treats "mktd non-zero exit + gates pass" as success, so these two gates are authoritative.

⇒ Step 7's `DONE WHEN` gate **can** see a plan that bypassed the per-task persist gate. Removing it would leak an empty scaffold into mktsk. So it is converted to per-task (per the issue's own decision rule), mirroring mktd's #1822 awk.

## The change

- `workflow.toml` Step 7: replace the global `grep -q 'DONE WHEN'` with a per-task `awk` — every **OPEN** task must carry its own `DONE WHEN:` clause.
- `is_open` matches `^- \[ \]` (not mktd's stricter `^- \[ \] .+`) **on purpose**: dev2merge's checkbox gate is a looser fixed-string match (`grep -qF '- [ ] '`) than mktd's, so the awk must also reject the empty placeholder to preserve *exactly* what the prior global check guarded against — no behavioral hole, no over-tightening.
- Only the `DONE WHEN` block changed; the checkbox gate and every `on_fail = "abort"` gate are intact.

## Sync + compile (rule 027)

`PATTERN.md` ↔ `workflow.toml` stay in sync (the Step 7 description/snippet updated in both); `weave compile` passes for the dev2merge pattern after the edit.

## Test coverage

`crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs` (+2 tests):
- **Conversion guard**: the global `grep -q 'DONE WHEN'` is gone and the per-task `awk` is present in the compiled workflow.
- **Behavioral (unix)**: extracts the real awk and asserts a fully-valid plan passes, while single-missing-`DONE WHEN`, partial, bare-subject, completed-only, and empty-scaffold plans all fail.
- `just pre-commit` (fmt + clippy + nextest + token-budget) green.

## Related

#1822 (per-task `DONE WHEN` conversion — this is the 4th sibling site), #1819/#1820/#1821 (mktd plan-hygiene cluster).

Refs #1843.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
