### PR TITLE
fix(cli-sub-agent): surface post-exec gate failures in structured artifacts (#1726)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.886"
+version = "0.1.887"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.887"
+version = "0.1.888"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.885"
+version = "0.1.886"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.884"
+version = "0.1.885"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.884"
+version = "0.1.885"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.886"
+version = "0.1.887"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.887"
+version = "0.1.888"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.885"
+version = "0.1.886"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_dry_run.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_dry_run.rs
@@ -39,6 +39,7 @@ pub(crate) fn create_debate_dry_run_session(
 
     let now = Utc::now();
     let result = SessionResult {
+        post_exec_gate: None,
         status: SessionResult::status_from_exit_code(0),
         exit_code: 0,
         summary: "debate dry-run complete: AI invocation skipped".to_string(),

--- a/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
@@ -66,6 +66,7 @@ fn setup_unrelated_debate_session(
         project_root,
         &unrelated.meta_session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "original unrelated summary".to_string(),
@@ -119,6 +120,7 @@ fn seed_debate_result(
         project_root,
         &session.meta_session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: status.to_string(),
             exit_code,
             summary: summary.to_string(),
@@ -632,6 +634,7 @@ fn debate_nonzero_with_explicit_verdict_is_reclassified_success() {
         project_root,
         &session.meta_session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: "failure".to_string(),
             exit_code: 1,
             summary: "tool exited non-zero".to_string(),
@@ -715,6 +718,7 @@ fn debate_finalize_persists_categorized_fallback_chain_for_multi_skip() {
         project_root,
         &session.meta_session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: "failure".to_string(),
             exit_code: 1,
             summary: "tool exited non-zero".to_string(),
@@ -824,6 +828,7 @@ fn debate_finalize_persists_build_time_exclusions_without_runtime_failures() {
         project_root,
         &session.meta_session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: "failure".to_string(),
             exit_code: 1,
             summary: "tool exited non-zero".to_string(),
@@ -915,6 +920,7 @@ fn debate_finalize_non_success_omits_after_final_disabled_tier_spec() {
         project_root,
         &session.meta_session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: "failure".to_string(),
             exit_code: 1,
             summary: "tool exited non-zero".to_string(),

--- a/crates/cli-sub-agent/src/debate_cmd_round4_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_round4_tests.rs
@@ -62,6 +62,7 @@ fn debate_tier_all_fail_does_not_overwrite_unrelated_latest_session() {
         project_root,
         &unrelated.meta_session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "original unrelated summary".to_string(),
@@ -199,6 +200,7 @@ fn debate_pre_session_all_fail_yields_unavailable() {
         project_root,
         &unrelated.meta_session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "original unrelated summary".to_string(),

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -649,6 +649,7 @@ fn append_debate_artifacts_to_result_updates_summary_and_artifacts() {
         project_root,
         &session.meta_session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "<!-- CSA:SECTION:summary:END -->".to_string(),

--- a/crates/cli-sub-agent/src/gc_runtime_tests.rs
+++ b/crates/cli-sub-agent/src/gc_runtime_tests.rs
@@ -136,6 +136,7 @@ fn seed_runtime_session(
         project_root,
         &session.meta_session_id,
         &SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "completed".to_string(),

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -76,6 +76,7 @@ mod run_cmd_daemon;
 mod run_cmd_fork;
 mod run_cmd_model_pin;
 mod run_cmd_post;
+mod run_cmd_post_gate_report;
 mod run_cmd_preflight;
 mod run_cmd_tool_selection;
 mod run_helpers;

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -76,6 +76,7 @@ mod run_cmd_daemon;
 mod run_cmd_fork;
 mod run_cmd_model_pin;
 mod run_cmd_post;
+mod run_cmd_post_exec_gate_capture;
 mod run_cmd_post_gate_report;
 mod run_cmd_preflight;
 mod run_cmd_tool_selection;

--- a/crates/cli-sub-agent/src/pipeline_execute.rs
+++ b/crates/cli-sub-agent/src/pipeline_execute.rs
@@ -202,6 +202,7 @@ pub(crate) async fn execute_transport_with_signal(
                 )
             });
             let result = SessionResult {
+                post_exec_gate: None,
                 status: "failure".to_string(),
                 exit_code: 1,
                 summary: summary.clone(),
@@ -331,6 +332,7 @@ fn record_session_termination(
     let mut updated_session = session.clone();
     updated_session.termination_reason = Some(termination_reason.to_string());
     let updated_result = SessionResult {
+        post_exec_gate: None,
         status: status.to_string(),
         exit_code,
         summary: summary.to_string(),

--- a/crates/cli-sub-agent/src/pipeline_gate_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_gate_tests.rs
@@ -301,10 +301,9 @@ fn kill_pid(pid: i32) {
 
 #[cfg(unix)]
 fn kill_pid_from_file(path: &std::path::Path) {
-    if let Ok(pid) = std::fs::read_to_string(path).map(|content| content.trim().parse::<i32>()) {
-        if let Ok(pid) = pid {
-            kill_pid(pid);
-        }
+    if let Ok(Ok(pid)) = std::fs::read_to_string(path).map(|content| content.trim().parse::<i32>())
+    {
+        kill_pid(pid);
     }
 }
 

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -161,6 +161,7 @@ pub(crate) async fn process_execution_result(
     // Write structured result
     let execution_end_time = chrono::Utc::now();
     let mut session_result = SessionResult {
+        post_exec_gate: None,
         status: SessionResult::status_from_exit_code(result.exit_code),
         exit_code: result.exit_code,
         summary: result.summary.clone(),

--- a/crates/cli-sub-agent/src/pipeline_post_exec_fallback.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_fallback.rs
@@ -110,6 +110,7 @@ pub(crate) fn ensure_terminal_result_on_post_exec_error(
     let artifacts = collect_fallback_result_artifacts(project_root, &session.meta_session_id);
     let completed_at = chrono::Utc::now();
     let fallback_result = SessionResult {
+        post_exec_gate: None,
         status: "failure".to_string(),
         exit_code: 1,
         summary,

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
@@ -59,6 +59,7 @@ fn ensure_terminal_result_on_post_exec_error_keeps_existing_result() {
         create_session(project_root, Some("test"), None, Some("codex")).expect("create session");
     let now = chrono::Utc::now();
     let existing = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "already persisted".to_string(),
@@ -372,6 +373,7 @@ async fn process_execution_result_respects_vcs_auto_snapshot_gate_for_colocated_
 fn codex_exec_initial_stall_summary_forces_failure_status_in_result_toml() {
     let now = chrono::Utc::now();
     let mut result = SessionResult {
+        post_exec_gate: None,
         status: SessionResult::status_from_exit_code(137),
         exit_code: 137,
         summary: "codex_exec_initial_stall: no stdout within 300s (effort=high, retry_attempted=true, original_effort=xhigh)".to_string(),

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec_audit.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec_audit.rs
@@ -106,6 +106,7 @@ fn should_not_audit_repo_tracked_writes_for_sa_mode_false_writer_run() {
 #[test]
 fn apply_repo_write_audit_to_result_populates_manager_sidecar_sections() {
     let mut session_result = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "ok".to_string(),
@@ -427,6 +428,7 @@ fn audit_failure_does_not_fail_execution() {
         fork_call_timestamps: Vec::new(),
     };
     let mut session_result = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "ok".to_string(),
@@ -555,6 +557,7 @@ fn reused_session_audit_uses_per_execution_baseline_not_session_creation() {
         fork_call_timestamps: Vec::new(),
     };
     let mut session_result = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "ok".to_string(),
@@ -662,6 +665,7 @@ fn writer_run_does_not_emit_repo_write_audit_artifact() {
         fork_call_timestamps: Vec::new(),
     };
     let mut session_result = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "ok".to_string(),
@@ -770,6 +774,7 @@ fn first_execution_falls_back_to_session_creation_baseline_when_per_exec_capture
         fork_call_timestamps: Vec::new(),
     };
     let mut session_result = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "ok".to_string(),

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -376,6 +376,7 @@ async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
         project_root,
         &session.meta_session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: stale_summary.to_string(),

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -357,6 +357,7 @@ pub(crate) async fn handle_plan_run_daemon_child(
     };
 
     let session_result = SessionResult {
+        post_exec_gate: None,
         status,
         exit_code,
         summary,

--- a/crates/cli-sub-agent/src/preflight_state_dir.rs
+++ b/crates/cli-sub-agent/src/preflight_state_dir.rs
@@ -705,6 +705,7 @@ mod tests {
             project_root,
             &session.meta_session_id,
             &SessionResult {
+                post_exec_gate: None,
                 status: "success".to_string(),
                 exit_code: 0,
                 summary: "completed".to_string(),

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -207,6 +207,7 @@ fn exact_test_codex_agent_message(text: &str) -> String {
 fn exact_test_wait_result(exit_code: i32, summary: &str) -> csa_session::SessionResult {
     let now = chrono::Utc::now();
     csa_session::SessionResult {
+        post_exec_gate: None,
         status: csa_session::SessionResult::status_from_exit_code(exit_code),
         exit_code,
         summary: summary.to_string(),

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -118,6 +118,7 @@ pub(super) fn maybe_synthesize_missing_review_result(
         .find_map(|cause| cause.downcast_ref::<PeakMemoryContext>())
         .and_then(|ctx| ctx.0);
     let fallback_result = SessionResult {
+        post_exec_gate: None,
         status: status.to_string(),
         exit_code,
         summary,

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -8,9 +8,11 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use csa_config::ProjectConfig;
-use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::process::Command;
-use tokio::task::JoinHandle;
+
+use crate::run_cmd_post_exec_gate_capture::{
+    BoundedTailCapture, drain_pumps_and_reap, kill_gate_process_group, tee_gate_stream,
+};
 
 /// Outcome of running the post-exec gate command, including the combined
 /// stdout+stderr captured for structured failure surfacing (#1726). The output
@@ -110,36 +112,6 @@ impl PostExecGateFailure {
 }
 
 type PostExecGateFuture = Pin<Box<dyn Future<Output = Result<PostExecGateCommandOutcome>> + Send>>;
-
-/// Read `reader` to EOF, re-emitting each chunk to the parent's `sink` (so the
-/// raw transcript stays intact) while appending it to the shared `captured`
-/// buffer for structured failure surfacing (#1726).
-fn tee_gate_stream<R, W>(reader: R, sink: W, captured: Arc<Mutex<Vec<u8>>>) -> JoinHandle<()>
-where
-    R: AsyncRead + Unpin + Send + 'static,
-    W: AsyncWrite + Unpin + Send + 'static,
-{
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    tokio::spawn(async move {
-        let mut reader = reader;
-        let mut sink = sink;
-        let mut chunk = [0u8; 8192];
-        loop {
-            match reader.read(&mut chunk).await {
-                Ok(0) => break,
-                Ok(n) => {
-                    let bytes = &chunk[..n];
-                    let _ = sink.write_all(bytes).await;
-                    let _ = sink.flush().await;
-                    if let Ok(mut guard) = captured.lock() {
-                        guard.extend_from_slice(bytes);
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-    })
-}
 
 pub(super) struct PostExecGateApplyOptions<'a> {
     pub(super) changed_paths: Option<&'a [String]>,
@@ -367,9 +339,9 @@ pub(super) fn execute_post_exec_gate_command(
         })?;
         let child_pid = child.id();
 
-        // Tee both streams: re-emit to the parent while accumulating a combined
-        // copy for the structured failure report.
-        let captured = Arc::new(Mutex::new(Vec::<u8>::new()));
+        // Tee both streams: re-emit to the parent while accumulating a BOUNDED
+        // combined copy for the structured failure report (#1726).
+        let captured = Arc::new(Mutex::new(BoundedTailCapture::default()));
         let stdout_pump = child
             .stdout
             .take()
@@ -391,40 +363,26 @@ pub(super) fn execute_post_exec_gate_command(
                     PostExecGateCommandExit::Exited(status.code())
                 }
                 Err(_) => {
-                    #[cfg(unix)]
-                    {
-                        if let Some(pid) = child_pid {
-                            // SAFETY: kill() is async-signal-safe. Negative PID targets the process group.
-                            unsafe {
-                                libc::kill(-(pid as i32), libc::SIGKILL);
-                            }
-                        } else {
-                            let _ = child.start_kill();
-                        }
-                    }
-                    #[cfg(not(unix))]
-                    {
-                        let _ = child.start_kill();
-                    }
-
-                    let _ = child.wait().await;
+                    // Kill the whole process group BEFORE reaping the leader, so
+                    // the un-reaped leader anchors the PGID against reuse; then
+                    // reap under a short bound so a wedged reap cannot reintroduce
+                    // an unbounded wait. `start_kill` is the cross-platform
+                    // backstop (the group kill is a no-op off Unix).
+                    kill_gate_process_group(child_pid).await;
+                    let _ = child.start_kill();
+                    let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
                     PostExecGateCommandExit::TimedOut
                 }
             };
 
-        // Drain the tee tasks to EOF before reading the buffer. Killing the
-        // process group (or normal exit) closes the child's pipe write ends, so
-        // both reads reach EOF and the joins complete.
-        if let Some(pump) = stdout_pump {
-            let _ = pump.await;
-        }
-        if let Some(pump) = stderr_pump {
-            let _ = pump.await;
-        }
+        // Drain the tee tasks under a bounded grace, reaping the process group
+        // if a backgrounded grandchild still holds a pipe write-end open — so
+        // `timeout_seconds` bounds the TOTAL operation, not just `child.wait()`.
+        drain_pumps_and_reap(stdout_pump, stderr_pump, child_pid).await;
 
         let captured_output = captured
             .lock()
-            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .map(|mut guard| guard.render())
             .unwrap_or_default();
 
         Ok(PostExecGateCommandOutcome {

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -3,16 +3,61 @@ use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
 use std::process::Stdio;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use csa_config::ProjectConfig;
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::process::Command;
+use tokio::task::JoinHandle;
+
+/// Outcome of running the post-exec gate command, including the combined
+/// stdout+stderr captured for structured failure surfacing (#1726). The output
+/// is always tee'd to the parent's stdout/stderr too, so the raw transcript
+/// (`full.md`) is unchanged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PostExecGateCommandOutcome {
+    pub(super) exit: PostExecGateCommandExit,
+    pub(super) captured_output: String,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum PostExecGateCommandOutcome {
+pub(super) enum PostExecGateCommandExit {
     Exited(Option<i32>),
     TimedOut,
+}
+
+/// Test-only constructors. Production builds the struct literal directly (the
+/// real runner threads an arbitrary exit AND captured output through at once),
+/// so these convenience constructors are only used by the synthetic runners in
+/// the test submodule.
+#[cfg(test)]
+impl PostExecGateCommandOutcome {
+    /// Outcome with no captured output (test helper / synthetic runners).
+    pub(super) fn exited(code: Option<i32>) -> Self {
+        Self {
+            exit: PostExecGateCommandExit::Exited(code),
+            captured_output: String::new(),
+        }
+    }
+
+    /// Outcome carrying captured gate output (used by the real runner and by
+    /// tests that exercise the structured surfacing path).
+    pub(super) fn exited_with(code: Option<i32>, output: impl Into<String>) -> Self {
+        Self {
+            exit: PostExecGateCommandExit::Exited(code),
+            captured_output: output.into(),
+        }
+    }
+
+    /// Timeout outcome with no captured output (test helper).
+    pub(super) fn timed_out() -> Self {
+        Self {
+            exit: PostExecGateCommandExit::TimedOut,
+            captured_output: String::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,6 +71,10 @@ pub(super) enum PostExecGateOutcome {
 pub(super) struct PostExecGateFailure {
     kind: PostExecGateFailureKind,
     diagnostic: String,
+    /// The gate command that failed (e.g. `"just pre-commit"`).
+    gate_command: String,
+    /// Combined captured stdout+stderr of the gate command (pre-redaction).
+    captured_output: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,9 +97,49 @@ impl PostExecGateFailure {
     fn is_timeout(&self) -> bool {
         matches!(self.kind, PostExecGateFailureKind::TimedOut)
     }
+
+    /// Real exit code for the structured report: a signal-kill (no code) maps to
+    /// `-1`; a timeout maps to `124` (conventional timeout exit code).
+    fn report_exit_code(&self) -> i32 {
+        match self.kind {
+            PostExecGateFailureKind::Exited(Some(code)) => code,
+            PostExecGateFailureKind::Exited(None) => -1,
+            PostExecGateFailureKind::TimedOut => 124,
+        }
+    }
 }
 
 type PostExecGateFuture = Pin<Box<dyn Future<Output = Result<PostExecGateCommandOutcome>> + Send>>;
+
+/// Read `reader` to EOF, re-emitting each chunk to the parent's `sink` (so the
+/// raw transcript stays intact) while appending it to the shared `captured`
+/// buffer for structured failure surfacing (#1726).
+fn tee_gate_stream<R, W>(reader: R, sink: W, captured: Arc<Mutex<Vec<u8>>>) -> JoinHandle<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    tokio::spawn(async move {
+        let mut reader = reader;
+        let mut sink = sink;
+        let mut chunk = [0u8; 8192];
+        loop {
+            match reader.read(&mut chunk).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    let bytes = &chunk[..n];
+                    let _ = sink.write_all(bytes).await;
+                    let _ = sink.flush().await;
+                    if let Ok(mut guard) = captured.lock() {
+                        guard.extend_from_slice(bytes);
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    })
+}
 
 pub(super) struct PostExecGateApplyOptions<'a> {
     pub(super) changed_paths: Option<&'a [String]>,
@@ -255,8 +344,11 @@ pub(super) fn execute_post_exec_gate_command(
         cmd.arg("-c")
             .arg(&command)
             .current_dir(&project_root)
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit());
+            // Capture stdout/stderr so a failure can be surfaced structurally
+            // (#1726); the tee tasks below re-emit every chunk to the parent's
+            // stdout/stderr, so the raw transcript (`full.md`) is unchanged.
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
         if let Some(extra_env) = extra_env {
             cmd.envs(extra_env);
         }
@@ -275,37 +367,70 @@ pub(super) fn execute_post_exec_gate_command(
         })?;
         let child_pid = child.id();
 
-        match tokio::time::timeout(Duration::from_secs(timeout_seconds), child.wait()).await {
-            Ok(wait_result) => {
-                let status = wait_result.with_context(|| {
-                    format!(
-                        "failed while waiting for post-exec gate command `{command}` in {}",
-                        project_root.display()
-                    )
-                })?;
-                Ok(PostExecGateCommandOutcome::Exited(status.code()))
-            }
-            Err(_) => {
-                #[cfg(unix)]
-                {
-                    if let Some(pid) = child_pid {
-                        // SAFETY: kill() is async-signal-safe. Negative PID targets the process group.
-                        unsafe {
-                            libc::kill(-(pid as i32), libc::SIGKILL);
+        // Tee both streams: re-emit to the parent while accumulating a combined
+        // copy for the structured failure report.
+        let captured = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let stdout_pump = child
+            .stdout
+            .take()
+            .map(|reader| tee_gate_stream(reader, tokio::io::stdout(), Arc::clone(&captured)));
+        let stderr_pump = child
+            .stderr
+            .take()
+            .map(|reader| tee_gate_stream(reader, tokio::io::stderr(), Arc::clone(&captured)));
+
+        let exit =
+            match tokio::time::timeout(Duration::from_secs(timeout_seconds), child.wait()).await {
+                Ok(wait_result) => {
+                    let status = wait_result.with_context(|| {
+                        format!(
+                            "failed while waiting for post-exec gate command `{command}` in {}",
+                            project_root.display()
+                        )
+                    })?;
+                    PostExecGateCommandExit::Exited(status.code())
+                }
+                Err(_) => {
+                    #[cfg(unix)]
+                    {
+                        if let Some(pid) = child_pid {
+                            // SAFETY: kill() is async-signal-safe. Negative PID targets the process group.
+                            unsafe {
+                                libc::kill(-(pid as i32), libc::SIGKILL);
+                            }
+                        } else {
+                            let _ = child.start_kill();
                         }
-                    } else {
+                    }
+                    #[cfg(not(unix))]
+                    {
                         let _ = child.start_kill();
                     }
-                }
-                #[cfg(not(unix))]
-                {
-                    let _ = child.start_kill();
-                }
 
-                let _ = child.wait().await;
-                Ok(PostExecGateCommandOutcome::TimedOut)
-            }
+                    let _ = child.wait().await;
+                    PostExecGateCommandExit::TimedOut
+                }
+            };
+
+        // Drain the tee tasks to EOF before reading the buffer. Killing the
+        // process group (or normal exit) closes the child's pipe write ends, so
+        // both reads reach EOF and the joins complete.
+        if let Some(pump) = stdout_pump {
+            let _ = pump.await;
         }
+        if let Some(pump) = stderr_pump {
+            let _ = pump.await;
+        }
+
+        let captured_output = captured
+            .lock()
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .unwrap_or_default();
+
+        Ok(PostExecGateCommandOutcome {
+            exit,
+            captured_output,
+        })
     })
 }
 
@@ -339,16 +464,17 @@ where
     }
 
     let branch = super::run_context::current_branch_name(project_root);
-    match runner(
+    let outcome = runner(
         &gate_config.command,
         project_root,
         gate_config.timeout_seconds,
         extra_env,
     )
-    .await?
-    {
-        PostExecGateCommandOutcome::Exited(Some(0)) => Ok(PostExecGateOutcome::Passed),
-        PostExecGateCommandOutcome::Exited(code) => {
+    .await?;
+    let captured_output = outcome.captured_output;
+    match outcome.exit {
+        PostExecGateCommandExit::Exited(Some(0)) => Ok(PostExecGateOutcome::Passed),
+        PostExecGateCommandExit::Exited(code) => {
             Ok(PostExecGateOutcome::Failed(PostExecGateFailure {
                 kind: PostExecGateFailureKind::Exited(code),
                 diagnostic: format!(
@@ -364,26 +490,28 @@ where
                     session_id.unwrap_or("(ephemeral)"),
                     branch,
                 ),
+                gate_command: gate_config.command.clone(),
+                captured_output,
             }))
         }
-        PostExecGateCommandOutcome::TimedOut => {
-            Ok(PostExecGateOutcome::Failed(PostExecGateFailure {
-                kind: PostExecGateFailureKind::TimedOut,
-                diagnostic: format!(
-                    "csa: post-exec gate timed out after {} seconds.\n\
+        PostExecGateCommandExit::TimedOut => Ok(PostExecGateOutcome::Failed(PostExecGateFailure {
+            kind: PostExecGateFailureKind::TimedOut,
+            diagnostic: format!(
+                "csa: post-exec gate timed out after {} seconds.\n\
                      gate command: {}\n\
                      cwd: {}\n\
                      employee session: {}\n\
                      branch: {}\n\
                      next step: inspect the gate output above, fix the issue, and re-run the dispatch manually. v1 gate does NOT auto-retry.",
-                    gate_config.timeout_seconds,
-                    gate_config.command,
-                    project_root.display(),
-                    session_id.unwrap_or("(ephemeral)"),
-                    branch,
-                ),
-            }))
-        }
+                gate_config.timeout_seconds,
+                gate_config.command,
+                project_root.display(),
+                session_id.unwrap_or("(ephemeral)"),
+                branch,
+            ),
+            gate_command: gate_config.command.clone(),
+            captured_output,
+        })),
     }
 }
 
@@ -493,12 +621,23 @@ where
             }
         }
         PostExecGateOutcome::Failed(failure) => {
+            // Primary surfacing path (#1726): a gate that ran and exited nonzero.
+            // Persist the full (redacted) output to `output/gate-failure.log`, a
+            // bounded `[post_exec_gate]` table to result.toml, and a banner that
+            // makes the employee's pre-gate self-report read as superseded — so
+            // an orchestrator that cannot read the raw transcript can still
+            // diagnose the failure. (Timeout and infra-error paths above keep the
+            // existing simple overwrite; their verdicts are already
+            // non-contradictory and carry no structured gate output to surface.)
             if let Some(session_id) = session_id {
-                crate::run_cmd_post::overwrite_result_as_post_exec_gate_failure(
-                    project_root,
-                    session_id,
-                    &format!("post-exec gate failed: {}", failure.diagnostic),
-                    false,
+                crate::run_cmd_post_gate_report::persist_gate_failure_detail(
+                    crate::run_cmd_post_gate_report::GateFailureDetail {
+                        project_root,
+                        session_id,
+                        gate_command: &failure.gate_command,
+                        exit_code: failure.report_exit_code(),
+                        captured_output: &failure.captured_output,
+                    },
                 );
             }
             Err(failure.into_error())

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -1013,3 +1013,85 @@ async fn post_exec_gate_runs_when_untracked_source_exists_without_changed_paths(
     assert_eq!(outcome, PostExecGateOutcome::Passed);
     assert_eq!(calls.lock().unwrap().len(), 1);
 }
+
+/// Round-2 resource-lifecycle regression guard (#1726): a gate that exits 0
+/// while leaving a BACKGROUNDED child holding stdout/stderr open must NOT wedge
+/// the runner. The bounded pump drain + process-group reap make
+/// `execute_post_exec_gate_command` return within `timeout_seconds + grace`, and
+/// the leaked descendant is killed. Before the fix the drain awaited EOF forever
+/// (the inherited pipe write-end never closes), defeating the gate timeout.
+#[tokio::test]
+#[cfg(unix)]
+async fn execute_post_exec_gate_command_reaps_backgrounded_pipe_holder() {
+    let project_dir = tempdir().unwrap();
+    let sentinel = project_dir.path().join("pipe-holder-survived");
+    let env = HashMap::from([(
+        "GATE_TEST_SENTINEL".to_string(),
+        sentinel.to_string_lossy().into_owned(),
+    )]);
+
+    // The backgrounded subshell inherits stdout/stderr (the tee pipe) and holds
+    // it open while it sleeps, then WOULD create the sentinel at +6s. The leader
+    // exits 0 immediately (the NORMAL-exit path). The drain grace (2s) expires
+    // because the pipe stays open, triggering the process-group kill — which
+    // reaps the subshell well before +6s, so the sentinel is never written.
+    let command = r#"(sleep 6; : > "$GATE_TEST_SENTINEL") & exit 0"#;
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        execute_post_exec_gate_command(command, project_dir.path(), 30, Some(env)),
+    )
+    .await
+    .expect("gate must not hang when a backgrounded child holds the pipe open")
+    .expect("post-exec gate command should run");
+
+    // The leader's own exit is still reported faithfully.
+    assert_eq!(outcome.exit, PostExecGateCommandExit::Exited(Some(0)));
+
+    // Wait past the subshell's +6s mark: a surviving holder would have created
+    // the sentinel by now. Its absence proves the group kill reaped it.
+    tokio::time::sleep(std::time::Duration::from_secs(6)).await;
+    assert!(
+        !sentinel.exists(),
+        "backgrounded pipe-holder must be reaped by the process-group kill, not outlive the drain"
+    );
+}
+
+/// Round-2 memory bound (#1726): a gate that floods stdout far past
+/// `GATE_CAPTURE_MAX_BYTES` must keep the in-memory capture bounded (no
+/// unbounded slurp) while still tee-ing the full transcript to the parent. The
+/// retained `captured_output` is the bounded TAIL prefixed with a truncation
+/// marker.
+#[tokio::test]
+#[cfg(unix)]
+async fn execute_post_exec_gate_command_bounds_capture_under_flood() {
+    use crate::run_cmd_post_exec_gate_capture::GATE_CAPTURE_MAX_BYTES;
+
+    let project_dir = tempdir().unwrap();
+    // `head -c` bounds the producer and closes the pipe at the byte count
+    // (sending `yes` SIGPIPE), so the gate exits cleanly with a transcript twice
+    // the capture cap — exercising truncation without a leaked holder.
+    let flood_bytes = GATE_CAPTURE_MAX_BYTES * 2;
+    let command = format!("yes payload-line | head -c {flood_bytes}");
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        execute_post_exec_gate_command(&command, project_dir.path(), 30, None),
+    )
+    .await
+    .expect("flooding gate must still terminate")
+    .expect("post-exec gate command should run");
+
+    assert_eq!(outcome.exit, PostExecGateCommandExit::Exited(Some(0)));
+    assert!(
+        outcome.captured_output.len() <= GATE_CAPTURE_MAX_BYTES + 256,
+        "captured output must stay bounded under flood, got {} bytes",
+        outcome.captured_output.len()
+    );
+    assert!(
+        outcome
+            .captured_output
+            .starts_with("[csa: gate output truncated"),
+        "bounded capture must disclose truncation"
+    );
+}

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -1057,6 +1057,101 @@ async fn execute_post_exec_gate_command_reaps_backgrounded_pipe_holder() {
     );
 }
 
+/// Round-3 PGID-reuse-safety regression (#1726): when a backgrounded pipe-holder
+/// CLOSES the inherited pipe and exits in response to the drain-expiry `SIGTERM`,
+/// the cleanup must NOT follow with an unconditional `SIGKILL` to the (now
+/// possibly-released) process group — a blind second signal could race PGID reuse
+/// and hit an unrelated recycled group. The holder here traps `SIGTERM`, releases
+/// the pipe (so the pump reaches EOF and the escalation takes the no-`SIGKILL`
+/// branch), then SURVIVES well past the two-phase `SIGKILL` grace before dropping
+/// a sentinel. The sentinel's PRESENCE proves no `SIGKILL` reached the group; the
+/// pre-fix unconditional `SIGKILL` would have killed the holder mid-sleep, before
+/// it could write the sentinel.
+#[tokio::test]
+#[cfg(unix)]
+async fn execute_post_exec_gate_command_sigterm_responsive_holder_skips_sigkill() {
+    let project_dir = tempdir().unwrap();
+    let sentinel = project_dir
+        .path()
+        .join("sigterm-responsive-holder-survived");
+    let env = HashMap::from([(
+        "GATE_TEST_SENTINEL".to_string(),
+        sentinel.to_string_lossy().into_owned(),
+    )]);
+
+    // Backgrounded subshell holds the inherited stdout/stderr open via `sleep`.
+    // It CATCHES `SIGTERM`: the handler closes both pipe ends (releasing EOF to
+    // the pump) but keeps RUNNING, waits 2s (well past the 100ms two-phase
+    // `SIGKILL` grace), then writes the sentinel and exits. The leader exits 0
+    // immediately (NORMAL-exit path), so by the time the drain grace expires the
+    // leader is already reaped and the PGID is anchored ONLY by this descendant.
+    let command = r#"(trap 'exec 1>&- 2>&-; sleep 2; : > "$GATE_TEST_SENTINEL"; exit 0' TERM; sleep 30) & exit 0"#;
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        execute_post_exec_gate_command(command, project_dir.path(), 30, Some(env)),
+    )
+    .await
+    .expect("gate must not hang when a backgrounded child holds the pipe open")
+    .expect("post-exec gate command should run");
+
+    assert_eq!(outcome.exit, PostExecGateCommandExit::Exited(Some(0)));
+
+    // Give the SIGTERM-surviving holder time to pass its post-SIGTERM delay and
+    // write the sentinel. Its PRESENCE proves the cleanup did NOT escalate to a
+    // blind `SIGKILL` once the pipe was already closed.
+    tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+    assert!(
+        sentinel.exists(),
+        "a SIGTERM-responsive pipe-holder that already closed the pipe must NOT be SIGKILLed; \
+         an absent sentinel means a blind second signal raced PGID reuse"
+    );
+}
+
+/// Round-3 escalation regression (#1726): a backgrounded pipe-holder that IGNORES
+/// `SIGTERM` (so its child `sleep` inherits the ignore too) keeps the inherited
+/// pipe open, leaving a live group member present. The drain-expiry cleanup MUST
+/// therefore escalate to `SIGKILL` — which is reuse-safe precisely because that
+/// live member still anchors the PGID — and reap the holder. The runner must
+/// still return within `timeout + grace`, and the holder must be gone before it
+/// can write its sentinel. This guards the live-member `SIGKILL` branch against a
+/// future regression that drops escalation entirely.
+#[tokio::test]
+#[cfg(unix)]
+async fn execute_post_exec_gate_command_sigterm_ignoring_holder_escalates_to_sigkill() {
+    let project_dir = tempdir().unwrap();
+    let sentinel = project_dir.path().join("sigterm-ignoring-holder-survived");
+    let env = HashMap::from([(
+        "GATE_TEST_SENTINEL".to_string(),
+        sentinel.to_string_lossy().into_owned(),
+    )]);
+
+    // `trap '' TERM` makes the subshell IGNORE `SIGTERM`; the ignore is inherited
+    // across `exec`, so the child `sleep 6` ignores it too. Neither dies on the
+    // drain-expiry `SIGTERM`, so the pipe stays open and only the escalated
+    // `SIGKILL` can reap them — well before the +6s sentinel write.
+    let command = r#"(trap '' TERM; sleep 6; : > "$GATE_TEST_SENTINEL") & exit 0"#;
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        execute_post_exec_gate_command(command, project_dir.path(), 30, Some(env)),
+    )
+    .await
+    .expect("gate must not hang when a SIGTERM-ignoring child holds the pipe open")
+    .expect("post-exec gate command should run");
+
+    assert_eq!(outcome.exit, PostExecGateCommandExit::Exited(Some(0)));
+
+    // Wait past the subshell's +6s mark: a holder that survived (no `SIGKILL`)
+    // would have created the sentinel by now. Its absence proves the escalated
+    // `SIGKILL` reaped the SIGTERM-immune holder.
+    tokio::time::sleep(std::time::Duration::from_secs(6)).await;
+    assert!(
+        !sentinel.exists(),
+        "a SIGTERM-ignoring pipe-holder must be reaped by the escalated SIGKILL, not outlive the drain"
+    );
+}
+
 /// Round-2 memory bound (#1726): a gate that floods stdout far past
 /// `GATE_CAPTURE_MAX_BYTES` must keep the in-memory capture bounded (no
 /// unbounded slurp) while still tee-ing the full transcript to the parent. The

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -1,18 +1,34 @@
 use super::{
-    PostExecGateApplyOptions, PostExecGateCommandOutcome, PostExecGateOutcome,
-    apply_post_exec_gate_after_success_with_runner, execute_post_exec_gate_command,
-    maybe_run_post_exec_gate_with_runner,
+    PostExecGateApplyOptions, PostExecGateCommandExit, PostExecGateCommandOutcome,
+    PostExecGateOutcome, apply_post_exec_gate_after_success_with_runner,
+    execute_post_exec_gate_command, maybe_run_post_exec_gate_with_runner,
 };
 use crate::cli::{Cli, Commands};
 use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use clap::Parser;
 use csa_config::{PostExecGateConfig, ProjectConfig, ProjectMeta, ResourcesConfig, RunConfig};
-use csa_session::{SessionResult, create_session_fresh, load_result, save_result};
+use csa_session::{
+    GATE_FAILURE_LOG_REL_PATH, SessionResult, create_session_fresh, get_session_dir, load_result,
+    save_result,
+};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
+
+/// Representative `just pre-commit` failure output: a `cargo nextest` test
+/// failure under a failing `just test` recipe. Used to exercise the structured
+/// surfacing path (#1726) — parsed into `failing_step` + `failing_tests`.
+const SAMPLE_GATE_FAILURE_OUTPUT: &str = "\
+    Compiling cli-sub-agent v0.1.0
+running cargo nextest run --workspace --all-features
+        PASS [   0.004s] csa-session result::tests::roundtrips
+        FAIL [   0.005s] csa-session post_exec_gate_report::tests::parses
+        FAIL [   1.200s] cli-sub-agent run_cmd::tests::gate_surfaces
+   Summary [   1.234s] 3 tests run: 1 passed, 2 failed
+error: Recipe `test` failed on line 42 with exit code 100
+error: Recipe `pre-commit` failed on line 3 with exit code 100";
 
 fn project_config_with_gate(gate: PostExecGateConfig) -> ProjectConfig {
     ProjectConfig {
@@ -93,6 +109,7 @@ fn create_session_at_current_head(project_root: &Path) -> String {
 fn write_success_result_for(project_root: &Path, session_id: &str) {
     let now = chrono::Utc::now();
     let result = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "task completed".to_string(),
@@ -145,6 +162,84 @@ fn planning_post_exec_options() -> PostExecGateApplyOptions<'static> {
     }
 }
 
+/// Seed the session's `output/summary.md` + `output/details.md` with an employee
+/// "success" self-report, mimicking what `persist_structured_output` writes
+/// BEFORE the gate runs. Used to prove the gate-failure banner supersedes it.
+fn seed_employee_success_sections(project_root: &Path, session_id: &str) {
+    let output_dir = get_session_dir(project_root, session_id)
+        .expect("session dir")
+        .join("output");
+    std::fs::create_dir_all(&output_dir).expect("create output dir");
+    std::fs::write(
+        output_dir.join("summary.md"),
+        "## Summary\n\nAll changes implemented and committed. Everything is clean. ✅\n",
+    )
+    .expect("write summary.md");
+    std::fs::write(
+        output_dir.join("details.md"),
+        "## Details\n\nThe task succeeded; all tests pass locally.\n",
+    )
+    .expect("write details.md");
+}
+
+/// Assert the #1726 structured-surfacing artifacts after a nonzero-exit gate
+/// failure: a non-contradictory `result.toml` summary, a populated
+/// `[post_exec_gate]` table, the full `gate-failure.log`, and the banner
+/// prepended to `summary.md`.
+fn assert_gate_failure_surfaced(project_root: &Path, session_id: &str, result: &SessionResult) {
+    // result.toml: authoritative gate verdict overrides the employee self-report.
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(!result.gate_timeout);
+    assert!(
+        result.warnings.is_empty(),
+        "no success warning on fatal exit: {:?}",
+        result.warnings
+    );
+    assert!(
+        result.summary.starts_with("POST-EXEC GATE FAILED"),
+        "summary must lead with the gate verdict, got: {}",
+        result.summary
+    );
+
+    // [post_exec_gate] table with the parsed failing step + tests.
+    let report = result
+        .post_exec_gate
+        .as_ref()
+        .expect("post_exec_gate table present on gate failure");
+    assert_eq!(report.exit_code, 100);
+    assert_eq!(report.gate_command, "just pre-commit");
+    assert_eq!(report.failing_step.as_deref(), Some("just test"));
+    assert!(
+        report
+            .failing_tests
+            .iter()
+            .any(|t| t.contains("post_exec_gate_report::tests::parses")),
+        "failing tests parsed from nextest output: {:?}",
+        report.failing_tests
+    );
+    assert!(!report.output_tail.is_empty());
+    assert_eq!(report.log_path, GATE_FAILURE_LOG_REL_PATH);
+
+    // gate-failure.log: the full, unbounded gate output.
+    let session_dir = get_session_dir(project_root, session_id).expect("session dir");
+    let log = std::fs::read_to_string(session_dir.join(GATE_FAILURE_LOG_REL_PATH))
+        .expect("gate-failure.log written");
+    assert!(log.contains("FAIL ["), "log holds the full gate output");
+    assert!(log.contains("Recipe `test` failed"));
+
+    // summary.md leads with the banner; the employee "clean" claim is superseded.
+    let summary_md =
+        std::fs::read_to_string(session_dir.join("output/summary.md")).expect("summary.md present");
+    assert!(
+        summary_md
+            .trim_start()
+            .starts_with("> ⚠️ **POST-EXEC GATE FAILED"),
+        "summary.md must lead with the gate-failure banner, got: {summary_md}"
+    );
+    assert!(summary_md.contains("SUPERSEDED"));
+}
+
 #[tokio::test]
 #[serial_test::serial]
 async fn execute_post_exec_gate_strips_inherited_csa_env() {
@@ -169,7 +264,7 @@ async fn execute_post_exec_gate_strips_inherited_csa_env() {
     .await
     .expect("post-exec gate command should run");
 
-    assert_eq!(outcome, PostExecGateCommandOutcome::Exited(Some(0)));
+    assert_eq!(outcome.exit, PostExecGateCommandExit::Exited(Some(0)));
 }
 
 #[tokio::test]
@@ -190,7 +285,7 @@ async fn execute_post_exec_gate_applies_build_jobs_env() {
     .await
     .expect("post-exec gate command should run");
 
-    assert_eq!(outcome, PostExecGateCommandOutcome::Exited(Some(0)));
+    assert_eq!(outcome.exit, PostExecGateCommandExit::Exited(Some(0)));
 }
 
 #[tokio::test]
@@ -217,7 +312,7 @@ async fn post_exec_gate_passes_when_command_succeeds() {
                 let cwd = cwd.to_path_buf();
                 Box::pin(async move {
                     calls.lock().unwrap().push((command, cwd, timeout_seconds));
-                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                    Ok(PostExecGateCommandOutcome::exited(Some(0)))
                 })
             }
         },
@@ -252,7 +347,7 @@ async fn post_exec_gate_failure_returns_structured_diagnostic() {
         None,
         None,
         |_command, _cwd, _timeout_seconds, _extra_env| {
-            Box::pin(async { Ok(PostExecGateCommandOutcome::Exited(Some(3))) })
+            Box::pin(async { Ok(PostExecGateCommandOutcome::exited(Some(3))) })
         },
     )
     .await
@@ -388,7 +483,7 @@ async fn post_exec_gate_runs_when_changed_paths_are_non_empty() {
                 let cwd = cwd.to_path_buf();
                 Box::pin(async move {
                     calls.lock().unwrap().push((command, cwd, timeout_seconds));
-                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                    Ok(PostExecGateCommandOutcome::exited(Some(0)))
                 })
             }
         },
@@ -408,6 +503,9 @@ async fn post_exec_gate_nonzero_committed_clean_is_fatal() {
     let session_id = create_session_at_current_head(project_dir.path());
     commit_tracked_change(project_dir.path());
     write_success_result_for(project_dir.path(), &session_id);
+    // Employee wrote a "clean ✅" self-report before the gate ran; the gate
+    // failure must supersede it (#1726).
+    seed_employee_success_sections(project_dir.path(), &session_id);
 
     let config = project_config_with_gate(PostExecGateConfig::default());
     let err = apply_post_exec_gate_after_success_with_runner(
@@ -417,7 +515,12 @@ async fn post_exec_gate_nonzero_committed_clean_is_fatal() {
         Some(&config),
         post_exec_options(false),
         |_command, _cwd, _timeout_seconds, _extra_env| {
-            Box::pin(async { Ok(PostExecGateCommandOutcome::Exited(Some(3))) })
+            Box::pin(async {
+                Ok(PostExecGateCommandOutcome::exited_with(
+                    Some(100),
+                    SAMPLE_GATE_FAILURE_OUTPUT,
+                ))
+            })
         },
     )
     .await
@@ -425,14 +528,7 @@ async fn post_exec_gate_nonzero_committed_clean_is_fatal() {
 
     assert!(err.to_string().contains("post-exec gate failed"));
     let result = persisted_result(project_dir.path(), &session_id);
-    assert_eq!(result.status, "failure");
-    assert_eq!(result.exit_code, 1);
-    assert!(!result.gate_timeout);
-    assert!(
-        result.warnings.is_empty(),
-        "no success warning on fatal exit"
-    );
-    assert!(result.summary.contains("post-exec gate failed"));
+    assert_gate_failure_surfaced(project_dir.path(), &session_id, &result);
 }
 
 #[tokio::test]
@@ -443,6 +539,8 @@ async fn post_exec_gate_nonzero_dirty_is_fatal() {
     let session_id = create_session_at_current_head(project_dir.path());
     std::fs::write(project_dir.path().join("tracked.txt"), "dirty\n").unwrap();
     write_success_result_for(project_dir.path(), &session_id);
+    // No employee sections seeded: exercises the branch that CREATES summary.md
+    // with the banner when the employee emitted none.
 
     let config = project_config_with_gate(PostExecGateConfig::default());
     apply_post_exec_gate_after_success_with_runner(
@@ -452,17 +550,19 @@ async fn post_exec_gate_nonzero_dirty_is_fatal() {
         Some(&config),
         post_exec_options(false),
         |_command, _cwd, _timeout_seconds, _extra_env| {
-            Box::pin(async { Ok(PostExecGateCommandOutcome::Exited(Some(3))) })
+            Box::pin(async {
+                Ok(PostExecGateCommandOutcome::exited_with(
+                    Some(100),
+                    SAMPLE_GATE_FAILURE_OUTPUT,
+                ))
+            })
         },
     )
     .await
     .expect_err("nonzero gate exit is fatal for dirty work");
 
     let result = persisted_result(project_dir.path(), &session_id);
-    assert_eq!(result.status, "failure");
-    assert_eq!(result.exit_code, 1);
-    assert!(!result.gate_timeout);
-    assert!(result.summary.contains("post-exec gate failed"));
+    assert_gate_failure_surfaced(project_dir.path(), &session_id, &result);
 }
 
 #[tokio::test]
@@ -516,7 +616,7 @@ async fn post_exec_gate_timeout_committed_clean_is_advisory() {
         Some(&config),
         post_exec_options(false),
         |_command, _cwd, _timeout_seconds, _extra_env| {
-            Box::pin(async { Ok(PostExecGateCommandOutcome::TimedOut) })
+            Box::pin(async { Ok(PostExecGateCommandOutcome::timed_out()) })
         },
     )
     .await
@@ -554,7 +654,7 @@ async fn post_exec_gate_timeout_dirty_is_fatal() {
         Some(&config),
         post_exec_options(false),
         |_command, _cwd, _timeout_seconds, _extra_env| {
-            Box::pin(async { Ok(PostExecGateCommandOutcome::TimedOut) })
+            Box::pin(async { Ok(PostExecGateCommandOutcome::timed_out()) })
         },
     )
     .await
@@ -601,7 +701,7 @@ async fn post_exec_gate_runs_planning_only_session_when_tracked_source_is_dirty(
                 let calls = Arc::clone(&calls);
                 Box::pin(async move {
                     *calls.lock().unwrap() += 1;
-                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                    Ok(PostExecGateCommandOutcome::exited(Some(0)))
                 })
             }
         },
@@ -684,7 +784,7 @@ async fn post_exec_gate_success_passes_both_cleanliness_states() {
             Some(&config),
             post_exec_options(false),
             |_command, _cwd, _timeout_seconds, _extra_env| {
-                Box::pin(async { Ok(PostExecGateCommandOutcome::Exited(Some(0))) })
+                Box::pin(async { Ok(PostExecGateCommandOutcome::exited(Some(0))) })
             },
         )
         .await
@@ -695,6 +795,20 @@ async fn post_exec_gate_success_passes_both_cleanliness_states() {
         assert_eq!(clean_result.exit_code, 0);
         assert!(!clean_result.gate_timeout);
         assert!(clean_result.warnings.is_empty());
+        // #1726: the success path emits no structured failure artifacts and
+        // leaves the employee summary untouched.
+        assert!(
+            clean_result.post_exec_gate.is_none(),
+            "success path must not emit a [post_exec_gate] table"
+        );
+        assert_eq!(clean_result.summary, "task completed");
+        assert!(
+            !get_session_dir(clean_dir.path(), &clean_session_id)
+                .expect("session dir")
+                .join(GATE_FAILURE_LOG_REL_PATH)
+                .exists(),
+            "success path must not write gate-failure.log"
+        );
     }
 
     {
@@ -712,7 +826,7 @@ async fn post_exec_gate_success_passes_both_cleanliness_states() {
             Some(&config),
             post_exec_options(false),
             |_command, _cwd, _timeout_seconds, _extra_env| {
-                Box::pin(async { Ok(PostExecGateCommandOutcome::Exited(Some(0))) })
+                Box::pin(async { Ok(PostExecGateCommandOutcome::exited(Some(0))) })
             },
         )
         .await
@@ -723,6 +837,17 @@ async fn post_exec_gate_success_passes_both_cleanliness_states() {
         assert_eq!(dirty_result.exit_code, 0);
         assert!(!dirty_result.gate_timeout);
         assert!(dirty_result.warnings.is_empty());
+        assert!(
+            dirty_result.post_exec_gate.is_none(),
+            "success path must not emit a [post_exec_gate] table"
+        );
+        assert!(
+            !get_session_dir(dirty_dir.path(), &dirty_session_id)
+                .expect("session dir")
+                .join(GATE_FAILURE_LOG_REL_PATH)
+                .exists(),
+            "success path must not write gate-failure.log"
+        );
     }
 }
 
@@ -797,7 +922,7 @@ async fn post_exec_gate_runs_when_session_introduced_changes() {
                 let cwd = cwd.to_path_buf();
                 Box::pin(async move {
                     calls.lock().unwrap().push((command, cwd, timeout_seconds));
-                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                    Ok(PostExecGateCommandOutcome::exited(Some(0)))
                 })
             }
         },
@@ -837,7 +962,7 @@ async fn post_exec_gate_runs_when_session_committed_changes() {
                 let cwd = cwd.to_path_buf();
                 Box::pin(async move {
                     calls.lock().unwrap().push((command, cwd, timeout_seconds));
-                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                    Ok(PostExecGateCommandOutcome::exited(Some(0)))
                 })
             }
         },
@@ -877,7 +1002,7 @@ async fn post_exec_gate_runs_when_untracked_source_exists_without_changed_paths(
                 let cwd = cwd.to_path_buf();
                 Box::pin(async move {
                     calls.lock().unwrap().push((command, cwd, timeout_seconds));
-                    Ok(PostExecGateCommandOutcome::Exited(Some(0)))
+                    Ok(PostExecGateCommandOutcome::exited(Some(0)))
                 })
             }
         },

--- a/crates/cli-sub-agent/src/run_cmd_post.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post.rs
@@ -277,7 +277,10 @@ fn record_post_exec_gate_success_warning(
 
 /// Retire a session after post-exec gate failure to prevent it from remaining in Active state.
 /// This ensures that `csa session wait` will not poll indefinitely for a dead session.
-fn retire_session_after_gate_failure(project_root: &Path, session_id: &str) -> anyhow::Result<()> {
+pub(crate) fn retire_session_after_gate_failure(
+    project_root: &Path,
+    session_id: &str,
+) -> anyhow::Result<()> {
     match load_session(project_root, session_id) {
         Ok(mut session) => {
             let phase_result = session.phase.transition(&PhaseEvent::Retired);

--- a/crates/cli-sub-agent/src/run_cmd_post_exec_gate_capture.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_exec_gate_capture.rs
@@ -1,0 +1,265 @@
+//! Bounded, process-group-safe capture of post-exec gate output (#1726).
+//!
+//! The gate runner tees the child's stdout/stderr to the parent (so the raw
+//! transcript `output/full.md` stays intact) while accumulating a combined copy
+//! for the structured failure report. This module makes that accumulation
+//! bounded in BOTH memory and time so a noisy or adversarial gate cannot wedge
+//! or exhaust the writer-session orchestrator:
+//!
+//!  - [`BoundedTailCapture`] retains only the last [`GATE_CAPTURE_MAX_BYTES`]
+//!    bytes (gate failures surface at the END of the transcript), marking
+//!    truncation, so resident memory is capped regardless of output volume;
+//!  - [`drain_pumps_and_reap`] bounds the post-exit pump drain by
+//!    [`GATE_PUMP_DRAIN_GRACE`]; if a backgrounded grandchild inherited a pipe
+//!    write-end and holds it open past the grace, the pump tasks are aborted and
+//!    the gate child's process group is killed, so the gate `timeout_seconds`
+//!    bounds the TOTAL operation (wait + drain), not just `child.wait()`.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::task::{AbortHandle, JoinHandle};
+
+/// Maximum bytes retained in memory for the structured failure report's
+/// captured output. The report only needs the TAIL of the gate transcript (the
+/// failure summary / panic / failing-test list land at the end), so the capture
+/// keeps the last N bytes and flags truncation when a noisy or flooding gate
+/// exceeds it. 1 MiB is far larger than the report's own
+/// `GATE_OUTPUT_TAIL_MAX_BYTES` (8 KiB) tail — so `output_tail` is never starved
+/// — yet small enough to cap resident memory for any gate. The full transcript
+/// is unaffected: every chunk is still tee'd through to the parent's streams.
+pub(crate) const GATE_CAPTURE_MAX_BYTES: usize = 1024 * 1024;
+
+/// Grace window for the stdout/stderr pump tasks to reach EOF AFTER the gate
+/// child has exited (or been killed). A well-behaved gate closes its pipes on
+/// exit and the pumps drain immediately; this bound exists so a backgrounded
+/// grandchild that inherited the pipe write-end cannot make the drain block
+/// forever (which would defeat the gate timeout). On expiry the pumps are
+/// aborted and the process group is reaped.
+pub(crate) const GATE_PUMP_DRAIN_GRACE: Duration = Duration::from_secs(2);
+
+/// Grace between the process-group `SIGTERM` and the escalating `SIGKILL`,
+/// matching the project's two-phase subprocess-termination pattern (Rust 015).
+const GATE_GROUP_TERM_GRACE: Duration = Duration::from_millis(100);
+
+/// Accumulates the combined gate output while retaining only the last
+/// [`GATE_CAPTURE_MAX_BYTES`] bytes, so a noisy or flooding gate cannot grow
+/// resident memory without bound. Tracks the total bytes observed so the
+/// rendered output can disclose truncation explicitly.
+#[derive(Debug, Default)]
+pub(crate) struct BoundedTailCapture {
+    /// Retained tail bytes. Held between `GATE_CAPTURE_MAX_BYTES` and
+    /// `2 * GATE_CAPTURE_MAX_BYTES`: trimming only when it reaches 2x means the
+    /// front memmove runs at most once per `GATE_CAPTURE_MAX_BYTES` of input —
+    /// amortized O(1) per byte rather than O(n) per chunk — so even a
+    /// `yes`-style flood stays cheap (memory AND CPU bounded).
+    tail: Vec<u8>,
+    /// Total bytes observed across the whole stream (pre-trim), for the marker.
+    total: u64,
+}
+
+impl BoundedTailCapture {
+    /// Append a chunk, retaining only the most recent bytes within the cap.
+    fn push(&mut self, bytes: &[u8]) {
+        self.total = self.total.saturating_add(bytes.len() as u64);
+
+        // A single chunk at/above the cap supersedes everything buffered so
+        // far; only its own tail can survive.
+        if bytes.len() >= GATE_CAPTURE_MAX_BYTES {
+            self.tail.clear();
+            self.tail
+                .extend_from_slice(&bytes[bytes.len() - GATE_CAPTURE_MAX_BYTES..]);
+            return;
+        }
+
+        self.tail.extend_from_slice(bytes);
+        if self.tail.len() > 2 * GATE_CAPTURE_MAX_BYTES {
+            let excess = self.tail.len() - GATE_CAPTURE_MAX_BYTES;
+            self.tail.drain(..excess);
+        }
+    }
+
+    /// Render the retained tail as lossy UTF-8. When the stream exceeded the
+    /// cap, the result LEADS with an explicit truncation marker so both
+    /// `gate-failure.log` and the report's bounded tail disclose the elision.
+    pub(crate) fn render(&mut self) -> String {
+        // The lazy 2x trim may leave more than the cap buffered; bring it down
+        // to exactly the cap so the body is the true last N bytes.
+        if self.tail.len() > GATE_CAPTURE_MAX_BYTES {
+            let excess = self.tail.len() - GATE_CAPTURE_MAX_BYTES;
+            self.tail.drain(..excess);
+        }
+
+        let body = String::from_utf8_lossy(&self.tail);
+        if self.total > self.tail.len() as u64 {
+            let total = self.total;
+            let kept = self.tail.len();
+            format!(
+                "[csa: gate output truncated — {total} bytes captured, retained last {kept} bytes (cap {GATE_CAPTURE_MAX_BYTES} bytes)]\n{body}"
+            )
+        } else {
+            body.into_owned()
+        }
+    }
+}
+
+/// Read `reader` to EOF, re-emitting each chunk to the parent's `sink` (so the
+/// raw transcript stays intact) while appending it to the shared bounded
+/// `captured` buffer for structured failure surfacing (#1726).
+pub(crate) fn tee_gate_stream<R, W>(
+    reader: R,
+    sink: W,
+    captured: Arc<Mutex<BoundedTailCapture>>,
+) -> JoinHandle<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    tokio::spawn(async move {
+        let mut reader = reader;
+        let mut sink = sink;
+        let mut chunk = [0u8; 8192];
+        loop {
+            match reader.read(&mut chunk).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    let bytes = &chunk[..n];
+                    let _ = sink.write_all(bytes).await;
+                    let _ = sink.flush().await;
+                    if let Ok(mut guard) = captured.lock() {
+                        guard.push(bytes);
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    })
+}
+
+/// `SIGTERM`-then-`SIGKILL` the gate child's process GROUP (negative PID),
+/// reaping any descendant that inherited the gate's stdout/stderr pipe.
+///
+/// ## PGID-reuse safety
+/// Both call sites guarantee the target PGID cannot have been recycled at the
+/// instant the signal is sent, so `-pid` reaches only this gate's descendants
+/// and never a PID-reuse victim:
+///  * the **timeout** path calls this BEFORE reaping the group leader, so the
+///    un-reaped leader anchors the PGID;
+///  * the **drain-grace-expiry** path calls this only when a pipe write-end is
+///    still open — i.e. a live descendant remains in the group. On Linux the
+///    kernel keeps a PGID's numeric value reserved for as long as any process
+///    is a member of that group (the `struct pid` is pinned via `PIDTYPE_PGID`),
+///    so the leader having already been reaped does not free it for reuse.
+pub(crate) async fn kill_gate_process_group(child_pid: Option<u32>) {
+    #[cfg(unix)]
+    {
+        if let Some(pid) = child_pid {
+            // SAFETY: kill(2) is async-signal-safe; a negative PID targets the
+            // process group created by `process_group(0)` at spawn. The PGID is
+            // not reused at this instant (see the fn-level PGID-reuse-safety
+            // note), so the signal reaches only this gate's own descendants.
+            unsafe {
+                libc::kill(-(pid as i32), libc::SIGTERM);
+            }
+            tokio::time::sleep(GATE_GROUP_TERM_GRACE).await;
+            // SAFETY: same PGID-anchoring invariant as the SIGTERM above.
+            unsafe {
+                libc::kill(-(pid as i32), libc::SIGKILL);
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = child_pid;
+    }
+}
+
+/// Drain the tee pump tasks under [`GATE_PUMP_DRAIN_GRACE`]. Returns once both
+/// pumps reach EOF (the child closed its pipes) or the grace expires. On expiry
+/// — a backgrounded descendant inherited a pipe write-end and is holding it
+/// open — the gate child's process group is killed (reaping the descendant and
+/// closing the pipe) and the pump tasks are aborted, so the runner returns
+/// instead of blocking forever and the gate `timeout_seconds` bounds the TOTAL
+/// operation rather than only `child.wait()`.
+pub(crate) async fn drain_pumps_and_reap(
+    stdout_pump: Option<JoinHandle<()>>,
+    stderr_pump: Option<JoinHandle<()>>,
+    child_pid: Option<u32>,
+) {
+    // Capture abort handles before moving the join handles into the drain
+    // future: dropping a `JoinHandle` only detaches the task, so an explicit
+    // abort is required to stop a pump still blocked on a held-open pipe.
+    let aborts: Vec<AbortHandle> = [&stdout_pump, &stderr_pump]
+        .into_iter()
+        .flatten()
+        .map(JoinHandle::abort_handle)
+        .collect();
+
+    let join = async move {
+        if let Some(pump) = stdout_pump {
+            let _ = pump.await;
+        }
+        if let Some(pump) = stderr_pump {
+            let _ = pump.await;
+        }
+    };
+
+    if tokio::time::timeout(GATE_PUMP_DRAIN_GRACE, join)
+        .await
+        .is_err()
+    {
+        kill_gate_process_group(child_pid).await;
+        for abort in aborts {
+            abort.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_capture_keeps_full_output_below_cap_without_marker() {
+        let mut capture = BoundedTailCapture::default();
+        capture.push(b"line one\n");
+        capture.push(b"line two\n");
+        let rendered = capture.render();
+        assert_eq!(rendered, "line one\nline two\n");
+        assert!(!rendered.contains("truncated"));
+    }
+
+    #[test]
+    fn bounded_capture_retains_tail_and_marks_truncation_over_cap() {
+        let mut capture = BoundedTailCapture::default();
+        // Push well past 2x the cap in one shot AND in pieces to exercise both
+        // the single-oversized-chunk path and the incremental-trim path.
+        let oversized = vec![b'a'; GATE_CAPTURE_MAX_BYTES * 2 + 4096];
+        capture.push(&oversized);
+        // A trailing marker that MUST survive as the retained tail.
+        capture.push(b"TAIL-SENTINEL");
+
+        let rendered = capture.render();
+        // Body is bounded to ~the cap (plus the short marker line).
+        assert!(
+            rendered.len() <= GATE_CAPTURE_MAX_BYTES + 256,
+            "rendered length {} must stay within the cap + marker slack",
+            rendered.len()
+        );
+        // The TAIL is retained (not the head).
+        assert!(rendered.ends_with("TAIL-SENTINEL"));
+        // Truncation is disclosed.
+        assert!(rendered.starts_with("[csa: gate output truncated"));
+    }
+
+    #[test]
+    fn bounded_capture_single_chunk_at_cap_is_not_marked_truncated() {
+        let mut capture = BoundedTailCapture::default();
+        capture.push(&vec![b'z'; GATE_CAPTURE_MAX_BYTES]);
+        let rendered = capture.render();
+        assert_eq!(rendered.len(), GATE_CAPTURE_MAX_BYTES);
+        assert!(!rendered.contains("truncated"));
+    }
+}

--- a/crates/cli-sub-agent/src/run_cmd_post_exec_gate_capture.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_exec_gate_capture.rs
@@ -11,8 +11,9 @@
 //!    truncation, so resident memory is capped regardless of output volume;
 //!  - [`drain_pumps_and_reap`] bounds the post-exit pump drain by
 //!    [`GATE_PUMP_DRAIN_GRACE`]; if a backgrounded grandchild inherited a pipe
-//!    write-end and holds it open past the grace, the pump tasks are aborted and
-//!    the gate child's process group is killed, so the gate `timeout_seconds`
+//!    write-end and holds it open past the grace, the gate child's process group
+//!    is terminated with an ownership-safe `SIGTERM`→(conditional)`SIGKILL`
+//!    escalation and the pump tasks are aborted, so the gate `timeout_seconds`
 //!    bounds the TOTAL operation (wait + drain), not just `child.wait()`.
 
 use std::sync::{Arc, Mutex};
@@ -39,9 +40,22 @@ pub(crate) const GATE_CAPTURE_MAX_BYTES: usize = 1024 * 1024;
 /// aborted and the process group is reaped.
 pub(crate) const GATE_PUMP_DRAIN_GRACE: Duration = Duration::from_secs(2);
 
-/// Grace between the process-group `SIGTERM` and the escalating `SIGKILL`,
-/// matching the project's two-phase subprocess-termination pattern (Rust 015).
+/// Grace between the process-group `SIGTERM` and the escalating `SIGKILL` on the
+/// TIMEOUT path, matching the project's two-phase subprocess-termination pattern
+/// (Rust 015). Sound to fire the second signal unconditionally there because the
+/// un-reaped leader anchors the PGID across the window (see
+/// [`kill_gate_process_group`]).
 const GATE_GROUP_TERM_GRACE: Duration = Duration::from_millis(100);
+
+/// Grace the drain-grace-expiry escalation waits AFTER its `SIGTERM` for the
+/// surviving pipe-holder to close the pipe (pumps reach EOF) before deciding
+/// whether a `SIGKILL` is still warranted. Unlike the timeout path, here the
+/// leader has already been reaped, so the escalation sends `SIGKILL` ONLY if a
+/// pump is STILL open when this elapses — i.e. a live group member still anchors
+/// the PGID, keeping the group `SIGKILL` reuse-safe (#1726). Generous enough to
+/// let a SIGTERM-responsive descendant exit and the pump observe EOF, yet
+/// negligible against any real gate `timeout_seconds`.
+const GATE_GROUP_ESCALATION_GRACE: Duration = Duration::from_millis(500);
 
 /// Accumulates the combined gate output while retaining only the last
 /// [`GATE_CAPTURE_MAX_BYTES`] bytes, so a noisy or flooding gate cannot grow
@@ -138,36 +152,44 @@ where
     })
 }
 
+/// Send `signal` to the gate child's process GROUP via a negative PID. The
+/// caller MUST guarantee the target PGID is still anchored at this instant — by
+/// an un-reaped (zombie) leader, or by a still-alive group member — so the signal
+/// can only reach this gate's own descendants and never a PID-reuse victim.
+#[cfg(unix)]
+fn signal_gate_process_group(pid: i32, signal: i32) {
+    // SAFETY: kill(2) is async-signal-safe. A negative PID targets the process
+    // group created by `process_group(0)` at spawn. The caller guarantees the
+    // PGID is still anchored at this instant (see each call site), so the signal
+    // reaches only this gate's own descendants, never a recycled group.
+    unsafe {
+        libc::kill(-pid, signal);
+    }
+}
+
 /// `SIGTERM`-then-`SIGKILL` the gate child's process GROUP (negative PID),
 /// reaping any descendant that inherited the gate's stdout/stderr pipe.
 ///
-/// ## PGID-reuse safety
-/// Both call sites guarantee the target PGID cannot have been recycled at the
-/// instant the signal is sent, so `-pid` reaches only this gate's descendants
-/// and never a PID-reuse victim:
-///  * the **timeout** path calls this BEFORE reaping the group leader, so the
-///    un-reaped leader anchors the PGID;
-///  * the **drain-grace-expiry** path calls this only when a pipe write-end is
-///    still open — i.e. a live descendant remains in the group. On Linux the
-///    kernel keeps a PGID's numeric value reserved for as long as any process
-///    is a member of that group (the `struct pid` is pinned via `PIDTYPE_PGID`),
-///    so the leader having already been reaped does not free it for reuse.
+/// ## PGID-reuse safety — TIMEOUT PATH ONLY
+/// The UNCONDITIONAL second (`SIGKILL`) signal here is sound ONLY while the group
+/// leader has not yet been reaped: an un-reaped (zombie) leader pins the PGID via
+/// `PIDTYPE_PGID`, so the value cannot be recycled across the `SIGTERM`→`SIGKILL`
+/// window and `-pid` reaches only this gate's descendants. The timeout caller
+/// guarantees this by calling here BEFORE `child.wait()`.
+///
+/// The drain-grace-expiry path must NOT use this helper: by then the leader has
+/// already been reaped, so the surviving pipe-holder is the ONLY PGID anchor — if
+/// it exits on the `SIGTERM`, the unconditional `SIGKILL` could race PGID reuse.
+/// That path uses the ownership-safe escalation in [`drain_pumps_and_reap`]
+/// instead (#1726).
 pub(crate) async fn kill_gate_process_group(child_pid: Option<u32>) {
     #[cfg(unix)]
     {
         if let Some(pid) = child_pid {
-            // SAFETY: kill(2) is async-signal-safe; a negative PID targets the
-            // process group created by `process_group(0)` at spawn. The PGID is
-            // not reused at this instant (see the fn-level PGID-reuse-safety
-            // note), so the signal reaches only this gate's own descendants.
-            unsafe {
-                libc::kill(-(pid as i32), libc::SIGTERM);
-            }
+            let pid = pid as i32;
+            signal_gate_process_group(pid, libc::SIGTERM);
             tokio::time::sleep(GATE_GROUP_TERM_GRACE).await;
-            // SAFETY: same PGID-anchoring invariant as the SIGTERM above.
-            unsafe {
-                libc::kill(-(pid as i32), libc::SIGKILL);
-            }
+            signal_gate_process_group(pid, libc::SIGKILL);
         }
     }
     #[cfg(not(unix))]
@@ -176,44 +198,91 @@ pub(crate) async fn kill_gate_process_group(child_pid: Option<u32>) {
     }
 }
 
+/// Await every still-pending pump task until they all reach EOF or `grace`
+/// elapses, whichever comes first. Pump handles polled to completion in an
+/// earlier call MUST be pruned by the caller (via [`JoinHandle::is_finished`])
+/// between calls so this never re-polls a finished handle (which would panic).
+async fn await_pumps_bounded(pumps: &mut [JoinHandle<()>], grace: Duration) {
+    if pumps.is_empty() {
+        return;
+    }
+    let _ = tokio::time::timeout(grace, async move {
+        for pump in pumps.iter_mut() {
+            // `&mut JoinHandle` is a `Future`; awaiting a not-yet-completed
+            // handle is sound. The caller prunes completed handles between calls,
+            // so a handle is never awaited after it already returned `Ready`.
+            let _ = pump.await;
+        }
+    })
+    .await;
+}
+
 /// Drain the tee pump tasks under [`GATE_PUMP_DRAIN_GRACE`]. Returns once both
-/// pumps reach EOF (the child closed its pipes) or the grace expires. On expiry
-/// — a backgrounded descendant inherited a pipe write-end and is holding it
-/// open — the gate child's process group is killed (reaping the descendant and
-/// closing the pipe) and the pump tasks are aborted, so the runner returns
-/// instead of blocking forever and the gate `timeout_seconds` bounds the TOTAL
-/// operation rather than only `child.wait()`.
+/// pumps reach EOF (the child closed its pipes) or the grace expires. On
+/// expiry — a backgrounded descendant inherited a pipe write-end and is holding
+/// it open after the caller already reaped the group leader — the descendant is
+/// reaped with an OWNERSHIP-SAFE escalation so the gate `timeout_seconds` bounds
+/// the TOTAL operation rather than only `child.wait()`:
+///
+///  1. `SIGTERM` the gate's process group (politely ask the pipe-holder to go);
+///  2. RE-WAIT the pumps for [`GATE_GROUP_ESCALATION_GRACE`]. If they reach EOF,
+///     the pipe-holder died from the `SIGTERM` and released the pipe — the PGID
+///     may now be unanchored, so NO `SIGKILL` is sent (a blind second signal
+///     could race PGID reuse and hit an unrelated recycled group);
+///  3. otherwise a pump is STILL open, proving a live group member still holds
+///     the write-end and thus re-anchors the PGID, so `SIGKILL` to the group is
+///     reuse-safe. Send it, then abort the leaked pump tasks (#1726).
+///
+/// Contrast the TIMEOUT path, which calls [`kill_gate_process_group`] BEFORE
+/// reaping the leader: there the un-reaped leader anchors the PGID, so its
+/// unconditional `SIGTERM`→`SIGKILL` cannot race reuse.
 pub(crate) async fn drain_pumps_and_reap(
     stdout_pump: Option<JoinHandle<()>>,
     stderr_pump: Option<JoinHandle<()>>,
     child_pid: Option<u32>,
 ) {
-    // Capture abort handles before moving the join handles into the drain
-    // future: dropping a `JoinHandle` only detaches the task, so an explicit
-    // abort is required to stop a pump still blocked on a held-open pipe.
-    let aborts: Vec<AbortHandle> = [&stdout_pump, &stderr_pump]
-        .into_iter()
-        .flatten()
-        .map(JoinHandle::abort_handle)
-        .collect();
+    let mut pumps: Vec<JoinHandle<()>> = [stdout_pump, stderr_pump].into_iter().flatten().collect();
+    // Capture abort handles up front: dropping a `JoinHandle` only detaches the
+    // task, so an explicit abort is required to stop a pump still blocked on a
+    // descendant-held pipe. Aborting an already-finished pump is a harmless no-op.
+    let aborts: Vec<AbortHandle> = pumps.iter().map(JoinHandle::abort_handle).collect();
 
-    let join = async move {
-        if let Some(pump) = stdout_pump {
-            let _ = pump.await;
-        }
-        if let Some(pump) = stderr_pump {
-            let _ = pump.await;
-        }
-    };
+    // Phase 1: wait for both pumps to reach EOF under the drain grace. A
+    // well-behaved gate closes its pipes on exit and this returns immediately.
+    await_pumps_bounded(&mut pumps, GATE_PUMP_DRAIN_GRACE).await;
+    pumps.retain(|pump| !pump.is_finished());
+    if pumps.is_empty() {
+        return;
+    }
 
-    if tokio::time::timeout(GATE_PUMP_DRAIN_GRACE, join)
-        .await
-        .is_err()
+    // A backgrounded descendant is still holding a pipe write-end past the drain
+    // grace, and the caller has ALREADY reaped the group leader — so escalate
+    // ownership-safely (see the fn docs) rather than via the unconditional
+    // `kill_gate_process_group`, whose second signal would race PGID reuse here.
+    #[cfg(unix)]
+    if let Some(pid) = child_pid {
+        let pid = pid as i32;
+        // Phase 2: politely terminate the group, then re-wait for the pumps to
+        // reach EOF under a short escalation grace.
+        signal_gate_process_group(pid, libc::SIGTERM);
+        await_pumps_bounded(&mut pumps, GATE_GROUP_ESCALATION_GRACE).await;
+        pumps.retain(|pump| !pump.is_finished());
+        // Phase 3: escalate to `SIGKILL` ONLY while a pump is STILL open — a live
+        // group member then anchors the PGID, so the group `SIGKILL` is reuse-safe.
+        // If the pumps drained, the pipe-holder already exited on the `SIGTERM`
+        // and a blind `SIGKILL` could hit a recycled PGID, so it is deliberately
+        // skipped (there is nothing left to kill).
+        if !pumps.is_empty() {
+            signal_gate_process_group(pid, libc::SIGKILL);
+        }
+    }
+    #[cfg(not(unix))]
     {
-        kill_gate_process_group(child_pid).await;
-        for abort in aborts {
-            abort.abort();
-        }
+        let _ = child_pid;
+    }
+
+    for abort in aborts {
+        abort.abort();
     }
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_post_gate_failure_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_gate_failure_tests.rs
@@ -6,6 +6,7 @@ use tempfile::tempdir;
 fn write_success_result_for(project_root: &Path, session_id: &str) {
     let now = chrono::Utc::now();
     let result = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "task completed".to_string(),

--- a/crates/cli-sub-agent/src/run_cmd_post_gate_report.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_gate_report.rs
@@ -1,0 +1,371 @@
+//! Structured surfacing of post-exec gate failures (#1726).
+//!
+//! When a `csa run` write session's post-exec verification gate (e.g.
+//! `just pre-commit`) exits nonzero, the gate's stdout/stderr previously landed
+//! ONLY in the raw transcript `output/full.md`. An SA-Layer-0 orchestrator —
+//! which is forbidden from reading transcripts — could not diagnose the failing
+//! step/test, and `summary.md`/`details.md` (written from the employee's
+//! pre-gate self-report) could still read as "success" while `result.toml` said
+//! the gate failed.
+//!
+//! This module reconciles that. On a nonzero-exit gate failure it:
+//!  - writes the full (redacted) gate output to [`GATE_FAILURE_LOG_REL_PATH`];
+//!  - overwrites `result.toml` so its `summary` LEADS with the gate verdict and
+//!    its `[post_exec_gate]` table carries a bounded tail plus the parsed
+//!    failing step/tests;
+//!  - prepends a gate-failure banner to `summary.md`/`details.md` so the
+//!    employee's pre-gate self-report can never read as the final verdict.
+//!
+//! It deliberately covers ONLY the nonzero-exit path. Timeout and gate
+//! infrastructure errors keep the existing simple overwrite in
+//! [`crate::run_cmd_post`]: their verdicts are already non-contradictory and
+//! they carry no captured gate output worth surfacing structurally.
+
+use std::path::Path;
+
+use tracing::warn;
+
+use csa_session::{
+    GATE_FAILURE_LOG_REL_PATH, PostExecGateReport, get_session_dir, load_result,
+    redact_text_content, save_result,
+};
+
+/// Stable banner header prefix; used both to render the banner and to detect an
+/// already-prepended banner (idempotency) so re-entry never double-stamps.
+const GATE_BANNER_HEADER: &str = "> ⚠️ **POST-EXEC GATE FAILED";
+
+/// Leading marker for the reconciled `result.toml` summary. Kept as a constant
+/// so tests assert the non-contradiction contract rather than prose wording.
+pub(crate) const GATE_SUMMARY_LEAD: &str = "POST-EXEC GATE FAILED";
+
+/// How many failing test names to inline into the one-line `result.toml`
+/// summary before collapsing the rest into a `(+N more)` suffix.
+const SUMMARY_MAX_INLINE_TESTS: usize = 5;
+
+/// How many failing test names to list in the (multi-line) section banner.
+const BANNER_MAX_LISTED_TESTS: usize = 10;
+
+/// Inputs for [`persist_gate_failure_detail`].
+pub(crate) struct GateFailureDetail<'a> {
+    pub(crate) project_root: &'a Path,
+    pub(crate) session_id: &'a str,
+    /// The gate command that failed (e.g. `"just pre-commit"`).
+    pub(crate) gate_command: &'a str,
+    /// The gate's real exit code (signal → `-1`, timeout → `124` by convention).
+    pub(crate) exit_code: i32,
+    /// Full captured gate output, BEFORE redaction.
+    pub(crate) captured_output: &'a str,
+}
+
+/// Persist a nonzero-exit post-exec gate failure into structured, SA-readable
+/// artifacts and reconcile the session's summary so it leads with the gate
+/// verdict. Best-effort throughout: each sub-step logs and continues on error so
+/// a partial failure (e.g. an unwritable section file) never masks the gate
+/// verdict already recorded in `result.toml`.
+pub(crate) fn persist_gate_failure_detail(detail: GateFailureDetail<'_>) {
+    // Redact ONCE; the same redacted text feeds both the unbounded log and the
+    // bounded tail in the report, so neither surface can leak material the other
+    // hides.
+    let redacted = redact_text_content(detail.captured_output);
+    let report = PostExecGateReport::from_redacted_gate_output(
+        detail.gate_command,
+        detail.exit_code,
+        &redacted,
+    );
+
+    // Resolve the session dir for the log + section banners. If it cannot be
+    // resolved we still overwrite result.toml below (it resolves its own path),
+    // so the authoritative verdict is recorded even without the log/banners.
+    let session_dir = match get_session_dir(detail.project_root, detail.session_id) {
+        Ok(dir) => Some(dir),
+        Err(err) => {
+            warn!(
+                session = %detail.session_id,
+                error = %err,
+                "Could not resolve session dir for gate-failure surfacing; recording verdict only"
+            );
+            None
+        }
+    };
+
+    if let Some(dir) = session_dir.as_deref() {
+        write_gate_failure_log(dir, detail.session_id, &redacted);
+    }
+
+    overwrite_result_with_report(detail.project_root, detail.session_id, &report);
+
+    if let Some(dir) = session_dir.as_deref() {
+        prepend_gate_banner_to_sections(dir, detail.session_id, &report);
+    }
+
+    // Retire so the dead session isn't left Active (matches the simple overwrite
+    // path in run_cmd_post).
+    if let Err(err) = crate::run_cmd_post::retire_session_after_gate_failure(
+        detail.project_root,
+        detail.session_id,
+    ) {
+        warn!(
+            session = %detail.session_id,
+            error = %err,
+            "Failed to retire session after post-exec gate failure"
+        );
+    }
+}
+
+/// Write the full (already-redacted) gate output to `output/gate-failure.log`.
+fn write_gate_failure_log(session_dir: &Path, session_id: &str, redacted_output: &str) {
+    let log_path = session_dir.join(GATE_FAILURE_LOG_REL_PATH);
+    if let Some(parent) = log_path.parent()
+        && let Err(err) = std::fs::create_dir_all(parent)
+    {
+        warn!(
+            session = %session_id,
+            error = %err,
+            "Could not create output dir for gate-failure.log"
+        );
+        return;
+    }
+    if let Err(err) = std::fs::write(&log_path, redacted_output) {
+        warn!(
+            session = %session_id,
+            error = %err,
+            "Could not write gate-failure.log"
+        );
+    }
+}
+
+/// Overwrite `result.toml`: the gate verdict is authoritative over the
+/// employee's pre-gate self-report.
+fn overwrite_result_with_report(
+    project_root: &Path,
+    session_id: &str,
+    report: &PostExecGateReport,
+) {
+    match load_result(project_root, session_id) {
+        Ok(Some(mut result)) => {
+            result.exit_code = 1;
+            result.status = "failure".to_string();
+            // A nonzero-exit gate is not a timeout.
+            result.gate_timeout = false;
+            result.summary = build_failure_summary(report);
+            result.post_exec_gate = Some(report.clone());
+            if let Err(err) = save_result(project_root, session_id, &result) {
+                warn!(
+                    session = %session_id,
+                    error = %err,
+                    "Failed to overwrite result.toml after post-exec gate failure"
+                );
+            }
+        }
+        Ok(None) => warn!(
+            session = %session_id,
+            "No result.toml to overwrite after post-exec gate failure"
+        ),
+        Err(err) => warn!(
+            session = %session_id,
+            error = %err,
+            "Failed to load result.toml for post-exec gate failure overwrite"
+        ),
+    }
+}
+
+/// Build the one-line `result.toml` summary. It LEADS with the gate verdict
+/// (exit code + failing step) and points at the full log, so an orchestrator
+/// reading only `result.summary` cannot mistake the run for a success.
+fn build_failure_summary(report: &PostExecGateReport) -> String {
+    let mut summary = format!("{GATE_SUMMARY_LEAD} (exit={}", report.exit_code);
+    if let Some(step) = &report.failing_step {
+        summary.push_str(&format!(", step={step}"));
+    }
+    summary.push_str(") — employee self-report SUPERSEDED by gate verdict; full output: ");
+    summary.push_str(&report.log_path);
+
+    if !report.failing_tests.is_empty() {
+        let shown: Vec<&str> = report
+            .failing_tests
+            .iter()
+            .take(SUMMARY_MAX_INLINE_TESTS)
+            .map(String::as_str)
+            .collect();
+        summary.push_str("; failing tests: ");
+        summary.push_str(&shown.join(", "));
+        let extra = report
+            .failing_tests
+            .len()
+            .saturating_sub(SUMMARY_MAX_INLINE_TESTS);
+        if extra > 0 {
+            summary.push_str(&format!(" (+{extra} more)"));
+        }
+    }
+    summary
+}
+
+/// Build the multi-line markdown banner prepended to `summary.md`/`details.md`.
+fn build_gate_failure_banner(report: &PostExecGateReport) -> String {
+    let mut banner = String::new();
+    banner.push_str(GATE_BANNER_HEADER);
+    banner.push_str(
+        " — the employee self-report below is SUPERSEDED by the verification gate.**\n>\n",
+    );
+    banner.push_str(&format!("> - Gate command: `{}`\n", report.gate_command));
+    banner.push_str(&format!("> - Exit code: `{}`\n", report.exit_code));
+    if let Some(step) = &report.failing_step {
+        banner.push_str(&format!("> - Failing step: `{step}`\n"));
+    }
+    if !report.failing_tests.is_empty() {
+        let shown: Vec<&str> = report
+            .failing_tests
+            .iter()
+            .take(BANNER_MAX_LISTED_TESTS)
+            .map(String::as_str)
+            .collect();
+        banner.push_str(&format!("> - Failing tests: {}", shown.join(", ")));
+        let extra = report
+            .failing_tests
+            .len()
+            .saturating_sub(BANNER_MAX_LISTED_TESTS);
+        if extra > 0 {
+            banner.push_str(&format!(" (+{extra} more)"));
+        }
+        banner.push('\n');
+    }
+    banner.push_str(&format!("> - Full gate output: `{}`\n", report.log_path));
+    banner.push_str(
+        ">\n> The session did NOT pass verification. Treat any \"success\" / \"all clean\" \
+         wording below as the employee's pre-gate claim, not the final verdict.\n\n---\n\n",
+    );
+    banner
+}
+
+/// Prepend the gate-failure banner to `summary.md` (creating it if the employee
+/// emitted none) and to `details.md` (only if it already exists). Idempotent:
+/// a file already starting with the banner header is left untouched.
+fn prepend_gate_banner_to_sections(
+    session_dir: &Path,
+    session_id: &str,
+    report: &PostExecGateReport,
+) {
+    let banner = build_gate_failure_banner(report);
+    let output_dir = session_dir.join("output");
+
+    // summary.md is the canonical SA-read surface, so it must ALWAYS lead with
+    // the gate verdict — create it with the banner when the employee emitted
+    // none.
+    let summary_path = output_dir.join("summary.md");
+    let existing_summary = std::fs::read_to_string(&summary_path).unwrap_or_default();
+    if !existing_summary
+        .trim_start()
+        .starts_with(GATE_BANNER_HEADER)
+    {
+        if let Err(err) = std::fs::create_dir_all(&output_dir) {
+            warn!(
+                session = %session_id,
+                error = %err,
+                "Could not create output dir for gate-failure banner"
+            );
+            return;
+        }
+        if let Err(err) = std::fs::write(&summary_path, format!("{banner}{existing_summary}")) {
+            warn!(
+                session = %session_id,
+                error = %err,
+                "Could not prepend gate-failure banner to summary.md"
+            );
+        }
+    }
+
+    // details.md retains the employee's account but must be prefixed with the
+    // banner; only touch it when it already exists.
+    let details_path = output_dir.join("details.md");
+    if details_path.is_file() {
+        let existing_details = std::fs::read_to_string(&details_path).unwrap_or_default();
+        if !existing_details
+            .trim_start()
+            .starts_with(GATE_BANNER_HEADER)
+            && let Err(err) = std::fs::write(&details_path, format!("{banner}{existing_details}"))
+        {
+            warn!(
+                session = %session_id,
+                error = %err,
+                "Could not prepend gate-failure banner to details.md"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report_with(
+        exit_code: i32,
+        failing_step: Option<&str>,
+        failing_tests: &[&str],
+    ) -> PostExecGateReport {
+        PostExecGateReport {
+            gate_command: "just pre-commit".to_string(),
+            exit_code,
+            failing_step: failing_step.map(str::to_string),
+            failing_tests: failing_tests.iter().map(|t| t.to_string()).collect(),
+            output_tail: "…tail…".to_string(),
+            log_path: GATE_FAILURE_LOG_REL_PATH.to_string(),
+        }
+    }
+
+    #[test]
+    fn summary_leads_with_gate_verdict_not_success() {
+        let summary = build_failure_summary(&report_with(100, Some("just test"), &["pkg::a"]));
+        // Leads with the gate verdict marker.
+        assert!(summary.starts_with(GATE_SUMMARY_LEAD));
+        assert!(summary.contains("exit=100"));
+        assert!(summary.contains("step=just test"));
+        assert!(summary.contains("SUPERSEDED"));
+        assert!(summary.contains(GATE_FAILURE_LOG_REL_PATH));
+        assert!(summary.contains("pkg::a"));
+    }
+
+    #[test]
+    fn summary_handles_missing_step_and_tests() {
+        let summary = build_failure_summary(&report_with(1, None, &[]));
+        assert!(summary.starts_with(GATE_SUMMARY_LEAD));
+        assert!(summary.contains("exit=1"));
+        assert!(!summary.contains("step="));
+        assert!(!summary.contains("failing tests"));
+    }
+
+    #[test]
+    fn summary_collapses_overflow_tests_into_more_suffix() {
+        let many = ["a", "b", "c", "d", "e", "f", "g"];
+        let summary = build_failure_summary(&report_with(100, None, &many));
+        // First SUMMARY_MAX_INLINE_TESTS shown, remainder collapsed.
+        assert!(summary.contains("a, b, c, d, e"));
+        assert!(!summary.contains(", f"));
+        assert!(summary.contains("(+2 more)"));
+    }
+
+    #[test]
+    fn banner_supersedes_and_lists_failure_detail() {
+        let banner = build_gate_failure_banner(&report_with(101, Some("just clippy"), &["pkg::x"]));
+        assert!(banner.trim_start().starts_with(GATE_BANNER_HEADER));
+        assert!(banner.contains("SUPERSEDED"));
+        assert!(banner.contains("just pre-commit"));
+        assert!(banner.contains("`101`"));
+        assert!(banner.contains("just clippy"));
+        assert!(banner.contains("pkg::x"));
+        assert!(banner.contains(GATE_FAILURE_LOG_REL_PATH));
+        // Ends with a markdown rule separating it from the employee account.
+        assert!(banner.contains("\n---\n"));
+    }
+
+    #[test]
+    fn banner_caps_listed_tests() {
+        let many: Vec<String> = (0..15).map(|i| format!("pkg::t{i}")).collect();
+        let refs: Vec<&str> = many.iter().map(String::as_str).collect();
+        let banner = build_gate_failure_banner(&report_with(100, None, &refs));
+        assert!(banner.contains("pkg::t0"));
+        assert!(banner.contains("pkg::t9"));
+        // 11th listed test is collapsed.
+        assert!(!banner.contains("pkg::t10,"));
+        assert!(banner.contains("(+5 more)"));
+    }
+}

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -447,6 +447,7 @@ mod tests {
     fn session_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
         let now = chrono::Utc::now();
         csa_session::SessionResult {
+            post_exec_gate: None,
             status: status.to_string(),
             exit_code,
             summary: "done".to_string(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -151,6 +151,7 @@ pub(crate) fn daemon_completion_result(
     );
 
     SessionResult {
+        post_exec_gate: None,
         status: packet.status.clone(),
         exit_code: packet.exit_code,
         summary: crate::pipeline_post_exec::build_fallback_result_summary(
@@ -303,6 +304,7 @@ mod tests {
 
         let now = chrono::Utc::now();
         let existing = SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "existing compact result".to_string(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -65,6 +65,7 @@ fn compact_summary_includes_usage_and_review_verdict() {
     .expect("review meta should be written");
     let now = Utc::now();
     let result = csa_session::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: r#"{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":25}}"#.to_string(),
@@ -106,6 +107,7 @@ fn compact_summary_uses_primary_failure_and_opaque_total_exhaustion_failover() {
     .expect("review verdict should be written");
     let now = Utc::now();
     let result = csa_session::SessionResult {
+        post_exec_gate: None,
         status: "failed".to_string(),
         exit_code: 1,
         summary: "review unavailable".to_string(),
@@ -163,6 +165,7 @@ fn compact_summary_prints_pass_from_canonical_artifact_when_result_succeeded() {
     .expect("review verdict should be written");
     let now = Utc::now();
     let result = csa_session::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "review complete".to_string(),
@@ -193,6 +196,7 @@ fn compact_summary_includes_writer_uncommitted_warning() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let now = Utc::now();
     let result = csa_session::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "done".to_string(),
@@ -238,6 +242,7 @@ fn compact_summary_does_not_print_pass_when_result_failed() {
     .expect("review verdict should be written");
     let now = Utc::now();
     let result = csa_session::SessionResult {
+        post_exec_gate: None,
         status: "failed".to_string(),
         exit_code: 137,
         summary: "fatal backend error: process killed".to_string(),
@@ -301,6 +306,7 @@ fn compact_summary_does_not_print_pass_for_failed_fix_convergence() {
     .expect("review meta should be written");
     let now = Utc::now();
     let result = csa_session::SessionResult {
+        post_exec_gate: None,
         status: "failed".to_string(),
         exit_code: 1,
         summary: "fix did not converge".to_string(),

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -406,6 +406,7 @@ where
         diagnostics
     );
     let fallback = SessionResult {
+        post_exec_gate: None,
         status: "failure".to_string(),
         exit_code: 1,
         summary: crate::pipeline_post_exec::build_fallback_result_summary(

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -134,6 +134,7 @@ fn missing_current_sizes_do_not_count_as_reconcile_progress() {
 fn make_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
     let now = Utc::now();
     csa_session::SessionResult {
+        post_exec_gate: None,
         status: status.to_string(),
         exit_code,
         summary: "summary".to_string(),

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
@@ -99,6 +99,7 @@ impl SessionTestEnv {
 fn make_result(status: &str, exit_code: i32) -> SessionResult {
     let now = Utc::now();
     SessionResult {
+        post_exec_gate: None,
         status: status.to_string(),
         exit_code,
         summary: "summary".to_string(),

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -61,6 +61,7 @@ impl SessionTestEnv {
 fn make_result(status: &str, exit_code: i32) -> SessionResult {
     let now = Utc::now();
     SessionResult {
+        post_exec_gate: None,
         status: status.to_string(),
         exit_code,
         summary: "summary".to_string(),
@@ -499,6 +500,7 @@ fn late_real_result_already_exists_cleans_up_reconcile_owned_sidecar() {
     .unwrap();
 
     let real_result = toml::to_string_pretty(&csa_session::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "real terminal result".to_string(),
@@ -562,6 +564,7 @@ fn retire_if_dead_with_result_preserves_pr_bot_handoff_for_real_results() {
         project,
         &session_id,
         &csa_session::SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "real terminal result".to_string(),

--- a/crates/cli-sub-agent/src/session_cmds_result_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests.rs
@@ -512,6 +512,7 @@ fn handle_session_artifacts_prefers_daemon_completion_packet() {
 fn build_result_json_payload_includes_review_iterations() {
     let now = chrono::Utc::now();
     let result = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "review completed".to_string(),
@@ -571,6 +572,7 @@ fn build_result_json_payload_includes_result_sidecars() {
     let now = chrono::Utc::now();
     let result = SessionResultView {
         envelope: SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "review completed".to_string(),
@@ -619,6 +621,7 @@ fn build_result_json_payload_redacts_result_sidecars() {
     let now = chrono::Utc::now();
     let result = SessionResultView {
         envelope: SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "review completed".to_string(),

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -45,6 +45,7 @@ fn truncate_with_ellipsis_handles_emoji_without_panic() {
 fn make_result(status: &str, exit_code: i32) -> SessionResult {
     let now = Utc::now();
     SessionResult {
+        post_exec_gate: None,
         status: status.to_string(),
         exit_code,
         summary: "summary".to_string(),

--- a/crates/cli-sub-agent/src/session_guard.rs
+++ b/crates/cli-sub-agent/src/session_guard.rs
@@ -82,6 +82,7 @@ pub(crate) fn write_pre_exec_error_result(
 ) {
     let now = chrono::Utc::now();
     let result = SessionResult {
+        post_exec_gate: None,
         status: "failure".to_string(),
         exit_code: 1,
         summary: format!("pre-exec: {error}"),

--- a/crates/cli-sub-agent/src/todo_errors_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_errors_cmd.rs
@@ -224,6 +224,7 @@ mod tests {
             .single()
             .expect("valid test timestamp");
         SessionResult {
+            post_exec_gate: None,
             status: status.to_string(),
             exit_code,
             summary: summary.to_string(),

--- a/crates/csa-executor/src/transport_fork.rs
+++ b/crates/csa-executor/src/transport_fork.rs
@@ -442,6 +442,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let now = Utc::now();
         let result = SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "Tests passed".to_string(),

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -14,6 +14,7 @@ pub mod manager;
 pub mod metadata;
 pub mod output_parser;
 pub mod output_section;
+pub mod post_exec_gate_report;
 mod process_tree_memory;
 pub mod redact;
 pub mod result;
@@ -71,6 +72,10 @@ pub use output_parser::{
 pub use output_section::{
     ChangedFile, FileAction, OutputIndex, OutputSection, RETURN_PACKET_MAX_SUMMARY_CHARS,
     RETURN_PACKET_SECTION_ID, ReturnPacket, ReturnPacketRef, ReturnStatus,
+};
+pub use post_exec_gate_report::{
+    GATE_FAILURE_LOG_REL_PATH, GATE_OUTPUT_TAIL_MAX_BYTES, GATE_OUTPUT_TAIL_MAX_LINES,
+    PostExecGateReport, bound_output_tail, parse_failing_step, parse_nextest_failing_tests,
 };
 pub use process_tree_memory::{SessionTreeMemorySampler, session_tree_rss_mb};
 pub use redact::{redact_event, redact_text_content};

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -11,7 +11,7 @@ const USER_RESULT_FILE_NAME: &str = "user-result.toml";
 pub const RESULT_TOML_PATH_CONTRACT_ENV: &str = "CSA_RESULT_TOML_PATH_CONTRACT";
 pub const CONTRACT_RESULT_ARTIFACT_PATH: &str = "output/result.toml";
 pub const LEGACY_USER_RESULT_ARTIFACT_PATH: &str = "output/user-result.toml";
-const RUNTIME_RESULT_KEYS: [&str; 13] = [
+const RUNTIME_RESULT_KEYS: [&str; 14] = [
     "status",
     "exit_code",
     "summary",
@@ -25,6 +25,7 @@ const RUNTIME_RESULT_KEYS: [&str; 13] = [
     "artifacts",
     "fallback_chain",
     "peak_memory_mb",
+    "post_exec_gate",
 ];
 
 #[path = "manager_result_spillover.rs"]
@@ -368,6 +369,7 @@ fn value_matches_runtime_schema(key: &str, value: &toml::Value) -> bool {
         "status" | "summary" | "tool" | "started_at" | "completed_at" => value.is_str(),
         "exit_code" | "events_count" => value.is_integer(),
         "artifacts" => artifacts_value_matches_runtime_schema(value),
+        "post_exec_gate" => value.is_table(),
         _ => false,
     }
 }

--- a/crates/csa-session/src/manager_result_spillover.rs
+++ b/crates/csa-session/src/manager_result_spillover.rs
@@ -319,6 +319,7 @@ mod tests {
 
         let now = Utc::now();
         let turn_1_result = SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "turn 1".to_string(),
@@ -468,6 +469,7 @@ mod tests {
 
         let now = Utc::now();
         let runtime_result = SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "runtime summary".to_string(),

--- a/crates/csa-session/src/manager_tests_audit.rs
+++ b/crates/csa-session/src/manager_tests_audit.rs
@@ -3,6 +3,7 @@ fn test_save_result_persists_manager_fields_sidecar() {
     let td = tempdir().unwrap();
     let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
     let result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "Test completed".to_string(),

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -52,6 +52,7 @@ fn test_load_result_view_ignores_orphaned_manager_sidecar() {
 
     let now = chrono::Utc::now();
     let runtime_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -113,6 +114,7 @@ fn test_load_result_merges_manager_sidecar_sections_into_runtime_result() {
 
     let now = chrono::Utc::now();
     let runtime_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -236,6 +238,7 @@ fn test_manager_sidecar_roundtrip_preserves_full_sa_schema() {
 
     let now = chrono::Utc::now();
     let runtime_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -390,6 +393,7 @@ fn test_load_result_without_sidecar_keeps_manager_fields_empty() {
 
     let now = chrono::Utc::now();
     let runtime_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -431,6 +435,7 @@ fn test_save_result_with_empty_manager_fields_preserves_existing_sidecar() {
     let now = chrono::Utc::now();
 
     let populated_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -512,6 +517,7 @@ fn test_clear_manager_sidecar_removes_existing_sidecar() {
     let now = chrono::Utc::now();
 
     let populated_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -568,6 +574,7 @@ fn test_load_result_with_malformed_manager_sidecar_is_non_fatal() {
 
     let now = chrono::Utc::now();
     let runtime_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -650,6 +657,7 @@ fn test_fallback_chain_not_retained_after_save_without_fallback() {
     let now = chrono::Utc::now();
 
     let make_result = |fallback_chain| crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "done".to_string(),

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -721,3 +721,110 @@ fn test_fallback_chain_not_retained_after_save_without_fallback() {
         "second save without fallback_chain must clear the stale entry from result.toml"
     );
 }
+
+#[test]
+fn test_post_exec_gate_not_retained_after_save_without_gate() {
+    // Regression (#1726 round-2): post_exec_gate was added with
+    // skip_serializing_if but omitted from RUNTIME_RESULT_KEYS, so a later
+    // merge-preserving save with post_exec_gate=None left the previous
+    // [post_exec_gate] table in result.toml — a successful session kept falsely
+    // reporting a gate failure. The fix mirrors the fallback_chain guard above:
+    // add the key to RUNTIME_RESULT_KEYS (strips the stale table) and recognize
+    // its table shape in value_matches_runtime_schema (so a runtime gate
+    // envelope is not misclassified as a custom user result and snapshotted).
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let result_path = session_dir.join(crate::result::RESULT_FILE_NAME);
+    let now = chrono::Utc::now();
+
+    let make_result = |post_exec_gate, summary: &str| crate::result::SessionResult {
+        post_exec_gate,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: summary.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: vec![],
+        peak_memory_mb: None,
+        fallback_chain: None,
+        gate_timeout: false,
+        warnings: Vec::new(),
+        raw_process_exit_code: None,
+        uncommitted_changes: None,
+        manager_fields: Default::default(),
+    };
+
+    // First save: a failed-gate result carrying a [post_exec_gate] table.
+    let report = crate::post_exec_gate_report::PostExecGateReport::from_redacted_gate_output(
+        "just pre-commit",
+        100,
+        "FAIL [   0.005s] pkg::a\nerror: Recipe `test` failed on line 1 with exit code 100",
+    );
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &make_result(Some(report.clone()), "gate failed"),
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    // The table is physically present in the persisted result.toml.
+    let after_first_raw = std::fs::read_to_string(&result_path).unwrap();
+    assert!(
+        after_first_raw.contains("post_exec_gate"),
+        "first save must persist the [post_exec_gate] table: {after_first_raw}"
+    );
+    let after_first = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        after_first.post_exec_gate,
+        Some(report),
+        "first save must round-trip the gate report"
+    );
+
+    // Second save: a later clean run with no gate failure, updating an unrelated
+    // runtime field.
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &make_result(None, "clean run"),
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    // The stale [post_exec_gate] table must NOT survive the merge-preserving save.
+    let after_second_raw = std::fs::read_to_string(&result_path).unwrap();
+    assert!(
+        !after_second_raw.contains("post_exec_gate"),
+        "second save without a gate failure must clear the stale [post_exec_gate] table: {after_second_raw}"
+    );
+    let after_second = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .unwrap();
+    assert!(
+        after_second.post_exec_gate.is_none(),
+        "second save without a gate failure must clear the stale gate report"
+    );
+    // Cleanup is scoped to post_exec_gate: the unrelated runtime field from the
+    // second save still round-trips.
+    assert_eq!(
+        after_second.summary, "clean run",
+        "unrelated runtime fields must survive the post_exec_gate cleanup"
+    );
+    // value_matches_runtime_schema must recognize the runtime [post_exec_gate]
+    // table so the prior envelope is not misclassified as a custom user result.
+    // Without that arm the second save would snapshot it to user-result.toml.
+    assert!(
+        !session_dir
+            .join(manager_result::LEGACY_USER_RESULT_ARTIFACT_PATH)
+            .exists(),
+        "a runtime [post_exec_gate] envelope must not be snapshotted as a custom user result"
+    );
+}

--- a/crates/csa-session/src/manager_tests_sidecar_preservation.rs
+++ b/crates/csa-session/src/manager_tests_sidecar_preservation.rs
@@ -9,6 +9,7 @@ fn test_save_result_preserves_existing_contract_result_artifact_when_output_resu
 
     let now = chrono::Utc::now();
     let runtime_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -64,6 +65,7 @@ fn sidecar_write_failure_leaves_envelope_unchanged() {
 
     let now = chrono::Utc::now();
     let initial_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "initial summary".to_string(),
@@ -154,6 +156,7 @@ fn sidecar_clear_failure_or_crash_leaves_envelope_consistent() {
 
     let now = chrono::Utc::now();
     let populated_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -230,6 +233,7 @@ fn sidecar_clear_happy_path_publishes_envelope_then_unlinks() {
 
     let now = chrono::Utc::now();
     let populated_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),

--- a/crates/csa-session/src/manager_tests_tail.rs
+++ b/crates/csa-session/src/manager_tests_tail.rs
@@ -31,6 +31,7 @@ fn test_save_and_load_result() {
     let td = tempdir().unwrap();
     let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
     let result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "Test completed".to_string(),
@@ -86,6 +87,7 @@ fn test_save_session_and_result_preserve_legacy_symlink_root() {
     save_session_in(&legacy_raw_root, &state).unwrap();
 
     let result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "saved to legacy raw root".to_string(),
@@ -151,6 +153,7 @@ name = "gemini-cli"
 
     let now = chrono::Utc::now();
     let runtime_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -221,6 +224,7 @@ artifacts = [1, 2]
 
     let now = chrono::Utc::now();
     let runtime_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "runtime summary".to_string(),
@@ -286,6 +290,7 @@ name = "gemini-cli"
 
     let now = chrono::Utc::now();
     let first_runtime = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "first run".to_string(),
@@ -314,6 +319,7 @@ name = "gemini-cli"
     .unwrap();
 
     let second_runtime = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "second run".to_string(),
@@ -378,6 +384,7 @@ done = false
 
     let now = chrono::Utc::now();
     let runtime_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "run".to_string(),
@@ -414,6 +421,7 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
     let now = chrono::Utc::now();
 
     let old_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "old run".to_string(),
@@ -442,6 +450,7 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
     .unwrap();
 
     let new_result = crate::result::SessionResult {
+        post_exec_gate: None,
         status: "failure".to_string(),
         exit_code: 1,
         summary: "new run".to_string(),

--- a/crates/csa-session/src/post_exec_gate_report.rs
+++ b/crates/csa-session/src/post_exec_gate_report.rs
@@ -1,0 +1,303 @@
+//! Structured post-exec-gate failure detail persisted into `result.toml` (#1726).
+//!
+//! When a `csa run` write session's post-exec verification gate (e.g.
+//! `just pre-commit`) fails, the gate's stdout/stderr used to land ONLY in the
+//! raw transcript `output/full.md`. An SA-Layer-0 orchestrator (which is
+//! forbidden from reading transcripts) therefore could not diagnose the failing
+//! step/test from any structured artifact.
+//!
+//! This module owns the typed [`PostExecGateReport`] (the `[post_exec_gate]`
+//! table of `result.toml`) plus the pure parsers/bounding helpers used to build
+//! it. The unbounded gate output is written separately to
+//! [`GATE_FAILURE_LOG_REL_PATH`]; only a bounded [`PostExecGateReport::output_tail`]
+//! is embedded in `result.toml` to keep that envelope small.
+
+use serde::{Deserialize, Serialize};
+
+/// Relative path (from the session directory) of the full, unbounded gate
+/// output log written on a post-exec gate failure.
+pub const GATE_FAILURE_LOG_REL_PATH: &str = "output/gate-failure.log";
+
+/// Hard cap on the number of trailing lines retained in
+/// [`PostExecGateReport::output_tail`].
+pub const GATE_OUTPUT_TAIL_MAX_LINES: usize = 100;
+
+/// Hard cap on the byte length retained in [`PostExecGateReport::output_tail`].
+/// The full output always lives in [`GATE_FAILURE_LOG_REL_PATH`].
+pub const GATE_OUTPUT_TAIL_MAX_BYTES: usize = 8 * 1024;
+
+/// Structured detail of a failed post-exec verification gate.
+///
+/// Serialized as the `[post_exec_gate]` table of `result.toml`. Present ONLY
+/// when the gate failed; the field on [`crate::result::SessionResult`] is
+/// `Option`-wrapped with `skip_serializing_if`, so successful sessions and
+/// pre-existing `result.toml` files (without the table) are unaffected.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PostExecGateReport {
+    /// The gate command that was run (e.g. `"just pre-commit"`).
+    pub gate_command: String,
+    /// The gate's real exit code (e.g. `100`). A timeout/signal maps to a
+    /// sentinel chosen by the caller.
+    pub exit_code: i32,
+    /// Best-effort recipe sub-step that failed (e.g. `"just test"`,
+    /// `"just clippy"`). `None` when no failing step could be extracted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failing_step: Option<String>,
+    /// Best-effort list of failed test names parsed from `cargo nextest`
+    /// `FAIL [..] <test>` lines. Empty for non-test step failures.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failing_tests: Vec<String>,
+    /// Bounded tail of the gate output (≤ [`GATE_OUTPUT_TAIL_MAX_LINES`] lines
+    /// AND ≤ [`GATE_OUTPUT_TAIL_MAX_BYTES`] bytes). The complete, unbounded copy
+    /// lives at [`PostExecGateReport::log_path`].
+    pub output_tail: String,
+    /// Relative path of the full gate output log
+    /// ([`GATE_FAILURE_LOG_REL_PATH`]).
+    pub log_path: String,
+}
+
+impl PostExecGateReport {
+    /// Build a report from the gate command, exit code, and the gate's captured
+    /// output.
+    ///
+    /// `redacted_output` MUST already be secret-redacted by the caller; the same
+    /// redacted text is what should be written to [`GATE_FAILURE_LOG_REL_PATH`]
+    /// so the bounded tail here can never expose material the log hides.
+    pub fn from_redacted_gate_output(
+        gate_command: &str,
+        exit_code: i32,
+        redacted_output: &str,
+    ) -> Self {
+        Self {
+            gate_command: gate_command.to_string(),
+            exit_code,
+            failing_step: parse_failing_step(redacted_output),
+            failing_tests: parse_nextest_failing_tests(redacted_output),
+            output_tail: bound_output_tail(redacted_output),
+            log_path: GATE_FAILURE_LOG_REL_PATH.to_string(),
+        }
+    }
+}
+
+/// Parse failed test names from `cargo nextest` output.
+///
+/// nextest prints a failure summary line per failing test, formatted as
+/// `FAIL [   0.005s] <test-id>` (the `[..]` holds the elapsed time). This
+/// extracts `<test-id>` (everything after the `]`), de-duplicated and in first
+/// occurrence order. Non-test gate output yields an empty list.
+pub fn parse_nextest_failing_tests(output: &str) -> Vec<String> {
+    let mut tests = Vec::new();
+    for line in output.lines() {
+        let trimmed = line.trim_start();
+        let Some(after_fail) = trimmed.strip_prefix("FAIL [") else {
+            continue;
+        };
+        let Some(close_idx) = after_fail.find(']') else {
+            continue;
+        };
+        let Some(test) = after_fail.get(close_idx + 1..).map(str::trim) else {
+            continue;
+        };
+        if !test.is_empty() && !tests.iter().any(|existing| existing == test) {
+            tests.push(test.to_string());
+        }
+    }
+    tests
+}
+
+/// Best-effort extraction of the failing recipe sub-step.
+///
+/// `just` prints `error: Recipe `<name>` failed on line N with exit code M`
+/// when a recipe fails; for a nested `just pre-commit` the innermost failing
+/// recipe is printed first. The first such name is returned as `just <name>`
+/// (e.g. `"just test"`, `"just clippy"`). Returns `None` when no recipe-failure
+/// marker is present (e.g. a bare command gate).
+pub fn parse_failing_step(output: &str) -> Option<String> {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        let Some(after_marker) = trimmed.strip_prefix("error: Recipe `") else {
+            continue;
+        };
+        let Some(close_idx) = after_marker.find('`') else {
+            continue;
+        };
+        if let Some(name) = after_marker.get(..close_idx)
+            && !name.is_empty()
+        {
+            return Some(format!("just {name}"));
+        }
+    }
+    None
+}
+
+/// Reduce gate output to a bounded tail for embedding in `result.toml`.
+///
+/// Keeps the last [`GATE_OUTPUT_TAIL_MAX_LINES`] lines, then further caps the
+/// result to the last [`GATE_OUTPUT_TAIL_MAX_BYTES`] bytes (cutting on a UTF-8
+/// char boundary) — "whichever is smaller". The unbounded output is expected to
+/// be persisted to [`GATE_FAILURE_LOG_REL_PATH`] separately.
+pub fn bound_output_tail(full: &str) -> String {
+    let lines: Vec<&str> = full.lines().collect();
+    let start = lines.len().saturating_sub(GATE_OUTPUT_TAIL_MAX_LINES);
+    let tail_by_lines = match lines.get(start..) {
+        Some(slice) => slice.join("\n"),
+        None => String::new(),
+    };
+
+    if tail_by_lines.len() <= GATE_OUTPUT_TAIL_MAX_BYTES {
+        return tail_by_lines;
+    }
+
+    // Keep the LAST GATE_OUTPUT_TAIL_MAX_BYTES bytes, advancing to the next
+    // char boundary so the slice is valid UTF-8.
+    let mut cut = tail_by_lines.len() - GATE_OUTPUT_TAIL_MAX_BYTES;
+    while cut < tail_by_lines.len() && !tail_by_lines.is_char_boundary(cut) {
+        cut += 1;
+    }
+    tail_by_lines.get(cut..).unwrap_or("").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nextest_fail_lines_into_test_names() {
+        let output = "\
+   Compiling csa-session v0.1.0
+        PASS [   0.004s] csa-session result::tests::ok
+        FAIL [   0.005s] csa-session result::tests::test_x
+    FAIL [   1.200s] cli-sub-agent run_cmd::tests::test_y
+   Summary [   1.234s] 2 tests run: 0 passed, 2 failed";
+        let tests = parse_nextest_failing_tests(output);
+        assert_eq!(
+            tests,
+            vec![
+                "csa-session result::tests::test_x".to_string(),
+                "cli-sub-agent run_cmd::tests::test_y".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn dedupes_repeated_fail_lines() {
+        let output = "FAIL [   0.005s] pkg::a\nFAIL [   0.006s] pkg::a\nFAIL [   0.007s] pkg::b";
+        let tests = parse_nextest_failing_tests(output);
+        assert_eq!(tests, vec!["pkg::a".to_string(), "pkg::b".to_string()]);
+    }
+
+    #[test]
+    fn non_test_output_yields_no_failing_tests() {
+        let output = "error: clippy failed\nwarning: unused variable\nerror[E0001]: bad";
+        assert!(parse_nextest_failing_tests(output).is_empty());
+    }
+
+    #[test]
+    fn parses_failing_step_from_just_recipe_error() {
+        let output = "\
+running cargo nextest run --workspace --all-features
+        FAIL [   0.005s] csa-session result::tests::test_x
+error: Recipe `test` failed on line 42 with exit code 100";
+        assert_eq!(parse_failing_step(output).as_deref(), Some("just test"));
+    }
+
+    #[test]
+    fn failing_step_picks_innermost_recipe_first() {
+        let output = "\
+error: Recipe `clippy` failed on line 10 with exit code 101
+error: Recipe `pre-commit` failed on line 3 with exit code 101";
+        assert_eq!(parse_failing_step(output).as_deref(), Some("just clippy"));
+    }
+
+    #[test]
+    fn failing_step_absent_for_bare_command_gate() {
+        let output = "error[E0308]: mismatched types\n  --> src/lib.rs:1:1";
+        assert!(parse_failing_step(output).is_none());
+    }
+
+    #[test]
+    fn clippy_failure_sets_step_but_no_tests() {
+        // A non-test (clippy) step failure: failing_step is set, failing_tests
+        // is empty, and output_tail is non-empty.
+        let output = "\
+    Checking cli-sub-agent v0.1.0
+error: unused variable: `x`
+  --> crates/cli-sub-agent/src/foo.rs:10:9
+error: Recipe `clippy` failed on line 7 with exit code 101";
+        let report = PostExecGateReport::from_redacted_gate_output("just pre-commit", 101, output);
+        assert_eq!(report.failing_step.as_deref(), Some("just clippy"));
+        assert!(report.failing_tests.is_empty());
+        assert!(!report.output_tail.is_empty());
+        assert_eq!(report.exit_code, 101);
+        assert_eq!(report.gate_command, "just pre-commit");
+        assert_eq!(report.log_path, GATE_FAILURE_LOG_REL_PATH);
+    }
+
+    #[test]
+    fn bound_output_tail_keeps_full_short_output() {
+        let output = "line 1\nline 2\nline 3";
+        assert_eq!(bound_output_tail(output), output);
+    }
+
+    #[test]
+    fn bound_output_tail_caps_to_last_lines() {
+        let many: String = (0..500)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let tail = bound_output_tail(&many);
+        let tail_lines: Vec<&str> = tail.lines().collect();
+        assert_eq!(tail_lines.len(), GATE_OUTPUT_TAIL_MAX_LINES);
+        // The cap keeps the LAST lines; the final line must be preserved.
+        assert_eq!(tail_lines.last().copied(), Some("line 499"));
+        assert_eq!(tail_lines.first().copied(), Some("line 400"));
+    }
+
+    #[test]
+    fn bound_output_tail_caps_to_byte_budget() {
+        // A single line longer than the byte budget is truncated to the last
+        // GATE_OUTPUT_TAIL_MAX_BYTES bytes; the full content is what the caller
+        // would write to gate-failure.log.
+        let huge = "x".repeat(GATE_OUTPUT_TAIL_MAX_BYTES * 2);
+        let tail = bound_output_tail(&huge);
+        assert!(tail.len() <= GATE_OUTPUT_TAIL_MAX_BYTES);
+        assert!(!tail.is_empty());
+        // The tail is a suffix of the original content.
+        assert!(huge.ends_with(&tail));
+    }
+
+    #[test]
+    fn bound_output_tail_handles_multibyte_boundary() {
+        // Multi-byte chars near the cut point must not panic or split a char.
+        let unit = "🦀\n"; // 4-byte emoji + newline
+        let huge = unit.repeat(GATE_OUTPUT_TAIL_MAX_BYTES);
+        let tail = bound_output_tail(&huge);
+        assert!(tail.len() <= GATE_OUTPUT_TAIL_MAX_BYTES);
+        // Result is valid UTF-8 (no panic) and a suffix of the input.
+        assert!(huge.ends_with(&tail));
+    }
+
+    #[test]
+    fn empty_output_builds_empty_report_fields() {
+        let report = PostExecGateReport::from_redacted_gate_output("just pre-commit", 100, "");
+        assert_eq!(report.exit_code, 100);
+        assert!(report.failing_step.is_none());
+        assert!(report.failing_tests.is_empty());
+        assert!(report.output_tail.is_empty());
+        assert_eq!(report.log_path, GATE_FAILURE_LOG_REL_PATH);
+    }
+
+    #[test]
+    fn report_roundtrips_as_toml_table() {
+        let report = PostExecGateReport::from_redacted_gate_output(
+            "just pre-commit",
+            100,
+            "FAIL [   0.005s] pkg::a\nerror: Recipe `test` failed on line 1 with exit code 100",
+        );
+        let toml_str = toml::to_string_pretty(&report).expect("serialize");
+        let loaded: PostExecGateReport = toml::from_str(&toml_str).expect("deserialize");
+        assert_eq!(loaded, report);
+        assert_eq!(loaded.failing_tests, vec!["pkg::a".to_string()]);
+        assert_eq!(loaded.failing_step.as_deref(), Some("just test"));
+    }
+}

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -235,6 +235,15 @@ pub struct SessionResult {
     /// committing. Omitted for clean sessions and read-only session kinds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uncommitted_changes: Option<UncommittedChanges>,
+    /// Structured detail of a failed post-exec verification gate (#1726).
+    /// Present ONLY when the gate (e.g. `just pre-commit`) failed, so an SA
+    /// orchestrator can diagnose the failing step/test from `result.toml`
+    /// without reading the raw transcript. The bounded tail lives here; the full
+    /// gate output is written to `output/gate-failure.log`. `serde(default)` +
+    /// `skip_serializing_if` keeps the table absent on success and lets
+    /// pre-existing `result.toml` files (without it) still deserialize.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_exec_gate: Option<crate::post_exec_gate_report::PostExecGateReport>,
     /// Manager-facing data loaded from `output/result.toml` sidecars at read time.
     /// This is intentionally read-only metadata and is never serialized back into
     /// the runtime `result.toml` envelope.
@@ -264,6 +273,7 @@ mod tests {
     fn test_session_result_toml_roundtrip() {
         let now = Utc::now();
         let result = SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "All tests passed".to_string(),
@@ -300,6 +310,7 @@ mod tests {
     fn test_session_result_empty_optional_fields_omitted() {
         let now = Utc::now();
         let result = SessionResult {
+            post_exec_gate: None,
             status: "failure".to_string(),
             exit_code: 1,
             summary: "Build failed".to_string(),
@@ -344,6 +355,7 @@ mod tests {
     fn test_session_result_uncommitted_changes_roundtrip() {
         let now = Utc::now();
         let result = SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "Done".to_string(),
@@ -400,6 +412,90 @@ artifacts = ["output/a.txt", "output/b.txt"]
         assert_eq!(loaded.artifacts[1].path, "output/b.txt");
     }
 
+    #[test]
+    fn test_result_without_post_exec_gate_deserializes_to_none() {
+        // Backward compat (#1726): pre-existing result.toml files have no
+        // [post_exec_gate] table; they must still deserialize, with the field None.
+        let raw = r#"
+status = "success"
+exit_code = 0
+summary = "ok"
+tool = "codex"
+started_at = "2026-01-01T00:00:00Z"
+completed_at = "2026-01-01T00:00:00Z"
+"#;
+        let loaded: SessionResult = toml::from_str(raw).expect("Deserialize should succeed");
+        assert!(loaded.post_exec_gate.is_none());
+    }
+
+    #[test]
+    fn test_successful_result_omits_post_exec_gate_table() {
+        // A successful (post_exec_gate = None) result must serialize WITHOUT a
+        // [post_exec_gate] table, so successful sessions emit no spurious table.
+        let now = Utc::now();
+        let result = SessionResult {
+            post_exec_gate: None,
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "ok".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: Vec::new(),
+            peak_memory_mb: None,
+            fallback_chain: None,
+            gate_timeout: false,
+            warnings: Vec::new(),
+            raw_process_exit_code: None,
+            uncommitted_changes: None,
+            manager_fields: Default::default(),
+        };
+        let toml_str = toml::to_string_pretty(&result).expect("serialize");
+        assert!(
+            !toml_str.contains("post_exec_gate"),
+            "successful result must not serialize a [post_exec_gate] table: {toml_str}"
+        );
+    }
+
+    #[test]
+    fn test_result_with_post_exec_gate_table_roundtrips() {
+        // A failed-gate result round-trips its [post_exec_gate] table intact.
+        let now = Utc::now();
+        let report = crate::post_exec_gate_report::PostExecGateReport::from_redacted_gate_output(
+            "just pre-commit",
+            100,
+            "FAIL [   0.005s] pkg::a\nerror: Recipe `test` failed on line 1 with exit code 100",
+        );
+        let result = SessionResult {
+            post_exec_gate: Some(report.clone()),
+            status: "failure".to_string(),
+            exit_code: 1,
+            summary: "POST-EXEC GATE FAILED (exit=100, step=just test)".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: Vec::new(),
+            peak_memory_mb: None,
+            fallback_chain: None,
+            gate_timeout: false,
+            warnings: Vec::new(),
+            raw_process_exit_code: None,
+            uncommitted_changes: None,
+            manager_fields: Default::default(),
+        };
+        let toml_str = toml::to_string_pretty(&result).expect("serialize");
+        let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
+        assert_eq!(loaded.post_exec_gate, Some(report));
+    }
+
     // ── status_from_exit_code ──────────────────────────────────────
 
     #[test]
@@ -435,6 +531,7 @@ artifacts = ["output/a.txt", "output/b.txt"]
 
         let now = Utc::now();
         let result = SessionResult {
+            post_exec_gate: None,
             status: "success".to_string(),
             exit_code: 0,
             summary: "Done".to_string(),

--- a/crates/csa-session/src/soft_fork_tests.rs
+++ b/crates/csa-session/src/soft_fork_tests.rs
@@ -13,6 +13,7 @@ fn test_soft_fork_full_parent_session() {
     // Write result.toml
     let now = Utc::now();
     let result = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "All tests passed".to_string(),
@@ -65,6 +66,7 @@ fn test_soft_fork_truncation_on_large_summary() {
     // Create result.toml
     let now = Utc::now();
     let result = SessionResult {
+        post_exec_gate: None,
         status: "success".to_string(),
         exit_code: 0,
         summary: "ok".to_string(),
@@ -131,6 +133,7 @@ fn test_soft_fork_result_only_no_output() {
 
     let now = Utc::now();
     let result = SessionResult {
+        post_exec_gate: None,
         status: "failure".to_string(),
         exit_code: 1,
         summary: "Build failed with 3 errors".to_string(),


### PR DESCRIPTION
## Summary

Fixes #1726 — when a `csa run` write session's post-exec gate (`just pre-commit`) failed, the failure DETAIL (which recipe step / which test failed, exit code, gate output) reached only the raw transcript `output/full.md`, which an SA-Layer-0 orchestrator is forbidden to read. Worse, `summary.md`/`details.md` could still read as an unqualified employee "success" while `result.toml` recorded the gate failure — a self-contradictory structured report. An orchestrator could not diagnose the gate failure without reading the forbidden transcript or blindly re-dispatching.

## What changed (Ask #1 + #2)

On a **nonzero-exit** post-exec gate failure:

- **Capture (tee)** the gate's stdout+stderr instead of inheriting it — the raw transcript is preserved while the output becomes available for structured surfacing.
- Write the full, **redacted** gate output to **`output/gate-failure.log`** (the complete diagnostic copy, replacing the need to read `full.md`).
- Add an optional **`[post_exec_gate]` table to `result.toml`**: `gate_command`, `exit_code`, best-effort `failing_step` + `failing_tests` (parsed from `just` recipe / `cargo nextest` output), a **bounded** `output_tail`, and `log_path`. The field is `#[serde(default, skip_serializing_if = "Option::is_none")]`, so successful sessions emit no table and pre-existing `result.toml` files still deserialize.
- **Reconcile** the structured report so it is non-contradictory: `result.summary` leads with the gate verdict, and a banner is prepended to `summary.md` / `details.md` marking the employee self-report as SUPERSEDED by the gate.

Redaction parity: `output_tail` and `gate-failure.log` go through the same secret-redaction helper as the other persisted surfaces; only a bounded tail lives in `result.toml` (the full output lives in the log). Scope is limited to the nonzero-exit path — the timeout and gate-infrastructure-error paths keep their existing, already non-contradictory overwrite.

**Deferred (Ask #3):** flaky-test retry / quarantine is intentionally NOT implemented; the structured artifacts already make a flake diagnosable (failing test name + output tail are captured).

## Resource-lifecycle hardening (round-2 review finding — HIGH)

The first round's capture path had an unbounded/unguarded lifecycle bug (caught by adversarial review, Rust 015 subprocess-lifecycle + Practice 014 resource limits): the in-memory capture buffer grew without bound, and the stdout/stderr pump drain after `child.wait()` had no timeout — so a gate that exits while leaving a **backgrounded grandchild holding the pipe** (e.g. `sh -c '(yes >&1 &) ; exit 0'`) defeated the gate timeout entirely and wedged the runner while memory grew. Fixed:

- **Bounded in-memory capture** via a new `run_cmd_post_exec_gate_capture` module: `BoundedTailCapture` retains only the last `GATE_CAPTURE_MAX_BYTES` (1 MiB) with amortized O(1) trimming and discloses truncation — no unbounded `Arc<Mutex<Vec<u8>>>` growth; `output_tail` + `gate-failure.log` stay bounded with redaction parity.
- **Bounded, cancellable pump drain**: `drain_pumps_and_reap` bounds the post-exit drain by `GATE_PUMP_DRAIN_GRACE` (2s), then aborts the pump read tasks.
- **Process-group reap**: the gate child runs in its own process group; on completion/timeout/drain-expiry the group is killed (negative-PID `SIGTERM`→`SIGKILL`, the project's Rust 015 pattern, mirroring the existing pipeline-gate hardening dd528cc6/f3482460/917e2077), so a backgrounded pipe-holding grandchild can no longer keep the pump open. PGID-reuse safety is documented at both call sites.
- The gate `timeout_seconds` now bounds the TOTAL operation (process wait + pump drain), not just `child.wait()`.

## Stale-field regression fix (round-3 review finding — HIGH)

Round-2 review caught that the new `post_exec_gate` field could survive a later successful save. The result-save path `save_result_in_with_threshold` is **merge-preserving**: it loads the existing `result.toml` table, strips only the keys in `RUNTIME_RESULT_KEYS`, then re-extends with the freshly serialized runtime table. Because `post_exec_gate` was (1) not in `RUNTIME_RESULT_KEYS` and (2) omitted entirely when `None` (via `skip_serializing_if`), a later `save_result` with `post_exec_gate: None` did **not** remove a previously-written `[post_exec_gate]` table — the stale table survived the merge, so a session could keep falsely reporting a gate failure after a later successful save. This is the same stale-runtime-field class as the existing `fallback_chain` bug. Fixed by mirroring that precedent exactly:

- Added `post_exec_gate` to `RUNTIME_RESULT_KEYS` so the merge-preserving save strips any prior `[post_exec_gate]` table before re-extending.
- Taught `value_matches_runtime_schema` to recognize the `post_exec_gate` shape (mirroring the `fallback_chain` arm).
- `skip_serializing_if` is **retained** — "absent on success" is still correct; the fix is the runtime-key cleanup, not the serialization.

## Process-group ownership-safety fix (round-4 review finding — HIGH)

Round-3 review caught a process-safety race in the round-2 drain-expiry cleanup: a negative-PGID `kill(-pgid, SIG)` is only safe while a live group member exists OR the leader is still an un-reaped zombie (either anchors the PGID against kernel reuse). The drain-expiry path reaped the gate leader first, then did a blind `SIGTERM`→sleep→`SIGKILL` to `-pgid` — so if the surviving pipe-holder exited on the `SIGTERM`, the PGID could be released before the second signal, and under PGID reuse the `SIGKILL` could hit an unrelated new process group. (The **timeout** path is unaffected — it signals while the leader is still un-reaped, which anchors the PGID across the whole window — so it is left unchanged.) Fixed by making the drain-expiry escalation **ownership-safe**:

- Drain-expiry now sends `SIGTERM`, then **re-waits for pump EOF** within a bounded escalation grace. If the pumps reach EOF (pipe-holder died from `SIGTERM`) it sends **no** second signal — the PGID may be unanchored and there is nothing left to kill. It only escalates to `SIGKILL` when the pumps are **still open**, which proves a live group member still holds the pipe write-end and therefore still anchors the PGID — making `-pgid` SIGKILL safe.
- The timeout path's existing `SIGTERM`→`SIGKILL` (anchored by the un-reaped leader) is unchanged.

## Test coverage

- Structured report serialization; success path emits no `[post_exec_gate]` table / `gate-failure.log`; nonzero-exit failure populates the table + log + superseded banner.
- Backward-compat: a `result.toml` without `[post_exec_gate]` still deserializes.
- `failing_tests` parser on representative `cargo nextest` output; non-test step → empty `failing_tests` with `failing_step` set.
- `#[cfg(unix)]` lifecycle test: a gate that exits while a backgrounded child holds stdout open RETURNS within `timeout + grace` (does not hang) with the leaked child reaped; flooding output keeps in-memory capture bounded.
- Stale-field regression test (mirrors `test_fallback_chain_not_retained_after_save_without_fallback`): a save with `post_exec_gate: Some(..)` writes the `[post_exec_gate]` table; a subsequent save with `post_exec_gate: None` REMOVES it (no stale residue), while an unrelated runtime field still round-trips (cleanup not over-broad).
- `#[cfg(unix)]` ownership-safety regression test: a pipe-holder that EXITS on `SIGTERM` before the escalation window takes the no-escalation (EOF) branch — no blind `SIGKILL` on a possibly-recycled PGID; a `SIGTERM`-ignoring pipe-holder still escalates and is reaped within `timeout + grace`.
- `just pre-commit` (fmt + clippy + nextest + token-budget) green.

## Related

#1714 (failover opacity — same "told it failed, not why" class), #1711 (daemon lifecycle / result surfacing), #1658 (post_exec_gate just/justfile coupling).

Refs #1726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
