### PR TITLE
test(cli-sub-agent): cover daemon-completion-packet finalize path in dead-active reconciler (#1855)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.893"
+version = "0.1.894"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.893"
+version = "0.1.894"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::test_env_lock::TEST_ENV_LOCK;
-use csa_session::{create_session, get_session_dir, load_result};
+use csa_session::{create_session, get_session_dir, load_result, load_session};
 use std::fs;
 use tokio::sync::OwnedMutexGuard;
 
@@ -94,6 +94,8 @@ fn synthesized_failure_summary_includes_post_mortem_diagnostics() {
     let session = create_session(project, Some("diagnostic-synthesis"), None, None).unwrap();
     let session_id = session.meta_session_id.clone();
     let session_dir = get_session_dir(project, &session_id).unwrap();
+    // Malformed TOML is intentional: strict packet parsing must fail so synthesis runs,
+    // while lenient diagnostics still surface the exit_code hint.
     fs::write(
         session_dir.join("daemon-completion.toml"),
         "exit_code = 137\nstatus = failure\n",
@@ -145,5 +147,61 @@ fn synthesized_failure_summary_includes_post_mortem_diagnostics() {
         result
             .summary
             .contains("acp_last_event={\"event\":\"last\"}")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_completion_packet_present_finalizes_dead_active_session() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session =
+        create_session(project, Some("diagnostic-daemon-completion"), None, None).unwrap();
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 137\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+    fs::write(session_dir.join("daemon.pid"), "424242 1\n").unwrap();
+    fs::write(
+        session_dir.join("stderr.log"),
+        "ACP transport failed: server shut down unexpectedly\nout of memory\n",
+    )
+    .unwrap();
+    fs::write(
+        session_dir.join("output.log"),
+        "[csa-heartbeat] ACP prompt still running: elapsed=44s idle=15s\n",
+    )
+    .unwrap();
+    fs::create_dir_all(session_dir.join("output")).unwrap();
+    fs::write(
+        session_dir.join("output").join("acp-events.jsonl"),
+        "{\"event\":\"last\"}\n",
+    )
+    .unwrap();
+    backdate_tree(&session_dir, 120);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session wait")
+            .unwrap();
+
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::DaemonCompletionFinalized
+    );
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("daemon completion result");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 137);
+    assert!(result.summary.contains("daemon completion recorded"));
+    let persisted = load_session(project, &session_id).unwrap();
+    assert_eq!(
+        persisted.termination_reason.as_deref(),
+        Some("daemon_completion")
     );
 }


### PR DESCRIPTION
## Summary

Completes the test coverage for the dead-active-session reconciler's daemon-completion-packet
precedence. Issues #1834/#1855/#1866 reported that
`session_cmds::reconcile::diagnostics_tests::synthesized_failure_summary_includes_post_mortem_diagnostics`
was deterministically red on `main`: the fixture seeded a valid `daemon-completion.toml` yet asserted
`SynthesizedFailure`, which became unreachable after `e2b5b2c0` (#1711) made the reconciler **prefer**
the packet (returning `DaemonCompletionFinalized`).

That red was already cleared on `main` by `a6757b3f` (an incidental change merged in PR #1871), which
made the fixture packet **intentionally malformed** (`status = failure`, an unquoted bareword) so the
strict `load_daemon_completion_packet` parse fails and the synthesize path is reached again, while the
lenient diagnostics gatherer still surfaces `daemon_completion_packet=exit_code=137`. The synthesize
path + all post-mortem diagnostics assertions are intact.

But that left a real gap: **the valid-packet → `DaemonCompletionFinalized` branch — the whole point of
#1711 — had zero test coverage** (a repo search for `DaemonCompletionFinalized` found only the enum
variant / match / production return, no test assertion). This PR closes that gap.

## What changed (test-only — no production behavior change)

- Adds a test asserting the reconciler returns `DeadActiveSessionReconciliation::DaemonCompletionFinalized`
  when a **valid** `daemon-completion.toml` packet is present for a dead-active session (the #1711
  precedence branch).
- Adds a regression-prevention comment on the existing synthesize test's intentionally-malformed
  packet fixture, so a future reader does not "fix" it back to valid TOML and silently re-break the
  test (re-introducing #1834/#1855/#1866).

## Verification

- New `DaemonCompletionFinalized` (valid-packet) test passes.
- Existing `synthesized_failure_summary_includes_post_mortem_diagnostics` test still passes.
- `cargo nextest run -p cli-sub-agent` reconcile module green.
- Full lefthook pre-commit gate (fmt + clippy + nextest + token-budget) green on the commit.

## Related

Closes #1834, #1855, #1866. Completes coverage for `e2b5b2c0` / #1711; follows the `a6757b3f` red-fix
that landed in #1871.
