### PR TITLE
fix(cli-sub-agent): make csa debate question input daemon-safe — drain stdin before detach + --question-file + fail-fast (#1886)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.907"
+version = "0.1.908"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.907"
+version = "0.1.908"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -541,10 +541,10 @@ pub struct DebateArgs {
     #[arg(long, value_delimiter = ',', value_name = "PATH")]
     pub extra_readable: Vec<PathBuf>,
 
-    /// Read the debate question from a file (bypasses shell quoting issues).
-    /// Use `-` or `/dev/stdin` to read the prompt from stdin (heredoc or pipe).
-    #[arg(long, value_name = "PATH", conflicts_with_all = ["question", "topic"])]
-    pub prompt_file: Option<PathBuf>,
+    /// Read the debate question from a file; use this for long multi-paragraph motions.
+    /// Use `-` or `/dev/stdin` to read from stdin (heredoc or pipe).
+    #[arg(long = "question-file", alias = "prompt-file", value_name = "PATH")]
+    pub question_file: Option<PathBuf>,
 
     /// [DEPRECATED] Daemon mode is now the default. This flag is a no-op.
     #[arg(long, hide = true)]

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -123,7 +123,7 @@ pub(crate) async fn handle_debate(
         .await?;
     }
 
-    // 3. Read question (--prompt-file / positional / --topic / stdin), strip
+    // 3. Read question (positional / --topic / --question-file / stdin), strip
     // difficulty frontmatter, prepend --context / --file (see
     // debate_cmd_question::build_debate_question).
     let (question, frontmatter_difficulty) = question::build_debate_question(&mut args)?;
@@ -321,6 +321,10 @@ mod tests;
 #[cfg(test)]
 #[path = "debate_cmd_readonly_tests.rs"]
 mod readonly_tests;
+
+#[cfg(test)]
+#[path = "debate_cmd_question_tests.rs"]
+mod question_tests;
 
 #[cfg(test)]
 #[path = "debate_cmd_round4_tests.rs"]

--- a/crates/cli-sub-agent/src/debate_cmd_question.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_question.rs
@@ -2,27 +2,60 @@
 //!
 //! Extracted verbatim from `debate_cmd::handle_debate` to keep that module
 //! under the monolith gate. Resolves the debate question from
-//! `--prompt-file` / positional / `--topic` / stdin, strips difficulty
+//! positional / `--topic` / `--question-file` / stdin, strips difficulty
 //! frontmatter, and prepends `--context` and repeated `--file` content.
 
 use anyhow::{Context, Result};
+use std::io::{IsTerminal, Read};
+use std::path::Path;
 
 use crate::cli::DebateArgs;
-use crate::run_helpers::resolve_prompt_with_file;
+use crate::debate_errors::EMPTY_DEBATE_QUESTION_ERROR;
+use crate::run_helpers::is_prompt_file_stdin_sentinel;
 
 /// Maximum size of a `--file` attachment for debate (5 MB).
 const MAX_FILE_SIZE: u64 = 5 * 1024 * 1024;
 
 /// Build the effective debate question and extract any difficulty frontmatter.
 ///
-/// Consumes `args.question` / `args.topic` (via `take`); reads `args.prompt_file`,
+/// Consumes `args.question` / `args.topic` (via `take`); reads `args.question_file`,
 /// `args.context`, and `args.file` by reference. Returns the assembled question
 /// plus the parsed frontmatter difficulty (if present).
 pub(super) fn build_debate_question(args: &mut DebateArgs) -> Result<(String, Option<String>)> {
-    let effective_question =
-        crate::run_helpers::resolve_positional_stdin_sentinel(args.question.take())?
-            .or_else(|| args.topic.take());
-    let mut question = resolve_prompt_with_file(effective_question, args.prompt_file.as_deref())?;
+    let mut stdin = std::io::stdin();
+    build_debate_question_from_reader(args, stdin.is_terminal(), &mut stdin)
+}
+
+#[cfg(test)]
+pub(super) fn build_debate_question_from_reader<R: Read>(
+    args: &mut DebateArgs,
+    stdin_is_terminal: bool,
+    reader: &mut R,
+) -> Result<(String, Option<String>)> {
+    build_debate_question_inner(args, stdin_is_terminal, reader)
+}
+
+#[cfg(not(test))]
+fn build_debate_question_from_reader<R: Read>(
+    args: &mut DebateArgs,
+    stdin_is_terminal: bool,
+    reader: &mut R,
+) -> Result<(String, Option<String>)> {
+    build_debate_question_inner(args, stdin_is_terminal, reader)
+}
+
+fn build_debate_question_inner<R: Read>(
+    args: &mut DebateArgs,
+    stdin_is_terminal: bool,
+    reader: &mut R,
+) -> Result<(String, Option<String>)> {
+    let mut question = resolve_question_from_reader(
+        args.question.take(),
+        args.topic.take(),
+        args.question_file.as_deref(),
+        stdin_is_terminal,
+        reader,
+    )?;
     let parsed_question = crate::difficulty_routing::strip_difficulty_frontmatter(question)?;
     let frontmatter_difficulty = parsed_question.difficulty;
     question = parsed_question.prompt;
@@ -52,4 +85,60 @@ pub(super) fn build_debate_question(args: &mut DebateArgs) -> Result<(String, Op
         question = format!("{attached_files}{question}");
     }
     Ok((question, frontmatter_difficulty))
+}
+
+fn resolve_question_from_reader<R: Read>(
+    question: Option<String>,
+    topic: Option<String>,
+    question_file: Option<&Path>,
+    stdin_is_terminal: bool,
+    reader: &mut R,
+) -> Result<String> {
+    if let Some(question) = question {
+        if question == "-" {
+            return read_question_from_stdin(stdin_is_terminal, reader);
+        }
+        return validate_inline_question(question);
+    }
+
+    if let Some(topic) = topic {
+        return validate_inline_question(topic);
+    }
+
+    if let Some(path) = question_file {
+        if is_prompt_file_stdin_sentinel(path) {
+            return read_question_from_stdin(stdin_is_terminal, reader);
+        }
+
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("--question-file: failed to read '{}'", path.display()))?;
+        if content.trim().is_empty() {
+            anyhow::bail!("--question-file '{}' is empty", path.display());
+        }
+        return Ok(content);
+    }
+
+    read_question_from_stdin(stdin_is_terminal, reader)
+}
+
+fn validate_inline_question(question: String) -> Result<String> {
+    if question.trim().is_empty() {
+        anyhow::bail!(EMPTY_DEBATE_QUESTION_ERROR);
+    }
+    Ok(question)
+}
+
+fn read_question_from_stdin<R: Read>(stdin_is_terminal: bool, reader: &mut R) -> Result<String> {
+    if stdin_is_terminal {
+        anyhow::bail!(EMPTY_DEBATE_QUESTION_ERROR);
+    }
+
+    let mut buffer = String::new();
+    reader
+        .read_to_string(&mut buffer)
+        .context("failed to read debate question from stdin")?;
+    if buffer.trim().is_empty() {
+        anyhow::bail!(EMPTY_DEBATE_QUESTION_ERROR);
+    }
+    Ok(buffer)
 }

--- a/crates/cli-sub-agent/src/debate_cmd_question_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_question_tests.rs
@@ -1,0 +1,97 @@
+use super::question;
+use crate::cli::{Cli, Commands, DebateArgs};
+use clap::Parser;
+
+fn parse_debate_args(argv: &[&str]) -> DebateArgs {
+    let cli = Cli::try_parse_from(argv).expect("debate CLI args should parse");
+    match cli.command {
+        Commands::Debate(args) => args,
+        _ => panic!("expected debate subcommand"),
+    }
+}
+
+#[test]
+fn debate_question_file_supplies_question() {
+    let temp = tempfile::tempdir().unwrap();
+    let question_file = temp.path().join("motion.md");
+    std::fs::write(&question_file, "question from file").unwrap();
+    let question_file_arg = question_file.display().to_string();
+    let mut args = parse_debate_args(&["csa", "debate", "--question-file", &question_file_arg]);
+    let mut stdin = std::io::Cursor::new("stdin should not win");
+
+    let (resolved, difficulty) =
+        question::build_debate_question_from_reader(&mut args, false, &mut stdin)
+            .expect("question file should build");
+
+    assert_eq!(resolved, "question from file");
+    assert_eq!(difficulty, None);
+}
+
+#[test]
+fn debate_empty_question_fails_with_clear_error() {
+    let mut args = parse_debate_args(&["csa", "debate"]);
+    let mut stdin = std::io::Cursor::new("");
+
+    let err = question::build_debate_question_from_reader(&mut args, true, &mut stdin)
+        .expect_err("missing question on terminal stdin must fail");
+
+    let message = err.to_string();
+    assert!(message.contains("debate question is empty"), "{message}");
+    assert!(
+        message.contains("stdin is not available to the detached daemon"),
+        "{message}"
+    );
+    assert!(message.contains("--question-file <path>"), "{message}");
+}
+
+#[test]
+fn debate_question_precedence_positional_then_file_then_stdin() {
+    let temp = tempfile::tempdir().unwrap();
+    let question_file = temp.path().join("motion.md");
+    std::fs::write(&question_file, "question from file").unwrap();
+    let question_file_arg = question_file.display().to_string();
+
+    let mut positional_args = parse_debate_args(&[
+        "csa",
+        "debate",
+        "--question-file",
+        &question_file_arg,
+        "question from positional",
+    ]);
+    let mut stdin = std::io::Cursor::new("question from stdin");
+    let (resolved, _) =
+        question::build_debate_question_from_reader(&mut positional_args, false, &mut stdin)
+            .expect("positional question should win");
+    assert_eq!(resolved, "question from positional");
+
+    let mut file_args =
+        parse_debate_args(&["csa", "debate", "--question-file", &question_file_arg]);
+    let mut stdin = std::io::Cursor::new("question from stdin");
+    let (resolved, _) =
+        question::build_debate_question_from_reader(&mut file_args, false, &mut stdin)
+            .expect("question file should win over stdin");
+    assert_eq!(resolved, "question from file");
+}
+
+#[test]
+fn debate_omitted_question_drains_piped_stdin() {
+    let mut args = parse_debate_args(&["csa", "debate"]);
+    let mut stdin = std::io::Cursor::new("question from piped stdin");
+
+    let (resolved, difficulty) =
+        question::build_debate_question_from_reader(&mut args, false, &mut stdin)
+            .expect("piped stdin should become the question");
+
+    assert_eq!(resolved, "question from piped stdin");
+    assert_eq!(difficulty, None);
+}
+
+#[test]
+fn debate_cli_parses_question_file() {
+    let args = parse_debate_args(&["csa", "debate", "--question-file", "motion.md"]);
+
+    assert_eq!(
+        args.question_file.as_deref(),
+        Some(std::path::Path::new("motion.md"))
+    );
+}

--- a/crates/cli-sub-agent/src/debate_errors.rs
+++ b/crates/cli-sub-agent/src/debate_errors.rs
@@ -3,6 +3,11 @@ use std::path::Path;
 use csa_process::{ExecutionResult, ToolLiveness};
 use csa_session::MetaSessionState;
 
+pub(crate) const EMPTY_DEBATE_QUESTION_ERROR: &str = concat!(
+    "debate question is empty (stdin is not available to the detached daemon - ",
+    "pass a positional QUESTION, use --question-file <path>, or pair --context with a QUESTION)"
+);
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DebateErrorKind {
     Transient(String),

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -516,7 +516,11 @@ async fn run() -> Result<()> {
                 &args.session_id,
                 args.cd.as_deref(),
                 &mut startup_env,
-                run_cmd_daemon::DaemonSpawnOptions::for_prompt_file(args.prompt_file.as_deref()),
+                run_cmd_daemon::DaemonSpawnOptions::for_debate(
+                    args.question.as_deref(),
+                    args.topic.as_deref(),
+                    args.question_file.as_deref(),
+                ),
             )?;
             let result =
                 debate_cmd::handle_debate(args, current_depth, output_format, &startup_env).await;

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
+use crate::debate_errors::EMPTY_DEBATE_QUESTION_ERROR;
 use crate::startup_env::StartupSubtreeEnv;
 
 const STDIN_PROMPT_MAX_BYTES: u64 = 10 * 1024 * 1024;
@@ -13,6 +14,9 @@ const STDIN_PROMPT_MAX_BYTES: u64 = 10 * 1024 * 1024;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct DaemonSpawnOptions {
     run_stdin_prompt: RunStdinPrompt,
+    prompt_file_to_capture: Option<PathBuf>,
+    remove_prompt_file_arg: bool,
+    prompt_file_forward_arg: PromptFileForwardArg,
     no_fs_sandbox: bool,
     extra_writable: Vec<PathBuf>,
 }
@@ -22,8 +26,32 @@ enum RunStdinPrompt {
     #[default]
     None,
     Omitted,
+    DebateOmitted,
     PositionalSentinel,
     PromptFileSentinel,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum PromptFileForwardArg {
+    #[default]
+    PromptFile,
+    QuestionFile,
+}
+
+impl PromptFileForwardArg {
+    fn flag(self) -> &'static str {
+        match self {
+            Self::PromptFile => "--prompt-file",
+            Self::QuestionFile => "--question-file",
+        }
+    }
+
+    fn accepted_flags(self) -> &'static [&'static str] {
+        match self {
+            Self::PromptFile => &["--prompt-file"],
+            Self::QuestionFile => &["--question-file", "--prompt-file"],
+        }
+    }
 }
 
 impl DaemonSpawnOptions {
@@ -50,21 +78,45 @@ impl DaemonSpawnOptions {
 
         Self {
             run_stdin_prompt,
+            prompt_file_forward_arg: PromptFileForwardArg::PromptFile,
             no_fs_sandbox,
             extra_writable: extra_writable.to_vec(),
+            ..Default::default()
         }
     }
 
-    pub(crate) fn for_prompt_file(prompt_file: Option<&Path>) -> Self {
-        let run_stdin_prompt =
-            if prompt_file.is_some_and(crate::run_helpers::is_prompt_file_stdin_sentinel) {
-                RunStdinPrompt::PromptFileSentinel
-            } else {
-                RunStdinPrompt::None
-            };
+    pub(crate) fn for_debate(
+        question: Option<&str>,
+        topic: Option<&str>,
+        question_file: Option<&Path>,
+    ) -> Self {
+        let question_from_stdin = question == Some("-");
+        let inline_question_available = question.is_some() || topic.is_some();
+        let question_file_is_stdin =
+            question_file.is_some_and(crate::run_helpers::is_prompt_file_stdin_sentinel);
+        let run_stdin_prompt = if question_from_stdin {
+            RunStdinPrompt::PositionalSentinel
+        } else if inline_question_available {
+            RunStdinPrompt::None
+        } else if question_file_is_stdin {
+            RunStdinPrompt::PromptFileSentinel
+        } else if question_file.is_none() {
+            RunStdinPrompt::DebateOmitted
+        } else {
+            RunStdinPrompt::None
+        };
+        let prompt_file_to_capture = if !inline_question_available && !question_file_is_stdin {
+            question_file.map(Path::to_path_buf)
+        } else {
+            None
+        };
+        let remove_prompt_file_arg = question_from_stdin && question_file.is_some();
 
         Self {
             run_stdin_prompt,
+            prompt_file_to_capture,
+            remove_prompt_file_arg,
+            prompt_file_forward_arg: PromptFileForwardArg::QuestionFile,
             ..Default::default()
         }
     }
@@ -272,9 +324,9 @@ pub(crate) fn spawn_and_exit(
     let sid = csa_session::new_session_id();
     let session_root = csa_session::get_session_root(&project_root)?;
     let session_dir = session_root.join("sessions").join(&sid);
-    let stdin_prompt = read_stdin_prompt_if_needed(&spawn_options)?;
+    let prompt_input = read_daemon_prompt_input_if_needed(&spawn_options)?;
     persist_daemon_placeholder_session(&project_root, &session_dir, &sid, subcommand)?;
-    let stdin_prompt_file = write_stdin_prompt_if_needed(&session_dir, stdin_prompt)?;
+    let prompt_input_file = write_daemon_prompt_input_if_needed(&session_dir, prompt_input)?;
 
     // Collect args to forward: everything after the subcommand verb.
     // spawn_daemon() injects '<subcommand> --daemon-child --session-id <ID>' itself.
@@ -285,7 +337,7 @@ pub(crate) fn spawn_and_exit(
         &all_args,
         subcommand,
         &spawn_options,
-        stdin_prompt_file.as_deref(),
+        prompt_input_file.as_deref(),
     );
 
     let csa_binary = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("csa"));
@@ -383,13 +435,31 @@ fn persist_daemon_placeholder_session(
     Ok(())
 }
 
-fn read_stdin_prompt_if_needed(spawn_options: &DaemonSpawnOptions) -> Result<Option<String>> {
+fn read_daemon_prompt_input_if_needed(
+    spawn_options: &DaemonSpawnOptions,
+) -> Result<Option<String>> {
+    let mut stdin = std::io::stdin();
+    read_daemon_prompt_input_if_needed_from_reader(spawn_options, stdin.is_terminal(), &mut stdin)
+}
+
+fn read_daemon_prompt_input_if_needed_from_reader<R: Read>(
+    spawn_options: &DaemonSpawnOptions,
+    stdin_is_terminal: bool,
+    reader: &mut R,
+) -> Result<Option<String>> {
+    if let Some(path) = &spawn_options.prompt_file_to_capture {
+        let prompt = read_daemon_prompt_file(path, spawn_options.prompt_file_forward_arg)?;
+        return Ok(Some(prompt));
+    }
+
     if spawn_options.run_stdin_prompt == RunStdinPrompt::None {
         return Ok(None);
     }
 
-    let mut stdin = std::io::stdin();
-    if stdin.is_terminal() {
+    if stdin_is_terminal {
+        if spawn_options.run_stdin_prompt == RunStdinPrompt::DebateOmitted {
+            anyhow::bail!(EMPTY_DEBATE_QUESTION_ERROR);
+        }
         anyhow::bail!(
             "No prompt provided and stdin is a terminal.\n\n\
              Usage:\n  \
@@ -398,12 +468,29 @@ fn read_stdin_prompt_if_needed(spawn_options: &DaemonSpawnOptions) -> Result<Opt
         );
     }
 
-    let prompt = read_bounded_stdin_prompt(&mut stdin, STDIN_PROMPT_MAX_BYTES)
-        .context("failed to read daemon run prompt from stdin")?;
+    let read_context = if spawn_options.run_stdin_prompt == RunStdinPrompt::DebateOmitted {
+        "failed to read daemon debate question from stdin"
+    } else {
+        "failed to read daemon run prompt from stdin"
+    };
+    let prompt = read_bounded_stdin_prompt(reader, STDIN_PROMPT_MAX_BYTES).context(read_context)?;
     if prompt.trim().is_empty() {
+        if spawn_options.run_stdin_prompt == RunStdinPrompt::DebateOmitted {
+            anyhow::bail!(EMPTY_DEBATE_QUESTION_ERROR);
+        }
         anyhow::bail!("Empty prompt from stdin. Provide a non-empty prompt.");
     }
     Ok(Some(prompt))
+}
+
+fn read_daemon_prompt_file(path: &Path, forward_arg: PromptFileForwardArg) -> Result<String> {
+    let flag = forward_arg.flag();
+    let prompt = std::fs::read_to_string(path)
+        .with_context(|| format!("{flag}: failed to read '{}'", path.display()))?;
+    if prompt.trim().is_empty() {
+        anyhow::bail!("{flag} '{}' is empty", path.display());
+    }
+    Ok(prompt)
 }
 
 fn read_bounded_stdin_prompt(reader: impl Read, max_bytes: u64) -> Result<String> {
@@ -419,7 +506,7 @@ fn read_bounded_stdin_prompt(reader: impl Read, max_bytes: u64) -> Result<String
     Ok(prompt)
 }
 
-fn write_stdin_prompt_if_needed(
+fn write_daemon_prompt_input_if_needed(
     session_dir: &Path,
     prompt: Option<String>,
 ) -> Result<Option<PathBuf>> {
@@ -467,30 +554,63 @@ fn build_forwarded_args(
     }
 
     if spawn_options.run_stdin_prompt == RunStdinPrompt::PromptFileSentinel {
-        remove_prompt_file_sentinel_arg(&mut forwarded_args);
+        remove_prompt_file_arg(
+            &mut forwarded_args,
+            spawn_options.prompt_file_forward_arg.accepted_flags(),
+            true,
+        );
+    }
+
+    if spawn_options.prompt_file_to_capture.is_some() {
+        remove_prompt_file_arg(
+            &mut forwarded_args,
+            spawn_options.prompt_file_forward_arg.accepted_flags(),
+            false,
+        );
+    }
+
+    if spawn_options.remove_prompt_file_arg {
+        remove_prompt_file_arg(
+            &mut forwarded_args,
+            spawn_options.prompt_file_forward_arg.accepted_flags(),
+            false,
+        );
     }
 
     if let Some(prompt_file) = stdin_prompt_file {
-        forwarded_args.push("--prompt-file".to_string());
+        forwarded_args.push(spawn_options.prompt_file_forward_arg.flag().to_string());
         forwarded_args.push(prompt_file.display().to_string());
     }
 
     forwarded_args
 }
 
-fn remove_prompt_file_sentinel_arg(args: &mut Vec<String>) {
-    let Some(pos) = args.iter().position(|arg| {
-        arg.strip_prefix("--prompt-file=").is_some_and(|value| {
-            crate::run_helpers::is_prompt_file_stdin_sentinel(Path::new(value))
-        }) || arg == "--prompt-file"
+fn remove_prompt_file_arg(args: &mut Vec<String>, flags: &[&str], sentinel_only: bool) {
+    let Some((pos, flag, value_in_arg)) = args.iter().enumerate().find_map(|(pos, arg)| {
+        flags.iter().find_map(|flag| {
+            if arg == flag {
+                Some((pos, *flag, None))
+            } else {
+                arg.strip_prefix(&format!("{flag}="))
+                    .map(|value| (pos, *flag, Some(value.to_string())))
+            }
+        })
     }) else {
         return;
     };
 
-    if args[pos] == "--prompt-file" {
-        if args.get(pos + 1).is_some_and(|value| {
-            crate::run_helpers::is_prompt_file_stdin_sentinel(Path::new(value))
-        }) {
+    if let Some(value) = value_in_arg {
+        if !sentinel_only || crate::run_helpers::is_prompt_file_stdin_sentinel(Path::new(&value)) {
+            args.remove(pos);
+        }
+        return;
+    }
+
+    if args[pos] == flag {
+        let Some(value) = args.get(pos + 1) else {
+            return;
+        };
+        if !sentinel_only || crate::run_helpers::is_prompt_file_stdin_sentinel(Path::new(value)) {
             args.drain(pos..=pos + 1);
         }
     } else {

--- a/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
@@ -26,8 +26,31 @@ fn run_daemon_options_detect_prompt_file_stdin_sentinel() {
 
 #[test]
 fn prompt_file_daemon_options_detect_dev_stdin() {
-    let options = DaemonSpawnOptions::for_prompt_file(Some(Path::new("/dev/stdin")));
+    let options = DaemonSpawnOptions::for_debate(None, None, Some(Path::new("/dev/stdin")));
     assert_eq!(options.run_stdin_prompt, RunStdinPrompt::PromptFileSentinel);
+}
+
+#[test]
+fn debate_daemon_options_detect_omitted_question_stdin() {
+    let options = DaemonSpawnOptions::for_debate(None, None, None);
+    assert_eq!(options.run_stdin_prompt, RunStdinPrompt::DebateOmitted);
+    assert_eq!(
+        options.prompt_file_forward_arg,
+        PromptFileForwardArg::QuestionFile
+    );
+}
+
+#[test]
+fn debate_daemon_options_detect_question_file_capture() {
+    let path = Path::new("motion.md");
+    let options = DaemonSpawnOptions::for_debate(None, None, Some(path));
+
+    assert_eq!(options.run_stdin_prompt, RunStdinPrompt::None);
+    assert_eq!(options.prompt_file_to_capture.as_deref(), Some(path));
+    assert_eq!(
+        options.prompt_file_forward_arg,
+        PromptFileForwardArg::QuestionFile
+    );
 }
 
 #[test]
@@ -156,6 +179,115 @@ fn forwarded_args_replace_prompt_file_equals_stdin_sentinel_with_prompt_file() {
             "/state/session/input/stdin-prompt.txt"
         ]
     );
+}
+
+#[test]
+fn forwarded_args_append_question_file_for_omitted_debate_stdin() {
+    let all_args = vec![
+        "csa".to_string(),
+        "debate".to_string(),
+        "--sa-mode".to_string(),
+        "true".to_string(),
+    ];
+    let prompt_file = Path::new("/state/session/input/stdin-prompt.txt");
+
+    let forwarded = build_forwarded_args(
+        &all_args,
+        "debate",
+        &DaemonSpawnOptions {
+            run_stdin_prompt: RunStdinPrompt::DebateOmitted,
+            prompt_file_forward_arg: PromptFileForwardArg::QuestionFile,
+            ..Default::default()
+        },
+        Some(prompt_file),
+    );
+
+    assert_eq!(
+        forwarded,
+        vec![
+            "--sa-mode",
+            "true",
+            "--question-file",
+            "/state/session/input/stdin-prompt.txt"
+        ]
+    );
+}
+
+#[test]
+fn forwarded_args_replace_question_file_with_captured_copy() {
+    let all_args = vec![
+        "csa".to_string(),
+        "debate".to_string(),
+        "--question-file".to_string(),
+        "motion.md".to_string(),
+    ];
+    let captured = Path::new("/state/session/input/stdin-prompt.txt");
+
+    let forwarded = build_forwarded_args(
+        &all_args,
+        "debate",
+        &DaemonSpawnOptions {
+            prompt_file_to_capture: Some(Path::new("motion.md").to_path_buf()),
+            prompt_file_forward_arg: PromptFileForwardArg::QuestionFile,
+            ..Default::default()
+        },
+        Some(captured),
+    );
+
+    assert_eq!(
+        forwarded,
+        vec!["--question-file", "/state/session/input/stdin-prompt.txt"]
+    );
+}
+
+#[test]
+fn forwarded_args_replace_prompt_file_alias_with_question_file() {
+    let all_args = vec![
+        "csa".to_string(),
+        "debate".to_string(),
+        "--prompt-file".to_string(),
+        "/dev/stdin".to_string(),
+    ];
+    let captured = Path::new("/state/session/input/stdin-prompt.txt");
+
+    let forwarded = build_forwarded_args(
+        &all_args,
+        "debate",
+        &DaemonSpawnOptions {
+            run_stdin_prompt: RunStdinPrompt::PromptFileSentinel,
+            prompt_file_forward_arg: PromptFileForwardArg::QuestionFile,
+            ..Default::default()
+        },
+        Some(captured),
+    );
+
+    assert_eq!(
+        forwarded,
+        vec!["--question-file", "/state/session/input/stdin-prompt.txt"]
+    );
+}
+
+#[test]
+fn debate_omitted_question_tty_fails_before_spawn() {
+    let options = DaemonSpawnOptions::for_debate(None, None, None);
+    let mut stdin = std::io::Cursor::new("");
+    let err = read_daemon_prompt_input_if_needed_from_reader(&options, true, &mut stdin)
+        .expect_err("TTY without question must fail before daemon spawn");
+
+    let message = err.to_string();
+    assert!(message.contains("debate question is empty"), "{message}");
+    assert!(message.contains("--question-file <path>"), "{message}");
+}
+
+#[test]
+fn debate_omitted_question_empty_stdin_fails_before_spawn() {
+    let options = DaemonSpawnOptions::for_debate(None, None, None);
+    let mut stdin = std::io::Cursor::new("   ");
+    let err = read_daemon_prompt_input_if_needed_from_reader(&options, false, &mut stdin)
+        .expect_err("empty piped stdin must fail before daemon spawn");
+
+    let message = err.to_string();
+    assert!(message.contains("debate question is empty"), "{message}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1886. `csa debate` documented reading the QUESTION from stdin when the positional arg is omitted, but
the session runs as a detached daemon that cannot read the *caller's* stdin — so the QUESTION arrived empty,
the debate failed during init with `status=failure exit=1` **before `result.toml` was written**, `Tool=unknown`,
~37s wasted, and no actionable error. The same motion via `--context "$(cat f)"` + a positional QUESTION
worked, making the failure confusing.

## Root cause

`csa run` already solved this with `--prompt-file` (the parent captures the input in the foreground and
hands it to the daemon). `csa debate`'s stdin path didn't account for daemon detach — the caller's stdin fd
isn't inherited by the detached daemon, so the read yielded empty and the debate was constructed with no
question.

## Fix (all three remedies from the issue, preference order)

- **Drain before detach**: the daemon parent now captures an omitted/piped-stdin (non-TTY) question, the
  stdin sentinels (`-`, `/dev/stdin`, `/proc/self/fd/0`), and `--question-file` contents in the foreground,
  writes them to the session input file, and forwards them to the daemon child — reusing the proven
  `csa run` daemon-safe input plumbing (`run_cmd_daemon.rs`).
- **`--question-file <path>`**: new canonical flag mirroring `csa run --prompt-file` (the old `--prompt-file`
  name is kept as an alias for parity). Daemon-safe way to pass a long multi-paragraph motion.
- **Fail-fast clear error**: when the resolved QUESTION is empty (no positional, no `--question-file`,
  stdin unavailable/TTY), the command fails in the foreground with a self-explaining message instead of a
  generic `exit=1`/missing-`result.toml`.

Resolution precedence: **positional/topic > `--question-file` > non-TTY stdin**; empty → fail-fast. The
empty-question error text is shared (`debate_errors.rs`) so the resolver and daemon paths can't diverge.

## Implementation

- `cli_review.rs` (flag), `debate_cmd_question.rs` (resolution), `run_cmd_daemon.rs` (capture-before-detach),
  `debate_errors.rs` (shared error), `debate_cmd.rs`/`main.rs` wiring.

## Tests

`debate_cmd_question_tests.rs` / `run_cmd_daemon_tests.rs`: question precedence, empty input fail-fast,
omitted piped-stdin capture, daemon arg rewriting, `--prompt-file` alias forwarding.
`cargo test -p cli-sub-agent debate_` 161 passed; `run_cmd_daemon` 21 passed; pre-commit monolith/deny/clippy
passed.

Closes #1886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
