### PR TITLE
fix(csa-process): write child stderr once in daemon mode (dedup spool+tee)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.920"
+version = "0.1.921"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.920"
+version = "0.1.921"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-process/src/lib.rs
+++ b/crates/csa-process/src/lib.rs
@@ -40,7 +40,7 @@ use output_helpers::{
     append_actionable_detail_for_opaque_payload, drain_if_over_high_water, extract_summary,
     failure_summary, flush_line_buf, flush_stderr_buf, maybe_emit_heartbeat,
     parse_legacy_terminal_reason, resolve_actionable_failure_detail, resolve_heartbeat_interval,
-    sanitize_opaque_object_payloads, spool_chunk,
+    sanitize_opaque_object_payloads, should_tee_stderr_to_parent, spool_chunk,
 };
 #[cfg(test)]
 use output_helpers::{last_non_empty_line, truncate_line};
@@ -266,3 +266,6 @@ mod tests_heartbeat;
 #[cfg(test)]
 #[path = "lib_tests_retry.rs"]
 mod tests_retry;
+#[cfg(test)]
+#[path = "lib_tests_stderr_dedup.rs"]
+mod tests_stderr_dedup;

--- a/crates/csa-process/src/lib_output_helpers.rs
+++ b/crates/csa-process/src/lib_output_helpers.rs
@@ -30,6 +30,8 @@ const OPAQUE_OBJECT_PATTERN: &str = "[object object]";
 const OPAQUE_OBJECT_REPLACEMENT: &str = "(opaque error payload)";
 const OPAQUE_PAYLOAD_MARKER: &str = "(opaque error payload)";
 const SPOOL_BUFFER_CAPACITY: usize = 64 * 1024;
+const DAEMON_SESSION_ID_ENV: &str = "CSA_DAEMON_SESSION_ID";
+const DAEMON_SESSION_DIR_ENV: &str = "CSA_DAEMON_SESSION_DIR";
 
 #[derive(Debug)]
 pub struct SpoolRotator {
@@ -183,6 +185,43 @@ pub(super) fn spool_chunk(spool: &mut Option<SpoolRotator>, bytes: &[u8]) {
     }
 }
 
+pub(super) fn should_tee_stderr_to_parent(
+    stream_mode: StreamMode,
+    session_dir: Option<&Path>,
+    stderr_spool_active: bool,
+) -> bool {
+    if stream_mode != StreamMode::TeeToStderr {
+        return false;
+    }
+    if !stderr_spool_active {
+        return true;
+    }
+
+    let Some(session_dir) = session_dir else {
+        return true;
+    };
+    if std::env::var_os(DAEMON_SESSION_ID_ENV).is_none() {
+        return true;
+    }
+    let Some(daemon_session_dir) = std::env::var_os(DAEMON_SESSION_DIR_ENV) else {
+        return true;
+    };
+
+    // In daemon mode fd 2 already drains into this session's stderr.log.
+    !same_session_dir(session_dir, Path::new(&daemon_session_dir))
+}
+
+fn same_session_dir(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
 /// Drain the front of an output accumulator if it exceeds the high-water mark.
 ///
 /// This bounds the in-memory accumulator to ~[`TAIL_BUFFER_HIGH_WATER`] bytes,
@@ -287,13 +326,13 @@ pub(super) fn accumulate_and_flush_stderr(
     chunk: &str,
     line_buf: &mut String,
     stderr_output: &mut String,
-    stream_mode: StreamMode,
+    tee_to_parent_stderr: bool,
 ) -> usize {
     let mut boundary_hits = 0usize;
     line_buf.push_str(chunk);
     while let Some(newline_pos) = line_buf.find('\n') {
         let line: String = line_buf.drain(..=newline_pos).collect();
-        if stream_mode == StreamMode::TeeToStderr {
+        if tee_to_parent_stderr {
             eprint!("{line}");
         }
         if is_workspace_boundary_error_line(&line) {
@@ -308,10 +347,10 @@ pub(super) fn accumulate_and_flush_stderr(
 pub(super) fn flush_stderr_buf(
     line_buf: &mut String,
     stderr_output: &mut String,
-    stream_mode: StreamMode,
+    tee_to_parent_stderr: bool,
 ) {
     if !line_buf.is_empty() {
-        if stream_mode == StreamMode::TeeToStderr {
+        if tee_to_parent_stderr {
             eprint!("{line_buf}");
         }
         stderr_output.push_str(line_buf);

--- a/crates/csa-process/src/lib_tests_stderr_dedup.rs
+++ b/crates/csa-process/src/lib_tests_stderr_dedup.rs
@@ -1,0 +1,182 @@
+use super::*;
+use std::ffi::OsString;
+use std::io::Write as _;
+use std::path::Path;
+use std::sync::{LazyLock, Mutex};
+
+const DAEMON_SESSION_ID_ENV: &str = "CSA_DAEMON_SESSION_ID";
+const DAEMON_SESSION_DIR_ENV: &str = "CSA_DAEMON_SESSION_DIR";
+static DAEMON_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+struct ScopedDaemonEnv {
+    original_id: Option<OsString>,
+    original_dir: Option<OsString>,
+}
+
+impl ScopedDaemonEnv {
+    fn set(session_dir: &Path) -> Self {
+        let original = Self::capture();
+        // SAFETY: tests that mutate daemon session env hold DAEMON_ENV_LOCK.
+        unsafe {
+            std::env::set_var(DAEMON_SESSION_ID_ENV, "01KTESTSESSION");
+            std::env::set_var(DAEMON_SESSION_DIR_ENV, session_dir.as_os_str());
+        }
+        original
+    }
+
+    fn unset() -> Self {
+        let original = Self::capture();
+        // SAFETY: tests that mutate daemon session env hold DAEMON_ENV_LOCK.
+        unsafe {
+            std::env::remove_var(DAEMON_SESSION_ID_ENV);
+            std::env::remove_var(DAEMON_SESSION_DIR_ENV);
+        }
+        original
+    }
+
+    fn capture() -> Self {
+        Self {
+            original_id: std::env::var_os(DAEMON_SESSION_ID_ENV),
+            original_dir: std::env::var_os(DAEMON_SESSION_DIR_ENV),
+        }
+    }
+}
+
+impl Drop for ScopedDaemonEnv {
+    fn drop(&mut self) {
+        restore_env(DAEMON_SESSION_ID_ENV, self.original_id.take());
+        restore_env(DAEMON_SESSION_DIR_ENV, self.original_dir.take());
+    }
+}
+
+fn restore_env(key: &str, value: Option<OsString>) {
+    // SAFETY: tests that mutate daemon session env hold DAEMON_ENV_LOCK.
+    unsafe {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+}
+
+fn line_occurrences(content: &str, expected: &str) -> usize {
+    content.lines().filter(|line| *line == expected).count()
+}
+
+fn emit_child_stderr(
+    payload: &str,
+    session_dir: &Path,
+    stderr_spool: &mut Option<output_helpers::SpoolRotator>,
+    parent_stderr: &mut std::fs::File,
+) -> bool {
+    let tee_to_parent = output_helpers::should_tee_stderr_to_parent(
+        StreamMode::TeeToStderr,
+        Some(session_dir),
+        stderr_spool.is_some(),
+    );
+    output_helpers::spool_chunk(stderr_spool, payload.as_bytes());
+    if tee_to_parent {
+        parent_stderr
+            .write_all(payload.as_bytes())
+            .expect("write parent stderr");
+        parent_stderr.flush().expect("flush parent stderr");
+    }
+    tee_to_parent
+}
+
+#[test]
+fn daemon_stderr_same_target_spool_writes_child_line_once() {
+    let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _daemon_env = ScopedDaemonEnv::set(tmp.path());
+    let stderr_log = tmp.path().join("stderr.log");
+    let mut stderr_spool = Some(
+        output_helpers::SpoolRotator::open(&stderr_log, DEFAULT_SPOOL_MAX_BYTES, true)
+            .expect("open stderr spool"),
+    );
+    let mut same_target = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&stderr_log)
+        .expect("open same tee target");
+
+    let tee_to_parent = emit_child_stderr(
+        "child-stderr-once\n",
+        tmp.path(),
+        &mut stderr_spool,
+        &mut same_target,
+    );
+    assert!(!tee_to_parent);
+    drop(same_target);
+    stderr_spool
+        .take()
+        .expect("stderr spool")
+        .finalize()
+        .expect("finalize stderr spool");
+
+    let content = std::fs::read_to_string(&stderr_log).expect("read stderr.log");
+    assert_eq!(line_occurrences(&content, "child-stderr-once"), 1);
+}
+
+#[test]
+fn foreground_stderr_distinct_targets_keep_spool_and_tee() {
+    let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
+    let _daemon_env = ScopedDaemonEnv::unset();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let stderr_log = tmp.path().join("stderr.log");
+    let tee_log = tmp.path().join("parent-stderr.log");
+    let mut stderr_spool = Some(
+        output_helpers::SpoolRotator::open(&stderr_log, DEFAULT_SPOOL_MAX_BYTES, true)
+            .expect("open stderr spool"),
+    );
+    let mut tee_target = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&tee_log)
+        .expect("open tee target");
+
+    let tee_to_parent = emit_child_stderr(
+        "foreground-child-stderr\n",
+        tmp.path(),
+        &mut stderr_spool,
+        &mut tee_target,
+    );
+    assert!(tee_to_parent);
+    stderr_spool
+        .take()
+        .expect("stderr spool")
+        .finalize()
+        .expect("finalize stderr spool");
+
+    let spool_content = std::fs::read_to_string(&stderr_log).expect("read stderr.log");
+    let tee_content = std::fs::read_to_string(&tee_log).expect("read tee log");
+    assert_eq!(
+        line_occurrences(&spool_content, "foreground-child-stderr"),
+        1
+    );
+    assert_eq!(line_occurrences(&tee_content, "foreground-child-stderr"), 1);
+}
+
+#[test]
+fn daemon_without_stderr_spool_keeps_parent_tee() {
+    let _env_lock = DAEMON_ENV_LOCK.lock().expect("daemon env lock poisoned");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let other = tempfile::tempdir().expect("other tempdir");
+    let _daemon_env = ScopedDaemonEnv::set(tmp.path());
+
+    assert!(output_helpers::should_tee_stderr_to_parent(
+        StreamMode::TeeToStderr,
+        Some(tmp.path()),
+        false
+    ));
+    assert!(output_helpers::should_tee_stderr_to_parent(
+        StreamMode::TeeToStderr,
+        Some(other.path()),
+        true
+    ));
+    assert!(!output_helpers::should_tee_stderr_to_parent(
+        StreamMode::BufferOnly,
+        Some(tmp.path()),
+        false
+    ));
+}

--- a/crates/csa-process/src/lib_wait_capture.rs
+++ b/crates/csa-process/src/lib_wait_capture.rs
@@ -63,6 +63,8 @@ pub async fn wait_and_capture_with_idle_timeout(
             }
         }
     }
+    let tee_stderr_to_parent =
+        should_tee_stderr_to_parent(stream_mode, session_dir, stderr_spool_file.is_some());
 
     const READ_BUF_SIZE: usize = 4096;
     let mut stdout_reader = BufReader::new(stdout);
@@ -165,7 +167,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                             flush_stderr_buf(
                                 &mut stderr_line_buf,
                                 &mut stderr_output,
-                                stream_mode,
+                                tee_stderr_to_parent,
                             );
                             stderr_done = true;
                         }
@@ -185,7 +187,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                                 &chunk,
                                 &mut stderr_line_buf,
                                 &mut stderr_output,
-                                stream_mode,
+                                tee_stderr_to_parent,
                             );
                             kill_on_persistent_rate_limit!(&stderr_output[previous_stderr_len..], "stderr");
                             drain_if_over_high_water(&mut stderr_output);
@@ -201,7 +203,7 @@ pub async fn wait_and_capture_with_idle_timeout(
                             flush_stderr_buf(
                                 &mut stderr_line_buf,
                                 &mut stderr_output,
-                                stream_mode,
+                                tee_stderr_to_parent,
                             );
                             stderr_done = true;
                         }


### PR DESCRIPTION
## Summary

Fixes #1704. In daemon mode, child stderr was written twice to `stderr.log`:
once by the spool sink (`spool_chunk` in `lib_wait_capture.rs`) and again by
the tee sink (`StreamMode::TeeToStderr` in `lib_output_helpers.rs`), because
the daemon parent's stderr is redirected to the same file.

The fix detects daemon mode and skips the tee write when the tee target is the
same file as the spool destination, preserving the distinct terminal+spool
behavior in foreground mode.

## Changes

- `crates/csa-process/src/lib_output_helpers.rs` — skip tee write in daemon mode
- `crates/csa-process/src/lib_wait_capture.rs` — daemon-mode detection for spool dedup
- `crates/csa-process/src/lib.rs` — wire dedup flag
- `crates/csa-process/src/lib_tests_stderr_dedup.rs` — write-count regression test

## Test plan

- [ ] Regression test `lib_tests_stderr_dedup` verifies single-write in daemon mode
- [ ] Foreground mode unchanged (tee to terminal + spool to file both active)

Closes #1704

🤖 Generated with [Claude Code](https://claude.com/claude-code)