### PR TITLE
fix(cli-sub-agent): surface actionable hint on lefthook core.hooksPath commit conflict (#1829)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "chrono",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.914"
+version = "0.1.915"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.914"
+version = "0.1.915"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/error_hints.rs
+++ b/crates/cli-sub-agent/src/error_hints.rs
@@ -22,6 +22,8 @@ const HINT_SESSION_NOT_FOUND: &str = "hint: list available sessions with 'csa se
 const HINT_CONFIG_ERROR: &str =
     "hint: validate config with 'csa config validate' or reinitialize with 'csa init'";
 const HINT_GEMINI_RUNTIME_HOME: &str = "hint: Gemini ACP needs a writable runtime home; current builds pin TMPDIR to a writable sandbox temp dir (private /tmp in bwrap, session tmp elsewhere) and seed under CSA session state, but older builds may still need re-run with TMPDIR=/tmp";
+const LEFTHOOK_CORE_HOOKSPATH_CONFLICT: &str = "core.hooksPath is set locally";
+const HINT_LEFTHOOK_CORE_HOOKSPATH_CONFLICT: &str = "hint: lefthook blocked git commit because core.hooksPath is set locally. Staged work may be uncommitted. Run `git config --unset-all --local core.hooksPath`, then rerun the commit or continue the session.";
 const SANDBOX_FS_DENIAL_MARKERS: [&str; 7] = [
     "read-only file system",
     "permission denied",
@@ -152,6 +154,18 @@ pub(crate) fn append_sandbox_fs_denial_hint(
     }
     stderr_output.push_str(&hint);
     stderr_output.push('\n');
+}
+
+pub(crate) fn lefthook_core_hookspath_conflict_hint(
+    stderr: &str,
+    stdout: &str,
+) -> Option<&'static str> {
+    if stderr.contains(LEFTHOOK_CORE_HOOKSPATH_CONFLICT)
+        || stdout.contains(LEFTHOOK_CORE_HOOKSPATH_CONFLICT)
+    {
+        return Some(HINT_LEFTHOOK_CORE_HOOKSPATH_CONFLICT);
+    }
+    None
 }
 
 fn extract_denied_path(text: &str) -> Option<String> {
@@ -299,6 +313,31 @@ mod tests {
     fn test_no_hint_for_generic_error() {
         let err = anyhow::anyhow!("something failed");
         assert_eq!(suggest_fix(&err), None);
+    }
+
+    #[test]
+    fn lefthook_core_hookspath_conflict_hint_detects_commit_failure_output() {
+        let stderr = r#"
+Error: core.hooksPath is set locally to '/x/.git/hooks'
+hint: Unset it:
+hint:   git config --unset-all --local core.hooksPath
+"#;
+        let hint = lefthook_core_hookspath_conflict_hint(stderr, "").unwrap();
+        assert!(
+            hint.contains("git config --unset-all --local core.hooksPath"),
+            "got: {hint}"
+        );
+        assert!(
+            hint.contains("Staged work may be uncommitted"),
+            "got: {hint}"
+        );
+    }
+
+    #[test]
+    fn lefthook_core_hookspath_conflict_hint_ignores_unrelated_commit_failure() {
+        let stderr = "error: Recipe `clippy` failed on line 12 with exit code 1";
+        let hint = lefthook_core_hookspath_conflict_hint(stderr, "");
+        assert!(hint.is_none(), "got: {hint:?}");
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -39,6 +39,8 @@ pub(crate) use fallback::{
 };
 #[path = "pipeline_post_exec_helpers.rs"]
 mod helpers;
+#[path = "pipeline_post_exec_lefthook.rs"]
+mod lefthook;
 #[path = "pipeline_post_exec_no_op.rs"]
 mod no_op;
 #[path = "pipeline_post_exec_progress.rs"]
@@ -394,6 +396,7 @@ pub(crate) async fn process_execution_result(
         session_result.raw_process_exit_code = Some(raw_exit_code);
         session_result.warnings.push(note);
     }
+    lefthook::maybe_record_core_hookspath_conflict(result, &mut session_result);
     crate::pipeline_jj_journal::maybe_record_post_run_snapshot(
         ctx.config.map(|config| &config.vcs),
         ctx.project_root,

--- a/crates/cli-sub-agent/src/pipeline_post_exec_lefthook.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_lefthook.rs
@@ -1,0 +1,115 @@
+use csa_session::SessionResult;
+
+pub(super) fn maybe_record_core_hookspath_conflict(
+    result: &mut csa_process::ExecutionResult,
+    session_result: &mut SessionResult,
+) {
+    let Some(hint) = crate::error_hints::lefthook_core_hookspath_conflict_hint(
+        &result.stderr_output,
+        &result.output,
+    ) else {
+        return;
+    };
+
+    append_unique_warning(&mut result.warnings, hint);
+    append_unique_warning(&mut session_result.warnings, hint);
+    if !result.stderr_output.contains(hint) {
+        if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+            result.stderr_output.push('\n');
+        }
+        result.stderr_output.push_str(hint);
+        result.stderr_output.push('\n');
+    }
+}
+
+fn append_unique_warning(warnings: &mut Vec<String>, warning: &str) {
+    if !warnings.iter().any(|existing| existing == warning) {
+        warnings.push(warning.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session_result() -> SessionResult {
+        let now = chrono::Utc::now();
+        SessionResult {
+            post_exec_gate: None,
+            status: "failure".to_string(),
+            exit_code: 1,
+            summary: "exit code 1".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: Vec::new(),
+            peak_memory_mb: None,
+            fallback_chain: None,
+            gate_timeout: false,
+            warnings: Vec::new(),
+            raw_process_exit_code: None,
+            uncommitted_changes: None,
+            manager_fields: Default::default(),
+        }
+    }
+
+    #[test]
+    fn records_core_hookspath_conflict_hint_in_session_result_warnings() {
+        let mut execution = csa_process::ExecutionResult {
+            stderr_output: "Error: core.hooksPath is set locally to '/x/.git/hooks'\nhint: Unset it:\nhint:   git config --unset-all --local core.hooksPath\n".to_string(),
+            exit_code: 1,
+            summary: "git commit failed".to_string(),
+            ..Default::default()
+        };
+        let mut result = session_result();
+
+        maybe_record_core_hookspath_conflict(&mut execution, &mut result);
+
+        let warning = result
+            .warnings
+            .iter()
+            .find(|warning| warning.contains("core.hooksPath is set locally"))
+            .expect("core.hooksPath warning should be recorded");
+        assert!(
+            warning.contains("git config --unset-all --local core.hooksPath"),
+            "got: {warning}"
+        );
+        assert!(
+            warning.contains("Staged work may be uncommitted"),
+            "got: {warning}"
+        );
+        assert!(
+            execution
+                .stderr_output
+                .contains("git config --unset-all --local core.hooksPath"),
+            "stderr should include actionable hint: {}",
+            execution.stderr_output
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_commit_failure_output() {
+        let mut execution = csa_process::ExecutionResult {
+            stderr_output: "error: Recipe `clippy` failed on line 12 with exit code 1".to_string(),
+            exit_code: 1,
+            summary: "clippy failed".to_string(),
+            ..Default::default()
+        };
+        let mut result = session_result();
+
+        maybe_record_core_hookspath_conflict(&mut execution, &mut result);
+
+        assert!(result.warnings.is_empty(), "got: {:?}", result.warnings);
+        assert!(
+            !execution
+                .stderr_output
+                .contains("git config --unset-all --local core.hooksPath"),
+            "stderr should not include core.hooksPath hint: {}",
+            execution.stderr_output
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1829 (part b). During a long `csa run` session, if `core.hooksPath` becomes set locally to `<repo>/.git/hooks` mid-session, lefthook refuses to run and the in-session `git commit` fails — but the failure surfaced only in the daemon's own `stdout.log`. From the orchestrator's view the commit silently did not happen, leaving the milestone STAGED BUT UNCOMMITTED (the same lost-work class as #1757/#1758/#1870).

## Fix (detect-and-surface — satisfies the issue's acceptance)

Added a classifier (`error_hints.rs` + `pipeline_post_exec_lefthook.rs`) that detects the lefthook `core.hooksPath` conflict in a failed in-session commit's captured output (stable substring `core.hooksPath is set locally`) and surfaces an actionable, structured hint in the normal session-outcome surface — recommending `git config --unset-all --local core.hooksPath` and noting that staged work may be uncommitted. The silent failure becomes a visible, fixable outcome.

Scope and safety:
- Detection is a stable substring match; it does not false-positive on unrelated commit failures (regression test covers both positive and negative).
- Mirrors the existing diagnostic-hint pattern (e.g. the #1771 post-finalizer hint).
- No change to hook/commit EXECUTION behavior; CSA does NOT auto-mutate the user's git config (surfacing the hint is the fix). Security pass confirmed the new code only matches captured output and appends a static warning — no command execution, config mutation, path traversal, or credential exposure.
- Errors degrade gracefully (no `unwrap`/`expect` on the detect/format path).

This is part (b) of #1829 (detect-and-surface). The root-cause guard (part a — preventing whatever sets `core.hooksPath` mid-session) is intentionally out of scope; the issue's acceptance is satisfied by either part.

## Tests

`error_hints` regression tests: a captured commit failure containing the lefthook `core.hooksPath is set locally` lines yields the actionable unset hint; an unrelated commit failure does not (no false positive).

## Review

Local tier-4 review (codex-fallback `--single`) PASS, single round; all four verdict artifacts agree (`decision=pass`, `findings.toml` empty, `details.md` no findings, security pass clean).

Closes #1829

🤖 Generated with [Claude Code](https://claude.com/claude-code)
