### PR TITLE
feat(cli-sub-agent): auto-escalate large diffs to a heterogeneous reviewer panel (#1815)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.896"
+version = "0.1.897"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.894"
+version = "0.1.895"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.895"
+version = "0.1.896"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.894"
+version = "0.1.895"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.896"
+version = "0.1.897"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.895"
+version = "0.1.896"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -160,9 +160,8 @@ pub(crate) async fn handle_review(
     .await?;
 
     let scope = derive_scope_for_project(&args, &project_root);
-    let diff_size = diff_size::compute_review_diff_size(&project_root, &scope);
-    let large_diff_warning =
-        diff_size::warn_if_large_diff(diff_size.as_ref(), config.as_ref(), &global_config);
+    let diff = diff_size::compute_review_diff_size(&project_root, &scope);
+    let large_warn = diff_size::warn_if_large_diff(diff.as_ref(), config.as_ref(), &global_config);
     let mode = if args.fix {
         "review-and-fix"
     } else {
@@ -216,7 +215,7 @@ pub(crate) async fn handle_review(
         prompt.push_str(summary);
     }
 
-    diff_size::append_cross_dimension_anchor(&mut prompt, diff_size.as_ref(), large_diff_warning);
+    diff_size::append_cross_dimension_anchor(&mut prompt, diff.as_ref(), large_warn);
 
     let detected_parent_tool = crate::run_helpers::detect_parent_tool();
     let parent_tool = crate::run_helpers::resolve_tool(detected_parent_tool, &global_config);
@@ -309,6 +308,7 @@ pub(crate) async fn handle_review(
         explicit_reviewer_count: args.reviewers.is_some(),
         single: args.single,
         scope_is_range: args.range.is_some(),
+        large_diff_auto_escalation: large_warn.is_some(),
         explicit_tool: explicit_review_tool(&args),
         explicit_model_spec: args.model_spec.as_deref(),
         primary_tool: tool,
@@ -407,7 +407,7 @@ pub(crate) async fn handle_review(
         let auth_prompt_failure = resolved.auth_prompt_failure;
         print!(
             "{}",
-            diff_size::add_review_diff_size_line(&sanitized, diff_size.as_ref())
+            diff_size::add_review_diff_size_line(&sanitized, diff.as_ref())
         );
         debug!(verdict, decision = %decision, empty_output, "Review verdict (legacy + four-value)");
         let review_iterations = result
@@ -449,17 +449,13 @@ pub(crate) async fn handle_review(
             &project_root,
             &review_meta,
             result.persistable_session_id.as_deref(),
-            diff_size.as_ref(),
-            large_diff_warning,
+            diff.as_ref(),
+            large_warn,
         );
         let effective_exit_code = persisted_verdict_exit_code.unwrap_or(effective_exit_code);
         if let Some(session_id) = result.persistable_session_id.as_deref() {
             persist_review_result_exit_code(&project_root, session_id, effective_exit_code);
-            diff_size::persist_review_diff_size_headers(
-                &project_root,
-                session_id,
-                diff_size.as_ref(),
-            );
+            diff_size::persist_review_diff_size_headers(&project_root, session_id, diff.as_ref());
         }
         if verdict != CLEAN {
             dirty_tree::maybe_emit_dirty_tree_hint(
@@ -540,8 +536,8 @@ pub(crate) async fn handle_review(
             extra_readable: &args.extra_readable,
             timeout: args.timeout,
             diff_report: diff_size::ReviewDiffReport {
-                diff_size: diff_size.as_ref(),
-                large_diff_warning,
+                diff_size: diff.as_ref(),
+                large_diff_warning: large_warn,
             },
             project_root: &project_root,
             scope,
@@ -596,8 +592,8 @@ pub(crate) async fn handle_review(
         global_config: &global_config,
         pre_session_hook: pre_session_hook.clone(),
         review_routing,
-        diff_size: diff_size.as_ref(),
-        large_diff_warning,
+        diff_size: diff.as_ref(),
+        large_diff_warning: large_warn,
         review_model,
         resolved_model_spec,
         resolved_tier_name,

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -99,7 +99,7 @@ use resolve::{
 };
 use result_handling::resolve_single_review_result;
 #[rustfmt::skip]
-use reviewers::{ AutoReviewerRequest, resolve_effective_reviewer_count };
+use reviewers::resolve_effective_reviewer_selection_for_args;
 #[cfg(test)]
 #[rustfmt::skip]
 pub(crate) use { fix::persist_fix_final_artifacts_for_tests, output::persist_review_verdict_for_tests };
@@ -302,20 +302,15 @@ pub(crate) async fn handle_review(
 
     let readonly_project_root = global_config.review.readonly_sandbox.unwrap_or(false);
 
-    let requested_reviewers = args.requested_reviewers() as usize;
-    let reviewers = resolve_effective_reviewer_count(&AutoReviewerRequest {
-        requested_reviewers,
-        explicit_reviewer_count: args.reviewers.is_some(),
-        single: args.single,
-        scope_is_range: args.range.is_some(),
-        large_diff_auto_escalation: large_warn.is_some(),
-        explicit_tool: explicit_review_tool(&args),
-        explicit_model_spec: args.model_spec.as_deref(),
-        primary_tool: tool,
-        resolved_tier_name: resolved_tier_name.as_deref(),
-        config: config.as_ref(),
-        global_config: &global_config,
-    });
+    let reviewer_selection = resolve_effective_reviewer_selection_for_args(
+        &args,
+        large_warn.is_some(),
+        tool,
+        resolved_tier_name.as_deref(),
+        config.as_ref(),
+        &global_config,
+    );
+    let reviewers = reviewer_selection.reviewers;
 
     if reviewers == 1 {
         let review_future = execute_review_with_tier_filter(
@@ -584,6 +579,7 @@ pub(crate) async fn handle_review(
     multi::run_multi_reviewer_review(multi::MultiReviewerReviewContext {
         args: &args,
         reviewers,
+        selected_reviewer_tools: reviewer_selection.selected_tools,
         tool,
         prompt: &prompt,
         scope: &scope,

--- a/crates/cli-sub-agent/src/review_cmd_diff_size_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_diff_size_tests.rs
@@ -267,3 +267,20 @@ fn resolve_large_diff_warn_lines_uses_default_when_absent_and_project_override_w
         Some(0)
     );
 }
+
+#[test]
+fn large_diff_warn_lines_zero_disables_auto_escalation_signal() {
+    let project: ProjectConfig =
+        toml::from_str("schema_version = 1\n[review]\nlarge_diff_warn_lines = 0\n")
+            .expect("parse project config with disabled threshold");
+    let diff_size = ReviewDiffSize {
+        files: 4,
+        changed_lines: 10_000,
+        bytes: 65_536,
+        notes: Vec::new(),
+    };
+
+    let warning = warn_if_large_diff(Some(&diff_size), Some(&project), &GlobalConfig::default());
+
+    assert!(warning.is_none());
+}

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -53,6 +53,7 @@ impl ReviewArgs {
 pub(super) struct MultiReviewerReviewContext<'a> {
     pub args: &'a ReviewArgs,
     pub reviewers: usize,
+    pub selected_reviewer_tools: Option<Vec<ToolName>>,
     pub tool: ToolName,
     pub prompt: &'a str,
     pub scope: &'a str,
@@ -88,6 +89,7 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
     let consensus_strategy = parse_consensus_strategy(&ctx.args.consensus)?;
     let reviewer_pool = resolve_multi_reviewer_pool(
         ctx.reviewers,
+        ctx.selected_reviewer_tools.as_deref(),
         explicit_review_tool(ctx.args),
         ctx.tool,
         ctx.resolved_tier_name.as_deref(),

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
@@ -167,6 +167,20 @@ fn issue_1657_unavailable_reviewer_plus_clean_reviewer_passes() {
 }
 
 #[test]
+fn issue_1815_unavailable_auto_escalated_co_reviewer_plus_clean_reviewer_passes() {
+    let outcomes = vec![
+        reviewer_outcome(0, ToolName::Codex, crate::review_consensus::CLEAN, None),
+        reviewer_outcome(1, ToolName::GeminiCli, UNAVAILABLE, Some("quota exhausted")),
+    ];
+
+    let verdict =
+        parent_verdict_for_outcomes(&outcomes, crate::review_consensus::HAS_ISSUES, false);
+
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, crate::review_consensus::CLEAN);
+}
+
+#[test]
 fn issue_1657_unavailable_reviewer_plus_blocking_reviewer_fails() {
     let outcomes = vec![
         reviewer_outcome(0, ToolName::GeminiCli, UNAVAILABLE, Some("quota exhausted")),

--- a/crates/cli-sub-agent/src/review_cmd_reviewers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers.rs
@@ -17,6 +17,7 @@ pub(crate) struct AutoReviewerRequest<'a> {
     pub(crate) explicit_reviewer_count: bool,
     pub(crate) single: bool,
     pub(crate) scope_is_range: bool,
+    pub(crate) large_diff_auto_escalation: bool,
     pub(crate) explicit_tool: Option<ToolName>,
     pub(crate) explicit_model_spec: Option<&'a str>,
     pub(crate) primary_tool: ToolName,
@@ -94,6 +95,56 @@ fn build_selected_tool_subset(
     selected
 }
 
+fn build_auto_heterogeneous_tool_subset(
+    primary_tool: ToolName,
+    tier_reviewer_tools: &[ToolName],
+    reviewers: usize,
+) -> Vec<ToolName> {
+    let mut selected = vec![primary_tool];
+    let mut selected_families = vec![primary_tool.model_family()];
+    let mut same_family_candidates = Vec::new();
+
+    for tool in tier_reviewer_tools {
+        if selected.contains(tool) {
+            continue;
+        }
+
+        let family = tool.model_family();
+        if selected_families.contains(&family) {
+            same_family_candidates.push(*tool);
+        } else {
+            selected_families.push(family);
+            selected.push(*tool);
+            if selected.len() == reviewers {
+                return selected;
+            }
+        }
+    }
+
+    for tool in same_family_candidates {
+        if selected.len() == reviewers {
+            break;
+        }
+        selected.push(tool);
+    }
+
+    selected
+}
+
+fn has_at_least_two_model_families(tools: &[ToolName]) -> bool {
+    let mut families = Vec::new();
+    for tool in tools {
+        let family = tool.model_family();
+        if !families.contains(&family) {
+            families.push(family);
+            if families.len() >= 2 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 fn repeat_reviewer_pool(pool: &[ToolName], reviewer_count: usize) -> Vec<ToolName> {
     (0..reviewer_count)
         .map(|idx| pool[idx % pool.len()])
@@ -106,7 +157,7 @@ pub(crate) fn resolve_auto_reviewer_selection(
     if request.requested_reviewers != 1
         || request.explicit_reviewer_count
         || request.single
-        || !request.scope_is_range
+        || !(request.scope_is_range || request.large_diff_auto_escalation)
         || request.explicit_tool.is_some()
         || request.explicit_model_spec.is_some()
     {
@@ -119,18 +170,18 @@ pub(crate) fn resolve_auto_reviewer_selection(
         request.global_config,
     );
     let tier_reviewer_tools = collect_unique_tier_tools(&tier_reviewer_specs);
-    let preference_order = effective_review_tool_preferences(request.config, request.global_config);
-    let unique_pool = build_selected_tool_subset(
+    let unique_pool = build_auto_heterogeneous_tool_subset(
         request.primary_tool,
         &tier_reviewer_tools,
         MAX_AUTO_HETEROGENEOUS_REVIEWERS,
-        &preference_order,
     );
 
-    (unique_pool.len() >= 2).then_some(AutoReviewerSelection {
-        reviewers: unique_pool.len(),
-        selected_tools: unique_pool,
-    })
+    (unique_pool.len() >= 2 && has_at_least_two_model_families(&unique_pool)).then_some(
+        AutoReviewerSelection {
+            reviewers: unique_pool.len(),
+            selected_tools: unique_pool,
+        },
+    )
 }
 
 pub(crate) fn resolve_effective_reviewer_count(request: &AutoReviewerRequest<'_>) -> usize {
@@ -217,7 +268,8 @@ pub(crate) fn resolve_multi_reviewer_pool(
 #[cfg(test)]
 mod tests {
     use super::{
-        AutoReviewerRequest, resolve_auto_reviewer_selection, resolve_multi_reviewer_pool,
+        AutoReviewerRequest, resolve_auto_reviewer_selection, resolve_effective_reviewer_count,
+        resolve_multi_reviewer_pool,
     };
     use crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV;
     use crate::test_env_lock::TEST_ENV_LOCK;
@@ -339,6 +391,17 @@ mod tests {
         config
     }
 
+    fn distinct_model_family_count(tools: &[ToolName]) -> usize {
+        let mut families = Vec::new();
+        for tool in tools {
+            let family = tool.model_family();
+            if !families.contains(&family) {
+                families.push(family);
+            }
+        }
+        families.len()
+    }
+
     #[test]
     fn auto_reviewer_selection_skips_single_tool_tier() {
         let (_env_lock, _available_guard) = assume_review_tools_available();
@@ -350,6 +413,7 @@ mod tests {
             explicit_reviewer_count: false,
             single: false,
             scope_is_range: true,
+            large_diff_auto_escalation: false,
             explicit_tool: None,
             explicit_model_spec: None,
             primary_tool: ToolName::Codex,
@@ -377,6 +441,7 @@ mod tests {
             explicit_reviewer_count: false,
             single: false,
             scope_is_range: true,
+            large_diff_auto_escalation: false,
             explicit_tool: None,
             explicit_model_spec: None,
             primary_tool: ToolName::GeminiCli,
@@ -390,6 +455,39 @@ mod tests {
         assert_eq!(
             selection.selected_tools,
             vec![ToolName::GeminiCli, ToolName::Codex, ToolName::Opencode]
+        );
+        assert_eq!(distinct_model_family_count(&selection.selected_tools), 3);
+    }
+
+    #[test]
+    fn large_diff_auto_escalation_selects_heterogeneous_reviewers_for_non_range_scope() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier(&[
+            "codex/openai/gpt-5.4/high",
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        ]);
+        let global = GlobalConfig::default();
+
+        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+            requested_reviewers: 1,
+            explicit_reviewer_count: false,
+            single: false,
+            scope_is_range: false,
+            large_diff_auto_escalation: true,
+            explicit_tool: None,
+            explicit_model_spec: None,
+            primary_tool: ToolName::Codex,
+            resolved_tier_name: Some("quality"),
+            config: Some(&config),
+            global_config: &global,
+        })
+        .expect("large non-range diff should auto-select heterogeneous reviewers");
+
+        assert!(selection.reviewers >= 2);
+        assert!(distinct_model_family_count(&selection.selected_tools) >= 2);
+        assert_eq!(
+            selection.selected_tools,
+            vec![ToolName::Codex, ToolName::GeminiCli]
         );
     }
 
@@ -440,6 +538,7 @@ mod tests {
             explicit_reviewer_count: false,
             single: true,
             scope_is_range: true,
+            large_diff_auto_escalation: true,
             explicit_tool: None,
             explicit_model_spec: None,
             primary_tool: ToolName::Codex,
@@ -465,6 +564,7 @@ mod tests {
             explicit_reviewer_count: true,
             single: false,
             scope_is_range: true,
+            large_diff_auto_escalation: true,
             explicit_tool: None,
             explicit_model_spec: None,
             primary_tool: ToolName::Codex,
@@ -474,6 +574,33 @@ mod tests {
         });
 
         assert!(selection.is_none());
+    }
+
+    #[test]
+    fn large_diff_auto_escalation_respects_explicit_reviewer_count() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier(&[
+            "codex/openai/gpt-5.4/high",
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "opencode/openrouter/sonnet/high",
+        ]);
+        let global = GlobalConfig::default();
+
+        let reviewers = resolve_effective_reviewer_count(&AutoReviewerRequest {
+            requested_reviewers: 2,
+            explicit_reviewer_count: true,
+            single: false,
+            scope_is_range: false,
+            large_diff_auto_escalation: true,
+            explicit_tool: None,
+            explicit_model_spec: None,
+            primary_tool: ToolName::Codex,
+            resolved_tier_name: Some("quality"),
+            config: Some(&config),
+            global_config: &global,
+        });
+
+        assert_eq!(reviewers, 2);
     }
 
     #[test]
@@ -490,6 +617,7 @@ mod tests {
             explicit_reviewer_count: false,
             single: false,
             scope_is_range: true,
+            large_diff_auto_escalation: true,
             explicit_tool: None,
             explicit_model_spec: Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
             primary_tool: ToolName::Codex,
@@ -515,9 +643,36 @@ mod tests {
             explicit_reviewer_count: false,
             single: false,
             scope_is_range: true,
+            large_diff_auto_escalation: true,
             explicit_tool: Some(ToolName::Codex),
             explicit_model_spec: None,
             primary_tool: ToolName::Codex,
+            resolved_tier_name: Some("quality"),
+            config: Some(&config),
+            global_config: &global,
+        });
+
+        assert!(selection.is_none());
+    }
+
+    #[test]
+    fn large_diff_auto_escalation_requires_two_model_families() {
+        let (_env_lock, _available_guard) = assume_review_tools_available();
+        let config = project_config_with_tier(&[
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "antigravity-cli/google/gemini-3.1-pro-preview/xhigh",
+        ]);
+        let global = GlobalConfig::default();
+
+        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+            requested_reviewers: 1,
+            explicit_reviewer_count: false,
+            single: false,
+            scope_is_range: false,
+            large_diff_auto_escalation: true,
+            explicit_tool: None,
+            explicit_model_spec: None,
+            primary_tool: ToolName::GeminiCli,
             resolved_tier_name: Some("quality"),
             config: Some(&config),
             global_config: &global,
@@ -540,6 +695,7 @@ mod tests {
             explicit_reviewer_count: false,
             single: false,
             scope_is_range: false,
+            large_diff_auto_escalation: false,
             explicit_tool: None,
             explicit_model_spec: None,
             primary_tool: ToolName::Codex,

--- a/crates/cli-sub-agent/src/review_cmd_reviewers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use tracing::{info, warn};
 
+use crate::cli::ReviewArgs;
 use crate::review_consensus::{build_reviewer_tools, validate_multi_reviewer_tier_pool};
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::ToolName;
@@ -10,6 +11,11 @@ const MAX_AUTO_HETEROGENEOUS_REVIEWERS: usize = 3;
 pub(crate) struct AutoReviewerSelection {
     pub(crate) reviewers: usize,
     pub(crate) selected_tools: Vec<ToolName>,
+}
+
+pub(crate) struct EffectiveReviewerSelection {
+    pub(crate) reviewers: usize,
+    pub(crate) selected_tools: Option<Vec<ToolName>>,
 }
 
 pub(crate) struct AutoReviewerRequest<'a> {
@@ -184,7 +190,9 @@ pub(crate) fn resolve_auto_reviewer_selection(
     )
 }
 
-pub(crate) fn resolve_effective_reviewer_count(request: &AutoReviewerRequest<'_>) -> usize {
+pub(crate) fn resolve_effective_reviewer_selection(
+    request: &AutoReviewerRequest<'_>,
+) -> EffectiveReviewerSelection {
     let auto_reviewer_selection = resolve_auto_reviewer_selection(request);
     if let Some(selection) = auto_reviewer_selection {
         let tool_list = selection
@@ -201,14 +209,44 @@ pub(crate) fn resolve_effective_reviewer_count(request: &AutoReviewerRequest<'_>
                 .unwrap_or("no tier name resolved"),
             tool_list
         );
-        selection.reviewers
+        EffectiveReviewerSelection {
+            reviewers: selection.reviewers,
+            selected_tools: Some(selection.selected_tools),
+        }
     } else {
-        request.requested_reviewers
+        EffectiveReviewerSelection {
+            reviewers: request.requested_reviewers,
+            selected_tools: None,
+        }
     }
+}
+
+pub(crate) fn resolve_effective_reviewer_selection_for_args(
+    args: &ReviewArgs,
+    large_diff_auto_escalation: bool,
+    primary_tool: ToolName,
+    resolved_tier_name: Option<&str>,
+    config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+) -> EffectiveReviewerSelection {
+    resolve_effective_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: args.requested_reviewers() as usize,
+        explicit_reviewer_count: args.reviewers.is_some(),
+        single: args.single,
+        scope_is_range: args.range.is_some(),
+        large_diff_auto_escalation,
+        explicit_tool: super::prior_rounds::explicit_review_tool(args),
+        explicit_model_spec: args.model_spec.as_deref(),
+        primary_tool,
+        resolved_tier_name,
+        config,
+        global_config,
+    })
 }
 
 pub(crate) fn resolve_multi_reviewer_pool(
     reviewers: usize,
+    selected_reviewer_tools: Option<&[ToolName]>,
     explicit_tool: Option<ToolName>,
     primary_tool: ToolName,
     resolved_tier_name: Option<&str>,
@@ -237,7 +275,9 @@ pub(crate) fn resolve_multi_reviewer_pool(
         }
     }
 
-    let reviewer_tools = if resolved_tier_name.is_some() && explicit_tool.is_none() {
+    let reviewer_tools = if let Some(selected_tools) = selected_reviewer_tools {
+        selected_tools.to_vec()
+    } else if resolved_tier_name.is_some() && explicit_tool.is_none() {
         let pool = build_selected_tool_subset(
             primary_tool,
             &tier_reviewer_tools,
@@ -266,444 +306,5 @@ pub(crate) fn resolve_multi_reviewer_pool(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{
-        AutoReviewerRequest, resolve_auto_reviewer_selection, resolve_effective_reviewer_count,
-        resolve_multi_reviewer_pool,
-    };
-    use crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV;
-    use crate::test_env_lock::TEST_ENV_LOCK;
-    use csa_config::config::TierConfig;
-    use csa_config::{
-        GlobalConfig, ProjectConfig, ProjectMeta, ResourcesConfig, ReviewConfig, TierStrategy,
-        ToolConfig, ToolSelection,
-    };
-    use csa_core::types::ToolName;
-    use std::collections::HashMap;
-    use tokio::sync::OwnedMutexGuard;
-
-    struct ScopedEnvVarRestore {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    impl ScopedEnvVarRestore {
-        fn set(key: &'static str, value: &str) -> Self {
-            let original = std::env::var(key).ok();
-            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, original }
-        }
-    }
-
-    impl Drop for ScopedEnvVarRestore {
-        fn drop(&mut self) {
-            // SAFETY: restoration of test-scoped env mutation.
-            unsafe {
-                match self.original.take() {
-                    Some(value) => std::env::set_var(self.key, value),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
-    }
-
-    fn assume_review_tools_available() -> (OwnedMutexGuard<()>, ScopedEnvVarRestore) {
-        (
-            TEST_ENV_LOCK.clone().blocking_lock_owned(),
-            ScopedEnvVarRestore::set(TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1"),
-        )
-    }
-
-    fn project_config_with_tier(models: &[&str]) -> ProjectConfig {
-        let mut tool_map = HashMap::new();
-        for tool in csa_config::global::all_known_tools() {
-            tool_map.insert(
-                tool.as_str().to_string(),
-                ToolConfig {
-                    enabled: false,
-                    restrictions: None,
-                    suppress_notify: true,
-                    ..Default::default()
-                },
-            );
-        }
-
-        for tool_name in models.iter().filter_map(|model| model.split('/').next()) {
-            tool_map.insert(
-                tool_name.to_string(),
-                ToolConfig {
-                    enabled: true,
-                    restrictions: None,
-                    suppress_notify: true,
-                    ..Default::default()
-                },
-            );
-        }
-
-        let mut tiers = HashMap::new();
-        tiers.insert(
-            "quality".to_string(),
-            TierConfig {
-                description: "Test tier".to_string(),
-                models: models.iter().map(|model| (*model).to_string()).collect(),
-                strategy: TierStrategy::default(),
-                token_budget: None,
-                max_turns: None,
-            },
-        );
-
-        ProjectConfig {
-            schema_version: 1,
-            project: ProjectMeta::default(),
-            resources: ResourcesConfig::default(),
-            acp: Default::default(),
-            tools: tool_map,
-            review: None,
-            debate: None,
-            tiers,
-            tier_mapping: HashMap::new(),
-            aliases: HashMap::new(),
-            tool_aliases: HashMap::new(),
-            preferences: None,
-            github: None,
-            session: Default::default(),
-            memory: Default::default(),
-            hooks: Default::default(),
-            run: Default::default(),
-            execution: Default::default(),
-            session_wait: None,
-            preflight: Default::default(),
-            vcs: Default::default(),
-            filesystem_sandbox: Default::default(),
-        }
-    }
-
-    fn project_config_with_tier_and_review_tool(
-        models: &[&str],
-        tool: ToolSelection,
-    ) -> ProjectConfig {
-        let mut config = project_config_with_tier(models);
-        config.review = Some(ReviewConfig {
-            tool,
-            ..ReviewConfig::default()
-        });
-        config
-    }
-
-    fn distinct_model_family_count(tools: &[ToolName]) -> usize {
-        let mut families = Vec::new();
-        for tool in tools {
-            let family = tool.model_family();
-            if !families.contains(&family) {
-                families.push(family);
-            }
-        }
-        families.len()
-    }
-
-    #[test]
-    fn auto_reviewer_selection_skips_single_tool_tier() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier(&["codex/openai/gpt-5.4/high"]);
-        let global = GlobalConfig::default();
-
-        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
-            requested_reviewers: 1,
-            explicit_reviewer_count: false,
-            single: false,
-            scope_is_range: true,
-            large_diff_auto_escalation: false,
-            explicit_tool: None,
-            explicit_model_spec: None,
-            primary_tool: ToolName::Codex,
-            resolved_tier_name: Some("quality"),
-            config: Some(&config),
-            global_config: &global,
-        });
-
-        assert!(selection.is_none());
-    }
-
-    #[test]
-    fn auto_reviewer_selection_uses_all_distinct_tier_tools_up_to_cap() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier(&[
-            "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-            "opencode/openrouter/sonnet/high",
-            "claude-code/anthropic/sonnet/xhigh",
-        ]);
-        let global = GlobalConfig::default();
-
-        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
-            requested_reviewers: 1,
-            explicit_reviewer_count: false,
-            single: false,
-            scope_is_range: true,
-            large_diff_auto_escalation: false,
-            explicit_tool: None,
-            explicit_model_spec: None,
-            primary_tool: ToolName::GeminiCli,
-            resolved_tier_name: Some("quality"),
-            config: Some(&config),
-            global_config: &global,
-        })
-        .expect("multi-tool tier should auto-select reviewers");
-
-        assert_eq!(selection.reviewers, 3);
-        assert_eq!(
-            selection.selected_tools,
-            vec![ToolName::GeminiCli, ToolName::Codex, ToolName::Opencode]
-        );
-        assert_eq!(distinct_model_family_count(&selection.selected_tools), 3);
-    }
-
-    #[test]
-    fn large_diff_auto_escalation_selects_heterogeneous_reviewers_for_non_range_scope() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier(&[
-            "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-        ]);
-        let global = GlobalConfig::default();
-
-        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
-            requested_reviewers: 1,
-            explicit_reviewer_count: false,
-            single: false,
-            scope_is_range: false,
-            large_diff_auto_escalation: true,
-            explicit_tool: None,
-            explicit_model_spec: None,
-            primary_tool: ToolName::Codex,
-            resolved_tier_name: Some("quality"),
-            config: Some(&config),
-            global_config: &global,
-        })
-        .expect("large non-range diff should auto-select heterogeneous reviewers");
-
-        assert!(selection.reviewers >= 2);
-        assert!(distinct_model_family_count(&selection.selected_tools) >= 2);
-        assert_eq!(
-            selection.selected_tools,
-            vec![ToolName::Codex, ToolName::GeminiCli]
-        );
-    }
-
-    #[test]
-    fn auto_range_reviewer_roster_prefers_review_tool_without_filtering_tier() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier_and_review_tool(
-            &[
-                "codex/openai/gpt-5.4/high",
-                "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-            ],
-            ToolSelection::Whitelist(vec!["codex".to_string()]),
-        );
-        let global = GlobalConfig::default();
-
-        let pool = resolve_multi_reviewer_pool(
-            2,
-            None,
-            ToolName::Codex,
-            Some("quality"),
-            Some(&config),
-            &global,
-        )
-        .expect("preferred single-tool roster should resolve");
-
-        assert_eq!(
-            pool.reviewer_tools,
-            vec![ToolName::Codex, ToolName::GeminiCli]
-        );
-        assert!(
-            pool.tier_reviewer_specs
-                .iter()
-                .any(|resolution| resolution.tool == ToolName::GeminiCli)
-        );
-    }
-
-    #[test]
-    fn auto_reviewer_selection_respects_single_flag() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier(&[
-            "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-        ]);
-        let global = GlobalConfig::default();
-
-        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
-            requested_reviewers: 1,
-            explicit_reviewer_count: false,
-            single: true,
-            scope_is_range: true,
-            large_diff_auto_escalation: true,
-            explicit_tool: None,
-            explicit_model_spec: None,
-            primary_tool: ToolName::Codex,
-            resolved_tier_name: Some("quality"),
-            config: Some(&config),
-            global_config: &global,
-        });
-
-        assert!(selection.is_none());
-    }
-
-    #[test]
-    fn auto_reviewer_selection_respects_explicit_reviewer_override() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier(&[
-            "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-        ]);
-        let global = GlobalConfig::default();
-
-        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
-            requested_reviewers: 1,
-            explicit_reviewer_count: true,
-            single: false,
-            scope_is_range: true,
-            large_diff_auto_escalation: true,
-            explicit_tool: None,
-            explicit_model_spec: None,
-            primary_tool: ToolName::Codex,
-            resolved_tier_name: Some("quality"),
-            config: Some(&config),
-            global_config: &global,
-        });
-
-        assert!(selection.is_none());
-    }
-
-    #[test]
-    fn large_diff_auto_escalation_respects_explicit_reviewer_count() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier(&[
-            "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-            "opencode/openrouter/sonnet/high",
-        ]);
-        let global = GlobalConfig::default();
-
-        let reviewers = resolve_effective_reviewer_count(&AutoReviewerRequest {
-            requested_reviewers: 2,
-            explicit_reviewer_count: true,
-            single: false,
-            scope_is_range: false,
-            large_diff_auto_escalation: true,
-            explicit_tool: None,
-            explicit_model_spec: None,
-            primary_tool: ToolName::Codex,
-            resolved_tier_name: Some("quality"),
-            config: Some(&config),
-            global_config: &global,
-        });
-
-        assert_eq!(reviewers, 2);
-    }
-
-    #[test]
-    fn auto_reviewer_selection_respects_explicit_model_spec_override() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier(&[
-            "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-        ]);
-        let global = GlobalConfig::default();
-
-        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
-            requested_reviewers: 1,
-            explicit_reviewer_count: false,
-            single: false,
-            scope_is_range: true,
-            large_diff_auto_escalation: true,
-            explicit_tool: None,
-            explicit_model_spec: Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
-            primary_tool: ToolName::Codex,
-            resolved_tier_name: Some("quality"),
-            config: Some(&config),
-            global_config: &global,
-        });
-
-        assert!(selection.is_none());
-    }
-
-    #[test]
-    fn auto_reviewer_selection_respects_explicit_tool_override() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier(&[
-            "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-        ]);
-        let global = GlobalConfig::default();
-
-        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
-            requested_reviewers: 1,
-            explicit_reviewer_count: false,
-            single: false,
-            scope_is_range: true,
-            large_diff_auto_escalation: true,
-            explicit_tool: Some(ToolName::Codex),
-            explicit_model_spec: None,
-            primary_tool: ToolName::Codex,
-            resolved_tier_name: Some("quality"),
-            config: Some(&config),
-            global_config: &global,
-        });
-
-        assert!(selection.is_none());
-    }
-
-    #[test]
-    fn large_diff_auto_escalation_requires_two_model_families() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier(&[
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-            "antigravity-cli/google/gemini-3.1-pro-preview/xhigh",
-        ]);
-        let global = GlobalConfig::default();
-
-        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
-            requested_reviewers: 1,
-            explicit_reviewer_count: false,
-            single: false,
-            scope_is_range: false,
-            large_diff_auto_escalation: true,
-            explicit_tool: None,
-            explicit_model_spec: None,
-            primary_tool: ToolName::GeminiCli,
-            resolved_tier_name: Some("quality"),
-            config: Some(&config),
-            global_config: &global,
-        });
-
-        assert!(selection.is_none());
-    }
-
-    #[test]
-    fn auto_reviewer_selection_skips_non_range_scope() {
-        let (_env_lock, _available_guard) = assume_review_tools_available();
-        let config = project_config_with_tier(&[
-            "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-        ]);
-        let global = GlobalConfig::default();
-
-        let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
-            requested_reviewers: 1,
-            explicit_reviewer_count: false,
-            single: false,
-            scope_is_range: false,
-            large_diff_auto_escalation: false,
-            explicit_tool: None,
-            explicit_model_spec: None,
-            primary_tool: ToolName::Codex,
-            resolved_tier_name: Some("quality"),
-            config: Some(&config),
-            global_config: &global,
-        });
-
-        assert!(selection.is_none());
-    }
-}
+#[path = "review_cmd_reviewers_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/review_cmd_reviewers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers.rs
@@ -22,6 +22,8 @@ pub(crate) struct AutoReviewerRequest<'a> {
     pub(crate) requested_reviewers: usize,
     pub(crate) explicit_reviewer_count: bool,
     pub(crate) single: bool,
+    pub(crate) fix: bool,
+    pub(crate) session_present: bool,
     pub(crate) scope_is_range: bool,
     pub(crate) large_diff_auto_escalation: bool,
     pub(crate) explicit_tool: Option<ToolName>,
@@ -163,6 +165,8 @@ pub(crate) fn resolve_auto_reviewer_selection(
     if request.requested_reviewers != 1
         || request.explicit_reviewer_count
         || request.single
+        || request.fix
+        || request.session_present
         || !(request.scope_is_range || request.large_diff_auto_escalation)
         || request.explicit_tool.is_some()
         || request.explicit_model_spec.is_some()
@@ -233,6 +237,8 @@ pub(crate) fn resolve_effective_reviewer_selection_for_args(
         requested_reviewers: args.requested_reviewers() as usize,
         explicit_reviewer_count: args.reviewers.is_some(),
         single: args.single,
+        fix: args.fix,
+        session_present: args.session.is_some(),
         scope_is_range: args.range.is_some(),
         large_diff_auto_escalation,
         explicit_tool: super::prior_rounds::explicit_review_tool(args),

--- a/crates/cli-sub-agent/src/review_cmd_reviewers_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers_tests.rs
@@ -1,0 +1,489 @@
+use super::{
+    AutoReviewerRequest, resolve_auto_reviewer_selection, resolve_effective_reviewer_selection,
+    resolve_multi_reviewer_pool,
+};
+use crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV;
+use crate::test_env_lock::TEST_ENV_LOCK;
+use csa_config::config::TierConfig;
+use csa_config::{
+    GlobalConfig, ProjectConfig, ProjectMeta, ResourcesConfig, ReviewConfig, TierStrategy,
+    ToolConfig, ToolSelection,
+};
+use csa_core::types::ToolName;
+use std::collections::HashMap;
+use tokio::sync::OwnedMutexGuard;
+
+struct ScopedEnvVarRestore {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl ScopedEnvVarRestore {
+    fn set(key: &'static str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for ScopedEnvVarRestore {
+    fn drop(&mut self) {
+        // SAFETY: restoration of test-scoped env mutation.
+        unsafe {
+            match self.original.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn assume_review_tools_available() -> (OwnedMutexGuard<()>, ScopedEnvVarRestore) {
+    (
+        TEST_ENV_LOCK.clone().blocking_lock_owned(),
+        ScopedEnvVarRestore::set(TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1"),
+    )
+}
+
+fn project_config_with_tier(models: &[&str]) -> ProjectConfig {
+    let mut tool_map = HashMap::new();
+    for tool in csa_config::global::all_known_tools() {
+        tool_map.insert(
+            tool.as_str().to_string(),
+            ToolConfig {
+                enabled: false,
+                restrictions: None,
+                suppress_notify: true,
+                ..Default::default()
+            },
+        );
+    }
+
+    for tool_name in models.iter().filter_map(|model| model.split('/').next()) {
+        tool_map.insert(
+            tool_name.to_string(),
+            ToolConfig {
+                enabled: true,
+                restrictions: None,
+                suppress_notify: true,
+                ..Default::default()
+            },
+        );
+    }
+
+    let mut tiers = HashMap::new();
+    tiers.insert(
+        "quality".to_string(),
+        TierConfig {
+            description: "Test tier".to_string(),
+            models: models.iter().map(|model| (*model).to_string()).collect(),
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+
+    ProjectConfig {
+        schema_version: 1,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: tool_map,
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        github: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    }
+}
+
+fn project_config_with_tier_and_review_tool(models: &[&str], tool: ToolSelection) -> ProjectConfig {
+    let mut config = project_config_with_tier(models);
+    config.review = Some(ReviewConfig {
+        tool,
+        ..ReviewConfig::default()
+    });
+    config
+}
+
+fn distinct_model_family_count(tools: &[ToolName]) -> usize {
+    let mut families = Vec::new();
+    for tool in tools {
+        let family = tool.model_family();
+        if !families.contains(&family) {
+            families.push(family);
+        }
+    }
+    families.len()
+}
+
+#[test]
+fn auto_reviewer_selection_skips_single_tool_tier() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&["codex/openai/gpt-5.4/high"]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: false,
+        single: false,
+        scope_is_range: true,
+        large_diff_auto_escalation: false,
+        explicit_tool: None,
+        explicit_model_spec: None,
+        primary_tool: ToolName::Codex,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    });
+
+    assert!(selection.is_none());
+}
+
+#[test]
+fn auto_reviewer_selection_uses_all_distinct_tier_tools_up_to_cap() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "codex/openai/gpt-5.4/high",
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        "opencode/openrouter/sonnet/high",
+        "claude-code/anthropic/sonnet/xhigh",
+    ]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: false,
+        single: false,
+        scope_is_range: true,
+        large_diff_auto_escalation: false,
+        explicit_tool: None,
+        explicit_model_spec: None,
+        primary_tool: ToolName::GeminiCli,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    })
+    .expect("multi-tool tier should auto-select reviewers");
+
+    assert_eq!(selection.reviewers, 3);
+    assert_eq!(
+        selection.selected_tools,
+        vec![ToolName::GeminiCli, ToolName::Codex, ToolName::Opencode]
+    );
+    assert_eq!(distinct_model_family_count(&selection.selected_tools), 3);
+}
+
+#[test]
+fn large_diff_auto_escalation_selects_heterogeneous_reviewers_for_non_range_scope() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "codex/openai/gpt-5.4/high",
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+    ]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: false,
+        single: false,
+        scope_is_range: false,
+        large_diff_auto_escalation: true,
+        explicit_tool: None,
+        explicit_model_spec: None,
+        primary_tool: ToolName::Codex,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    })
+    .expect("large non-range diff should auto-select heterogeneous reviewers");
+
+    assert!(selection.reviewers >= 2);
+    assert!(distinct_model_family_count(&selection.selected_tools) >= 2);
+    assert_eq!(
+        selection.selected_tools,
+        vec![ToolName::Codex, ToolName::GeminiCli]
+    );
+}
+
+#[test]
+fn auto_range_reviewer_roster_prefers_review_tool_without_filtering_tier() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier_and_review_tool(
+        &[
+            "codex/openai/gpt-5.4/high",
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        ],
+        ToolSelection::Whitelist(vec!["codex".to_string()]),
+    );
+    let global = GlobalConfig::default();
+
+    let pool = resolve_multi_reviewer_pool(
+        2,
+        None,
+        None,
+        ToolName::Codex,
+        Some("quality"),
+        Some(&config),
+        &global,
+    )
+    .expect("preferred single-tool roster should resolve");
+
+    assert_eq!(
+        pool.reviewer_tools,
+        vec![ToolName::Codex, ToolName::GeminiCli]
+    );
+    assert!(
+        pool.tier_reviewer_specs
+            .iter()
+            .any(|resolution| resolution.tool == ToolName::GeminiCli)
+    );
+}
+
+fn assert_auto_execution_uses_selected_heterogeneous_roster(large_diff_auto_escalation: bool) {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        "antigravity-cli/google/gemini-3.1-pro-preview/xhigh",
+        "codex/openai/gpt-5.4/high",
+    ]);
+    let global = GlobalConfig::default();
+    let effective = resolve_effective_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: false,
+        single: false,
+        scope_is_range: !large_diff_auto_escalation,
+        large_diff_auto_escalation,
+        explicit_tool: None,
+        explicit_model_spec: None,
+        primary_tool: ToolName::GeminiCli,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    });
+    let selected_tools = effective
+        .selected_tools
+        .expect("auto path should carry the roster");
+    assert_eq!(effective.reviewers, selected_tools.len());
+    let pool = resolve_multi_reviewer_pool(
+        effective.reviewers,
+        Some(&selected_tools),
+        None,
+        ToolName::GeminiCli,
+        Some("quality"),
+        Some(&config),
+        &global,
+    )
+    .expect("auto-selected reviewer roster should resolve for execution");
+    let same_family_pair = [ToolName::GeminiCli, ToolName::AntigravityCli];
+    assert_eq!(pool.reviewer_tools, selected_tools);
+    assert!(distinct_model_family_count(&pool.reviewer_tools) >= 2);
+    assert_eq!(
+        &pool.reviewer_tools[..2],
+        [ToolName::GeminiCli, ToolName::Codex].as_slice()
+    );
+    assert_ne!(&pool.reviewer_tools[..2], same_family_pair.as_slice());
+}
+
+#[test]
+fn auto_execution_uses_selected_heterogeneous_reviewer_roster_for_range_and_large_diff() {
+    assert_auto_execution_uses_selected_heterogeneous_roster(false);
+    assert_auto_execution_uses_selected_heterogeneous_roster(true);
+}
+
+#[test]
+fn auto_reviewer_selection_respects_single_flag() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "codex/openai/gpt-5.4/high",
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+    ]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: false,
+        single: true,
+        scope_is_range: true,
+        large_diff_auto_escalation: true,
+        explicit_tool: None,
+        explicit_model_spec: None,
+        primary_tool: ToolName::Codex,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    });
+
+    assert!(selection.is_none());
+}
+
+#[test]
+fn auto_reviewer_selection_respects_explicit_reviewer_override() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "codex/openai/gpt-5.4/high",
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+    ]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: true,
+        single: false,
+        scope_is_range: true,
+        large_diff_auto_escalation: true,
+        explicit_tool: None,
+        explicit_model_spec: None,
+        primary_tool: ToolName::Codex,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    });
+
+    assert!(selection.is_none());
+}
+
+#[test]
+fn large_diff_auto_escalation_respects_explicit_reviewer_count() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "codex/openai/gpt-5.4/high",
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        "opencode/openrouter/sonnet/high",
+    ]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_effective_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 2,
+        explicit_reviewer_count: true,
+        single: false,
+        scope_is_range: false,
+        large_diff_auto_escalation: true,
+        explicit_tool: None,
+        explicit_model_spec: None,
+        primary_tool: ToolName::Codex,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    });
+
+    assert_eq!(selection.reviewers, 2);
+    assert!(selection.selected_tools.is_none());
+}
+
+#[test]
+fn auto_reviewer_selection_respects_explicit_model_spec_override() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "codex/openai/gpt-5.4/high",
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+    ]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: false,
+        single: false,
+        scope_is_range: true,
+        large_diff_auto_escalation: true,
+        explicit_tool: None,
+        explicit_model_spec: Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        primary_tool: ToolName::Codex,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    });
+
+    assert!(selection.is_none());
+}
+
+#[test]
+fn auto_reviewer_selection_respects_explicit_tool_override() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "codex/openai/gpt-5.4/high",
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+    ]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: false,
+        single: false,
+        scope_is_range: true,
+        large_diff_auto_escalation: true,
+        explicit_tool: Some(ToolName::Codex),
+        explicit_model_spec: None,
+        primary_tool: ToolName::Codex,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    });
+
+    assert!(selection.is_none());
+}
+
+#[test]
+fn large_diff_auto_escalation_requires_two_model_families() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        "antigravity-cli/google/gemini-3.1-pro-preview/xhigh",
+    ]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: false,
+        single: false,
+        scope_is_range: false,
+        large_diff_auto_escalation: true,
+        explicit_tool: None,
+        explicit_model_spec: None,
+        primary_tool: ToolName::GeminiCli,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    });
+
+    assert!(selection.is_none());
+}
+
+#[test]
+fn auto_reviewer_selection_skips_non_range_scope() {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "codex/openai/gpt-5.4/high",
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+    ]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: false,
+        single: false,
+        scope_is_range: false,
+        large_diff_auto_escalation: false,
+        explicit_tool: None,
+        explicit_model_spec: None,
+        primary_tool: ToolName::Codex,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    });
+
+    assert!(selection.is_none());
+}

--- a/crates/cli-sub-agent/src/review_cmd_reviewers_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers_tests.rs
@@ -140,6 +140,8 @@ fn auto_reviewer_selection_skips_single_tool_tier() {
         requested_reviewers: 1,
         explicit_reviewer_count: false,
         single: false,
+        fix: false,
+        session_present: false,
         scope_is_range: true,
         large_diff_auto_escalation: false,
         explicit_tool: None,
@@ -168,6 +170,8 @@ fn auto_reviewer_selection_uses_all_distinct_tier_tools_up_to_cap() {
         requested_reviewers: 1,
         explicit_reviewer_count: false,
         single: false,
+        fix: false,
+        session_present: false,
         scope_is_range: true,
         large_diff_auto_escalation: false,
         explicit_tool: None,
@@ -200,6 +204,8 @@ fn large_diff_auto_escalation_selects_heterogeneous_reviewers_for_non_range_scop
         requested_reviewers: 1,
         explicit_reviewer_count: false,
         single: false,
+        fix: false,
+        session_present: false,
         scope_is_range: false,
         large_diff_auto_escalation: true,
         explicit_tool: None,
@@ -217,6 +223,44 @@ fn large_diff_auto_escalation_selects_heterogeneous_reviewers_for_non_range_scop
         selection.selected_tools,
         vec![ToolName::Codex, ToolName::GeminiCli]
     );
+}
+
+fn assert_large_diff_auto_escalation_stays_single_reviewer(fix: bool, session_present: bool) {
+    let (_env_lock, _available_guard) = assume_review_tools_available();
+    let config = project_config_with_tier(&[
+        "codex/openai/gpt-5.4/high",
+        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+    ]);
+    let global = GlobalConfig::default();
+
+    let selection = resolve_effective_reviewer_selection(&AutoReviewerRequest {
+        requested_reviewers: 1,
+        explicit_reviewer_count: false,
+        single: false,
+        fix,
+        session_present,
+        scope_is_range: false,
+        large_diff_auto_escalation: true,
+        explicit_tool: None,
+        explicit_model_spec: None,
+        primary_tool: ToolName::Codex,
+        resolved_tier_name: Some("quality"),
+        config: Some(&config),
+        global_config: &global,
+    });
+
+    assert_eq!(selection.reviewers, 1);
+    assert!(selection.selected_tools.is_none());
+}
+
+#[test]
+fn large_diff_auto_escalation_keeps_fix_on_single_reviewer_path() {
+    assert_large_diff_auto_escalation_stays_single_reviewer(true, false);
+}
+
+#[test]
+fn large_diff_auto_escalation_keeps_session_on_single_reviewer_path() {
+    assert_large_diff_auto_escalation_stays_single_reviewer(false, true);
 }
 
 #[test]
@@ -265,6 +309,8 @@ fn assert_auto_execution_uses_selected_heterogeneous_roster(large_diff_auto_esca
         requested_reviewers: 1,
         explicit_reviewer_count: false,
         single: false,
+        fix: false,
+        session_present: false,
         scope_is_range: !large_diff_auto_escalation,
         large_diff_auto_escalation,
         explicit_tool: None,
@@ -317,6 +363,8 @@ fn auto_reviewer_selection_respects_single_flag() {
         requested_reviewers: 1,
         explicit_reviewer_count: false,
         single: true,
+        fix: false,
+        session_present: false,
         scope_is_range: true,
         large_diff_auto_escalation: true,
         explicit_tool: None,
@@ -343,6 +391,8 @@ fn auto_reviewer_selection_respects_explicit_reviewer_override() {
         requested_reviewers: 1,
         explicit_reviewer_count: true,
         single: false,
+        fix: false,
+        session_present: false,
         scope_is_range: true,
         large_diff_auto_escalation: true,
         explicit_tool: None,
@@ -370,6 +420,8 @@ fn large_diff_auto_escalation_respects_explicit_reviewer_count() {
         requested_reviewers: 2,
         explicit_reviewer_count: true,
         single: false,
+        fix: false,
+        session_present: false,
         scope_is_range: false,
         large_diff_auto_escalation: true,
         explicit_tool: None,
@@ -397,6 +449,8 @@ fn auto_reviewer_selection_respects_explicit_model_spec_override() {
         requested_reviewers: 1,
         explicit_reviewer_count: false,
         single: false,
+        fix: false,
+        session_present: false,
         scope_is_range: true,
         large_diff_auto_escalation: true,
         explicit_tool: None,
@@ -423,6 +477,8 @@ fn auto_reviewer_selection_respects_explicit_tool_override() {
         requested_reviewers: 1,
         explicit_reviewer_count: false,
         single: false,
+        fix: false,
+        session_present: false,
         scope_is_range: true,
         large_diff_auto_escalation: true,
         explicit_tool: Some(ToolName::Codex),
@@ -449,6 +505,8 @@ fn large_diff_auto_escalation_requires_two_model_families() {
         requested_reviewers: 1,
         explicit_reviewer_count: false,
         single: false,
+        fix: false,
+        session_present: false,
         scope_is_range: false,
         large_diff_auto_escalation: true,
         explicit_tool: None,
@@ -475,6 +533,8 @@ fn auto_reviewer_selection_skips_non_range_scope() {
         requested_reviewers: 1,
         explicit_reviewer_count: false,
         single: false,
+        fix: false,
+        session_present: false,
         scope_is_range: false,
         large_diff_auto_escalation: false,
         explicit_tool: None,


### PR DESCRIPTION
## Summary

Implements #1815: `csa review` now auto-escalates a **large committed diff** from a single reviewer
to a **heterogeneous multi-reviewer panel**. #1645 already shipped diff-size measurement, the
`review.large_diff_warn_lines` threshold, the large-diff warning, and multi-reviewer machinery — but
the warning only *suggested* heterogeneous review; there was no size→reviewer-count link. This PR adds
that link (a surgical delta, reusing the existing threshold and selection/consensus code).

## What changed

- `AutoReviewerRequest` gains a `large_diff_auto_escalation` flag; `review_cmd` passes
  `large_diff_warning.is_some()` into reviewer-count resolution.
- `resolve_auto_reviewer_selection` now auto-selects a panel when `scope_is_range ||
  large_diff_auto_escalation`, preferring reviewers with **distinct `ToolName::model_family()`** and
  requiring at least two families.
- **Reuses `review.large_diff_warn_lines`** as the escalation trigger (default 1000; `0` disables) —
  no new config field, no drift from the #1645 warning / #1841 gating that already use it.
- Cap unchanged: `MAX_AUTO_HETEROGENEOUS_REVIEWERS = 3`.

## Precedence (explicit overrides always win)

- `--single` and `--reviewers N` → honored, escalation suppressed.
- `--tool X` / `--model-spec ...` → exact pin, escalation suppressed (via existing
  `explicit_model_spec`).
- `--no-failover` **alone** does not suppress a panel (it is a runtime retry policy, not a count
  override); `--model-spec --no-failover` stays suppressed as an exact pin.

## Graceful degrade

If escalation cannot assemble ≥2 distinct model families, CSA falls back to the normal single
reviewer (with a status note) — **not** `UNAVAILABLE`/`FAIL`. Runtime reviewer unavailability keeps
reusing the existing `ReviewerOutcome { verdict: UNAVAILABLE }` + consensus-exclusion semantics
(no regression to #1761/#1832/#1852).

## Verification

Unit tests cover: above-threshold non-range diff escalates to ≥2 heterogeneous reviewers;
below-threshold stays single; `--single` / explicit `--reviewers` / `--tool` / `--model-spec`
suppress; above-threshold-but-single-family degrades to single (not UNAVAILABLE/FAIL); unavailable
co-reviewer with another reviewer PASS does not force a false FAIL; `large_diff_warn_lines = 0`
disables size escalation. Full lefthook pre-commit gate (fmt + clippy + nextest + token-budget) green.

## Review-round corrections (pre-PR review caught two integration bugs)

- **R1 (heterogeneity loss):** the heterogeneously-selected roster was reduced to a count and then
  rebuilt by tier order, so a same-family pair (e.g. `[gemini-cli, antigravity-cli]`) could execute
  instead of the selected distinct-family set. Fixed by threading the selected roster through to
  execution (selected == executed) + a `[gemini-cli, antigravity-cli, codex]` regression test.
- **R2 (`--fix`/`--session` routing regression):** auto-escalation expanded the auto-select path from
  `--range`-only to any large diff, which could route the single-reviewer-only `--fix` / `--session`
  modes into the multi-reviewer runner (which rejects them) — failing the review before any reviewer
  ran. Fixed by modeling `fix` / `session_present` in `AutoReviewerRequest` and suppressing escalation
  for those modes at the same precedence as `--single` + regression tests.

## Related

Closes #1815. Parent #1796; origin #1645 (size report + multi-reviewer machinery this builds on).
Chunked/hierarchical large-diff review (#1816) is tracked separately as a new review mode.
