### PR TITLE
fix(cli-sub-agent): auto-heal weave.lock stamp on bump-patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.921"
+version = "0.1.922"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.921"
+version = "0.1.922"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/justfile
+++ b/justfile
@@ -372,6 +372,8 @@ install:
 # Requires: cargo-edit (cargo install cargo-edit)
 bump-patch:
     cargo set-version --bump patch -p cli-sub-agent
+    @cargo run --quiet -p cli-sub-agent -- migrate
+    git add Cargo.toml Cargo.lock weave.lock
     @echo "Bumped workspace version:"
     @cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent" or .name == "weave") | "  \(.name) = \(.version)"'
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.826"
-weave = "0.1.826"
+csa = "0.1.922"
+weave = "0.1.922"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Fixes #1910. The `weave.lock` version stamp drifted ~93 patches behind the
workspace version because `just bump-patch` never updated it. This caused a
`WARNING: weave.lock records stale version stamp(s)` line on every `csa`
invocation — hundreds per session.

The fix adds a `csa migrate` step to the `bump-patch` recipe that updates the
`weave.lock` stamp in the same commit as the version bump. The migrate step is
**not** failure-suppressed — if it fails, the bump aborts, ensuring the stamp
never silently drifts again.

## Changes

- `justfile` — add `csa migrate` after version bump, stage `weave.lock`
- `weave.lock` — stamp updated to current version
- `Cargo.toml` / `Cargo.lock` — version bump

## Test plan

- [ ] `just bump-patch` updates weave.lock stamp (no stale warning after)
- [ ] `csa migrate` failure aborts bump-patch (not silently suppressed)

Closes #1910

🤖 Generated with [Claude Code](https://claude.com/claude-code)