### PR TITLE
fix(cli-sub-agent): tolerate missing extra_writable sandbox paths instead of hard-aborting pre-exec (#1881)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.906"
+version = "0.1.907"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.906"
+version = "0.1.907"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -4,7 +4,6 @@
 //! Handles enforcement mode checking, capability detection, config resolution,
 //! and first-turn telemetry recording.
 
-use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 
 use csa_config::ProjectConfig;
@@ -15,6 +14,9 @@ use csa_resource::isolation_plan::{
 };
 use csa_session::MetaSessionState;
 use tracing::{info, warn};
+
+#[path = "pipeline_sandbox_writable.rs"]
+mod writable_sources;
 
 /// Outcome of sandbox resolution — either enriched options or a fatal error string
 /// (for `Required` mode with no capability).
@@ -34,74 +36,6 @@ fn resolve_session_dir_for_sandbox(project_root: &Path, session_id: &str) -> Pat
     })
 }
 
-fn resolve_and_prepare_writable_sources(
-    paths: &[PathBuf],
-    project_root: &Path,
-    source_label: &str,
-    removal_target: &str,
-) -> Result<Vec<PathBuf>, String> {
-    let resolved = csa_resource::isolation_plan::resolve_writable_paths(paths, project_root)
-        .map_err(|e| format!("{source_label} validation failed: {e}"))?;
-
-    for (path, candidate) in paths.iter().zip(resolved.iter()) {
-        match candidate.try_exists() {
-            Ok(true) => {}
-            Ok(false) => {
-                if path_looks_like_file(path) {
-                    prepare_missing_file_source(candidate, path, source_label)?;
-                } else {
-                    return Err(format!(
-                        "{source_label} path '{}' does not exist. Create it first or remove the {removal_target}.",
-                        path.display()
-                    ));
-                }
-            }
-            Err(error) => {
-                return Err(format!(
-                    "{source_label} path '{}' could not be checked before session launch: {error}",
-                    path.display()
-                ));
-            }
-        }
-    }
-    Ok(resolved)
-}
-
-fn path_looks_like_file(path: &Path) -> bool {
-    path.extension().is_some()
-}
-
-fn prepare_missing_file_source(
-    candidate: &Path,
-    original: &Path,
-    source_label: &str,
-) -> Result<(), String> {
-    let parent = candidate.parent().ok_or_else(|| {
-        format!(
-            "{source_label} path '{}' has no parent directory for file pre-creation.",
-            original.display()
-        )
-    })?;
-    std::fs::create_dir_all(parent).map_err(|error| {
-        format!(
-            "{source_label} path '{}' parent '{}' could not be created before session launch: {error}",
-            original.display(),
-            parent.display()
-        )
-    })?;
-    OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(candidate)
-        .map(|_| ())
-        .map_err(|error| {
-            format!(
-                "{source_label} path '{}' could not be created before session launch: {error}",
-                original.display()
-            )
-        })
-}
-
 pub(crate) fn validate_run_extra_writable_sources_exist(
     config: Option<&ProjectConfig>,
     project_root: &Path,
@@ -112,22 +46,16 @@ pub(crate) fn validate_run_extra_writable_sources_exist(
         return Ok(());
     }
     if !extra_writable.is_empty() {
-        resolve_and_prepare_writable_sources(
+        writable_sources::resolve_and_prepare_writable_sources(
             extra_writable,
             project_root,
             "--extra-writable",
-            "flag",
         )?;
     }
     if let Some(cfg) = config
         && !cfg.filesystem_sandbox.extra_writable.is_empty()
     {
-        resolve_and_prepare_writable_sources(
-            &cfg.filesystem_sandbox.extra_writable,
-            project_root,
-            "filesystem_sandbox.extra_writable",
-            "config entry",
-        )?;
+        writable_sources::resolve_config_extra_writable_sources(cfg, project_root)?;
     }
     Ok(())
 }
@@ -231,11 +159,10 @@ pub(crate) fn resolve_sandbox_options(
             }
             // CLI --extra-writable / --expose-readable (no-config path).
             if !extra_writable.is_empty() {
-                let resolved = match resolve_and_prepare_writable_sources(
+                let resolved = match writable_sources::resolve_and_prepare_writable_sources(
                     extra_writable,
                     project_root,
                     "--extra-writable",
-                    "flag",
                 ) {
                     Ok(paths) => paths,
                     Err(message) => {
@@ -359,7 +286,12 @@ pub(crate) fn resolve_sandbox_options(
 
     // Per-tool filesystem sandbox: check for REPLACE-semantics writable paths.
     let per_tool_writable = if !no_fs_sandbox {
-        cfg.sandbox_writable_paths(tool_name)
+        match writable_sources::resolve_per_tool_writable_sources(cfg, tool_name, project_root) {
+            Ok(paths) => paths,
+            Err(message) => {
+                return SandboxResolution::RequiredButUnavailable(message);
+            }
+        }
     } else {
         None
     };
@@ -398,27 +330,15 @@ pub(crate) fn resolve_sandbox_options(
 
     if !no_fs_sandbox {
         if let Some(ref paths) = per_tool_writable {
-            let resolved =
-                match csa_resource::isolation_plan::resolve_writable_paths(paths, project_root) {
-                    Ok(paths) => paths,
-                    Err(e) => {
-                        return SandboxResolution::RequiredButUnavailable(format!(
-                            "Per-tool writable_paths validation failed for '{tool_name}': {e}"
-                        ));
-                    }
-                };
-            for path in resolved {
-                builder = builder.with_writable_path(path);
+            for path in paths {
+                builder = builder.with_writable_path(path.clone());
             }
         } else {
             // No per-tool override — apply global extra_writable paths.
-            let fs_config = &cfg.filesystem_sandbox;
-            if !fs_config.extra_writable.is_empty() {
-                let resolved = match resolve_and_prepare_writable_sources(
-                    &fs_config.extra_writable,
+            if !cfg.filesystem_sandbox.extra_writable.is_empty() {
+                let resolved = match writable_sources::resolve_config_extra_writable_sources(
+                    cfg,
                     project_root,
-                    "filesystem_sandbox.extra_writable",
-                    "config entry",
                 ) {
                     Ok(paths) => paths,
                     Err(message) => {
@@ -447,11 +367,10 @@ pub(crate) fn resolve_sandbox_options(
 
     // CLI --extra-writable paths: always appended (APPEND semantics, not REPLACE).
     if !no_fs_sandbox && !extra_writable.is_empty() {
-        let resolved = match resolve_and_prepare_writable_sources(
+        let resolved = match writable_sources::resolve_and_prepare_writable_sources(
             extra_writable,
             project_root,
             "--extra-writable",
-            "flag",
         ) {
             Ok(paths) => paths,
             Err(message) => {

--- a/crates/cli-sub-agent/src/pipeline_sandbox_extra_writable_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_extra_writable_tests.rs
@@ -65,7 +65,7 @@ enforcement_mode = "best-effort"
 }
 
 #[test]
-fn test_extra_writable_rejects_nonexistent_path_before_sandbox_launch() {
+fn test_extra_writable_creates_missing_directory_before_sandbox_launch() {
     let project_root = tempfile::tempdir().expect("project root tempdir");
     let missing = project_root.path().join("missing-extra");
     let cfg = parse_project_config(
@@ -92,15 +92,22 @@ enforcement_mode = "best-effort"
         &[],
     );
 
-    let SandboxResolution::RequiredButUnavailable(message) = result else {
-        panic!("Expected missing --extra-writable path to fail before sandbox launch");
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("Expected missing --extra-writable directory to be created before sandbox launch");
     };
-    assert_eq!(
-        message,
-        format!(
-            "--extra-writable path '{}' does not exist. Create it first or remove the flag.",
-            missing.display()
-        )
+    assert!(
+        missing.is_dir(),
+        "missing --extra-writable directory should be created"
+    );
+
+    let sandbox = opts.sandbox.expect("expected sandbox context");
+    assert!(
+        sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&missing.canonicalize().unwrap()),
+        "created directory should be in writable_paths, got: {:?}",
+        sandbox.isolation_plan.writable_paths
     );
 }
 
@@ -167,20 +174,17 @@ fn test_run_extra_writable_pre_daemon_validation_creates_missing_file_source() {
 }
 
 #[test]
-fn test_run_extra_writable_pre_daemon_validation_rejects_nonexistent_path() {
+fn test_run_extra_writable_pre_daemon_validation_creates_missing_directory() {
     let project_root = tempfile::tempdir().expect("project root tempdir");
     let missing = project_root.path().join("missing-extra");
     let extra = vec![missing.clone()];
 
-    let err = validate_run_extra_writable_sources_exist(None, project_root.path(), false, &extra)
-        .expect_err("missing --extra-writable path should fail before daemon spawn");
+    validate_run_extra_writable_sources_exist(None, project_root.path(), false, &extra)
+        .expect("missing --extra-writable directory should be created before daemon spawn");
 
-    assert_eq!(
-        err,
-        format!(
-            "--extra-writable path '{}' does not exist. Create it first or remove the flag.",
-            missing.display()
-        )
+    assert!(
+        missing.is_dir(),
+        "pre-daemon validation should create missing --extra-writable directory"
     );
 }
 
@@ -231,8 +235,9 @@ extra_writable = ["drafts"]
 }
 
 #[test]
-fn test_global_extra_writable_rejects_nonexistent_path_before_sandbox_launch() {
+fn test_global_extra_writable_creates_missing_path_before_sandbox_launch() {
     let project_root = tempfile::tempdir().expect("project root tempdir");
+    let missing = project_root.path().join("missing-extra");
     let cfg = parse_project_config(
         r#"
 [resources]
@@ -259,20 +264,95 @@ extra_writable = ["missing-extra"]
         &[],
     );
 
-    let SandboxResolution::RequiredButUnavailable(message) = result else {
-        panic!(
-            "Expected missing filesystem_sandbox.extra_writable path to fail before sandbox launch"
-        );
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("Expected missing filesystem_sandbox.extra_writable path to be created");
     };
-    assert_eq!(
-        message,
-        "filesystem_sandbox.extra_writable path 'missing-extra' does not exist. Create it first or remove the config entry."
+    assert!(
+        missing.is_dir(),
+        "missing filesystem_sandbox.extra_writable directory should be created"
+    );
+
+    let sandbox = opts.sandbox.expect("expected sandbox context");
+    assert!(
+        sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&missing.canonicalize().unwrap()),
+        "created global extra_writable path should be in writable_paths, got: {:?}",
+        sandbox.isolation_plan.writable_paths
+    );
+}
+
+#[test]
+fn test_global_extra_writable_creates_missing_path_with_per_tool_writable_paths() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let tool_writable = project_root.path().join("tool-writable");
+    let missing = project_root.path().join("missing-extra");
+    std::fs::create_dir_all(&tool_writable).expect("create tool writable dir");
+    let cfg = parse_project_config(
+        r#"
+[resources]
+memory_max_mb = 2048
+enforcement_mode = "best-effort"
+
+[filesystem_sandbox]
+extra_writable = ["missing-extra"]
+
+[tools.codex.filesystem_sandbox]
+writable_paths = ["tool-writable"]
+"#,
+    );
+
+    let result = resolve_sandbox_options(
+        Some(&cfg),
+        "codex",
+        "test-session",
+        project_root.path(),
+        StreamMode::BufferOnly,
+        120,
+        600,
+        Some(120),
+        false,
+        false,
+        &[],
+        &[],
+    );
+
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("Expected global extra_writable path to be created with per-tool writable_paths");
+    };
+    assert!(
+        missing.is_dir(),
+        "missing global extra_writable directory should be created even with per-tool writable_paths"
+    );
+
+    let sandbox = opts.sandbox.expect("expected sandbox context");
+    assert!(
+        sandbox.isolation_plan.readonly_project_root,
+        "per-tool writable_paths should keep project root read-only"
+    );
+    assert!(
+        sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&tool_writable.canonicalize().unwrap()),
+        "tool writable path should remain in writable_paths, got: {:?}",
+        sandbox.isolation_plan.writable_paths
+    );
+    assert!(
+        sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&missing.canonicalize().unwrap()),
+        "created global extra_writable path should be appended, got: {:?}",
+        sandbox.isolation_plan.writable_paths
     );
 }
 
 #[test]
 fn test_run_extra_writable_pre_daemon_validation_checks_global_config() {
     let project_root = tempfile::tempdir().expect("project root tempdir");
+    let missing = project_root.path().join("missing-extra");
     let cfg = parse_project_config(
         r#"
 [filesystem_sandbox]
@@ -280,15 +360,92 @@ extra_writable = ["missing-extra"]
 "#,
     );
 
-    let err =
-        validate_run_extra_writable_sources_exist(Some(&cfg), project_root.path(), false, &[])
-            .expect_err(
-                "missing filesystem_sandbox.extra_writable path should fail before daemon spawn",
-            );
+    validate_run_extra_writable_sources_exist(Some(&cfg), project_root.path(), false, &[]).expect(
+        "missing filesystem_sandbox.extra_writable path should be created before daemon spawn",
+    );
 
-    assert_eq!(
-        err,
-        "filesystem_sandbox.extra_writable path 'missing-extra' does not exist. Create it first or remove the config entry."
+    assert!(
+        missing.is_dir(),
+        "pre-daemon validation should create global extra_writable directory"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_global_extra_writable_skips_path_when_missing_directory_cannot_be_created() {
+    use std::os::unix::fs::PermissionsExt;
+
+    struct RestorePermissions {
+        path: PathBuf,
+        mode: u32,
+    }
+
+    impl Drop for RestorePermissions {
+        fn drop(&mut self) {
+            if let Ok(metadata) = std::fs::metadata(&self.path) {
+                let mut permissions = metadata.permissions();
+                permissions.set_mode(self.mode);
+                let _ = std::fs::set_permissions(&self.path, permissions);
+            }
+        }
+    }
+
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let locked_parent = project_root.path().join("locked");
+    std::fs::create_dir_all(&locked_parent).expect("create locked parent");
+    let original_mode = std::fs::metadata(&locked_parent)
+        .expect("locked parent metadata")
+        .permissions()
+        .mode();
+    let _restore = RestorePermissions {
+        path: locked_parent.clone(),
+        mode: original_mode,
+    };
+    let mut locked_permissions = std::fs::metadata(&locked_parent)
+        .expect("locked parent metadata")
+        .permissions();
+    locked_permissions.set_mode(0o500);
+    std::fs::set_permissions(&locked_parent, locked_permissions).expect("make parent read-only");
+
+    let missing = locked_parent.join("missing-extra");
+    let cfg = parse_project_config(
+        r#"
+[resources]
+memory_max_mb = 2048
+enforcement_mode = "best-effort"
+
+[filesystem_sandbox]
+extra_writable = ["locked/missing-extra"]
+"#,
+    );
+
+    let result = resolve_sandbox_options(
+        Some(&cfg),
+        "codex",
+        "test-session",
+        project_root.path(),
+        StreamMode::BufferOnly,
+        120,
+        600,
+        Some(120),
+        false,
+        false,
+        &[],
+        &[],
+    );
+
+    if missing.exists() {
+        return;
+    }
+
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("mkdir failure for allowed extra_writable should skip the entry, not abort");
+    };
+    let sandbox = opts.sandbox.expect("expected sandbox context");
+    assert!(
+        !sandbox.isolation_plan.writable_paths.contains(&missing),
+        "uncreated extra_writable path should be skipped, got: {:?}",
+        sandbox.isolation_plan.writable_paths
     );
 }
 
@@ -322,6 +479,41 @@ enforcement_mode = "best-effort"
     assert!(
         matches!(result, SandboxResolution::RequiredButUnavailable(ref msg) if msg.contains("extra-writable")),
         "dangerous path in --extra-writable should be rejected"
+    );
+}
+
+#[test]
+fn test_global_extra_writable_rejects_dangerous_paths() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let cfg = parse_project_config(
+        r#"
+[resources]
+memory_max_mb = 2048
+enforcement_mode = "best-effort"
+
+[filesystem_sandbox]
+extra_writable = ["/etc/shadow"]
+"#,
+    );
+
+    let result = resolve_sandbox_options(
+        Some(&cfg),
+        "codex",
+        "test-session",
+        project_root.path(),
+        StreamMode::BufferOnly,
+        120,
+        600,
+        Some(120),
+        false,
+        false,
+        &[],
+        &[],
+    );
+
+    assert!(
+        matches!(result, SandboxResolution::RequiredButUnavailable(ref msg) if msg.contains("filesystem_sandbox.extra_writable validation failed")),
+        "dangerous global extra_writable path should be rejected before creation"
     );
 }
 

--- a/crates/cli-sub-agent/src/pipeline_sandbox_writable.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_writable.rs
@@ -1,0 +1,150 @@
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
+
+use csa_config::ProjectConfig;
+use tracing::{info, warn};
+
+pub(crate) fn resolve_and_prepare_writable_sources(
+    paths: &[PathBuf],
+    project_root: &Path,
+    source_label: &str,
+) -> Result<Vec<PathBuf>, String> {
+    let resolved = csa_resource::isolation_plan::resolve_writable_paths(paths, project_root)
+        .map_err(|e| format!("{source_label} validation failed: {e}"))?;
+
+    let mut prepared = Vec::with_capacity(resolved.len());
+    for (path, candidate) in paths.iter().zip(resolved.iter()) {
+        match candidate.try_exists() {
+            Ok(true) => prepared.push(candidate.clone()),
+            Ok(false) => prepare_missing_source(path, candidate, source_label, &mut prepared),
+            Err(error) => warn!(
+                source = source_label,
+                path = %candidate.display(),
+                error = %error,
+                "Skipping writable source because it could not be checked before session launch"
+            ),
+        }
+    }
+    Ok(prepared)
+}
+
+pub(crate) fn resolve_config_extra_writable_sources(
+    config: &ProjectConfig,
+    project_root: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    if config.filesystem_sandbox.extra_writable.is_empty() {
+        return Ok(Vec::new());
+    }
+    resolve_and_prepare_writable_sources(
+        &config.filesystem_sandbox.extra_writable,
+        project_root,
+        "filesystem_sandbox.extra_writable",
+    )
+}
+
+pub(crate) fn resolve_per_tool_writable_sources(
+    config: &ProjectConfig,
+    tool_name: &str,
+    project_root: &Path,
+) -> Result<Option<Vec<PathBuf>>, String> {
+    let tool_paths = config
+        .tools
+        .get(tool_name)
+        .and_then(|tool| tool.filesystem_sandbox.as_ref())
+        .and_then(|sandbox| sandbox.writable_paths.as_ref());
+    if let Some(paths) = tool_paths {
+        return resolve_paths_with_extra(config, tool_name, project_root, paths).map(Some);
+    }
+
+    if let Some(paths) = config
+        .filesystem_sandbox
+        .tool_writable_overrides
+        .get(tool_name)
+    {
+        return resolve_paths_with_extra(config, tool_name, project_root, paths).map(Some);
+    }
+
+    Ok(None)
+}
+
+fn resolve_paths_with_extra(
+    config: &ProjectConfig,
+    tool_name: &str,
+    project_root: &Path,
+    paths: &[PathBuf],
+) -> Result<Vec<PathBuf>, String> {
+    let mut resolved = csa_resource::isolation_plan::resolve_writable_paths(paths, project_root)
+        .map_err(|e| format!("Per-tool writable_paths validation failed for '{tool_name}': {e}"))?;
+    resolved.extend(resolve_config_extra_writable_sources(config, project_root)?);
+    Ok(resolved)
+}
+
+fn prepare_missing_source(
+    original: &Path,
+    candidate: &Path,
+    source_label: &str,
+    prepared: &mut Vec<PathBuf>,
+) {
+    if path_looks_like_file(original) {
+        match prepare_missing_file_source(candidate, original, source_label) {
+            Ok(()) => prepared.push(candidate.to_path_buf()),
+            Err(message) => warn!(
+                source = source_label,
+                path = %candidate.display(),
+                reason = %message,
+                "Skipping missing writable source because it could not be created"
+            ),
+        }
+        return;
+    }
+
+    info!(
+        source = source_label,
+        path = %candidate.display(),
+        "Creating missing writable directory before sandbox launch"
+    );
+    match std::fs::create_dir_all(candidate) {
+        Ok(()) => prepared.push(candidate.to_path_buf()),
+        Err(error) => warn!(
+            source = source_label,
+            path = %candidate.display(),
+            error = %error,
+            "Skipping missing writable directory because it could not be created"
+        ),
+    }
+}
+
+fn path_looks_like_file(path: &Path) -> bool {
+    path.extension().is_some()
+}
+
+fn prepare_missing_file_source(
+    candidate: &Path,
+    original: &Path,
+    source_label: &str,
+) -> Result<(), String> {
+    let parent = candidate.parent().ok_or_else(|| {
+        format!(
+            "{source_label} path '{}' has no parent directory for file pre-creation.",
+            original.display()
+        )
+    })?;
+    std::fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "{source_label} path '{}' parent '{}' could not be created before session launch: {error}",
+            original.display(),
+            parent.display()
+        )
+    })?;
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(candidate)
+        .map(|_| ())
+        .map_err(|error| {
+            format!(
+                "{source_label} path '{}' could not be created before session launch: {error}",
+                original.display()
+            )
+        })
+}


### PR DESCRIPTION
## Summary

Fixes #1881. A `csa run` / `csa review` / `csa debate` session hard-failed at pre-exec (exit 1, 0s) when ANY
configured `[filesystem_sandbox].extra_writable` path did not exist on disk
(`pre-exec: filesystem_sandbox.extra_writable path '...' does not exist. Create it first or remove the
config entry.`). This turned a transiently-missing optional cache dir (e.g. an MCP server's index dir that
was cleaned up) into a total session blocker, breaking otherwise-headless automation until a manual
`mkdir -p`.

`extra_writable` declares intent ("the sandbox MAY write here"); an allowed-but-absent path is the normal
lifecycle of a tool cache, not a fatal misconfiguration.

## Fix

In the pre-exec writable-source preparation (extracted to `pipeline_sandbox_writable.rs`):

- Boundary/sensitive-path validation runs FIRST (existing `csa_resource::isolation_plan::resolve_writable_paths`)
  — paths outside the allowed roots are still rejected before any creation.
- An ALLOWED but MISSING directory-like `extra_writable` source is now auto-created
  (`std::fs::create_dir_all`) before the bind/Landlock rule is built, then added to the writable set.
- If creation fails (EACCES/EPERM/ENOSPC), the entry is `warn!`-logged and SKIPPED — the session proceeds;
  no write is rerouted to any alternate path (a real write attempt later fails naturally at write time).
- The per-tool `writable_paths` (REPLACE-semantics) branch and the global `[filesystem_sandbox].extra_writable`
  branch both go through the same create/skip path, so the merge case is covered.

This is not a write-fallback dir (rules 037/041): it creates the exact path the user declared — what the old
error message itself instructed ("Create it first") — and never routes writes elsewhere.

## Implementation

- `crates/cli-sub-agent/src/pipeline_sandbox_writable.rs` (new), call sites in `pipeline_sandbox.rs`.

## Tests

New `pipeline_sandbox_extra_writable_tests.rs`: auto-create case, pre-daemon validation, per-tool branch,
mkdir-failure skip, dangerous-path rejection. `cargo test -p cli-sub-agent extra_writable` 13 passed;
`cargo test -p csa-resource isolation_plan` 50 passed; pre-commit monolith/fmt/deny/clippy passed.

Closes #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)
