### PR TITLE
fix(cli-sub-agent): correct stale fast-path header in generated review-check.sh (#1813)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.912"
+version = "0.1.913"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.912"
+version = "0.1.913"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/setup_cmds/review-check.sh
+++ b/crates/cli-sub-agent/src/setup_cmds/review-check.sh
@@ -2,9 +2,10 @@
 # Git pre-push hook: verify csa review has been run on current HEAD.
 # Installed by: csa setup review-gate
 #
-# Fast path: stat .csa/state/review-gate/<branch_safe>-<short_sha>.pass
-#   millisecond check; new commits auto-invalidate (different SHA → different filename).
-# Slow path (fallback): csa review --check-verdict scans session store.
+# The gate ALWAYS validates the session verdict via `csa review --check-verdict`.
+# A SHA-pinned marker (.csa/state/review-gate/<branch_safe>-<short_sha>.pass) may exist
+#   from a prior run; it is informational only (logged, never a standalone pass), so a
+#   stale or forged marker cannot satisfy the gate without a recorded passing review.
 
 set -euo pipefail
 

--- a/scripts/hooks/review-check.sh
+++ b/scripts/hooks/review-check.sh
@@ -2,9 +2,10 @@
 # Git pre-push hook: verify csa review has been run on current HEAD.
 # Installed by: csa setup review-gate
 #
-# Fast path: stat .csa/state/review-gate/<branch_safe>-<short_sha>.pass
-#   millisecond check; new commits auto-invalidate (different SHA → different filename).
-# Slow path (fallback): csa review --check-verdict scans session store.
+# The gate ALWAYS validates the session verdict via `csa review --check-verdict`.
+# A SHA-pinned marker (.csa/state/review-gate/<branch_safe>-<short_sha>.pass) may exist
+#   from a prior run; it is informational only (logged, never a standalone pass), so a
+#   stale or forged marker cannot satisfy the gate without a recorded passing review.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Fixes #1813. The review-gate hook template (`crates/cli-sub-agent/src/setup_cmds/review-check.sh`, generated into a consuming repo by `csa setup review-gate`) carried a stale top-of-file header advertising a "Fast path / Slow path" marker bypass that the body no longer has. Post-#1889 the gate ALWAYS validates via `csa review --check-verdict`; the SHA-pinned marker is informational only (logged, never a standalone pass). The generated artifact was internally inconsistent.

Beyond the cosmetic inconsistency, this caused real downstream churn: the generator re-applies its canonical bytes on every `csa run` in a consuming repo, so a downstream repo that committed a corrected header diverged from the canonical bytes and got `review-check.sh` dirtied on **every** invocation — the only way to stop the churn was to commit the stale comment verbatim. (Reported from `RyderFreeman4Logos/audio-condenser` adopting the hardened gate.)

## Fix (comment-only — no control-flow change)

Replaced the stale "Fast path / Slow path" header block with an accurate description: the gate always validates the verdict via `csa review --check-verdict`, and a SHA-pinned marker may exist from a prior run but is informational only (logged, never a standalone pass) so a stale or forged marker cannot satisfy the gate without a recorded passing review. The `Installed by: csa setup review-gate` ownership marker line (used by #1892's install guard) is preserved verbatim.

The correction is applied to **both** the embedded template (`crates/cli-sub-agent/src/setup_cmds/review-check.sh`) and this repo's tracked `scripts/hooks/review-check.sh`, keeping them byte-identical — which is what #1889/#1892 rely on (session start no-ops on the tracked hook instead of clobbering it, and avoids perpetual churn).

## Review

Local tier-4 review (codex-fallback `--single`) PASS, single round; all four verdict artifacts agree (`decision=pass`, `findings.toml` empty, `details.md` "No findings."). Reviewer confirmed: the two hook files are byte-identical, no old `Fast path:`/`Slow path (fallback)` header remains, the marker path stays non-authoritative (a passing `csa review --check-verdict` is still required before push), and version/lockfile are synced to 0.1.913.

Closes #1813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
