### PR TITLE
fix(cli-sub-agent): prevent mid-flight session dir deletion + side-effect-free dry-run (#1870)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.898"
+version = "0.1.899"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.898"
+version = "0.1.899"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -8,7 +8,7 @@ use csa_core::types::OutputFormat;
 use csa_resource::cleanup_orphan_scopes;
 use csa_session::{
     MetaSessionState, SessionPhase, delete_session, get_session_dir, get_session_root,
-    list_sessions, save_session_in,
+    list_sessions, list_sessions_readonly, save_session_in,
 };
 
 mod auto_gc;
@@ -119,7 +119,11 @@ pub(crate) fn handle_gc(
 ) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(cd)?;
     let session_root = get_session_root(&project_root)?;
-    let sessions = list_sessions(&project_root, None)?;
+    let sessions = if dry_run {
+        list_sessions_readonly(&project_root, None)?
+    } else {
+        list_sessions(&project_root, None)?
+    };
     let gc_config = GcConfig::load_for_project(&project_root)?;
     let now = chrono::Utc::now();
     let runtime_reap_max_age_days =
@@ -248,7 +252,11 @@ pub(crate) fn handle_gc(
     let session_root = csa_session::get_session_root(&project_root)?;
     let rotation_path = session_root.join("rotation.toml");
     if rotation_path.exists() {
-        let remaining = list_sessions(&project_root, None)?;
+        let remaining = if dry_run {
+            list_sessions_readonly(&project_root, None)?
+        } else {
+            list_sessions(&project_root, None)?
+        };
         if remaining.is_empty() {
             if dry_run {
                 eprintln!("[dry-run] Would remove rotation state: {rotation_path:?}");

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -7,7 +7,8 @@ use csa_config::{GcConfig, GlobalConfig};
 use csa_core::types::OutputFormat;
 use csa_resource::cleanup_orphan_scopes;
 use csa_session::{
-    delete_session, get_session_dir, get_session_root, list_sessions, save_session_in,
+    MetaSessionState, SessionPhase, delete_session, get_session_dir, get_session_root,
+    list_sessions, save_session_in,
 };
 
 mod auto_gc;
@@ -39,6 +40,22 @@ const RUNTIME_DIR_NAME: &str = "runtime";
 const ORPHAN_SLOT_GRACE_SECS: i64 = 30;
 
 pub(crate) type RuntimeReapStats = reaper::RuntimeReapStats;
+
+pub(crate) fn should_skip_whole_session_delete(
+    session: &MetaSessionState,
+    session_dir: &Path,
+) -> bool {
+    session.phase == SessionPhase::Active
+        || csa_process::ToolLiveness::has_live_process(session_dir)
+        || csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
+        || csa_process::ToolLiveness::is_alive(session_dir)
+}
+
+pub(crate) fn should_skip_orphan_session_dir_delete(session_dir: &Path) -> bool {
+    csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
+        || csa_process::ToolLiveness::has_live_process(session_dir)
+        || csa_process::ToolLiveness::is_alive(session_dir)
+}
 
 pub(crate) fn handle_gc_args(
     args: GcArgs,
@@ -132,6 +149,11 @@ pub(crate) fn handle_gc(
                     session.meta_session_id
                 );
                 empty_sessions_removed += 1;
+            } else if should_skip_whole_session_delete(session, &session_dir) {
+                info!(
+                    session = %session.meta_session_id,
+                    "Skipped whole-session delete for Active or live session"
+                );
             } else if delete_session(&project_root, &session.meta_session_id).is_ok() {
                 empty_sessions_removed += 1;
             }
@@ -183,6 +205,11 @@ pub(crate) fn handle_gc(
                     age.num_days()
                 );
                 expired_sessions_removed += 1;
+            } else if should_skip_whole_session_delete(session, &session_dir) {
+                info!(
+                    session = %session.meta_session_id,
+                    "Skipped expired whole-session delete for Active or live session"
+                );
             } else if delete_session(&project_root, &session.meta_session_id).is_ok() {
                 info!("Removed expired session: {}", session.meta_session_id);
                 expired_sessions_removed += 1;
@@ -217,6 +244,11 @@ pub(crate) fn handle_gc(
                         session_dir.display()
                     );
                     orphan_dirs_removed += 1;
+                } else if should_skip_orphan_session_dir_delete(&session_dir) {
+                    info!(
+                        "Skipped orphan-looking live session directory: {}",
+                        session_dir.display()
+                    );
                 } else if fs::remove_dir_all(&session_dir).is_ok() {
                     info!(
                         "Removed orphan directory without state.toml: {}",

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -143,17 +143,17 @@ pub(crate) fn handle_gc(
         }
 
         if session.tools.is_empty() {
-            if dry_run {
+            if should_skip_whole_session_delete(session, &session_dir) {
+                info!(
+                    session = %session.meta_session_id,
+                    "Skipped whole-session delete for Active or live session"
+                );
+            } else if dry_run {
                 eprintln!(
                     "[dry-run] Would remove empty session: {}",
                     session.meta_session_id
                 );
                 empty_sessions_removed += 1;
-            } else if should_skip_whole_session_delete(session, &session_dir) {
-                info!(
-                    session = %session.meta_session_id,
-                    "Skipped whole-session delete for Active or live session"
-                );
             } else if delete_session(&project_root, &session.meta_session_id).is_ok() {
                 empty_sessions_removed += 1;
             }
@@ -198,18 +198,18 @@ pub(crate) fn handle_gc(
             && let Some(days) = max_age_days
             && age.num_days() > days as i64
         {
-            if dry_run {
+            if should_skip_whole_session_delete(session, &session_dir) {
+                info!(
+                    session = %session.meta_session_id,
+                    "Skipped expired whole-session delete for Active or live session"
+                );
+            } else if dry_run {
                 eprintln!(
                     "[dry-run] Would remove expired session: {} (last accessed {} days ago)",
                     session.meta_session_id,
                     age.num_days()
                 );
                 expired_sessions_removed += 1;
-            } else if should_skip_whole_session_delete(session, &session_dir) {
-                info!(
-                    session = %session.meta_session_id,
-                    "Skipped expired whole-session delete for Active or live session"
-                );
             } else if delete_session(&project_root, &session.meta_session_id).is_ok() {
                 info!("Removed expired session: {}", session.meta_session_id);
                 expired_sessions_removed += 1;

--- a/crates/cli-sub-agent/src/gc.rs
+++ b/crates/cli-sub-agent/src/gc.rs
@@ -41,20 +41,47 @@ const ORPHAN_SLOT_GRACE_SECS: i64 = 30;
 
 pub(crate) type RuntimeReapStats = reaper::RuntimeReapStats;
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum LivenessProbeMode {
+    PersistSnapshot,
+    ReadOnly,
+}
+
+impl LivenessProbeMode {
+    pub(crate) fn for_dry_run(dry_run: bool) -> Self {
+        if dry_run {
+            Self::ReadOnly
+        } else {
+            Self::PersistSnapshot
+        }
+    }
+
+    fn is_alive(self, session_dir: &Path) -> bool {
+        match self {
+            Self::PersistSnapshot => csa_process::ToolLiveness::is_alive(session_dir),
+            Self::ReadOnly => csa_process::ToolLiveness::is_alive_read_only(session_dir),
+        }
+    }
+}
+
 pub(crate) fn should_skip_whole_session_delete(
     session: &MetaSessionState,
     session_dir: &Path,
+    liveness_probe_mode: LivenessProbeMode,
 ) -> bool {
     session.phase == SessionPhase::Active
         || csa_process::ToolLiveness::has_live_process(session_dir)
         || csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
-        || csa_process::ToolLiveness::is_alive(session_dir)
+        || liveness_probe_mode.is_alive(session_dir)
 }
 
-pub(crate) fn should_skip_orphan_session_dir_delete(session_dir: &Path) -> bool {
+pub(crate) fn should_skip_orphan_session_dir_delete(
+    session_dir: &Path,
+    liveness_probe_mode: LivenessProbeMode,
+) -> bool {
     csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
         || csa_process::ToolLiveness::has_live_process(session_dir)
-        || csa_process::ToolLiveness::is_alive(session_dir)
+        || liveness_probe_mode.is_alive(session_dir)
 }
 
 pub(crate) fn handle_gc_args(
@@ -104,6 +131,7 @@ pub(crate) fn handle_gc(
     let mut expired_sessions_removed = 0;
     let mut sessions_retired = 0u64;
     let mut orphan_scopes_cleaned = 0u64;
+    let liveness_probe_mode = LivenessProbeMode::for_dry_run(dry_run);
 
     if dry_run {
         eprintln!("[dry-run] No changes will be made.");
@@ -143,7 +171,7 @@ pub(crate) fn handle_gc(
         }
 
         if session.tools.is_empty() {
-            if should_skip_whole_session_delete(session, &session_dir) {
+            if should_skip_whole_session_delete(session, &session_dir, liveness_probe_mode) {
                 info!(
                     session = %session.meta_session_id,
                     "Skipped whole-session delete for Active or live session"
@@ -198,7 +226,7 @@ pub(crate) fn handle_gc(
             && let Some(days) = max_age_days
             && age.num_days() > days as i64
         {
-            if should_skip_whole_session_delete(session, &session_dir) {
+            if should_skip_whole_session_delete(session, &session_dir, liveness_probe_mode) {
                 info!(
                     session = %session.meta_session_id,
                     "Skipped expired whole-session delete for Active or live session"
@@ -238,17 +266,17 @@ pub(crate) fn handle_gc(
         for entry in entries.flatten() {
             if entry.file_type().is_ok_and(|ft| ft.is_dir()) && is_orphan_session_dir(&entry) {
                 let session_dir = entry.path();
-                if dry_run {
+                if should_skip_orphan_session_dir_delete(&session_dir, liveness_probe_mode) {
+                    info!(
+                        "Skipped orphan-looking live session directory: {}",
+                        session_dir.display()
+                    );
+                } else if dry_run {
                     eprintln!(
                         "[dry-run] Would remove orphan directory: {}",
                         session_dir.display()
                     );
                     orphan_dirs_removed += 1;
-                } else if should_skip_orphan_session_dir_delete(&session_dir) {
-                    info!(
-                        "Skipped orphan-looking live session directory: {}",
-                        session_dir.display()
-                    );
                 } else if fs::remove_dir_all(&session_dir).is_ok() {
                     info!(
                         "Removed orphan directory without state.toml: {}",

--- a/crates/cli-sub-agent/src/gc/auto_gc.rs
+++ b/crates/cli-sub-agent/src/gc/auto_gc.rs
@@ -105,7 +105,13 @@ pub(crate) fn handle_gc_global(
             }
 
             if session.tools.is_empty() {
-                if dry_run {
+                if should_skip_whole_session_delete(session, &session_dir) {
+                    info!(
+                        session = %session.meta_session_id,
+                        root = %session_root.display(),
+                        "Skipped whole-session delete for Active or live session"
+                    );
+                } else if dry_run {
                     eprintln!(
                         "[dry-run] Would remove empty session: {} (in {})",
                         session.meta_session_id,
@@ -113,12 +119,6 @@ pub(crate) fn handle_gc_global(
                     );
                     total_empty_sessions += 1;
                     project_removed += 1;
-                } else if should_skip_whole_session_delete(session, &session_dir) {
-                    info!(
-                        session = %session.meta_session_id,
-                        root = %session_root.display(),
-                        "Skipped whole-session delete for Active or live session"
-                    );
                 } else if csa_session::delete_session_from_root(
                     session_root,
                     &session.meta_session_id,
@@ -174,7 +174,13 @@ pub(crate) fn handle_gc_global(
                 && let Some(days) = max_age_days
                 && age.num_days() > days as i64
             {
-                if dry_run {
+                if should_skip_whole_session_delete(session, &session_dir) {
+                    info!(
+                        session = %session.meta_session_id,
+                        root = %session_root.display(),
+                        "Skipped expired whole-session delete for Active or live session"
+                    );
+                } else if dry_run {
                     eprintln!(
                         "[dry-run] Would remove expired session: {} ({} days old, in {})",
                         session.meta_session_id,
@@ -183,12 +189,6 @@ pub(crate) fn handle_gc_global(
                     );
                     total_expired_sessions += 1;
                     project_removed += 1;
-                } else if should_skip_whole_session_delete(session, &session_dir) {
-                    info!(
-                        session = %session.meta_session_id,
-                        root = %session_root.display(),
-                        "Skipped expired whole-session delete for Active or live session"
-                    );
                 } else if csa_session::delete_session_from_root(
                     session_root,
                     &session.meta_session_id,

--- a/crates/cli-sub-agent/src/gc/auto_gc.rs
+++ b/crates/cli-sub-agent/src/gc/auto_gc.rs
@@ -14,7 +14,7 @@ use super::reaper::{
     sessions_with_dry_run_retirements, stale_session_retirement_candidate,
 };
 use super::{
-    RETIRE_AFTER_DAYS, STATE_DIR_SIZE_CACHE_FILENAME, extract_pid_from_lock,
+    LivenessProbeMode, RETIRE_AFTER_DAYS, STATE_DIR_SIZE_CACHE_FILENAME, extract_pid_from_lock,
     has_confirmed_sessions, is_orphan_session_dir, is_process_alive, runtime_reap_max_age_days,
     should_skip_orphan_session_dir_delete, should_skip_whole_session_delete,
 };
@@ -50,6 +50,7 @@ pub(crate) fn handle_gc_global(
     let mut total_transcripts_removed = 0u64;
     let mut total_transcript_bytes_reclaimed = 0u64;
     let mut projects_failed = 0u64;
+    let liveness_probe_mode = LivenessProbeMode::for_dry_run(dry_run);
 
     if dry_run {
         eprintln!("[dry-run] Global GC — no changes will be made.");
@@ -105,7 +106,7 @@ pub(crate) fn handle_gc_global(
             }
 
             if session.tools.is_empty() {
-                if should_skip_whole_session_delete(session, &session_dir) {
+                if should_skip_whole_session_delete(session, &session_dir, liveness_probe_mode) {
                     info!(
                         session = %session.meta_session_id,
                         root = %session_root.display(),
@@ -174,7 +175,7 @@ pub(crate) fn handle_gc_global(
                 && let Some(days) = max_age_days
                 && age.num_days() > days as i64
             {
-                if should_skip_whole_session_delete(session, &session_dir) {
+                if should_skip_whole_session_delete(session, &session_dir, liveness_probe_mode) {
                     info!(
                         session = %session.meta_session_id,
                         root = %session_root.display(),
@@ -215,17 +216,17 @@ pub(crate) fn handle_gc_global(
             for entry in entries.flatten() {
                 if entry.file_type().is_ok_and(|ft| ft.is_dir()) && is_orphan_session_dir(&entry) {
                     let session_dir = entry.path();
-                    if dry_run {
+                    if should_skip_orphan_session_dir_delete(&session_dir, liveness_probe_mode) {
+                        info!(
+                            "Skipped orphan-looking live session directory: {}",
+                            session_dir.display()
+                        );
+                    } else if dry_run {
                         eprintln!(
                             "[dry-run] Would remove orphan directory: {}",
                             session_dir.display()
                         );
                         total_orphan_dirs += 1;
-                    } else if should_skip_orphan_session_dir_delete(&session_dir) {
-                        info!(
-                            "Skipped orphan-looking live session directory: {}",
-                            session_dir.display()
-                        );
                     } else if fs::remove_dir_all(&session_dir).is_ok() {
                         info!("Removed orphan directory: {}", session_dir.display());
                         total_orphan_dirs += 1;

--- a/crates/cli-sub-agent/src/gc/auto_gc.rs
+++ b/crates/cli-sub-agent/src/gc/auto_gc.rs
@@ -16,6 +16,7 @@ use super::reaper::{
 use super::{
     RETIRE_AFTER_DAYS, STATE_DIR_SIZE_CACHE_FILENAME, extract_pid_from_lock,
     has_confirmed_sessions, is_orphan_session_dir, is_process_alive, runtime_reap_max_age_days,
+    should_skip_orphan_session_dir_delete, should_skip_whole_session_delete,
 };
 
 pub(crate) fn handle_gc_global(
@@ -112,6 +113,12 @@ pub(crate) fn handle_gc_global(
                     );
                     total_empty_sessions += 1;
                     project_removed += 1;
+                } else if should_skip_whole_session_delete(session, &session_dir) {
+                    info!(
+                        session = %session.meta_session_id,
+                        root = %session_root.display(),
+                        "Skipped whole-session delete for Active or live session"
+                    );
                 } else if csa_session::delete_session_from_root(
                     session_root,
                     &session.meta_session_id,
@@ -176,6 +183,12 @@ pub(crate) fn handle_gc_global(
                     );
                     total_expired_sessions += 1;
                     project_removed += 1;
+                } else if should_skip_whole_session_delete(session, &session_dir) {
+                    info!(
+                        session = %session.meta_session_id,
+                        root = %session_root.display(),
+                        "Skipped expired whole-session delete for Active or live session"
+                    );
                 } else if csa_session::delete_session_from_root(
                     session_root,
                     &session.meta_session_id,
@@ -208,6 +221,11 @@ pub(crate) fn handle_gc_global(
                             session_dir.display()
                         );
                         total_orphan_dirs += 1;
+                    } else if should_skip_orphan_session_dir_delete(&session_dir) {
+                        info!(
+                            "Skipped orphan-looking live session directory: {}",
+                            session_dir.display()
+                        );
                     } else if fs::remove_dir_all(&session_dir).is_ok() {
                         info!("Removed orphan directory: {}", session_dir.display());
                         total_orphan_dirs += 1;

--- a/crates/cli-sub-agent/src/gc_runtime_tests.rs
+++ b/crates/cli-sub-agent/src/gc_runtime_tests.rs
@@ -4,7 +4,7 @@ use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_core::types::OutputFormat;
 use csa_session::{
     SessionArtifact, SessionPhase, SessionResult, ToolState, create_session, get_session_root,
-    list_sessions, save_result, save_session,
+    list_sessions, load_session, save_result, save_session,
 };
 use std::io;
 use std::sync::{Arc, LazyLock, Mutex};
@@ -12,6 +12,55 @@ use tempfile::tempdir;
 use tracing_subscriber::fmt::MakeWriter;
 
 static CURRENT_DIR_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[cfg(target_os = "linux")]
+fn read_process_start_time_ticks(pid: u32) -> u64 {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).unwrap();
+    let after_comm = stat.rsplit_once(") ").unwrap().1;
+    after_comm
+        .split_whitespace()
+        .nth(19)
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_record(pid: u32) -> String {
+    format!("{pid} {}\n", read_process_start_time_ticks(pid))
+}
+
+#[cfg(unix)]
+fn set_file_mtime_seconds_ago(path: &std::path::Path, seconds_ago: u64) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before unix epoch");
+    let target = now.saturating_sub(std::time::Duration::from_secs(seconds_ago));
+    let tv_sec = target.as_secs() as libc::time_t;
+    let tv_nsec = target.subsec_nanos() as libc::c_long;
+    let times = [
+        libc::timespec { tv_sec, tv_nsec },
+        libc::timespec { tv_sec, tv_nsec },
+    ];
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("path contains NUL");
+    // SAFETY: `utimensat` is called with a valid NUL-terminated path and stack-allocated timespec array.
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    assert_eq!(rc, 0, "utimensat failed for {}", path.display());
+}
+
+#[cfg(unix)]
+fn backdate_tree(path: &std::path::Path, seconds_ago: u64) {
+    if path.is_dir() {
+        for entry in std::fs::read_dir(path).expect("read_dir") {
+            let entry = entry.expect("dir entry");
+            backdate_tree(&entry.path(), seconds_ago);
+        }
+    }
+    set_file_mtime_seconds_ago(path, seconds_ago);
+}
 
 #[derive(Clone, Default)]
 struct SharedLogBuffer {
@@ -462,6 +511,112 @@ fn test_handle_gc_reaps_runtime_after_retiring_stale_session() {
     assert!(
         !runtime_dir.exists(),
         "default csa gc must reap runtime/ once a stale session is retired"
+    );
+}
+
+#[test]
+fn test_handle_gc_preserves_active_empty_tools_session() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let _cwd_lock = CURRENT_DIR_LOCK.lock().expect("current dir lock");
+    let project_root = tmp.path().join("project");
+    std::fs::create_dir_all(&project_root).unwrap();
+    let mut session =
+        create_session(&project_root, Some("active empty tools"), None, None).unwrap();
+    session.phase = SessionPhase::Active;
+    session.tools.clear();
+    session.last_accessed = chrono::Utc::now() - chrono::Duration::days(40);
+    save_session(&session).unwrap();
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).unwrap();
+    let _cwd = CurrentDirGuard::enter(&project_root);
+
+    handle_gc(false, Some(1), false, OutputFormat::Text, None, None).unwrap();
+
+    assert!(
+        session_dir.join("state.toml").exists(),
+        "Active sessions with empty tools must not be whole-session deleted"
+    );
+    let loaded = load_session(&project_root, &session.meta_session_id).unwrap();
+    assert_eq!(loaded.phase, SessionPhase::Active);
+    assert!(loaded.tools.is_empty());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_handle_gc_preserves_empty_session_with_live_daemon_pid() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let _cwd_lock = CURRENT_DIR_LOCK.lock().expect("current dir lock");
+    let project_root = tmp.path().join("project");
+    std::fs::create_dir_all(&project_root).unwrap();
+    let mut session =
+        create_session(&project_root, Some("live daemon empty tools"), None, None).unwrap();
+    session.phase = SessionPhase::Retired;
+    session.tools.clear();
+    session.last_accessed = chrono::Utc::now() - chrono::Duration::days(40);
+    save_session(&session).unwrap();
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).unwrap();
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .unwrap();
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .unwrap();
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+    let _cwd = CurrentDirGuard::enter(&project_root);
+
+    handle_gc(false, Some(1), false, OutputFormat::Text, None, None).unwrap();
+
+    child.kill().ok();
+    child.wait().ok();
+
+    assert!(
+        session_dir.join("state.toml").exists(),
+        "live daemon.pid must block whole-session empty delete"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_handle_gc_deletes_dead_retired_expired_session() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let _cwd_lock = CURRENT_DIR_LOCK.lock().expect("current dir lock");
+    let project_root = tmp.path().join("project");
+    std::fs::create_dir_all(&project_root).unwrap();
+    let mut session =
+        create_session(&project_root, Some("dead retired expired"), None, None).unwrap();
+    let last_accessed = chrono::Utc::now() - chrono::Duration::days(40);
+    session.phase = SessionPhase::Retired;
+    session.last_accessed = last_accessed;
+    session.tools.insert(
+        "codex".to_string(),
+        ToolState {
+            provider_session_id: Some("provider-session".to_string()),
+            last_action_summary: "completed".to_string(),
+            last_exit_code: 0,
+            updated_at: last_accessed,
+            tool_version: None,
+            token_usage: None,
+        },
+    );
+    save_session(&session).unwrap();
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).unwrap();
+    backdate_tree(&session_dir, 120);
+    let _cwd = CurrentDirGuard::enter(&project_root);
+
+    handle_gc(false, Some(1), false, OutputFormat::Text, None, None).unwrap();
+
+    assert!(
+        !session_dir.exists(),
+        "dead Retired sessions must remain deletable by expired whole-session GC"
     );
 }
 

--- a/crates/cli-sub-agent/src/gc_tests.rs
+++ b/crates/cli-sub-agent/src/gc_tests.rs
@@ -516,6 +516,100 @@ fn test_gc_global_preserves_active_empty_tools_session() {
     );
 }
 
+fn session_dir_entries(session_dir: &std::path::Path) -> Vec<String> {
+    let mut entries = fs::read_dir(session_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    entries.sort();
+    entries
+}
+
+fn create_corrupt_session_state(
+    project_root: &std::path::Path,
+) -> (String, std::path::PathBuf, std::path::PathBuf, Vec<u8>) {
+    let session = csa_session::create_session(project_root, Some("corrupt"), None, None).unwrap();
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id).unwrap();
+    let state_path = session_dir.join("state.toml");
+    let corrupt_state = b"not valid toml = [".to_vec();
+    fs::write(&state_path, &corrupt_state).unwrap();
+    (
+        session.meta_session_id,
+        session_dir,
+        state_path,
+        corrupt_state,
+    )
+}
+
+#[test]
+fn test_handle_gc_dry_run_preserves_corrupt_state_without_recovery() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path().join("project");
+    fs::create_dir_all(&project_root).unwrap();
+    let (_, session_dir, state_path, corrupt_state) = create_corrupt_session_state(&project_root);
+    let entries_before = session_dir_entries(&session_dir);
+
+    handle_gc(
+        true,
+        Some(0),
+        false,
+        OutputFormat::Text,
+        None,
+        Some(project_root.to_string_lossy().as_ref()),
+    )
+    .expect("gc dry-run should not require corrupt-state recovery");
+
+    assert_eq!(session_dir_entries(&session_dir), entries_before);
+    assert_eq!(fs::read(&state_path).unwrap(), corrupt_state);
+    assert!(!session_dir.join("state.toml.corrupt").exists());
+}
+
+#[test]
+fn test_handle_gc_global_dry_run_preserves_corrupt_state_without_recovery() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path().join("project");
+    fs::create_dir_all(&project_root).unwrap();
+    let (_, session_dir, state_path, corrupt_state) = create_corrupt_session_state(&project_root);
+    let entries_before = session_dir_entries(&session_dir);
+
+    handle_gc_global(true, Some(0), false, OutputFormat::Text, None)
+        .expect("global gc dry-run should not require corrupt-state recovery");
+
+    assert_eq!(session_dir_entries(&session_dir), entries_before);
+    assert_eq!(fs::read(&state_path).unwrap(), corrupt_state);
+    assert!(!session_dir.join("state.toml.corrupt").exists());
+}
+
+#[test]
+fn test_handle_gc_recovers_corrupt_state_when_not_dry_run() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path().join("project");
+    fs::create_dir_all(&project_root).unwrap();
+    let (session_id, session_dir, state_path, corrupt_state) =
+        create_corrupt_session_state(&project_root);
+
+    handle_gc(
+        false,
+        Some(0),
+        false,
+        OutputFormat::Text,
+        None,
+        Some(project_root.to_string_lossy().as_ref()),
+    )
+    .expect("gc execution should recover corrupt state");
+
+    assert!(session_dir.join("state.toml.corrupt").exists());
+    assert_ne!(fs::read(&state_path).unwrap(), corrupt_state);
+    let recovered = csa_session::load_session(&project_root, &session_id).unwrap();
+    assert_eq!(
+        recovered.description.as_deref(),
+        Some("(recovered from corrupt state)")
+    );
+}
+
 // --- Retirement logic tests ---
 
 /// Verify that the retirement guard accepts Active and Available phases.

--- a/crates/cli-sub-agent/src/gc_tests.rs
+++ b/crates/cli-sub-agent/src/gc_tests.rs
@@ -4,6 +4,23 @@ use csa_core::types::OutputFormat;
 use std::os::unix::fs as unix_fs;
 use tempfile::tempdir;
 
+#[cfg(target_os = "linux")]
+fn read_process_start_time_ticks(pid: u32) -> u64 {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).unwrap();
+    let after_comm = stat.rsplit_once(") ").unwrap().1;
+    after_comm
+        .split_whitespace()
+        .nth(19)
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_record(pid: u32) -> String {
+    format!("{pid} {}\n", read_process_start_time_ticks(pid))
+}
+
 /// Create a minimal project root with a session dir containing `state.toml`.
 fn make_project_root(base: &std::path::Path, segments: &[&str]) {
     let mut path = base.to_path_buf();
@@ -246,6 +263,75 @@ fn test_orphan_check_skips_path_segments_and_non_ulid() {
     assert_eq!(orphans[0].file_name().to_string_lossy(), orphan_name);
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn test_orphan_cleanup_preserves_dir_with_live_daemon_pid() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path().join("project");
+    fs::create_dir_all(&project_root).unwrap();
+    let session_root = csa_session::get_session_root(&project_root).unwrap();
+    let orphan_dir = session_root
+        .join("sessions")
+        .join("01CCCC0000000000000000000D");
+    fs::create_dir_all(&orphan_dir).unwrap();
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .unwrap();
+    fs::write(orphan_dir.join("daemon.pid"), daemon_pid_record(child.id())).unwrap();
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&orphan_dir));
+
+    handle_gc(
+        false,
+        None,
+        false,
+        OutputFormat::Text,
+        None,
+        Some(project_root.to_str().unwrap()),
+    )
+    .unwrap();
+
+    child.kill().ok();
+    child.wait().ok();
+
+    assert!(
+        orphan_dir.exists(),
+        "orphan-looking dir with live daemon.pid must be preserved"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_orphan_cleanup_preserves_dir_with_live_lock() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path().join("project");
+    fs::create_dir_all(&project_root).unwrap();
+    let session_root = csa_session::get_session_root(&project_root).unwrap();
+    let orphan_dir = session_root
+        .join("sessions")
+        .join("01DDDD0000000000000000000E");
+    fs::create_dir_all(&orphan_dir).unwrap();
+    let _lock = csa_lock::acquire_lock(&orphan_dir, "codex", "orphan cleanup test").unwrap();
+    assert!(csa_process::ToolLiveness::has_live_process(&orphan_dir));
+
+    handle_gc(
+        false,
+        None,
+        false,
+        OutputFormat::Text,
+        None,
+        Some(project_root.to_str().unwrap()),
+    )
+    .unwrap();
+
+    assert!(
+        orphan_dir.exists(),
+        "orphan-looking dir with live lock must be preserved"
+    );
+}
+
 #[test]
 fn test_discover_skips_symlinked_sessions_dir() {
     let tmp = tempdir().unwrap();
@@ -403,6 +489,31 @@ scanned_at = 1
             cache_path.display()
         );
     }
+}
+
+#[test]
+fn test_gc_global_preserves_active_empty_tools_session() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path().join("project");
+    fs::create_dir_all(&project_root).unwrap();
+    let mut session =
+        csa_session::create_session(&project_root, Some("global active empty"), None, None)
+            .unwrap();
+    session.phase = csa_session::SessionPhase::Active;
+    session.tools.clear();
+    session.last_accessed = chrono::Utc::now() - chrono::Duration::days(40);
+    csa_session::save_session(&session).unwrap();
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).unwrap();
+
+    handle_gc_global(false, Some(1), false, OutputFormat::Text, None)
+        .expect("global gc should succeed");
+
+    assert!(
+        session_dir.join("state.toml").exists(),
+        "global empty-session sweep must preserve Active sessions"
+    );
 }
 
 // --- Retirement logic tests ---

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -438,7 +438,11 @@ pub(crate) fn handle_session_clean(
 ) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
     let tool_filter: Option<Vec<&str>> = tool.as_ref().map(|t| t.split(',').collect());
-    let sessions = list_sessions(&project_root, tool_filter.as_deref())?;
+    let sessions = if dry_run {
+        csa_session::list_sessions_readonly(&project_root, tool_filter.as_deref())?
+    } else {
+        list_sessions(&project_root, tool_filter.as_deref())?
+    };
     let now = chrono::Utc::now();
     let mut removed = 0;
     let liveness_probe_mode = crate::gc::LivenessProbeMode::for_dry_run(dry_run);

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -449,24 +449,22 @@ pub(crate) fn handle_session_clean(
     for session in &sessions {
         let age = now.signed_duration_since(session.last_accessed);
         if age.num_days() > days as i64 {
-            if dry_run {
+            let session_dir = get_session_dir(&project_root, &session.meta_session_id)?;
+            if crate::gc::should_skip_whole_session_delete(session, &session_dir) {
+                info!(
+                    session = %session.meta_session_id,
+                    "Skipped session clean delete for Active or live session"
+                );
+            } else if dry_run {
                 eprintln!(
                     "[dry-run] Would remove: {} (last accessed {} days ago)",
                     &session.meta_session_id[..11.min(session.meta_session_id.len())],
                     age.num_days()
                 );
                 removed += 1;
-            } else {
-                let session_dir = get_session_dir(&project_root, &session.meta_session_id)?;
-                if crate::gc::should_skip_whole_session_delete(session, &session_dir) {
-                    info!(
-                        session = %session.meta_session_id,
-                        "Skipped session clean delete for Active or live session"
-                    );
-                } else if delete_session(&project_root, &session.meta_session_id).is_ok() {
-                    info!("Removed expired session: {}", session.meta_session_id);
-                    removed += 1;
-                }
+            } else if delete_session(&project_root, &session.meta_session_id).is_ok() {
+                info!("Removed expired session: {}", session.meta_session_id);
+                removed += 1;
             }
         }
     }

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -441,6 +441,7 @@ pub(crate) fn handle_session_clean(
     let sessions = list_sessions(&project_root, tool_filter.as_deref())?;
     let now = chrono::Utc::now();
     let mut removed = 0;
+    let liveness_probe_mode = crate::gc::LivenessProbeMode::for_dry_run(dry_run);
 
     if dry_run {
         eprintln!("[dry-run] No changes will be made.");
@@ -450,7 +451,11 @@ pub(crate) fn handle_session_clean(
         let age = now.signed_duration_since(session.last_accessed);
         if age.num_days() > days as i64 {
             let session_dir = get_session_dir(&project_root, &session.meta_session_id)?;
-            if crate::gc::should_skip_whole_session_delete(session, &session_dir) {
+            if crate::gc::should_skip_whole_session_delete(
+                session,
+                &session_dir,
+                liveness_probe_mode,
+            ) {
                 info!(
                     session = %session.meta_session_id,
                     "Skipped session clean delete for Active or live session"

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use tracing::info;
 
 use csa_core::types::OutputFormat;
-use csa_session::{delete_session, list_sessions, list_sessions_tree_filtered};
+use csa_session::{delete_session, get_session_dir, list_sessions, list_sessions_tree_filtered};
 
 use crate::stdout_write::{write_stdout, write_stdout_line};
 
@@ -455,10 +455,19 @@ pub(crate) fn handle_session_clean(
                     &session.meta_session_id[..11.min(session.meta_session_id.len())],
                     age.num_days()
                 );
-            } else if delete_session(&project_root, &session.meta_session_id).is_ok() {
-                info!("Removed expired session: {}", session.meta_session_id);
+                removed += 1;
+            } else {
+                let session_dir = get_session_dir(&project_root, &session.meta_session_id)?;
+                if crate::gc::should_skip_whole_session_delete(session, &session_dir) {
+                    info!(
+                        session = %session.meta_session_id,
+                        "Skipped session clean delete for Active or live session"
+                    );
+                } else if delete_session(&project_root, &session.meta_session_id).is_ok() {
+                    info!("Removed expired session: {}", session.meta_session_id);
+                    removed += 1;
+                }
             }
-            removed += 1;
         }
     }
 

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -3,9 +3,9 @@ use super::{
     DeadActiveSessionReconciliation, display_acp_events, display_daemon_spool_logs,
     display_log_files, ensure_terminal_result_for_dead_active_session,
     ensure_terminal_result_for_dead_active_session_with_before_write,
-    filter_sessions_by_csa_version, handle_session_is_alive, handle_session_kill,
-    handle_session_list, handle_session_wait, is_session_stale_for_test, print_content_with_tail,
-    resolve_session_status, select_sessions_for_list, session_to_json,
+    filter_sessions_by_csa_version, handle_session_clean, handle_session_is_alive,
+    handle_session_kill, handle_session_list, handle_session_wait, is_session_stale_for_test,
+    print_content_with_tail, resolve_session_status, select_sessions_for_list, session_to_json,
     status_from_phase_and_result, truncate_with_ellipsis,
 };
 use crate::cli::{Cli, Commands, SessionCommands};
@@ -40,6 +40,25 @@ fn truncate_with_ellipsis_handles_multibyte_chinese() {
 fn truncate_with_ellipsis_handles_emoji_without_panic() {
     let input = "session 😀😃😄😁 description";
     assert_eq!(truncate_with_ellipsis(input, 12), "session 😀...");
+}
+
+#[test]
+fn session_clean_preserves_active_session() {
+    let td = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
+    let project = td.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let mut session = create_session(&project, Some("active clean guard"), None, None).unwrap();
+    session.phase = SessionPhase::Active;
+    session.last_accessed = Utc::now() - chrono::Duration::days(40);
+    session.tools.clear();
+    save_session(&session).unwrap();
+
+    handle_session_clean(1, false, None, Some(project.to_string_lossy().to_string())).unwrap();
+
+    let loaded = load_session(&project, &session.meta_session_id).unwrap();
+    assert_eq!(loaded.phase, SessionPhase::Active);
+    assert!(loaded.tools.is_empty());
 }
 
 fn make_result(status: &str, exit_code: i32) -> SessionResult {

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -61,6 +61,69 @@ fn session_clean_preserves_active_session() {
     assert!(loaded.tools.is_empty());
 }
 
+fn session_dir_entries(session_dir: &std::path::Path) -> Vec<String> {
+    let mut entries = std::fs::read_dir(session_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    entries.sort();
+    entries
+}
+
+fn create_corrupt_session_state(
+    project: &std::path::Path,
+) -> (String, std::path::PathBuf, std::path::PathBuf, Vec<u8>) {
+    let session = create_session(project, Some("corrupt"), None, None).unwrap();
+    let session_dir = get_session_dir(project, &session.meta_session_id).unwrap();
+    let state_path = session_dir.join("state.toml");
+    let corrupt_state = b"not valid toml = [".to_vec();
+    std::fs::write(&state_path, &corrupt_state).unwrap();
+    (
+        session.meta_session_id,
+        session_dir,
+        state_path,
+        corrupt_state,
+    )
+}
+
+#[test]
+fn session_clean_dry_run_preserves_corrupt_state_without_recovery() {
+    let td = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
+    let project = td.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let (_, session_dir, state_path, corrupt_state) = create_corrupt_session_state(&project);
+    let entries_before = session_dir_entries(&session_dir);
+
+    handle_session_clean(0, true, None, Some(project.to_string_lossy().to_string()))
+        .expect("session clean dry-run should not require corrupt-state recovery");
+
+    assert_eq!(session_dir_entries(&session_dir), entries_before);
+    assert_eq!(std::fs::read(&state_path).unwrap(), corrupt_state);
+    assert!(!session_dir.join("state.toml.corrupt").exists());
+}
+
+#[test]
+fn session_clean_recovers_corrupt_state_when_not_dry_run() {
+    let td = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&td);
+    let project = td.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let (session_id, session_dir, state_path, corrupt_state) =
+        create_corrupt_session_state(&project);
+
+    handle_session_clean(0, false, None, Some(project.to_string_lossy().to_string()))
+        .expect("session clean execution should recover corrupt state");
+
+    assert!(session_dir.join("state.toml.corrupt").exists());
+    assert_ne!(std::fs::read(&state_path).unwrap(), corrupt_state);
+    let recovered = load_session(&project, &session_id).unwrap();
+    assert_eq!(
+        recovered.description.as_deref(),
+        Some("(recovered from corrupt state)")
+    );
+}
+
 fn make_result(status: &str, exit_code: i32) -> SessionResult {
     let now = Utc::now();
     SessionResult {

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -117,7 +117,10 @@ struct PreviewScenario {
     live_dir: PathBuf,
     dead_empty_dir: PathBuf,
     dead_expired_dir: PathBuf,
+    live_orphan_dir: PathBuf,
+    dead_orphan_dir: PathBuf,
     _live_lock: csa_lock::SessionLock,
+    _live_orphan_lock: csa_lock::SessionLock,
 }
 
 #[cfg(unix)]
@@ -155,6 +158,14 @@ fn backdate_tree(path: &Path, seconds_ago: u64) {
         }
     }
     set_file_mtime_seconds_ago(path, seconds_ago);
+}
+
+#[cfg(unix)]
+fn seed_liveness_snapshot_candidate(session_dir: &Path) {
+    let acp_path = session_dir.join("output").join("acp-events.jsonl");
+    std::fs::create_dir_all(acp_path.parent().expect("acp path parent")).unwrap();
+    std::fs::write(&acp_path, "{}\n").unwrap();
+    set_file_mtime_seconds_ago(&acp_path, 120);
 }
 
 #[cfg(unix)]
@@ -218,8 +229,25 @@ fn seed_preview_scenario(project_root: &Path) -> PreviewScenario {
         SessionPhase::Retired,
         true,
     );
+    seed_liveness_snapshot_candidate(&dead_empty_dir);
+    seed_liveness_snapshot_candidate(&dead_expired_dir);
+
     let live_lock = csa_lock::acquire_lock(&live_dir, "codex", "gc dry-run preview test").unwrap();
     assert!(csa_process::ToolLiveness::has_live_process(&live_dir));
+    let sessions_dir = csa_session::get_session_root(project_root)
+        .unwrap()
+        .join("sessions");
+    let live_orphan_dir = sessions_dir.join("01EEEE0000000000000000000F");
+    let dead_orphan_dir = sessions_dir.join("01FFFF0000000000000000000G");
+    std::fs::create_dir_all(&live_orphan_dir).unwrap();
+    std::fs::create_dir_all(&dead_orphan_dir).unwrap();
+    seed_liveness_snapshot_candidate(&dead_orphan_dir);
+    let live_orphan_lock =
+        csa_lock::acquire_lock(&live_orphan_dir, "codex", "gc dry-run orphan preview test")
+            .unwrap();
+    assert!(csa_process::ToolLiveness::has_live_process(
+        &live_orphan_dir
+    ));
 
     PreviewScenario {
         active_id,
@@ -230,7 +258,10 @@ fn seed_preview_scenario(project_root: &Path) -> PreviewScenario {
         live_dir,
         dead_empty_dir,
         dead_expired_dir,
+        live_orphan_dir,
+        dead_orphan_dir,
         _live_lock: live_lock,
+        _live_orphan_lock: live_orphan_lock,
     }
 }
 
@@ -286,6 +317,25 @@ fn assert_gc_preview_matches_execution_candidates(preview: &str, scenario: &Prev
             .any(|line| line.contains(&scenario.dead_expired_id)),
         "dry-run preview must list the dead expired session that execution deletes: {preview}"
     );
+
+    let orphan_lines: Vec<_> = preview
+        .lines()
+        .filter(|line| line.contains("Would remove orphan directory"))
+        .collect();
+    let live_orphan_dir = scenario.live_orphan_dir.display().to_string();
+    let dead_orphan_dir = scenario.dead_orphan_dir.display().to_string();
+    assert!(
+        !orphan_lines
+            .iter()
+            .any(|line| line.contains(&live_orphan_dir)),
+        "dry-run orphan preview must not list live orphan dirs: {preview}"
+    );
+    assert!(
+        orphan_lines
+            .iter()
+            .any(|line| line.contains(&dead_orphan_dir)),
+        "dry-run orphan preview must list the dead orphan dir execution deletes: {preview}"
+    );
 }
 
 #[cfg(unix)]
@@ -329,6 +379,94 @@ fn assert_execution_deleted_only_preview_candidates(scenario: &PreviewScenario) 
         !scenario.dead_expired_dir.exists(),
         "execution must delete the dead expired session shown in preview"
     );
+}
+
+#[cfg(unix)]
+fn assert_gc_execution_deleted_only_preview_candidates(scenario: &PreviewScenario) {
+    assert_execution_deleted_only_preview_candidates(scenario);
+    assert!(
+        scenario.live_orphan_dir.exists(),
+        "execution must preserve live orphan dirs"
+    );
+    assert!(
+        !scenario.dead_orphan_dir.exists(),
+        "execution must delete the dead orphan dir shown in preview"
+    );
+}
+
+#[cfg(unix)]
+fn preview_target_dirs(scenario: &PreviewScenario) -> Vec<&Path> {
+    vec![
+        scenario.active_dir.as_path(),
+        scenario.live_dir.as_path(),
+        scenario.dead_empty_dir.as_path(),
+        scenario.dead_expired_dir.as_path(),
+        scenario.live_orphan_dir.as_path(),
+        scenario.dead_orphan_dir.as_path(),
+    ]
+}
+
+#[cfg(unix)]
+fn relative_file_set(dir: &Path) -> std::collections::BTreeSet<PathBuf> {
+    fn visit(root: &Path, dir: &Path, files: &mut std::collections::BTreeSet<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                visit(root, &path, files);
+            } else {
+                files.insert(
+                    path.strip_prefix(root)
+                        .expect("path under root")
+                        .to_path_buf(),
+                );
+            }
+        }
+    }
+
+    let mut files = std::collections::BTreeSet::new();
+    visit(dir, dir, &mut files);
+    files
+}
+
+#[cfg(unix)]
+fn snapshot_preview_target_files(
+    scenario: &PreviewScenario,
+) -> Vec<(PathBuf, std::collections::BTreeSet<PathBuf>)> {
+    preview_target_dirs(scenario)
+        .into_iter()
+        .map(|dir| (dir.to_path_buf(), relative_file_set(dir)))
+        .collect()
+}
+
+#[cfg(unix)]
+fn assert_preview_target_files_unchanged(
+    before: &[(PathBuf, std::collections::BTreeSet<PathBuf>)],
+) {
+    for (dir, files_before) in before {
+        assert_eq!(
+            &relative_file_set(dir),
+            files_before,
+            "dry-run preview must not create or remove files under {}",
+            dir.display()
+        );
+    }
+}
+
+#[cfg(unix)]
+fn assert_no_liveness_snapshots(scenario: &PreviewScenario) {
+    for dir in preview_target_dirs(scenario) {
+        assert!(
+            !dir.join(".liveness.snapshot").exists(),
+            "dry-run preview must not write .liveness.snapshot in {}",
+            dir.display()
+        );
+    }
 }
 
 /// Run `csa init` (minimal mode) inside the given temp directory.
@@ -969,6 +1107,7 @@ fn gc_dry_run_preview_excludes_active_and_live_sessions() {
     let project_root = tmp.path().join("project");
     let scenario = seed_preview_scenario(&project_root);
     let cd = project_root.to_string_lossy().to_string();
+    let dry_run_files = snapshot_preview_target_files(&scenario);
 
     let preview_output = csa_cmd(tmp.path())
         .args(["gc", "--dry-run", "--max-age-days", "1", "--cd", &cd])
@@ -978,13 +1117,15 @@ fn gc_dry_run_preview_excludes_active_and_live_sessions() {
     let preview = output_text(&preview_output);
 
     assert_gc_preview_matches_execution_candidates(&preview, &scenario);
+    assert_preview_target_files_unchanged(&dry_run_files);
+    assert_no_liveness_snapshots(&scenario);
 
     let execution_output = csa_cmd(tmp.path())
         .args(["gc", "--max-age-days", "1", "--cd", &cd])
         .output()
         .expect("failed to run csa gc");
     assert_command_success(&execution_output, "csa gc");
-    assert_execution_deleted_only_preview_candidates(&scenario);
+    assert_gc_execution_deleted_only_preview_candidates(&scenario);
 }
 
 #[cfg(unix)]
@@ -995,6 +1136,7 @@ fn gc_global_dry_run_preview_excludes_active_and_live_sessions() {
     let _env = E2eEnvGuard::set(tmp.path());
     let project_root = tmp.path().join("project");
     let scenario = seed_preview_scenario(&project_root);
+    let dry_run_files = snapshot_preview_target_files(&scenario);
 
     let preview_output = csa_cmd(tmp.path())
         .args(["gc", "--global", "--dry-run", "--max-age-days", "1"])
@@ -1004,13 +1146,15 @@ fn gc_global_dry_run_preview_excludes_active_and_live_sessions() {
     let preview = output_text(&preview_output);
 
     assert_gc_preview_matches_execution_candidates(&preview, &scenario);
+    assert_preview_target_files_unchanged(&dry_run_files);
+    assert_no_liveness_snapshots(&scenario);
 
     let execution_output = csa_cmd(tmp.path())
         .args(["gc", "--global", "--max-age-days", "1"])
         .output()
         .expect("failed to run csa gc --global");
     assert_command_success(&execution_output, "csa gc --global");
-    assert_execution_deleted_only_preview_candidates(&scenario);
+    assert_gc_execution_deleted_only_preview_candidates(&scenario);
 }
 
 #[cfg(unix)]
@@ -1022,6 +1166,7 @@ fn session_clean_dry_run_preview_excludes_active_and_live_sessions() {
     let project_root = tmp.path().join("project");
     let scenario = seed_preview_scenario(&project_root);
     let cd = project_root.to_string_lossy().to_string();
+    let dry_run_files = snapshot_preview_target_files(&scenario);
 
     let preview_output = csa_cmd(tmp.path())
         .args(["session", "clean", "--days", "1", "--dry-run", "--cd", &cd])
@@ -1031,6 +1176,8 @@ fn session_clean_dry_run_preview_excludes_active_and_live_sessions() {
     let preview = output_text(&preview_output);
 
     assert_session_clean_preview_matches_execution_candidates(&preview, &scenario);
+    assert_preview_target_files_unchanged(&dry_run_files);
+    assert_no_liveness_snapshots(&scenario);
 
     let execution_output = csa_cmd(tmp.path())
         .args(["session", "clean", "--days", "1", "--cd", &cd])

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -9,9 +9,22 @@ mod gc;
 use clap::Parser;
 use cli_defs::{AuditCommands, Cli, Commands, McpHubCommands, validate_command_args};
 use csa_core::types::OutputFormat;
+#[cfg(unix)]
+use csa_session::{SessionPhase, ToolState};
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::ffi::OsString;
 use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 use std::process::Command;
+#[cfg(unix)]
+use std::process::Output;
+#[cfg(unix)]
+use std::sync::Mutex;
+
+#[cfg(unix)]
+static E2E_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 /// Create a [`Command`] pointing at the built `csa` binary with HOME, XDG_STATE_HOME,
 /// and XDG_CONFIG_HOME redirected to the given temp directory so tests never touch
@@ -42,6 +55,280 @@ fn global_config_path(tmp: &Path) -> std::path::PathBuf {
     } else {
         tmp.join(".config/cli-sub-agent/config.toml")
     }
+}
+
+#[cfg(unix)]
+struct E2eEnvGuard {
+    originals: Vec<(&'static str, Option<OsString>)>,
+}
+
+#[cfg(unix)]
+impl E2eEnvGuard {
+    fn set(tmp: &Path) -> Self {
+        let keys = [
+            "HOME",
+            "XDG_STATE_HOME",
+            "XDG_CONFIG_HOME",
+            "CSA_DAEMON_SESSION_ID",
+            "CSA_DAEMON_SESSION_DIR",
+            "CSA_DAEMON_PROJECT_ROOT",
+        ];
+        let originals = keys
+            .iter()
+            .map(|key| (*key, std::env::var_os(key)))
+            .collect();
+
+        // SAFETY: e2e tests that mutate process env hold E2E_ENV_LOCK.
+        unsafe {
+            std::env::set_var("HOME", tmp);
+            std::env::set_var("XDG_STATE_HOME", tmp.join(".local/state"));
+            std::env::set_var("XDG_CONFIG_HOME", tmp.join(".config"));
+            std::env::remove_var("CSA_DAEMON_SESSION_ID");
+            std::env::remove_var("CSA_DAEMON_SESSION_DIR");
+            std::env::remove_var("CSA_DAEMON_PROJECT_ROOT");
+        }
+
+        Self { originals }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for E2eEnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.originals {
+            // SAFETY: e2e tests that mutate process env hold E2E_ENV_LOCK.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+struct PreviewScenario {
+    active_id: String,
+    live_id: String,
+    dead_empty_id: String,
+    dead_expired_id: String,
+    active_dir: PathBuf,
+    live_dir: PathBuf,
+    dead_empty_dir: PathBuf,
+    dead_expired_dir: PathBuf,
+    _live_lock: csa_lock::SessionLock,
+}
+
+#[cfg(unix)]
+fn short_id(session_id: &str) -> &str {
+    &session_id[..11.min(session_id.len())]
+}
+
+#[cfg(unix)]
+fn set_file_mtime_seconds_ago(path: &Path, seconds_ago: u64) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before unix epoch");
+    let target = now.saturating_sub(std::time::Duration::from_secs(seconds_ago));
+    let tv_sec = target.as_secs() as libc::time_t;
+    let tv_nsec = target.subsec_nanos() as libc::c_long;
+    let times = [
+        libc::timespec { tv_sec, tv_nsec },
+        libc::timespec { tv_sec, tv_nsec },
+    ];
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("path contains NUL");
+    // SAFETY: `utimensat` receives a valid NUL-terminated path and stack-allocated timespec array.
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    assert_eq!(rc, 0, "utimensat failed for {}", path.display());
+}
+
+#[cfg(unix)]
+fn backdate_tree(path: &Path, seconds_ago: u64) {
+    if path.is_dir() {
+        for entry in std::fs::read_dir(path).expect("read_dir") {
+            let entry = entry.expect("dir entry");
+            backdate_tree(&entry.path(), seconds_ago);
+        }
+    }
+    set_file_mtime_seconds_ago(path, seconds_ago);
+}
+
+#[cfg(unix)]
+fn seed_preview_session(
+    project_root: &Path,
+    description: &str,
+    phase: SessionPhase,
+    with_tool: bool,
+) -> (String, PathBuf) {
+    let last_accessed = chrono::Utc::now() - chrono::Duration::days(40);
+    let mut session =
+        csa_session::create_session(project_root, Some(description), None, None).unwrap();
+    session.phase = phase;
+    session.last_accessed = last_accessed;
+    session.tools.clear();
+    if with_tool {
+        session.tools.insert(
+            "codex".to_string(),
+            ToolState {
+                provider_session_id: Some(format!("provider-{}", session.meta_session_id)),
+                last_action_summary: "completed".to_string(),
+                last_exit_code: 0,
+                updated_at: last_accessed,
+                tool_version: None,
+                token_usage: None,
+            },
+        );
+    }
+    csa_session::save_session(&session).unwrap();
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id).unwrap();
+    backdate_tree(&session_dir, 120);
+
+    (session.meta_session_id, session_dir)
+}
+
+#[cfg(unix)]
+fn seed_preview_scenario(project_root: &Path) -> PreviewScenario {
+    std::fs::create_dir_all(project_root).unwrap();
+
+    let (active_id, active_dir) = seed_preview_session(
+        project_root,
+        "active preview guard",
+        SessionPhase::Active,
+        true,
+    );
+    let (live_id, live_dir) = seed_preview_session(
+        project_root,
+        "live preview guard",
+        SessionPhase::Retired,
+        false,
+    );
+    let (dead_empty_id, dead_empty_dir) = seed_preview_session(
+        project_root,
+        "dead empty preview",
+        SessionPhase::Retired,
+        false,
+    );
+    let (dead_expired_id, dead_expired_dir) = seed_preview_session(
+        project_root,
+        "dead expired preview",
+        SessionPhase::Retired,
+        true,
+    );
+    let live_lock = csa_lock::acquire_lock(&live_dir, "codex", "gc dry-run preview test").unwrap();
+    assert!(csa_process::ToolLiveness::has_live_process(&live_dir));
+
+    PreviewScenario {
+        active_id,
+        live_id,
+        dead_empty_id,
+        dead_expired_id,
+        active_dir,
+        live_dir,
+        dead_empty_dir,
+        dead_expired_dir,
+        _live_lock: live_lock,
+    }
+}
+
+#[cfg(unix)]
+fn output_text(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[cfg(unix)]
+fn assert_command_success(output: &Output, command: &str) {
+    assert!(
+        output.status.success(),
+        "{command} should exit 0\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+fn assert_gc_preview_matches_execution_candidates(preview: &str, scenario: &PreviewScenario) {
+    let removal_lines: Vec<_> = preview
+        .lines()
+        .filter(|line| {
+            line.contains("Would remove empty session")
+                || line.contains("Would remove expired session")
+        })
+        .collect();
+    assert!(
+        !removal_lines
+            .iter()
+            .any(|line| line.contains(&scenario.active_id)),
+        "dry-run removal preview must not list Active sessions: {preview}"
+    );
+    assert!(
+        !removal_lines
+            .iter()
+            .any(|line| line.contains(&scenario.live_id)),
+        "dry-run removal preview must not list live sessions: {preview}"
+    );
+    assert!(
+        removal_lines
+            .iter()
+            .any(|line| line.contains(&scenario.dead_empty_id)),
+        "dry-run preview must list the dead empty session that execution deletes: {preview}"
+    );
+    assert!(
+        removal_lines
+            .iter()
+            .any(|line| line.contains(&scenario.dead_expired_id)),
+        "dry-run preview must list the dead expired session that execution deletes: {preview}"
+    );
+}
+
+#[cfg(unix)]
+fn assert_session_clean_preview_matches_execution_candidates(
+    preview: &str,
+    scenario: &PreviewScenario,
+) {
+    assert!(
+        !preview.contains(short_id(&scenario.active_id)),
+        "session clean dry-run preview must not list Active sessions: {preview}"
+    );
+    assert!(
+        !preview.contains(short_id(&scenario.live_id)),
+        "session clean dry-run preview must not list live sessions: {preview}"
+    );
+    assert!(
+        preview.contains(short_id(&scenario.dead_empty_id)),
+        "session clean dry-run preview must list the dead empty session execution deletes: {preview}"
+    );
+    assert!(
+        preview.contains(short_id(&scenario.dead_expired_id)),
+        "session clean dry-run preview must list the dead expired session execution deletes: {preview}"
+    );
+}
+
+#[cfg(unix)]
+fn assert_execution_deleted_only_preview_candidates(scenario: &PreviewScenario) {
+    assert!(
+        scenario.active_dir.join("state.toml").exists(),
+        "execution must preserve Active sessions"
+    );
+    assert!(
+        scenario.live_dir.join("state.toml").exists(),
+        "execution must preserve live sessions"
+    );
+    assert!(
+        !scenario.dead_empty_dir.exists(),
+        "execution must delete the dead empty session shown in preview"
+    );
+    assert!(
+        !scenario.dead_expired_dir.exists(),
+        "execution must delete the dead expired session shown in preview"
+    );
 }
 
 /// Run `csa init` (minimal mode) inside the given temp directory.
@@ -671,6 +958,86 @@ fn gc_dry_run_exits_zero() {
         combined.contains("dry-run"),
         "output should mention dry-run mode"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn gc_dry_run_preview_excludes_active_and_live_sessions() {
+    let _env_lock = E2E_ENV_LOCK.lock().expect("e2e env lock");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _env = E2eEnvGuard::set(tmp.path());
+    let project_root = tmp.path().join("project");
+    let scenario = seed_preview_scenario(&project_root);
+    let cd = project_root.to_string_lossy().to_string();
+
+    let preview_output = csa_cmd(tmp.path())
+        .args(["gc", "--dry-run", "--max-age-days", "1", "--cd", &cd])
+        .output()
+        .expect("failed to run csa gc --dry-run");
+    assert_command_success(&preview_output, "csa gc --dry-run");
+    let preview = output_text(&preview_output);
+
+    assert_gc_preview_matches_execution_candidates(&preview, &scenario);
+
+    let execution_output = csa_cmd(tmp.path())
+        .args(["gc", "--max-age-days", "1", "--cd", &cd])
+        .output()
+        .expect("failed to run csa gc");
+    assert_command_success(&execution_output, "csa gc");
+    assert_execution_deleted_only_preview_candidates(&scenario);
+}
+
+#[cfg(unix)]
+#[test]
+fn gc_global_dry_run_preview_excludes_active_and_live_sessions() {
+    let _env_lock = E2E_ENV_LOCK.lock().expect("e2e env lock");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _env = E2eEnvGuard::set(tmp.path());
+    let project_root = tmp.path().join("project");
+    let scenario = seed_preview_scenario(&project_root);
+
+    let preview_output = csa_cmd(tmp.path())
+        .args(["gc", "--global", "--dry-run", "--max-age-days", "1"])
+        .output()
+        .expect("failed to run csa gc --global --dry-run");
+    assert_command_success(&preview_output, "csa gc --global --dry-run");
+    let preview = output_text(&preview_output);
+
+    assert_gc_preview_matches_execution_candidates(&preview, &scenario);
+
+    let execution_output = csa_cmd(tmp.path())
+        .args(["gc", "--global", "--max-age-days", "1"])
+        .output()
+        .expect("failed to run csa gc --global");
+    assert_command_success(&execution_output, "csa gc --global");
+    assert_execution_deleted_only_preview_candidates(&scenario);
+}
+
+#[cfg(unix)]
+#[test]
+fn session_clean_dry_run_preview_excludes_active_and_live_sessions() {
+    let _env_lock = E2E_ENV_LOCK.lock().expect("e2e env lock");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _env = E2eEnvGuard::set(tmp.path());
+    let project_root = tmp.path().join("project");
+    let scenario = seed_preview_scenario(&project_root);
+    let cd = project_root.to_string_lossy().to_string();
+
+    let preview_output = csa_cmd(tmp.path())
+        .args(["session", "clean", "--days", "1", "--dry-run", "--cd", &cd])
+        .output()
+        .expect("failed to run csa session clean --dry-run");
+    assert_command_success(&preview_output, "csa session clean --dry-run");
+    let preview = output_text(&preview_output);
+
+    assert_session_clean_preview_matches_execution_candidates(&preview, &scenario);
+
+    let execution_output = csa_cmd(tmp.path())
+        .args(["session", "clean", "--days", "1", "--cd", &cd])
+        .output()
+        .expect("failed to run csa session clean");
+    assert_command_success(&execution_output, "csa session clean");
+    assert_execution_deleted_only_preview_candidates(&scenario);
 }
 
 #[test]

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -88,8 +88,21 @@ struct LivenessSnapshot {
 /// 4) stderr growth (`stderr.log`)
 pub struct ToolLiveness;
 
+#[derive(Debug, Clone, Copy)]
+enum SnapshotPersistence {
+    Persist,
+    ReadOnly,
+}
+
 impl ToolLiveness {
     pub(crate) fn probe(session_dir: &Path) -> LivenessSignals {
+        Self::probe_with_snapshot_persistence(session_dir, SnapshotPersistence::Persist)
+    }
+
+    fn probe_with_snapshot_persistence(
+        session_dir: &Path,
+        snapshot_persistence: SnapshotPersistence,
+    ) -> LivenessSignals {
         let now = SystemTime::now();
         let mut snapshot = load_snapshot(session_dir);
         let daemon_pid_alive = Self::daemon_pid_is_alive(session_dir);
@@ -105,12 +118,20 @@ impl ToolLiveness {
             fatal_error: provider_error.is_some(),
         };
 
-        save_snapshot(session_dir, &snapshot);
+        if matches!(snapshot_persistence, SnapshotPersistence::Persist) {
+            save_snapshot(session_dir, &snapshot);
+        }
         signals
     }
 
     pub fn is_alive(session_dir: &Path) -> bool {
         Self::probe(session_dir).has_any_signal()
+    }
+
+    /// Return coarse liveness without updating the watchdog snapshot file.
+    pub fn is_alive_read_only(session_dir: &Path) -> bool {
+        Self::probe_with_snapshot_persistence(session_dir, SnapshotPersistence::ReadOnly)
+            .has_any_signal()
     }
 
     /// Return a live process PID that still matches this session's context.

--- a/crates/csa-process/src/tool_liveness_tests.rs
+++ b/crates/csa-process/src/tool_liveness_tests.rs
@@ -207,6 +207,26 @@ fn record_spool_bytes_written_persists_monotonic_counter() {
 }
 
 #[test]
+fn is_alive_read_only_does_not_persist_liveness_snapshot() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let acp_path = tmp.path().join("output").join("acp-events.jsonl");
+    fs::create_dir_all(acp_path.parent().expect("acp path parent")).expect("create output dir");
+    fs::write(&acp_path, "{}\n").expect("write acp events");
+
+    assert!(ToolLiveness::is_alive_read_only(tmp.path()));
+    assert!(
+        !tmp.path().join(SNAPSHOT_FILE).exists(),
+        "read-only liveness checks must not write the watchdog snapshot"
+    );
+
+    assert!(ToolLiveness::probe(tmp.path()).has_any_signal());
+    assert!(
+        tmp.path().join(SNAPSHOT_FILE).exists(),
+        "the normal execution/watchdog probe must still persist the snapshot"
+    );
+}
+
+#[test]
 fn probe_detects_spool_byte_growth_after_rotation() {
     let tmp = tempfile::tempdir().expect("tempdir");
     fs::write(

--- a/crates/csa-session/src/atomic_state_write.rs
+++ b/crates/csa-session/src/atomic_state_write.rs
@@ -1,0 +1,69 @@
+use anyhow::{Context, Result, anyhow};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+pub(super) fn write_state_atomically(
+    session_dir: &Path,
+    state_path: &Path,
+    contents: &str,
+) -> Result<()> {
+    let mut temp_file = tempfile::NamedTempFile::new_in(session_dir).with_context(|| {
+        format!(
+            "Failed to create temporary state file in {}",
+            session_dir.display()
+        )
+    })?;
+    temp_file
+        .as_file_mut()
+        .write_all(contents.as_bytes())
+        .with_context(|| {
+            format!(
+                "Failed to write temporary state file: {}",
+                state_path.display()
+            )
+        })?;
+    temp_file.as_file_mut().sync_all().with_context(|| {
+        format!(
+            "Failed to sync temporary state file: {}",
+            state_path.display()
+        )
+    })?;
+    preserve_existing_state_permissions_if_present(temp_file.as_file_mut(), state_path)?;
+    temp_file.persist(state_path).map_err(|err| {
+        anyhow!(
+            "Failed to persist state file {}: {}",
+            state_path.display(),
+            err.error
+        )
+    })?;
+
+    Ok(())
+}
+
+fn preserve_existing_state_permissions_if_present(
+    temp_file: &mut File,
+    state_path: &Path,
+) -> Result<()> {
+    let permissions = match fs::metadata(state_path) {
+        Ok(metadata) => Some(metadata.permissions()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!(
+                    "Failed to read state file metadata before preserving permissions: {}",
+                    state_path.display()
+                )
+            });
+        }
+    };
+    if let Some(permissions) = permissions {
+        temp_file.set_permissions(permissions).with_context(|| {
+            format!(
+                "Failed to preserve existing state file permissions: {}",
+                state_path.display()
+            )
+        })?;
+    }
+    Ok(())
+}

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -97,11 +97,11 @@ pub use manager::{
     find_sessions, get_session_dir, get_session_dir_global, get_session_root,
     legacy_user_result_path, list_all_project_session_roots, list_all_sessions,
     list_all_sessions_all_projects, list_artifacts, list_sessions, list_sessions_from_root,
-    list_sessions_from_root_readonly, load_metadata, load_result, load_result_view, load_session,
-    load_session_global_exact, redact_result_sidecar_value, render_redacted_result_sidecar,
-    resolve_fork_source, resolve_resume_session, save_result, save_result_with_options,
-    save_session, save_session_in, update_last_accessed, validate_tool_access,
-    write_audit_warning_artifact,
+    list_sessions_from_root_readonly, list_sessions_readonly, load_metadata, load_result,
+    load_result_view, load_session, load_session_global_exact, redact_result_sidecar_value,
+    render_redacted_result_sidecar, resolve_fork_source, resolve_resume_session, save_result,
+    save_result_with_options, save_session, save_session_in, update_last_accessed,
+    validate_tool_access, write_audit_warning_artifact,
 };
 
 pub use manager::ResumeSessionResolution;

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -7,8 +7,11 @@ use chrono::Utc;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
+#[path = "atomic_state_write.rs"]
+mod atomic_state_write;
+#[path = "manager_access.rs"]
+mod manager_access;
 #[path = "manager_audit.rs"]
 mod manager_audit;
 #[path = "manager_daemon.rs"]
@@ -17,9 +20,17 @@ mod manager_daemon;
 mod manager_legacy;
 #[path = "manager_paths.rs"]
 mod manager_paths;
+#[path = "manager_recovery.rs"]
+mod manager_recovery;
 #[path = "manager_result.rs"]
 mod manager_result;
+#[path = "manager_vcs.rs"]
+mod manager_vcs;
 
+#[cfg(test)]
+pub(crate) use manager_access::load_metadata_in;
+pub(crate) use manager_access::validate_tool_access_in;
+pub use manager_access::{load_metadata, resolve_fork_source, validate_tool_access};
 pub use manager_audit::{RepoWriteAudit, compute_repo_write_audit, write_audit_warning_artifact};
 pub use manager_daemon::{ResumeSessionResolution, create_session_with_daemon_env};
 use manager_daemon::{SessionIdStrategy, preassigned_daemon_session_id_from_env};
@@ -41,6 +52,8 @@ pub use manager_result::{
 pub(crate) use manager_result::{
     list_artifacts_in, load_result_in, load_result_view_in, save_result_in,
 };
+pub use manager_vcs::detect_git_head;
+use manager_vcs::{detect_change_id, detect_current_branch, detect_git_status_porcelain};
 
 const STATE_FILE_NAME: &str = "state.toml";
 const DAEMON_SESSION_ID_ENV: &str = "CSA_DAEMON_SESSION_ID";
@@ -231,51 +244,6 @@ fn create_session_in_with_strategy(
 
     Ok(state)
 }
-pub fn detect_git_head(project_path: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .current_dir(project_path)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let head = String::from_utf8(output.stdout).ok()?;
-    let trimmed = head.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
-
-fn detect_git_status_porcelain(project_path: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["status", "--porcelain=v1", "-z"])
-        .current_dir(project_path)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    String::from_utf8(output.stdout).ok()
-}
-
-/// Detect a VCS change identifier for session-change binding using the active backend.
-fn detect_change_id(project_path: &Path) -> Option<String> {
-    let backend = crate::vcs_backends::create_vcs_backend(project_path);
-    backend.head_id(project_path).ok().flatten()
-}
-
-fn detect_current_branch(project_path: &Path) -> Option<String> {
-    let backend = crate::vcs_backends::create_vcs_backend(project_path);
-    backend.current_branch(project_path).ok().flatten()
-}
-
 /// Load an existing session
 pub fn load_session(project_path: &Path, session_id: &str) -> Result<MetaSessionState> {
     let base_dir = resolve_read_base_dir(project_path, Some(session_id))?;
@@ -364,10 +332,7 @@ pub fn save_session_in(base_dir: &Path, state: &MetaSessionState) -> Result<()> 
 
     let contents = toml::to_string_pretty(state).context("Failed to serialize session state")?;
 
-    fs::write(&state_path, contents)
-        .with_context(|| format!("Failed to write state file: {}", state_path.display()))?;
-
-    Ok(())
+    atomic_state_write::write_state_atomically(&session_dir, &state_path, &contents)
 }
 
 /// Delete a session and its directory
@@ -461,65 +426,15 @@ fn list_all_sessions_impl(base_dir: &Path, recover: bool) -> Result<Vec<MetaSess
                 );
             }
             Err(e) => {
-                // BUG-11: Corrupt state.toml recovery
                 let session_dir = get_session_dir_in(base_dir, &session_id);
-                let state_path = session_dir.join(STATE_FILE_NAME);
-                if !state_path.exists() {
-                    tracing::warn!(session_id = %session_id, "No state.toml");
-                    continue;
+                if let Some(minimal_state) = manager_recovery::recover_corrupt_session_state(
+                    base_dir,
+                    &session_dir,
+                    &session_id,
+                    &e,
+                ) {
+                    sessions.push(minimal_state);
                 }
-                let backup_path = session_dir.join("state.toml.corrupt");
-                if let Err(backup_err) = fs::rename(&state_path, &backup_path) {
-                    tracing::warn!(
-                        session_id = %session_id,
-                        error = %backup_err,
-                        "Failed to backup corrupt state.toml"
-                    );
-                    continue;
-                }
-                tracing::warn!(
-                    session_id = %session_id,
-                    error = %e,
-                    "Recovered corrupt state.toml → state.toml.corrupt"
-                );
-                let now = chrono::Utc::now();
-                let minimal_state = MetaSessionState {
-                    meta_session_id: session_id.clone(),
-                    description: Some("(recovered from corrupt state)".to_string()),
-                    project_path: "(unknown)".to_string(),
-                    branch: None,
-                    created_at: now,
-                    last_accessed: now,
-                    csa_version: None,
-                    genealogy: crate::state::Genealogy::default(),
-                    tools: HashMap::new(),
-                    context_status: Default::default(),
-                    total_token_usage: None,
-                    phase: Default::default(),
-                    task_context: Default::default(),
-                    turn_count: 0,
-                    token_budget: None,
-                    sandbox_info: None,
-                    termination_reason: None,
-                    is_seed_candidate: false,
-                    git_head_at_creation: None,
-                    pre_session_porcelain: None,
-                    last_return_packet: None,
-                    change_id: None,
-                    spec_id: None,
-                    fork_call_timestamps: Vec::new(),
-                    vcs_identity: None,
-                    identity_version: 1,
-                };
-                if let Err(save_err) = save_session_in(base_dir, &minimal_state) {
-                    tracing::warn!(
-                        session_id = %session_id,
-                        error = %save_err,
-                        "Failed to save minimal state after recovery"
-                    );
-                    continue;
-                }
-                sessions.push(minimal_state);
             }
         }
     }
@@ -691,103 +606,6 @@ pub(crate) fn complete_session_in(
     validate_session_id(session_id)?;
     let sessions_dir = base_dir.join("sessions");
     crate::git::commit_session(&sessions_dir, session_id, message)
-}
-
-/// Load session metadata (tool ownership info)
-pub fn load_metadata(
-    project_path: &Path,
-    session_id: &str,
-) -> Result<Option<crate::metadata::SessionMetadata>> {
-    let base_dir = resolve_read_base_dir(project_path, Some(session_id))?;
-    load_metadata_in(&base_dir, session_id)
-}
-
-/// Internal implementation: load metadata from explicit base directory
-pub(crate) fn load_metadata_in(
-    base_dir: &Path,
-    session_id: &str,
-) -> Result<Option<crate::metadata::SessionMetadata>> {
-    validate_session_id(session_id)?;
-    let session_dir = get_session_dir_in(base_dir, session_id);
-    let metadata_path = session_dir.join(crate::metadata::METADATA_FILE_NAME);
-
-    if !metadata_path.exists() {
-        return Ok(None);
-    }
-
-    let contents = fs::read_to_string(&metadata_path)
-        .with_context(|| format!("Failed to read metadata: {}", metadata_path.display()))?;
-    let metadata: crate::metadata::SessionMetadata = toml::from_str(&contents)
-        .with_context(|| format!("Failed to parse metadata: {}", metadata_path.display()))?;
-
-    Ok(Some(metadata))
-}
-
-/// Resolve a session reference as a fork source without tool-lock enforcement.
-///
-/// Unlike [`resolve_resume_session`], this function does NOT check `tool_locked`
-/// because soft forks only read context from the parent session and do not require
-/// tool ownership. The returned `provider_session_id` is from the *source* tool
-/// (not the fork target), which native forks may need.
-pub fn resolve_fork_source(
-    project_path: &Path,
-    session_ref: &str,
-) -> Result<ResumeSessionResolution> {
-    let primary = get_session_root(project_path)?;
-    match resolve_fork_source_in(&primary, session_ref) {
-        Ok(resolution) => Ok(resolution),
-        Err(primary_error) => {
-            let Some(legacy) = legacy_session_root(project_path) else {
-                return Err(primary_error);
-            };
-            if !legacy.join("sessions").exists() {
-                return Err(primary_error);
-            }
-            resolve_fork_source_in(&legacy, session_ref).map_err(|_| primary_error)
-        }
-    }
-}
-
-/// Internal implementation: resolve fork source IDs without tool-lock check.
-fn resolve_fork_source_in(base_dir: &Path, session_ref: &str) -> Result<ResumeSessionResolution> {
-    let sessions_dir = base_dir.join("sessions");
-    let meta_session_id = resolve_session_prefix(&sessions_dir, session_ref)?;
-
-    // Load session to find the source tool's provider session ID (for native fork).
-    // We take the first tool entry that has a provider_session_id.
-    let session = load_session_in(base_dir, &meta_session_id)?;
-    let provider_session_id = session
-        .tools
-        .values()
-        .find_map(|state| state.provider_session_id.clone());
-
-    Ok(ResumeSessionResolution {
-        meta_session_id,
-        provider_session_id,
-    })
-}
-
-/// Validate that the given tool can access this session.
-/// Returns Ok(()) if access is allowed, Err if tool_locked and tool doesn't match.
-pub fn validate_tool_access(project_path: &Path, session_id: &str, tool: &str) -> Result<()> {
-    let base_dir = resolve_read_base_dir(project_path, Some(session_id))?;
-    validate_tool_access_in(&base_dir, session_id, tool)
-}
-
-/// Internal implementation: validate tool access in explicit base directory
-pub(crate) fn validate_tool_access_in(base_dir: &Path, session_id: &str, tool: &str) -> Result<()> {
-    if let Some(metadata) = load_metadata_in(base_dir, session_id)?
-        && metadata.tool_locked
-        && metadata.tool != tool
-    {
-        anyhow::bail!(
-            "Session '{}' is locked to tool '{}', cannot access with '{}'",
-            session_id,
-            metadata.tool,
-            tool
-        );
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -453,20 +453,44 @@ pub fn list_sessions(
     list_sessions_in(&base_dir, tool_filter)
 }
 
+/// Read-only variant of [`list_sessions`] (skips corrupt-state recovery).
+pub fn list_sessions_readonly(
+    project_path: &Path,
+    tool_filter: Option<&[&str]>,
+) -> Result<Vec<MetaSessionState>> {
+    let base_dir = resolve_read_base_dir(project_path, None)?;
+    list_sessions_in_readonly(&base_dir, tool_filter)
+}
+
 /// Internal implementation: list sessions with optional filter
 pub(crate) fn list_sessions_in(
     base_dir: &Path,
     tool_filter: Option<&[&str]>,
 ) -> Result<Vec<MetaSessionState>> {
     let all_sessions = list_all_sessions_in(base_dir)?;
+    Ok(filter_sessions_by_tool(all_sessions, tool_filter))
+}
 
+/// Read-only internal implementation: list sessions with optional filter.
+pub(crate) fn list_sessions_in_readonly(
+    base_dir: &Path,
+    tool_filter: Option<&[&str]>,
+) -> Result<Vec<MetaSessionState>> {
+    let all_sessions = list_all_sessions_in_readonly(base_dir)?;
+    Ok(filter_sessions_by_tool(all_sessions, tool_filter))
+}
+
+fn filter_sessions_by_tool(
+    all_sessions: Vec<MetaSessionState>,
+    tool_filter: Option<&[&str]>,
+) -> Vec<MetaSessionState> {
     if let Some(tools) = tool_filter {
-        Ok(all_sessions
+        all_sessions
             .into_iter()
             .filter(|session| tools.iter().any(|tool| session.tools.contains_key(*tool)))
-            .collect())
+            .collect()
     } else {
-        Ok(all_sessions)
+        all_sessions
     }
 }
 

--- a/crates/csa-session/src/manager_access.rs
+++ b/crates/csa-session/src/manager_access.rs
@@ -1,0 +1,106 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+
+use super::{
+    ResumeSessionResolution, get_session_dir_in, get_session_root, legacy_session_root,
+    load_session_in, resolve_read_base_dir,
+};
+use crate::validate::{resolve_session_prefix, validate_session_id};
+
+/// Load session metadata (tool ownership info)
+pub fn load_metadata(
+    project_path: &Path,
+    session_id: &str,
+) -> Result<Option<crate::metadata::SessionMetadata>> {
+    let base_dir = resolve_read_base_dir(project_path, Some(session_id))?;
+    load_metadata_in(&base_dir, session_id)
+}
+
+/// Internal implementation: load metadata from explicit base directory
+pub(crate) fn load_metadata_in(
+    base_dir: &Path,
+    session_id: &str,
+) -> Result<Option<crate::metadata::SessionMetadata>> {
+    validate_session_id(session_id)?;
+    let session_dir = get_session_dir_in(base_dir, session_id);
+    let metadata_path = session_dir.join(crate::metadata::METADATA_FILE_NAME);
+
+    if !metadata_path.exists() {
+        return Ok(None);
+    }
+
+    let contents = fs::read_to_string(&metadata_path)
+        .with_context(|| format!("Failed to read metadata: {}", metadata_path.display()))?;
+    let metadata: crate::metadata::SessionMetadata = toml::from_str(&contents)
+        .with_context(|| format!("Failed to parse metadata: {}", metadata_path.display()))?;
+
+    Ok(Some(metadata))
+}
+
+/// Resolve a session reference as a fork source without tool-lock enforcement.
+///
+/// Unlike [`super::resolve_resume_session`], this function does NOT check `tool_locked`
+/// because soft forks only read context from the parent session and do not require
+/// tool ownership. The returned `provider_session_id` is from the *source* tool
+/// (not the fork target), which native forks may need.
+pub fn resolve_fork_source(
+    project_path: &Path,
+    session_ref: &str,
+) -> Result<ResumeSessionResolution> {
+    let primary = get_session_root(project_path)?;
+    match resolve_fork_source_in(&primary, session_ref) {
+        Ok(resolution) => Ok(resolution),
+        Err(primary_error) => {
+            let Some(legacy) = legacy_session_root(project_path) else {
+                return Err(primary_error);
+            };
+            if !legacy.join("sessions").exists() {
+                return Err(primary_error);
+            }
+            resolve_fork_source_in(&legacy, session_ref).map_err(|_| primary_error)
+        }
+    }
+}
+
+/// Internal implementation: resolve fork source IDs without tool-lock check.
+fn resolve_fork_source_in(base_dir: &Path, session_ref: &str) -> Result<ResumeSessionResolution> {
+    let sessions_dir = base_dir.join("sessions");
+    let meta_session_id = resolve_session_prefix(&sessions_dir, session_ref)?;
+
+    // Load session to find the source tool's provider session ID (for native fork).
+    // We take the first tool entry that has a provider_session_id.
+    let session = load_session_in(base_dir, &meta_session_id)?;
+    let provider_session_id = session
+        .tools
+        .values()
+        .find_map(|state| state.provider_session_id.clone());
+
+    Ok(ResumeSessionResolution {
+        meta_session_id,
+        provider_session_id,
+    })
+}
+
+/// Validate that the given tool can access this session.
+/// Returns Ok(()) if access is allowed, Err if tool_locked and tool doesn't match.
+pub fn validate_tool_access(project_path: &Path, session_id: &str, tool: &str) -> Result<()> {
+    let base_dir = resolve_read_base_dir(project_path, Some(session_id))?;
+    validate_tool_access_in(&base_dir, session_id, tool)
+}
+
+/// Internal implementation: validate tool access in explicit base directory
+pub(crate) fn validate_tool_access_in(base_dir: &Path, session_id: &str, tool: &str) -> Result<()> {
+    if let Some(metadata) = load_metadata_in(base_dir, session_id)?
+        && metadata.tool_locked
+        && metadata.tool != tool
+    {
+        anyhow::bail!(
+            "Session '{}' is locked to tool '{}', cannot access with '{}'",
+            session_id,
+            metadata.tool,
+            tool
+        );
+    }
+    Ok(())
+}

--- a/crates/csa-session/src/manager_recovery.rs
+++ b/crates/csa-session/src/manager_recovery.rs
@@ -1,0 +1,72 @@
+use crate::state::MetaSessionState;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use super::{STATE_FILE_NAME, save_session_in};
+
+pub(super) fn recover_corrupt_session_state(
+    base_dir: &Path,
+    session_dir: &Path,
+    session_id: &str,
+    error: &anyhow::Error,
+) -> Option<MetaSessionState> {
+    // BUG-11: Corrupt state.toml recovery
+    let state_path = session_dir.join(STATE_FILE_NAME);
+    if !state_path.exists() {
+        tracing::warn!(session_id = %session_id, "No state.toml");
+        return None;
+    }
+    let backup_path = session_dir.join("state.toml.corrupt");
+    if let Err(backup_err) = fs::rename(&state_path, &backup_path) {
+        tracing::warn!(
+            session_id = %session_id,
+            error = %backup_err,
+            "Failed to backup corrupt state.toml"
+        );
+        return None;
+    }
+    tracing::warn!(
+        session_id = %session_id,
+        error = %error,
+        "Recovered corrupt state.toml → state.toml.corrupt"
+    );
+    let now = chrono::Utc::now();
+    let minimal_state = MetaSessionState {
+        meta_session_id: session_id.to_string(),
+        description: Some("(recovered from corrupt state)".to_string()),
+        project_path: "(unknown)".to_string(),
+        branch: None,
+        created_at: now,
+        last_accessed: now,
+        csa_version: None,
+        genealogy: crate::state::Genealogy::default(),
+        tools: HashMap::new(),
+        context_status: Default::default(),
+        total_token_usage: None,
+        phase: Default::default(),
+        task_context: Default::default(),
+        turn_count: 0,
+        token_budget: None,
+        sandbox_info: None,
+        termination_reason: None,
+        is_seed_candidate: false,
+        git_head_at_creation: None,
+        pre_session_porcelain: None,
+        last_return_packet: None,
+        change_id: None,
+        spec_id: None,
+        fork_call_timestamps: Vec::new(),
+        vcs_identity: None,
+        identity_version: 1,
+    };
+    if let Err(save_err) = save_session_in(base_dir, &minimal_state) {
+        tracing::warn!(
+            session_id = %session_id,
+            error = %save_err,
+            "Failed to save minimal state after recovery"
+        );
+        return None;
+    }
+    Some(minimal_state)
+}

--- a/crates/csa-session/src/manager_tests.rs
+++ b/crates/csa-session/src/manager_tests.rs
@@ -229,6 +229,44 @@ fn test_list_sessions_with_tool_filter() {
 }
 
 #[test]
+fn test_list_sessions_readonly_preserves_corrupt_state_without_recovery() {
+    let td = tempdir().unwrap();
+    let _xdg = ScopedXdgOverride::new(&td);
+    let session = create_session_in(td.path(), td.path(), Some("corrupt"), None, None).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &session.meta_session_id);
+    let state_path = session_dir.join(STATE_FILE_NAME);
+    let corrupt_state = b"not valid toml = [".to_vec();
+    std::fs::write(&state_path, &corrupt_state).unwrap();
+
+    let sessions = list_sessions_in_readonly(td.path(), None).unwrap();
+
+    assert!(sessions.is_empty());
+    assert_eq!(std::fs::read(&state_path).unwrap(), corrupt_state);
+    assert!(!session_dir.join("state.toml.corrupt").exists());
+}
+
+#[test]
+fn test_list_sessions_recovers_corrupt_state() {
+    let td = tempdir().unwrap();
+    let _xdg = ScopedXdgOverride::new(&td);
+    let session = create_session_in(td.path(), td.path(), Some("corrupt"), None, None).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &session.meta_session_id);
+    let state_path = session_dir.join(STATE_FILE_NAME);
+    std::fs::write(&state_path, b"not valid toml = [").unwrap();
+
+    let sessions = list_sessions_in(td.path(), None).unwrap();
+
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].meta_session_id, session.meta_session_id);
+    assert!(session_dir.join("state.toml.corrupt").exists());
+    let recovered = load_session_in(td.path(), &session.meta_session_id).unwrap();
+    assert_eq!(
+        recovered.description.as_deref(),
+        Some("(recovered from corrupt state)")
+    );
+}
+
+#[test]
 fn test_resolve_resume_session_with_provider_id() {
     let td = tempdir().unwrap();
     let mut state = create_session_in(td.path(), td.path(), Some("Resume"), None, None).unwrap();

--- a/crates/csa-session/src/manager_tests_tail_2.rs
+++ b/crates/csa-session/src/manager_tests_tail_2.rs
@@ -36,6 +36,26 @@ fn test_save_session_in_explicit_base() {
 }
 
 #[test]
+fn test_save_session_in_publishes_complete_parseable_state() {
+    let td = tempdir().unwrap();
+    let mut state =
+        create_session_in(td.path(), td.path(), Some("Atomic save"), None, None).unwrap();
+    state.description = Some("updated through atomic save".to_string());
+
+    save_session_in(td.path(), &state).unwrap();
+
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let state_path = session_dir.join(STATE_FILE_NAME);
+    let contents = std::fs::read_to_string(&state_path).unwrap();
+    let parsed: MetaSessionState = toml::from_str(&contents).unwrap();
+    assert_eq!(parsed.meta_session_id, state.meta_session_id);
+    assert_eq!(
+        parsed.description,
+        Some("updated through atomic save".to_string())
+    );
+}
+
+#[test]
 fn test_list_sessions_empty_and_missing() {
     let td = tempdir().unwrap();
     assert!(list_all_sessions_in(td.path()).unwrap().is_empty());
@@ -346,4 +366,3 @@ fn test_prefix_stays_project_scoped() {
     let result = crate::validate::resolve_session_prefix(&sessions_dir_b, &s1.meta_session_id);
     assert!(result.is_err());
 }
-

--- a/crates/csa-session/src/manager_vcs.rs
+++ b/crates/csa-session/src/manager_vcs.rs
@@ -1,0 +1,47 @@
+use std::path::Path;
+use std::process::Command;
+
+pub fn detect_git_head(project_path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(project_path)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let head = String::from_utf8(output.stdout).ok()?;
+    let trimmed = head.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+pub(super) fn detect_git_status_porcelain(project_path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain=v1", "-z"])
+        .current_dir(project_path)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8(output.stdout).ok()
+}
+
+/// Detect a VCS change identifier for session-change binding using the active backend.
+pub(super) fn detect_change_id(project_path: &Path) -> Option<String> {
+    let backend = crate::vcs_backends::create_vcs_backend(project_path);
+    backend.head_id(project_path).ok().flatten()
+}
+
+pub(super) fn detect_current_branch(project_path: &Path) -> Option<String> {
+    let backend = crate::vcs_backends::create_vcs_backend(project_path);
+    backend.current_branch(project_path).ok().flatten()
+}


### PR DESCRIPTION
## Summary

Fixes #1870: a long-running `csa run` **write** session's directory + record disappeared **mid-flight**
(worker alive ~100 min in, edits fully staged but never committed), and `csa session wait` returned
`Session '<ULID>' not found` instead of a terminal result — stranding ~100 min of validated work as
staged-but-uncommitted changes.

## Root cause

A read-only RECON traced the mechanism:

1. `save_session_in` wrote `state.toml` with a **non-atomic** `fs::write`.
2. A concurrent **recovering enumerator** (GC / list scan) could read a **partial** `state.toml`, trip
   the corrupt-state recovery path, and rewrite it as a **minimal Active state with empty `tools`**.
3. GC's empty/expired **whole-session DELETE** paths then removed the session dir **with no
   phase/liveness guard** — deleting an Active, still-alive session.

Once the dir/state was gone, `session wait`'s reconcile (which must `load_session` first) could not
synthesize a terminal `result.toml`, so it surfaced `not found`.

## Fix (defense in depth)

**Layer 1 — prevent the catastrophic deletion (primary):** a shared guard predicate now blocks
sweep-style whole-session deletion when the session is `Active` **or** shows liveness
(`ToolLiveness::has_live_process` / `daemon_pid_is_alive` / `is_alive`). Applied to all five
whole-session sweep-delete sites (local + global GC empty/expired, `session clean`) and a dir-only
liveness guard to the two orphan-dir sweeps.
- The guard is **only** on whole-session DELETE paths. The RETIRE (Active→Retired marking), runtime-only
  reaper, and dead-Active result-synthesis paths are unchanged, so a genuinely-dead session still flows
  dead-Active → RETIRE → EXPIRE-delete (#543 / #540 / #1711 preserved).
- Explicit `csa session delete` / MCP delete stay **forceful** (operator path, unguarded).

**Layer 2 — eliminate the trigger (root-cause hardening):** `save_session_in` now writes `state.toml`
**atomically** (temp file + rename in the same directory), reusing the existing reconcile atomic-writer
pattern, so a concurrent enumerator can never observe a half-written file.

**Layer 3 — dry-run/preview must be side-effect-free:** the Layer-1 guard reuse + subsequent review
surfaced three independent ways `csa gc --dry-run` / `csa session clean --dry-run` could still mutate
session dirs while printing "No changes will be made". All three are now read-only in preview, while the
EXECUTION + liveness-watchdog paths keep their mutating behavior (no #1758 regression):
- **Preview liveness probe** no longer persists `.liveness.snapshot` — a non-persisting
  `ToolLiveness::is_alive_read_only` is used for all five whole-session preview sites; execution and the
  CPU/output-growth watchdog keep the persisting probe.
- **Orphan-dir preview** now consults the same `should_skip_orphan_session_dir_delete` guard as execution
  (side-effect-free), so dry-run lists exactly what execution would delete.
- **Recovery-on-list** no longer fires in preview: dry-run listing uses a read-only
  `list_sessions_readonly` (recover = false), so a corrupt `state.toml` is **not** renamed to
  `.corrupt` / replaced with a minimal stub during a dry-run; execution keeps `recover = true`
  self-healing.

**Monolith budget (in-scope refactor):** the Layer-1/Layer-2 additions pushed
`crates/csa-session/src/manager.rs` to 843 lines, over the 800-line monolith gate. To land cleanly the
new/cohesive code was extracted (pure move, behavior unchanged) into csa-session submodules —
`atomic_state_write.rs`, `manager_access.rs`, `manager_recovery.rs`, `manager_vcs.rs` — dropping
`manager.rs` to **613 lines**. The Layer-1 guard logic is unchanged; the Layer-2 atomic-write sequence
was relocated with identical operations and error strings.

## Verification

New tests: whole-session GC preserves an Active (even empty-tools) session; preserves a session with a
live process / live daemon PID; orphan-looking dir with a live daemon/lock is preserved; a dead
**Retired** session is still deletable by the expired path (guard does not over-block); `state.toml`
writes are atomic; `--dry-run` (whole-session + orphan-dir) is provably side-effect-free (no
`.liveness.snapshot` written); dry-run listing leaves a corrupt `state.toml` intact (no `.corrupt` /
minimal stub) while the execution path still recovers it. Existing GC / reconcile / cleanup regression
tests stay green.

Reviewed across 5 tier-4 rounds (codex rounds 1–4, gemini round 5), each round surfacing and fixing a
**distinct** concrete write-path; round 5 (heterogeneous, gemini) is a clean PASS confirming the prior
FAIL is resolved with no new defects. Per-commit local lefthook pre-commit gate (fmt + clippy + deny +
monolith-size + version-bump + chinese-check) green; full test suite validated by CI.

## Related

Closes #1870. Lifecycle family with #1711 / #1757 / #1758 (distinct fingerprint: dir vanishes while the
worker is alive). Secondary atomic-write hardening also reduces partial-state-read risk for any
recovering enumerator. Followup (filed separately): a typed read-only/preview capability so dry-run
mutation paths are unreachable at compile time, rather than per-call-site opt-out.
