### PR TITLE
fix(cli-sub-agent): fail closed on prose-only review findings (#1887)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.903"
+version = "0.1.904"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.903"
+version = "0.1.904"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -165,7 +165,24 @@ pub(in crate::review_cmd) fn load_canonical_review_text(
             .flatten()
             .collect::<Vec<_>>()
             .join("\n");
-        return Ok((!structured_text.trim().is_empty()).then_some(structured_text));
+        if !structured_text.trim().is_empty() {
+            return Ok(Some(structured_text));
+        }
+
+        let mut file_text = Vec::new();
+        for file_name in ["summary.md", "details.md"] {
+            let path = session_dir.join("output").join(file_name);
+            if !path.exists() {
+                continue;
+            }
+            let content = fs::read_to_string(&path)
+                .map_err(|error| anyhow::anyhow!("read {}: {error}", path.display()))?;
+            if !content.trim().is_empty() {
+                file_text.push(content);
+            }
+        }
+        let file_text = file_text.join("\n");
+        return Ok((!file_text.trim().is_empty()).then_some(file_text));
     }
 
     let full_output_path = session_dir.join("output").join("full.md");

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -58,8 +58,11 @@ pub(super) fn enforce_final_verdict_consistency(
     let blocking_structured = has_blocking_severity(&artifact.severity_counts);
     let parsed_findings_prose = prose_signals.parsed_findings_sections;
     let unparsed_findings_prose = prose_signals.unparseable_findings_sections;
+    let checklist_violation_mismatch = prose_signals.checklist_violation_findings
+        && !has_structured_findings
+        && severity_counts_are_zero(&artifact.severity_counts);
 
-    if unparsed_findings_prose {
+    if unparsed_findings_prose || checklist_violation_mismatch {
         artifact
             .failure_reason
             .get_or_insert_with(|| PROSE_FINDINGS_UNPARSED_REASON.to_string());
@@ -76,6 +79,7 @@ pub(super) fn enforce_final_verdict_consistency(
             || blocking_structured
             || parsed_findings_prose
             || unparsed_findings_prose
+            || checklist_violation_mismatch
             || structured_mismatch)
     {
         artifact.decision = ReviewDecision::Fail;

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -18,6 +18,7 @@ pub(super) struct ReviewProseSignals {
     pub(super) blocking_summary: bool,
     pub(super) parsed_findings_sections: bool,
     pub(super) unparseable_findings_sections: bool,
+    pub(super) checklist_violation_findings: bool,
     pub(super) findings: Vec<ReviewFinding>,
 }
 
@@ -28,6 +29,7 @@ pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSign
         blocking_summary: prose.blocking_summary,
         parsed_findings_sections: false,
         unparseable_findings_sections: false,
+        checklist_violation_findings: false,
         findings: Vec::new(),
     };
     let default_unlabeled_severity = prose.blocking_summary.then_some(Severity::Medium);
@@ -100,6 +102,7 @@ fn record_review_prose_signal(
         classify_findings_sections(content, default_unlabeled_severity.clone());
     signals.parsed_findings_sections |= parsed_findings_sections;
     signals.unparseable_findings_sections |= unparseable_findings_sections;
+    signals.checklist_violation_findings |= checklist_violation_references_finding(content);
     let findings =
         extract_review_findings_from_prose_with_default(content, default_unlabeled_severity);
     let counts = severity_counts_from_review_findings(&findings);
@@ -132,6 +135,63 @@ fn classify_findings_sections(
 
 fn contains_canonical_clean_conclusion(content: &str) -> bool {
     contains_clean_phrase(content) || detect_prose_clean_conclusion(content)
+}
+
+fn checklist_violation_references_finding(content: &str) -> bool {
+    let mut in_checklist_section = false;
+    let mut in_code_fence = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
+        if trimmed.starts_with('#') {
+            in_checklist_section = is_checklist_heading(trimmed);
+            continue;
+        }
+        if in_checklist_section && line_violation_references_finding_id(trimmed) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn is_checklist_heading(line: &str) -> bool {
+    let normalized = line.trim_start_matches('#').trim();
+    let normalized = normalized
+        .split_once('(')
+        .map_or(normalized, |(heading, _)| heading.trim_end());
+    normalized.to_ascii_lowercase().contains("checklist")
+}
+
+fn line_violation_references_finding_id(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    if !lower.contains("violation") {
+        return false;
+    }
+    let Some(index) = lower.find("finding") else {
+        return false;
+    };
+    line.get(index + "finding".len()..)
+        .unwrap_or_default()
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '-' || ch == '_'))
+        .any(token_looks_like_finding_id)
+}
+
+fn token_looks_like_finding_id(token: &str) -> bool {
+    let token = token.trim();
+    let has_alpha = token.chars().any(|ch| ch.is_ascii_alphabetic());
+    token.len() >= 2
+        && has_alpha
+        && (token.chars().any(|ch| ch.is_ascii_digit())
+            || token.contains('-')
+            || token.contains('_'))
 }
 
 fn merge_severity_counts_add(

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1876_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1876_tests.rs
@@ -250,3 +250,166 @@ fn issue_1876_nonempty_findings_with_zero_counts_fail_closed() {
 
     assert_eq!(decision, ReviewDecision::Fail);
 }
+
+#[test]
+fn issue_1887_physical_details_word_severity_findings_fail_and_populate_counts() {
+    let session_id = "01TEST1887PHYSDETAILSHIGH";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1887-physical-details-high", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    fs::write(
+        session_dir.join("output").join("details.md"),
+        r#"## Findings
+
+1. [High][regression] Shared monolith checker ignores non-Rust files (scripts/monolith/check.sh:280, confidence=0.94)
+2. [Medium][test-gap] Monolith checker shell tests are not run by repo verification (scripts/tests/monolith-check-tests.sh:249, confidence=0.89)
+
+## AGENTS.md Checklist
+
+| Rule | Status |
+| --- | --- |
+| 016 testing | VIOLATION via finding MONO-002 |
+"#,
+    )
+    .expect("write details.md");
+    assert!(!session_dir.join("output").join("index.toml").exists());
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 2);
+    assert_eq!(findings.findings[0].severity, Severity::High);
+    assert_eq!(
+        findings.findings[0].file_ranges[0].path,
+        "scripts/monolith/check.sh"
+    );
+    assert_eq!(findings.findings[0].file_ranges[0].start, 280);
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1887_physical_details_empty_findings_stays_pass() {
+    let session_id = "01TEST1887PHYSDETAILSPASS";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1887-physical-details-pass", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    fs::write(
+        session_dir.join("output").join("details.md"),
+        "## Findings\n\nNo findings.\n",
+    )
+    .expect("write details.md");
+    assert!(!session_dir.join("output").join("index.toml").exists());
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1887_high_category_numbered_line_parses_to_high() {
+    let session_id = "01TEST1887PARSEHIGH000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1887-parse-high", session_id);
+
+    fs::write(
+        session_dir.join("output").join("details.md"),
+        "## Findings\n\n1. [High][regression] Parser recognizes word severity (src/lib.rs:7, confidence=0.94)\n",
+    )
+    .expect("write details.md");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    crate::review_cmd::findings_toml::persist_review_findings_toml(&project_root, &meta);
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].severity, Severity::High);
+    assert_eq!(findings.findings[0].file_ranges[0].path, "src/lib.rs");
+    assert_eq!(findings.findings[0].file_ranges[0].start, 7);
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1887_medium_category_numbered_line_parses_to_medium() {
+    let session_id = "01TEST1887PARSEMEDIUM0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1887-parse-medium", session_id);
+
+    fs::write(
+        session_dir.join("output").join("details.md"),
+        "## Findings\n\n1. [Medium][test-gap] Parser recognizes medium severity (tests/review.rs:42, confidence=0.89)\n",
+    )
+    .expect("write details.md");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    crate::review_cmd::findings_toml::persist_review_findings_toml(&project_root, &meta);
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].severity, Severity::Medium);
+    assert_eq!(findings.findings[0].file_ranges[0].path, "tests/review.rs");
+    assert_eq!(findings.findings[0].file_ranges[0].start, 42);
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1887_checklist_violation_referencing_finding_id_fails_closed() {
+    let session_id = "01TEST1887CHECKLIST000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1887-checklist-violation", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+No findings.
+
+## AGENTS.md Checklist
+
+| Rule | Status |
+| --- | --- |
+| 016 testing | VIOLATION via finding MONO-001 |
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        Some("prose_findings_present_but_unparsed")
+    );
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}


### PR DESCRIPTION
## Summary

Fixes #1887. A codex `--single` review whose `details.md` enumerated concrete findings (e.g.
`[High][regression] ...`) was recorded as a clean PASS (`review-verdict.json` decision=pass, all
`severity_counts` 0, `findings.toml=[]`) — a merge-gate hole that would let a HIGH-severity regression
merge. Recurrence of the #1804 / #1806 / #1876 false-PASS class.

## Root cause

`load_canonical_review_text` claimed to fall back to physical `output/details.md`, but only read indexed
sections via `read_all_sections`. A physical `details.md` written WITHOUT `output/index.toml` was invisible
to both `findings.toml` derivation and `review_prose_signals`, so the #1806 fail-closed consistency guard
had no prose-finding signal to act on.

## Fix

- `review_cmd_findings_toml.rs`: real fallback to physical `output/summary.md` / `output/details.md` when
  indexed sections are empty.
- `review_cmd_output_prose_signals.rs`: detect checklist rows of the form `VIOLATION via finding <id>`.
- `review_cmd_output_consistency.rs`: `enforce_final_verdict_consistency` fails closed on the
  empty-structured-artifact-vs-prose-findings mismatch (and the checklist-violation signal) only when
  structured findings are empty and severity counts are zero.

The word-severity bracket grammar (`[High][category] Title (path:line, confidence=X)`) already parsed once
prose reached the parser; the missing piece was the loader/guard path. Genuine "No findings" stays PASS
(verified by test).

## Tests

New `issue_1887` regression tests: physical `details.md` with `[High]`/`[Medium]` findings, genuine-empty
stays pass, severity parsing, checklist-violation backstop. Existing `verdict_1804` / `verdict_1876` (28)
and `findings_toml` (17) tests stay green.

Closes #1887

🤖 Generated with [Claude Code](https://claude.com/claude-code)
