### PR TITLE
fix(cli-sub-agent): fail-closed on prose-findings vs empty-structured verdict mismatch (#1896)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.909"
+version = "0.1.910"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -124,8 +124,10 @@ fn derive_findings_toml_artifact(
 /// Load the canonical review prose for a session.
 ///
 /// Resolves the authoritative review text via a fixed source precedence:
-/// when persisted `details` sections exist, prefer `output/full.md`, then the raw
-/// `output.log`, then the `details.md` body; otherwise fall back to `output/full.md`.
+/// when persisted `details` sections exist, preserve valid fenced TOML from
+/// `output/full.md`/`output.log`, then combine the final persisted
+/// `summary.md`/`details.md` prose with any distinct raw transcript/log prose.
+/// Otherwise fall back to `output/full.md`.
 /// This is the SINGLE source of review prose shared by both the findings extractor
 /// and the fail-closed verdict detector ([`super::output::clean_detection::
 /// review_contains_prose_fail_conclusion`]). Sharing one loader keeps their source
@@ -138,6 +140,7 @@ pub(in crate::review_cmd) fn load_canonical_review_text(
 ) -> Result<Option<String>, anyhow::Error> {
     let details_path = session_dir.join("output").join("details.md");
     if details_path.exists() {
+        let mut raw_review_texts = Vec::new();
         for candidate in [
             session_dir.join("output").join("full.md"),
             session_dir.join("output.log"),
@@ -148,7 +151,10 @@ pub(in crate::review_cmd) fn load_canonical_review_text(
             let raw_output = fs::read_to_string(&candidate)
                 .map_err(|error| anyhow::anyhow!("read {}: {error}", candidate.display()))?;
             if let Some(review_text) = extract_review_text(&raw_output) {
-                return Ok(Some(review_text));
+                if extract_findings_toml_from_text(&review_text).is_some() {
+                    return Ok(Some(review_text));
+                }
+                push_distinct_review_text(&mut raw_review_texts, review_text);
             }
         }
         let mut latest_summary = None;
@@ -165,8 +171,9 @@ pub(in crate::review_cmd) fn load_canonical_review_text(
             .flatten()
             .collect::<Vec<_>>()
             .join("\n");
+        let mut review_texts = Vec::new();
         if !structured_text.trim().is_empty() {
-            return Ok(Some(structured_text));
+            push_distinct_review_text(&mut review_texts, structured_text);
         }
 
         let mut file_text = Vec::new();
@@ -182,7 +189,13 @@ pub(in crate::review_cmd) fn load_canonical_review_text(
             }
         }
         let file_text = file_text.join("\n");
-        return Ok((!file_text.trim().is_empty()).then_some(file_text));
+        if !file_text.trim().is_empty() {
+            push_distinct_review_text(&mut review_texts, file_text);
+        }
+        for review_text in raw_review_texts {
+            push_distinct_review_text(&mut review_texts, review_text);
+        }
+        return Ok((!review_texts.is_empty()).then_some(review_texts.join("\n")));
     }
 
     let full_output_path = session_dir.join("output").join("full.md");
@@ -193,6 +206,17 @@ pub(in crate::review_cmd) fn load_canonical_review_text(
     let raw_output = fs::read_to_string(&full_output_path)
         .map_err(|error| anyhow::anyhow!("read {}: {error}", full_output_path.display()))?;
     Ok(extract_review_text(&raw_output))
+}
+
+fn push_distinct_review_text(texts: &mut Vec<String>, candidate: String) {
+    let trimmed = candidate.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    if texts.iter().any(|text| text.trim() == trimmed) {
+        return;
+    }
+    texts.push(candidate);
 }
 
 pub(super) fn extract_findings_toml_from_text(text: &str) -> Option<FindingsFile> {

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -106,10 +106,18 @@ fn derive_findings_toml_artifact(
         return Ok((FindingsFile::default(), Some("review text unavailable")));
     };
 
+    let prose_artifact = findings_file_from_prose(&review_text);
     match extract_findings_toml_from_text(&review_text) {
+        Some(artifact) if artifact.findings.is_empty() => {
+            if let Some(prose_artifact) = prose_artifact {
+                Ok((prose_artifact, None))
+            } else {
+                Ok((artifact, None))
+            }
+        }
         Some(artifact) => Ok((artifact, None)),
         None => {
-            if let Some(artifact) = findings_file_from_prose(&review_text) {
+            if let Some(artifact) = prose_artifact {
                 Ok((artifact, None))
             } else {
                 Ok((
@@ -123,11 +131,11 @@ fn derive_findings_toml_artifact(
 
 /// Load the canonical review prose for a session.
 ///
-/// Resolves the authoritative review text via a fixed source precedence:
-/// when persisted `details` sections exist, preserve valid fenced TOML from
-/// `output/full.md`/`output.log`, then combine the final persisted
-/// `summary.md`/`details.md` prose with any distinct raw transcript/log prose.
-/// Otherwise fall back to `output/full.md`.
+/// Resolves the authoritative review text by unioning every available prose
+/// source: persisted `summary`/`details` sections, physical `summary.md` and
+/// `details.md`, plus raw `output/full.md` and `output.log` review text. Valid
+/// fenced `findings.toml` content is preserved inside the raw text, but never
+/// causes physical review prose to be skipped.
 /// This is the SINGLE source of review prose shared by both the findings extractor
 /// and the fail-closed verdict detector ([`super::output::clean_detection::
 /// review_contains_prose_fail_conclusion`]). Sharing one loader keeps their source
@@ -138,74 +146,53 @@ fn derive_findings_toml_artifact(
 pub(in crate::review_cmd) fn load_canonical_review_text(
     session_dir: &Path,
 ) -> Result<Option<String>, anyhow::Error> {
-    let details_path = session_dir.join("output").join("details.md");
-    if details_path.exists() {
-        let mut raw_review_texts = Vec::new();
-        for candidate in [
-            session_dir.join("output").join("full.md"),
-            session_dir.join("output.log"),
-        ] {
-            if !candidate.exists() {
-                continue;
-            }
-            let raw_output = fs::read_to_string(&candidate)
-                .map_err(|error| anyhow::anyhow!("read {}: {error}", candidate.display()))?;
-            if let Some(review_text) = extract_review_text(&raw_output) {
-                if extract_findings_toml_from_text(&review_text).is_some() {
-                    return Ok(Some(review_text));
-                }
-                push_distinct_review_text(&mut raw_review_texts, review_text);
-            }
-        }
-        let mut latest_summary = None;
-        let mut latest_details = None;
-        for (section, content) in csa_session::read_all_sections(session_dir)? {
-            match section.id.as_str() {
-                "summary" => latest_summary = Some(content),
-                "details" => latest_details = Some(content),
-                _ => {}
-            }
-        }
-        let structured_text = [latest_summary, latest_details]
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-            .join("\n");
-        let mut review_texts = Vec::new();
-        if !structured_text.trim().is_empty() {
-            push_distinct_review_text(&mut review_texts, structured_text);
-        }
+    let mut review_texts = Vec::new();
+    let mut latest_summary = None;
+    let mut latest_details = None;
 
-        let mut file_text = Vec::new();
-        for file_name in ["summary.md", "details.md"] {
-            let path = session_dir.join("output").join(file_name);
-            if !path.exists() {
-                continue;
-            }
-            let content = fs::read_to_string(&path)
-                .map_err(|error| anyhow::anyhow!("read {}: {error}", path.display()))?;
-            if !content.trim().is_empty() {
-                file_text.push(content);
-            }
+    for (section, content) in csa_session::read_all_sections(session_dir)? {
+        match section.id.as_str() {
+            "summary" => latest_summary = Some(content),
+            "details" => latest_details = Some(content),
+            _ => {}
         }
-        let file_text = file_text.join("\n");
-        if !file_text.trim().is_empty() {
-            push_distinct_review_text(&mut review_texts, file_text);
+    }
+    let structured_text = [latest_summary, latest_details]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join("\n");
+    push_distinct_review_text(&mut review_texts, structured_text);
+
+    let mut file_text = Vec::new();
+    for file_name in ["summary.md", "details.md"] {
+        let path = session_dir.join("output").join(file_name);
+        if !path.exists() {
+            continue;
         }
-        for review_text in raw_review_texts {
+        let content = fs::read_to_string(&path)
+            .map_err(|error| anyhow::anyhow!("read {}: {error}", path.display()))?;
+        if !content.trim().is_empty() {
+            file_text.push(content);
+        }
+    }
+    push_distinct_review_text(&mut review_texts, file_text.join("\n"));
+
+    for candidate in [
+        session_dir.join("output").join("full.md"),
+        session_dir.join("output.log"),
+    ] {
+        if !candidate.exists() {
+            continue;
+        }
+        let raw_output = fs::read_to_string(&candidate)
+            .map_err(|error| anyhow::anyhow!("read {}: {error}", candidate.display()))?;
+        if let Some(review_text) = extract_review_text(&raw_output) {
             push_distinct_review_text(&mut review_texts, review_text);
         }
-        return Ok((!review_texts.is_empty()).then_some(review_texts.join("\n")));
     }
 
-    let full_output_path = session_dir.join("output").join("full.md");
-    if !full_output_path.exists() {
-        return Ok(None);
-    }
-
-    let raw_output = fs::read_to_string(&full_output_path)
-        .map_err(|error| anyhow::anyhow!("read {}: {error}", full_output_path.display()))?;
-    Ok(extract_review_text(&raw_output))
+    Ok((!review_texts.is_empty()).then_some(review_texts.join("\n")))
 }
 
 fn push_distinct_review_text(texts: &mut Vec<String>, candidate: String) {
@@ -223,6 +210,8 @@ pub(super) fn extract_findings_toml_from_text(text: &str) -> Option<FindingsFile
     let mut in_block = false;
     let mut block_info = String::new();
     let mut block_content = Vec::new();
+    let mut parsed_findings = Vec::new();
+    let mut saw_findings_toml = false;
 
     for line in text.lines() {
         let trimmed = line.trim();
@@ -239,7 +228,12 @@ pub(super) fn extract_findings_toml_from_text(text: &str) -> Option<FindingsFile
             if is_findings_toml_fence_label(&block_info) {
                 let content = block_content.join("\n");
                 if let Ok(artifact) = toml::from_str::<FindingsFile>(&content) {
-                    return Some(artifact);
+                    saw_findings_toml = true;
+                    for finding in artifact.findings {
+                        if !parsed_findings.contains(&finding) {
+                            parsed_findings.push(finding);
+                        }
+                    }
                 }
             }
             in_block = false;
@@ -251,7 +245,9 @@ pub(super) fn extract_findings_toml_from_text(text: &str) -> Option<FindingsFile
         block_content.push(line.to_string());
     }
 
-    None
+    saw_findings_toml.then_some(FindingsFile {
+        findings: parsed_findings,
+    })
 }
 
 fn is_findings_toml_fence_label(info: &str) -> bool {
@@ -259,6 +255,9 @@ fn is_findings_toml_fence_label(info: &str) -> bool {
         .any(|token| token.eq_ignore_ascii_case(FINDINGS_TOML_FENCE_LABEL))
 }
 
+#[cfg(test)]
+#[path = "review_cmd_findings_toml_source_set_tests.rs"]
+mod source_set_tests;
 #[cfg(test)]
 #[path = "review_cmd_findings_toml_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml_source_set_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml_source_set_tests.rs
@@ -1,0 +1,53 @@
+use super::extract_findings_toml_from_text;
+use csa_session::{FindingsFile, ReviewFinding, ReviewFindingFileRange, Severity};
+
+#[test]
+fn extract_findings_toml_from_text_merges_multiple_labeled_blocks() {
+    let review_text = r#"```findings.toml
+findings = []
+```
+
+```toml findings.toml
+[[findings]]
+id = "f1"
+severity = "high"
+description = "Later non-empty labeled block must not be hidden."
+
+[[findings.file_ranges]]
+path = "crates/cli-sub-agent/src/review_cmd_findings_toml.rs"
+start = 154
+```
+
+```findings.toml
+[[findings]]
+id = "f1"
+severity = "high"
+description = "Later non-empty labeled block must not be hidden."
+
+[[findings.file_ranges]]
+path = "crates/cli-sub-agent/src/review_cmd_findings_toml.rs"
+start = 154
+```
+"#;
+
+    let parsed =
+        extract_findings_toml_from_text(review_text).expect("findings.toml block should parse");
+
+    assert_eq!(
+        parsed,
+        FindingsFile {
+            findings: vec![ReviewFinding {
+                id: "f1".to_string(),
+                severity: Severity::High,
+                file_ranges: vec![ReviewFindingFileRange {
+                    path: "crates/cli-sub-agent/src/review_cmd_findings_toml.rs".to_string(),
+                    start: 154,
+                    end: None,
+                }],
+                is_regression_of_commit: None,
+                suggested_test_scenario: None,
+                description: "Later non-empty labeled block must not be hidden.".to_string(),
+            }],
+        }
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -58,11 +58,15 @@ pub(super) fn enforce_final_verdict_consistency(
     let blocking_structured = has_blocking_severity(&artifact.severity_counts);
     let parsed_findings_prose = prose_signals.parsed_findings_sections;
     let unparsed_findings_prose = prose_signals.unparseable_findings_sections;
+    let cross_dimension_blocker = prose_signals.cross_dimension_blockers;
     let checklist_violation_mismatch = prose_signals.checklist_violation_findings
         && !has_structured_findings
         && severity_counts_are_zero(&artifact.severity_counts);
+    let cross_dimension_blocker_mismatch = cross_dimension_blocker
+        && !has_structured_findings
+        && severity_counts_are_zero(&artifact.severity_counts);
 
-    if unparsed_findings_prose || checklist_violation_mismatch {
+    if unparsed_findings_prose || checklist_violation_mismatch || cross_dimension_blocker_mismatch {
         artifact
             .failure_reason
             .get_or_insert_with(|| PROSE_FINDINGS_UNPARSED_REASON.to_string());
@@ -79,7 +83,9 @@ pub(super) fn enforce_final_verdict_consistency(
             || blocking_structured
             || parsed_findings_prose
             || unparsed_findings_prose
+            || cross_dimension_blocker
             || checklist_violation_mismatch
+            || cross_dimension_blocker_mismatch
             || structured_mismatch)
     {
         artifact.decision = ReviewDecision::Fail;

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -133,34 +133,34 @@ fn ensure_fail_closed_grade(
     }
 }
 
-/// Highest reviewer-assigned severity GRADE legible in the persisted review
-/// sections (`summary`/`details`), tolerant of markdown inline-code backticks
-/// around the tag (e.g. `` `[HIGH]` ``). The structured finding parsers require
-/// the bracket to start the body and therefore skip backtick-wrapped tags, so
-/// the fail-closed grader consults this to avoid under-grading a real HIGH whose
-/// machine-readable findings failed to parse (#1852). Returns `None` when no
-/// bracketed severity tag is present. Best-effort: an unreadable section index
-/// yields `None` (callers fall back to MEDIUM), never an error.
+/// Highest reviewer-assigned severity GRADE legible in the canonical review
+/// text, tolerant of markdown inline-code backticks around the tag (e.g.
+/// `` `[HIGH]` ``). The structured finding parsers require the bracket to start
+/// the body and therefore skip backtick-wrapped tags, so the fail-closed grader
+/// consults this to avoid under-grading a real HIGH whose machine-readable
+/// findings failed to parse (#1852). Returns `None` when no bracketed severity
+/// tag is present. Best-effort: unreadable review text yields `None` (callers
+/// fall back to MEDIUM), never an error.
 fn highest_prose_severity_grade(session_dir: &Path) -> Option<Severity> {
-    let sections = csa_session::read_all_sections(session_dir).ok()?;
+    let review_text = crate::review_cmd::findings_toml::load_canonical_review_text(session_dir)
+        .ok()
+        .flatten()?;
     let mut best: Option<Severity> = None;
-    for (_, content) in sections {
-        let mut in_code_fence = false;
-        for line in content.lines() {
-            let trimmed = line.trim();
-            if trimmed.starts_with("```") {
-                in_code_fence = !in_code_fence;
-                continue;
-            }
-            if in_code_fence {
-                continue;
-            }
-            for severity in bracketed_severities_in_line(trimmed) {
-                best = Some(match best {
-                    Some(current) => current.max(severity),
-                    None => severity,
-                });
-            }
+    let mut in_code_fence = false;
+    for line in review_text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
+        for severity in bracketed_severities_in_line(trimmed) {
+            best = Some(match best {
+                Some(current) => current.max(severity),
+                None => severity,
+            });
         }
     }
     best

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -107,10 +107,26 @@ fn push_review_content(contents: &mut Vec<(String, String)>, section_id: &str, c
 }
 
 fn review_content_is_covered_by_sections(contents: &[(String, String)], candidate: &str) -> bool {
-    !contents.is_empty()
-        && contents
-            .iter()
-            .all(|(_, content)| candidate.contains(content.trim()))
+    let mut residual = candidate.trim().to_string();
+    if residual.is_empty() {
+        return true;
+    }
+
+    for (_, content) in contents {
+        let trimmed = content.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        while let Some(start) = residual.find(trimmed) {
+            let end = start + trimmed.len();
+            residual.replace_range(start..end, "");
+        }
+        if residual.trim().is_empty() {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn record_review_prose_signal(
@@ -307,4 +323,44 @@ pub(super) fn reconcile_counts_with_prose(
         *count = (*count).max(*prose_count);
     }
     structured_counts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::review_content_is_covered_by_sections;
+
+    fn review_contents() -> Vec<(String, String)> {
+        vec![
+            ("summary".to_string(), "PASS".to_string()),
+            (
+                "details".to_string(),
+                "## Findings\n\nNo findings.".to_string(),
+            ),
+        ]
+    }
+
+    #[test]
+    fn exact_duplicate_candidate_is_covered_by_sections() {
+        let candidate = "PASS\n## Findings\n\nNo findings.";
+
+        assert!(review_content_is_covered_by_sections(
+            &review_contents(),
+            candidate
+        ));
+    }
+
+    #[test]
+    fn superset_candidate_with_raw_extra_is_not_covered_by_sections() {
+        let candidate = concat!(
+            "PASS\n",
+            "## Findings\n\nNo findings.\n\n",
+            "## Cross-Dimension Blocking Enumeration\n",
+            "1. Correctness: raw transcript blocker only present in output.log.\n"
+        );
+
+        assert!(!review_content_is_covered_by_sections(
+            &review_contents(),
+            candidate
+        ));
+    }
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -18,6 +18,7 @@ pub(super) struct ReviewProseSignals {
     pub(super) blocking_summary: bool,
     pub(super) parsed_findings_sections: bool,
     pub(super) unparseable_findings_sections: bool,
+    pub(super) cross_dimension_blockers: bool,
     pub(super) checklist_violation_findings: bool,
     pub(super) findings: Vec<ReviewFinding>,
 }
@@ -29,6 +30,7 @@ pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSign
         blocking_summary: prose.blocking_summary,
         parsed_findings_sections: false,
         unparseable_findings_sections: false,
+        cross_dimension_blockers: false,
         checklist_violation_findings: false,
         findings: Vec::new(),
     };
@@ -68,28 +70,47 @@ fn current_round_review_prose_contents(
         .as_deref()
         .is_some_and(contains_blocking_issue_signal);
 
-    if let Some(content) =
-        crate::review_cmd::findings_toml::load_canonical_review_text(session_dir)?
-    {
-        return Ok(CurrentRoundReviewProseContents {
-            blocking_summary,
-            contents: vec![("canonical".to_string(), content)],
-        });
-    }
-
     let mut contents = Vec::new();
     if let Some(content) = latest_summary {
-        contents.push(("summary".to_string(), content));
+        push_review_content(&mut contents, "summary", content);
     }
 
     if let Some(content) = latest_details {
-        contents.push(("details".to_string(), content));
+        push_review_content(&mut contents, "details", content);
+    }
+
+    if let Some(content) =
+        crate::review_cmd::findings_toml::load_canonical_review_text(session_dir)?
+        && !review_content_is_covered_by_sections(&contents, &content)
+    {
+        push_review_content(&mut contents, "canonical", content);
     }
 
     Ok(CurrentRoundReviewProseContents {
         blocking_summary,
         contents,
     })
+}
+
+fn push_review_content(contents: &mut Vec<(String, String)>, section_id: &str, content: String) {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    if contents
+        .iter()
+        .any(|(_, existing)| existing.trim() == trimmed)
+    {
+        return;
+    }
+    contents.push((section_id.to_string(), content));
+}
+
+fn review_content_is_covered_by_sections(contents: &[(String, String)], candidate: &str) -> bool {
+    !contents.is_empty()
+        && contents
+            .iter()
+            .all(|(_, content)| candidate.contains(content.trim()))
 }
 
 fn record_review_prose_signal(
@@ -102,6 +123,7 @@ fn record_review_prose_signal(
         classify_findings_sections(content, default_unlabeled_severity.clone());
     signals.parsed_findings_sections |= parsed_findings_sections;
     signals.unparseable_findings_sections |= unparseable_findings_sections;
+    signals.cross_dimension_blockers |= cross_dimension_enumeration_has_blocker(content);
     signals.checklist_violation_findings |= checklist_violation_references_finding(content);
     let findings =
         extract_review_findings_from_prose_with_default(content, default_unlabeled_severity);
@@ -131,6 +153,79 @@ fn classify_findings_sections(
         }
     }
     (parsed_findings_sections, unparseable_findings_sections)
+}
+
+fn cross_dimension_enumeration_has_blocker(content: &str) -> bool {
+    let mut in_section = false;
+    let mut in_code_fence = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
+        if trimmed.starts_with('#') {
+            in_section = is_cross_dimension_enumeration_heading(trimmed);
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        if let Some(body) = numbered_item_body(trimmed)
+            && enumeration_item_has_blocker(body)
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn is_cross_dimension_enumeration_heading(line: &str) -> bool {
+    let normalized = line.trim_start_matches('#').trim().to_ascii_lowercase();
+    normalized == "cross-dimension blocking enumeration"
+        || normalized == "cross dimension blocking enumeration"
+}
+
+fn numbered_item_body(line: &str) -> Option<&str> {
+    let (index, rest) = line.split_once('.')?;
+    if index.is_empty() || !index.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    Some(rest.trim_start())
+}
+
+fn enumeration_item_has_blocker(body: &str) -> bool {
+    let substantive = body
+        .split_once(':')
+        .map_or(body, |(_, description)| description)
+        .trim();
+    !substantive.is_empty() && !is_no_independent_blocker_phrase(substantive)
+}
+
+fn is_no_independent_blocker_phrase(text: &str) -> bool {
+    let normalized = text
+        .trim()
+        .trim_matches(|ch: char| ch.is_ascii_punctuation() || ch.is_whitespace())
+        .to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "none"
+            | "n/a"
+            | "not applicable"
+            | "no blocker"
+            | "no blockers"
+            | "no blocker found"
+            | "no blockers found"
+            | "no independent blocker"
+            | "no independent blockers"
+            | "no independent blocker found"
+            | "no independent blockers found"
+    )
 }
 
 fn contains_canonical_clean_conclusion(content: &str) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1876_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1876_tests.rs
@@ -582,6 +582,55 @@ No findings.
 }
 
 #[test]
+fn issue_1896_raw_superset_cross_dimension_blocker_fails_closed() {
+    let session_id = "01TEST1896RAWSUPERSET0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1896-raw-superset-blocker", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+No findings.
+
+## Cross-Dimension Blocking Enumeration
+1. Correctness: no independent blocker found.
+2. Security: no independent blocker found.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+    fs::write(
+        session_dir.join("output.log"),
+        r#"## Cross-Dimension Blocking Enumeration
+1. Correctness: raw transcript reports a concrete blocker only present in output.log.
+2. Security: no independent blocker found.
+"#,
+    )
+    .expect("write raw review log");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        Some("prose_findings_present_but_unparsed")
+    );
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_1896_findings_none_and_empty_cross_dimension_stays_pass() {
     let session_id = "01TEST1896CLEANNONE000";
     let (_env_lock, project_root, session_dir) =

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1876_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1876_tests.rs
@@ -666,3 +666,6 @@ Findings: none.
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+#[path = "review_cmd_output_verdict_1896_source_set_tests.rs"]
+mod source_set_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1876_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1876_tests.rs
@@ -413,3 +413,207 @@ No findings.
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+const ISSUE_1896_DETAILS: &str = r#"# Code Review Report
+
+## Scope
+- Scope: `range:main...HEAD`
+- Mode: `review-only`
+- Review mode: `standard`
+- Security mode: `auto`
+- Project profile: `rust`
+
+## Findings
+
+1. [high][correctness] `PathEnvGuard` mutates global `PATH` in a parallel test binary (`crates/csa-process/src/tool_liveness_tests.rs:37`, confidence=0.86)
+
+Trigger: `cargo test -p csa-process` runs tests in parallel by default. The new test changes process-wide `PATH`, while the same crate has many tests that concurrently spawn `sh`, `sleep`, `bash`, `echo`, and `true` through `Command::new(...)`, which reads `PATH`.
+
+Expected: the test should avoid process-global env mutation, or run the probe in an isolated subprocess with `.env("PATH", patched_path)`, or otherwise prove no concurrent environment access can occur.
+
+Actual: `PathEnvGuard::prepend` calls `unsafe { std::env::set_var("PATH", joined) }`, and `Drop` restores/removes `PATH`. The safety comment only says tests do not concurrently mutate `PATH`; Rust's safety requirement is stronger because concurrent environment reads are also unsafe on Unix.
+
+Impact: test-only undefined behavior / CI instability under Rust 2024 env-mutation rules. This is not a design preference; it is an unsafe-block soundness issue.
+
+Evidence:
+- New unsafe env mutation: `crates/csa-process/src/tool_liveness_tests.rs:35-37`
+- Restore path repeats the same global mutation: `crates/csa-process/src/tool_liveness_tests.rs:45-49`
+- Same test binary contains concurrent PATH readers via command spawning, e.g. `tool_liveness_tests.rs:80`, `:115`, `:133`, plus many `lib_tests*.rs` command spawns found by `rg`.
+
+Class sweep: 2 new same-class sites in this diff: initial `set_var("PATH", ...)` and Drop restore/remove.
+
+## Cross-Dimension Blocking Enumeration
+1. Correctness / unsafe soundness: global `PATH` mutation in a parallel test binary.
+2. Security: no independent blocker found.
+3. Contract/doc-sync: no independent blocker found.
+4. Ordering/completeness: no independent blocker found.
+"#;
+
+#[test]
+fn issue_1896_golden_progress_full_md_does_not_hide_details_findings() {
+    let session_id = "01TEST1896GOLDENFULLMD00";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1896-golden-full-md", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    fs::write(
+        session_dir
+            .join("output")
+            .join(crate::review_cmd::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER),
+        "",
+    )
+    .expect("write synthetic marker");
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        "Loaded review protocol.\nCollecting diff context.\nPreparing final report.\n",
+    )
+    .expect("write progress-only full.md");
+    fs::write(
+        session_dir.join("output").join("summary.md"),
+        "One high-severity issue found.\n",
+    )
+    .expect("write summary.md");
+    fs::write(
+        session_dir.join("output").join("details.md"),
+        ISSUE_1896_DETAILS,
+    )
+    .expect("write details.md");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    crate::review_cmd::findings_toml::persist_review_findings_toml(&project_root, &meta);
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].severity, Severity::High);
+    assert_eq!(
+        findings.findings[0].file_ranges[0].path,
+        "crates/csa-process/src/tool_liveness_tests.rs"
+    );
+    assert_eq!(findings.findings[0].file_ranges[0].start, 37);
+
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1896_ordinal_double_bracket_high_finding_parses() {
+    let session_id = "01TEST1896PARSEHIGH000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1896-parse-high", session_id);
+
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+1. [high][correctness] Parser recognizes this finding (`crates/example/src/lib.rs:12`, confidence=0.90)
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    crate::review_cmd::findings_toml::persist_review_findings_toml(&project_root, &meta);
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].severity, Severity::High);
+    assert_eq!(
+        findings.findings[0].file_ranges[0].path,
+        "crates/example/src/lib.rs"
+    );
+    assert_eq!(findings.findings[0].file_ranges[0].start, 12);
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1896_cross_dimension_concrete_blocker_fails_closed() {
+    let session_id = "01TEST1896CROSSBLOCKER";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1896-cross-blocker", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+No findings.
+
+## Cross-Dimension Blocking Enumeration
+1. Correctness / unsafe soundness: global PATH mutation in a parallel test binary.
+2. Security: no independent blocker found.
+3. Contract/doc-sync: none.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_ne!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        Some("prose_findings_present_but_unparsed")
+    );
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1896_findings_none_and_empty_cross_dimension_stays_pass() {
+    let session_id = "01TEST1896CLEANNONE000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1896-clean-none", session_id);
+
+    write_empty_findings_toml(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+Findings: none.
+
+## Cross-Dimension Blocking Enumeration
+1. Correctness: no independent blocker found.
+2. Security: none.
+3. Contract/doc-sync: no independent blockers found.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1896_source_set_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1896_source_set_tests.rs
@@ -1,0 +1,89 @@
+use super::*;
+
+#[test]
+fn issue_1896_raw_empty_findings_toml_does_not_hide_physical_details_finding() {
+    let session_id = "01TEST1896RAWEMPTYHIGH";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1896-raw-empty-details-high", session_id);
+
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        r#"PASS
+
+```findings.toml
+findings = []
+```
+"#,
+    )
+    .expect("write full.md");
+    fs::write(
+        session_dir.join("output").join("details.md"),
+        r#"## Findings
+
+1. [high][correctness] Physical details finding must override raw empty structured output (crates/example/src/lib.rs:9, confidence=0.90)
+"#,
+    )
+    .expect("write details.md");
+    assert!(!session_dir.join("output").join("index.toml").exists());
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    crate::review_cmd::findings_toml::persist_review_findings_toml(&project_root, &meta);
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].severity, Severity::High);
+    assert_eq!(
+        findings.findings[0].file_ranges[0].path,
+        "crates/example/src/lib.rs"
+    );
+    assert_eq!(findings.findings[0].file_ranges[0].start, 9);
+
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1896_raw_empty_findings_toml_with_physical_clean_details_stays_pass() {
+    let session_id = "01TEST1896RAWEMPTYCLEAN";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1896-raw-empty-details-clean", session_id);
+
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        r#"PASS
+
+```findings.toml
+findings = []
+```
+"#,
+    )
+    .expect("write full.md");
+    fs::write(
+        session_dir.join("output").join("details.md"),
+        "Findings: none.\n",
+    )
+    .expect("write details.md");
+    assert!(!session_dir.join("output").join("index.toml").exists());
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    crate::review_cmd::findings_toml::persist_review_findings_toml(&project_root, &meta);
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}


### PR DESCRIPTION
## Summary

Fixes #1896. `csa review` (codex-fallback `--single`) produced a **false PASS**: `output/details.md` carried a `[high][correctness]` blocking finding while `review-verdict.json` said `decision="pass"` with empty `findings.toml` — a recurrence of the #1804/#1876/#1754 false-PASS class at a newer build (0.1.909), slipping the #1806 fail-closed guard. This repo gates merges on the local review verdict (cloud bot disabled), so a false PASS can merge a `[high]` bug; it was caught only by a manual 4-artifact cross-read.

## Root cause + fix (converged over 3 review rounds, each a distinct concrete bug)

1. **Prose-variant parse + fail-closed mismatch guard** (`b8ab6626`): the codex `N. [severity][dimension]` ordinal+double-bracket finding form under `## Findings` (severity-word tags like `[high]`, vs the already-handled `[P1]`) was not parsed, and the #1806 guard didn't fail-closed on the prose↔structured mismatch. Now the variant is parsed into structured findings, and a non-empty prose `## Findings` / a concrete `## Cross-Dimension Blocking Enumeration` blocker with empty structured findings resolves NON-PASS.
2. **Canonical superset dedupe** (`bd4be97f`): `review_content_is_covered_by_sections` only checked that each persisted section was a *substring* of the canonical candidate, so a `summary + details + raw-extra` candidate was wrongly deemed "covered" and skipped — dropping `raw-extra` (distinct raw transcript/log prose) from the signal scan. Corrected to fail-safe toward scanning; superset candidates are never silently dropped.
3. **Complete canonical source set** (`6d644eac`): `load_canonical_review_text` returned early whenever raw text held any valid fenced TOML, bypassing the physical `summary.md`/`details.md` read (so a raw empty `findings = []` hid physical `details.md` high findings on the no-`index.toml` path). Restructured to unconditionally union all prose sources (physical summary+details, raw full.md+output.log, fenced TOML) with no source-dropping early-return; both sinks (`persist_review_findings_toml`, `enforce_final_verdict_consistency`) now grade over the complete set, and contradictions fail closed.

## Tests

Regressions cover: the prose `[high]` variant parse; fail-closed on prose-findings vs empty-structured mismatch; superset `summary+details+raw-extra` is scanned; raw empty `findings.toml` + physical `details.md` high finding + no `index.toml` → non-pass; multiple labeled TOML blocks; and genuine-clean (`Findings: none.`) still PASS. Existing #1804/#1806/#1876 tests stay green.

## Review

Local tier-4 review (codex-fallback `--single`) round 3 PASS; all four verdict artifacts agree (`decision=pass`, `findings.toml` empty, `details.md` "No blocking findings", summary PASS). Rounds 1–2 each surfaced a distinct sibling source-set hole (fixed in commits 2 and 3); round 3 clean.

Closes #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)
