### PR TITLE
fix(cli-sub-agent): offload multi-reviewer artifact clear off the async executor (#1708)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.918"
+version = "0.1.919"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -110,10 +110,8 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         &reviewer_tool_plan,
         &tier_reviewer_specs,
     );
-    super::parent_artifacts::clear_multi_reviewer_artifact_dirs(
-        ctx.reviewers,
-        &parent_startup_env,
-    )?;
+    super::parent_artifacts::clear_multi_reviewer_artifact_dirs(ctx.reviewers, &parent_startup_env)
+        .await?;
 
     let mut join_set = JoinSet::new();
     for (reviewer_index, reviewer_tool) in reviewer_tools.into_iter().enumerate() {

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -48,7 +48,7 @@ pub(super) struct MultiReviewerConsensusArtifacts<'a> {
     pub(super) large_diff_warning: Option<LargeDiffWarning>,
 }
 
-pub(super) fn clear_multi_reviewer_artifact_dirs(
+pub(super) async fn clear_multi_reviewer_artifact_dirs(
     reviewers: usize,
     startup_env: &StartupSubtreeEnv,
 ) -> Result<()> {
@@ -56,17 +56,22 @@ pub(super) fn clear_multi_reviewer_artifact_dirs(
         return Ok(());
     };
 
-    for reviewer_index in 1..=reviewers {
-        let reviewer_dir = session_dir.join(format!("reviewer-{reviewer_index}"));
-        match fs::remove_dir_all(&reviewer_dir) {
-            Ok(()) => {}
-            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-            Err(err) => {
-                return Err(err)
-                    .with_context(|| format!("failed to clear {}", reviewer_dir.display()));
+    tokio::task::spawn_blocking(move || {
+        for reviewer_index in 1..=reviewers {
+            let reviewer_dir = session_dir.join(format!("reviewer-{reviewer_index}"));
+            match fs::remove_dir_all(&reviewer_dir) {
+                Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(err)
+                        .with_context(|| format!("failed to clear {}", reviewer_dir.display()));
+                }
             }
         }
-    }
+        Ok(())
+    })
+    .await
+    .context("failed to join multi-reviewer artifact cleanup task")??;
     Ok(())
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts_tests.rs
@@ -1312,12 +1312,11 @@ fn write_multi_reviewer_parent_artifacts_fails_closed_when_empty_artifact_masks_
     );
 }
 
-#[test]
-fn clear_multi_reviewer_artifact_dirs_removes_stale_empty_artifact_so_dissenter_fails_closed() {
-    // #1681: the parent/daemon session dir can survive across review invocations in a
-    // plan. If reviewer-1 left an empty artifact in round 1, round 2 must clear it before
-    // accepting reviewer-1 as a persisted HAS_ISSUES dissenter.
-    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+#[tokio::test]
+async fn clear_multi_reviewer_artifact_dirs_removes_stale_empty_artifact_so_dissenter_fails_closed()
+{
+    // #1681: stale parent/daemon reviewer artifacts must be cleared before round 2.
+    let _env_lock = TEST_ENV_LOCK.lock().await;
     let temp = tempdir().expect("tempdir should be created");
     let session_dir = temp.path().display().to_string();
     let _session_dir_guard = ScopedEnvVarRestore::set(CSA_SESSION_DIR_ENV_KEY, &session_dir);
@@ -1354,6 +1353,7 @@ fn clear_multi_reviewer_artifact_dirs_removes_stale_empty_artifact_so_dissenter_
         2,
         &startup_env_for_parent_session(temp.path(), "01PARENTSESSION000000000000"),
     )
+    .await
     .expect("stale reviewer dirs should be cleared");
 
     assert!(


### PR DESCRIPTION
## Summary

Fixes #1708. `clear_multi_reviewer_artifact_dirs` cleared stale `reviewer-N/`
artifact directories with a synchronous `fs::remove_dir_all` call executed
directly on the async executor thread (called from `run_multi_reviewer_review`
just before reviewer subprocesses are spawned). Blocking the tokio runtime with
synchronous filesystem I/O is an async-hygiene defect (Rust rule 006).

## Fix

The stale-dir clearing no longer runs synchronous `remove_dir_all` on the
executor — the blocking filesystem work is offloaded so the runtime is not
parked while directories are removed.

Invariants preserved:

- **Clear-before-spawn ordering (TOCTOU)**: the clear still fully completes
  (awaited) *before* any reviewer subprocess is spawned, so no reviewer can
  write into a directory that is about to be removed.
- **Error context**: removal failures are still propagated with context (join
  + inner error), not swallowed.

## Tests

- `clear_multi_reviewer_artifact_dirs_removes_stale_empty_artifact_so_dissenter_fails_closed`
  stays green (the stale-artifact → dissenter-fails-closed contract is unchanged).
- Relevant `review_cmd_multi` / `parent_artifacts` tests pass.
- `cargo clippy` clean (no `#[allow]`).

Practically low-impact (sub-millisecond over a handful of tiny dirs, once per
round) but removes a real runtime-blocking call on the review hot path.

Closes #1708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
