### PR TITLE
fix: flock-authoritative worktree write lock + release-on-drop (#1873, #1838)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "chrono",
@@ -830,11 +830,12 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "axum",
@@ -857,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "chrono",
@@ -895,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -911,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "chrono",
@@ -929,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "chrono",
@@ -955,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4558,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.916"
+version = "0.1.917"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.916"
+version = "0.1.917"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec_bootstrap.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_bootstrap.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::ToolName;
 use csa_session::{
@@ -138,6 +138,12 @@ pub(super) async fn bootstrap_session(
         if let Err(e) = session.apply_phase_event(PhaseEvent::Resumed) {
             warn!(session = %session.meta_session_id, error = %e, "Skipping phase transition on resume");
         } else {
+            csa_session::save_session(&session).with_context(|| {
+                format!(
+                    "failed to persist resumed Active phase for session {}",
+                    session.meta_session_id
+                )
+            })?;
             info!(session = %session.meta_session_id, "Session resumed and marked Active");
         }
     }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -66,10 +66,10 @@ fn session_mutates_worktree(readonly_project_root: bool) -> bool {
 
 fn holder_session_liveness(project_root: &Path, session_id: &str) -> HolderSessionLiveness {
     match csa_session::load_session(project_root, session_id) {
-        Ok(session) => classify_holder_session(&session),
+        Ok(session) => classify_loaded_holder_session(&session),
         Err(project_err) => match csa_session::load_session_global_exact(session_id) {
-            Ok(Some(session)) => classify_holder_session(&session),
-            Ok(None) => HolderSessionLiveness::Dead,
+            Ok(Some(session)) => classify_loaded_holder_session(&session),
+            Ok(None) => HolderSessionLiveness::RegistryAbsent,
             Err(global_err) => {
                 tracing::warn!(
                     session_id,
@@ -83,7 +83,7 @@ fn holder_session_liveness(project_root: &Path, session_id: &str) -> HolderSessi
     }
 }
 
-fn classify_holder_session(session: &MetaSessionState) -> HolderSessionLiveness {
+fn classify_loaded_holder_session(session: &MetaSessionState) -> HolderSessionLiveness {
     let project_root = Path::new(&session.project_path);
     let session_dir = match csa_session::get_session_dir(project_root, &session.meta_session_id) {
         Ok(dir) => dir,
@@ -208,6 +208,8 @@ fn push_lineage(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
+    use std::fs;
 
     #[test]
     fn worktree_mutation_predicate_keys_on_readonly_not_session_type() {
@@ -225,8 +227,9 @@ mod tests {
     #[test]
     fn holder_session_liveness_treats_completed_active_session_as_dead() {
         let temp = tempfile::tempdir().unwrap();
-        let session = csa_session::create_session(temp.path(), Some("done"), None, Some("codex"))
-            .expect("create session");
+        let session =
+            csa_session::create_session_fresh(temp.path(), Some("done"), None, Some("codex"))
+                .expect("create session");
         save_success_result(temp.path(), &session.meta_session_id);
 
         assert_eq!(
@@ -239,7 +242,7 @@ mod tests {
     fn holder_session_liveness_keeps_active_session_without_result_live() {
         let temp = tempfile::tempdir().unwrap();
         let session =
-            csa_session::create_session(temp.path(), Some("running"), None, Some("codex"))
+            csa_session::create_session_fresh(temp.path(), Some("running"), None, Some("codex"))
                 .expect("create session");
 
         assert_eq!(
@@ -249,16 +252,29 @@ mod tests {
     }
 
     #[test]
+    fn holder_session_liveness_keeps_missing_registry_entry_distinct_from_dead() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing_session_id = csa_session::new_session_id();
+
+        assert_eq!(
+            holder_session_liveness(temp.path(), &missing_session_id),
+            HolderSessionLiveness::RegistryAbsent
+        );
+    }
+
+    #[test]
     fn acquire_if_needed_reclaims_completed_holder_session_lock() {
         let temp = tempfile::tempdir().unwrap();
-        let holder = csa_session::create_session(temp.path(), Some("done"), None, Some("codex"))
-            .expect("create holder session");
+        let holder =
+            csa_session::create_session_fresh(temp.path(), Some("done"), None, Some("codex"))
+                .expect("create holder session");
         save_success_result(temp.path(), &holder.meta_session_id);
         let _holder_lock =
             csa_lock::acquire_worktree_write_lock(temp.path(), &holder.meta_session_id, &[])
                 .expect("holder lock");
-        let candidate = csa_session::create_session(temp.path(), Some("next"), None, Some("codex"))
-            .expect("create candidate session");
+        let candidate =
+            csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
+                .expect("create candidate session");
 
         let lock = acquire_if_needed(temp.path(), &candidate, false)
             .expect("completed holder should be reclaimed")
@@ -268,15 +284,51 @@ mod tests {
     }
 
     #[test]
+    fn acquire_if_needed_reclaims_registry_absent_holder_only_when_pid_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let holder =
+            csa_session::create_session_fresh(temp.path(), Some("gone"), None, Some("codex"))
+                .expect("create holder session");
+        let holder_session_id = holder.meta_session_id.clone();
+        let holder_lock =
+            csa_lock::acquire_worktree_write_lock(temp.path(), &holder_session_id, &[])
+                .expect("holder lock");
+        overwrite_worktree_lock_diagnostic(
+            holder_lock.lock_path(),
+            missing_pid(),
+            &holder_session_id,
+            temp.path(),
+        );
+        csa_session::delete_session(temp.path(), &holder_session_id).expect("delete holder");
+        let candidate =
+            csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
+                .expect("create candidate session");
+        assert_eq!(
+            holder_session_liveness(temp.path(), &holder_session_id),
+            HolderSessionLiveness::RegistryAbsent
+        );
+
+        let lock = acquire_if_needed(temp.path(), &candidate, false)
+            .expect("missing registry entry with dead pid should be reclaimed")
+            .expect("writer should acquire a lock");
+
+        assert!(!lock.is_lineage_reentry());
+        drop(holder_lock);
+        drop(lock);
+    }
+
+    #[test]
     fn acquire_if_needed_keeps_active_holder_session_blocked() {
         let temp = tempfile::tempdir().unwrap();
-        let holder = csa_session::create_session(temp.path(), Some("running"), None, Some("codex"))
-            .expect("create holder session");
+        let holder =
+            csa_session::create_session_fresh(temp.path(), Some("running"), None, Some("codex"))
+                .expect("create holder session");
         let _holder_lock =
             csa_lock::acquire_worktree_write_lock(temp.path(), &holder.meta_session_id, &[])
                 .expect("holder lock");
-        let candidate = csa_session::create_session(temp.path(), Some("next"), None, Some("codex"))
-            .expect("create candidate session");
+        let candidate =
+            csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
+                .expect("create candidate session");
 
         let err = acquire_if_needed(temp.path(), &candidate, false)
             .expect_err("active holder with no result must still block")
@@ -284,6 +336,84 @@ mod tests {
 
         assert!(err.contains("concurrent write session blocked"));
         assert!(err.contains(&holder.meta_session_id));
+    }
+
+    #[test]
+    fn acquire_if_needed_blocks_registry_absent_holder_with_signalable_pid() {
+        let temp = tempfile::tempdir().unwrap();
+        let holder =
+            csa_session::create_session_fresh(temp.path(), Some("missing"), None, Some("codex"))
+                .expect("create holder session");
+        let holder_session_id = holder.meta_session_id.clone();
+        let holder_lock =
+            csa_lock::acquire_worktree_write_lock(temp.path(), &holder_session_id, &[])
+                .expect("holder lock");
+        let lock_path = holder_lock.lock_path().to_path_buf();
+        overwrite_worktree_lock_diagnostic(
+            &lock_path,
+            std::process::id(),
+            &holder_session_id,
+            temp.path(),
+        );
+        csa_session::delete_session(temp.path(), &holder_session_id).expect("delete holder");
+        let candidate =
+            csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
+                .expect("create candidate session");
+        assert_eq!(
+            holder_session_liveness(temp.path(), &holder_session_id),
+            HolderSessionLiveness::RegistryAbsent
+        );
+
+        let err = acquire_if_needed(temp.path(), &candidate, false)
+            .expect_err("missing registry entry with signalable pid must block")
+            .to_string();
+
+        assert!(err.contains("concurrent write session blocked"));
+        assert!(err.contains(&holder_session_id));
+        assert!(
+            lock_path.exists(),
+            "canonical lock path must not be moved aside"
+        );
+    }
+
+    #[test]
+    fn acquire_if_needed_blocks_unreadable_holder_state_with_signalable_pid() {
+        let temp = tempfile::tempdir().unwrap();
+        let holder =
+            csa_session::create_session_fresh(temp.path(), Some("corrupt"), None, Some("codex"))
+                .expect("create holder session");
+        let holder_session_id = holder.meta_session_id.clone();
+        let holder_lock =
+            csa_lock::acquire_worktree_write_lock(temp.path(), &holder_session_id, &[])
+                .expect("holder lock");
+        let lock_path = holder_lock.lock_path().to_path_buf();
+        overwrite_worktree_lock_diagnostic(
+            &lock_path,
+            std::process::id(),
+            &holder_session_id,
+            temp.path(),
+        );
+        let holder_dir =
+            csa_session::get_session_dir(temp.path(), &holder_session_id).expect("holder dir");
+        fs::write(holder_dir.join("state.toml"), "not valid toml").expect("corrupt state");
+        let candidate =
+            csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
+                .expect("create candidate session");
+        assert_eq!(
+            holder_session_liveness(temp.path(), &holder_session_id),
+            HolderSessionLiveness::Unknown
+        );
+
+        let err = acquire_if_needed(temp.path(), &candidate, false)
+            .expect_err("unreadable holder state must block")
+            .to_string();
+
+        assert!(err.contains("concurrent write session blocked"));
+        assert!(err.contains(&holder_session_id));
+        assert!(
+            lock_path.exists(),
+            "canonical lock path must not be moved aside"
+        );
     }
 
     fn save_success_result(project_root: &Path, session_id: &str) {
@@ -313,5 +443,39 @@ mod tests {
             },
         )
         .expect("save result");
+    }
+
+    fn overwrite_worktree_lock_diagnostic(
+        lock_path: &Path,
+        pid: u32,
+        session_id: &str,
+        worktree_root: &Path,
+    ) {
+        let diagnostic = serde_json::json!({
+            "pid": pid,
+            "tool_name": "worktree-write:exclusive",
+            "acquired_at": Utc::now(),
+            "reason": format!(
+                "write session {session_id} holds worktree {}",
+                worktree_root.display()
+            ),
+            "holder_session_id": session_id,
+            "resource_path": worktree_root.display().to_string(),
+        });
+        fs::write(lock_path, serde_json::to_string(&diagnostic).unwrap())
+            .expect("overwrite lock diagnostic");
+    }
+
+    fn missing_pid() -> u32 {
+        [4_000_000, 8_000_000, 16_000_000, 1_000_000_000]
+            .into_iter()
+            .find(|pid| process_is_missing(*pid))
+            .expect("test host should have at least one definitely missing pid")
+    }
+
+    fn process_is_missing(pid: u32) -> bool {
+        // SAFETY: signal 0 checks process existence without sending a signal.
+        let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        ret != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -263,24 +263,34 @@ mod tests {
     }
 
     #[test]
-    fn acquire_if_needed_reclaims_completed_holder_session_lock() {
+    fn acquire_if_needed_blocks_completed_holder_session_with_signalable_pid() {
         let temp = tempfile::tempdir().unwrap();
         let holder =
             csa_session::create_session_fresh(temp.path(), Some("done"), None, Some("codex"))
                 .expect("create holder session");
         save_success_result(temp.path(), &holder.meta_session_id);
-        let _holder_lock =
+        let holder_lock =
             csa_lock::acquire_worktree_write_lock(temp.path(), &holder.meta_session_id, &[])
                 .expect("holder lock");
+        let lock_path = holder_lock.lock_path().to_path_buf();
         let candidate =
             csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
                 .expect("create candidate session");
+        assert_eq!(
+            holder_session_liveness(temp.path(), &holder.meta_session_id),
+            HolderSessionLiveness::Dead
+        );
 
-        let lock = acquire_if_needed(temp.path(), &candidate, false)
-            .expect("completed holder should be reclaimed")
-            .expect("writer should acquire a lock");
+        let err = acquire_if_needed(temp.path(), &candidate, false)
+            .expect_err("completed holder with signalable pid must block")
+            .to_string();
 
-        assert!(!lock.is_lineage_reentry());
+        assert!(err.contains("concurrent write session blocked"));
+        assert!(err.contains(&holder.meta_session_id));
+        assert!(
+            lock_path.exists(),
+            "canonical lock path must not be moved aside"
+        );
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -167,6 +167,11 @@ fn holder_session_is_active(project_root: &Path, session_id: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipeline::{ParentSessionSource, SessionCreationMode};
+    use crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV;
+    use crate::test_session_sandbox::ScopedSessionSandbox;
+    use csa_core::types::ToolName;
+    use csa_session::{PhaseEvent, ToolState, save_session};
 
     #[test]
     fn worktree_mutation_predicate_keys_on_readonly_not_session_type() {
@@ -235,6 +240,86 @@ mod tests {
 
         assert!(err.contains("concurrent write session blocked"));
         assert!(err.contains(&holder.meta_session_id));
+    }
+
+    #[tokio::test]
+    async fn resumed_available_holder_persists_active_before_lineage_lock_check() {
+        let temp = tempfile::tempdir().unwrap();
+        let _sandbox = ScopedSessionSandbox::new(&temp).await;
+        let project_root = temp.path();
+        let mut holder =
+            csa_session::create_session(project_root, Some("holder"), None, Some("codex"))
+                .expect("create holder session");
+        holder.tools.insert(
+            "codex".to_string(),
+            ToolState {
+                provider_session_id: Some("provider-holder".to_string()),
+                last_action_summary: String::new(),
+                last_exit_code: 0,
+                updated_at: chrono::Utc::now(),
+                tool_version: Some("codex-test".to_string()),
+                token_usage: None,
+            },
+        );
+        holder
+            .apply_phase_event(PhaseEvent::Compressed)
+            .expect("holder should become Available");
+        save_session(&holder).expect("save Available holder");
+        let holder_session_id = holder.meta_session_id.clone();
+        assert_eq!(
+            csa_session::load_session(project_root, &holder_session_id)
+                .expect("load saved holder")
+                .phase,
+            SessionPhase::Available
+        );
+
+        let bootstrapped = super::super::session_exec_bootstrap::bootstrap_session(
+            &ToolName::Codex,
+            "resume holder",
+            Some(&holder_session_id),
+            false,
+            None,
+            None,
+            project_root,
+            None,
+            None,
+            Some("run"),
+            None,
+            ParentSessionSource::ExplicitOrEnv,
+            SessionCreationMode::DaemonManaged,
+            &EMPTY_STARTUP_SUBTREE_ENV,
+        )
+        .await
+        .expect("resume holder session");
+        assert_eq!(bootstrapped.session.phase, SessionPhase::Active);
+        assert_eq!(
+            csa_session::load_session(project_root, &holder_session_id)
+                .expect("load resumed holder")
+                .phase,
+            SessionPhase::Active,
+            "resumed holder phase must be persisted before worktree-lock lineage checks"
+        );
+
+        let _holder_lock = acquire_if_needed(project_root, &bootstrapped.session, false)
+            .expect("resumed holder should acquire worktree lock")
+            .expect("writable holder should take a lock");
+        let child = csa_session::create_session(
+            project_root,
+            Some("lineage child"),
+            Some(&holder_session_id),
+            Some("codex"),
+        )
+        .expect("create lineage child");
+
+        let child_lock = acquire_if_needed(project_root, &child, false)
+            .expect("child should re-enter under persisted-active holder")
+            .expect("writable child should get a lock guard");
+
+        assert!(child_lock.is_lineage_reentry());
+        assert_eq!(
+            child_lock.holder_session_id(),
+            Some(holder_session_id.as_str())
+        );
     }
 
     fn save_success_result(project_root: &Path, session_id: &str) {

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -1,8 +1,9 @@
 use super::session_exec_pre_exec::persist_pipeline_pre_exec_failure;
 use crate::session_guard::SessionCleanupGuard;
 use anyhow::{Context, Result};
+use csa_lock::HolderSessionLiveness;
 use csa_lock::WorktreeWriteLock;
-use csa_session::MetaSessionState;
+use csa_session::{MetaSessionState, SessionPhase};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -37,10 +38,11 @@ pub(super) fn acquire_if_needed(
 
     let worktree_root = resolve_worktree_lock_root(project_root)?;
     let ancestor_session_ids = collect_lineage_session_ids(project_root, session)?;
-    csa_lock::acquire_worktree_write_lock(
+    csa_lock::acquire_worktree_write_lock_with_liveness(
         &worktree_root,
         &session.meta_session_id,
         &ancestor_session_ids,
+        |holder_session_id| holder_session_liveness(project_root, holder_session_id),
     )
     .map(Some)
 }
@@ -60,6 +62,60 @@ pub(super) fn acquire_if_needed(
 /// acquires no lock and never contends.
 fn session_mutates_worktree(readonly_project_root: bool) -> bool {
     !readonly_project_root
+}
+
+fn holder_session_liveness(project_root: &Path, session_id: &str) -> HolderSessionLiveness {
+    match csa_session::load_session(project_root, session_id) {
+        Ok(session) => classify_holder_session(&session),
+        Err(project_err) => match csa_session::load_session_global_exact(session_id) {
+            Ok(Some(session)) => classify_holder_session(&session),
+            Ok(None) => HolderSessionLiveness::Dead,
+            Err(global_err) => {
+                tracing::warn!(
+                    session_id,
+                    project_error = %project_err,
+                    global_error = %global_err,
+                    "could not determine worktree lock holder session liveness"
+                );
+                HolderSessionLiveness::Unknown
+            }
+        },
+    }
+}
+
+fn classify_holder_session(session: &MetaSessionState) -> HolderSessionLiveness {
+    let project_root = Path::new(&session.project_path);
+    let session_dir = match csa_session::get_session_dir(project_root, &session.meta_session_id) {
+        Ok(dir) => dir,
+        Err(err) => {
+            tracing::warn!(
+                session_id = %session.meta_session_id,
+                error = %err,
+                "could not resolve worktree lock holder session dir"
+            );
+            return HolderSessionLiveness::Unknown;
+        }
+    };
+
+    if csa_process::ToolLiveness::has_live_process(&session_dir)
+        || csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir)
+    {
+        return HolderSessionLiveness::Live;
+    }
+
+    match csa_session::load_result(project_root, &session.meta_session_id) {
+        Ok(Some(_)) => HolderSessionLiveness::Dead,
+        Err(err) => {
+            tracing::warn!(
+                session_id = %session.meta_session_id,
+                error = %err,
+                "could not read worktree lock holder result"
+            );
+            HolderSessionLiveness::Unknown
+        }
+        Ok(None) if matches!(session.phase, SessionPhase::Active) => HolderSessionLiveness::Live,
+        Ok(None) => HolderSessionLiveness::Dead,
+    }
 }
 
 fn resolve_worktree_lock_root(project_root: &Path) -> Result<PathBuf> {
@@ -164,5 +220,98 @@ mod tests {
         // A read-only sandbox cannot mutate the worktree → no lock, no
         // contention.
         assert!(!session_mutates_worktree(true));
+    }
+
+    #[test]
+    fn holder_session_liveness_treats_completed_active_session_as_dead() {
+        let temp = tempfile::tempdir().unwrap();
+        let session = csa_session::create_session(temp.path(), Some("done"), None, Some("codex"))
+            .expect("create session");
+        save_success_result(temp.path(), &session.meta_session_id);
+
+        assert_eq!(
+            holder_session_liveness(temp.path(), &session.meta_session_id),
+            HolderSessionLiveness::Dead
+        );
+    }
+
+    #[test]
+    fn holder_session_liveness_keeps_active_session_without_result_live() {
+        let temp = tempfile::tempdir().unwrap();
+        let session =
+            csa_session::create_session(temp.path(), Some("running"), None, Some("codex"))
+                .expect("create session");
+
+        assert_eq!(
+            holder_session_liveness(temp.path(), &session.meta_session_id),
+            HolderSessionLiveness::Live
+        );
+    }
+
+    #[test]
+    fn acquire_if_needed_reclaims_completed_holder_session_lock() {
+        let temp = tempfile::tempdir().unwrap();
+        let holder = csa_session::create_session(temp.path(), Some("done"), None, Some("codex"))
+            .expect("create holder session");
+        save_success_result(temp.path(), &holder.meta_session_id);
+        let _holder_lock =
+            csa_lock::acquire_worktree_write_lock(temp.path(), &holder.meta_session_id, &[])
+                .expect("holder lock");
+        let candidate = csa_session::create_session(temp.path(), Some("next"), None, Some("codex"))
+            .expect("create candidate session");
+
+        let lock = acquire_if_needed(temp.path(), &candidate, false)
+            .expect("completed holder should be reclaimed")
+            .expect("writer should acquire a lock");
+
+        assert!(!lock.is_lineage_reentry());
+    }
+
+    #[test]
+    fn acquire_if_needed_keeps_active_holder_session_blocked() {
+        let temp = tempfile::tempdir().unwrap();
+        let holder = csa_session::create_session(temp.path(), Some("running"), None, Some("codex"))
+            .expect("create holder session");
+        let _holder_lock =
+            csa_lock::acquire_worktree_write_lock(temp.path(), &holder.meta_session_id, &[])
+                .expect("holder lock");
+        let candidate = csa_session::create_session(temp.path(), Some("next"), None, Some("codex"))
+            .expect("create candidate session");
+
+        let err = acquire_if_needed(temp.path(), &candidate, false)
+            .expect_err("active holder with no result must still block")
+            .to_string();
+
+        assert!(err.contains("concurrent write session blocked"));
+        assert!(err.contains(&holder.meta_session_id));
+    }
+
+    fn save_success_result(project_root: &Path, session_id: &str) {
+        csa_session::save_result(
+            project_root,
+            session_id,
+            &csa_session::SessionResult {
+                status: "success".to_string(),
+                exit_code: 0,
+                summary: "done".to_string(),
+                tool: "codex".to_string(),
+                original_tool: None,
+                fallback_tool: None,
+                fallback_reason: None,
+                started_at: chrono::Utc::now(),
+                completed_at: chrono::Utc::now(),
+                events_count: 0,
+                artifacts: Vec::new(),
+                peak_memory_mb: None,
+                fallback_chain: None,
+                gate_timeout: false,
+                warnings: Vec::new(),
+                raw_process_exit_code: None,
+                uncommitted_changes: None,
+                post_exec_gate: None,
+                manager_fields: Default::default(),
+            },
+        )
+        .expect("save result");
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -1,9 +1,8 @@
 use super::session_exec_pre_exec::persist_pipeline_pre_exec_failure;
 use crate::session_guard::SessionCleanupGuard;
 use anyhow::{Context, Result};
-use csa_lock::HolderSessionLiveness;
 use csa_lock::WorktreeWriteLock;
-use csa_session::{MetaSessionState, SessionPhase};
+use csa_session::MetaSessionState;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -38,11 +37,10 @@ pub(super) fn acquire_if_needed(
 
     let worktree_root = resolve_worktree_lock_root(project_root)?;
     let ancestor_session_ids = collect_lineage_session_ids(project_root, session)?;
-    csa_lock::acquire_worktree_write_lock_with_liveness(
+    csa_lock::acquire_worktree_write_lock(
         &worktree_root,
         &session.meta_session_id,
         &ancestor_session_ids,
-        |holder_session_id| holder_session_liveness(project_root, holder_session_id),
     )
     .map(Some)
 }
@@ -62,60 +60,6 @@ pub(super) fn acquire_if_needed(
 /// acquires no lock and never contends.
 fn session_mutates_worktree(readonly_project_root: bool) -> bool {
     !readonly_project_root
-}
-
-fn holder_session_liveness(project_root: &Path, session_id: &str) -> HolderSessionLiveness {
-    match csa_session::load_session(project_root, session_id) {
-        Ok(session) => classify_loaded_holder_session(&session),
-        Err(project_err) => match csa_session::load_session_global_exact(session_id) {
-            Ok(Some(session)) => classify_loaded_holder_session(&session),
-            Ok(None) => HolderSessionLiveness::RegistryAbsent,
-            Err(global_err) => {
-                tracing::warn!(
-                    session_id,
-                    project_error = %project_err,
-                    global_error = %global_err,
-                    "could not determine worktree lock holder session liveness"
-                );
-                HolderSessionLiveness::Unknown
-            }
-        },
-    }
-}
-
-fn classify_loaded_holder_session(session: &MetaSessionState) -> HolderSessionLiveness {
-    let project_root = Path::new(&session.project_path);
-    let session_dir = match csa_session::get_session_dir(project_root, &session.meta_session_id) {
-        Ok(dir) => dir,
-        Err(err) => {
-            tracing::warn!(
-                session_id = %session.meta_session_id,
-                error = %err,
-                "could not resolve worktree lock holder session dir"
-            );
-            return HolderSessionLiveness::Unknown;
-        }
-    };
-
-    if csa_process::ToolLiveness::has_live_process(&session_dir)
-        || csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir)
-    {
-        return HolderSessionLiveness::Live;
-    }
-
-    match csa_session::load_result(project_root, &session.meta_session_id) {
-        Ok(Some(_)) => HolderSessionLiveness::Dead,
-        Err(err) => {
-            tracing::warn!(
-                session_id = %session.meta_session_id,
-                error = %err,
-                "could not read worktree lock holder result"
-            );
-            HolderSessionLiveness::Unknown
-        }
-        Ok(None) if matches!(session.phase, SessionPhase::Active) => HolderSessionLiveness::Live,
-        Ok(None) => HolderSessionLiveness::Dead,
-    }
 }
 
 fn resolve_worktree_lock_root(project_root: &Path) -> Result<PathBuf> {
@@ -208,8 +152,6 @@ fn push_lineage(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
-    use std::fs;
 
     #[test]
     fn worktree_mutation_predicate_keys_on_readonly_not_session_type() {
@@ -225,45 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn holder_session_liveness_treats_completed_active_session_as_dead() {
-        let temp = tempfile::tempdir().unwrap();
-        let session =
-            csa_session::create_session_fresh(temp.path(), Some("done"), None, Some("codex"))
-                .expect("create session");
-        save_success_result(temp.path(), &session.meta_session_id);
-
-        assert_eq!(
-            holder_session_liveness(temp.path(), &session.meta_session_id),
-            HolderSessionLiveness::Dead
-        );
-    }
-
-    #[test]
-    fn holder_session_liveness_keeps_active_session_without_result_live() {
-        let temp = tempfile::tempdir().unwrap();
-        let session =
-            csa_session::create_session_fresh(temp.path(), Some("running"), None, Some("codex"))
-                .expect("create session");
-
-        assert_eq!(
-            holder_session_liveness(temp.path(), &session.meta_session_id),
-            HolderSessionLiveness::Live
-        );
-    }
-
-    #[test]
-    fn holder_session_liveness_keeps_missing_registry_entry_distinct_from_dead() {
-        let temp = tempfile::tempdir().unwrap();
-        let missing_session_id = csa_session::new_session_id();
-
-        assert_eq!(
-            holder_session_liveness(temp.path(), &missing_session_id),
-            HolderSessionLiveness::RegistryAbsent
-        );
-    }
-
-    #[test]
-    fn acquire_if_needed_blocks_completed_holder_session_with_signalable_pid() {
+    fn acquire_if_needed_blocks_post_exec_holder_while_guard_is_live() {
         let temp = tempfile::tempdir().unwrap();
         let holder =
             csa_session::create_session_fresh(temp.path(), Some("done"), None, Some("codex"))
@@ -276,13 +180,9 @@ mod tests {
         let candidate =
             csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
                 .expect("create candidate session");
-        assert_eq!(
-            holder_session_liveness(temp.path(), &holder.meta_session_id),
-            HolderSessionLiveness::Dead
-        );
 
         let err = acquire_if_needed(temp.path(), &candidate, false)
-            .expect_err("completed holder with signalable pid must block")
+            .expect_err("completed holder with live flock must block")
             .to_string();
 
         assert!(err.contains("concurrent write session blocked"));
@@ -291,40 +191,6 @@ mod tests {
             lock_path.exists(),
             "canonical lock path must not be moved aside"
         );
-    }
-
-    #[test]
-    fn acquire_if_needed_reclaims_registry_absent_holder_only_when_pid_missing() {
-        let temp = tempfile::tempdir().unwrap();
-        let holder =
-            csa_session::create_session_fresh(temp.path(), Some("gone"), None, Some("codex"))
-                .expect("create holder session");
-        let holder_session_id = holder.meta_session_id.clone();
-        let holder_lock =
-            csa_lock::acquire_worktree_write_lock(temp.path(), &holder_session_id, &[])
-                .expect("holder lock");
-        overwrite_worktree_lock_diagnostic(
-            holder_lock.lock_path(),
-            missing_pid(),
-            &holder_session_id,
-            temp.path(),
-        );
-        csa_session::delete_session(temp.path(), &holder_session_id).expect("delete holder");
-        let candidate =
-            csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
-                .expect("create candidate session");
-        assert_eq!(
-            holder_session_liveness(temp.path(), &holder_session_id),
-            HolderSessionLiveness::RegistryAbsent
-        );
-
-        let lock = acquire_if_needed(temp.path(), &candidate, false)
-            .expect("missing registry entry with dead pid should be reclaimed")
-            .expect("writer should acquire a lock");
-
-        assert!(!lock.is_lineage_reentry());
-        drop(holder_lock);
-        drop(lock);
     }
 
     #[test]
@@ -346,84 +212,6 @@ mod tests {
 
         assert!(err.contains("concurrent write session blocked"));
         assert!(err.contains(&holder.meta_session_id));
-    }
-
-    #[test]
-    fn acquire_if_needed_blocks_registry_absent_holder_with_signalable_pid() {
-        let temp = tempfile::tempdir().unwrap();
-        let holder =
-            csa_session::create_session_fresh(temp.path(), Some("missing"), None, Some("codex"))
-                .expect("create holder session");
-        let holder_session_id = holder.meta_session_id.clone();
-        let holder_lock =
-            csa_lock::acquire_worktree_write_lock(temp.path(), &holder_session_id, &[])
-                .expect("holder lock");
-        let lock_path = holder_lock.lock_path().to_path_buf();
-        overwrite_worktree_lock_diagnostic(
-            &lock_path,
-            std::process::id(),
-            &holder_session_id,
-            temp.path(),
-        );
-        csa_session::delete_session(temp.path(), &holder_session_id).expect("delete holder");
-        let candidate =
-            csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
-                .expect("create candidate session");
-        assert_eq!(
-            holder_session_liveness(temp.path(), &holder_session_id),
-            HolderSessionLiveness::RegistryAbsent
-        );
-
-        let err = acquire_if_needed(temp.path(), &candidate, false)
-            .expect_err("missing registry entry with signalable pid must block")
-            .to_string();
-
-        assert!(err.contains("concurrent write session blocked"));
-        assert!(err.contains(&holder_session_id));
-        assert!(
-            lock_path.exists(),
-            "canonical lock path must not be moved aside"
-        );
-    }
-
-    #[test]
-    fn acquire_if_needed_blocks_unreadable_holder_state_with_signalable_pid() {
-        let temp = tempfile::tempdir().unwrap();
-        let holder =
-            csa_session::create_session_fresh(temp.path(), Some("corrupt"), None, Some("codex"))
-                .expect("create holder session");
-        let holder_session_id = holder.meta_session_id.clone();
-        let holder_lock =
-            csa_lock::acquire_worktree_write_lock(temp.path(), &holder_session_id, &[])
-                .expect("holder lock");
-        let lock_path = holder_lock.lock_path().to_path_buf();
-        overwrite_worktree_lock_diagnostic(
-            &lock_path,
-            std::process::id(),
-            &holder_session_id,
-            temp.path(),
-        );
-        let holder_dir =
-            csa_session::get_session_dir(temp.path(), &holder_session_id).expect("holder dir");
-        fs::write(holder_dir.join("state.toml"), "not valid toml").expect("corrupt state");
-        let candidate =
-            csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
-                .expect("create candidate session");
-        assert_eq!(
-            holder_session_liveness(temp.path(), &holder_session_id),
-            HolderSessionLiveness::Unknown
-        );
-
-        let err = acquire_if_needed(temp.path(), &candidate, false)
-            .expect_err("unreadable holder state must block")
-            .to_string();
-
-        assert!(err.contains("concurrent write session blocked"));
-        assert!(err.contains(&holder_session_id));
-        assert!(
-            lock_path.exists(),
-            "canonical lock path must not be moved aside"
-        );
     }
 
     fn save_success_result(project_root: &Path, session_id: &str) {
@@ -453,39 +241,5 @@ mod tests {
             },
         )
         .expect("save result");
-    }
-
-    fn overwrite_worktree_lock_diagnostic(
-        lock_path: &Path,
-        pid: u32,
-        session_id: &str,
-        worktree_root: &Path,
-    ) {
-        let diagnostic = serde_json::json!({
-            "pid": pid,
-            "tool_name": "worktree-write:exclusive",
-            "acquired_at": Utc::now(),
-            "reason": format!(
-                "write session {session_id} holds worktree {}",
-                worktree_root.display()
-            ),
-            "holder_session_id": session_id,
-            "resource_path": worktree_root.display().to_string(),
-        });
-        fs::write(lock_path, serde_json::to_string(&diagnostic).unwrap())
-            .expect("overwrite lock diagnostic");
-    }
-
-    fn missing_pid() -> u32 {
-        [4_000_000, 8_000_000, 16_000_000, 1_000_000_000]
-            .into_iter()
-            .find(|pid| process_is_missing(*pid))
-            .expect("test host should have at least one definitely missing pid")
-    }
-
-    fn process_is_missing(pid: u32) -> bool {
-        // SAFETY: signal 0 checks process existence without sending a signal.
-        let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
-        ret != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -2,7 +2,7 @@ use super::session_exec_pre_exec::persist_pipeline_pre_exec_failure;
 use crate::session_guard::SessionCleanupGuard;
 use anyhow::{Context, Result};
 use csa_lock::WorktreeWriteLock;
-use csa_session::MetaSessionState;
+use csa_session::{MetaSessionState, SessionPhase};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -41,6 +41,7 @@ pub(super) fn acquire_if_needed(
         &worktree_root,
         &session.meta_session_id,
         &ancestor_session_ids,
+        |holder_session_id| holder_session_is_active(project_root, holder_session_id),
     )
     .map(Some)
 }
@@ -149,6 +150,20 @@ fn push_lineage(
     Ok(())
 }
 
+fn holder_session_is_active(project_root: &Path, session_id: &str) -> bool {
+    match csa_session::load_session(project_root, session_id) {
+        Ok(state) => state.phase == SessionPhase::Active,
+        Err(err) => {
+            tracing::debug!(
+                session_id,
+                error = %err,
+                "treating unreadable lineage holder session as not live"
+            );
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -173,9 +188,13 @@ mod tests {
             csa_session::create_session_fresh(temp.path(), Some("done"), None, Some("codex"))
                 .expect("create holder session");
         save_success_result(temp.path(), &holder.meta_session_id);
-        let holder_lock =
-            csa_lock::acquire_worktree_write_lock(temp.path(), &holder.meta_session_id, &[])
-                .expect("holder lock");
+        let holder_lock = csa_lock::acquire_worktree_write_lock(
+            temp.path(),
+            &holder.meta_session_id,
+            &[],
+            |_| false,
+        )
+        .expect("holder lock");
         let lock_path = holder_lock.lock_path().to_path_buf();
         let candidate =
             csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
@@ -199,9 +218,13 @@ mod tests {
         let holder =
             csa_session::create_session_fresh(temp.path(), Some("running"), None, Some("codex"))
                 .expect("create holder session");
-        let _holder_lock =
-            csa_lock::acquire_worktree_write_lock(temp.path(), &holder.meta_session_id, &[])
-                .expect("holder lock");
+        let _holder_lock = csa_lock::acquire_worktree_write_lock(
+            temp.path(),
+            &holder.meta_session_id,
+            &[],
+            |_| false,
+        )
+        .expect("holder lock");
         let candidate =
             csa_session::create_session_fresh(temp.path(), Some("next"), None, Some("codex"))
                 .expect("create candidate session");

--- a/crates/cli-sub-agent/src/pipeline_tests_locking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_locking.rs
@@ -59,7 +59,10 @@ fn acquire_active_holder_worktree_lock(
 ) -> (String, csa_lock::WorktreeWriteLock) {
     let holder =
         csa_session::create_session(project_root, Some("holder"), None, Some("codex")).unwrap();
-    let lock = csa_lock::acquire_worktree_write_lock(project_root, &holder.meta_session_id, &[])
+    let lock =
+        csa_lock::acquire_worktree_write_lock(project_root, &holder.meta_session_id, &[], |_| {
+            false
+        })
         .expect("holder worktree write lock should succeed");
     (holder.meta_session_id, lock)
 }
@@ -305,8 +308,10 @@ async fn review_fix_reenters_under_ancestor_worktree_write_lock() {
     let holder =
         csa_session::create_session(project_root, Some("holder"), None, Some("codex")).unwrap();
     let _worktree_lock =
-        csa_lock::acquire_worktree_write_lock(project_root, &holder.meta_session_id, &[])
-            .expect("ancestor worktree write lock should succeed");
+        csa_lock::acquire_worktree_write_lock(project_root, &holder.meta_session_id, &[], |_| {
+            false
+        })
+        .expect("ancestor worktree write lock should succeed");
 
     // A `--fix` child WITHIN the holder's lineage must re-enter the lock, not
     // fail fast (#1828 reuses #1672's lineage re-entry path).

--- a/crates/cli-sub-agent/src/pipeline_tests_locking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_locking.rs
@@ -54,11 +54,22 @@ async fn run_pipeline_for_worktree_lock_test(
     .await
 }
 
+fn acquire_active_holder_worktree_lock(
+    project_root: &std::path::Path,
+) -> (String, csa_lock::WorktreeWriteLock) {
+    let holder =
+        csa_session::create_session(project_root, Some("holder"), None, Some("codex")).unwrap();
+    let lock = csa_lock::acquire_worktree_write_lock(project_root, &holder.meta_session_id, &[])
+        .expect("holder worktree write lock should succeed");
+    (holder.meta_session_id, lock)
+}
+
 /// Assert the pipeline failed fast on the per-worktree write lock, surfacing the
-/// non-lineage holder session id `01HOLDER` and serialize guidance (#1672).
+/// non-lineage holder session id and serialize guidance (#1672).
 fn assert_worktree_write_lock_blocked(
     execution: anyhow::Result<crate::pipeline::SessionExecutionResult>,
     project_root: &std::path::Path,
+    expected_holder_session_id: &str,
 ) {
     let err = match execution {
         Ok(_) => panic!("held worktree write lock must reject non-lineage writer"),
@@ -68,7 +79,10 @@ fn assert_worktree_write_lock_blocked(
         err.contains("concurrent write session blocked"),
         "unexpected error: {err}"
     );
-    assert!(err.contains("01HOLDER"), "missing holder session id: {err}");
+    assert!(
+        err.contains(expected_holder_session_id),
+        "missing holder session id: {err}"
+    );
     assert!(
         err.contains(&project_root.display().to_string()),
         "missing worktree path: {err}"
@@ -185,12 +199,11 @@ async fn run_writer_fails_fast_when_worktree_write_lock_is_held() {
     let _sandbox = ScopedSessionSandbox::new(&temp).await;
     let project_root = temp.path();
 
-    let _holder = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
-        .expect("holder worktree write lock should succeed");
+    let (holder_session_id, _worktree_lock) = acquire_active_holder_worktree_lock(project_root);
 
     let execution =
         run_pipeline_for_worktree_lock_test(project_root, Some("run"), None, false).await;
-    assert_worktree_write_lock_blocked(execution, project_root);
+    assert_worktree_write_lock_blocked(execution, project_root, &holder_session_id);
 }
 
 #[tokio::test]
@@ -199,8 +212,7 @@ async fn review_fix_fails_fast_when_worktree_write_lock_is_held() {
     let _sandbox = ScopedSessionSandbox::new(&temp).await;
     let project_root = temp.path();
 
-    let _holder = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
-        .expect("holder worktree write lock should succeed");
+    let (holder_session_id, _worktree_lock) = acquire_active_holder_worktree_lock(project_root);
 
     // `csa review --fix` runs as a `reviewer_sub_session` with a writable
     // project root (`readonly_project_root == false`), so it mutates the shared
@@ -213,7 +225,7 @@ async fn review_fix_fails_fast_when_worktree_write_lock_is_held() {
         false,
     )
     .await;
-    assert_worktree_write_lock_blocked(execution, project_root);
+    assert_worktree_write_lock_blocked(execution, project_root, &holder_session_id);
 }
 
 #[tokio::test]
@@ -222,14 +234,13 @@ async fn debate_write_mode_fails_fast_when_worktree_write_lock_is_held() {
     let _sandbox = ScopedSessionSandbox::new(&temp).await;
     let project_root = temp.path();
 
-    let _holder = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
-        .expect("holder worktree write lock should succeed");
+    let (holder_session_id, _worktree_lock) = acquire_active_holder_worktree_lock(project_root);
 
     // A write-mode debate (`readonly_project_root == false`) can mutate the
     // worktree and must serialize against concurrent writers (#1828).
     let execution =
         run_pipeline_for_worktree_lock_test(project_root, Some("debate"), None, false).await;
-    assert_worktree_write_lock_blocked(execution, project_root);
+    assert_worktree_write_lock_blocked(execution, project_root, &holder_session_id);
 }
 
 #[tokio::test]
@@ -245,8 +256,7 @@ async fn readonly_review_is_not_blocked_by_worktree_write_lock() {
     // Hold the per-session lock so the pipeline has a deterministic failure point
     // AFTER the worktree-lock gate.
     let _session_lock = csa_lock::acquire_lock(&session_dir, "codex", "active review").unwrap();
-    let _worktree_lock = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
-        .expect("holder worktree write lock should succeed");
+    let (_holder_session_id, _worktree_lock) = acquire_active_holder_worktree_lock(project_root);
 
     // A read-only review (`readonly_project_root == true`) cannot mutate the
     // worktree, acquires no worktree lock, and must not contend with the holder.
@@ -271,8 +281,7 @@ async fn readonly_debate_is_not_blocked_by_worktree_write_lock() {
             .unwrap();
     let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id).unwrap();
     let _session_lock = csa_lock::acquire_lock(&session_dir, "codex", "active debate").unwrap();
-    let _worktree_lock = csa_lock::acquire_worktree_write_lock(project_root, "01HOLDER", &[])
-        .expect("holder worktree write lock should succeed");
+    let (_holder_session_id, _worktree_lock) = acquire_active_holder_worktree_lock(project_root);
 
     // A read-only debate (`readonly_project_root == true`) acquires no worktree
     // lock → it is not blocked by the holder.

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -92,10 +92,10 @@ use resolve::build_review_instruction;
 pub(crate) use resolve::resolve_review_tool;
 use resolve::{
     ReviewProjectPromptOptions, build_review_instruction_for_project, derive_scope_for_project,
-    resolve_review_effective_tier, resolve_review_model, resolve_review_selection,
-    resolve_review_stream_mode, resolve_review_thinking, resolve_review_tier_name,
-    review_scope_allows_auto_discovery, validate_review_direct_tool_tier_restriction,
-    verify_review_skill_available,
+    resolve_review_effective_tier, resolve_review_model, resolve_review_readonly_configured,
+    resolve_review_selection, resolve_review_stream_mode, resolve_review_thinking,
+    resolve_review_tier_name, review_scope_allows_auto_discovery,
+    validate_review_direct_tool_tier_restriction, verify_review_skill_available,
 };
 use result_handling::resolve_single_review_result;
 #[rustfmt::skip]
@@ -300,8 +300,10 @@ pub(crate) async fn handle_review(
         tool.as_str(),
     );
 
-    let readonly_project_root =
-        resolve_review_readonly_project_root(args.fix, global_config.review.readonly_sandbox);
+    let readonly_project_root = resolve_review_readonly_project_root(
+        args.fix,
+        resolve_review_readonly_configured(config.as_ref(), &global_config),
+    );
 
     let reviewer_selection = resolve_effective_reviewer_selection_for_args(
         &args,

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -300,7 +300,8 @@ pub(crate) async fn handle_review(
         tool.as_str(),
     );
 
-    let readonly_project_root = global_config.review.readonly_sandbox.unwrap_or(false);
+    let readonly_project_root =
+        resolve_review_readonly_project_root(args.fix, global_config.review.readonly_sandbox);
 
     let reviewer_selection = resolve_effective_reviewer_selection_for_args(
         &args,
@@ -604,6 +605,14 @@ pub(crate) async fn handle_review(
         startup_env,
     })
     .await
+}
+
+fn resolve_review_readonly_project_root(fix: bool, configured: Option<bool>) -> bool {
+    if fix {
+        false
+    } else {
+        configured.unwrap_or(true)
+    }
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -169,6 +169,16 @@ pub(crate) fn resolve_review_thinking(
     })
 }
 
+pub(crate) fn resolve_review_readonly_configured(
+    project_config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+) -> Option<bool> {
+    project_config
+        .and_then(|c| c.review.as_ref())
+        .and_then(|r| r.readonly_sandbox)
+        .or(global_config.review.readonly_sandbox)
+}
+
 fn resolve_review_tool_from_selection(
     selection: &csa_config::ToolSelection,
     parent_tool: Option<&str>,

--- a/crates/cli-sub-agent/src/review_cmd_tests_barrel.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_barrel.rs
@@ -25,3 +25,76 @@ fn review_fix_forces_writable_project_root() {
     assert!(!resolve_review_readonly_project_root(true, Some(true)));
     assert!(!resolve_review_readonly_project_root(true, Some(false)));
 }
+
+fn project_config_with_review_readonly(readonly_sandbox: Option<bool>) -> ProjectConfig {
+    let mut config = project_config_with_enabled_tools(&["codex"]);
+    config.review = Some(csa_config::global::ReviewConfig {
+        readonly_sandbox,
+        ..Default::default()
+    });
+    config
+}
+
+#[test]
+fn review_readonly_configured_prefers_project_over_global() {
+    let mut global = GlobalConfig::default();
+    global.review.readonly_sandbox = Some(false);
+    let project = project_config_with_review_readonly(Some(true));
+    assert_eq!(
+        resolve_review_readonly_configured(Some(&project), &global),
+        Some(true)
+    );
+    assert!(resolve_review_readonly_project_root(
+        false,
+        resolve_review_readonly_configured(Some(&project), &global)
+    ));
+
+    let mut global = GlobalConfig::default();
+    global.review.readonly_sandbox = Some(true);
+    let project = project_config_with_review_readonly(Some(false));
+    assert_eq!(
+        resolve_review_readonly_configured(Some(&project), &global),
+        Some(false)
+    );
+    assert!(!resolve_review_readonly_project_root(
+        false,
+        resolve_review_readonly_configured(Some(&project), &global)
+    ));
+
+    let global = GlobalConfig::default();
+    let project = project_config_with_review_readonly(Some(false));
+    assert_eq!(
+        resolve_review_readonly_configured(Some(&project), &global),
+        Some(false)
+    );
+    assert!(!resolve_review_readonly_project_root(
+        false,
+        resolve_review_readonly_configured(Some(&project), &global)
+    ));
+}
+
+#[test]
+fn review_readonly_configured_falls_back_to_global_when_project_unset() {
+    let project = project_config_with_review_readonly(None);
+
+    let mut global = GlobalConfig::default();
+    global.review.readonly_sandbox = Some(true);
+    assert_eq!(
+        resolve_review_readonly_configured(Some(&project), &global),
+        Some(true)
+    );
+    assert!(resolve_review_readonly_project_root(
+        false,
+        resolve_review_readonly_configured(Some(&project), &global)
+    ));
+
+    global.review.readonly_sandbox = Some(false);
+    assert_eq!(
+        resolve_review_readonly_configured(Some(&project), &global),
+        Some(false)
+    );
+    assert!(!resolve_review_readonly_project_root(
+        false,
+        resolve_review_readonly_configured(Some(&project), &global)
+    ));
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_barrel.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_barrel.rs
@@ -11,3 +11,17 @@ mod safety_preamble_tests;
 mod tests_full_consistency;
 #[path = "review_cmd_timeout_tests.rs"]
 mod timeout_tests;
+
+#[test]
+fn review_readonly_project_root_defaults_to_readonly_without_fix() {
+    assert!(resolve_review_readonly_project_root(false, None));
+    assert!(resolve_review_readonly_project_root(false, Some(true)));
+    assert!(!resolve_review_readonly_project_root(false, Some(false)));
+}
+
+#[test]
+fn review_fix_forces_writable_project_root() {
+    assert!(!resolve_review_readonly_project_root(true, None));
+    assert!(!resolve_review_readonly_project_root(true, Some(true)));
+    assert!(!resolve_review_readonly_project_root(true, Some(false)));
+}

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -261,8 +261,12 @@ async fn handle_run_fails_fast_when_worktree_write_lock_is_held() {
     }
     let config = run_config_with_tier("default", vec!["codex/openai/o4-mini/high"], &["codex"]);
     write_project_config(project_dir.path(), &config);
-    let _holder = csa_lock::acquire_worktree_write_lock(project_dir.path(), "01HOLDER", &[])
-        .expect("holder worktree write lock should succeed");
+    let holder =
+        csa_session::create_session(project_dir.path(), Some("holder"), None, Some("codex"))
+            .unwrap();
+    let _holder_lock =
+        csa_lock::acquire_worktree_write_lock(project_dir.path(), &holder.meta_session_id, &[])
+            .expect("holder worktree write lock should succeed");
 
     let err = handle_run(
         Some(ToolArg::Specific(ToolName::Codex)),
@@ -324,7 +328,10 @@ async fn handle_run_fails_fast_when_worktree_write_lock_is_held() {
         err.contains("concurrent write session blocked"),
         "unexpected error: {err}"
     );
-    assert!(err.contains("01HOLDER"), "missing holder session id: {err}");
+    assert!(
+        err.contains(&holder.meta_session_id),
+        "missing holder session id: {err}"
+    );
     assert!(
         err.contains(&project_dir.path().display().to_string()),
         "missing worktree path: {err}"

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -264,9 +264,13 @@ async fn handle_run_fails_fast_when_worktree_write_lock_is_held() {
     let holder =
         csa_session::create_session(project_dir.path(), Some("holder"), None, Some("codex"))
             .unwrap();
-    let _holder_lock =
-        csa_lock::acquire_worktree_write_lock(project_dir.path(), &holder.meta_session_id, &[])
-            .expect("holder worktree write lock should succeed");
+    let _holder_lock = csa_lock::acquire_worktree_write_lock(
+        project_dir.path(),
+        &holder.meta_session_id,
+        &[],
+        |_| false,
+    )
+    .expect("holder worktree write lock should succeed");
 
     let err = handle_run(
         Some(ToolArg::Specific(ToolName::Codex)),

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -377,9 +377,7 @@ pub struct ReviewConfig {
         skip_serializing_if = "is_default_gate_timeout"
     )]
     pub gate_timeout_secs: u64,
-    /// When true, enforce filesystem-level read-only access to the project root
-    /// during review sessions. This prevents the review tool from writing files
-    /// even if instructed to. Default: false (allows resume-to-fix workflow).
+    /// Standard review is read-only by default; `csa review --fix` stays writable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub readonly_sandbox: Option<bool>,
 }

--- a/crates/csa-lock/Cargo.toml
+++ b/crates/csa-lock/Cargo.toml
@@ -13,6 +13,7 @@ serde_json.workspace = true
 chrono.workspace = true
 sha2.workspace = true
 directories.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -12,7 +12,10 @@
 pub mod slot;
 mod worktree;
 
-pub use worktree::{WorktreeWriteLock, acquire_worktree_write_lock};
+pub use worktree::{
+    HolderSessionLiveness, WorktreeWriteLock, acquire_worktree_write_lock,
+    acquire_worktree_write_lock_with_liveness,
+};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -26,14 +29,14 @@ use std::path::{Path, PathBuf};
 /// Diagnostic information written to lock files
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct LockDiagnostic {
-    pid: u32,
+    pub(crate) pid: u32,
     tool_name: String,
-    acquired_at: DateTime<Utc>,
+    pub(crate) acquired_at: DateTime<Utc>,
     reason: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) holder_session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    resource_path: Option<String>,
+    pub(crate) resource_path: Option<String>,
 }
 
 /// Session lock guard backed by `flock(2)`.

--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -12,10 +12,7 @@
 pub mod slot;
 mod worktree;
 
-pub use worktree::{
-    HolderSessionLiveness, WorktreeWriteLock, acquire_worktree_write_lock,
-    acquire_worktree_write_lock_with_liveness,
-};
+pub use worktree::{WorktreeWriteLock, acquire_worktree_write_lock};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -30,6 +27,8 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct LockDiagnostic {
     pub(crate) pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) pid_start_time_ticks: Option<u64>,
     tool_name: String,
     pub(crate) acquired_at: DateTime<Utc>,
     reason: String,
@@ -142,6 +141,7 @@ pub(crate) fn acquire_lock_at_path_with_metadata(
 
         let diagnostic = LockDiagnostic {
             pid: std::process::id(),
+            pid_start_time_ticks: process_start_time_ticks(std::process::id()),
             tool_name: lock_name.to_string(),
             acquired_at: Utc::now(),
             reason: reason.to_string(),
@@ -178,6 +178,18 @@ pub(crate) fn acquire_lock_at_path_with_metadata(
 
         Err(anyhow::anyhow!(error_msg))
     }
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn process_start_time_ticks(pid: u32) -> Option<u64> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_comm = stat.rsplit_once(") ")?.1;
+    after_comm.split_whitespace().nth(19)?.parse().ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn process_start_time_ticks(_pid: u32) -> Option<u64> {
+    None
 }
 
 fn format_lock_diagnostic(diagnostic: &LockDiagnostic) -> String {

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -124,8 +124,10 @@ impl Drop for WorktreeWriteLock {
 pub enum HolderSessionLiveness {
     /// The holder session is still running or otherwise registered as live.
     Live,
-    /// The holder session is completed, retired, or not registered.
+    /// The holder session is positively known to be completed or retired.
     Dead,
+    /// The holder session was not found in the registry; diagnostic PID proof is still required.
+    RegistryAbsent,
     /// The caller could not determine holder-session state.
     Unknown,
 }
@@ -136,9 +138,14 @@ impl HolderSessionLiveness {
         Self::Live
     }
 
-    /// Construct a dead holder-session state for external liveness callbacks.
+    /// Construct a positively dead holder-session state for external liveness callbacks.
     pub const fn dead() -> Self {
         Self::Dead
+    }
+
+    /// Construct a registry-absent holder-session state for external liveness callbacks.
+    pub const fn registry_absent() -> Self {
+        Self::RegistryAbsent
     }
 
     /// Construct an unknown holder-session state for external liveness callbacks.
@@ -363,12 +370,19 @@ fn stale_holder_can_be_reclaimed(
 ) -> bool {
     match holder_session_liveness(holder_session_id) {
         HolderSessionLiveness::Live | HolderSessionLiveness::Unknown => return false,
+        HolderSessionLiveness::RegistryAbsent => {
+            return matches!(
+                process_probe_state(diagnostic.pid),
+                ProcessProbeState::Missing
+            );
+        }
         HolderSessionLiveness::Dead => {}
     }
 
-    // A signalable PID alone is not proof that it is still the holder: PIDs can
-    // be reused after the CSA session dies. EPERM or probe failure stays
-    // conservative because we cannot inspect enough to rule out the holder.
+    // Loaded terminal session state is stronger than a signalable diagnostic
+    // PID because the numeric PID may have been reused after the CSA holder
+    // exited. EPERM or probe failure stays conservative because we cannot
+    // inspect enough to rule out the holder.
     !matches!(
         process_probe_state(diagnostic.pid),
         ProcessProbeState::PermissionDenied | ProcessProbeState::Unknown
@@ -420,217 +434,5 @@ fn stale_lock_path(lock_path: &Path, acquired_at: DateTime<Utc>) -> PathBuf {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::LockDiagnostic;
-    use chrono::Utc;
-    use std::ffi::OsString;
-    use std::fs;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-    use tempfile::tempdir;
-
-    fn env_test_lock() -> MutexGuard<'static, ()> {
-        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        ENV_LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-
-    struct EnvVarGuard {
-        key: &'static str,
-        original: Option<OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set_os(key: &'static str, value: &Path) -> Self {
-            let original = std::env::var_os(key);
-            // SAFETY: test-scoped env mutation is isolated to the current test.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, original }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match self.original.take() {
-                // SAFETY: test-scoped env restoration is isolated to the current test.
-                Some(value) => unsafe { std::env::set_var(self.key, value) },
-                // SAFETY: test-scoped env restoration is isolated to the current test.
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
-    }
-
-    #[test]
-    fn test_worktree_write_lock_conflicts_for_same_worktree_root() {
-        let _env_lock = env_test_lock();
-        let state_home = tempdir().expect("state-home tempdir");
-        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
-
-        let worktree_root = tempdir().expect("worktree tempdir");
-        let _lock1 = acquire_worktree_write_lock(worktree_root.path(), "01PARENT", &[])
-            .expect("first worktree write lock should succeed");
-
-        let err = acquire_worktree_write_lock(worktree_root.path(), "01OTHER", &[])
-            .expect_err("non-lineage writer should fail fast")
-            .to_string();
-
-        assert!(err.contains("01PARENT"), "missing holder session id: {err}");
-        assert!(
-            err.contains(&worktree_root.path().display().to_string()),
-            "missing worktree path: {err}"
-        );
-        assert!(
-            err.contains("sequentially"),
-            "missing serialize guidance: {err}"
-        );
-    }
-
-    #[test]
-    fn test_worktree_write_lock_allows_lineage_reentry() {
-        let _env_lock = env_test_lock();
-        let state_home = tempdir().expect("state-home tempdir");
-        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
-
-        let worktree_root = tempdir().expect("worktree tempdir");
-        let _parent = acquire_worktree_write_lock(worktree_root.path(), "01PARENT", &[])
-            .expect("parent worktree write lock should succeed");
-
-        let child =
-            acquire_worktree_write_lock(worktree_root.path(), "01CHILD", &["01PARENT".to_string()])
-                .expect("child should re-enter under ancestor lock");
-
-        assert!(child.is_lineage_reentry());
-        assert_eq!(child.holder_session_id(), Some("01PARENT"));
-    }
-
-    #[test]
-    fn test_worktree_write_lock_allows_different_worktree_roots() {
-        let _env_lock = env_test_lock();
-        let state_home = tempdir().expect("state-home tempdir");
-        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
-
-        let worktree_a = tempdir().expect("worktree a tempdir");
-        let worktree_b = tempdir().expect("worktree b tempdir");
-
-        let lock_a = acquire_worktree_write_lock(worktree_a.path(), "01A", &[]);
-        let lock_b = acquire_worktree_write_lock(worktree_b.path(), "01B", &[]);
-
-        assert!(lock_a.is_ok());
-        assert!(lock_b.is_ok());
-    }
-
-    #[test]
-    fn worktree_write_lock_removes_lock_file_on_drop() {
-        let _env_lock = env_test_lock();
-        let state_home = tempdir().expect("state-home tempdir");
-        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
-
-        let worktree_root = tempdir().expect("worktree tempdir");
-        let lock = acquire_worktree_write_lock(worktree_root.path(), "01OWNER", &[])
-            .expect("worktree write lock should succeed");
-        let lock_path = lock.lock_path().to_path_buf();
-        assert!(lock_path.exists(), "lock file should exist while held");
-
-        drop(lock);
-
-        assert!(
-            !lock_path.exists(),
-            "owned worktree lock file should be removed when guard drops"
-        );
-        acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
-            .expect("next writer should acquire after guard drop");
-    }
-
-    #[test]
-    fn worktree_write_lock_reclaims_dead_holder_lock() {
-        let _env_lock = env_test_lock();
-        let state_home = tempdir().expect("state-home tempdir");
-        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
-
-        let worktree_root = tempdir().expect("worktree tempdir");
-        let holder = acquire_worktree_write_lock(worktree_root.path(), "01DEAD", &[])
-            .expect("holder lock should succeed");
-        overwrite_worktree_lock_diagnostic(
-            holder.lock_path(),
-            4_000_000,
-            "01DEAD",
-            worktree_root.path(),
-        );
-
-        let lock =
-            acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
-                HolderSessionLiveness::Dead
-            })
-            .expect("dead holder lock should be reclaimed");
-
-        assert!(!lock.is_lineage_reentry());
-        drop(holder);
-        drop(lock);
-    }
-
-    #[test]
-    fn worktree_write_lock_keeps_live_holder_blocked() {
-        let _env_lock = env_test_lock();
-        let state_home = tempdir().expect("state-home tempdir");
-        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
-
-        let worktree_root = tempdir().expect("worktree tempdir");
-        let _holder = acquire_worktree_write_lock(worktree_root.path(), "01LIVE", &[])
-            .expect("holder lock should succeed");
-
-        let err =
-            acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
-                HolderSessionLiveness::Live
-            })
-            .expect_err("live holder must still block")
-            .to_string();
-
-        assert!(err.contains("concurrent write session blocked"));
-        assert!(err.contains("01LIVE"));
-    }
-
-    #[test]
-    fn worktree_write_lock_reclaims_dead_session_with_reused_pid() {
-        let _env_lock = env_test_lock();
-        let state_home = tempdir().expect("state-home tempdir");
-        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
-
-        let worktree_root = tempdir().expect("worktree tempdir");
-        let holder = acquire_worktree_write_lock(worktree_root.path(), "01REUSED", &[])
-            .expect("holder lock should succeed");
-        overwrite_worktree_lock_diagnostic(
-            holder.lock_path(),
-            std::process::id(),
-            "01REUSED",
-            worktree_root.path(),
-        );
-
-        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
-            HolderSessionLiveness::Dead
-        })
-        .expect("dead session id should authorize reclaim despite a signalable reused pid");
-    }
-
-    fn overwrite_worktree_lock_diagnostic(
-        lock_path: &Path,
-        pid: u32,
-        session_id: &str,
-        worktree_root: &Path,
-    ) {
-        let diagnostic = LockDiagnostic {
-            pid,
-            tool_name: "worktree-write:exclusive".to_string(),
-            acquired_at: Utc::now(),
-            reason: format!(
-                "write session {session_id} holds worktree {}",
-                worktree_root.display()
-            ),
-            holder_session_id: Some(session_id.to_string()),
-            resource_path: Some(worktree_root.display().to_string()),
-        };
-        fs::write(lock_path, serde_json::to_string(&diagnostic).unwrap())
-            .expect("overwrite lock diagnostic");
-    }
-}
+#[path = "worktree_tests.rs"]
+mod tests;

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -2,7 +2,10 @@ use crate::{
     SessionLock, acquire_lock_at_path_with_metadata, project_resource_lock_path,
     read_lock_diagnostic,
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 /// Guard for a write-capable CSA session sharing one git worktree.
@@ -16,8 +19,13 @@ pub struct WorktreeWriteLock {
 }
 
 enum WorktreeWriteLockKind {
-    Acquired { _lock: SessionLock },
-    LineageReentry { holder_session_id: String },
+    Acquired {
+        _lock: SessionLock,
+        owner_session_id: String,
+    },
+    LineageReentry {
+        holder_session_id: String,
+    },
 }
 
 impl std::fmt::Debug for WorktreeWriteLock {
@@ -60,6 +68,85 @@ impl WorktreeWriteLock {
     }
 }
 
+impl Drop for WorktreeWriteLock {
+    fn drop(&mut self) {
+        let WorktreeWriteLockKind::Acquired {
+            owner_session_id, ..
+        } = &self.inner
+        else {
+            return;
+        };
+
+        match read_lock_diagnostic(&self.lock_path) {
+            Ok(Some(diagnostic))
+                if diagnostic.holder_session_id.as_deref() == Some(owner_session_id.as_str()) =>
+            {
+                // Remove while the fd-level flock is still held so this drop
+                // cannot remove a successor's freshly-created lock file.
+                match fs::remove_file(&self.lock_path) {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == ErrorKind::NotFound => {}
+                    Err(err) => tracing::warn!(
+                        lock_path = %self.lock_path.display(),
+                        owner_session_id,
+                        error = %err,
+                        "failed to remove worktree write lock file on drop"
+                    ),
+                }
+            }
+            Ok(Some(diagnostic)) => tracing::warn!(
+                lock_path = %self.lock_path.display(),
+                owner_session_id,
+                current_holder = diagnostic.holder_session_id.as_deref().unwrap_or("unknown"),
+                "skipping worktree write lock removal because lock file holder changed"
+            ),
+            Ok(None) => tracing::warn!(
+                lock_path = %self.lock_path.display(),
+                owner_session_id,
+                "skipping worktree write lock removal because diagnostic is unreadable"
+            ),
+            Err(err) => {
+                if self.lock_path.exists() {
+                    tracing::warn!(
+                        lock_path = %self.lock_path.display(),
+                        owner_session_id,
+                        error = %err,
+                        "skipping worktree write lock removal after diagnostic read failure"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Session-registry liveness for the holder recorded in a worktree lock file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HolderSessionLiveness {
+    /// The holder session is still running or otherwise registered as live.
+    Live,
+    /// The holder session is completed, retired, or not registered.
+    Dead,
+    /// The caller could not determine holder-session state.
+    Unknown,
+}
+
+impl HolderSessionLiveness {
+    /// Construct a live holder-session state for external liveness callbacks.
+    pub const fn live() -> Self {
+        Self::Live
+    }
+
+    /// Construct a dead holder-session state for external liveness callbacks.
+    pub const fn dead() -> Self {
+        Self::Dead
+    }
+
+    /// Construct an unknown holder-session state for external liveness callbacks.
+    pub const fn unknown() -> Self {
+        Self::Unknown
+    }
+}
+
 /// Acquire a fail-fast exclusive write lock for a canonical git worktree root.
 ///
 /// Lock path:
@@ -72,6 +159,22 @@ pub fn acquire_worktree_write_lock(
     worktree_root: &Path,
     session_id: &str,
     ancestor_session_ids: &[String],
+) -> Result<WorktreeWriteLock> {
+    acquire_worktree_write_lock_with_liveness(
+        worktree_root,
+        session_id,
+        ancestor_session_ids,
+        |_| HolderSessionLiveness::unknown(),
+    )
+}
+
+/// Acquire a worktree write lock, reclaiming a stale lock only when the holder
+/// session is known dead by the caller-provided registry check.
+pub fn acquire_worktree_write_lock_with_liveness(
+    worktree_root: &Path,
+    session_id: &str,
+    ancestor_session_ids: &[String],
+    holder_session_liveness: impl FnMut(&str) -> HolderSessionLiveness,
 ) -> Result<WorktreeWriteLock> {
     let session_id = session_id.trim();
     if session_id.is_empty() {
@@ -93,7 +196,10 @@ pub fn acquire_worktree_write_lock(
         Some(&canonical_root),
     ) {
         Ok(lock) => Ok(WorktreeWriteLock {
-            inner: WorktreeWriteLockKind::Acquired { _lock: lock },
+            inner: WorktreeWriteLockKind::Acquired {
+                _lock: lock,
+                owner_session_id: session_id.to_string(),
+            },
             lock_path,
         }),
         Err(lock_error) => {
@@ -108,6 +214,24 @@ pub fn acquire_worktree_write_lock(
                 return Ok(WorktreeWriteLock {
                     inner: WorktreeWriteLockKind::LineageReentry {
                         holder_session_id: holder_session_id.clone(),
+                    },
+                    lock_path,
+                });
+            }
+
+            if let Some(lock) = try_reclaim_stale_worktree_lock(
+                &lock_path,
+                &lock_name,
+                &reason,
+                session_id,
+                &canonical_root,
+                diagnostic.as_ref(),
+                holder_session_liveness,
+            )? {
+                return Ok(WorktreeWriteLock {
+                    inner: WorktreeWriteLockKind::Acquired {
+                        _lock: lock,
+                        owner_session_id: session_id.to_string(),
                     },
                     lock_path,
                 });
@@ -129,10 +253,179 @@ pub fn acquire_worktree_write_lock(
     }
 }
 
+fn try_reclaim_stale_worktree_lock(
+    lock_path: &Path,
+    lock_name: &str,
+    reason: &str,
+    session_id: &str,
+    canonical_root: &Path,
+    diagnostic: Option<&crate::LockDiagnostic>,
+    mut holder_session_liveness: impl FnMut(&str) -> HolderSessionLiveness,
+) -> Result<Option<SessionLock>> {
+    let Some(diagnostic) = diagnostic else {
+        return Ok(None);
+    };
+    let Some(holder_session_id) = diagnostic.holder_session_id.as_deref() else {
+        return Ok(None);
+    };
+
+    if !stale_holder_can_be_reclaimed(diagnostic, holder_session_id, &mut holder_session_liveness) {
+        return Ok(None);
+    }
+
+    let reclaim_lock_path = lock_path.with_file_name(".reclaim.lock");
+    let _reclaim_guard = match acquire_lock_at_path_with_metadata(
+        &reclaim_lock_path,
+        "worktree-write:reclaim",
+        "serialize stale worktree lock reclaim",
+        Some(session_id),
+        Some(canonical_root),
+    ) {
+        Ok(guard) => guard,
+        Err(err) => {
+            tracing::warn!(
+                lock_path = %lock_path.display(),
+                holder_session_id,
+                error = %err,
+                "failed to acquire worktree stale-lock reclaim guard; keeping existing lock"
+            );
+            return Ok(None);
+        }
+    };
+
+    let current = read_lock_diagnostic(lock_path)?;
+    let Some(current) = current else {
+        return Ok(None);
+    };
+    if !same_lock_holder(&current, diagnostic) {
+        return Ok(None);
+    }
+
+    let stale_path = stale_lock_path(lock_path, diagnostic.acquired_at);
+    fs::rename(lock_path, &stale_path).with_context(|| {
+        format!(
+            "failed to atomically move stale worktree lock '{}' aside",
+            lock_path.display()
+        )
+    })?;
+
+    tracing::warn!(
+        lock_path = %lock_path.display(),
+        stale_path = %stale_path.display(),
+        old_holder_pid = diagnostic.pid,
+        old_holder_session_id = holder_session_id,
+        old_acquired_at = %diagnostic.acquired_at,
+        "reclaimed stale worktree write lock"
+    );
+
+    let lock = match acquire_lock_at_path_with_metadata(
+        lock_path,
+        lock_name,
+        reason,
+        Some(session_id),
+        Some(canonical_root),
+    ) {
+        Ok(lock) => lock,
+        Err(err) => {
+            if let Err(restore_err) = fs::rename(&stale_path, lock_path)
+                && restore_err.kind() != ErrorKind::NotFound
+            {
+                tracing::warn!(
+                    lock_path = %lock_path.display(),
+                    stale_path = %stale_path.display(),
+                    error = %restore_err,
+                    "failed to restore stale worktree lock after reclaim acquisition error"
+                );
+            }
+            return Err(err).with_context(|| {
+                format!(
+                    "failed to acquire worktree write lock after reclaiming stale holder {holder_session_id}"
+                )
+            });
+        }
+    };
+    if let Err(err) = fs::remove_file(&stale_path)
+        && err.kind() != ErrorKind::NotFound
+    {
+        tracing::warn!(
+            stale_path = %stale_path.display(),
+            error = %err,
+            "failed to remove reclaimed stale worktree lock artifact"
+        );
+    }
+    Ok(Some(lock))
+}
+
+fn stale_holder_can_be_reclaimed(
+    diagnostic: &crate::LockDiagnostic,
+    holder_session_id: &str,
+    holder_session_liveness: &mut impl FnMut(&str) -> HolderSessionLiveness,
+) -> bool {
+    match holder_session_liveness(holder_session_id) {
+        HolderSessionLiveness::Live | HolderSessionLiveness::Unknown => return false,
+        HolderSessionLiveness::Dead => {}
+    }
+
+    // A signalable PID alone is not proof that it is still the holder: PIDs can
+    // be reused after the CSA session dies. EPERM or probe failure stays
+    // conservative because we cannot inspect enough to rule out the holder.
+    !matches!(
+        process_probe_state(diagnostic.pid),
+        ProcessProbeState::PermissionDenied | ProcessProbeState::Unknown
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessProbeState {
+    Missing,
+    Signalable,
+    PermissionDenied,
+    Unknown,
+}
+
+fn process_probe_state(pid: u32) -> ProcessProbeState {
+    #[cfg(unix)]
+    {
+        // SAFETY: signal 0 checks process existence without sending a signal.
+        let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if ret == 0 {
+            return ProcessProbeState::Signalable;
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ESRCH) => ProcessProbeState::Missing,
+            Some(libc::EPERM) => ProcessProbeState::PermissionDenied,
+            _ => ProcessProbeState::Unknown,
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        ProcessProbeState::Unknown
+    }
+}
+
+fn same_lock_holder(left: &crate::LockDiagnostic, right: &crate::LockDiagnostic) -> bool {
+    left.pid == right.pid
+        && left.holder_session_id == right.holder_session_id
+        && left.acquired_at == right.acquired_at
+        && left.resource_path == right.resource_path
+}
+
+fn stale_lock_path(lock_path: &Path, acquired_at: DateTime<Utc>) -> PathBuf {
+    let suffix = acquired_at
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| Utc::now().timestamp_nanos_opt().unwrap_or_default());
+    lock_path.with_file_name(format!(".exclusive.stale.{suffix}.lock"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::LockDiagnostic;
+    use chrono::Utc;
     use std::ffi::OsString;
+    use std::fs;
     use std::sync::{Mutex, MutexGuard, OnceLock};
     use tempfile::tempdir;
 
@@ -226,5 +519,118 @@ mod tests {
 
         assert!(lock_a.is_ok());
         assert!(lock_b.is_ok());
+    }
+
+    #[test]
+    fn worktree_write_lock_removes_lock_file_on_drop() {
+        let _env_lock = env_test_lock();
+        let state_home = tempdir().expect("state-home tempdir");
+        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+        let worktree_root = tempdir().expect("worktree tempdir");
+        let lock = acquire_worktree_write_lock(worktree_root.path(), "01OWNER", &[])
+            .expect("worktree write lock should succeed");
+        let lock_path = lock.lock_path().to_path_buf();
+        assert!(lock_path.exists(), "lock file should exist while held");
+
+        drop(lock);
+
+        assert!(
+            !lock_path.exists(),
+            "owned worktree lock file should be removed when guard drops"
+        );
+        acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
+            .expect("next writer should acquire after guard drop");
+    }
+
+    #[test]
+    fn worktree_write_lock_reclaims_dead_holder_lock() {
+        let _env_lock = env_test_lock();
+        let state_home = tempdir().expect("state-home tempdir");
+        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+        let worktree_root = tempdir().expect("worktree tempdir");
+        let holder = acquire_worktree_write_lock(worktree_root.path(), "01DEAD", &[])
+            .expect("holder lock should succeed");
+        overwrite_worktree_lock_diagnostic(
+            holder.lock_path(),
+            4_000_000,
+            "01DEAD",
+            worktree_root.path(),
+        );
+
+        let lock =
+            acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
+                HolderSessionLiveness::Dead
+            })
+            .expect("dead holder lock should be reclaimed");
+
+        assert!(!lock.is_lineage_reentry());
+        drop(holder);
+        drop(lock);
+    }
+
+    #[test]
+    fn worktree_write_lock_keeps_live_holder_blocked() {
+        let _env_lock = env_test_lock();
+        let state_home = tempdir().expect("state-home tempdir");
+        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+        let worktree_root = tempdir().expect("worktree tempdir");
+        let _holder = acquire_worktree_write_lock(worktree_root.path(), "01LIVE", &[])
+            .expect("holder lock should succeed");
+
+        let err =
+            acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
+                HolderSessionLiveness::Live
+            })
+            .expect_err("live holder must still block")
+            .to_string();
+
+        assert!(err.contains("concurrent write session blocked"));
+        assert!(err.contains("01LIVE"));
+    }
+
+    #[test]
+    fn worktree_write_lock_reclaims_dead_session_with_reused_pid() {
+        let _env_lock = env_test_lock();
+        let state_home = tempdir().expect("state-home tempdir");
+        let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+        let worktree_root = tempdir().expect("worktree tempdir");
+        let holder = acquire_worktree_write_lock(worktree_root.path(), "01REUSED", &[])
+            .expect("holder lock should succeed");
+        overwrite_worktree_lock_diagnostic(
+            holder.lock_path(),
+            std::process::id(),
+            "01REUSED",
+            worktree_root.path(),
+        );
+
+        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
+            HolderSessionLiveness::Dead
+        })
+        .expect("dead session id should authorize reclaim despite a signalable reused pid");
+    }
+
+    fn overwrite_worktree_lock_diagnostic(
+        lock_path: &Path,
+        pid: u32,
+        session_id: &str,
+        worktree_root: &Path,
+    ) {
+        let diagnostic = LockDiagnostic {
+            pid,
+            tool_name: "worktree-write:exclusive".to_string(),
+            acquired_at: Utc::now(),
+            reason: format!(
+                "write session {session_id} holds worktree {}",
+                worktree_root.display()
+            ),
+            holder_session_id: Some(session_id.to_string()),
+            resource_path: Some(worktree_root.display().to_string()),
+        };
+        fs::write(lock_path, serde_json::to_string(&diagnostic).unwrap())
+            .expect("overwrite lock diagnostic");
     }
 }

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -2,10 +2,11 @@ use crate::{
     SessionLock, acquire_lock_at_path_with_metadata, project_resource_lock_path,
     read_lock_diagnostic,
 };
-use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
+use anyhow::Result;
 use std::fs;
 use std::io::ErrorKind;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 /// Guard for a write-capable CSA session sharing one git worktree.
@@ -119,41 +120,6 @@ impl Drop for WorktreeWriteLock {
     }
 }
 
-/// Session-registry liveness for the holder recorded in a worktree lock file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HolderSessionLiveness {
-    /// The holder session is still running or otherwise registered as live.
-    Live,
-    /// The holder session is positively known to be completed or retired.
-    Dead,
-    /// The holder session was not found in the registry; diagnostic PID proof is still required.
-    RegistryAbsent,
-    /// The caller could not determine holder-session state.
-    Unknown,
-}
-
-impl HolderSessionLiveness {
-    /// Construct a live holder-session state for external liveness callbacks.
-    pub const fn live() -> Self {
-        Self::Live
-    }
-
-    /// Construct a positively dead holder-session state for external liveness callbacks.
-    pub const fn dead() -> Self {
-        Self::Dead
-    }
-
-    /// Construct a registry-absent holder-session state for external liveness callbacks.
-    pub const fn registry_absent() -> Self {
-        Self::RegistryAbsent
-    }
-
-    /// Construct an unknown holder-session state for external liveness callbacks.
-    pub const fn unknown() -> Self {
-        Self::Unknown
-    }
-}
-
 /// Acquire a fail-fast exclusive write lock for a canonical git worktree root.
 ///
 /// Lock path:
@@ -166,22 +132,6 @@ pub fn acquire_worktree_write_lock(
     worktree_root: &Path,
     session_id: &str,
     ancestor_session_ids: &[String],
-) -> Result<WorktreeWriteLock> {
-    acquire_worktree_write_lock_with_liveness(
-        worktree_root,
-        session_id,
-        ancestor_session_ids,
-        |_| HolderSessionLiveness::unknown(),
-    )
-}
-
-/// Acquire a worktree write lock, reclaiming a stale lock only when the holder
-/// session is known dead by the caller-provided registry check.
-pub fn acquire_worktree_write_lock_with_liveness(
-    worktree_root: &Path,
-    session_id: &str,
-    ancestor_session_ids: &[String],
-    holder_session_liveness: impl FnMut(&str) -> HolderSessionLiveness,
 ) -> Result<WorktreeWriteLock> {
     let session_id = session_id.trim();
     if session_id.is_empty() {
@@ -217,28 +167,13 @@ pub fn acquire_worktree_write_lock_with_liveness(
                 && ancestor_session_ids
                     .iter()
                     .any(|ancestor| ancestor == holder_session_id)
+                && diagnostic
+                    .as_ref()
+                    .is_some_and(|diag| diagnostic_matches_current_flock_owner(&lock_path, diag))
             {
                 return Ok(WorktreeWriteLock {
                     inner: WorktreeWriteLockKind::LineageReentry {
                         holder_session_id: holder_session_id.clone(),
-                    },
-                    lock_path,
-                });
-            }
-
-            if let Some(lock) = try_reclaim_stale_worktree_lock(
-                &lock_path,
-                &lock_name,
-                &reason,
-                session_id,
-                &canonical_root,
-                diagnostic.as_ref(),
-                holder_session_liveness,
-            )? {
-                return Ok(WorktreeWriteLock {
-                    inner: WorktreeWriteLockKind::Acquired {
-                        _lock: lock,
-                        owner_session_id: session_id.to_string(),
                     },
                     lock_path,
                 });
@@ -260,167 +195,73 @@ pub fn acquire_worktree_write_lock_with_liveness(
     }
 }
 
-fn try_reclaim_stale_worktree_lock(
+fn diagnostic_matches_current_flock_owner(
     lock_path: &Path,
-    lock_name: &str,
-    reason: &str,
-    session_id: &str,
-    canonical_root: &Path,
-    diagnostic: Option<&crate::LockDiagnostic>,
-    mut holder_session_liveness: impl FnMut(&str) -> HolderSessionLiveness,
-) -> Result<Option<SessionLock>> {
-    let Some(diagnostic) = diagnostic else {
-        return Ok(None);
-    };
-    let Some(holder_session_id) = diagnostic.holder_session_id.as_deref() else {
-        return Ok(None);
-    };
-
-    if !stale_holder_can_be_reclaimed(diagnostic, holder_session_id, &mut holder_session_liveness) {
-        return Ok(None);
-    }
-
-    let reclaim_lock_path = lock_path.with_file_name(".reclaim.lock");
-    let _reclaim_guard = match acquire_lock_at_path_with_metadata(
-        &reclaim_lock_path,
-        "worktree-write:reclaim",
-        "serialize stale worktree lock reclaim",
-        Some(session_id),
-        Some(canonical_root),
-    ) {
-        Ok(guard) => guard,
-        Err(err) => {
-            tracing::warn!(
-                lock_path = %lock_path.display(),
-                holder_session_id,
-                error = %err,
-                "failed to acquire worktree stale-lock reclaim guard; keeping existing lock"
-            );
-            return Ok(None);
-        }
-    };
-
-    let current = read_lock_diagnostic(lock_path)?;
-    let Some(current) = current else {
-        return Ok(None);
-    };
-    if !same_lock_holder(&current, diagnostic) {
-        return Ok(None);
-    }
-
-    let stale_path = stale_lock_path(lock_path, diagnostic.acquired_at);
-    fs::rename(lock_path, &stale_path).with_context(|| {
-        format!(
-            "failed to atomically move stale worktree lock '{}' aside",
-            lock_path.display()
-        )
-    })?;
-
-    tracing::warn!(
-        lock_path = %lock_path.display(),
-        stale_path = %stale_path.display(),
-        old_holder_pid = diagnostic.pid,
-        old_holder_session_id = holder_session_id,
-        old_acquired_at = %diagnostic.acquired_at,
-        "reclaimed stale worktree write lock"
-    );
-
-    let lock = match acquire_lock_at_path_with_metadata(
-        lock_path,
-        lock_name,
-        reason,
-        Some(session_id),
-        Some(canonical_root),
-    ) {
-        Ok(lock) => lock,
-        Err(err) => {
-            if let Err(restore_err) = fs::rename(&stale_path, lock_path)
-                && restore_err.kind() != ErrorKind::NotFound
-            {
-                tracing::warn!(
-                    lock_path = %lock_path.display(),
-                    stale_path = %stale_path.display(),
-                    error = %restore_err,
-                    "failed to restore stale worktree lock after reclaim acquisition error"
-                );
-            }
-            return Err(err).with_context(|| {
-                format!(
-                    "failed to acquire worktree write lock after reclaiming stale holder {holder_session_id}"
-                )
-            });
-        }
-    };
-    if let Err(err) = fs::remove_file(&stale_path)
-        && err.kind() != ErrorKind::NotFound
-    {
-        tracing::warn!(
-            stale_path = %stale_path.display(),
-            error = %err,
-            "failed to remove reclaimed stale worktree lock artifact"
-        );
-    }
-    Ok(Some(lock))
-}
-
-fn stale_holder_can_be_reclaimed(
     diagnostic: &crate::LockDiagnostic,
-    holder_session_id: &str,
-    holder_session_liveness: &mut impl FnMut(&str) -> HolderSessionLiveness,
 ) -> bool {
-    match holder_session_liveness(holder_session_id) {
-        HolderSessionLiveness::Dead | HolderSessionLiveness::RegistryAbsent => {
-            matches!(
-                process_probe_state(diagnostic.pid),
-                ProcessProbeState::Missing
-            )
-        }
-        HolderSessionLiveness::Live | HolderSessionLiveness::Unknown => false,
+    let Some(owner_pid) = current_flock_owner_pid(lock_path) else {
+        return false;
+    };
+    owner_pid == diagnostic.pid && diagnostic_process_identity_matches(diagnostic)
+}
+
+#[cfg(target_os = "linux")]
+fn current_flock_owner_pid(lock_path: &Path) -> Option<u32> {
+    let metadata = fs::metadata(lock_path).ok()?;
+    let (major, minor) = linux_dev_major_minor(metadata.dev());
+    let inode = metadata.ino();
+    fs::read_to_string("/proc/locks")
+        .ok()?
+        .lines()
+        .find_map(|line| proc_lock_owner_for_inode(line, major, minor, inode))
+}
+
+#[cfg(target_os = "linux")]
+fn proc_lock_owner_for_inode(line: &str, major: u64, minor: u64, inode: u64) -> Option<u32> {
+    let mut fields = line.split_whitespace();
+    let _id = fields.next()?;
+    if fields.next()? != "FLOCK" {
+        return None;
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ProcessProbeState {
-    Missing,
-    Signalable,
-    PermissionDenied,
-    Unknown,
-}
-
-fn process_probe_state(pid: u32) -> ProcessProbeState {
-    #[cfg(unix)]
-    {
-        // SAFETY: signal 0 checks process existence without sending a signal.
-        let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
-        if ret == 0 {
-            return ProcessProbeState::Signalable;
-        }
-        match std::io::Error::last_os_error().raw_os_error() {
-            Some(libc::ESRCH) => ProcessProbeState::Missing,
-            Some(libc::EPERM) => ProcessProbeState::PermissionDenied,
-            _ => ProcessProbeState::Unknown,
-        }
+    let _scope = fields.next()?;
+    if fields.next()? != "WRITE" {
+        return None;
     }
-
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        ProcessProbeState::Unknown
+    let pid = fields.next()?.parse::<u32>().ok()?;
+    let lock_id = fields.next()?;
+    let mut parts = lock_id.split(':');
+    let lock_major = u64::from_str_radix(parts.next()?, 16).ok()?;
+    let lock_minor = u64::from_str_radix(parts.next()?, 16).ok()?;
+    let lock_inode = parts.next()?.parse::<u64>().ok()?;
+    if parts.next().is_some() {
+        return None;
     }
+    (lock_major == major && lock_minor == minor && lock_inode == inode).then_some(pid)
 }
 
-fn same_lock_holder(left: &crate::LockDiagnostic, right: &crate::LockDiagnostic) -> bool {
-    left.pid == right.pid
-        && left.holder_session_id == right.holder_session_id
-        && left.acquired_at == right.acquired_at
-        && left.resource_path == right.resource_path
+#[cfg(target_os = "linux")]
+fn linux_dev_major_minor(dev: u64) -> (u64, u64) {
+    let major = ((dev >> 8) & 0x0fff) | ((dev >> 32) & !0x0fff);
+    let minor = (dev & 0x00ff) | ((dev >> 12) & !0x00ff);
+    (major, minor)
 }
 
-fn stale_lock_path(lock_path: &Path, acquired_at: DateTime<Utc>) -> PathBuf {
-    let suffix = acquired_at
-        .timestamp_nanos_opt()
-        .unwrap_or_else(|| Utc::now().timestamp_nanos_opt().unwrap_or_default());
-    lock_path.with_file_name(format!(".exclusive.stale.{suffix}.lock"))
+#[cfg(target_os = "linux")]
+fn diagnostic_process_identity_matches(diagnostic: &crate::LockDiagnostic) -> bool {
+    let Some(expected_start_time) = diagnostic.pid_start_time_ticks else {
+        return false;
+    };
+    crate::process_start_time_ticks(diagnostic.pid) == Some(expected_start_time)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn current_flock_owner_pid(_lock_path: &Path) -> Option<u32> {
+    Some(std::process::id())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn diagnostic_process_identity_matches(diagnostic: &crate::LockDiagnostic) -> bool {
+    diagnostic.pid == std::process::id()
 }
 
 #[cfg(test)]

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -369,24 +369,14 @@ fn stale_holder_can_be_reclaimed(
     holder_session_liveness: &mut impl FnMut(&str) -> HolderSessionLiveness,
 ) -> bool {
     match holder_session_liveness(holder_session_id) {
-        HolderSessionLiveness::Live | HolderSessionLiveness::Unknown => return false,
-        HolderSessionLiveness::RegistryAbsent => {
-            return matches!(
+        HolderSessionLiveness::Dead | HolderSessionLiveness::RegistryAbsent => {
+            matches!(
                 process_probe_state(diagnostic.pid),
                 ProcessProbeState::Missing
-            );
+            )
         }
-        HolderSessionLiveness::Dead => {}
+        HolderSessionLiveness::Live | HolderSessionLiveness::Unknown => false,
     }
-
-    // Loaded terminal session state is stronger than a signalable diagnostic
-    // PID because the numeric PID may have been reused after the CSA holder
-    // exited. EPERM or probe failure stays conservative because we cannot
-    // inspect enough to rule out the holder.
-    !matches!(
-        process_probe_state(diagnostic.pid),
-        ProcessProbeState::PermissionDenied | ProcessProbeState::Unknown
-    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -5,8 +5,6 @@ use crate::{
 use anyhow::Result;
 use std::fs;
 use std::io::ErrorKind;
-#[cfg(target_os = "linux")]
-use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 /// Guard for a write-capable CSA session sharing one git worktree.
@@ -126,12 +124,17 @@ impl Drop for WorktreeWriteLock {
 /// `${XDG_STATE_HOME:-$HOME/.local/state}/cli-sub-agent/worktree-write-locks/<sha256(canonical(worktree_root))>/exclusive.lock`
 ///
 /// If the lock holder is one of `ancestor_session_ids`, the current session is
-/// allowed to proceed under the ancestor's flock. This prevents fork-call child
-/// sessions from self-deadlocking while still blocking unrelated write sessions.
+/// allowed to proceed only while that ancestor is still live. This prevents
+/// fork-call child sessions from self-deadlocking while still blocking stale
+/// lineage diagnostics that name dead ancestors.
+///
+/// `holder_session_is_live` must read caller-owned session state, not process
+/// PID liveness; `csa-lock` stays independent of the session registry crate.
 pub fn acquire_worktree_write_lock(
     worktree_root: &Path,
     session_id: &str,
     ancestor_session_ids: &[String],
+    holder_session_is_live: impl Fn(&str) -> bool,
 ) -> Result<WorktreeWriteLock> {
     let session_id = session_id.trim();
     if session_id.is_empty() {
@@ -167,9 +170,7 @@ pub fn acquire_worktree_write_lock(
                 && ancestor_session_ids
                     .iter()
                     .any(|ancestor| ancestor == holder_session_id)
-                && diagnostic
-                    .as_ref()
-                    .is_some_and(|diag| diagnostic_matches_current_flock_owner(&lock_path, diag))
+                && holder_session_is_live(holder_session_id)
             {
                 return Ok(WorktreeWriteLock {
                     inner: WorktreeWriteLockKind::LineageReentry {
@@ -193,75 +194,6 @@ pub fn acquire_worktree_write_lock(
             )
         }
     }
-}
-
-fn diagnostic_matches_current_flock_owner(
-    lock_path: &Path,
-    diagnostic: &crate::LockDiagnostic,
-) -> bool {
-    let Some(owner_pid) = current_flock_owner_pid(lock_path) else {
-        return false;
-    };
-    owner_pid == diagnostic.pid && diagnostic_process_identity_matches(diagnostic)
-}
-
-#[cfg(target_os = "linux")]
-fn current_flock_owner_pid(lock_path: &Path) -> Option<u32> {
-    let metadata = fs::metadata(lock_path).ok()?;
-    let (major, minor) = linux_dev_major_minor(metadata.dev());
-    let inode = metadata.ino();
-    fs::read_to_string("/proc/locks")
-        .ok()?
-        .lines()
-        .find_map(|line| proc_lock_owner_for_inode(line, major, minor, inode))
-}
-
-#[cfg(target_os = "linux")]
-fn proc_lock_owner_for_inode(line: &str, major: u64, minor: u64, inode: u64) -> Option<u32> {
-    let mut fields = line.split_whitespace();
-    let _id = fields.next()?;
-    if fields.next()? != "FLOCK" {
-        return None;
-    }
-    let _scope = fields.next()?;
-    if fields.next()? != "WRITE" {
-        return None;
-    }
-    let pid = fields.next()?.parse::<u32>().ok()?;
-    let lock_id = fields.next()?;
-    let mut parts = lock_id.split(':');
-    let lock_major = u64::from_str_radix(parts.next()?, 16).ok()?;
-    let lock_minor = u64::from_str_radix(parts.next()?, 16).ok()?;
-    let lock_inode = parts.next()?.parse::<u64>().ok()?;
-    if parts.next().is_some() {
-        return None;
-    }
-    (lock_major == major && lock_minor == minor && lock_inode == inode).then_some(pid)
-}
-
-#[cfg(target_os = "linux")]
-fn linux_dev_major_minor(dev: u64) -> (u64, u64) {
-    let major = ((dev >> 8) & 0x0fff) | ((dev >> 32) & !0x0fff);
-    let minor = (dev & 0x00ff) | ((dev >> 12) & !0x00ff);
-    (major, minor)
-}
-
-#[cfg(target_os = "linux")]
-fn diagnostic_process_identity_matches(diagnostic: &crate::LockDiagnostic) -> bool {
-    let Some(expected_start_time) = diagnostic.pid_start_time_ticks else {
-        return false;
-    };
-    crate::process_start_time_ticks(diagnostic.pid) == Some(expected_start_time)
-}
-
-#[cfg(not(target_os = "linux"))]
-fn current_flock_owner_pid(_lock_path: &Path) -> Option<u32> {
-    Some(std::process::id())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn diagnostic_process_identity_matches(diagnostic: &crate::LockDiagnostic) -> bool {
-    diagnostic.pid == std::process::id()
 }
 
 #[cfg(test)]

--- a/crates/csa-lock/src/worktree_tests.rs
+++ b/crates/csa-lock/src/worktree_tests.rs
@@ -1,0 +1,292 @@
+use super::*;
+use crate::LockDiagnostic;
+use chrono::Utc;
+use std::ffi::OsString;
+use std::fs;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use tempfile::tempdir;
+
+fn env_test_lock() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set_os(key: &'static str, value: &Path) -> Self {
+        let original = std::env::var_os(key);
+        // SAFETY: test-scoped env mutation is isolated to the current test.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.original.take() {
+            // SAFETY: test-scoped env restoration is isolated to the current test.
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            // SAFETY: test-scoped env restoration is isolated to the current test.
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+#[test]
+fn test_worktree_write_lock_conflicts_for_same_worktree_root() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let _lock1 = acquire_worktree_write_lock(worktree_root.path(), "01PARENT", &[])
+        .expect("first worktree write lock should succeed");
+
+    let err = acquire_worktree_write_lock(worktree_root.path(), "01OTHER", &[])
+        .expect_err("non-lineage writer should fail fast")
+        .to_string();
+
+    assert!(err.contains("01PARENT"), "missing holder session id: {err}");
+    assert!(
+        err.contains(&worktree_root.path().display().to_string()),
+        "missing worktree path: {err}"
+    );
+    assert!(
+        err.contains("sequentially"),
+        "missing serialize guidance: {err}"
+    );
+}
+
+#[test]
+fn test_worktree_write_lock_allows_lineage_reentry() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let _parent = acquire_worktree_write_lock(worktree_root.path(), "01PARENT", &[])
+        .expect("parent worktree write lock should succeed");
+
+    let child =
+        acquire_worktree_write_lock(worktree_root.path(), "01CHILD", &["01PARENT".to_string()])
+            .expect("child should re-enter under ancestor lock");
+
+    assert!(child.is_lineage_reentry());
+    assert_eq!(child.holder_session_id(), Some("01PARENT"));
+}
+
+#[test]
+fn test_worktree_write_lock_allows_different_worktree_roots() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_a = tempdir().expect("worktree a tempdir");
+    let worktree_b = tempdir().expect("worktree b tempdir");
+
+    let lock_a = acquire_worktree_write_lock(worktree_a.path(), "01A", &[]);
+    let lock_b = acquire_worktree_write_lock(worktree_b.path(), "01B", &[]);
+
+    assert!(lock_a.is_ok());
+    assert!(lock_b.is_ok());
+}
+
+#[test]
+fn worktree_write_lock_removes_lock_file_on_drop() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let lock = acquire_worktree_write_lock(worktree_root.path(), "01OWNER", &[])
+        .expect("worktree write lock should succeed");
+    let lock_path = lock.lock_path().to_path_buf();
+    assert!(lock_path.exists(), "lock file should exist while held");
+
+    drop(lock);
+
+    assert!(
+        !lock_path.exists(),
+        "owned worktree lock file should be removed when guard drops"
+    );
+    acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
+        .expect("next writer should acquire after guard drop");
+}
+
+#[test]
+fn worktree_write_lock_reclaims_dead_holder_lock() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let holder = acquire_worktree_write_lock(worktree_root.path(), "01DEAD", &[])
+        .expect("holder lock should succeed");
+    overwrite_worktree_lock_diagnostic(
+        holder.lock_path(),
+        missing_pid(),
+        "01DEAD",
+        worktree_root.path(),
+    );
+
+    let lock =
+        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
+            HolderSessionLiveness::Dead
+        })
+        .expect("dead holder lock should be reclaimed");
+
+    assert!(!lock.is_lineage_reentry());
+    drop(holder);
+    drop(lock);
+}
+
+#[test]
+fn worktree_write_lock_keeps_live_holder_blocked() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let _holder = acquire_worktree_write_lock(worktree_root.path(), "01LIVE", &[])
+        .expect("holder lock should succeed");
+
+    let err =
+        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
+            HolderSessionLiveness::Live
+        })
+        .expect_err("live holder must still block")
+        .to_string();
+
+    assert!(err.contains("concurrent write session blocked"));
+    assert!(err.contains("01LIVE"));
+}
+
+#[test]
+fn worktree_write_lock_keeps_registry_absent_signalable_holder_blocked() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let holder = acquire_worktree_write_lock(worktree_root.path(), "01ABSENT", &[])
+        .expect("holder lock should succeed");
+    let lock_path = holder.lock_path().to_path_buf();
+    overwrite_worktree_lock_diagnostic(
+        &lock_path,
+        std::process::id(),
+        "01ABSENT",
+        worktree_root.path(),
+    );
+
+    let err =
+        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
+            HolderSessionLiveness::RegistryAbsent
+        })
+        .expect_err("registry-absent holder with signalable pid must block")
+        .to_string();
+
+    assert!(err.contains("concurrent write session blocked"));
+    assert!(err.contains("01ABSENT"));
+    assert!(
+        lock_path.exists(),
+        "canonical lock path must not be moved aside"
+    );
+    let diagnostic = read_lock_diagnostic(&lock_path)
+        .expect("read retained diagnostic")
+        .expect("retained diagnostic should parse");
+    assert_eq!(diagnostic.holder_session_id.as_deref(), Some("01ABSENT"));
+}
+
+#[test]
+fn worktree_write_lock_keeps_unknown_signalable_holder_blocked() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let holder = acquire_worktree_write_lock(worktree_root.path(), "01UNKNOWN", &[])
+        .expect("holder lock should succeed");
+    let lock_path = holder.lock_path().to_path_buf();
+    overwrite_worktree_lock_diagnostic(
+        &lock_path,
+        std::process::id(),
+        "01UNKNOWN",
+        worktree_root.path(),
+    );
+
+    let err =
+        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
+            HolderSessionLiveness::Unknown
+        })
+        .expect_err("unknown holder liveness must block")
+        .to_string();
+
+    assert!(err.contains("concurrent write session blocked"));
+    assert!(err.contains("01UNKNOWN"));
+    assert!(
+        lock_path.exists(),
+        "canonical lock path must not be moved aside"
+    );
+}
+
+#[test]
+fn worktree_write_lock_reclaims_registry_absent_holder_with_missing_pid() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let holder = acquire_worktree_write_lock(worktree_root.path(), "01ABSENT", &[])
+        .expect("holder lock should succeed");
+    overwrite_worktree_lock_diagnostic(
+        holder.lock_path(),
+        missing_pid(),
+        "01ABSENT",
+        worktree_root.path(),
+    );
+
+    let lock =
+        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
+            HolderSessionLiveness::RegistryAbsent
+        })
+        .expect("registry-absent holder with missing pid should be reclaimed");
+
+    assert!(!lock.is_lineage_reentry());
+    drop(holder);
+    drop(lock);
+}
+
+fn overwrite_worktree_lock_diagnostic(
+    lock_path: &Path,
+    pid: u32,
+    session_id: &str,
+    worktree_root: &Path,
+) {
+    let diagnostic = LockDiagnostic {
+        pid,
+        tool_name: "worktree-write:exclusive".to_string(),
+        acquired_at: Utc::now(),
+        reason: format!(
+            "write session {session_id} holds worktree {}",
+            worktree_root.display()
+        ),
+        holder_session_id: Some(session_id.to_string()),
+        resource_path: Some(worktree_root.display().to_string()),
+    };
+    fs::write(lock_path, serde_json::to_string(&diagnostic).unwrap())
+        .expect("overwrite lock diagnostic");
+}
+
+fn missing_pid() -> u32 {
+    [4_000_000, 8_000_000, 16_000_000, 1_000_000_000]
+        .into_iter()
+        .find(|pid| matches!(process_probe_state(*pid), ProcessProbeState::Missing))
+        .expect("test host should have at least one definitely missing pid")
+}

--- a/crates/csa-lock/src/worktree_tests.rs
+++ b/crates/csa-lock/src/worktree_tests.rs
@@ -2,7 +2,8 @@ use super::*;
 use crate::LockDiagnostic;
 use chrono::Utc;
 use std::ffi::OsString;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::os::unix::io::AsRawFd;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use tempfile::tempdir;
 
@@ -121,29 +122,32 @@ fn worktree_write_lock_removes_lock_file_on_drop() {
 }
 
 #[test]
-fn worktree_write_lock_reclaims_dead_holder_lock() {
+fn worktree_write_lock_acquires_over_stale_file_without_held_flock() {
     let _env_lock = env_test_lock();
     let state_home = tempdir().expect("state-home tempdir");
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let holder = acquire_worktree_write_lock(worktree_root.path(), "01DEAD", &[])
+    let holder = acquire_worktree_write_lock(worktree_root.path(), "01OLDOWNER", &[])
         .expect("holder lock should succeed");
+    let lock_path = holder.lock_path().to_path_buf();
     overwrite_worktree_lock_diagnostic(
-        holder.lock_path(),
-        missing_pid(),
-        "01DEAD",
+        &lock_path,
+        std::process::id(),
+        crate::process_start_time_ticks(std::process::id()),
+        "01STALE",
         worktree_root.path(),
     );
+    drop(holder);
 
-    let lock =
-        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
-            HolderSessionLiveness::Dead
-        })
-        .expect("dead holder lock should be reclaimed");
+    let lock = acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
+        .expect("stale diagnostic file without a held flock must not block acquisition");
 
     assert!(!lock.is_lineage_reentry());
-    drop(holder);
+    let diagnostic = read_lock_diagnostic(&lock_path)
+        .expect("read refreshed diagnostic")
+        .expect("refreshed diagnostic should parse");
+    assert_eq!(diagnostic.holder_session_id.as_deref(), Some("01NEXT"));
     drop(lock);
 }
 
@@ -157,10 +161,7 @@ fn worktree_write_lock_keeps_live_holder_blocked() {
     let _holder = acquire_worktree_write_lock(worktree_root.path(), "01LIVE", &[])
         .expect("holder lock should succeed");
 
-    let err =
-        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
-            HolderSessionLiveness::Live
-        })
+    let err = acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
         .expect_err("live holder must still block")
         .to_string();
 
@@ -169,108 +170,117 @@ fn worktree_write_lock_keeps_live_holder_blocked() {
 }
 
 #[test]
-fn worktree_write_lock_keeps_registry_absent_signalable_holder_blocked() {
+fn worktree_write_lock_blocks_post_exec_window_with_live_flock() {
     let _env_lock = env_test_lock();
     let state_home = tempdir().expect("state-home tempdir");
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let holder = acquire_worktree_write_lock(worktree_root.path(), "01ABSENT", &[])
+    let holder = acquire_worktree_write_lock(worktree_root.path(), "01DONE", &[])
         .expect("holder lock should succeed");
     let lock_path = holder.lock_path().to_path_buf();
     overwrite_worktree_lock_diagnostic(
         &lock_path,
         std::process::id(),
-        "01ABSENT",
+        crate::process_start_time_ticks(std::process::id()),
+        "01DONE",
         worktree_root.path(),
     );
 
-    let err =
-        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
-            HolderSessionLiveness::RegistryAbsent
-        })
-        .expect_err("registry-absent holder with signalable pid must block")
+    let err = acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
+        .expect_err("post-exec holder with live flock must block")
         .to_string();
 
     assert!(err.contains("concurrent write session blocked"));
-    assert!(err.contains("01ABSENT"));
+    assert!(err.contains("01DONE"));
     assert!(
         lock_path.exists(),
-        "canonical lock path must not be moved aside"
+        "canonical lock path must stay in place while the live flock is held"
     );
-    let diagnostic = read_lock_diagnostic(&lock_path)
-        .expect("read retained diagnostic")
-        .expect("retained diagnostic should parse");
-    assert_eq!(diagnostic.holder_session_id.as_deref(), Some("01ABSENT"));
 }
 
 #[test]
-fn worktree_write_lock_keeps_unknown_signalable_holder_blocked() {
+fn worktree_write_lock_blocks_stale_diagnostic_with_live_unrelated_flock_without_stealing_inode() {
     let _env_lock = env_test_lock();
     let state_home = tempdir().expect("state-home tempdir");
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let holder = acquire_worktree_write_lock(worktree_root.path(), "01UNKNOWN", &[])
-        .expect("holder lock should succeed");
-    let lock_path = holder.lock_path().to_path_buf();
+    let stale_holder = acquire_worktree_write_lock(worktree_root.path(), "01OLDOWNER", &[])
+        .expect("stale holder setup lock should succeed");
+    let lock_path = stale_holder.lock_path().to_path_buf();
+    overwrite_worktree_lock_diagnostic(&lock_path, 4_000_000, None, "01DEAD", worktree_root.path());
+    drop(stale_holder);
+    let before_inode = fs::metadata(&lock_path).expect("lock metadata").ino();
+    let _manual_holder = ManualFlock::acquire(&lock_path);
+
+    let err = acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
+        .expect_err("live unrelated flock must block despite stale diagnostic")
+        .to_string();
+
+    assert!(err.contains("concurrent write session blocked"));
+    assert!(err.contains("01DEAD"));
+    assert!(
+        lock_path.exists(),
+        "canonical lock path must not be moved aside"
+    );
+    assert_eq!(
+        fs::metadata(&lock_path).expect("lock metadata").ino(),
+        before_inode,
+        "canonical lock inode must not be replaced"
+    );
+    assert_no_reclaim_artifacts(&lock_path);
+}
+
+#[test]
+fn worktree_write_lock_blocks_lineage_reentry_when_stale_diagnostic_is_not_flock_owner() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let stale_holder = acquire_worktree_write_lock(worktree_root.path(), "01OLDOWNER", &[])
+        .expect("stale holder setup lock should succeed");
+    let lock_path = stale_holder.lock_path().to_path_buf();
     overwrite_worktree_lock_diagnostic(
         &lock_path,
         std::process::id(),
-        "01UNKNOWN",
+        Some(0),
+        "01DEAD",
         worktree_root.path(),
     );
+    drop(stale_holder);
+    let before_inode = fs::metadata(&lock_path).expect("lock metadata").ino();
+    let _manual_holder = ManualFlock::acquire(&lock_path);
 
-    let err =
-        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
-            HolderSessionLiveness::Unknown
-        })
-        .expect_err("unknown holder liveness must block")
-        .to_string();
+    let err = acquire_worktree_write_lock(
+        worktree_root.path(),
+        "01DESCENDANT",
+        &["01DEAD".to_string()],
+    )
+    .expect_err("stale ancestor diagnostic must not bypass a live unrelated flock")
+    .to_string();
 
     assert!(err.contains("concurrent write session blocked"));
-    assert!(err.contains("01UNKNOWN"));
-    assert!(
-        lock_path.exists(),
-        "canonical lock path must not be moved aside"
+    assert!(err.contains("01DEAD"));
+    assert_eq!(
+        fs::metadata(&lock_path).expect("lock metadata").ino(),
+        before_inode,
+        "canonical lock inode must not be replaced"
     );
-}
-
-#[test]
-fn worktree_write_lock_reclaims_registry_absent_holder_with_missing_pid() {
-    let _env_lock = env_test_lock();
-    let state_home = tempdir().expect("state-home tempdir");
-    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
-
-    let worktree_root = tempdir().expect("worktree tempdir");
-    let holder = acquire_worktree_write_lock(worktree_root.path(), "01ABSENT", &[])
-        .expect("holder lock should succeed");
-    overwrite_worktree_lock_diagnostic(
-        holder.lock_path(),
-        missing_pid(),
-        "01ABSENT",
-        worktree_root.path(),
-    );
-
-    let lock =
-        acquire_worktree_write_lock_with_liveness(worktree_root.path(), "01NEXT", &[], |_| {
-            HolderSessionLiveness::RegistryAbsent
-        })
-        .expect("registry-absent holder with missing pid should be reclaimed");
-
-    assert!(!lock.is_lineage_reentry());
-    drop(holder);
-    drop(lock);
+    assert_no_reclaim_artifacts(&lock_path);
 }
 
 fn overwrite_worktree_lock_diagnostic(
     lock_path: &Path,
     pid: u32,
+    pid_start_time_ticks: Option<u64>,
     session_id: &str,
     worktree_root: &Path,
 ) {
     let diagnostic = LockDiagnostic {
         pid,
+        pid_start_time_ticks,
         tool_name: "worktree-write:exclusive".to_string(),
         acquired_at: Utc::now(),
         reason: format!(
@@ -284,9 +294,46 @@ fn overwrite_worktree_lock_diagnostic(
         .expect("overwrite lock diagnostic");
 }
 
-fn missing_pid() -> u32 {
-    [4_000_000, 8_000_000, 16_000_000, 1_000_000_000]
-        .into_iter()
-        .find(|pid| matches!(process_probe_state(*pid), ProcessProbeState::Missing))
-        .expect("test host should have at least one definitely missing pid")
+struct ManualFlock {
+    file: File,
+}
+
+impl ManualFlock {
+    fn acquire(lock_path: &Path) -> Self {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(lock_path)
+            .expect("open canonical lock file");
+        // SAFETY: `file` owns a valid fd, and LOCK_EX requests an advisory flock.
+        let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        assert_eq!(ret, 0, "manual flock setup should acquire the lock");
+        Self { file }
+    }
+}
+
+impl Drop for ManualFlock {
+    fn drop(&mut self) {
+        // SAFETY: `file` owns a valid fd; unlocking before close is deterministic cleanup.
+        unsafe {
+            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+fn assert_no_reclaim_artifacts(lock_path: &Path) {
+    let lock_dir = lock_path.parent().expect("lock path should have parent");
+    for entry in fs::read_dir(lock_dir).expect("read lock dir") {
+        let entry = entry.expect("read lock dir entry");
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        assert_ne!(
+            file_name, ".reclaim.lock",
+            "reclaim guard must not be created"
+        );
+        assert!(
+            !file_name.starts_with(".exclusive.stale."),
+            "stale lock artifact must not be created: {file_name}"
+        );
+    }
 }

--- a/crates/csa-lock/src/worktree_tests.rs
+++ b/crates/csa-lock/src/worktree_tests.rs
@@ -3,7 +3,9 @@ use crate::LockDiagnostic;
 use chrono::Utc;
 use std::ffi::OsString;
 use std::fs::{self, File, OpenOptions};
+use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::AsRawFd;
+use std::process::Command;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use tempfile::tempdir;
 
@@ -40,6 +42,20 @@ impl Drop for EnvVarGuard {
     }
 }
 
+fn acquire_test_worktree_write_lock(
+    worktree_root: &Path,
+    session_id: &str,
+    ancestor_session_ids: &[String],
+    live_holder_session_ids: &[&str],
+) -> Result<WorktreeWriteLock> {
+    acquire_worktree_write_lock(
+        worktree_root,
+        session_id,
+        ancestor_session_ids,
+        |holder_session_id| live_holder_session_ids.contains(&holder_session_id),
+    )
+}
+
 #[test]
 fn test_worktree_write_lock_conflicts_for_same_worktree_root() {
     let _env_lock = env_test_lock();
@@ -47,10 +63,10 @@ fn test_worktree_write_lock_conflicts_for_same_worktree_root() {
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let _lock1 = acquire_worktree_write_lock(worktree_root.path(), "01PARENT", &[])
+    let _lock1 = acquire_test_worktree_write_lock(worktree_root.path(), "01PARENT", &[], &[])
         .expect("first worktree write lock should succeed");
 
-    let err = acquire_worktree_write_lock(worktree_root.path(), "01OTHER", &[])
+    let err = acquire_test_worktree_write_lock(worktree_root.path(), "01OTHER", &[], &[])
         .expect_err("non-lineage writer should fail fast")
         .to_string();
 
@@ -72,15 +88,70 @@ fn test_worktree_write_lock_allows_lineage_reentry() {
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let _parent = acquire_worktree_write_lock(worktree_root.path(), "01PARENT", &[])
+    let _parent = acquire_test_worktree_write_lock(worktree_root.path(), "01PARENT", &[], &[])
         .expect("parent worktree write lock should succeed");
 
-    let child =
-        acquire_worktree_write_lock(worktree_root.path(), "01CHILD", &["01PARENT".to_string()])
-            .expect("child should re-enter under ancestor lock");
+    let child = acquire_test_worktree_write_lock(
+        worktree_root.path(),
+        "01CHILD",
+        &["01PARENT".to_string()],
+        &["01PARENT"],
+    )
+    .expect("child should re-enter under live ancestor lock");
 
     assert!(child.is_lineage_reentry());
     assert_eq!(child.holder_session_id(), Some("01PARENT"));
+}
+
+#[test]
+fn test_worktree_write_lock_allows_cross_process_lineage_reentry() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let holder_session_id = "01PARENT";
+    let _parent =
+        acquire_test_worktree_write_lock(worktree_root.path(), holder_session_id, &[], &[])
+            .expect("parent worktree write lock should succeed");
+
+    let output = Command::new(std::env::current_exe().expect("current test binary"))
+        .arg("cross_process_lineage_reentry_child_entrypoint")
+        .arg("--nocapture")
+        .env("XDG_STATE_HOME", state_home.path())
+        .env("CSA_LOCK_CROSS_PROCESS_WORKTREE", worktree_root.path())
+        .env("CSA_LOCK_CROSS_PROCESS_HOLDER", holder_session_id)
+        .output()
+        .expect("run child test process");
+    let child_stdout = String::from_utf8_lossy(&output.stdout);
+    let child_stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success() && !child_stdout.contains("running 0 tests"),
+        "child process should re-enter under live ancestor lock\nstdout:\n{}\nstderr:\n{}",
+        child_stdout,
+        child_stderr
+    );
+}
+
+#[test]
+fn cross_process_lineage_reentry_child_entrypoint() {
+    let Some(worktree_root) = std::env::var_os("CSA_LOCK_CROSS_PROCESS_WORKTREE") else {
+        return;
+    };
+    let holder_session_id =
+        std::env::var("CSA_LOCK_CROSS_PROCESS_HOLDER").expect("holder session id env");
+
+    let child = acquire_worktree_write_lock(
+        Path::new(&worktree_root),
+        "01CHILD",
+        std::slice::from_ref(&holder_session_id),
+        |candidate| candidate == holder_session_id.as_str(),
+    )
+    .expect("child should re-enter under live ancestor lock held by parent process");
+
+    assert!(child.is_lineage_reentry());
+    assert_eq!(child.holder_session_id(), Some(holder_session_id.as_str()));
 }
 
 #[test]
@@ -92,8 +163,8 @@ fn test_worktree_write_lock_allows_different_worktree_roots() {
     let worktree_a = tempdir().expect("worktree a tempdir");
     let worktree_b = tempdir().expect("worktree b tempdir");
 
-    let lock_a = acquire_worktree_write_lock(worktree_a.path(), "01A", &[]);
-    let lock_b = acquire_worktree_write_lock(worktree_b.path(), "01B", &[]);
+    let lock_a = acquire_test_worktree_write_lock(worktree_a.path(), "01A", &[], &[]);
+    let lock_b = acquire_test_worktree_write_lock(worktree_b.path(), "01B", &[], &[]);
 
     assert!(lock_a.is_ok());
     assert!(lock_b.is_ok());
@@ -106,7 +177,7 @@ fn worktree_write_lock_removes_lock_file_on_drop() {
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let lock = acquire_worktree_write_lock(worktree_root.path(), "01OWNER", &[])
+    let lock = acquire_test_worktree_write_lock(worktree_root.path(), "01OWNER", &[], &[])
         .expect("worktree write lock should succeed");
     let lock_path = lock.lock_path().to_path_buf();
     assert!(lock_path.exists(), "lock file should exist while held");
@@ -117,7 +188,7 @@ fn worktree_write_lock_removes_lock_file_on_drop() {
         !lock_path.exists(),
         "owned worktree lock file should be removed when guard drops"
     );
-    acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
+    acquire_test_worktree_write_lock(worktree_root.path(), "01NEXT", &[], &[])
         .expect("next writer should acquire after guard drop");
 }
 
@@ -128,7 +199,7 @@ fn worktree_write_lock_acquires_over_stale_file_without_held_flock() {
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let holder = acquire_worktree_write_lock(worktree_root.path(), "01OLDOWNER", &[])
+    let holder = acquire_test_worktree_write_lock(worktree_root.path(), "01OLDOWNER", &[], &[])
         .expect("holder lock should succeed");
     let lock_path = holder.lock_path().to_path_buf();
     overwrite_worktree_lock_diagnostic(
@@ -140,7 +211,7 @@ fn worktree_write_lock_acquires_over_stale_file_without_held_flock() {
     );
     drop(holder);
 
-    let lock = acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
+    let lock = acquire_test_worktree_write_lock(worktree_root.path(), "01NEXT", &[], &[])
         .expect("stale diagnostic file without a held flock must not block acquisition");
 
     assert!(!lock.is_lineage_reentry());
@@ -158,10 +229,10 @@ fn worktree_write_lock_keeps_live_holder_blocked() {
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let _holder = acquire_worktree_write_lock(worktree_root.path(), "01LIVE", &[])
+    let _holder = acquire_test_worktree_write_lock(worktree_root.path(), "01LIVE", &[], &[])
         .expect("holder lock should succeed");
 
-    let err = acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
+    let err = acquire_test_worktree_write_lock(worktree_root.path(), "01NEXT", &[], &[])
         .expect_err("live holder must still block")
         .to_string();
 
@@ -176,7 +247,7 @@ fn worktree_write_lock_blocks_post_exec_window_with_live_flock() {
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let holder = acquire_worktree_write_lock(worktree_root.path(), "01DONE", &[])
+    let holder = acquire_test_worktree_write_lock(worktree_root.path(), "01DONE", &[], &[])
         .expect("holder lock should succeed");
     let lock_path = holder.lock_path().to_path_buf();
     overwrite_worktree_lock_diagnostic(
@@ -187,7 +258,7 @@ fn worktree_write_lock_blocks_post_exec_window_with_live_flock() {
         worktree_root.path(),
     );
 
-    let err = acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
+    let err = acquire_test_worktree_write_lock(worktree_root.path(), "01NEXT", &[], &[])
         .expect_err("post-exec holder with live flock must block")
         .to_string();
 
@@ -206,15 +277,16 @@ fn worktree_write_lock_blocks_stale_diagnostic_with_live_unrelated_flock_without
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let stale_holder = acquire_worktree_write_lock(worktree_root.path(), "01OLDOWNER", &[])
-        .expect("stale holder setup lock should succeed");
+    let stale_holder =
+        acquire_test_worktree_write_lock(worktree_root.path(), "01OLDOWNER", &[], &[])
+            .expect("stale holder setup lock should succeed");
     let lock_path = stale_holder.lock_path().to_path_buf();
     overwrite_worktree_lock_diagnostic(&lock_path, 4_000_000, None, "01DEAD", worktree_root.path());
     drop(stale_holder);
     let before_inode = fs::metadata(&lock_path).expect("lock metadata").ino();
     let _manual_holder = ManualFlock::acquire(&lock_path);
 
-    let err = acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[])
+    let err = acquire_test_worktree_write_lock(worktree_root.path(), "01NEXT", &[], &[])
         .expect_err("live unrelated flock must block despite stale diagnostic")
         .to_string();
 
@@ -233,14 +305,15 @@ fn worktree_write_lock_blocks_stale_diagnostic_with_live_unrelated_flock_without
 }
 
 #[test]
-fn worktree_write_lock_blocks_lineage_reentry_when_stale_diagnostic_is_not_flock_owner() {
+fn worktree_write_lock_blocks_lineage_reentry_when_ancestor_session_is_not_live() {
     let _env_lock = env_test_lock();
     let state_home = tempdir().expect("state-home tempdir");
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
 
     let worktree_root = tempdir().expect("worktree tempdir");
-    let stale_holder = acquire_worktree_write_lock(worktree_root.path(), "01OLDOWNER", &[])
-        .expect("stale holder setup lock should succeed");
+    let stale_holder =
+        acquire_test_worktree_write_lock(worktree_root.path(), "01OLDOWNER", &[], &[])
+            .expect("stale holder setup lock should succeed");
     let lock_path = stale_holder.lock_path().to_path_buf();
     overwrite_worktree_lock_diagnostic(
         &lock_path,
@@ -253,12 +326,13 @@ fn worktree_write_lock_blocks_lineage_reentry_when_stale_diagnostic_is_not_flock
     let before_inode = fs::metadata(&lock_path).expect("lock metadata").ino();
     let _manual_holder = ManualFlock::acquire(&lock_path);
 
-    let err = acquire_worktree_write_lock(
+    let err = acquire_test_worktree_write_lock(
         worktree_root.path(),
         "01DESCENDANT",
         &["01DEAD".to_string()],
+        &[],
     )
-    .expect_err("stale ancestor diagnostic must not bypass a live unrelated flock")
+    .expect_err("dead ancestor diagnostic must not bypass a live unrelated flock")
     .to_string();
 
     assert!(err.contains("concurrent write session blocked"));

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -253,14 +253,12 @@ pub fn load_session(project_path: &Path, session_id: &str) -> Result<MetaSession
 /// Load a session via global exact ULID lookup (cross-project, read-only).
 ///
 /// Returns `None` if no session with this exact ULID is found anywhere.
+/// Returns an error if an exact registry entry exists but cannot be loaded.
 /// Unlike `load_session`, this bypasses project path validation.
 pub fn load_session_global_exact(session_id: &str) -> Result<Option<MetaSessionState>> {
     use manager_paths::resolve_read_base_dir_global_exact;
     if let Some((base_dir, _)) = resolve_read_base_dir_global_exact(session_id)? {
-        match load_session_in(&base_dir, session_id) {
-            Ok(state) => return Ok(Some(state)),
-            Err(_) => return Ok(None),
-        }
+        return load_session_in(&base_dir, session_id).map(Some);
     }
     Ok(None)
 }


### PR DESCRIPTION
## Summary

Fixes #1873 and #1838. The `worktree-write:exclusive` lock subsystem (`csa-lock`)
leaked stale lock files on session exit, so a finished or crashed session could
leave an `exclusive.lock` behind. The original remedy added a "reclaim the stale
lock by renaming it aside" path, but a tier-4 design debate showed that
reclaim-by-rename is both **unnecessary** and **unsafe** (it renames a file whose
`flock` a *live* unrelated writer may already hold — re-introducing the #1672
commit-clobber it was meant to prevent). The merged design makes the kernel
`flock(2)` the **sole authority** and treats the on-disk lock file purely as a
human-readable diagnostic.

## Design — flock is the single source of truth

- **L1 — release on drop (root cause of the leak):** an owned `WorktreeWriteLock`
  guard removes its own `exclusive.lock` diagnostic on drop *while it still holds
  the fd `flock`*, so the lock is released on every session-exit path, not just
  some. This is what fixes the #1838 stale-lock leak on normal exit.
- **Flock-authoritative acquisition (replaces reclaim-by-rename):** acquisition is
  `open(create)` → `flock(LOCK_EX|LOCK_NB)`; the diagnostic is written only on
  success and read only on failure (for the error message / lineage check). A
  leftover lock *file* never blocks acquisition — only a live `flock` does. So
  #1838's crash-stale case is covered without any reclaim: the kernel releases the
  dead holder's `flock` on fd close, and the next `open+flock` succeeds and
  overwrites the stale diagnostic. The entire reclaim machinery
  (`try_reclaim_stale_worktree_lock`, process-probe liveness, `.reclaim.lock`,
  `.exclusive.stale.*` artifacts, rename-aside) is **deleted** — eliminating the
  rename-TOCTOU class outright.
- **Lineage reentry, cross-platform (fork-call):** a `csa run --fork-call` parent
  holds the worktree lock and stays alive, paused, while awaiting the child's
  return, so a descendant child must be allowed to re-enter the ancestor's held
  lock. That re-entry is gated on the diagnostic's `holder_session_id` being one of
  the child's ancestors **and that holder session still being live** (resolved via
  the session registry — no `/proc/locks`, no flock-owner-PID lookup, identical on
  Linux/macOS). This admits the legitimate fork-call child on every platform while
  blocking the stale-diagnostic bypass (a dead ancestor whose `flock` an unrelated
  live writer has since taken cannot be re-entered, because a dead holder is not
  live).
- **T1 — right-size the review lock:** standard `csa review` defaults to
  `readonly_project_root=true` and takes **no** worktree-write lock, so read-only
  reviews neither block writers nor leak locks; `csa review --fix` forces writable
  mode and keeps the exclusive lock.
- **Config-precedence fix:** the T1 readonly default honors **project-level**
  `[review] readonly_sandbox` with project-over-global precedence, matching the
  adjacent `model`/`thinking` review fields (previously only the global value was
  consulted, silently ignoring a per-project review-sandbox policy).

## Why no reclaim, no #1838 regression

A stale `exclusive.lock` file is harmless: it is a diagnostic, not a gate. The
only authoritative signal is the kernel `flock`, which the OS releases when the
holding process dies. L1 removes the diagnostic on clean exit; kernel
flock-release + overwrite-on-next-acquire handles the crash path. No component
treats lock-file existence as authority (`csa session list` derives status from
session state, not the lock file; reporting reads the diagnostic for error text
only).

## Tests

Targeted `csa-lock` + `pipeline_session_exec_write_lock` tests cover: L1
release-on-drop; **#1838** — a stale lock file with no held `flock` is acquirable
and overwritten; a live `flock` holder still blocks (incl. the post-exec window
where `result.toml` is written but the guard is still alive); **#1672 / R4** — a
stale diagnostic naming a dead ancestor while an unrelated live writer holds the
`flock` does **not** let a descendant re-enter (no rename, no `.exclusive.stale.*`
artifact); **cross-process lineage** — holding the lock in one process and
acquiring as a fork child in another returns `LineageReentry` (the regression a
same-process-only test missed); and project-over-global `readonly_sandbox`
precedence.

## Review

Local tier-4 review (`csa review --range main...HEAD`, gemini-primary →
codex-fallback, `--single`) over several iterative rounds, each surfacing a
**distinct** correctness issue and moving monotonically toward safer locking — a
mid-stream tier-4 debate pivoted the approach from reclaim-by-rename to
flock-authority. All four verdict artifacts were cross-read for prose↔structured
agreement each round.

## Deferred (follow-up)

A manual `csa session unlock` / `csa worktree unlock` recovery command is deferred
to a follow-up issue. With L1 (reliable release) + flock-authority (a stale file
never blocks), the manual command is a low-value convenience rather than a needed
recovery path.

Closes #1873
Closes #1838

🤖 Generated with [Claude Code](https://claude.com/claude-code)
