### PR TITLE
refactor(cli-sub-agent): remove redundant sanitize-reparse in review section helpers (#1701)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.919"
+version = "0.1.920"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.919"
+version = "0.1.920"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output_sections.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_sections.rs
@@ -54,10 +54,9 @@ pub(crate) fn has_structured_review_content(output: &str) -> bool {
 }
 
 pub(crate) fn derive_review_result_summary(output: &str) -> Option<String> {
-    let sanitized = sanitize_review_output(output);
-    let sections = parse_sections(&sanitized);
-    let content = last_non_empty_section_content(&sanitized, &sections, "summary")
-        .or_else(|| last_non_empty_section_content(&sanitized, &sections, "details"))?;
+    let sections = parse_sections(output);
+    let content = last_non_empty_section_content(output, &sections, "summary")
+        .or_else(|| last_non_empty_section_content(output, &sections, "details"))?;
 
     content
         .lines()
@@ -66,7 +65,7 @@ pub(crate) fn derive_review_result_summary(output: &str) -> Option<String> {
         .map(truncate_review_result_summary)
 }
 
-fn last_non_empty_section_content(
+pub(super) fn last_non_empty_section_content(
     output: &str,
     sections: &[OutputSection],
     section_id: &str,
@@ -92,10 +91,14 @@ fn extract_section_content(output: &str, section: &OutputSection) -> String {
 
     let start = section.line_start - 1;
     let count = section.line_end - start;
-    output
-        .lines()
-        .skip(start)
-        .take(count)
-        .collect::<Vec<&str>>()
-        .join("\n")
+    let mut lines = output.lines().skip(start).take(count);
+    let Some(first) = lines.next() else {
+        return String::new();
+    };
+    let mut content = String::from(first);
+    for line in lines {
+        content.push('\n');
+        content.push_str(line);
+    }
+    content
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_summary.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_summary.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use csa_session::output_parser::parse_sections;
 use csa_session::{OutputIndex, OutputSection};
 
+use super::sections::last_non_empty_section_content;
 use super::{derive_review_result_summary, has_structured_review_content, sanitize_review_output};
 
 pub(crate) fn is_edit_restriction_summary(summary: &str) -> bool {
@@ -18,30 +19,9 @@ pub(crate) fn truncate_review_result_summary(line: &str) -> String {
         .collect()
 }
 
-fn current_run_has_summary_section(output: &str) -> bool {
-    let sanitized = sanitize_review_output(output);
-    let sections = parse_sections(&sanitized);
-    sections.iter().rev().any(|section| {
-        section.id == "summary"
-            && !extract_section_content(&sanitized, section)
-                .trim()
-                .is_empty()
-    })
-}
-
-fn extract_section_content(output: &str, section: &OutputSection) -> String {
-    if section.line_start == 0 || section.line_end < section.line_start {
-        return String::new();
-    }
-
-    let start = section.line_start - 1;
-    let count = section.line_end - start;
-    output
-        .lines()
-        .skip(start)
-        .take(count)
-        .collect::<Vec<&str>>()
-        .join("\n")
+fn current_run_summary_section(output: &str) -> Option<String> {
+    let sections = parse_sections(output);
+    last_non_empty_section_content(output, &sections, "summary")
 }
 
 pub(crate) fn ensure_review_summary_artifact(session_dir: &Path, output: &str) -> Result<()> {
@@ -53,28 +33,10 @@ pub(crate) fn ensure_review_summary_artifact(session_dir: &Path, output: &str) -
     fs::create_dir_all(&output_dir)
         .map_err(|error| anyhow::anyhow!("create {}: {error}", output_dir.display()))?;
     let summary_path = output_dir.join("summary.md");
-    let summary = if current_run_has_summary_section(output) {
-        let sanitized = sanitize_review_output(output);
-        let sections = parse_sections(&sanitized);
-        if let Some(summary) = sections
-            .iter()
-            .rev()
-            .find(|section| section.id == "summary")
-            .map(|section| extract_section_content(&sanitized, section))
-            .filter(|summary| !summary.trim().is_empty())
-        {
-            fs::write(&summary_path, &summary)
-                .map_err(|error| anyhow::anyhow!("write {}: {error}", summary_path.display()))?;
-            summary
-        } else {
-            let Some(summary) = fs::read_to_string(&summary_path)
-                .ok()
-                .filter(|summary| !summary.trim().is_empty())
-            else {
-                return Ok(());
-            };
-            summary
-        }
+    let summary = if let Some(summary) = current_run_summary_section(output) {
+        fs::write(&summary_path, &summary)
+            .map_err(|error| anyhow::anyhow!("write {}: {error}", summary_path.display()))?;
+        summary
     } else {
         let Some(summary) = derive_review_result_summary(output) else {
             return Ok(());


### PR DESCRIPTION
## Summary

Fixes #1701 (#1675 MEDIUM followup). Removes the redundant sanitize-then-reparse
in the review-output section helpers and the residual whole-output allocation in
section extraction. **Pure refactor — observable behavior is unchanged.**

## Findings addressed (all MEDIUM efficiency, from PR #1695 cloud review)

1. `has_structured_review_content` — no longer sanitizes-then-reparses.
2. `derive_review_result_summary` — no longer sanitizes-then-reparses.
3. `extract_section_content` — the remaining selected-line `Vec<&str>`
   materialization is gone; the selected line range is streamed directly into
   the output string, and that raw-section helper is now shared with summary
   artifact generation.

## Why this is behavior-preserving

`sanitize_review_output` is **not load-bearing for section boundary detection**:
it already parsed the raw output with `parse_sections` and then re-rendered the
last non-empty summary/details sections. The helpers now parse the raw output
directly, keeping the same **summary-before-details** ordering and
**last-non-empty** selection semantics — so the observable review output is
identical.

## Regression guards (this code feeds the verdict gate)

Because the section helpers feed the review verdict gate (the area of the
#1804/#1876/#1896 false-PASS cascade), the full verdict-gate test set was run as
a regression guard:

- `sanitize_review_output`, `derive_review_result_summary`,
  `has_structured_review_content`, `ensure_review_summary_artifact`
- `issue_1754`, `issue_1804`, `issue_1876`, `issue_1896`
- `cargo clippy -p cli-sub-agent --all-targets -- -D warnings` clean.

All green — no false-PASS hole reopened.

Closes #1701

🤖 Generated with [Claude Code](https://claude.com/claude-code)
