### PR TITLE
fix(cli-sub-agent): restore Linux CI test baseline + gate bwrap preflight on sandbox capability (#1879)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,10 +158,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install nextest
         uses: taiki-e/install-action@f1d55f103dfbf9be3d3cf757ce9e198778ba8687
+      - name: Install bubblewrap
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
       - name: Run workspace tests (default features)
-        run: cargo nextest run --workspace
+        run: cargo nextest run --workspace --no-fail-fast
       - name: Run workspace tests (all features)
-        run: cargo nextest run --workspace --all-features
+        run: cargo nextest run --workspace --all-features --no-fail-fast
       - name: Run cli-sub-agent e2e tests
         if: matrix.os == 'ubuntu-latest'
-        run: cargo nextest run --package cli-sub-agent --test e2e --all-features
+        run: cargo nextest run --package cli-sub-agent --test e2e --all-features --no-fail-fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.899"
+version = "0.1.900"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.899"
+version = "0.1.900"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -396,36 +396,51 @@ pub(crate) async fn build_and_validate_executor(
         );
         anyhow::bail!("{e}");
     }
-    ensure_tool_runtime_prerequisites(executor.tool_name()).await?;
-
     Ok(executor)
 }
 
-async fn ensure_tool_runtime_prerequisites(tool_name: &str) -> Result<()> {
+async fn ensure_tool_runtime_prerequisites(
+    tool_name: &str,
+    filesystem_capability: csa_resource::FilesystemCapability,
+) -> Result<()> {
     if tool_name != "codex" {
+        return Ok(());
+    }
+    if !matches!(
+        filesystem_capability,
+        csa_resource::FilesystemCapability::Bwrap
+    ) {
         return Ok(());
     }
     if std::env::var("CSA_SKIP_BWRAP_PREFLIGHT").ok().as_deref() == Some("1") {
         return Ok(());
     }
 
-    #[cfg(target_os = "linux")]
-    {
-        let has_bwrap = tokio::process::Command::new("which")
-            .arg("bwrap")
-            .output()
-            .await
-            .map(|out| out.status.success())
-            .unwrap_or(false);
-        if !has_bwrap {
-            anyhow::bail!(
-                "codex preflight failed: required runtime dependency 'bwrap' (bubblewrap) is missing.\n\
-                 Install bubblewrap first, then re-run the command."
-            );
-        }
+    let has_bwrap = tokio::process::Command::new("which")
+        .arg("bwrap")
+        .output()
+        .await
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    if !has_bwrap {
+        anyhow::bail!(
+            "codex preflight failed: required runtime dependency 'bwrap' (bubblewrap) is missing.\n\
+             Install bubblewrap first, then re-run the command."
+        );
     }
 
     Ok(())
+}
+
+fn resolved_filesystem_capability(
+    execute_options: &csa_executor::ExecuteOptions,
+) -> csa_resource::FilesystemCapability {
+    execute_options
+        .sandbox
+        .as_ref()
+        .map_or(csa_resource::FilesystemCapability::None, |ctx| {
+            ctx.isolation_plan.filesystem
+        })
 }
 
 /// Acquire global concurrency slot for the executor.

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -403,6 +403,11 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             ));
         }
     };
+    super::ensure_tool_runtime_prerequisites(
+        executor.tool_name(),
+        super::resolved_filesystem_capability(&execute_options),
+    )
+    .await?;
     let spool_max_mb = config
         .map(|cfg| cfg.session.resolved_spool_max_mb())
         .unwrap_or((csa_process::DEFAULT_SPOOL_MAX_BYTES / (1024 * 1024)) as u32);

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -696,6 +696,32 @@ fn config_with_tier_for_tool(_tool_prefix: &str, model_spec: &str) -> ProjectCon
     }
 }
 
+#[tokio::test]
+async fn codex_bwrap_preflight_follows_filesystem_capability() {
+    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
+    let empty_path = tempfile::tempdir().unwrap();
+    let _path_guard = crate::test_env_lock::ScopedEnvVarRestore::set("PATH", empty_path.path());
+    let _skip_guard = crate::test_env_lock::ScopedEnvVarRestore::unset("CSA_SKIP_BWRAP_PREFLIGHT");
+
+    let disabled =
+        ensure_tool_runtime_prerequisites("codex", csa_resource::FilesystemCapability::None).await;
+    assert!(
+        disabled.is_ok(),
+        "codex preflight must not require bwrap when filesystem sandboxing is disabled"
+    );
+
+    let enabled =
+        ensure_tool_runtime_prerequisites("codex", csa_resource::FilesystemCapability::Bwrap).await;
+    assert!(
+        enabled.is_err(),
+        "codex preflight must require bwrap when bwrap filesystem sandboxing is enabled"
+    );
+    assert!(
+        enabled.unwrap_err().to_string().contains("bwrap"),
+        "enabled bwrap preflight error should name the missing dependency"
+    );
+}
+
 /// When `enforce_tier=true`, passing a model spec not in the tier whitelist
 /// must produce a tier-related error.
 #[tokio::test]

--- a/crates/cli-sub-agent/src/review_cmd_tests_fix_fallback.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_fix_fallback.rs
@@ -8,10 +8,6 @@ async fn handle_review_fix_loop_uses_effective_fallback_tool() {
 
     let project_dir = setup_git_repo();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
-    if which::which("bwrap").is_err() {
-        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
-        return;
-    }
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let opencode_count_path = project_dir.path().join("opencode-count.txt");

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -733,6 +733,13 @@ fn install_pattern(project_root: &Path, name: &str) {
 async fn handle_review_fix_clean_initial_persists_no_fix_attempt() {
     use std::os::unix::fs::PermissionsExt;
 
+    if which::which("bwrap").is_err() {
+        eprintln!(
+            "SKIP handle_review_fix_clean_initial_persists_no_fix_attempt: bwrap (bubblewrap) not available"
+        );
+        return;
+    }
+
     let project_dir = setup_git_repo();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -733,13 +733,6 @@ fn install_pattern(project_root: &Path, name: &str) {
 async fn handle_review_fix_clean_initial_persists_no_fix_attempt() {
     use std::os::unix::fs::PermissionsExt;
 
-    if which::which("bwrap").is_err() {
-        eprintln!(
-            "SKIP handle_review_fix_clean_initial_persists_no_fix_attempt: bwrap (bubblewrap) not available"
-        );
-        return;
-    }
-
     let project_dir = setup_git_repo();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");


### PR DESCRIPTION
## Summary

Restores the **Linux `Test` CI job** baseline (the test-signal half of #1879) and fixes a real
production preflight bug it surfaced. The 93-file token-monolith gate calibration (the `Check` /
pre-commit-quality-gate jobs) is the **design half** and is tracked separately in **#1880** — those
jobs remain red until #1880 lands. macOS-only residuals (e.g. the `e2e` tier-column env assertion)
are pre-existing and out of scope (ignored while Linux is green, per project policy).

## Root cause (the original CI failure)

The Linux `Test` job failed on a test that drives `csa run`/review with `--no-fs-sandbox`:

```
codex preflight failed: required runtime dependency 'bwrap' (bubblewrap) is missing
```

The codex tool preflight (`ensure_tool_runtime_prerequisites`) required `bwrap`
**unconditionally**, even when the resolved filesystem-isolation capability is `None` (sandbox
disabled). With `--no-fs-sandbox` no `bwrap` is ever spawned, so requiring it is wrong — and it also
broke real `csa run --no-fs-sandbox` usage on macOS / any host without bubblewrap.

## Changes

**Round 1 — CI infra (`.github/workflows/ci.yml`):**
- Install `bubblewrap` on the Linux `Test` job so sandbox-ENABLED tests exercise the real bwrap path.
- Add `--no-fail-fast` to every `cargo nextest run` so all baseline failures surface in one run
  instead of aborting at the first (the matrix already set `fail-fast: false`, but nextest itself was
  still fail-fast within a job — #635 lesson).
- Workspace version bump → `0.1.900`.

**Round 2 — preflight root-cause fix (review-driven):**
- `ensure_tool_runtime_prerequisites` now requires `bwrap` **only when** the resolved filesystem
  capability is `Bwrap`. With `--no-fs-sandbox` (capability `None`) preflight no longer requires or
  raises on missing `bwrap`; the requirement is preserved when the sandbox IS enabled.
  (`crates/cli-sub-agent/src/pipeline.rs`, `pipeline_session_exec.rs`.)
- Removed two incorrect `which::which("bwrap")` skip-guards on sandbox-disabled review-fix tests
  (`review_cmd_tests_tail.rs`, `review_cmd_tests_fix_fallback.rs`). The round-1 guard would have
  skipped those tests on ALL macOS / bwrap-less hosts (coverage loss); the preflight fix lets them
  run on every platform.
- Added a unit test proving both directions: preflight with fs-sandbox DISABLED succeeds without
  `bwrap`; preflight with fs-sandbox ENABLED still errors when `bwrap` is absent.
  (`pipeline_tests.rs`.)

## Review

- Round 1: tier-4 gemini → **FAIL** — correctly flagged the platform-incorrect bwrap skip-guard as
  macOS coverage loss.
- Round 2: re-dispatched after the preflight root-cause fix → tier-4 gemini → **PASS**.

## Scope / not in this PR

- The 93-file token-monolith gate calibration (CI-vs-local divergence, test-file exemption,
  grandfather-vs-split, single-source-of-truth) is **out of scope** and tracked in **#1880** (needs
  design + debate; touches the user-mandated 8K module-token gate). The `Check` /
  pre-commit-quality-gate CI jobs stay red until #1880.

Refs #1879

🤖 Generated with [Claude Code](https://claude.com/claude-code)
