### PR TITLE
fix(csa-process): scope fatal backend markers to active attempt (#1849)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.904"
+version = "0.1.905"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.904"
+version = "0.1.905"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
@@ -58,6 +58,17 @@ pub(super) fn write_fatal_error_marker_sidecar(
     tool_name: &str,
     cleanup_guard: &mut Option<SessionCleanupGuard>,
 ) -> anyhow::Result<()> {
+    csa_process::reset_liveness_scope(session_dir, tool_name).map_err(|err| {
+        persist_pipeline_pre_exec_failure(
+            project_root,
+            session,
+            tool_name,
+            anyhow::anyhow!(err).context("Failed to reset active liveness scope"),
+            cleanup_guard,
+            None,
+        )
+    })?;
+
     let Some(cfg) = config else {
         return Ok(());
     };

--- a/crates/csa-process/src/idle_watchdog.rs
+++ b/crates/csa-process/src/idle_watchdog.rs
@@ -75,7 +75,7 @@ pub(crate) fn idle_timeout_note(
         return (
             "fatal backend error",
             format!(
-                "fatal backend error: matched configured 4xx/5xx/provider marker and observed no {progress_kind} for 30s; process killed"
+                "fatal backend error: active backend matched configured 4xx/5xx/provider marker and observed no {progress_kind} for 30s; process killed"
             ),
         );
     }
@@ -437,6 +437,7 @@ mod tests {
 
         assert_eq!(kind, "fatal backend error");
         assert!(note.contains("fatal backend error"));
+        assert!(note.contains("active backend"));
     }
 
     #[test]

--- a/crates/csa-process/src/idle_watchdog_provider_error_tests.rs
+++ b/crates/csa-process/src/idle_watchdog_provider_error_tests.rs
@@ -85,3 +85,76 @@ fn progress_signal_clears_transient_provider_backoff() {
         ProviderErrorBackoff::default()
     );
 }
+
+#[test]
+fn stale_failed_over_provider_marker_does_not_kill_progressing_active_backend() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("stderr.log"),
+        "gemini failed: HTTP 429 Too Many Requests reason: 'QUOTA_EXHAUSTED'\n",
+    )
+    .expect("write stale stderr");
+    crate::reset_liveness_scope(tmp.path(), "codex").expect("reset liveness scope");
+    crate::tool_liveness::record_spool_bytes_written(tmp.path(), 32);
+
+    let mut state = IdleWatchdogState {
+        liveness_dead_since: Some(Instant::now() - Duration::from_secs(5)),
+        next_liveness_poll_at: Some(Instant::now() - Duration::from_secs(1)),
+        provider_error_backoff: ProviderErrorBackoff {
+            retries_used: TRANSIENT_PROVIDER_ERROR_RETRY_BUDGET,
+            retry_after: Some(Instant::now() - Duration::from_secs(1)),
+        },
+    };
+    let mut last_activity = Instant::now() - FATAL_ERROR_PROGRESS_GRACE - Duration::from_secs(1);
+
+    let terminate = should_terminate_for_idle_with_state(
+        &mut last_activity,
+        Duration::from_secs(7200),
+        Duration::from_secs(1),
+        Some(tmp.path()),
+        &mut state,
+        true,
+    );
+
+    assert_eq!(
+        terminate, None,
+        "stale provider marker from failed-over backend must not kill active backend progress"
+    );
+    assert_eq!(
+        state.provider_error_backoff,
+        ProviderErrorBackoff::default()
+    );
+}
+
+#[test]
+fn active_provider_marker_still_kills_when_current_backend_stalls() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    crate::reset_liveness_scope(tmp.path(), "codex").expect("reset liveness scope");
+    std::fs::write(
+        tmp.path().join("stderr.log"),
+        "codex failed: HTTP 429 Too Many Requests\n",
+    )
+    .expect("write active stderr");
+    let _ = ToolLiveness::probe(tmp.path());
+
+    let mut state = IdleWatchdogState {
+        provider_error_backoff: ProviderErrorBackoff {
+            retries_used: TRANSIENT_PROVIDER_ERROR_RETRY_BUDGET,
+            retry_after: Some(Instant::now() - Duration::from_secs(1)),
+        },
+        next_liveness_poll_at: Some(Instant::now() - Duration::from_secs(1)),
+        ..IdleWatchdogState::default()
+    };
+    let mut last_activity = Instant::now() - FATAL_ERROR_PROGRESS_GRACE - Duration::from_secs(1);
+
+    let terminate = should_terminate_for_idle_with_state(
+        &mut last_activity,
+        Duration::from_secs(7200),
+        Duration::from_secs(600),
+        Some(tmp.path()),
+        &mut state,
+        true,
+    );
+
+    assert_eq!(terminate, Some(IdleTerminationReason::FatalError));
+}

--- a/crates/csa-process/src/lib.rs
+++ b/crates/csa-process/src/lib.rs
@@ -47,6 +47,7 @@ use output_helpers::{last_non_empty_line, truncate_line};
 pub use subprocess_helpers::check_tool_installed;
 use subprocess_helpers::terminate_child_process_group;
 use tool_liveness::record_spool_bytes_written;
+pub use tool_liveness::reset_liveness_scope;
 pub use tool_liveness::{DEFAULT_LIVENESS_DEAD_SECS, ToolLiveness, write_fatal_error_markers};
 #[cfg(test)]
 use workspace_boundary::WORKSPACE_BOUNDARY_THRESHOLD_ENV;

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -20,6 +20,7 @@ const STDERR_LOG_FILE: &str = "stderr.log";
 #[cfg(test)]
 const OUTPUT_LOG_FILE: &str = "output.log";
 const SNAPSHOT_FILE: &str = ".liveness.snapshot";
+const LIVENESS_SCOPE_FILE: &str = ".liveness.scope";
 const FATAL_ERROR_MARKERS_FILE: &str = ".fatal-error-markers";
 pub const DEFAULT_LIVENESS_DEAD_SECS: u64 = 600;
 #[derive(Debug, Clone, Copy)]
@@ -77,6 +78,11 @@ struct LivenessSnapshot {
     acp_events_size: Option<u64>,
     stderr_log_size: Option<u64>,
     process_cpu_ticks: Option<u64>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct LivenessScope {
+    stderr_start_offset: Option<u64>,
 }
 
 /// Filesystem-only liveness probe for a running tool session.
@@ -216,6 +222,32 @@ pub fn write_fatal_error_markers(session_dir: &Path, markers: &[String]) -> std:
         writeln!(file, "{marker}")?;
     }
     Ok(())
+}
+
+/// Start a fresh liveness/fatal-marker window for the backend that is about to run.
+///
+/// Session logs are append-only for auditability, so failover must not truncate
+/// `stderr.log` or `output.log`. This records the current offsets instead and
+/// seeds the progress snapshot at those offsets, making subsequent probes
+/// evaluate only the newly active backend's provider markers and progress.
+pub fn reset_liveness_scope(session_dir: &Path, active_tool: &str) -> std::io::Result<()> {
+    let output_start_offset = file_len(&session_dir.join("output.log")).unwrap_or(0);
+    let stderr_start_offset = file_len(&session_dir.join(STDERR_LOG_FILE)).unwrap_or(0);
+    let acp_events_size = Some(file_len(&session_dir.join(ACP_EVENTS_LOG_FILE)).unwrap_or(0));
+
+    let snapshot = LivenessSnapshot {
+        spool_bytes_written: Some(output_start_offset),
+        observed_spool_bytes_written: Some(output_start_offset),
+        acp_events_size,
+        stderr_log_size: Some(stderr_start_offset),
+        process_cpu_ticks: None,
+    };
+    write_snapshot(session_dir, &snapshot)?;
+
+    fs::write(
+        session_dir.join(LIVENESS_SCOPE_FILE),
+        format!("active_tool={active_tool}\nstderr_start_offset={stderr_start_offset}\n"),
+    )
 }
 
 pub(crate) fn record_spool_bytes_written(session_dir: &Path, bytes_written: u64) {
@@ -557,7 +589,11 @@ fn load_snapshot(session_dir: &Path) -> LivenessSnapshot {
 }
 
 fn save_snapshot(session_dir: &Path, snapshot: &LivenessSnapshot) {
-    let mut lines = Vec::with_capacity(4);
+    let _ = write_snapshot(session_dir, snapshot);
+}
+
+fn write_snapshot(session_dir: &Path, snapshot: &LivenessSnapshot) -> std::io::Result<()> {
+    let mut lines = Vec::with_capacity(5);
     if let Some(value) = snapshot.spool_bytes_written {
         lines.push(format!("spool_bytes_written={value}"));
     }
@@ -574,9 +610,30 @@ fn save_snapshot(session_dir: &Path, snapshot: &LivenessSnapshot) {
         lines.push(format!("process_cpu_ticks={value}"));
     }
     if lines.is_empty() {
-        return;
+        return Ok(());
     }
-    let _ = fs::write(snapshot_path(session_dir), lines.join("\n"));
+    fs::write(snapshot_path(session_dir), lines.join("\n"))
+}
+
+fn load_liveness_scope(session_dir: &Path) -> LivenessScope {
+    let path = session_dir.join(LIVENESS_SCOPE_FILE);
+    let Ok(content) = fs::read_to_string(path) else {
+        return LivenessScope::default();
+    };
+    let mut scope = LivenessScope::default();
+    for line in content.lines() {
+        let mut parts = line.splitn(2, '=');
+        let key = parts.next().unwrap_or_default().trim();
+        let value = parts.next().unwrap_or_default().trim();
+        if key == "stderr_start_offset" {
+            scope.stderr_start_offset = value.parse::<u64>().ok();
+        }
+    }
+    scope
+}
+
+fn file_len(path: &Path) -> Option<u64> {
+    fs::metadata(path).ok().map(|meta| meta.len())
 }
 
 fn extract_pid(lock_content: &str) -> Option<u32> {

--- a/crates/csa-process/src/tool_liveness_fatal_error.rs
+++ b/crates/csa-process/src/tool_liveness_fatal_error.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::sync::OnceLock;
 
 use super::ProviderErrorKind;
-use super::{FATAL_ERROR_MARKERS_FILE, STDERR_LOG_FILE};
+use super::{FATAL_ERROR_MARKERS_FILE, STDERR_LOG_FILE, load_liveness_scope};
 
 const FATAL_ERROR_TAIL_BYTES: u64 = 4096;
 
@@ -160,7 +160,12 @@ fn read_fatal_error_marker_file(marker_path: &Path) -> Vec<String> {
 /// separation).
 pub(super) fn provider_error_signal(session_dir: &Path) -> Option<ProviderErrorKind> {
     let regexes = fatal_error_regexes_for_session(session_dir);
-    let stderr_tail = read_file_tail(&session_dir.join(STDERR_LOG_FILE)).ok();
+    let scope = load_liveness_scope(session_dir);
+    let stderr_tail = read_file_tail_after(
+        &session_dir.join(STDERR_LOG_FILE),
+        scope.stderr_start_offset,
+    )
+    .ok();
 
     if matches_provider_error(&regexes.permanent, stderr_tail.as_deref()) {
         return Some(ProviderErrorKind::Permanent);
@@ -237,11 +242,17 @@ pub(super) fn build_fatal_error_regex(markers: &[String]) -> Option<Regex> {
         .ok()
 }
 
-fn read_file_tail(path: &Path) -> std::io::Result<String> {
+fn read_file_tail_after(path: &Path, start_offset: Option<u64>) -> std::io::Result<String> {
     let mut file = File::open(path)?;
     let file_len = file.metadata()?.len();
-    let tail_len = file_len.min(FATAL_ERROR_TAIL_BYTES);
-    file.seek(SeekFrom::Start(file_len.saturating_sub(tail_len)))?;
+    let active_start = start_offset
+        .filter(|offset| *offset <= file_len)
+        .unwrap_or(0);
+    let active_len = file_len.saturating_sub(active_start);
+    let tail_len = active_len.min(FATAL_ERROR_TAIL_BYTES);
+    file.seek(SeekFrom::Start(
+        active_start + active_len.saturating_sub(tail_len),
+    ))?;
 
     let mut buf = Vec::with_capacity(tail_len as usize);
     file.take(tail_len).read_to_end(&mut buf)?;

--- a/crates/csa-process/src/tool_liveness_tests.rs
+++ b/crates/csa-process/src/tool_liveness_tests.rs
@@ -261,6 +261,73 @@ fn probe_detects_fatal_error_marker_in_stderr_tail() {
 }
 
 #[test]
+fn active_scope_ignores_provider_marker_from_failed_over_backend() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        tmp.path().join(STDERR_LOG_FILE),
+        "gemini failed: HTTP 429 Too Many Requests reason: 'QUOTA_EXHAUSTED'\n",
+    )
+    .expect("write stale stderr");
+
+    reset_liveness_scope(tmp.path(), "codex").expect("reset active scope");
+
+    let signals = ToolLiveness::probe(tmp.path());
+
+    assert!(
+        !signals.fatal_error,
+        "provider marker before active scope must not trip fallback backend"
+    );
+}
+
+#[test]
+fn active_scope_detects_provider_marker_from_current_backend() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        tmp.path().join(STDERR_LOG_FILE),
+        "gemini failed: HTTP 429 Too Many Requests reason: 'QUOTA_EXHAUSTED'\n",
+    )
+    .expect("write stale stderr");
+    reset_liveness_scope(tmp.path(), "codex").expect("reset active scope");
+    fs::OpenOptions::new()
+        .append(true)
+        .open(tmp.path().join(STDERR_LOG_FILE))
+        .expect("open stderr")
+        .write_all(b"codex failed: HTTP 500 Internal Server Error\n")
+        .expect("append active stderr");
+
+    let signals = ToolLiveness::probe(tmp.path());
+
+    assert!(
+        signals.fatal_error,
+        "provider marker after active scope must still trip current backend"
+    );
+}
+
+#[test]
+fn reset_liveness_scope_seeds_progress_baseline_for_new_backend() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    fs::write(tmp.path().join(OUTPUT_LOG_FILE), "old output\n").expect("write output");
+    fs::write(
+        tmp.path().join(SNAPSHOT_FILE),
+        "spool_bytes_written=999\nobserved_spool_bytes_written=999\nstderr_log_size=999\n",
+    )
+    .expect("write stale snapshot");
+
+    reset_liveness_scope(tmp.path(), "codex").expect("reset active scope");
+    let current_len = fs::metadata(tmp.path().join(OUTPUT_LOG_FILE))
+        .expect("output metadata")
+        .len();
+    record_spool_bytes_written(tmp.path(), current_len + 8);
+
+    let signals = ToolLiveness::probe(tmp.path());
+
+    assert!(
+        signals.output_growth,
+        "first active backend output after reset should count as fresh progress"
+    );
+}
+
+#[test]
 fn probe_ignores_broad_http_markers_in_output_log_content() {
     let tmp = tempfile::tempdir().expect("tempdir");
     fs::write(


### PR DESCRIPTION
## Summary

Fixes #1849. A `csa review --tier tier-4-critical` run with gemini primary + exhausted quota
(HTTP 429 `QUOTA_EXHAUSTED`) failed to cleanly fall back: the abandoned primary's 429 marker stayed
in the session's combined output stream, the fatal-backend-error detector matched it, observed "no
output progress for 30s", and SIGKILLed the **entire** session (exit 137) — even though the active
reviewer had already failed over to codex and was emitting real progress right up to the kill. Net:
the review never produced a verdict and the operator had to manually re-run with `--tool codex`.

## Root cause

The fatal-marker scan + the "no output progress for Ns" killer operated over the session's
combined/historical output, which still contained the **abandoned** primary backend's 429 marker
*after* failover swapped the active backend. A stale marker from a backend already failed-over-away-from
could kill a new, progressing active backend.

## Fix

- `csa-process/tool_liveness.rs`: scope `LivenessSnapshot` / fatal-scan state to the active attempt;
  add `reset_liveness_scope` which records the current `stderr.log` offset and resets the
  `.liveness.snapshot` output/stderr/acp baselines to the active backend's start (aligned with
  `SpoolRotator`'s current-file byte baseline).
- `csa-process/tool_liveness_fatal_error.rs`: `provider_error_signal` now scans only `stderr.log`
  bytes **after** `stderr_start_offset`, preserving the active backend's own fatal detection.
- `cli-sub-agent/pipeline_session_exec_pre_exec.rs`: call `reset_liveness_scope` under the session
  lock before spawning each backend (before writing the fatal-marker sidecar), so an abandoned
  primary's 429 can no longer affect the fallback backend.
- `csa-process/idle_watchdog.rs`: fatal note now explicitly says "active backend" instead of the old
  generic attribution.

Protective behavior preserved: a genuinely-stalled **active** backend (its own marker + truly no
progress for the window) is still killed as before.

## Tests

New regression coverage (co-located with the fatal-detector / failover tests): stale failed-over
markers do not trip the killer against a progressing fallback; an active backend's own marker + no
progress still kills; failover resets the progress baseline so the new backend gets a fresh window.
Focused suites green: `csa-process` 14 passed, `csa-scheduler` failover/rate-limit 70 passed,
`cli-sub-agent` 1 passed; pre-commit quality-gates + clippy passed.

Closes #1849

🤖 Generated with [Claude Code](https://claude.com/claude-code)
