### PR TITLE
fix(cli-sub-agent): ignore stale resume prose findings — restore #1754 verdict test (#1904)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.917"
+version = "0.1.918"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -131,11 +131,12 @@ fn derive_findings_toml_artifact(
 
 /// Load the canonical review prose for a session.
 ///
-/// Resolves the authoritative review text by unioning every available prose
-/// source: persisted `summary`/`details` sections, physical `summary.md` and
-/// `details.md`, plus raw `output/full.md` and `output.log` review text. Valid
-/// fenced `findings.toml` content is preserved inside the raw text, but never
-/// causes physical review prose to be skipped.
+/// Resolves the authoritative review text by unioning current prose sources:
+/// indexed `summary`/`details` sections, legacy physical `summary.md` and
+/// `details.md` when no indexed review prose exists, plus raw `output/full.md`
+/// and `output.log` review text. Valid fenced `findings.toml` content is
+/// preserved inside the raw text, but never causes current review prose to be
+/// skipped.
 /// This is the SINGLE source of review prose shared by both the findings extractor
 /// and the fail-closed verdict detector ([`super::output::clean_detection::
 /// review_contains_prose_fail_conclusion`]). Sharing one loader keeps their source
@@ -149,11 +150,18 @@ pub(in crate::review_cmd) fn load_canonical_review_text(
     let mut review_texts = Vec::new();
     let mut latest_summary = None;
     let mut latest_details = None;
+    let mut has_indexed_review_prose = false;
 
     for (section, content) in csa_session::read_all_sections(session_dir)? {
         match section.id.as_str() {
-            "summary" => latest_summary = Some(content),
-            "details" => latest_details = Some(content),
+            "summary" => {
+                has_indexed_review_prose = true;
+                latest_summary = Some(content);
+            }
+            "details" => {
+                has_indexed_review_prose = true;
+                latest_details = Some(content);
+            }
             _ => {}
         }
     }
@@ -164,19 +172,21 @@ pub(in crate::review_cmd) fn load_canonical_review_text(
         .join("\n");
     push_distinct_review_text(&mut review_texts, structured_text);
 
-    let mut file_text = Vec::new();
-    for file_name in ["summary.md", "details.md"] {
-        let path = session_dir.join("output").join(file_name);
-        if !path.exists() {
-            continue;
+    if !has_indexed_review_prose {
+        let mut file_text = Vec::new();
+        for file_name in ["summary.md", "details.md"] {
+            let path = session_dir.join("output").join(file_name);
+            if !path.exists() {
+                continue;
+            }
+            let content = fs::read_to_string(&path)
+                .map_err(|error| anyhow::anyhow!("read {}: {error}", path.display()))?;
+            if !content.trim().is_empty() {
+                file_text.push(content);
+            }
         }
-        let content = fs::read_to_string(&path)
-            .map_err(|error| anyhow::anyhow!("read {}: {error}", path.display()))?;
-        if !content.trim().is_empty() {
-            file_text.push(content);
-        }
+        push_distinct_review_text(&mut review_texts, file_text.join("\n"));
     }
-    push_distinct_review_text(&mut review_texts, file_text.join("\n"));
 
     for candidate in [
         session_dir.join("output").join("full.md"),


### PR DESCRIPTION
## Summary

Fixes #1904. The #1754 resume-clean verdict test
(`issue_1754_resume_clean_output_ignores_historical_prose_findings`) failed
deterministically — `findings.findings` was non-empty on an otherwise clean
multi-round resume.

## Root cause

`load_canonical_review_text` treated indexed summary/details and legacy physical
`summary.md` / `details.md` as **additive** sources. On a multi-round resume,
`read_all_sections` correctly selected the latest *indexed* summary/details, but
the loader then re-added the stale **first-round physical** section files.
`review_prose_signals` parsed those prior-round prose findings, and
`enforce_final_verdict_consistency` wrote them back into `findings.toml` on an
otherwise clean resume — re-populating exactly the historical findings that the
#1754 clean-resume contract is supposed to suppress.

## Fix

Make indexed summary/details the **authoritative** source for review prose
whenever the output index contains review-prose sections. Legacy physical
`summary.md` / `details.md` are honored **only for no-index sessions**. Because
current-round indexed prose still flows through the same extractor and
consistency gate, all sibling guarantees hold:

- **#1754 resume-clean** restored: prior-round physical prose no longer leaks
  into a clean resume's findings.
- **#1804 / #1876 fail-closed** preserved: real *current-round* prose findings
  are still parsed (or the gate fails closed on a prose↔structured mismatch) —
  no false-PASS.
- **#1896** preserved: no-index sessions still fall back to raw physical details.

## Tests

- `issue_1754_resume_clean_output_ignores_historical_prose_findings` passes
  deterministically (run 2×).
- `verdict_1754_tests`, `review_cmd::output::tests`, and the `verdict` / `findings`
  filters are green.
- `cargo fmt --check` and `cargo clippy -p cli-sub-agent --all-targets
  --all-features -- -D warnings` clean.

This restores the test signal on `main` (a deterministic verdict-gate test was
red) without weakening any false-PASS protection.

Closes #1904

🤖 Generated with [Claude Code](https://claude.com/claude-code)
