### PR TITLE
fix(cli-sub-agent): make csa merge post-merge checkout robust to weave.lock pin drift (#1686)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.913"
+version = "0.1.914"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.913"
+version = "0.1.914"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/merge_cmd.rs
+++ b/crates/cli-sub-agent/src/merge_cmd.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use crate::cli::MergeArgs;
 
 const DEFAULT_BRANCH_FALLBACK: &str = "main";
+const REGENERABLE_WEAVE_LOCK_PATH: &str = "weave.lock";
 
 pub(crate) fn handle_merge(args: MergeArgs) -> Result<()> {
     let pr_number = args.pr_number;
@@ -74,12 +75,7 @@ fn warn_base_fallback() -> String {
 }
 
 fn sync_base_branch_best_effort(project_root: &Path, base_branch: &str) {
-    if let Err(err) = run_checked(
-        project_root,
-        "git",
-        &["checkout", base_branch],
-        "checkout base branch",
-    ) {
+    if let Err(err) = checkout_base_branch_after_weave_lock_restore(project_root, base_branch) {
         eprintln!("WARNING: merge succeeded, but post-merge checkout failed:\n{err:#}");
         return;
     }
@@ -92,6 +88,56 @@ fn sync_base_branch_best_effort(project_root: &Path, base_branch: &str) {
     ) {
         eprintln!("WARNING: merge succeeded, but post-merge pull failed:\n{err:#}");
     }
+}
+
+fn checkout_base_branch_after_weave_lock_restore(
+    project_root: &Path,
+    base_branch: &str,
+) -> Result<()> {
+    restore_weave_lock_drift_before_checkout(project_root);
+    run_checked(
+        project_root,
+        "git",
+        &["checkout", base_branch],
+        "checkout base branch",
+    )
+}
+
+fn restore_weave_lock_drift_before_checkout(project_root: &Path) {
+    let Ok(output) = Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .current_dir(project_root)
+        .output()
+    else {
+        return;
+    };
+
+    if !output.status.success() {
+        return;
+    }
+
+    let status = String::from_utf8_lossy(&output.stdout);
+    if !has_unstaged_weave_lock_change(&status) {
+        return;
+    }
+
+    if let Err(err) = run_checked(
+        project_root,
+        "git",
+        &["checkout", "--", REGENERABLE_WEAVE_LOCK_PATH],
+        "restore weave.lock",
+    ) {
+        tracing::debug!(error = %err, "failed to restore transient weave.lock drift before checkout");
+    }
+}
+
+fn has_unstaged_weave_lock_change(status: &str) -> bool {
+    status.lines().any(|line| {
+        let second_status = line.as_bytes().get(1).copied();
+        let path = line.get(3..);
+        second_status.is_some_and(|status| status != b' ')
+            && path == Some(REGENERABLE_WEAVE_LOCK_PATH)
+    })
 }
 
 fn run_checked(project_root: &Path, program: &str, args: &[&str], action: &str) -> Result<()> {
@@ -137,9 +183,15 @@ fn command_output_text(output: &Output) -> String {
 
 #[cfg(test)]
 mod tests {
-    use clap::Parser;
+    use std::path::Path;
 
-    use super::shell_command;
+    use clap::Parser;
+    use tempfile::TempDir;
+
+    use super::{
+        checkout_base_branch_after_weave_lock_restore, has_unstaged_weave_lock_change,
+        shell_command,
+    };
     use crate::cli::{Cli, Commands};
 
     #[test]
@@ -189,5 +241,113 @@ mod tests {
             shell_command("gh", &["pr", "merge", "--merge", "1626"]),
             "gh pr merge --merge 1626"
         );
+    }
+
+    #[test]
+    fn detects_unstaged_weave_lock_change_only_for_repo_root_lockfile() {
+        assert!(has_unstaged_weave_lock_change(" M weave.lock\n"));
+        assert!(has_unstaged_weave_lock_change("MM weave.lock\n"));
+        assert!(!has_unstaged_weave_lock_change("M  weave.lock\n"));
+        assert!(!has_unstaged_weave_lock_change(" M nested/weave.lock\n"));
+        assert!(!has_unstaged_weave_lock_change(" M other.txt\n"));
+    }
+
+    #[test]
+    fn checkout_restores_dirty_weave_lock_before_switching_to_base() {
+        let repo = setup_checkout_blocked_repo();
+
+        git(&repo, &["checkout", "-b", "feature"]);
+        write(repo.path(), "weave.lock", "feature lock\n");
+        git(&repo, &["add", "weave.lock"]);
+        git(&repo, &["commit", "-m", "feature lock"]);
+        write(repo.path(), "weave.lock", "dirty lock\n");
+
+        checkout_base_branch_after_weave_lock_restore(repo.path(), "main")
+            .expect("checkout should restore weave.lock drift and switch to main");
+
+        assert_eq!(current_branch(&repo), "main");
+        assert_eq!(read(repo.path(), "weave.lock"), "main lock\n");
+        assert_eq!(git_stdout(&repo, &["status", "--porcelain"]), "");
+    }
+
+    #[test]
+    fn checkout_preserves_other_dirty_file_and_reports_checkout_failure() {
+        let repo = setup_checkout_blocked_repo();
+
+        git(&repo, &["checkout", "-b", "feature"]);
+        write(repo.path(), "weave.lock", "feature lock\n");
+        write(repo.path(), "tracked.txt", "feature contents\n");
+        git(&repo, &["add", "weave.lock", "tracked.txt"]);
+        git(&repo, &["commit", "-m", "feature changes"]);
+        write(repo.path(), "weave.lock", "dirty lock\n");
+        write(repo.path(), "tracked.txt", "dirty contents\n");
+
+        let err = checkout_base_branch_after_weave_lock_restore(repo.path(), "main")
+            .expect_err("other dirty tracked files should still block checkout");
+        let err = format!("{err:#}");
+
+        assert!(err.contains("failed to checkout base branch"));
+        assert!(err.contains("tracked.txt"));
+        assert_eq!(current_branch(&repo), "feature");
+        assert_eq!(read(repo.path(), "weave.lock"), "feature lock\n");
+        assert_eq!(read(repo.path(), "tracked.txt"), "dirty contents\n");
+    }
+
+    fn setup_checkout_blocked_repo() -> TempDir {
+        let repo = TempDir::new().expect("tempdir");
+        git(&repo, &["init", "-b", "main"]);
+        git(&repo, &["config", "core.excludesFile", ""]);
+        git(&repo, &["config", "user.email", "test@example.com"]);
+        git(&repo, &["config", "user.name", "Test User"]);
+        write(repo.path(), "weave.lock", "main lock\n");
+        write(repo.path(), "tracked.txt", "main contents\n");
+        git(&repo, &["add", "weave.lock", "tracked.txt"]);
+        git(&repo, &["commit", "-m", "initial"]);
+        repo
+    }
+
+    fn git(repo: &TempDir, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo.path())
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_stdout(repo: &TempDir, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo.path())
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).to_string()
+    }
+
+    fn current_branch(repo: &TempDir) -> String {
+        git_stdout(repo, &["branch", "--show-current"])
+            .trim()
+            .to_string()
+    }
+
+    fn read(repo: &Path, path: &str) -> String {
+        std::fs::read_to_string(repo.join(path)).expect("read file")
+    }
+
+    fn write(repo: &Path, path: &str, contents: &str) {
+        std::fs::write(repo.join(path), contents).expect("write file");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1686. `weave.lock` carries a workflow-pin (`commit = "<hash>"`) that any weave-workflow run (`csa plan run`, dev2merge, pr-bot, `csa merge`) re-pins to match the installed binary but does not commit — leaving `weave.lock` dirty in the worktree. After a successful `csa merge`, the post-merge base-branch checkout (`git checkout <base>`) then **aborted** because the dirty `weave.lock` would be overwritten, leaving base-branch sync incomplete and requiring manual `git stash`/restore.

```
WARNING: merge succeeded, but post-merge checkout failed:
error: Your local changes to the following files would be overwritten by checkout:
	weave.lock
Aborting
```

## Fix

`csa merge`'s post-merge base checkout now restores only **unstaged repo-root `weave.lock` drift** (`git checkout -- weave.lock`) before the checkout. The pin is regenerable (re-applied by the next workflow run), so discarding this transient drift loses no real work and lets the base sync complete.

Safety guarantees (no data loss):
- Only the repo-root `weave.lock` path is auto-restored — never any other file.
- **Staged** lockfile changes and **any other dirty tracked file** are left untouched and continue to hit the existing clear "post-merge checkout failed" path — arbitrary user changes are never silently discarded.
- The CORE merge logic (merge invocation, empty-diff guard, MERGED-state verification, merge strategy) is unchanged — `csa merge` remains fully functional.
- Git ops degrade gracefully (no `unwrap`/`expect`); a restore failure falls back to the existing warning rather than panicking.

## Tests

Added focused regression tests in `merge_cmd.rs`: weave.lock-only dirty → post-merge checkout succeeds and weave.lock matches committed state; a non-weave.lock dirty tracked file → not discarded, existing checkout-failure behavior preserved.

## Review

Local tier-4 review (codex-fallback `--single`) PASS, single round; all four verdict artifacts agree (`decision=pass`, `findings.toml` empty, `details.md` "no blocking findings"). Reviewer confirmed the restore is scoped to unstaged root weave.lock only, staged/other dirty files stay on the failure path, and the tests cover the intended behavior.

Note: this PR is itself merged via `csa merge`, exercising the fixed post-merge checkout path as a live dogfood.

Closes #1686

🤖 Generated with [Claude Code](https://claude.com/claude-code)
