### PR TITLE
fix(cli-sub-agent): fail-loud on csa review --fix no-op (close #1877)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.901"
+version = "0.1.902"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.901"
+version = "0.1.902"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix.rs
@@ -26,14 +26,18 @@ mod clean_output;
 mod convergence;
 #[path = "review_cmd_fix_diff_report.rs"]
 mod diff_report_artifacts;
+#[path = "review_cmd_fix_noop.rs"]
+mod noop;
 use convergence::{
     FixTerminalOutcome, fix_exit_code_for_convergence, pre_verdict_non_convergence_reason,
 };
 #[cfg(test)]
 pub(crate) use diff_report_artifacts::{
-    persist_fix_final_artifacts_for_tests, persist_fix_final_artifacts_for_tests_with_output,
+    persist_fix_final_artifacts_for_tests, persist_fix_final_artifacts_for_tests_with_noop_probe,
+    persist_fix_final_artifacts_for_tests_with_output,
     persist_fix_final_artifacts_for_tests_with_output_and_diff_report,
 };
+use noop::{FixNoOpProbe, apply_fix_loop_noop_signal, is_fix_loop_noop_failure_reason};
 
 /// Context for review fix-loop execution.
 pub(crate) struct FixLoopContext<'a> {
@@ -81,6 +85,7 @@ pub(crate) struct FixLoopContext<'a> {
 pub(crate) async fn run_fix_loop(ctx: FixLoopContext<'_>) -> Result<i32> {
     let mut session_id = ctx.initial_session_id;
     let diff_report = ctx.diff_report;
+    let noop_probe = FixNoOpProbe::capture(ctx.project_root);
     // Entering the fix loop means the current review is not clean; any existing
     // marker for this SHA is stale until genuine clean convergence rewrites it.
     remove_review_gate_marker_for_current_head(ctx.project_root, &session_id);
@@ -250,6 +255,7 @@ pub(crate) async fn run_fix_loop(ctx: FixLoopContext<'_>) -> Result<i32> {
                 true,
                 Some(&fix_output),
                 diff_report,
+                Some(&noop_probe),
             );
             if final_decision == ReviewDecision::Pass {
                 info!(
@@ -294,6 +300,7 @@ pub(crate) async fn run_fix_loop(ctx: FixLoopContext<'_>) -> Result<i32> {
         last_gate_passed,
         last_fix_output.as_deref(),
         diff_report,
+        Some(&noop_probe),
     );
     error!(
         max_rounds = ctx.max_rounds,
@@ -321,6 +328,7 @@ fn persist_fix_final_artifacts(
         quality_gate_passed,
         None,
         diff_report_artifacts::empty_diff_report(),
+        None,
     )
 }
 
@@ -330,6 +338,7 @@ fn persist_fix_final_artifacts_with_current_output(
     quality_gate_passed: bool,
     current_fix_output: Option<&str>,
     diff_report: super::diff_size::ReviewDiffReport<'_>,
+    noop_probe: Option<&FixNoOpProbe>,
 ) -> ReviewDecision {
     let fix_output_was_substantive = current_fix_output
         .map(|output| !is_review_output_empty(output))
@@ -404,7 +413,15 @@ fn persist_fix_final_artifacts_with_current_output(
         final_verdict.decision,
     );
     let final_meta = review_meta_for_final_verdict(&meta_for_verdict, &final_verdict, &outcome);
+    let final_meta = apply_fix_loop_noop_signal(project_root, final_meta, &outcome, noop_probe);
     diff_report_artifacts::persist_fix_review_meta(project_root, &final_meta, diff_report);
+    if final_meta
+        .failure_reason
+        .as_deref()
+        .is_some_and(is_fix_loop_noop_failure_reason)
+    {
+        diff_report_artifacts::persist_fix_review_verdict(project_root, &final_meta, diff_report);
+    }
     super::diff_size::persist_review_diff_size_headers(
         project_root,
         &final_meta.session_id,

--- a/crates/cli-sub-agent/src/review_cmd_fix_convergence_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_convergence_tests.rs
@@ -1,13 +1,14 @@
 use super::convergence::{fix_exit_code_for_convergence, reached_genuine_clean_convergence};
 use super::{
-    CLEAN, persist_fix_final_artifacts_for_tests_with_output,
+    CLEAN, persist_fix_final_artifacts_for_tests_with_noop_probe,
+    persist_fix_final_artifacts_for_tests_with_output,
     persist_fix_final_artifacts_for_tests_with_output_and_diff_report,
 };
 use crate::test_env_lock::ScopedTestEnvVar;
 use csa_core::types::ReviewDecision;
 use csa_session::state::ReviewSessionMeta;
 use csa_session::{
-    FindingsFile, ReviewDiffSize, ReviewFinding, ReviewFindingFileRange, Severity,
+    FindingsFile, ReviewDiffSize, ReviewFinding, ReviewFindingFileRange, SessionResult, Severity,
     write_findings_toml,
 };
 use std::fs;
@@ -101,6 +102,32 @@ fn read_review_meta(session_dir: &Path) -> ReviewSessionMeta {
         &fs::read_to_string(session_dir.join("review_meta.json")).expect("read meta"),
     )
     .expect("parse meta")
+}
+
+fn seed_session_result(project_root: &Path, session_id: &str, summary: &str) {
+    let now = chrono::Utc::now();
+    let result = SessionResult {
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: summary.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        fallback_chain: None,
+        gate_timeout: false,
+        warnings: Vec::new(),
+        raw_process_exit_code: None,
+        uncommitted_changes: None,
+        post_exec_gate: None,
+        manager_fields: Default::default(),
+    };
+    csa_session::save_result(project_root, session_id, &result).expect("save result.toml");
 }
 
 fn stale_finding() -> ReviewFinding {
@@ -581,6 +608,63 @@ fn persist_fix_final_artifacts_current_round_blocking_prose_blocks_exit_and_gate
         false,
         "post_consistency_non_pass",
     );
+}
+
+#[test]
+fn persist_fix_final_artifacts_noop_probe_marks_meta_verdict_and_result() {
+    let branch = "fix-1877-noop";
+    let project_root = temp_git_project_root("persist-fix-noop-probe", branch);
+    let state_home = temp_project_root("persist-fix-noop-probe-state");
+    let _state_home = ScopedTestEnvVar::set("XDG_STATE_HOME", state_home);
+    let session_id = ulid::Ulid::new().to_string();
+    let session_dir = create_session_dir(&project_root, &session_id);
+    let current_output = "<!-- CSA:SECTION:summary -->\nBlocking issues still remain.\n<!-- CSA:SECTION:summary:END -->\n<!-- CSA:SECTION:details -->\nMedium: src/lib.rs:99 current-round finding.\n<!-- CSA:SECTION:details:END -->\n";
+    persist_prior_blocking_review_with_current_output(&session_dir, current_output);
+    seed_session_result(&project_root, &session_id, "review still reports a finding");
+
+    let mut meta = make_clean_review_meta(&session_id);
+    meta.head_sha = csa_session::detect_git_head(&project_root).expect("detect HEAD");
+    meta.decision = ReviewDecision::Fail.as_str().to_string();
+    meta.verdict = "HAS_ISSUES".to_string();
+    meta.exit_code = 1;
+
+    let final_decision = persist_fix_final_artifacts_for_tests_with_noop_probe(
+        &project_root,
+        &meta,
+        true,
+        current_output,
+        Some(meta.head_sha.clone()),
+    );
+
+    assert_eq!(final_decision, ReviewDecision::Fail);
+    let persisted_meta = read_review_meta(&session_dir);
+    assert_eq!(
+        persisted_meta.failure_reason.as_deref(),
+        Some("fix_loop_noop:head_unchanged_worktree_clean")
+    );
+    assert_fix_convergence(
+        &persisted_meta,
+        true,
+        true,
+        ReviewDecision::Fail,
+        false,
+        "fix_loop_noop:head_unchanged_worktree_clean",
+    );
+
+    let artifact = read_review_verdict(&session_dir);
+    assert_eq!(
+        artifact.failure_reason.as_deref(),
+        Some("fix_loop_noop:head_unchanged_worktree_clean")
+    );
+
+    let result = csa_session::load_result(&project_root, &session_id)
+        .expect("load result")
+        .expect("result should exist");
+    assert_eq!(
+        result.summary,
+        "fix loop did not engage: head_unchanged_worktree_clean"
+    );
+    assert!(result.warnings.contains(&result.summary));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_fix_diff_report.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_diff_report.rs
@@ -68,6 +68,7 @@ pub(crate) fn persist_fix_final_artifacts_for_tests_with_output(
         quality_gate_passed,
         Some(current_fix_output),
         empty_diff_report(),
+        None,
     )
 }
 
@@ -85,5 +86,25 @@ pub(crate) fn persist_fix_final_artifacts_for_tests_with_output_and_diff_report(
         quality_gate_passed,
         Some(current_fix_output),
         diff_report,
+        None,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn persist_fix_final_artifacts_for_tests_with_noop_probe(
+    project_root: &Path,
+    review_meta: &ReviewSessionMeta,
+    quality_gate_passed: bool,
+    current_fix_output: &str,
+    initial_head: Option<String>,
+) -> ReviewDecision {
+    let noop_probe = super::FixNoOpProbe { initial_head };
+    super::persist_fix_final_artifacts_with_current_output(
+        project_root,
+        review_meta,
+        quality_gate_passed,
+        Some(current_fix_output),
+        empty_diff_report(),
+        Some(&noop_probe),
     )
 }

--- a/crates/cli-sub-agent/src/review_cmd_fix_noop.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_noop.rs
@@ -1,0 +1,116 @@
+use std::path::Path;
+use std::process::Command;
+
+use csa_core::types::ReviewDecision;
+use csa_session::state::ReviewSessionMeta;
+use tracing::warn;
+
+use super::convergence::FixTerminalOutcome;
+
+const FIX_LOOP_NOOP_REASON: &str = "head_unchanged_worktree_clean";
+const FIX_LOOP_NOOP_FAILURE_PREFIX: &str = "fix_loop_noop";
+
+#[derive(Debug)]
+pub(super) struct FixNoOpProbe {
+    pub(super) initial_head: Option<String>,
+}
+
+impl FixNoOpProbe {
+    pub(super) fn capture(project_root: &Path) -> Self {
+        Self {
+            initial_head: csa_session::detect_git_head(project_root),
+        }
+    }
+}
+
+pub(super) fn apply_fix_loop_noop_signal(
+    project_root: &Path,
+    mut final_meta: ReviewSessionMeta,
+    outcome: &FixTerminalOutcome,
+    noop_probe: Option<&FixNoOpProbe>,
+) -> ReviewSessionMeta {
+    let Some(reason) = detect_fix_loop_noop(project_root, outcome, noop_probe) else {
+        return final_meta;
+    };
+    let failure_reason = fix_loop_noop_failure_reason(reason);
+    final_meta.failure_reason = Some(failure_reason.clone());
+    if let Some(convergence) = final_meta.fix_convergence.as_mut() {
+        convergence.terminal_reason = failure_reason;
+    }
+    persist_fix_loop_noop_result_signal(project_root, &final_meta.session_id, reason);
+    final_meta
+}
+
+fn detect_fix_loop_noop(
+    project_root: &Path,
+    outcome: &FixTerminalOutcome,
+    noop_probe: Option<&FixNoOpProbe>,
+) -> Option<&'static str> {
+    if outcome.reached_genuine_clean_convergence()
+        || outcome.post_consistency_decision != ReviewDecision::Fail
+    {
+        return None;
+    }
+    let initial_head = noop_probe?.initial_head.as_deref()?.trim();
+    if initial_head.is_empty() {
+        return None;
+    }
+    let current_head = csa_session::detect_git_head(project_root)?;
+    if current_head.trim() != initial_head {
+        return None;
+    }
+    git_worktree_is_clean(project_root).then_some(FIX_LOOP_NOOP_REASON)
+}
+
+fn git_worktree_is_clean(project_root: &Path) -> bool {
+    let Ok(output) = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["status", "--porcelain=v1", "--untracked-files=normal"])
+        .output()
+    else {
+        return false;
+    };
+    output.status.success() && output.stdout.is_empty()
+}
+
+fn fix_loop_noop_failure_reason(reason: &str) -> String {
+    format!("{FIX_LOOP_NOOP_FAILURE_PREFIX}:{reason}")
+}
+
+pub(super) fn is_fix_loop_noop_failure_reason(reason: &str) -> bool {
+    reason
+        .strip_prefix(FIX_LOOP_NOOP_FAILURE_PREFIX)
+        .is_some_and(|suffix| suffix.starts_with(':'))
+}
+
+fn fix_loop_noop_message(reason: &str) -> String {
+    format!("fix loop did not engage: {reason}")
+}
+
+fn persist_fix_loop_noop_result_signal(project_root: &Path, session_id: &str, reason: &str) {
+    let message = fix_loop_noop_message(reason);
+    let mut result = match csa_session::load_result(project_root, session_id) {
+        Ok(Some(result)) => result,
+        Ok(None) => return,
+        Err(error) => {
+            warn!(
+                session_id,
+                error = %error,
+                "Failed to load result.toml while recording fix-loop no-op signal"
+            );
+            return;
+        }
+    };
+    result.summary = message.clone();
+    if !result.warnings.iter().any(|warning| warning == &message) {
+        result.warnings.push(message);
+    }
+    if let Err(error) = csa_session::save_result(project_root, session_id, &result) {
+        warn!(
+            session_id,
+            error = %error,
+            "Failed to persist result.toml fix-loop no-op signal"
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -284,6 +284,13 @@ fn read_review_verdict_label(
 ) -> Option<String> {
     if let Some(artifact) = read_review_verdict_artifact(session_dir) {
         let meta = read_review_meta_for_label(session_dir);
+        if let Some(label) = meta
+            .as_ref()
+            .and_then(|meta| format_fix_loop_noop_label(meta.failure_reason.as_deref()))
+            .or_else(|| format_fix_loop_noop_label(artifact.failure_reason.as_deref()))
+        {
+            return Some(label);
+        }
         if artifact.decision == ReviewDecision::Pass {
             if !wait_result_allows_pass_verdict(result) {
                 return Some("UNAVAILABLE".to_string());
@@ -312,6 +319,9 @@ fn read_review_verdict_label(
         && let Ok(raw) = std::fs::read_to_string(&meta_path)
         && let Ok(meta) = serde_json::from_str::<ReviewSessionMeta>(&raw)
     {
+        if let Some(label) = format_fix_loop_noop_label(meta.failure_reason.as_deref()) {
+            return Some(label);
+        }
         if meta.fix_attempted && !meta.fix_clean_converged() {
             return Some("UNAVAILABLE".to_string());
         }
@@ -319,6 +329,14 @@ fn read_review_verdict_label(
     }
 
     None
+}
+
+fn format_fix_loop_noop_label(reason: Option<&str>) -> Option<String> {
+    let reason = reason?.strip_prefix("fix_loop_noop:")?.trim();
+    if reason.is_empty() {
+        return None;
+    }
+    Some(format!("FIX-LOOP-NO-OP ({reason})"))
 }
 
 fn read_review_verdict_artifact(session_dir: &Path) -> Option<ReviewVerdictArtifact> {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -96,6 +96,70 @@ fn compact_summary_includes_usage_and_review_verdict() {
 }
 
 #[test]
+fn compact_summary_labels_fix_loop_noop_from_review_meta() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let output_dir = temp.path().join("output");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+    std::fs::write(
+        output_dir.join("review-verdict.json"),
+        r#"{"schema_version":1,"session_id":"01TESTWAITNOOP","timestamp":"2026-04-01T00:00:00Z","decision":"fail","verdict_legacy":"HAS_ISSUES","severity_counts":{"critical":0,"high":0,"medium":1,"low":0},"failure_reason":"fix_loop_noop:head_unchanged_worktree_clean","prior_round_refs":[]}"#,
+    )
+    .expect("review verdict should be written");
+    std::fs::write(
+        temp.path().join("review_meta.json"),
+        r#"{
+  "session_id": "01TESTWAITNOOP",
+  "head_sha": "deadbeef",
+  "decision": "fail",
+  "verdict": "HAS_ISSUES",
+  "failure_reason": "fix_loop_noop:head_unchanged_worktree_clean",
+  "tool": "codex",
+  "scope": "range:main...HEAD",
+  "exit_code": 1,
+  "fix_attempted": true,
+  "fix_rounds": 1,
+  "timestamp": "2026-04-01T00:00:00Z",
+  "fix_convergence": {
+    "quality_gate_passed": true,
+    "fix_output_was_substantive": true,
+    "post_consistency_decision": "fail",
+    "reached_genuine_clean_convergence": false,
+    "terminal_reason": "fix_loop_noop:head_unchanged_worktree_clean"
+  }
+}"#,
+    )
+    .expect("review meta should be written");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "fix loop did not engage: head_unchanged_worktree_clean".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        fallback_chain: None,
+        gate_timeout: false,
+        warnings: vec!["fix loop did not engage: head_unchanged_worktree_clean".to_string()],
+        raw_process_exit_code: None,
+        uncommitted_changes: None,
+        manager_fields: Default::default(),
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITNOOP", &result);
+
+    assert!(summary.contains("Review verdict: FIX-LOOP-NO-OP (head_unchanged_worktree_clean)"));
+    assert!(summary.contains("Warning: fix loop did not engage: head_unchanged_worktree_clean"));
+    assert!(summary.contains("Summary: fix loop did not engage: head_unchanged_worktree_clean"));
+}
+
+#[test]
 fn compact_summary_uses_primary_failure_and_opaque_total_exhaustion_failover() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let output_dir = temp.path().join("output");


### PR DESCRIPTION
## Summary

Fixes #1877. `csa review --range <r> --fix` on a single-reviewer **codex** session behaved as a SILENT
review-only no-op — it re-reviewed, re-reported the identical finding, exited FAIL, but applied no edit and
made no commit (HEAD unchanged, working tree clean), with no signal that the fix loop never engaged. The
orchestrator could not distinguish this from an ordinary review FAIL, so it silently wasted a round and the
documented KV-cache fix path (rule 054) became unreliable.

## Root cause

`run_fix_loop` reaches terminal artifact persistence, but when the reviewer re-reports failure with HEAD
unchanged and a clean worktree, the old code wrote the result as a plain HAS_ISSUES/FAIL — no distinct
fix-loop-no-op signal.

## Fix (Option B — fail-loud)

When `--fix`'s terminal state shows no change (HEAD unchanged + worktree clean) while a finding was
re-reported, emit a DISTINCT structured signal instead of masquerading as a plain review FAIL:

- `failure_reason = "fix_loop_noop:head_unchanged_worktree_clean"`
- `result.toml` summary/warning: `fix loop did not engage: head_unchanged_worktree_clean`
- session-wait summary: `Review verdict: FIX-LOOP-NO-OP (head_unchanged_worktree_clean)`

The orchestrator can now detect a non-converging `--fix` and fall back to a full `csa run` write
deliberately, instead of being misled.

This implements the issue's accepted fail-loud branch. Making `--fix` actually engage the edit loop and
converge for codex `--single` (the issue's preferred Option A) is a larger capability change tracked as a
followup in **#1884**.

## Changes (`crates/cli-sub-agent/src/`)

- `review_cmd_fix.rs`: fix loop captures `FixNoOpProbe`; applies the no-op signal after terminal
  persistence.
- `review_cmd_fix_noop.rs` (new): no-op detection + `result.toml` signal writer.
- `session_cmds_daemon_wait_summary.rs`: wait summary shows the distinct label.

## Tests

- `persist_fix_final_artifacts_noop_probe_marks_meta_verdict_and_result`
- `compact_summary_labels_fix_loop_noop_from_review_meta`

Full `just pre-commit` green (5587 + 5829 tests).

## Scope

Targets the `--fix` fix-loop orchestration / terminal-result path; does not loosen any existing fail path
or merge gate. Pre-production: no compat shims.

Closes #1877

🤖 Generated with [Claude Code](https://claude.com/claude-code)
