### PR TITLE
fix(cli-sub-agent): size untracked working-tree files in uncommitted review diff report (#1818)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.888"
+version = "0.1.889"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.889"
+version = "0.1.890"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.889"
+version = "0.1.890"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.888"
+version = "0.1.889"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -120,6 +120,7 @@ mod todo_persist_cmd;
 mod todo_ref_cmd;
 mod tool_version;
 mod triage_cmd;
+mod untracked_size;
 mod verdict_exit_code;
 mod verify_cmd;
 mod xurl_cmd;

--- a/crates/cli-sub-agent/src/review_cmd_diff_size.rs
+++ b/crates/cli-sub-agent/src/review_cmd_diff_size.rs
@@ -350,9 +350,35 @@ fn collect_review_diff_payload(project_root: &Path, scope: &str) -> Option<Vec<u
 }
 
 fn compute_uncommitted_review_diff_size(project_root: &Path) -> Option<ReviewDiffSize> {
-    // Working-tree/untracked sizing is deferred to #1796; keep this path git-computed only.
+    // Tracked working-tree changes (staged + unstaged vs HEAD). Untracked,
+    // never-staged files never appear in `git diff HEAD`, so they are sized
+    // separately under the hard resource caps in `crate::untracked_size` (#1818)
+    // and merged in; the committed-range path (`collect_review_diff_payload`) is
+    // untouched.
     let payload = run_git(project_root, &["diff", "HEAD", "--no-color"])?;
-    Some(diff_size_from_payload(&payload))
+    let mut size = diff_size_from_payload(&payload);
+    merge_untracked_diff_size(
+        &mut size,
+        crate::untracked_size::untracked_diff_size(project_root),
+    );
+    Some(size)
+}
+
+/// Fold the untracked working-tree contribution into a tracked diff size. File
+/// counts, changed lines, and bytes add; the untracked cap/estimate/truncation
+/// notes are appended so the rendered report distinguishes exact totals from
+/// lower bounds. Saturating arithmetic keeps a pathological working tree from
+/// overflowing the report.
+fn merge_untracked_diff_size(
+    size: &mut ReviewDiffSize,
+    untracked: crate::untracked_size::UntrackedDiffSize,
+) {
+    size.files = size.files.saturating_add(untracked.files);
+    size.changed_lines = size.changed_lines.saturating_add(untracked.lines);
+    size.bytes = size
+        .bytes
+        .saturating_add(usize::try_from(untracked.bytes).unwrap_or(usize::MAX));
+    size.notes.extend(untracked.notes);
 }
 
 fn collect_uncommitted_diff_payload(project_root: &Path) -> Option<Vec<u8>> {
@@ -398,267 +424,5 @@ fn diff_size_from_payload(diff: &[u8]) -> ReviewDiffSize {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::process::Command;
-
-    use csa_core::types::ReviewDecision;
-    use csa_session::ReviewVerdictArtifact;
-    use tempfile::tempdir;
-
-    use super::*;
-
-    fn run_git_command(project_root: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(project_root)
-            .output()
-            .expect("git command should execute");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    fn setup_diff_size_git_repo() -> tempfile::TempDir {
-        let temp = tempdir().expect("tempdir");
-        run_git_command(temp.path(), &["init"]);
-        run_git_command(temp.path(), &["config", "user.email", "test@example.com"]);
-        run_git_command(temp.path(), &["config", "user.name", "Test User"]);
-        std::fs::write(temp.path().join("tracked.txt"), "baseline\n").expect("write tracked file");
-        run_git_command(temp.path(), &["add", "tracked.txt"]);
-        run_git_command(temp.path(), &["commit", "-m", "initial"]);
-        temp
-    }
-
-    fn review_meta(session_id: &str) -> ReviewSessionMeta {
-        ReviewSessionMeta {
-            session_id: session_id.to_string(),
-            head_sha: "HEAD".to_string(),
-            decision: ReviewDecision::Pass.as_str().to_string(),
-            verdict: "CLEAN".to_string(),
-            status_reason: None,
-            routed_to: None,
-            primary_failure: None,
-            failure_reason: None,
-            tool: "codex".to_string(),
-            scope: "range:main...HEAD".to_string(),
-            exit_code: 0,
-            fix_attempted: false,
-            fix_rounds: 0,
-            review_iterations: 1,
-            timestamp: chrono::Utc::now(),
-            diff_fingerprint: Some("fingerprint".to_string()),
-            fix_convergence: None,
-        }
-    }
-
-    #[test]
-    fn diff_size_from_payload_counts_multi_file_changed_lines_and_bytes() {
-        let diff = concat!(
-            "diff --git a/one.txt b/one.txt\n",
-            "index 1111111..2222222 100644\n",
-            "--- a/one.txt\n",
-            "+++ b/one.txt\n",
-            "@@ -1,2 +1,3 @@\n",
-            " keep\n",
-            "-old one\n",
-            "+new one\n",
-            "+added one\n",
-            "diff --git a/two.txt b/two.txt\n",
-            "index 3333333..4444444 100644\n",
-            "--- a/two.txt\n",
-            "+++ b/two.txt\n",
-            "@@ -1 +1 @@\n",
-            "-old two\n",
-            "+new two\n",
-        );
-
-        let size = diff_size_from_payload(diff.as_bytes());
-
-        assert_eq!(size.files, 2);
-        assert_eq!(size.changed_lines, 5);
-        assert_eq!(size.bytes, diff.len());
-    }
-
-    #[test]
-    fn diff_size_from_payload_counts_hunk_content_that_looks_like_file_headers() {
-        let diff = concat!(
-            "diff --git a/operators.txt b/operators.txt\n",
-            "index 1111111..2222222 100644\n",
-            "--- a/operators.txt\n",
-            "+++ b/operators.txt\n",
-            "@@ -1,3 +1,3 @@\n",
-            " unchanged\n",
-            "---removed operator line\n",
-            "+++added operator line\n",
-        );
-
-        let size = diff_size_from_payload(diff.as_bytes());
-
-        assert_eq!(size.files, 1);
-        assert_eq!(
-            size.changed_lines, 2,
-            "file headers must be ignored, but hunk content beginning with ++/-- must count"
-        );
-        assert_eq!(size.bytes, diff.len());
-    }
-
-    #[test]
-    fn committed_range_diff_size_counts_only_committed_git_diff() {
-        let repo = setup_diff_size_git_repo();
-        run_git_command(repo.path(), &["branch", "base"]);
-        std::fs::write(repo.path().join("tracked.txt"), "baseline\ncommitted\n")
-            .expect("write committed change");
-        run_git_command(repo.path(), &["add", "tracked.txt"]);
-        run_git_command(repo.path(), &["commit", "-m", "change tracked file"]);
-        std::fs::write(repo.path().join("new.txt"), "untracked\ncontent\n")
-            .expect("write untracked file");
-
-        let size =
-            compute_review_diff_size(repo.path(), "range:base...HEAD").expect("compute diff size");
-
-        assert_eq!(size.files, 1);
-        assert_eq!(size.changed_lines, 1);
-        assert!(size.bytes > 0);
-        assert!(size.notes.is_empty());
-    }
-
-    #[test]
-    fn uncommitted_diff_size_ignores_untracked_files_without_warning() {
-        let repo = setup_diff_size_git_repo();
-        std::fs::write(repo.path().join("new.txt"), "one\ntwo\nthree\n")
-            .expect("write untracked file");
-
-        let size = compute_review_diff_size(repo.path(), "uncommitted").expect("compute diff size");
-
-        assert_eq!(size.files, 0);
-        assert_eq!(size.changed_lines, 0);
-        assert_eq!(size.bytes, 0);
-        assert!(size.notes.is_empty());
-        assert!(large_diff_warning(&size, Some(2)).is_none());
-    }
-
-    #[test]
-    fn uncommitted_diff_size_counts_overlapping_staged_and_unstaged_edit_once() {
-        let repo = setup_diff_size_git_repo();
-        let tracked_path = repo.path().join("tracked.txt");
-        std::fs::write(&tracked_path, "staged\n").expect("write staged version");
-        run_git_command(repo.path(), &["add", "tracked.txt"]);
-        std::fs::write(&tracked_path, "final\n").expect("write unstaged version");
-
-        let size = compute_review_diff_size(repo.path(), "uncommitted").expect("compute diff size");
-
-        assert_eq!(size.files, 1);
-        assert_eq!(size.changed_lines, 2);
-    }
-
-    #[test]
-    fn large_diff_warning_respects_threshold_boundaries_and_disabled_values() {
-        let size = ReviewDiffSize {
-            files: 3,
-            changed_lines: 1001,
-            bytes: 4096,
-            notes: Vec::new(),
-        };
-
-        assert!(large_diff_warning(&size, Some(1001)).is_none());
-        assert!(large_diff_warning(&size, Some(0)).is_none());
-        assert!(large_diff_warning(&size, None).is_none());
-
-        let warning = large_diff_warning(&size, Some(1000)).expect("above threshold warns");
-        assert_eq!(warning.changed_lines, 1001);
-        assert_eq!(warning.threshold, 1000);
-        assert!(format_large_diff_warning(warning).starts_with("warning: review diff is large"));
-    }
-
-    #[test]
-    fn write_review_meta_with_diff_report_records_size_and_large_diff_warning() {
-        let session_dir = tempdir().expect("tempdir");
-        let diff_size = ReviewDiffSize {
-            files: 2,
-            changed_lines: 1549,
-            bytes: 8192,
-            notes: Vec::new(),
-        };
-        let warning = LargeDiffWarning {
-            changed_lines: 1549,
-            threshold: 1000,
-        };
-
-        write_review_meta_with_diff_report(
-            session_dir.path(),
-            &review_meta("01REVIEWMETA000000000000"),
-            Some(&diff_size),
-            Some(warning),
-        )
-        .expect("write review meta");
-
-        let raw = std::fs::read_to_string(session_dir.path().join("review_meta.json"))
-            .expect("read review meta");
-        let value: serde_json::Value = serde_json::from_str(&raw).expect("parse review meta");
-        assert_eq!(value["diff_size"]["files"], 2);
-        assert_eq!(value["diff_size"]["changed_lines"], 1549);
-        assert_eq!(value["diff_size"]["bytes"], 8192);
-        assert_eq!(value["large_diff_warning"], true);
-        assert_eq!(value["large_diff_warning_threshold"], 1000);
-        assert_eq!(value["large_diff_warning_changed_lines"], 1549);
-    }
-
-    #[test]
-    fn persist_review_verdict_diff_report_records_size_without_changing_pass_exit_code() {
-        let mut artifact = ReviewVerdictArtifact::from_parts(
-            "01VERDICT00000000000000",
-            ReviewDecision::Pass,
-            "CLEAN",
-            &[],
-            Vec::new(),
-        );
-        let diff_size = ReviewDiffSize {
-            files: 2,
-            changed_lines: 1549,
-            bytes: 8192,
-            notes: Vec::new(),
-        };
-        let warning = LargeDiffWarning {
-            changed_lines: 1549,
-            threshold: 1000,
-        };
-        let project_root = tempdir().expect("tempdir");
-
-        persist_review_verdict_diff_report(
-            project_root.path(),
-            "01VERDICT00000000000000",
-            &mut artifact,
-            Some(&diff_size),
-            Some(warning),
-        );
-
-        assert_eq!(artifact.decision, ReviewDecision::Pass);
-        assert_eq!(artifact.verdict_legacy, "CLEAN");
-        assert_eq!(
-            crate::verdict_exit_code::exit_code_from_review_decision(artifact.decision),
-            0
-        );
-        assert_eq!(artifact.diff_size, Some(diff_size));
-        assert!(artifact.large_diff_warning);
-        assert_eq!(artifact.large_diff_warning_threshold, Some(1000));
-        assert_eq!(artifact.large_diff_warning_changed_lines, Some(1549));
-    }
-
-    #[test]
-    fn resolve_large_diff_warn_lines_uses_default_when_absent_and_project_override_when_set() {
-        let global: GlobalConfig = toml::from_str("[review]\ntool = \"auto\"\n")
-            .expect("parse global config without threshold");
-        assert_eq!(resolve_large_diff_warn_lines(None, &global), Some(1000));
-
-        let project: ProjectConfig =
-            toml::from_str("schema_version = 1\n[review]\nlarge_diff_warn_lines = 0\n")
-                .expect("parse project config with disabled threshold");
-        assert_eq!(
-            resolve_large_diff_warn_lines(Some(&project), &GlobalConfig::default()),
-            Some(0)
-        );
-    }
-}
+#[path = "review_cmd_diff_size_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/review_cmd_diff_size_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_diff_size_tests.rs
@@ -1,0 +1,268 @@
+//! Tests for [`crate::review_cmd_diff_size`], in a sibling file so the
+//! implementation module stays within the per-module token budget (#1818).
+
+use std::process::Command;
+
+use csa_core::types::ReviewDecision;
+use csa_session::ReviewVerdictArtifact;
+use tempfile::tempdir;
+
+use super::*;
+
+fn run_git_command(project_root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn setup_diff_size_git_repo() -> tempfile::TempDir {
+    let temp = tempdir().expect("tempdir");
+    run_git_command(temp.path(), &["init"]);
+    run_git_command(temp.path(), &["config", "user.email", "test@example.com"]);
+    run_git_command(temp.path(), &["config", "user.name", "Test User"]);
+    std::fs::write(temp.path().join("tracked.txt"), "baseline\n").expect("write tracked file");
+    run_git_command(temp.path(), &["add", "tracked.txt"]);
+    run_git_command(temp.path(), &["commit", "-m", "initial"]);
+    temp
+}
+
+fn review_meta(session_id: &str) -> ReviewSessionMeta {
+    ReviewSessionMeta {
+        session_id: session_id.to_string(),
+        head_sha: "HEAD".to_string(),
+        decision: ReviewDecision::Pass.as_str().to_string(),
+        verdict: "CLEAN".to_string(),
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "codex".to_string(),
+        scope: "range:main...HEAD".to_string(),
+        exit_code: 0,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: Some("fingerprint".to_string()),
+        fix_convergence: None,
+    }
+}
+
+#[test]
+fn diff_size_from_payload_counts_multi_file_changed_lines_and_bytes() {
+    let diff = concat!(
+        "diff --git a/one.txt b/one.txt\n",
+        "index 1111111..2222222 100644\n",
+        "--- a/one.txt\n",
+        "+++ b/one.txt\n",
+        "@@ -1,2 +1,3 @@\n",
+        " keep\n",
+        "-old one\n",
+        "+new one\n",
+        "+added one\n",
+        "diff --git a/two.txt b/two.txt\n",
+        "index 3333333..4444444 100644\n",
+        "--- a/two.txt\n",
+        "+++ b/two.txt\n",
+        "@@ -1 +1 @@\n",
+        "-old two\n",
+        "+new two\n",
+    );
+
+    let size = diff_size_from_payload(diff.as_bytes());
+
+    assert_eq!(size.files, 2);
+    assert_eq!(size.changed_lines, 5);
+    assert_eq!(size.bytes, diff.len());
+}
+
+#[test]
+fn diff_size_from_payload_counts_hunk_content_that_looks_like_file_headers() {
+    let diff = concat!(
+        "diff --git a/operators.txt b/operators.txt\n",
+        "index 1111111..2222222 100644\n",
+        "--- a/operators.txt\n",
+        "+++ b/operators.txt\n",
+        "@@ -1,3 +1,3 @@\n",
+        " unchanged\n",
+        "---removed operator line\n",
+        "+++added operator line\n",
+    );
+
+    let size = diff_size_from_payload(diff.as_bytes());
+
+    assert_eq!(size.files, 1);
+    assert_eq!(
+        size.changed_lines, 2,
+        "file headers must be ignored, but hunk content beginning with ++/-- must count"
+    );
+    assert_eq!(size.bytes, diff.len());
+}
+
+#[test]
+fn committed_range_diff_size_counts_only_committed_git_diff() {
+    let repo = setup_diff_size_git_repo();
+    run_git_command(repo.path(), &["branch", "base"]);
+    std::fs::write(repo.path().join("tracked.txt"), "baseline\ncommitted\n")
+        .expect("write committed change");
+    run_git_command(repo.path(), &["add", "tracked.txt"]);
+    run_git_command(repo.path(), &["commit", "-m", "change tracked file"]);
+    std::fs::write(repo.path().join("new.txt"), "untracked\ncontent\n")
+        .expect("write untracked file");
+
+    let size =
+        compute_review_diff_size(repo.path(), "range:base...HEAD").expect("compute diff size");
+
+    assert_eq!(size.files, 1);
+    assert_eq!(size.changed_lines, 1);
+    assert!(size.bytes > 0);
+    assert!(size.notes.is_empty());
+}
+
+#[test]
+fn uncommitted_diff_size_counts_untracked_files() {
+    let repo = setup_diff_size_git_repo();
+    std::fs::write(repo.path().join("new.txt"), "one\ntwo\nthree\n").expect("write untracked file");
+
+    let size = compute_review_diff_size(repo.path(), "uncommitted").expect("compute diff size");
+
+    // The uncommitted path now includes untracked files (#1818): the new file
+    // is one of three exact lines, with no estimated/capped note.
+    assert_eq!(size.files, 1);
+    assert_eq!(size.changed_lines, 3);
+    assert!(size.bytes > 0);
+    assert!(size.notes.is_empty());
+    // Three changed lines now crosses a threshold of two — previously
+    // suppressed when untracked files were ignored.
+    assert!(large_diff_warning(&size, Some(2)).is_some());
+}
+
+#[test]
+fn uncommitted_diff_size_counts_overlapping_staged_and_unstaged_edit_once() {
+    let repo = setup_diff_size_git_repo();
+    let tracked_path = repo.path().join("tracked.txt");
+    std::fs::write(&tracked_path, "staged\n").expect("write staged version");
+    run_git_command(repo.path(), &["add", "tracked.txt"]);
+    std::fs::write(&tracked_path, "final\n").expect("write unstaged version");
+
+    let size = compute_review_diff_size(repo.path(), "uncommitted").expect("compute diff size");
+
+    assert_eq!(size.files, 1);
+    assert_eq!(size.changed_lines, 2);
+}
+
+#[test]
+fn large_diff_warning_respects_threshold_boundaries_and_disabled_values() {
+    let size = ReviewDiffSize {
+        files: 3,
+        changed_lines: 1001,
+        bytes: 4096,
+        notes: Vec::new(),
+    };
+
+    assert!(large_diff_warning(&size, Some(1001)).is_none());
+    assert!(large_diff_warning(&size, Some(0)).is_none());
+    assert!(large_diff_warning(&size, None).is_none());
+
+    let warning = large_diff_warning(&size, Some(1000)).expect("above threshold warns");
+    assert_eq!(warning.changed_lines, 1001);
+    assert_eq!(warning.threshold, 1000);
+    assert!(format_large_diff_warning(warning).starts_with("warning: review diff is large"));
+}
+
+#[test]
+fn write_review_meta_with_diff_report_records_size_and_large_diff_warning() {
+    let session_dir = tempdir().expect("tempdir");
+    let diff_size = ReviewDiffSize {
+        files: 2,
+        changed_lines: 1549,
+        bytes: 8192,
+        notes: Vec::new(),
+    };
+    let warning = LargeDiffWarning {
+        changed_lines: 1549,
+        threshold: 1000,
+    };
+
+    write_review_meta_with_diff_report(
+        session_dir.path(),
+        &review_meta("01REVIEWMETA000000000000"),
+        Some(&diff_size),
+        Some(warning),
+    )
+    .expect("write review meta");
+
+    let raw = std::fs::read_to_string(session_dir.path().join("review_meta.json"))
+        .expect("read review meta");
+    let value: serde_json::Value = serde_json::from_str(&raw).expect("parse review meta");
+    assert_eq!(value["diff_size"]["files"], 2);
+    assert_eq!(value["diff_size"]["changed_lines"], 1549);
+    assert_eq!(value["diff_size"]["bytes"], 8192);
+    assert_eq!(value["large_diff_warning"], true);
+    assert_eq!(value["large_diff_warning_threshold"], 1000);
+    assert_eq!(value["large_diff_warning_changed_lines"], 1549);
+}
+
+#[test]
+fn persist_review_verdict_diff_report_records_size_without_changing_pass_exit_code() {
+    let mut artifact = ReviewVerdictArtifact::from_parts(
+        "01VERDICT00000000000000",
+        ReviewDecision::Pass,
+        "CLEAN",
+        &[],
+        Vec::new(),
+    );
+    let diff_size = ReviewDiffSize {
+        files: 2,
+        changed_lines: 1549,
+        bytes: 8192,
+        notes: Vec::new(),
+    };
+    let warning = LargeDiffWarning {
+        changed_lines: 1549,
+        threshold: 1000,
+    };
+    let project_root = tempdir().expect("tempdir");
+
+    persist_review_verdict_diff_report(
+        project_root.path(),
+        "01VERDICT00000000000000",
+        &mut artifact,
+        Some(&diff_size),
+        Some(warning),
+    );
+
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_eq!(
+        crate::verdict_exit_code::exit_code_from_review_decision(artifact.decision),
+        0
+    );
+    assert_eq!(artifact.diff_size, Some(diff_size));
+    assert!(artifact.large_diff_warning);
+    assert_eq!(artifact.large_diff_warning_threshold, Some(1000));
+    assert_eq!(artifact.large_diff_warning_changed_lines, Some(1549));
+}
+
+#[test]
+fn resolve_large_diff_warn_lines_uses_default_when_absent_and_project_override_when_set() {
+    let global: GlobalConfig = toml::from_str("[review]\ntool = \"auto\"\n")
+        .expect("parse global config without threshold");
+    assert_eq!(resolve_large_diff_warn_lines(None, &global), Some(1000));
+
+    let project: ProjectConfig =
+        toml::from_str("schema_version = 1\n[review]\nlarge_diff_warn_lines = 0\n")
+            .expect("parse project config with disabled threshold");
+    assert_eq!(
+        resolve_large_diff_warn_lines(Some(&project), &GlobalConfig::default()),
+        Some(0)
+    );
+}

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -166,89 +166,26 @@ pub(crate) fn working_tree_changed_lines(project_root: &Path) -> usize {
     tracked.saturating_add(untracked_non_ignored_lines(project_root))
 }
 
-/// Sum of line counts across untracked, non-ignored files.
+/// Sum of line counts across untracked, non-ignored files, delegating to the
+/// shared bounded scanner in [`crate::untracked_size`] so this writer guard and
+/// the `csa review` diff-size report (#1818) share one enumeration
+/// (`git ls-files --others --exclude-standard`) and one bounded per-file line
+/// counter rather than duplicating either.
 ///
-/// `git ls-files --others --exclude-standard` enumerates files git is neither
-/// tracking nor ignoring, so build artifacts and `.gitignore`d paths never
-/// inflate the size measure, and the index/worktree are never mutated. `--others`
-/// excludes anything already in the index (including intent-to-add entries, which
-/// `git diff HEAD` already counts), so there is no double-counting with the
-/// tracked diff. Fail-open: returns `0` when `project_root` is not a git worktree
-/// or git fails.
+/// The per-file read is bounded (streamed through a fixed buffer, never slurped)
+/// and the number of files scanned is capped at
+/// [`crate::untracked_size::MAX_UNTRACKED_FILES`]; beyond the cap the running
+/// total is already far above `TRIVIAL_DIFF_MAX_LINES`, so the
+/// trivial-vs-substantial outcome the guard cares about is unchanged. Non-regular
+/// entries (symlinks, FIFOs, sockets, devices) and unreadable files contribute
+/// `0`. Returns `0` when `project_root` is not a git worktree or git fails
+/// (fail-open), matching the rest of the guard.
 fn untracked_non_ignored_lines(project_root: &Path) -> usize {
-    if !super::git::is_git_worktree(project_root) {
-        return 0;
-    }
-    let Some(listing) = run_git_capture(
-        project_root,
-        &["ls-files", "--others", "--exclude-standard", "-z"],
-    ) else {
-        return 0;
-    };
-    listing
-        .split('\0')
-        .filter(|path| !path.is_empty())
-        .map(|rel| count_file_lines(&project_root.join(rel)))
+    crate::untracked_size::list_untracked(project_root)
+        .iter()
+        .take(crate::untracked_size::MAX_UNTRACKED_FILES)
+        .map(|path| crate::untracked_size::count_file_lines(path))
         .sum()
-}
-
-/// Per-file byte ceiling when counting untracked-file lines. The gate only
-/// distinguishes trivial (`<= TRIVIAL_DIFF_MAX_LINES`) from substantial, so
-/// scanning past ~1 MiB of a single file cannot change the outcome; the ceiling
-/// keeps a pathological large non-ignored file from forcing an unbounded read
-/// (bounded-read discipline, mirroring the guard's other reads).
-const MAX_LINE_SCAN_BYTES: usize = 1 << 20;
-
-/// Count newline-delimited lines in `path` with bounded memory and IO.
-///
-/// Streams the file through a fixed buffer (never loading it whole) counting
-/// `\n` bytes, stopping after [`MAX_LINE_SCAN_BYTES`]; a final line lacking a
-/// trailing newline still counts. Fail-open: any IO error (including a missing
-/// file) yields `0` so a transient read failure cannot abort the guard.
-///
-/// Only regular files are opened. `path` comes straight from an untracked
-/// worktree enumeration ([`untracked_non_ignored_lines`]), which can legitimately
-/// surface symlinks, FIFOs, sockets, or device nodes. `File::open` follows
-/// symlinks and blocks indefinitely on a FIFO (and can hang or error on other
-/// special files), so the path is first classified with `symlink_metadata` (which
-/// does NOT follow symlinks); anything that is not a regular file is skipped
-/// (counted as `0`) without ever being opened. Mirrors the classify-before-touch
-/// pattern in [`crate::edit_restriction_guard`]'s `capture_path_state`.
-fn count_file_lines(path: &Path) -> usize {
-    use std::io::Read;
-
-    // Classify WITHOUT following symlinks and WITHOUT opening: only a regular file
-    // is safe to hand to `File::open` here. A stat error (missing/unreadable) or
-    // any non-regular type (symlink, FIFO, socket, device) fails open to `0`.
-    if !std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_file()) {
-        return 0;
-    }
-
-    let Ok(file) = std::fs::File::open(path) else {
-        return 0;
-    };
-    let mut reader = std::io::BufReader::new(file);
-    let mut buf = [0u8; 16 * 1024];
-    let mut newlines = 0usize;
-    let mut scanned = 0usize;
-    let mut last_byte = None;
-    while scanned < MAX_LINE_SCAN_BYTES {
-        match reader.read(&mut buf) {
-            Ok(0) => break,
-            Ok(n) => {
-                newlines += buf[..n].iter().filter(|&&b| b == b'\n').count();
-                last_byte = Some(buf[n - 1]);
-                scanned = scanned.saturating_add(n);
-            }
-            Err(_) => return 0,
-        }
-    }
-    // A non-empty file whose final scanned byte is not a newline has a trailing
-    // partial line; an empty file (`None`) or one ending in `\n` does not.
-    match last_byte {
-        Some(b) if b != b'\n' => newlines.saturating_add(1),
-        _ => newlines,
-    }
 }
 
 fn collect_uncommitted_changes(project_root: &Path) -> Option<csa_session::UncommittedChanges> {
@@ -502,89 +439,6 @@ mod tests {
         run_git(root, &["add", "seed.txt"]);
         run_git(root, &["commit", "-q", "-m", "initial"]);
         temp
-    }
-
-    #[test]
-    fn count_file_lines_handles_trailing_newline_partial_line_and_missing() {
-        let temp = tempfile::tempdir().unwrap();
-        let with_nl = temp.path().join("with_nl.txt");
-        std::fs::write(&with_nl, "x\ny\nz\n").unwrap();
-        assert_eq!(count_file_lines(&with_nl), 3);
-
-        let no_nl = temp.path().join("no_nl.txt");
-        std::fs::write(&no_nl, "x\ny\nz").unwrap();
-        assert_eq!(count_file_lines(&no_nl), 3);
-
-        let empty = temp.path().join("empty.txt");
-        std::fs::write(&empty, "").unwrap();
-        assert_eq!(count_file_lines(&empty), 0);
-
-        assert_eq!(count_file_lines(&temp.path().join("missing.txt")), 0);
-    }
-
-    /// Create a FIFO (named pipe) at `path`. Unix-only; used to prove the
-    /// regular-file gate skips special files instead of blocking on `File::open`.
-    #[cfg(unix)]
-    fn make_fifo(path: &Path) {
-        use std::os::unix::ffi::OsStrExt;
-        let c_path =
-            std::ffi::CString::new(path.as_os_str().as_bytes()).expect("fifo path has no NUL byte");
-        // SAFETY: `c_path` is a valid NUL-terminated path that outlives the call;
-        // mode 0o600 is a standard FIFO permission. The return code is checked.
-        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-        assert_eq!(
-            rc,
-            0,
-            "mkfifo({}) failed: {}",
-            path.display(),
-            std::io::Error::last_os_error()
-        );
-    }
-
-    #[test]
-    fn count_file_lines_skips_non_regular_paths_without_blocking() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path();
-
-        // (a) A regular file is still counted normally.
-        let regular = root.join("regular.rs");
-        std::fs::write(&regular, "a\nb\nc\n").unwrap();
-        assert_eq!(count_file_lines(&regular), 3);
-
-        // (b) A symlink is non-regular: it MUST be skipped (0), not FOLLOWED to its
-        // regular target (which would count 3). Proves classification uses
-        // symlink_metadata rather than following the link.
-        #[cfg(unix)]
-        {
-            let link = root.join("link.rs");
-            std::os::unix::fs::symlink(&regular, &link).unwrap();
-            assert_eq!(
-                count_file_lines(&link),
-                0,
-                "symlink must be skipped, not followed"
-            );
-        }
-
-        // (c) A FIFO makes a blocking `File::open` hang forever pre-fix. Probe on a
-        // worker thread so a regression surfaces as a bounded timeout failure
-        // instead of an indefinite CI hang.
-        #[cfg(unix)]
-        {
-            use std::sync::mpsc;
-            use std::time::Duration;
-
-            let fifo = root.join("pipe");
-            make_fifo(&fifo);
-            let probe = fifo.clone();
-            let (tx, rx) = mpsc::channel();
-            std::thread::spawn(move || {
-                let _ = tx.send(count_file_lines(&probe));
-            });
-            let counted = rx.recv_timeout(Duration::from_secs(5)).expect(
-                "count_file_lines blocked on a FIFO — regression: regular-file gate missing",
-            );
-            assert_eq!(counted, 0, "FIFO must be skipped, not opened");
-        }
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -182,8 +182,8 @@ pub(crate) fn working_tree_changed_lines(project_root: &Path) -> usize {
 /// (fail-open), matching the rest of the guard.
 fn untracked_non_ignored_lines(project_root: &Path) -> usize {
     crate::untracked_size::list_untracked(project_root)
+        .paths
         .iter()
-        .take(crate::untracked_size::MAX_UNTRACKED_FILES)
         .map(|path| crate::untracked_size::count_file_lines(path))
         .sum()
 }

--- a/crates/cli-sub-agent/src/untracked_size.rs
+++ b/crates/cli-sub-agent/src/untracked_size.rs
@@ -17,8 +17,9 @@
 //! number of files scanned is itself capped. Any single unreadable/race-deleted
 //! file is tolerated (skipped), never fatal.
 
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 /// Per-file byte ceiling. A regular file larger than this is recorded as
 /// "large, not line-counted" (its byte size only) instead of being read, so a
@@ -64,7 +65,6 @@ pub(crate) struct UntrackedDiffSize {
 /// (git failure is fail-open, never fatal).
 pub(crate) fn untracked_diff_size(project_root: &Path) -> UntrackedDiffSize {
     let listing = list_untracked(project_root);
-    let total = listing.len();
 
     let mut out = UntrackedDiffSize {
         files: 0,
@@ -75,7 +75,7 @@ pub(crate) fn untracked_diff_size(project_root: &Path) -> UntrackedDiffSize {
     let mut capped_files = 0usize;
     let mut uncounted_files = 0usize; // large + binary: sized but not line-counted
 
-    for path in listing.iter().take(MAX_UNTRACKED_FILES) {
+    for path in &listing.paths {
         match classify_untracked_file(path) {
             FileClass::Text {
                 lines,
@@ -98,8 +98,6 @@ pub(crate) fn untracked_diff_size(project_root: &Path) -> UntrackedDiffSize {
         }
     }
 
-    let scanned = total.min(MAX_UNTRACKED_FILES);
-    let truncated = total.saturating_sub(scanned);
     if uncounted_files > 0 {
         out.notes.push(format!(
             "{uncounted_files} untracked file(s) not line-counted (binary or > {} MiB); changed-line total is a lower bound",
@@ -111,9 +109,9 @@ pub(crate) fn untracked_diff_size(project_root: &Path) -> UntrackedDiffSize {
             "{capped_files} untracked file(s) line-counted up to {MAX_LINES_PER_FILE} lines (capped); changed-line total is a lower bound"
         ));
     }
-    if truncated > 0 {
+    if listing.truncated {
         out.notes.push(format!(
-            "untracked scan truncated: sized first {MAX_UNTRACKED_FILES} of {total} untracked files; totals are a lower bound"
+            "untracked scan truncated: sized the first {MAX_UNTRACKED_FILES} untracked files (the working tree has more, not enumerated); totals are a lower bound"
         ));
     }
     out
@@ -146,26 +144,106 @@ pub(crate) fn count_file_lines(path: &Path) -> usize {
         .unwrap_or(0)
 }
 
-/// Untracked, non-ignored working-tree paths under `project_root`, absolute.
+/// A bounded enumeration of untracked, non-ignored working-tree paths.
+///
+/// `paths` holds at most [`MAX_UNTRACKED_FILES`] absolute paths; `truncated` is
+/// set when the working tree held more and enumeration stopped early, so the
+/// surplus files were never listed, allocated, or sized.
+pub(crate) struct UntrackedListing {
+    pub(crate) paths: Vec<PathBuf>,
+    pub(crate) truncated: bool,
+}
+
+/// Untracked, non-ignored working-tree paths under `project_root`, absolute and
+/// hard-capped at [`MAX_UNTRACKED_FILES`].
 ///
 /// `git ls-files --others --exclude-standard` lists files git is neither
 /// tracking nor ignoring, so `.gitignore`d paths and indexed entries (including
 /// intent-to-add, which `git diff HEAD` already counts) are excluded — no
-/// double-counting and no inflation from build artifacts. `-z` keeps paths with
-/// embedded newlines intact. Fail-open: returns an empty vec when `project_root`
-/// is not a git worktree or git fails.
-pub(crate) fn list_untracked(project_root: &Path) -> Vec<PathBuf> {
-    let Some(output) = run_git_stdout(
-        project_root,
-        &["ls-files", "--others", "--exclude-standard", "-z"],
-    ) else {
-        return Vec::new();
+/// double-counting and no inflation from build artifacts. `-z` NUL-delimits the
+/// paths so embedded newlines stay intact.
+///
+/// The enumeration is streamed, not buffered: git's stdout is read one
+/// NUL-delimited path at a time and, once the cap is reached, the read handle is
+/// dropped and the `git ls-files` child is killed and reaped so it stops walking
+/// an arbitrarily large (attacker- or accident-shaped) tree. Peak memory and the
+/// returned `Vec` are therefore bounded to ~the cap regardless of how many
+/// untracked files exist — the cap is enforced *during* enumeration, never after
+/// a full collection. Fail-open: returns an empty, untruncated listing when
+/// `project_root` is not a git worktree or git cannot be spawned.
+pub(crate) fn list_untracked(project_root: &Path) -> UntrackedListing {
+    let Ok(mut child) = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["ls-files", "--others", "--exclude-standard", "-z"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return UntrackedListing {
+            paths: Vec::new(),
+            truncated: false,
+        };
     };
-    output
-        .split('\0')
-        .filter(|entry| !entry.is_empty())
-        .map(|rel| project_root.join(rel))
-        .collect()
+    let Some(stdout) = child.stdout.take() else {
+        // Unreachable with `Stdio::piped()`, but never leave a child unreaped.
+        let _ = child.kill();
+        let _ = child.wait();
+        return UntrackedListing {
+            paths: Vec::new(),
+            truncated: false,
+        };
+    };
+
+    // Parse up to the cap, then drop the read end (closing the pipe) before
+    // terminating git. Git's exit status is intentionally NOT inspected: on
+    // truncation we kill it on purpose, so a "killed" status is expected and the
+    // paths already collected stay valid.
+    let (rels, truncated) =
+        read_nul_delimited_capped(std::io::BufReader::new(stdout), MAX_UNTRACKED_FILES);
+    let _ = child.kill(); // benign if git already exited on its own
+    let _ = child.wait(); // reap to avoid a zombie
+
+    UntrackedListing {
+        paths: rels.into_iter().map(|rel| project_root.join(rel)).collect(),
+        truncated,
+    }
+}
+
+/// Read up to `cap` NUL-delimited entries from `reader`, one at a time, so a
+/// caller streaming from a subprocess can stop the producer before it emits an
+/// unbounded amount. Empty entries are skipped (defensive: `git ls-files -z`
+/// does not emit them). Entries are decoded lossily because git can surface
+/// non-UTF-8 paths — matching the previous whole-output `from_utf8_lossy`.
+///
+/// Returns the collected entries and whether the cap was reached with at least
+/// one more entry pending (`truncated`). At most `cap + 1` entries are consumed:
+/// the one-entry probe distinguishes "exactly `cap` entries" (not truncated)
+/// from "more than `cap`" (truncated) without draining the remaining stream, so
+/// an arbitrarily large input is never fully read. A mid-stream read error ends
+/// the scan fail-open with whatever was collected.
+fn read_nul_delimited_capped<R: BufRead>(mut reader: R, cap: usize) -> (Vec<String>, bool) {
+    let mut entries = Vec::new();
+    let mut segment = Vec::new();
+    loop {
+        segment.clear();
+        match reader.read_until(0u8, &mut segment) {
+            Ok(0) => return (entries, false), // EOF: at most `cap` entries ⇒ not truncated
+            Ok(_) => {}
+            Err(_) => return (entries, false), // fail-open with what we have
+        }
+        if segment.last() == Some(&0u8) {
+            segment.pop(); // strip the NUL terminator
+        }
+        if segment.is_empty() {
+            continue;
+        }
+        if entries.len() == cap {
+            return (entries, true); // this is the (cap + 1)-th entry: truncate here
+        }
+        entries.push(String::from_utf8_lossy(&segment).into_owned());
+    }
 }
 
 /// Per-file outcome of [`classify_untracked_file`].
@@ -291,19 +369,6 @@ fn scan_file_bounded(file: std::fs::File, line_cap: usize) -> Option<BoundedScan
         hit_line_cap,
         saw_nul,
     })
-}
-
-fn run_git_stdout(project_root: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(project_root)
-        .args(args)
-        .output()
-        .ok()?;
-    output
-        .status
-        .success()
-        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/untracked_size.rs
+++ b/crates/cli-sub-agent/src/untracked_size.rs
@@ -1,0 +1,311 @@
+//! Bounded sizing of untracked working-tree files.
+//!
+//! Untracked (never-staged) files never appear in `git diff HEAD`, so any size
+//! measure derived solely from that diff is blind to brand-new files. Two call
+//! sites need them counted: the review-aware writer guard (#1842) and the
+//! `csa review` uncommitted diff-size report (#1818). Both share the same hazard
+//! — an untracked set is attacker/accident-shaped (huge blobs, binaries, device
+//! nodes, an unbounded number of files) — so the enumeration and the per-file
+//! line counter live here once, with hard resource caps, rather than being
+//! duplicated per call site.
+//!
+//! All work is bounded regardless of file size, type, or count: files are
+//! enumerated with `git ls-files --others --exclude-standard` (so `.gitignore`d
+//! build artifacts are never scanned), non-regular entries are skipped without
+//! being opened, oversized files are recorded by size instead of read, line
+//! counting streams through a fixed buffer and stops at a per-file cap, and the
+//! number of files scanned is itself capped. Any single unreadable/race-deleted
+//! file is tolerated (skipped), never fatal.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Per-file byte ceiling. A regular file larger than this is recorded as
+/// "large, not line-counted" (its byte size only) instead of being read, so a
+/// pathological multi-GiB untracked blob can never force an unbounded read.
+const MAX_LINE_SCAN_BYTES: u64 = 1 << 20; // 1 MiB
+
+/// Per-file line ceiling. Line counting stops here and the count is flagged
+/// capped, bounding the work spent on an adversarial file that is mostly
+/// newlines (e.g. millions of empty lines under the byte ceiling).
+const MAX_LINES_PER_FILE: usize = 50_000;
+
+/// Prefix window scanned for a NUL byte to classify a file as binary. Matches
+/// git's own heuristic (a NUL in the first few KiB ⇒ binary) and keeps the
+/// sniff bounded independent of file size.
+const BINARY_SNIFF_BYTES: u64 = 8 * 1024; // 8 KiB
+
+/// Streaming read buffer. Fixes peak per-file memory to a constant regardless
+/// of file size — the file is never slurped whole.
+const READ_BUF_BYTES: usize = 16 * 1024; // 16 KiB
+
+/// Total untracked files line-counted before the scan is truncated. Beyond this
+/// the scan stops and the report is marked truncated, so an untracked set with
+/// an arbitrarily large number of files can never spin an unbounded loop.
+pub(crate) const MAX_UNTRACKED_FILES: usize = 1_000;
+
+/// Aggregate size contribution of the untracked working-tree files, ready to be
+/// merged into a [`csa_session::ReviewDiffSize`]. `bytes` is the on-disk size of
+/// the scanned regular files (including large/binary ones, whose lines are not
+/// counted). `notes` is empty when every counted total is exact; otherwise it
+/// carries human-readable markers stating which totals are a lower bound
+/// (capped, binary/large, or truncated), so a reader is never misled into
+/// treating an estimate as exact.
+pub(crate) struct UntrackedDiffSize {
+    pub(crate) files: usize,
+    pub(crate) lines: usize,
+    pub(crate) bytes: u64,
+    pub(crate) notes: Vec<String>,
+}
+
+/// Size the untracked, non-ignored working-tree files under `project_root` with
+/// every resource cap in this module enforced. Returns an all-zero, note-free
+/// result when `project_root` is not a git worktree or has no untracked files
+/// (git failure is fail-open, never fatal).
+pub(crate) fn untracked_diff_size(project_root: &Path) -> UntrackedDiffSize {
+    let listing = list_untracked(project_root);
+    let total = listing.len();
+
+    let mut out = UntrackedDiffSize {
+        files: 0,
+        lines: 0,
+        bytes: 0,
+        notes: Vec::new(),
+    };
+    let mut capped_files = 0usize;
+    let mut uncounted_files = 0usize; // large + binary: sized but not line-counted
+
+    for path in listing.iter().take(MAX_UNTRACKED_FILES) {
+        match classify_untracked_file(path) {
+            FileClass::Text {
+                lines,
+                capped,
+                bytes,
+            } => {
+                out.files += 1;
+                out.lines = out.lines.saturating_add(lines);
+                out.bytes = out.bytes.saturating_add(bytes);
+                if capped {
+                    capped_files += 1;
+                }
+            }
+            FileClass::Large { bytes } | FileClass::Binary { bytes } => {
+                out.files += 1;
+                out.bytes = out.bytes.saturating_add(bytes);
+                uncounted_files += 1;
+            }
+            FileClass::Skipped => {}
+        }
+    }
+
+    let scanned = total.min(MAX_UNTRACKED_FILES);
+    let truncated = total.saturating_sub(scanned);
+    if uncounted_files > 0 {
+        out.notes.push(format!(
+            "{uncounted_files} untracked file(s) not line-counted (binary or > {} MiB); changed-line total is a lower bound",
+            MAX_LINE_SCAN_BYTES >> 20
+        ));
+    }
+    if capped_files > 0 {
+        out.notes.push(format!(
+            "{capped_files} untracked file(s) line-counted up to {MAX_LINES_PER_FILE} lines (capped); changed-line total is a lower bound"
+        ));
+    }
+    if truncated > 0 {
+        out.notes.push(format!(
+            "untracked scan truncated: sized first {MAX_UNTRACKED_FILES} of {total} untracked files; totals are a lower bound"
+        ));
+    }
+    out
+}
+
+/// Count newline-delimited lines in `path` with bounded memory and IO, for the
+/// review-aware writer guard (#1842), whose size measure only needs a single
+/// running total (trivial vs substantial), not the richer per-file
+/// classification the review report needs.
+///
+/// Only regular files are opened: `path` comes from an untracked-worktree
+/// enumeration that can legitimately surface symlinks, FIFOs, sockets, or device
+/// nodes, and opening those could follow a link or block indefinitely. Streams
+/// through a fixed buffer counting `\n`, bounded by [`MAX_LINE_SCAN_BYTES`]; a
+/// final line lacking a trailing newline still counts. Fail-open: a non-regular
+/// path or any IO error (including a missing/race-deleted file) yields `0` so a
+/// transient failure cannot abort the guard.
+pub(crate) fn count_file_lines(path: &Path) -> usize {
+    if regular_file_meta(path).is_none() {
+        return 0;
+    }
+    let Ok(file) = std::fs::File::open(path) else {
+        return 0;
+    };
+    // `usize::MAX` line cap: the guard never wants a per-file line ceiling, only
+    // the byte ceiling, preserving the pre-extraction behavior exactly (a huge
+    // file still contributes its first 1 MiB of lines = substantial work).
+    scan_file_bounded(file, usize::MAX)
+        .map(|scan| scan.lines)
+        .unwrap_or(0)
+}
+
+/// Untracked, non-ignored working-tree paths under `project_root`, absolute.
+///
+/// `git ls-files --others --exclude-standard` lists files git is neither
+/// tracking nor ignoring, so `.gitignore`d paths and indexed entries (including
+/// intent-to-add, which `git diff HEAD` already counts) are excluded — no
+/// double-counting and no inflation from build artifacts. `-z` keeps paths with
+/// embedded newlines intact. Fail-open: returns an empty vec when `project_root`
+/// is not a git worktree or git fails.
+pub(crate) fn list_untracked(project_root: &Path) -> Vec<PathBuf> {
+    let Some(output) = run_git_stdout(
+        project_root,
+        &["ls-files", "--others", "--exclude-standard", "-z"],
+    ) else {
+        return Vec::new();
+    };
+    output
+        .split('\0')
+        .filter(|entry| !entry.is_empty())
+        .map(|rel| project_root.join(rel))
+        .collect()
+}
+
+/// Per-file outcome of [`classify_untracked_file`].
+enum FileClass {
+    /// Regular text file line-counted. `capped` is set when the count hit
+    /// [`MAX_LINES_PER_FILE`] and is therefore a lower bound.
+    Text {
+        lines: usize,
+        capped: bool,
+        bytes: u64,
+    },
+    /// Regular file above [`MAX_LINE_SCAN_BYTES`]: sized but not read.
+    Large { bytes: u64 },
+    /// Regular file with a NUL byte in its prefix: sized but not line-counted.
+    Binary { bytes: u64 },
+    /// Non-regular (symlink/FIFO/socket/device/dir) or unreadable/race-deleted:
+    /// contributes nothing and is tolerated, never fatal.
+    Skipped,
+}
+
+/// Classify one untracked path for the review diff-size report, enforcing the
+/// byte ceiling (large files are not read), binary detection (no bogus line
+/// counts), and the per-file line cap. A stat/open/read error is folded into
+/// [`FileClass::Skipped`] so a single unreadable file never aborts the scan.
+fn classify_untracked_file(path: &Path) -> FileClass {
+    let Some(meta) = regular_file_meta(path) else {
+        return FileClass::Skipped; // non-regular, or stat error (race/EACCES)
+    };
+    let bytes = meta.len();
+    if bytes > MAX_LINE_SCAN_BYTES {
+        return FileClass::Large { bytes }; // never opened: bounded by skipping the read
+    }
+    let Ok(file) = std::fs::File::open(path) else {
+        return FileClass::Skipped; // raced between stat and open
+    };
+    match scan_file_bounded(file, MAX_LINES_PER_FILE) {
+        None => FileClass::Skipped, // read error mid-stream
+        Some(scan) if scan.saw_nul => FileClass::Binary { bytes },
+        Some(scan) => FileClass::Text {
+            lines: scan.lines,
+            capped: scan.hit_line_cap,
+            bytes,
+        },
+    }
+}
+
+/// Metadata for `path` iff it is a regular file, classified WITHOUT following
+/// symlinks (`symlink_metadata`) so a symlink is never followed to its target
+/// and a non-regular type is never opened. `None` on a stat error or any
+/// non-regular type.
+fn regular_file_meta(path: &Path) -> Option<std::fs::Metadata> {
+    std::fs::symlink_metadata(path)
+        .ok()
+        .filter(|meta| meta.file_type().is_file())
+}
+
+/// Result of a bounded newline scan of a regular file.
+struct BoundedScan {
+    /// Newlines counted (plus one for a trailing partial line), saturating at
+    /// `line_cap` when `hit_line_cap` is set.
+    lines: usize,
+    /// The scan stopped at `line_cap`; `lines` is a lower bound.
+    hit_line_cap: bool,
+    /// A NUL byte appeared within the first [`BINARY_SNIFF_BYTES`].
+    saw_nul: bool,
+}
+
+/// Stream `file` counting `\n`, bounded by [`MAX_LINE_SCAN_BYTES`] and
+/// `line_cap`, sniffing for a NUL within the first [`BINARY_SNIFF_BYTES`]. The
+/// caller must have confirmed `file` is a regular file. Returns `None` on a read
+/// error so the caller can skip the file.
+fn scan_file_bounded(file: std::fs::File, line_cap: usize) -> Option<BoundedScan> {
+    use std::io::Read;
+
+    let mut reader = std::io::BufReader::new(file);
+    let mut buf = [0u8; READ_BUF_BYTES];
+    let mut lines = 0usize;
+    let mut scanned: u64 = 0;
+    let mut last_byte: Option<u8> = None;
+    let mut saw_nul = false;
+    let mut hit_line_cap = false;
+
+    while scanned < MAX_LINE_SCAN_BYTES {
+        let n = match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => return None,
+        };
+        let chunk = buf.get(..n)?;
+
+        if !saw_nul && scanned < BINARY_SNIFF_BYTES {
+            let window = ((BINARY_SNIFF_BYTES - scanned) as usize).min(n);
+            if let Some(prefix) = chunk.get(..window) {
+                saw_nul = prefix.contains(&0u8);
+            }
+        }
+
+        for &byte in chunk {
+            if byte == b'\n' {
+                lines = lines.saturating_add(1);
+                if lines >= line_cap {
+                    hit_line_cap = true;
+                    break;
+                }
+            }
+        }
+        last_byte = chunk.last().copied();
+        scanned = scanned.saturating_add(n as u64);
+        if hit_line_cap {
+            break;
+        }
+    }
+
+    // A non-empty file whose final scanned byte is not a newline has a trailing
+    // partial line. Skip this when the line cap was hit: the count is already a
+    // lower bound, so adding a partial line on top would be meaningless.
+    if !hit_line_cap && matches!(last_byte, Some(byte) if byte != b'\n') {
+        lines = lines.saturating_add(1);
+    }
+
+    Some(BoundedScan {
+        lines,
+        hit_line_cap,
+        saw_nul,
+    })
+}
+
+fn run_git_stdout(project_root: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(test)]
+#[path = "untracked_size_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/untracked_size_tests.rs
+++ b/crates/cli-sub-agent/src/untracked_size_tests.rs
@@ -1,0 +1,312 @@
+//! Tests for [`crate::untracked_size`], in a sibling file so the implementation
+//! module stays well within the per-module token budget (#1818).
+
+use super::*;
+
+fn run_git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A throwaway git repo. Hooks and GPG signing are disabled so the test stays
+/// hermetic regardless of the host's global git config. No commit is made —
+/// `git ls-files --others` works without `HEAD`.
+fn init_repo() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    run_git(root, &["init", "-q"]);
+    run_git(root, &["config", "user.email", "test@example.com"]);
+    run_git(root, &["config", "user.name", "Test User"]);
+    run_git(root, &["config", "commit.gpgsign", "false"]);
+    run_git(
+        root,
+        &["config", "core.hooksPath", "/nonexistent-csa-hooks"],
+    );
+    temp
+}
+
+#[test]
+fn classify_counts_exact_small_text_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("a.rs");
+    std::fs::write(&file, "one\ntwo\nthree\n").unwrap();
+
+    match classify_untracked_file(&file) {
+        FileClass::Text {
+            lines,
+            capped,
+            bytes,
+        } => {
+            assert_eq!(lines, 3);
+            assert!(!capped, "small file must not be flagged capped");
+            assert_eq!(bytes, 14);
+        }
+        _ => panic!("expected a counted text file"),
+    }
+}
+
+#[test]
+fn classify_counts_trailing_partial_line() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("no_nl.txt");
+    std::fs::write(&file, "x\ny\nz").unwrap(); // no trailing newline
+
+    match classify_untracked_file(&file) {
+        FileClass::Text { lines, .. } => assert_eq!(lines, 3),
+        _ => panic!("expected a counted text file"),
+    }
+}
+
+#[test]
+fn classify_marks_large_file_without_reading_it() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("big.bin");
+    // One byte over the ceiling, all newlines: a naive line count would report
+    // > 1M lines. `Large` proves it was sized, not read.
+    let size = (MAX_LINE_SCAN_BYTES + 1) as usize;
+    std::fs::write(&file, vec![b'\n'; size]).unwrap();
+
+    match classify_untracked_file(&file) {
+        FileClass::Large { bytes } => assert_eq!(bytes, MAX_LINE_SCAN_BYTES + 1),
+        _ => panic!("a file above the byte ceiling must be classified Large, not line-counted"),
+    }
+}
+
+#[test]
+fn classify_detects_binary_via_nul_byte() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("blob.bin");
+    std::fs::write(&file, b"text\n\0\x01\x02\nmore\n").unwrap();
+
+    match classify_untracked_file(&file) {
+        FileClass::Binary { bytes } => assert_eq!(bytes, 14),
+        _ => panic!("a file with a NUL byte must be classified Binary, no bogus line count"),
+    }
+}
+
+#[test]
+fn classify_caps_pathological_line_count() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("many_lines.txt");
+    // Under the byte ceiling but over the line ceiling: MAX_LINES_PER_FILE+10
+    // newlines occupy ~50 KiB, well below 1 MiB.
+    std::fs::write(&file, vec![b'\n'; MAX_LINES_PER_FILE + 10]).unwrap();
+
+    match classify_untracked_file(&file) {
+        FileClass::Text { lines, capped, .. } => {
+            assert_eq!(lines, MAX_LINES_PER_FILE);
+            assert!(capped, "line count at the ceiling must be flagged capped");
+        }
+        _ => panic!("expected a capped text file"),
+    }
+}
+
+#[test]
+fn classify_tolerates_missing_path() {
+    let temp = tempfile::tempdir().unwrap();
+    assert!(matches!(
+        classify_untracked_file(&temp.path().join("missing.txt")),
+        FileClass::Skipped
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn classify_skips_symlink_without_following_it() {
+    let temp = tempfile::tempdir().unwrap();
+    let target = temp.path().join("target.rs");
+    std::fs::write(&target, "a\nb\nc\n").unwrap();
+    let link = temp.path().join("link.rs");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    assert!(
+        matches!(classify_untracked_file(&link), FileClass::Skipped),
+        "a symlink must be skipped, not followed to its regular target"
+    );
+}
+
+/// Create a FIFO at `path`. Used to prove the regular-file gate skips special
+/// files instead of blocking forever on `File::open`.
+#[cfg(unix)]
+fn make_fifo(path: &Path) {
+    use std::os::unix::ffi::OsStrExt;
+    let c_path =
+        std::ffi::CString::new(path.as_os_str().as_bytes()).expect("fifo path has no NUL byte");
+    // SAFETY: `c_path` is a valid NUL-terminated path that outlives the call;
+    // mode 0o600 is a standard FIFO permission. The return code is checked.
+    let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+    assert_eq!(
+        rc,
+        0,
+        "mkfifo({}) failed: {}",
+        path.display(),
+        std::io::Error::last_os_error()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn classify_skips_fifo_without_blocking() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let temp = tempfile::tempdir().unwrap();
+    let fifo = temp.path().join("pipe");
+    make_fifo(&fifo);
+
+    let probe = fifo.clone();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(matches!(
+            classify_untracked_file(&probe),
+            FileClass::Skipped
+        ));
+    });
+    let skipped = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("classify blocked on a FIFO — regression: regular-file gate missing");
+    assert!(skipped, "a FIFO must be skipped, not opened");
+}
+
+#[test]
+fn count_file_lines_matches_exact_partial_and_missing() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let with_nl = temp.path().join("with_nl.txt");
+    std::fs::write(&with_nl, "x\ny\nz\n").unwrap();
+    assert_eq!(count_file_lines(&with_nl), 3);
+
+    let no_nl = temp.path().join("no_nl.txt");
+    std::fs::write(&no_nl, "x\ny\nz").unwrap();
+    assert_eq!(count_file_lines(&no_nl), 3);
+
+    let empty = temp.path().join("empty.txt");
+    std::fs::write(&empty, "").unwrap();
+    assert_eq!(count_file_lines(&empty), 0);
+
+    assert_eq!(count_file_lines(&temp.path().join("missing.txt")), 0);
+}
+
+#[test]
+fn untracked_diff_size_counts_exact_small_files() {
+    let temp = init_repo();
+    let root = temp.path();
+    std::fs::write(root.join("a.txt"), "1\n2\n3\n").unwrap();
+    std::fs::write(root.join("b.txt"), "4\n5\n").unwrap();
+
+    let size = untracked_diff_size(root);
+
+    assert_eq!(size.files, 2);
+    assert_eq!(size.lines, 5);
+    assert_eq!(size.bytes, 6 + 4);
+    assert!(
+        size.notes.is_empty(),
+        "exact small files need no estimated/capped note, got {:?}",
+        size.notes
+    );
+}
+
+#[test]
+fn untracked_diff_size_excludes_gitignored_files() {
+    let temp = init_repo();
+    let root = temp.path();
+    std::fs::write(root.join(".gitignore"), "build/\n*.log\n").unwrap();
+    run_git(root, &["add", ".gitignore"]);
+    run_git(root, &["commit", "-q", "-m", "ignore"]);
+
+    std::fs::create_dir_all(root.join("build")).unwrap();
+    let big: String = (0..500).map(|i| format!("artifact {i}\n")).collect();
+    std::fs::write(root.join("build/out.txt"), &big).unwrap();
+    std::fs::write(root.join("debug.log"), &big).unwrap();
+
+    let size = untracked_diff_size(root);
+    assert_eq!(size.files, 0, "ignored files must not be scanned");
+    assert_eq!(size.lines, 0);
+    assert!(size.notes.is_empty());
+}
+
+#[test]
+fn untracked_diff_size_marks_large_and_binary_without_inflating_lines() {
+    let temp = init_repo();
+    let root = temp.path();
+    std::fs::write(root.join("ok.txt"), "a\nb\n").unwrap();
+    std::fs::write(
+        root.join("huge.bin"),
+        vec![b'\n'; (MAX_LINE_SCAN_BYTES + 1) as usize],
+    )
+    .unwrap();
+    std::fs::write(root.join("blob.bin"), b"x\n\0\0\0\n").unwrap();
+
+    let size = untracked_diff_size(root);
+
+    assert_eq!(size.files, 3, "all three regular files are sized");
+    assert_eq!(size.lines, 2, "only the exact text file contributes lines");
+    assert_eq!(
+        size.notes.len(),
+        1,
+        "large+binary collapse into one not-line-counted note, got {:?}",
+        size.notes
+    );
+    assert!(size.notes[0].contains("not line-counted"));
+    assert!(size.notes[0].contains("lower bound"));
+}
+
+#[test]
+fn untracked_diff_size_truncates_beyond_file_cap() {
+    let temp = init_repo();
+    let root = temp.path();
+    let extra = 5;
+    for i in 0..(MAX_UNTRACKED_FILES + extra) {
+        std::fs::write(root.join(format!("f{i}.txt")), "x\n").unwrap();
+    }
+
+    let size = untracked_diff_size(root);
+
+    assert_eq!(
+        size.files, MAX_UNTRACKED_FILES,
+        "the scan must stop at the file cap"
+    );
+    assert_eq!(size.lines, MAX_UNTRACKED_FILES, "one line per scanned file");
+    assert!(
+        size.notes.iter().any(|note| note.contains("truncated")),
+        "exceeding the file cap must set a truncation note, got {:?}",
+        size.notes
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn untracked_diff_size_tolerates_non_regular_entry() {
+    let temp = init_repo();
+    let root = temp.path();
+    std::fs::write(root.join("good.txt"), "a\nb\nc\n").unwrap();
+    // An untracked symlink (git lists it under --others) must be skipped, and the
+    // good file still counted — one bad entry never aborts the scan.
+    std::os::unix::fs::symlink(root.join("good.txt"), root.join("link.txt")).unwrap();
+
+    let size = untracked_diff_size(root);
+    assert_eq!(size.files, 1, "only the regular file is sized");
+    assert_eq!(size.lines, 3);
+}
+
+#[test]
+fn untracked_diff_size_empty_for_non_git_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("loose.txt"), "ignored without git\n").unwrap();
+
+    let size = untracked_diff_size(temp.path());
+    assert_eq!(size.files, 0);
+    assert_eq!(size.lines, 0);
+    assert_eq!(size.bytes, 0);
+    assert!(size.notes.is_empty());
+}

--- a/crates/cli-sub-agent/src/untracked_size_tests.rs
+++ b/crates/cli-sub-agent/src/untracked_size_tests.rs
@@ -310,3 +310,86 @@ fn untracked_diff_size_empty_for_non_git_dir() {
     assert_eq!(size.bytes, 0);
     assert!(size.notes.is_empty());
 }
+
+// --- Enumeration-boundary tests -------------------------------------------
+//
+// The `untracked_diff_size_truncates_beyond_file_cap` test above proves the
+// *report* is bounded, but it cannot prove the enumeration STOPS EARLY rather
+// than collecting every path and truncating afterward. These exercise
+// `read_nul_delimited_capped` directly — the streaming core — so a regression
+// back to "buffer everything, then `.take(cap)`" fails a test.
+
+#[test]
+fn nul_parser_stops_early_without_draining_the_stream() {
+    // Far more NUL-delimited entries than the cap. Fixed-width names (10 bytes +
+    // a NUL = 11 bytes each) keep the consumed-byte arithmetic exact.
+    let cap = MAX_UNTRACKED_FILES;
+    let entries = cap * 50;
+    let mut input = Vec::new();
+    for i in 0..entries {
+        input.extend_from_slice(format!("f{i:09}").as_bytes());
+        input.push(0u8);
+    }
+    let total_len = input.len();
+    let mut cursor = std::io::Cursor::new(input);
+
+    let (paths, truncated) = read_nul_delimited_capped(&mut cursor, cap);
+
+    assert_eq!(paths.len(), cap, "enumeration must yield exactly the cap");
+    assert!(
+        truncated,
+        "more entries than the cap must set the truncated flag"
+    );
+    // The parser must NOT have read the whole stream: it consumes only the `cap`
+    // entries plus the single probe entry that proves truncation. A `Cursor`'s
+    // position is the exact byte offset consumed (no `BufReader` read-ahead), so
+    // this asserts early-stop, not merely post-collection truncation.
+    let consumed = cursor.position() as usize;
+    assert!(
+        consumed < total_len / 10,
+        "early stop expected: consumed {consumed} of {total_len} bytes (no full drain)"
+    );
+}
+
+#[test]
+fn nul_parser_exactly_cap_entries_is_not_truncated() {
+    // Exactly `cap` entries must NOT report truncation: the +1 probe hits EOF.
+    let mut input = Vec::new();
+    for i in 0..3 {
+        input.extend_from_slice(format!("p{i}").as_bytes());
+        input.push(0u8);
+    }
+    let mut cursor = std::io::Cursor::new(input);
+
+    let (paths, truncated) = read_nul_delimited_capped(&mut cursor, 3);
+
+    assert_eq!(paths, vec!["p0", "p1", "p2"]);
+    assert!(!truncated, "exactly cap entries is not truncation");
+}
+
+#[test]
+fn nul_parser_below_cap_returns_all_entries() {
+    let mut input = Vec::new();
+    for i in 0..4 {
+        input.extend_from_slice(format!("p{i}").as_bytes());
+        input.push(0u8);
+    }
+    let mut cursor = std::io::Cursor::new(input);
+
+    let (paths, truncated) = read_nul_delimited_capped(&mut cursor, 100);
+
+    assert_eq!(paths, vec!["p0", "p1", "p2", "p3"]);
+    assert!(!truncated);
+}
+
+#[test]
+fn nul_parser_skips_empty_and_tolerates_unterminated_tail() {
+    // "a\0\0b": the empty middle entry is skipped; the final "b" has no trailing
+    // NUL (git -z always terminates, but the parser must not drop the tail).
+    let mut cursor = std::io::Cursor::new(b"a\0\0b".to_vec());
+
+    let (paths, truncated) = read_nul_delimited_capped(&mut cursor, 100);
+
+    assert_eq!(paths, vec!["a", "b"]);
+    assert!(!truncated);
+}


### PR DESCRIPTION
## Summary

Fixes #1818 — `csa review`'s diff-size report (shipped in #1645 for committed ranges) did NOT account for **untracked** working-tree files when reviewing uncommitted/working-tree changes, so the size signal could under-report the real review surface. The untracked scan was deferred in #1645 because it has several resource-safety edges (huge files, binaries, symlinks/FIFOs, unbounded untracked sets). This PR adds the untracked scan to the **uncommitted path only**, with hard resource caps on every axis.

## What changed

When `csa review` sizes an UNCOMMITTED / working-tree review, the diff-size report now also enumerates untracked files via `git ls-files --others --exclude-standard` (so `.gitignore`d build artifacts are never scanned) and sizes them under strict caps. The committed-range (`--range`, `git numstat`) path is unchanged.

### Resource-safety properties (the point of the issue)

- **Bounded per-file counting** — newlines counted via a fixed-size streaming buffer, never slurping the whole file; a per-file line cap stops counting beyond the cap and marks the count CAPPED/ESTIMATED.
- **Non-regular files skipped** — symlinks (not followed), FIFOs, sockets, devices, and directories are stat-checked and skipped; only regular files are line-counted.
- **Huge regular files** — files above a byte cap are recorded as "large, not line-counted" with their byte size (counted as capped), never slurped or full-scanned.
- **Binary detection** — a NUL byte within the first probe window classifies the file as binary; no bogus line counts for binaries.
- **Total untracked-file cap** — the scan stops after a capped number of untracked files and marks the report "untracked scan truncated (N+ files)"; the loop is always bounded.
- **EXACT vs CAPPED/ESTIMATED** — the report distinguishes exact totals from capped/estimated/truncated ones so a capped number is never mistaken for exact.
- **Fault tolerance** — a single unreadable / race-deleted untracked file (EACCES, deleted between `ls-files` and `stat`) is skipped, never aborting the review.

All caps are named constants with rationale comments.

## Streaming-bound enumeration (round-2 review finding — HIGH)

Round-1 review caught that the file-count cap was applied **after** the full untracked list had already been materialized: `list_untracked` ran `git ls-files --others --exclude-standard -z` via `Command::output()` (buffering ALL of git's stdout), built a `String`, and collected every path into a `Vec<PathBuf>` — only then did callers `.take(MAX_UNTRACKED_FILES)`. So a worktree with a huge untracked set still paid unbounded git enumeration + stdout buffering + allocation before the cap could help, defeating the issue's whole point. Fixed by bounding the **enumeration itself**:

- `git ls-files … -z` is now `spawn()`ed with piped stdout and read **incrementally** as a NUL-delimited stream, parsing one path at a time with a running count.
- Once `MAX_UNTRACKED_FILES` is reached, the truncation marker is set and the child is **terminated early** (stdout handle dropped, child killed + reaped) so git stops enumerating an arbitrarily large tree. Memory/path-Vec size is bounded to ~the cap regardless of working-tree size.
- Both consumers benefit through the shared helper (`untracked_diff_size` for the review report and `run_cmd_uncommitted::untracked_non_ignored_lines` for the writer-guard sizing).
- A regression test targets the enumeration boundary directly (a reader with far more than the cap of NUL-delimited entries stops early / stays bounded), not just post-collection truncation.

## Test coverage

- Non-regular files (symlink; FIFO under `#[cfg(unix)]`) are skipped, not followed.
- A regular file above the byte cap is recorded as large/capped, not line-counted (not slurped).
- A file with NUL bytes is classified binary (no bogus line count).
- More untracked files than the count cap → truncation marker set, loop bounded.
- Normal small text files report EXACT line counts.
- A single unreadable/race-deleted untracked file does not abort the scan.
- `just pre-commit` (fmt + clippy + nextest + token-budget) green.

## Boundaries

- Committed-range numstat reporting unchanged.
- Review verdict, escalation, and chunking logic untouched — this is a sizing/reporting feature only.
- No new un-redacted persisted surface: only counts/sizes/paths in the report, never file contents.

## Related

Split from the #1645 / #1796 diff-size work (origin: #1645 attention-dilution size report). Companion to the #1842 review-aware writer guard's untracked size-gating.

Refs #1818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
