### PR TITLE
fix(cli-sub-agent): classify gemini non-interactive OAuth error as tool-unavailable for tier failover (#1867)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.897"
+version = "0.1.898"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.897"
+version = "0.1.898"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/failover_trace.rs
+++ b/crates/cli-sub-agent/src/failover_trace.rs
@@ -23,6 +23,8 @@ use csa_core::types::{FallbackAttempt, ToolName, provider_for_tool_name};
 /// undetected / errored tools.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FailoverSkipKind {
+    /// Authentication is unavailable in non-interactive mode.
+    AuthUnavailable,
     /// OAuth / subscription quota exhausted (e.g. gemini "monthly spending cap").
     OauthQuota,
     /// Provider returned an HTTP 429 / rate-limit marker.
@@ -40,10 +42,11 @@ pub(crate) enum FailoverSkipKind {
 }
 
 impl FailoverSkipKind {
-    /// Stable, machine-readable category string (kebab-case). This is what the
-    /// orchestrator parses out of the fallback chain.
+    /// Stable, machine-readable category string. This is what the orchestrator
+    /// parses out of the fallback chain.
     pub(crate) const fn category(self) -> &'static str {
         match self {
+            Self::AuthUnavailable => "auth_unavailable",
             Self::OauthQuota => "oauth-quota",
             Self::RateLimit429 => "rate-limit-429",
             Self::Disabled => "disabled",
@@ -94,7 +97,10 @@ impl FailoverSkipKind {
         // narrowly first via the canonical detector, then a bare `oauth` marker.
         // A generic "quota" substring is deliberately NOT treated as permanent
         // here — that is the transient class handled below.
-        if csa_core::gemini::detect_permanent_quota_exhaustion_pattern(&lower).is_some()
+        if lower.contains("auth_unavailable") || lower.contains("manual authorization is required")
+        {
+            Self::AuthUnavailable
+        } else if csa_core::gemini::detect_permanent_quota_exhaustion_pattern(&lower).is_some()
             || lower.contains("oauth")
         {
             Self::OauthQuota

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -26,7 +26,9 @@ use csa_session::{
 };
 use tracing::{info, warn};
 
-use crate::review_routing::{ReviewRoutingMetadata, persist_review_routing_artifact};
+use crate::review_routing::{
+    ReviewRoutingMetadata, persist_review_routing_artifact_with_fallback_chain,
+};
 use crate::startup_env::StartupSubtreeEnv;
 use crate::tier_model_fallback::{
     TierAttemptFailure, chain_failure_reasons, classify_next_model_failure_with_elapsed,
@@ -409,18 +411,7 @@ pub(crate) async fn execute_review_with_tier_filter(
                         &err,
                     );
                     if let Some(session_id) = extract_meta_session_id_from_error(&err) {
-                        persist_fallback_result_fields(
-                            project_root,
-                            &session_id,
-                            tool,
-                            *attempt_tool,
-                            fallback_reason_for_result(&failures),
-                        );
-                        persist_fallback_chain(
-                            project_root,
-                            &session_id,
-                            tool,
-                            *attempt_tool,
+                        let fallback_chain =
                             crate::tier_model_fallback::build_fallback_chain_for_result(
                                 project_config,
                                 tier_name.as_deref(),
@@ -429,7 +420,26 @@ pub(crate) async fn execute_review_with_tier_filter(
                                 // the full chain.
                                 None,
                                 &tier_preference_order,
-                            ),
+                            );
+                        persist_fallback_result_fields(
+                            project_root,
+                            &session_id,
+                            tool,
+                            *attempt_tool,
+                            fallback_reason_for_result(&failures),
+                        );
+                        persist_review_routing_artifact_with_fallback_chain(
+                            project_root,
+                            &session_id,
+                            &review_routing,
+                            &fallback_chain,
+                        );
+                        persist_fallback_chain(
+                            project_root,
+                            &session_id,
+                            tool,
+                            *attempt_tool,
+                            fallback_chain,
                         );
                     }
                     let failure_reason = format_all_models_failed_reason_with_reset(
@@ -471,7 +481,6 @@ pub(crate) async fn execute_review_with_tier_filter(
             }
         };
 
-        persist_review_routing_artifact(project_root, &execution.meta_session_id, &review_routing);
         repair_completed_review_restriction_result(project_root, *attempt_tool, &mut execution)?;
 
         let mut status_reason = None;
@@ -527,11 +536,6 @@ pub(crate) async fn execute_review_with_tier_filter(
                         return Err(err);
                     }
                 };
-                persist_review_routing_artifact(
-                    project_root,
-                    &retried.meta_session_id,
-                    &review_routing,
-                );
                 repair_completed_review_restriction_result(
                     project_root,
                     *attempt_tool,
@@ -605,19 +609,26 @@ pub(crate) async fn execute_review_with_tier_filter(
                     *attempt_tool,
                     fallback_reason_for_result(&failures),
                 );
+                let fallback_chain = crate::tier_model_fallback::build_fallback_chain_for_result(
+                    project_config,
+                    tier_name.as_deref(),
+                    &failures,
+                    // Every tier model failed: no winner, persist full chain.
+                    None,
+                    &tier_preference_order,
+                );
+                persist_review_routing_artifact_with_fallback_chain(
+                    project_root,
+                    &execution.meta_session_id,
+                    &review_routing,
+                    &fallback_chain,
+                );
                 persist_fallback_chain(
                     project_root,
                     &execution.meta_session_id,
                     tool,
                     *attempt_tool,
-                    crate::tier_model_fallback::build_fallback_chain_for_result(
-                        project_config,
-                        tier_name.as_deref(),
-                        &failures,
-                        // Every tier model failed: no winner, persist full chain.
-                        None,
-                        &tier_preference_order,
-                    ),
+                    fallback_chain,
                 );
                 let persistable_session_id = Some(execution.meta_session_id.clone());
                 return Ok(ReviewExecutionOutcome {
@@ -650,21 +661,28 @@ pub(crate) async fn execute_review_with_tier_filter(
             *attempt_tool,
             fallback_reason_for_result(&failures),
         );
+        let fallback_chain = crate::tier_model_fallback::build_fallback_chain_for_result(
+            project_config,
+            tier_name.as_deref(),
+            &failures,
+            // The winning model: bounds the persisted chain to before-winner
+            // skips so a first-choice success omits never-reached tier
+            // models (#1714).
+            attempt_model_spec.as_deref(),
+            &tier_preference_order,
+        );
+        persist_review_routing_artifact_with_fallback_chain(
+            project_root,
+            &execution.meta_session_id,
+            &review_routing,
+            &fallback_chain,
+        );
         persist_fallback_chain(
             project_root,
             &execution.meta_session_id,
             tool,
             *attempt_tool,
-            crate::tier_model_fallback::build_fallback_chain_for_result(
-                project_config,
-                tier_name.as_deref(),
-                &failures,
-                // The winning model: bounds the persisted chain to before-winner
-                // skips so a first-choice success omits never-reached tier
-                // models (#1714).
-                attempt_model_spec.as_deref(),
-                &tier_preference_order,
-            ),
+            fallback_chain,
         );
         let routed_to = (attempt_tool != &tool
             || attempt_model_spec.as_deref() != tier_model_spec.as_deref())

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
@@ -26,6 +26,10 @@ fn config_with_review_tier(enabled_tools: &[&str], models: &[&str]) -> csa_confi
     config
 }
 
+const GEMINI_MANUAL_AUTHORIZATION_STDERR: &str = "\
+Error: Manual authorization is required. \
+Please run the Gemini CLI in an interactive terminal to log in.";
+
 #[test]
 fn build_failover_chain_records_build_time_exclusions_without_runtime_failures() {
     let _available_guard =
@@ -255,6 +259,134 @@ async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metad
         persisted.fallback_reason.as_deref(),
         Some("429_quota_exhausted")
     );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn execute_review_falls_back_from_gemini_manual_auth_to_codex_and_persists_routing_chain() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if which::which("bwrap").is_err() {
+        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
+        return;
+    }
+
+    let project_dir = setup_git_repo();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    let bin_dir = project_dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+
+    std::fs::write(
+        bin_dir.join("gemini"),
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf '%s\\n' '{GEMINI_MANUAL_AUTHORIZATION_STDERR}' >&2\nexit 1\n"
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        bin_dir.join("codex"),
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-cli 1.0.0\\n'\n  exit 0\nfi\nprintf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS' '<!-- CSA:SECTION:summary:END -->' '<!-- CSA:SECTION:details -->' 'No blocking issues found.' '<!-- CSA:SECTION:details:END -->'\n",
+    )
+    .unwrap();
+    for binary in ["gemini", "codex"] {
+        let path = bin_dir.join(binary);
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+    let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
+
+    let config = config_with_review_tier(
+        &["gemini-cli", "codex"],
+        &[
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "codex/openai/gpt-5.4/high",
+        ],
+    );
+    let global = GlobalConfig::default();
+
+    let result = execute_review(
+        ToolName::GeminiCli,
+        "scope=uncommitted mode=review-only security=auto".to_string(),
+        None,
+        None,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string()),
+        Some("quality".to_string()),
+        true,
+        None,
+        "review: manual-auth-tier-fallback-success".to_string(),
+        project_dir.path(),
+        Some(&config),
+        &global,
+        None,
+        ReviewRoutingMetadata {
+            project_profile: ProjectProfile::Unknown,
+            detection_method: "auto",
+        },
+        csa_process::StreamMode::BufferOnly,
+        crate::pipeline::DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        &[],
+        &[],
+        Some(false),
+    )
+    .await
+    .expect("manual-auth tier fallback should succeed");
+
+    assert_eq!(result.executed_tool, ToolName::Codex);
+    assert_eq!(
+        result.routed_to.as_deref(),
+        Some("codex/openai/gpt-5.4/high")
+    );
+    assert!(result.forced_decision.is_none());
+    assert!(result.status_reason.is_none());
+    assert!(result.primary_failure.is_none());
+    assert!(result.failure_reason.is_none());
+
+    let session_dir =
+        csa_session::get_session_dir(project_dir.path(), &result.execution.meta_session_id)
+            .unwrap();
+    let persisted = csa_session::load_result(project_dir.path(), &result.execution.meta_session_id)
+        .unwrap()
+        .expect("result.toml should exist");
+    assert_eq!(persisted.original_tool.as_deref(), Some("gemini-cli"));
+    assert_eq!(persisted.fallback_tool.as_deref(), Some("codex"));
+    assert!(
+        persisted.fallback_reason.is_none(),
+        "legacy fallback_reason stays quota-only; auth provenance lives in fallback_chain"
+    );
+    let fallback_chain = persisted
+        .fallback_chain
+        .as_ref()
+        .expect("result fallback_chain");
+    assert_eq!(fallback_chain.len(), 1);
+    assert_eq!(fallback_chain[0].tool, "gemini-cli");
+    assert_eq!(
+        fallback_chain[0].model_spec.as_deref(),
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
+    );
+    assert_eq!(fallback_chain[0].skip_reason, "auth_unavailable");
+    assert!(!fallback_chain[0].quota_exhausted);
+
+    let routing_json =
+        std::fs::read_to_string(session_dir.join("output").join("review-routing.json")).unwrap();
+    let routing: serde_json::Value =
+        serde_json::from_str(&routing_json).expect("review-routing json");
+    let routing_chain = routing["fallback_chain"]
+        .as_array()
+        .expect("routing fallback_chain array");
+    assert_eq!(routing_chain.len(), 1);
+    assert_eq!(routing_chain[0]["tool"], "gemini-cli");
+    assert_eq!(routing_chain[0]["skip_reason"], "auth_unavailable");
+    assert_eq!(routing_chain[0]["quota_exhausted"], false);
 }
 
 #[cfg(unix)]
@@ -509,6 +641,124 @@ async fn execute_review_marks_unavailable_when_all_tier_models_fail() {
     );
     assert!(failure_reason.contains("codex/openai/gpt-5.4/high=HTTP 401"));
     assert!(failure_reason.contains("claude-code/anthropic/claude-sonnet/high=HTTP 403"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn execute_review_manual_auth_then_codex_unavailable_stays_unavailable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if which::which("bwrap").is_err() {
+        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
+        return;
+    }
+
+    let project_dir = setup_git_repo();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    let bin_dir = project_dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+
+    std::fs::write(
+        bin_dir.join("gemini"),
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf '%s\\n' '{GEMINI_MANUAL_AUTHORIZATION_STDERR}' >&2\nexit 1\n"
+        ),
+    )
+    .unwrap();
+    for binary in ["codex", "codex-acp"] {
+        std::fs::write(
+            bin_dir.join(binary),
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-cli 1.0.0\\n'\n  exit 0\nfi\nprintf 'HTTP 401 Invalid API key\\n' >&2\nexit 1\n",
+        )
+        .unwrap();
+    }
+    for binary in ["gemini", "codex", "codex-acp"] {
+        let path = bin_dir.join(binary);
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+    let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
+
+    let config = config_with_review_tier(
+        &["gemini-cli", "codex"],
+        &[
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "codex/openai/gpt-5.4/high",
+        ],
+    );
+    let global = GlobalConfig::default();
+
+    let result = execute_review(
+        ToolName::GeminiCli,
+        "scope=uncommitted mode=review-only security=auto".to_string(),
+        None,
+        None,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string()),
+        Some("quality".to_string()),
+        true,
+        None,
+        "review: manual-auth-tier-all-failed".to_string(),
+        project_dir.path(),
+        Some(&config),
+        &global,
+        None,
+        ReviewRoutingMetadata {
+            project_profile: ProjectProfile::Unknown,
+            detection_method: "auto",
+        },
+        csa_process::StreamMode::BufferOnly,
+        crate::pipeline::DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        &[],
+        &[],
+        Some(false),
+    )
+    .await
+    .expect("all-failed fallback should return an unavailable outcome");
+
+    assert_eq!(result.executed_tool, ToolName::Codex);
+    assert_eq!(result.forced_decision, Some(ReviewDecision::Unavailable));
+    assert_eq!(
+        result.status_reason.as_deref(),
+        Some("tier_models_unavailable")
+    );
+    assert!(result.routed_to.is_none());
+    assert_ne!(result.execution.execution.exit_code, 0);
+    let primary_failure = result.primary_failure.as_deref().expect("primary_failure");
+    assert!(primary_failure.contains("auth_unavailable"));
+    assert!(primary_failure.contains("HTTP 401"));
+    let failure_reason = result.failure_reason.as_deref().expect("failure_reason");
+    assert!(
+        failure_reason.contains("gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable")
+    );
+    assert!(failure_reason.contains("codex/openai/gpt-5.4/high=HTTP 401"));
+
+    let session_dir =
+        csa_session::get_session_dir(project_dir.path(), &result.execution.meta_session_id)
+            .unwrap();
+    let routing_json =
+        std::fs::read_to_string(session_dir.join("output").join("review-routing.json")).unwrap();
+    let routing: serde_json::Value =
+        serde_json::from_str(&routing_json).expect("review-routing json");
+    let routing_chain = routing["fallback_chain"]
+        .as_array()
+        .expect("routing fallback_chain array");
+    assert_eq!(routing_chain.len(), 2);
+    assert_eq!(routing_chain[0]["tool"], "gemini-cli");
+    assert_eq!(routing_chain[0]["skip_reason"], "auth_unavailable");
+    assert_eq!(routing_chain[0]["quota_exhausted"], false);
+    assert_eq!(routing_chain[1]["tool"], "codex");
+    assert_eq!(routing_chain[1]["skip_reason"], "attempted-and-errored");
+    assert_eq!(routing_chain[1]["quota_exhausted"], false);
 }
 
 #[cfg(unix)]

--- a/crates/cli-sub-agent/src/review_routing.rs
+++ b/crates/cli-sub-agent/src/review_routing.rs
@@ -22,19 +22,6 @@ pub(crate) fn detect_review_routing_metadata(
     }
 }
 
-pub(crate) fn persist_review_routing_artifact(
-    project_root: &Path,
-    meta_session_id: &str,
-    review_routing: &ReviewRoutingMetadata,
-) {
-    persist_review_routing_artifact_with_fallback_chain(
-        project_root,
-        meta_session_id,
-        review_routing,
-        &[],
-    );
-}
-
 pub(crate) fn persist_review_routing_artifact_with_fallback_chain(
     project_root: &Path,
     meta_session_id: &str,

--- a/crates/cli-sub-agent/src/tier_model_fallback_tests.rs
+++ b/crates/cli-sub-agent/src/tier_model_fallback_tests.rs
@@ -196,6 +196,9 @@ codex/openai/gpt-5.5/xhigh=HTTP 429; earliest_reset=1h 0m"
 /// The exact stderr gemini-cli emits when its key is rejected mid-run (a 400
 /// from inside `ModelRouterService.route` once a session is established).
 const GEMINI_400_API_KEY_INVALID_STDERR: &str = r#"Error talking to Gemini API in ModelRouterService.route: _ApiError: {"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"API_KEY_INVALID","domain":"googleapis.com"}]}}"#;
+const GEMINI_MANUAL_AUTHORIZATION_STDERR: &str = "\
+Error: Manual authorization is required. \
+Please run the Gemini CLI in an interactive terminal to log in.";
 
 #[test]
 fn issue_1848_midrun_gemini_api_key_invalid_advances_past_init_window() {
@@ -215,6 +218,35 @@ fn issue_1848_midrun_gemini_api_key_invalid_advances_past_init_window() {
     assert_eq!(detected.reason, "auth_unavailable");
     assert!(detected.advance_to_next_model);
     assert!(!detected.quota_exhausted);
+}
+
+#[test]
+fn issue_1867_midrun_gemini_manual_authorization_advances_past_init_window() {
+    let detected = classify_next_model_failure_with_elapsed(
+        "gemini-cli",
+        GEMINI_MANUAL_AUTHORIZATION_STDERR,
+        "",
+        1,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        Some(Duration::from_secs(39)),
+    )
+    .expect("mid-run manual auth prompt must advance to the next tier candidate (#1867)");
+    assert_eq!(detected.reason, "auth_unavailable");
+    assert!(detected.advance_to_next_model);
+    assert!(!detected.quota_exhausted);
+
+    let generic_400 = classify_next_model_failure_with_elapsed(
+        "gemini-cli",
+        "Error: request failed with status: 400 Bad Request (malformed request payload)",
+        "",
+        1,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        Some(Duration::from_secs(39)),
+    );
+    assert!(
+        generic_400.is_none(),
+        "a generic non-auth 400 past the init window must remain gated (#1736)"
+    );
 }
 
 #[test]

--- a/crates/csa-scheduler/src/rate_limit.rs
+++ b/crates/csa-scheduler/src/rate_limit.rs
@@ -207,6 +207,18 @@ fn patterns_for_tool(tool: &str) -> &'static [FailoverPattern] {
                 quota_exhausted: false,
             },
             FailoverPattern {
+                pattern: "manual authorization is required",
+                reason: "auth_unavailable",
+                advance_to_next_model: true,
+                quota_exhausted: false,
+            },
+            FailoverPattern {
+                pattern: "please run the gemini cli in an interactive terminal to log in",
+                reason: "auth_unavailable",
+                advance_to_next_model: true,
+                quota_exhausted: false,
+            },
+            FailoverPattern {
                 pattern: "monthly spending cap",
                 reason: "QUOTA_EXHAUSTED",
                 advance_to_next_model: true,

--- a/crates/csa-scheduler/src/rate_limit_tests.rs
+++ b/crates/csa-scheduler/src/rate_limit_tests.rs
@@ -95,6 +95,27 @@ fn test_gemini_oauth_browser_prompt_is_auth_unavailable_failover() {
 }
 
 #[test]
+fn test_gemini_manual_authorization_required_is_auth_unavailable_failover() {
+    let stderr = "\
+Error: Manual authorization is required. \
+Please run the Gemini CLI in an interactive terminal to log in.";
+    let detected = detect_rate_limit(
+        "gemini-cli",
+        stderr,
+        "",
+        1,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+    )
+    .expect("manual authorization prompt should classify");
+
+    assert_eq!(detected.matched_pattern, "auth_unavailable");
+    assert_eq!(detected.reason, "auth_unavailable");
+    assert!(detected.advance_to_next_model);
+    assert!(!detected.quota_exhausted);
+    assert!(!requires_init_failure_window(&detected));
+}
+
+#[test]
 fn issue_1719_quota_and_auth_failover_are_transient_and_sanitized() {
     let cases = [
         ("reason: QUOTA_EXHAUSTED", "rate-limit-429", "HTTP 429"),


### PR DESCRIPTION
## Summary

Fixes #1867: `csa review` (and `debate`/`run`, which share the classifier) now treats gemini-cli's
non-interactive **"Manual authorization is required"** OAuth error as **tool-unavailable**, so tier
failover advances to the codex candidate instead of exiting `UNCERTAIN` in ~3s without ever trying the
fallback the tier + `[review].tool` whitelist make available.

This restores the operator contract: *tier-4 gemini reviews; when gemini is unavailable, CSA
auto-falls-back to codex.* An autonomous burn-down orchestrator relying on gemini→codex auto-fallback
is no longer hard-blocked by a mid-run gemini OAuth credential lapse.

## Root cause

Same error-classification family as #1714 / #1736 / #1648 / #1848. The shared scheduler classifier
(`csa_scheduler::detect_rate_limit`) recognized 429 / quota / `api key not valid` (#1848) markers but
**not** gemini's interactive-OAuth-required / non-interactive-auth error, so that error fell through as
a generic terminal failure instead of advancing the tier chain. The review path already routes both
pre-completion and completed-nonzero errors through this classifier (via
`classify_next_model_failure_with_elapsed`), so the fix is a **small delta** to the shared classifier
plus routing-artifact wiring — no new failover plumbing.

## What changed

- **`csa-scheduler/src/rate_limit.rs`** — two new gemini/antigravity `FailoverPattern`s mapping
  `"manual authorization is required"` and `"please run the gemini cli in an interactive terminal to
  log in"` to `auth_unavailable` (`advance_to_next_model: true`, `quota_exhausted: false`). **No**
  generic `status 400` / `http 400` / `oauth` / ADC markers were added — generic HTTP 400 stays
  intentionally init-window-gated. (#179's `status:400` OAuth-cap variant is out of scope, left to #179.)
- **`cli-sub-agent/src/failover_trace.rs`** — `FailoverSkipKind::classify` now maps the
  auth-unavailable reason to a stable machine-readable `skip_reason = "auth_unavailable"` (was falling
  through to `attempted-and-errored`), so the fallback chain records the real reason.
- **`cli-sub-agent/src/review_cmd_execute.rs`** — single-review now persists the gemini→codex
  `fallback_chain` to `output/review-routing.json` (matching multi-review), in both the
  successful-fallback and all-candidates-failed paths; the previously-transient empty-chain write is
  deferred until after chain construction.

## Invariants preserved (regression surface)

- **#1832 total-exhaustion** — gemini-auth + codex-also-unavailable still returns
  `ReviewDecision::Unavailable` / `tier_models_unavailable` (fail-closed, NOT a clean verdict).
- **#1761 clean-review-mergeable** — a *successful* codex fallback keeps `status_reason` /
  `primary_failure` / `failure_reason` empty, so the verdict is accepted and merge-able.
- **#1852 provenance** — success path keeps `primary_failure: None`; provenance lives only in
  `fallback_chain` / `routed_to` / legacy `fallback_reason`.
- **#648 soft-preference** — `[review].tool` remains a soft preference; codex stays a reachable tier
  candidate.

## Verification

New tests: scheduler classifies the captured manual-auth stderr as `auth_unavailable`
(advance, not quota, not init-window-gated); tier helper advances manual-auth past the 39s init window
while generic 400 stays gated; review integration test (gemini manual-auth → codex clean PASS) asserts
`executed_tool == Codex`, `primary_failure.is_none()`, and `result.toml` + `review-routing.json`
fallback chains record `gemini-cli` with `skip_reason == "auth_unavailable"`; total-exhaustion test
(gemini manual-auth + codex unavailable) asserts forced `Unavailable`. Full lefthook pre-commit gate
(fmt + clippy + nextest + token-budget) green.

## Related

Closes #1867. Same family as #1714 / #1736 / #1648 / #1848 (run/plan path). #179 (gemini `status:400`
OAuth-cap no-failover) remains a separate, related issue.
