### PR TITLE
fix(cli-sub-agent): narrow executor recursion guard to only block dev2merge self-recursion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.923"
+version = "0.1.924"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.923"
+version = "0.1.924"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/executor_csa_guard.rs
+++ b/crates/cli-sub-agent/src/executor_csa_guard.rs
@@ -4,50 +4,28 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 
-use crate::cli::{
-    Commands, ConfigCommands, PlanCommands, TodoCommands, TodoRefCommands, TokuinCommands,
-};
+use crate::cli::{Commands, SkillCommands};
 
 const CSA_SKILL_MODE_ENV: &str = "CSA_SKILL_MODE";
 const CSA_SKILL_MODE_EXECUTOR: &str = "executor";
-
-const EXECUTOR_SAFE_CSA_COMMAND_PREFIXES: &[&[&str]] = &[
-    &["todo", "create"],
-    &["todo", "save"],
-    &["todo", "persist"],
-    &["todo", "attest"],
-    &["todo", "ref", "add"],
-    &["todo", "ref", "list"],
-    &["todo", "ref", "show"],
-    &["todo", "show"],
-    &["todo", "list"],
-    &["todo", "find"],
-    &["tokuin", "estimate"],
-    &["tokuin", "models"],
-    &["health"],
-    &["config", "get"],
-    &["config", "show"],
-];
 
 pub(crate) fn enforce(command: &Commands) -> Result<()> {
     if !is_active() {
         return Ok(());
     }
 
-    let prefix = command_prefix(command);
-    if is_safe_prefix(&prefix) {
-        tracing::info!(
-            command = %format_command_prefix(&prefix),
-            "allowed non-recursive csa command in executor mode"
+    enforce_active(command)
+}
+
+fn enforce_active(command: &Commands) -> Result<()> {
+    if let Some(skill) = recursive_dev2merge_skill(command) {
+        anyhow::bail!(
+            "executor mode blocks recursive dev2merge invocation `csa run --skill {skill}`"
         );
-        return Ok(());
     }
 
-    anyhow::bail!(
-        "executor mode blocks recursive csa command `{}`. Allowed non-recursive csa command prefixes: {}",
-        format_command_prefix(&prefix),
-        format_safe_prefixes(),
-    );
+    tracing::info!("allowed non-recursive csa command in executor mode");
+    Ok(())
 }
 
 pub(crate) fn mark_skill_executor_env(env: &mut Option<HashMap<String, String>>, is_skill: bool) {
@@ -65,148 +43,85 @@ fn is_active() -> bool {
         .unwrap_or(false)
 }
 
-fn is_safe_prefix(prefix: &[&str]) -> bool {
-    EXECUTOR_SAFE_CSA_COMMAND_PREFIXES.contains(&prefix)
-}
-
-fn command_prefix(command: &Commands) -> Vec<&'static str> {
+fn recursive_dev2merge_skill(command: &Commands) -> Option<&str> {
     match command {
-        Commands::Run { .. } => vec!["run"],
-        Commands::Review(_) => vec!["review"],
-        Commands::Debate(_) => vec!["debate"],
-        Commands::Plan {
-            cmd: PlanCommands::Run { .. },
-        } => vec!["plan", "run"],
-        Commands::Todo { cmd } => todo_prefix(cmd),
-        Commands::Config { cmd } => config_prefix(cmd),
-        Commands::Tokuin {
-            cmd: TokuinCommands::Estimate { .. },
-        } => vec!["tokuin", "estimate"],
-        Commands::Tokuin {
-            cmd: TokuinCommands::Models,
-        } => vec!["tokuin", "models"],
-        Commands::Verify(_) => vec!["verify"],
-        Commands::Health(_) => vec!["health"],
-        Commands::Hunt(_) => vec!["hunt"],
-        Commands::Arch(_) => vec!["arch"],
-        Commands::Triage(_) => vec!["triage"],
-        Commands::Mktsk(_) => vec!["mktsk"],
-        Commands::Session { .. } => vec!["session"],
-        Commands::Push(_) => vec!["push"],
-        Commands::Merge(_) => vec!["merge"],
-        Commands::Audit { .. } => vec!["audit"],
-        Commands::Init { .. } => vec!["init"],
-        Commands::Gc(_) => vec!["gc"],
-        Commands::Memory { .. } => vec!["memory"],
-        Commands::Eval { .. } => vec!["eval"],
-        Commands::Doctor { .. } => vec!["doctor"],
-        Commands::Batch { .. } => vec!["batch"],
-        Commands::McpServer => vec!["mcp-server"],
-        Commands::McpHub { .. } => vec!["mcp-hub"],
-        Commands::Skill { .. } => vec!["skill"],
-        Commands::Setup { .. } => vec!["setup"],
-        Commands::Tiers { .. } => vec!["tiers"],
-        Commands::Checklist { .. } => vec!["checklist"],
-        Commands::Migrate { .. } => vec!["migrate"],
-        Commands::SelfUpdate { .. } => vec!["self-update"],
-        Commands::ClaudeSubAgent(_) => vec!["claude-sub-agent"],
-        Commands::Xurl { .. } => vec!["xurl"],
-        Commands::Recall(_) => vec!["recall"],
-        Commands::Hooks { .. } => vec!["hooks"],
+        Commands::Run {
+            skill: Some(skill), ..
+        } if is_dev2merge_skill(skill) => Some(skill.as_str()),
+        Commands::Skill {
+            cmd: SkillCommands::Run { name, .. },
+        } if is_dev2merge_skill(name) => Some(name.as_str()),
+        _ => None,
     }
 }
 
-fn todo_prefix(cmd: &TodoCommands) -> Vec<&'static str> {
-    match cmd {
-        TodoCommands::Create { .. } => vec!["todo", "create"],
-        TodoCommands::Save { .. } => vec!["todo", "save"],
-        TodoCommands::Persist { .. } => vec!["todo", "persist"],
-        TodoCommands::Attest { .. } => vec!["todo", "attest"],
-        TodoCommands::List { .. } => vec!["todo", "list"],
-        TodoCommands::Find { .. } => vec!["todo", "find"],
-        TodoCommands::Errors { .. } => vec!["todo", "errors"],
-        TodoCommands::Show { .. } => vec!["todo", "show"],
-        TodoCommands::Ref { cmd } => match cmd {
-            TodoRefCommands::Add { .. } => vec!["todo", "ref", "add"],
-            TodoRefCommands::List { .. } => vec!["todo", "ref", "list"],
-            TodoRefCommands::Show { .. } => vec!["todo", "ref", "show"],
-            TodoRefCommands::ImportTranscript { .. } => vec!["todo", "ref", "import-transcript"],
-        },
-        TodoCommands::Diff { .. } => vec!["todo", "diff"],
-        TodoCommands::History { .. } => vec!["todo", "history"],
-        TodoCommands::Update { .. } => vec!["todo", "update"],
-        TodoCommands::Status { .. } => vec!["todo", "status"],
-        TodoCommands::Dag { .. } => vec!["todo", "dag"],
-        TodoCommands::Epic { .. } => vec!["todo", "epic"],
-    }
-}
-
-fn config_prefix(cmd: &ConfigCommands) -> Vec<&'static str> {
-    match cmd {
-        ConfigCommands::Get { .. } => vec!["config", "get"],
-        ConfigCommands::Show { .. } => vec!["config", "show"],
-        ConfigCommands::Edit { .. } => vec!["config", "edit"],
-        ConfigCommands::Validate { .. } => vec!["config", "validate"],
-        ConfigCommands::Set { .. } => vec!["config", "set"],
-    }
-}
-
-fn format_command_prefix(prefix: &[&str]) -> String {
-    format!("csa {}", prefix.join(" "))
-}
-
-fn format_safe_prefixes() -> String {
-    EXECUTOR_SAFE_CSA_COMMAND_PREFIXES
-        .iter()
-        .map(|prefix| format_command_prefix(prefix))
-        .collect::<Vec<_>>()
-        .join(", ")
+fn is_dev2merge_skill(skill: &str) -> bool {
+    matches!(skill, "dev2merge" | "dev-to-merge")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::Cli;
+    use clap::Parser;
 
-    #[test]
-    fn safe_prefixes_allow_todo_persistence_commands() {
-        for prefix in [
-            &["todo", "create"][..],
-            &["todo", "save"][..],
-            // Regression (#1822 round-3): `csa todo persist` must be allowed in
-            // executor mode so mktd Step 13 can persist generated plans.
-            &["todo", "persist"][..],
-            &["todo", "ref", "add"][..],
-            &["todo", "ref", "list"][..],
-            &["todo", "ref", "show"][..],
-            &["todo", "show"][..],
-            &["todo", "list"][..],
-            &["todo", "find"][..],
-            &["tokuin", "estimate"][..],
-            &["config", "get"][..],
-            &["config", "show"][..],
-            &["health"][..],
-        ] {
-            assert!(
-                is_safe_prefix(prefix),
-                "prefix should be allowed: {prefix:?}"
-            );
-        }
+    fn parse_command(args: &[&str]) -> Commands {
+        Cli::try_parse_from(args)
+            .expect("test command should parse")
+            .command
+    }
+
+    fn assert_executor_guard_allows(args: &[&str]) {
+        let command = parse_command(args);
+        enforce_active(&command).expect("executor guard should allow command");
+    }
+
+    fn assert_executor_guard_blocks(args: &[&str]) {
+        let command = parse_command(args);
+        let err = enforce_active(&command).expect_err("executor guard should block command");
+        assert!(
+            err.to_string().contains("recursive dev2merge invocation"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
-    fn safe_prefixes_block_recursive_execution_commands() {
-        for prefix in [
-            &["run"][..],
-            &["review"][..],
-            &["debate"][..],
-            &["plan", "run"][..],
-            &["todo", "ref", "import-transcript"][..],
-            &["config", "set"][..],
-        ] {
-            assert!(
-                !is_safe_prefix(prefix),
-                "prefix should be blocked: {prefix:?}"
-            );
-        }
+    fn executor_guard_allows_review() {
+        assert_executor_guard_allows(&["csa", "review", "--diff"]);
+    }
+
+    #[test]
+    fn executor_guard_allows_debate() {
+        assert_executor_guard_allows(&["csa", "debate", "question"]);
+    }
+
+    #[test]
+    fn executor_guard_blocks_dev2merge_skill_run() {
+        assert_executor_guard_blocks(&["csa", "run", "--skill", "dev2merge", "prompt"]);
+    }
+
+    #[test]
+    fn executor_guard_blocks_dev_to_merge_skill_run() {
+        assert_executor_guard_blocks(&["csa", "run", "--skill", "dev-to-merge", "prompt"]);
+    }
+
+    #[test]
+    fn executor_guard_blocks_dev2merge_skill_subcommand_run() {
+        assert_executor_guard_blocks(&["csa", "skill", "run", "dev2merge", "prompt"]);
+    }
+
+    #[test]
+    fn executor_guard_blocks_dev_to_merge_skill_subcommand_run() {
+        assert_executor_guard_blocks(&["csa", "skill", "run", "dev-to-merge", "prompt"]);
+    }
+
+    #[test]
+    fn executor_guard_allows_mktd_skill_run() {
+        assert_executor_guard_allows(&["csa", "run", "--skill", "mktd", "prompt"]);
+    }
+
+    #[test]
+    fn executor_guard_allows_general_run() {
+        assert_executor_guard_allows(&["csa", "run", "prompt"]);
     }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.923"
-weave = "0.1.923"
+csa = "0.1.924"
+weave = "0.1.924"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Fixes #1654. The dev2merge executor recursion guard used an allowlist that
blocked ALL `csa` subcommands — including `csa review` and `csa debate` — even
though the dev2merge SKILL.md explicitly permits these commands.

The guard now only blocks true self-recursion (`csa run --skill dev2merge` and
`csa skill run dev2merge`, plus `dev-to-merge` aliases), allowing the executor
to call `csa review`, `csa debate`, `csa run --skill mktd`, and other non-recursive
subcommands as intended by the skill contract.

## Changes

- `crates/cli-sub-agent/src/executor_csa_guard.rs` — narrow guard to skill-specific
  self-recursion check; covers both `csa run --skill` and `csa skill run` paths

## Test plan

- [ ] `csa review` passes the guard (no longer blocked)
- [ ] `csa debate` passes the guard
- [ ] `csa run --skill mktd` passes the guard
- [ ] `csa run --skill dev2merge` still blocked (self-recursion)
- [ ] `csa skill run dev2merge` still blocked (R2 fix)

Closes #1654

🤖 Generated with [Claude Code](https://claude.com/claude-code)