### PR TITLE
fix(cli-sub-agent): enforce git hook-bypass strip and push ban at execution layer (#1667)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.924"
+version = "0.1.925"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.924"
+version = "0.1.925"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -571,6 +571,10 @@ mod thinking_tests;
 mod prompt_guard_tests;
 
 #[cfg(test)]
+#[path = "pipeline_tests_git_guard_env.rs"]
+mod git_guard_env_tests;
+
+#[cfg(test)]
 #[path = "pipeline_tests_preflight.rs"]
 mod preflight_tests;
 

--- a/crates/cli-sub-agent/src/pipeline_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_env.rs
@@ -18,6 +18,7 @@ pub(crate) fn build_merged_env(
     tool_name: &str,
     current_depth: u32,
     pattern_internal: bool,
+    sa_mode: bool,
 ) -> HashMap<String, String> {
     let suppress = config
         .map(|c| c.should_suppress_notify(tool_name))
@@ -79,6 +80,11 @@ pub(crate) fn build_merged_env(
             csa_core::env::CSA_PATTERN_INTERNAL_ENV_KEY.to_string(),
             "1".to_string(),
         );
+    }
+    if sa_mode {
+        merged_env.insert("CSA_GIT_PUSH_ALLOWED".to_string(), "true".to_string());
+    } else {
+        merged_env.remove("CSA_GIT_PUSH_ALLOWED");
     }
 
     merged_env

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -293,6 +293,9 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             .await?;
     let result_file_cleared = clear_expected_result_artifacts_for_prompt(prompt, &session_dir);
     let execution_start_time = chrono::Utc::now();
+    let sa_mode =
+        std::env::var_os(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)
+            .is_some_and(|value| value == "true" || value == "1");
     let session_config = global_config.map(|gc| {
         let mcp_servers = resolve_mcp_servers(project_root, gc);
         if !mcp_servers.is_empty() {
@@ -315,6 +318,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         executor.tool_name(),
         startup_env.current_depth(),
         startup_env.pattern_internal(),
+        sa_mode,
     );
     crate::pipeline_env::apply_task_target_dir_guards(
         task_type,
@@ -550,10 +554,6 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
             },
         );
     }
-    let sa_mode = std::env::var(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)
-        .ok()
-        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1"))
-        .unwrap_or(false);
     let post_ctx = crate::pipeline_post_exec::PostExecContext {
         executor,
         prompt,

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -483,8 +483,15 @@ fn test_config_with_node_heap_limit(node_heap_limit_mb: Option<u64>) -> ProjectC
 #[test]
 fn build_merged_env_injects_node_options_when_heap_limit_configured() {
     let cfg = test_config_with_node_heap_limit(Some(2048));
-    let merged =
-        crate::pipeline_env::build_merged_env(None, Some(&cfg), None, "claude-code", 0, false);
+    let merged = crate::pipeline_env::build_merged_env(
+        None,
+        Some(&cfg),
+        None,
+        "claude-code",
+        0,
+        false,
+        false,
+    );
     assert_eq!(
         merged.get("NODE_OPTIONS"),
         Some(&"--max-old-space-size=2048".to_string())
@@ -501,7 +508,7 @@ fn build_merged_env_does_not_inject_node_options_without_heap_limit() {
     let cfg = test_config_with_node_heap_limit(None);
     // Use a lightweight tool (opencode); heavyweight tools default node_heap_limit_mb to Some(2048).
     let merged =
-        crate::pipeline_env::build_merged_env(None, Some(&cfg), None, "opencode", 0, false);
+        crate::pipeline_env::build_merged_env(None, Some(&cfg), None, "opencode", 0, false, false);
 
     assert!(
         !merged.contains_key("NODE_OPTIONS"),
@@ -517,7 +524,7 @@ fn build_merged_env_preserves_current_path_for_tool_runtime_resolution() {
     };
 
     let merged =
-        crate::pipeline_env::build_merged_env(None, Some(&cfg), None, "opencode", 0, false);
+        crate::pipeline_env::build_merged_env(None, Some(&cfg), None, "opencode", 0, false, false);
 
     assert_eq!(
         merged.get("PATH"),
@@ -529,8 +536,15 @@ fn build_merged_env_preserves_current_path_for_tool_runtime_resolution() {
 fn build_merged_env_disables_gemini_direct_launch_in_tests() {
     let cfg = test_config_with_node_heap_limit(None);
 
-    let merged =
-        crate::pipeline_env::build_merged_env(None, Some(&cfg), None, "gemini-cli", 0, false);
+    let merged = crate::pipeline_env::build_merged_env(
+        None,
+        Some(&cfg),
+        None,
+        "gemini-cli",
+        0,
+        false,
+        false,
+    );
 
     assert_eq!(
         merged.get("CSA_TEST_DISABLE_GEMINI_DIRECT_LAUNCH"),
@@ -550,6 +564,7 @@ fn build_merged_env_appends_node_options_when_existing_value_present() {
         None,
         "claude-code",
         0,
+        false,
         false,
     );
 
@@ -597,6 +612,7 @@ fn build_merged_env_scrubs_stale_contract_then_sets_fresh_invocation_env() {
         "opencode",
         4,
         false,
+        false,
     );
 
     assert_eq!(
@@ -625,34 +641,6 @@ fn build_merged_env_scrubs_stale_contract_then_sets_fresh_invocation_env() {
             "stale subtree-contract key {key} must not survive build_merged_env"
         );
     }
-}
-
-#[test]
-fn build_merged_env_propagates_pattern_internal_marker_to_leaf_tool() {
-    let cfg = test_config_with_node_heap_limit(None);
-
-    // pattern_internal = true: the leaf tool (and any nested `csa` it spawns)
-    // must inherit CSA_PATTERN_INTERNAL=1 so the fatal-error-marker scan stays
-    // OFF down the whole subtree (#1847). The key is NOT a scrubbed subtree
-    // contract key, so it survives the transport env filter.
-    let marked =
-        crate::pipeline_env::build_merged_env(None, Some(&cfg), None, "claude-code", 0, true);
-    assert_eq!(
-        marked
-            .get(csa_core::env::CSA_PATTERN_INTERNAL_ENV_KEY)
-            .map(String::as_str),
-        Some("1"),
-        "pattern-internal session must propagate CSA_PATTERN_INTERNAL=1 to the leaf tool"
-    );
-
-    // pattern_internal = false: an ordinary interactive session must NOT leak
-    // the marker, so its leaf tool keeps the default scan-ON behavior.
-    let unmarked =
-        crate::pipeline_env::build_merged_env(None, Some(&cfg), None, "claude-code", 0, false);
-    assert!(
-        !unmarked.contains_key(csa_core::env::CSA_PATTERN_INTERNAL_ENV_KEY),
-        "non-pattern-internal session must not emit CSA_PATTERN_INTERNAL"
-    );
 }
 
 // --- enforce_tier regression tests ---

--- a/crates/cli-sub-agent/src/pipeline_tests_git_guard_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_git_guard_env.rs
@@ -1,0 +1,104 @@
+use chrono::Utc;
+use csa_config::config::CURRENT_SCHEMA_VERSION;
+use csa_config::{ProjectConfig, ProjectMeta, ResourcesConfig};
+use std::collections::HashMap;
+
+fn test_config() -> ProjectConfig {
+    ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        github: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    }
+}
+
+#[test]
+fn build_merged_env_propagates_pattern_internal_marker_to_leaf_tool() {
+    let cfg = test_config();
+
+    let marked = crate::pipeline_env::build_merged_env(
+        None,
+        Some(&cfg),
+        None,
+        "claude-code",
+        0,
+        true,
+        false,
+    );
+    assert_eq!(
+        marked
+            .get(csa_core::env::CSA_PATTERN_INTERNAL_ENV_KEY)
+            .map(String::as_str),
+        Some("1")
+    );
+
+    let unmarked = crate::pipeline_env::build_merged_env(
+        None,
+        Some(&cfg),
+        None,
+        "claude-code",
+        0,
+        false,
+        false,
+    );
+    assert!(!unmarked.contains_key(csa_core::env::CSA_PATTERN_INTERNAL_ENV_KEY));
+}
+
+#[test]
+fn build_merged_env_allows_git_push_only_for_sa_mode() {
+    let cfg = test_config();
+    let allowed = crate::pipeline_env::build_merged_env(
+        None,
+        Some(&cfg),
+        None,
+        "claude-code",
+        0,
+        false,
+        true,
+    );
+
+    assert_eq!(
+        allowed.get("CSA_GIT_PUSH_ALLOWED").map(String::as_str),
+        Some("true")
+    );
+}
+
+#[test]
+fn build_merged_env_removes_spoofed_git_push_permission_for_leaf_workers() {
+    let cfg = test_config();
+    let extra_env = HashMap::from([("CSA_GIT_PUSH_ALLOWED".to_string(), "true".to_string())]);
+
+    let leaf = crate::pipeline_env::build_merged_env(
+        Some(&extra_env),
+        Some(&cfg),
+        None,
+        "claude-code",
+        0,
+        false,
+        false,
+    );
+
+    assert!(!leaf.contains_key("CSA_GIT_PUSH_ALLOWED"));
+}

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -48,11 +48,12 @@ fn make_result(status: &str, exit_code: i32) -> SessionResult {
 }
 
 fn run_git(dir: &std::path::Path, args: &[&str]) {
-    let output = std::process::Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .unwrap();
+    let mut command = std::process::Command::new("git");
+    command.args(args).current_dir(dir);
+    if args.first() == Some(&"push") {
+        command.env("CSA_GIT_PUSH_ALLOWED", "true");
+    }
+    let output = command.output().unwrap();
     assert!(
         output.status.success(),
         "git {:?} failed: stdout={} stderr={}",

--- a/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests_part2.rs
@@ -584,29 +584,23 @@ fn test_build_command_codex_strips_lefthook_env_reinjected_by_extra_env() {
 
     let envs: Vec<_> = cmd.as_std().get_envs().collect();
     let env_map: HashMap<&std::ffi::OsStr, Option<&std::ffi::OsStr>> = envs.into_iter().collect();
+    let os = std::ffi::OsStr::new;
 
-    assert_eq!(env_map.get(std::ffi::OsStr::new("LEFTHOOK")), Some(&None));
-    assert_eq!(
-        env_map.get(std::ffi::OsStr::new("LEFTHOOK_SKIP_PRE_COMMIT")),
-        Some(&None)
-    );
-    assert_eq!(
-        env_map.get(std::ffi::OsStr::new("SAFE_ENV")),
-        Some(&Some(std::ffi::OsStr::new("ok")))
-    );
-    assert!(
-        env_map
-            .get(std::ffi::OsStr::new("CSA_REAL_GIT"))
-            .is_some_and(Option::is_some),
-        "git guard should expose the real git binary"
-    );
-    assert!(
-        env_map
-            .get(std::ffi::OsStr::new("PATH"))
-            .and_then(|value| value.as_ref())
-            .is_some_and(|value| value.to_string_lossy().contains("guards")),
-        "git guard should prepend its wrapper directory to PATH"
-    );
+    assert_eq!(env_map.get(os("LEFTHOOK")), Some(&None));
+    assert_eq!(env_map.get(os("LEFTHOOK_SKIP_PRE_COMMIT")), Some(&None));
+    assert_eq!(env_map.get(os("SAFE_ENV")), Some(&Some(os("ok"))));
+    assert!(env_map.get(os("CSA_REAL_GIT")).is_some_and(Option::is_some));
+    let session_dir = env_map
+        .get(os("CSA_SESSION_DIR"))
+        .and_then(|value| value.as_ref())
+        .unwrap()
+        .to_string_lossy();
+    let path = env_map
+        .get(os("PATH"))
+        .and_then(|value| value.as_ref())
+        .unwrap()
+        .to_string_lossy();
+    assert!(path.starts_with(&format!("{session_dir}/bin")));
 }
 
 #[test]

--- a/crates/csa-executor/src/executor_env.rs
+++ b/crates/csa-executor/src/executor_env.rs
@@ -38,13 +38,15 @@ pub(crate) fn apply_subtree_pin(cmd: &mut Command, pin: Option<&csa_core::env::S
 
 pub(crate) fn inject_git_guard_env(cmd: &mut Command) {
     let mut guard_env = HashMap::new();
-    if let Some(path) = cmd
-        .as_std()
-        .get_envs()
-        .find_map(|(key, value)| (key == OsStr::new("PATH")).then_some(value))
-        .flatten()
-    {
-        guard_env.insert("PATH".to_string(), path.to_string_lossy().into_owned());
+    for key in ["PATH", "CSA_SESSION_DIR"] {
+        if let Some(value) = cmd
+            .as_std()
+            .get_envs()
+            .find_map(|(env_key, value)| (env_key == OsStr::new(key)).then_some(value))
+            .flatten()
+        {
+            guard_env.insert(key.to_string(), value.to_string_lossy().into_owned());
+        }
     }
 
     csa_hooks::git_guard::inject_git_guard_env(&mut guard_env);

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -359,10 +359,8 @@ fn test_build_env_codex_strips_lefthook_bypass_env_only_for_codex() {
         env.get("CSA_REAL_GIT").is_some_and(|value| !value.is_empty()),
         "ACP env should expose real git for the git guard"
     );
-    assert!(
-        env.get("PATH").is_some_and(|value| value.contains("guards")),
-        "ACP env should prepend the git guard wrapper directory to PATH"
-    );
+    let session_bin = format!("{}/bin", env.get("CSA_SESSION_DIR").unwrap());
+    assert!(env.get("PATH").unwrap().starts_with(&session_bin));
 }
 
 #[test]

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -3,8 +3,8 @@
 //! CSA tool subprocesses share the caller's `.git` directory, so Git hooks are
 //! the last deterministic local gate before an agent-created commit lands in
 //! the repository.  This module injects a `git` wrapper ahead of the real Git
-//! binary in `PATH` and blocks known hook-bypass forms before the commit is
-//! created.
+//! binary in `PATH`, strips hook-bypass inputs from commits, and blocks leaf
+//! worker pushes.
 
 use std::collections::HashMap;
 use std::fs;
@@ -15,23 +15,27 @@ use std::sync::{LazyLock, Mutex};
 
 use anyhow::{Context, Result};
 
-const GUARD_DIR_NAME: &str = "guards";
+const FALLBACK_GUARD_DIR_NAME: &str = "guards";
+const SESSION_GUARD_DIR_NAME: &str = "bin";
+const CSA_SESSION_DIR_ENV: &str = "CSA_SESSION_DIR";
 static GUARD_SETUP_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-const GIT_WRAPPER: &str = r#"#!/usr/bin/env bash
-# CSA git guard: blocks git commit hook bypass.
+const GIT_WRAPPER: &str = r#"#!/bin/sh
+# CSA git guard: strips git commit hook bypass and blocks leaf-worker pushes.
 # Injected by CSA via PATH.
-set -euo pipefail
+set -eu
 
 REAL_GIT="${CSA_REAL_GIT:-}"
 if [ -z "${REAL_GIT}" ]; then
   GUARD_DIR="$(cd "$(dirname "$0")" && pwd)"
   CLEAN_PATH=""
-  IFS=: read -ra _PATH_DIRS <<< "${PATH:-}"
-  for _dir in "${_PATH_DIRS[@]}"; do
+  OLD_IFS="${IFS}"
+  IFS=:
+  for _dir in ${PATH:-}; do
     [ -z "${_dir}" ] && continue
     [ "${_dir}" = "${GUARD_DIR}" ] && continue
     CLEAN_PATH="${CLEAN_PATH:+${CLEAN_PATH}:}${_dir}"
   done
+  IFS="${OLD_IFS}"
   REAL_GIT="$(PATH="${CLEAN_PATH}" command -v git 2>/dev/null)" || true
 fi
 
@@ -47,10 +51,66 @@ is_hooks_path_config() {
   esac
 }
 
+strip_hook_bypass_env() {
+  unset LEFTHOOK || true
+  unset LEFTHOOK_DISABLED || true
+  unset HUSKY || true
+  unset HUSKY_DISABLE || true
+  unset SKIP_HOOKS || true
+  unset SKIP_GIT_HOOKS || true
+  unset PRE_COMMIT_ALLOW_NO_CONFIG || true
+  unset LEFTHOOK_SKIP || true
+  unset LEFTHOOK_EXCLUDE || true
+  unset SKIP || true
+
+  for env_name in $(env | sed -n \
+    -e 's/^\(LEFTHOOK_SKIP_[A-Za-z0-9_]*\)=.*/\1/p' \
+    -e 's/^\(LEFTHOOK_EXCLUDE_[A-Za-z0-9_]*\)=.*/\1/p'); do
+    unset "${env_name}" || true
+  done
+}
+
+append_sanitized_arg() {
+  quoted_arg="'$(printf "%s" "$1" | sed "s/'/'\\\\''/g")'"
+  if [ -z "${SANITIZED_ARGS}" ]; then
+    SANITIZED_ARGS="${quoted_arg}"
+  else
+    SANITIZED_ARGS="${SANITIZED_ARGS} ${quoted_arg}"
+  fi
+}
+
+strip_commit_short_arg() {
+  short_options="${1#-}"
+  rebuilt_options=""
+  while [ -n "${short_options}" ]; do
+    short_remainder="${short_options#?}"
+    short_option="${short_options%"${short_remainder}"}"
+    short_options="${short_remainder}"
+    case "${short_option}" in
+      n)
+        STRIPPED_NO_VERIFY=true
+        ;;
+      C|F|c|m|t)
+        rebuilt_options="${rebuilt_options}${short_option}${short_options}"
+        short_options=""
+        ;;
+      *)
+        rebuilt_options="${rebuilt_options}${short_option}"
+        ;;
+    esac
+  done
+
+  if [ -n "${rebuilt_options}" ]; then
+    STRIPPED_SHORT_RESULT="-${rebuilt_options}"
+  else
+    STRIPPED_SHORT_RESULT=""
+  fi
+}
+
 COMMAND=""
 BLOCK_HOOKS_PATH_OVERRIDE=false
 EXPECT_VALUE=""
-for arg in "$@"; do
+for arg do
   if [ -n "${EXPECT_VALUE}" ]; then
     if [ "${EXPECT_VALUE}" = "config" ] && is_hooks_path_config "${arg}"; then
       BLOCK_HOOKS_PATH_OVERRIDE=true
@@ -61,7 +121,7 @@ for arg in "$@"; do
 
   case "${arg}" in
     --help|-h)
-      exec "${REAL_GIT}" "$@"
+      continue
       ;;
     -c|--config)
       EXPECT_VALUE="config"
@@ -98,6 +158,13 @@ for arg in "$@"; do
   esac
 done
 
+strip_hook_bypass_env
+
+if [ "${COMMAND}" = "push" ] && [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]; then
+  echo "CSA git-guard: git push blocked for leaf-worker sessions." >&2
+  exit 128
+fi
+
 if [ "${COMMAND}" != "commit" ]; then
   exec "${REAL_GIT}" "$@"
 fi
@@ -107,73 +174,94 @@ if [ "${BLOCK_HOOKS_PATH_OVERRIDE}" = "true" ]; then
   exit 1
 fi
 
+SANITIZED_ARGS=""
+STRIPPED_NO_VERIFY=false
+COMMAND_SEEN=false
+END_OF_COMMIT_OPTIONS=false
+EXPECT_GLOBAL_VALUE=""
 EXPECT_COMMIT_VALUE=""
-for arg in "$@"; do
+for arg do
+  if [ "${COMMAND_SEEN}" = "false" ]; then
+    append_sanitized_arg "${arg}"
+    if [ -n "${EXPECT_GLOBAL_VALUE}" ]; then
+      EXPECT_GLOBAL_VALUE=""
+      continue
+    fi
+
+    case "${arg}" in
+      -c|--config|-C|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix|--config-env)
+        EXPECT_GLOBAL_VALUE="1"
+        continue
+        ;;
+      --config=*|--git-dir=*|--work-tree=*|--namespace=*|--exec-path=*|--super-prefix=*|--config-env=*)
+        continue
+        ;;
+      --*)
+        continue
+        ;;
+      -*)
+        continue
+        ;;
+      *)
+        [ "${arg}" = "commit" ] && COMMAND_SEEN=true
+        continue
+        ;;
+    esac
+  fi
+
+  if [ "${END_OF_COMMIT_OPTIONS}" = "true" ]; then
+    append_sanitized_arg "${arg}"
+    continue
+  fi
+
   if [ -n "${EXPECT_COMMIT_VALUE}" ]; then
+    append_sanitized_arg "${arg}"
     EXPECT_COMMIT_VALUE=""
     continue
   fi
 
   case "${arg}" in
     --no-verify|--no-verify=*)
-      echo "BLOCKED: CSA git guard prohibits git commit --no-verify." >&2
-      exit 1
+      STRIPPED_NO_VERIFY=true
       ;;
     --)
-      break
+      append_sanitized_arg "${arg}"
+      END_OF_COMMIT_OPTIONS=true
+      continue
       ;;
     --author|--cleanup|--date|--file|--fixup|--message|--pathspec-from-file|--reuse-message|--reedit-message|--squash|--template|--trailer)
+      append_sanitized_arg "${arg}"
       EXPECT_COMMIT_VALUE="commit-option"
       continue
       ;;
     --author=*|--cleanup=*|--date=*|--file=*|--fixup=*|--message=*|--pathspec-from-file=*|--reuse-message=*|--reedit-message=*|--squash=*|--template=*|--trailer=*)
+      append_sanitized_arg "${arg}"
       continue
       ;;
     --*)
+      append_sanitized_arg "${arg}"
       ;;
     -*)
-      # Git commit uses -n as the short form of --no-verify. Short options that
-      # take values consume the rest of the cluster or the next argument, so a
-      # leading dash inside that value must not be parsed as another option.
-      short_options="${arg#-}"
-      while [ -n "${short_options}" ]; do
-        short_option="${short_options:0:1}"
-        short_options="${short_options:1}"
-        case "${short_option}" in
-          n)
-            echo "BLOCKED: CSA git guard prohibits git commit -n/short -n combinations." >&2
-            exit 1
-            ;;
-          C|F|c|m|t)
-            if [ -z "${short_options}" ]; then
-              EXPECT_COMMIT_VALUE="commit-option"
-            fi
-            break
-            ;;
-        esac
-      done
+      STRIPPED_SHORT_RESULT=""
+      strip_commit_short_arg "${arg}"
+      if [ -n "${STRIPPED_SHORT_RESULT}" ]; then
+        append_sanitized_arg "${STRIPPED_SHORT_RESULT}"
+      fi
+      case "${STRIPPED_SHORT_RESULT}" in
+        -*[CFcmt])
+          EXPECT_COMMIT_VALUE="commit-option"
+          ;;
+      esac
+      ;;
+    *)
+      append_sanitized_arg "${arg}"
       ;;
   esac
 done
 
-if [ "${LEFTHOOK:-}" = "0" ]; then
-  echo "BLOCKED: CSA git guard prohibits LEFTHOOK=0 during git commit." >&2
-  exit 1
+if [ "${STRIPPED_NO_VERIFY}" = "true" ]; then
+  echo "CSA git-guard: stripped --no-verify from git commit (hook bypass forbidden)" >&2
 fi
-
-if [ -n "${LEFTHOOK_SKIP:-}" ] || [ -n "${LEFTHOOK_EXCLUDE:-}" ] || [ -n "${SKIP:-}" ]; then
-  echo "BLOCKED: CSA git guard prohibits LEFTHOOK_SKIP/LEFTHOOK_EXCLUDE/SKIP during git commit." >&2
-  exit 1
-fi
-
-while IFS='=' read -r name _value; do
-  case "${name}" in
-    LEFTHOOK_SKIP_*|LEFTHOOK_EXCLUDE_*)
-      echo "BLOCKED: CSA git guard prohibits ${name} during git commit." >&2
-      exit 1
-      ;;
-  esac
-done < <(env)
 
 if "${REAL_GIT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   top="$("${REAL_GIT}" rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -187,23 +275,8 @@ if "${REAL_GIT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 
   if [ -n "${lefthook_config}" ]; then
     hooks_path="$("${REAL_GIT}" config --path --get core.hooksPath 2>/dev/null || true)"
-    lefthook_hooks=()
-    while IFS= read -r line || [ -n "${line}" ]; do
-      line="${line%$'\r'}"
-      case "${line}" in
-        ""|\#*|" "*|$'\t'*) continue ;;
-      esac
-      hook_name="${line%%:*}"
-      [ "${hook_name}" = "${line}" ] && continue
-      case "${hook_name}" in
-        applypatch-msg|commit-msg|fsmonitor-watchman|p4-changelist|p4-post-changelist|p4-pre-submit|p4-prepare-changelist|post-applypatch|post-checkout|post-commit|post-index-change|post-merge|post-receive|post-rewrite|post-update|pre-applypatch|pre-auto-gc|pre-commit|pre-merge-commit|pre-push|pre-rebase|pre-receive|prepare-commit-msg|proc-receive|push-to-checkout|reference-transaction|sendemail-validate|update)
-          lefthook_hooks+=("${hook_name}")
-          ;;
-      esac
-    done < "${lefthook_config}"
-
     hook_path_for() {
-      local hook_name="$1"
+      hook_name="$1"
       if [ -n "${hooks_path}" ]; then
         case "${hooks_path}" in
           /*) printf '%s\n' "${hooks_path}/${hook_name}" ;;
@@ -214,31 +287,55 @@ if "${REAL_GIT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
       fi
     }
 
-    for hook_name in "${lefthook_hooks[@]}"; do
-      hook_path="$(hook_path_for "${hook_name}")"
-      if [ -z "${hook_path}" ] || [ ! -x "${hook_path}" ]; then
-        echo "BLOCKED: lefthook config defines ${hook_name} but no executable ${hook_name} hook is active." >&2
-        echo "Run: lefthook install" >&2
-        if [ -n "${hook_path}" ]; then
-          echo "Expected hook: ${hook_path}" >&2
-        fi
-        exit 1
-      fi
-    done
+    while IFS= read -r line || [ -n "${line}" ]; do
+      case "${line}" in
+        ""|\#*|" "*) continue ;;
+      esac
+      hook_name="${line%%:*}"
+      [ "${hook_name}" = "${line}" ] && continue
+      case "${hook_name}" in
+        applypatch-msg|commit-msg|fsmonitor-watchman|p4-changelist|p4-post-changelist|p4-pre-submit|p4-prepare-changelist|post-applypatch|post-checkout|post-commit|post-index-change|post-merge|post-receive|post-rewrite|post-update|pre-applypatch|pre-auto-gc|pre-commit|pre-merge-commit|pre-push|pre-rebase|pre-receive|prepare-commit-msg|proc-receive|push-to-checkout|reference-transaction|sendemail-validate|update)
+          hook_path="$(hook_path_for "${hook_name}")"
+          if [ -z "${hook_path}" ] || [ ! -x "${hook_path}" ]; then
+            echo "BLOCKED: lefthook config defines ${hook_name} but no executable ${hook_name} hook is active." >&2
+            echo "Run: lefthook install" >&2
+            if [ -n "${hook_path}" ]; then
+              echo "Expected hook: ${hook_path}" >&2
+            fi
+            exit 1
+          fi
+          ;;
+      esac
+    done < "${lefthook_config}"
   fi
 fi
 
+eval "set -- ${SANITIZED_ARGS}"
 exec "${REAL_GIT}" "$@"
 "#;
 
 pub fn ensure_git_guard_dir() -> Result<PathBuf> {
     let data_dir = csa_config::paths::state_dir()
         .context("cannot determine CSA state directory")?
-        .join(GUARD_DIR_NAME);
+        .join(FALLBACK_GUARD_DIR_NAME);
 
-    fs::create_dir_all(&data_dir)
+    ensure_git_guard_dir_at(&data_dir)
+}
+
+fn ensure_git_guard_dir_for_env(env: &HashMap<String, String>) -> Result<PathBuf> {
+    if let Some(session_dir) = env
+        .get(CSA_SESSION_DIR_ENV)
+        .filter(|value| !value.is_empty())
+    {
+        return ensure_git_guard_dir_at(&Path::new(session_dir).join(SESSION_GUARD_DIR_NAME));
+    }
+
+    ensure_git_guard_dir()
+}
+
+fn ensure_git_guard_dir_at(data_dir: &Path) -> Result<PathBuf> {
+    fs::create_dir_all(data_dir)
         .with_context(|| format!("failed to create guard dir: {}", data_dir.display()))?;
-
     let wrapper_path = data_dir.join("git");
     fs::write(&wrapper_path, GIT_WRAPPER)
         .with_context(|| format!("failed to write git wrapper: {}", wrapper_path.display()))?;
@@ -246,7 +343,7 @@ pub fn ensure_git_guard_dir() -> Result<PathBuf> {
     fs::set_permissions(&wrapper_path, fs::Permissions::from_mode(0o755))
         .with_context(|| format!("failed to chmod git wrapper: {}", wrapper_path.display()))?;
 
-    Ok(data_dir)
+    Ok(data_dir.to_path_buf())
 }
 
 pub fn inject_git_guard_env(env: &mut HashMap<String, String>) {
@@ -257,7 +354,7 @@ pub fn inject_git_guard_env(env: &mut HashMap<String, String>) {
             return;
         }
     };
-    let guard_dir = match ensure_git_guard_dir() {
+    let guard_dir = match ensure_git_guard_dir_for_env(env) {
         Ok(dir) => dir,
         Err(error) => {
             tracing::warn!("git guard setup failed (best-effort skip): {error:#}");
@@ -314,376 +411,4 @@ fn prepend_guard_dir(env: &mut HashMap<String, String>, guard_dir: &Path) {
 #[must_use]
 pub fn git_wrapper_script() -> &'static str {
     GIT_WRAPPER
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(unix)]
-    use crate::test_support::ENV_LOCK;
-
-    use super::{git_wrapper_script, inject_git_guard_env};
-    use std::collections::HashMap;
-    #[cfg(unix)]
-    use std::io::Write;
-    #[cfg(unix)]
-    use std::os::unix::fs::PermissionsExt;
-    #[cfg(unix)]
-    use std::path::Path;
-    #[cfg(unix)]
-    use std::time::Duration;
-
-    #[cfg(unix)]
-    fn write_executable(path: &Path, contents: impl AsRef<[u8]>) {
-        let mut file = std::fs::File::create(path).unwrap();
-        file.write_all(contents.as_ref()).unwrap();
-        file.sync_all().unwrap();
-        drop(file);
-
-        for attempt in 0..5 {
-            match std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)) {
-                Ok(()) => return,
-                Err(err) if err.raw_os_error() == Some(libc::ETXTBSY) && attempt < 4 => {
-                    std::thread::sleep(Duration::from_millis(10));
-                }
-                Err(err) => panic!("failed to mark {} executable: {err}", path.display()),
-            }
-        }
-    }
-
-    #[cfg(unix)]
-    fn write_fake_worktree_git(path: &Path) {
-        write_executable(
-            path,
-            r#"#!/usr/bin/env bash
-set -euo pipefail
-case "$*" in
-  "rev-parse --is-inside-work-tree") exit 0 ;;
-  "rev-parse --show-toplevel") printf '%s\n' "${FAKE_TOP}" ; exit 0 ;;
-  "config --path --get core.hooksPath") exit 1 ;;
-esac
-if [ "${1:-}" = "rev-parse" ] && [ "${2:-}" = "--git-path" ]; then
-  printf '%s\n' "${FAKE_TOP}/.git/${3}"
-  exit 0
-fi
-printf '%s\n' "$*"
-"#,
-        );
-    }
-
-    #[test]
-    fn inject_git_guard_env_sets_real_git_and_path() {
-        let mut env = HashMap::new();
-        inject_git_guard_env(&mut env);
-
-        assert!(env.contains_key("PATH"));
-        assert!(
-            env.get("PATH")
-                .is_some_and(|value| value.contains("guards"))
-        );
-        assert!(env.contains_key("CSA_REAL_GIT"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wrapper_blocks_no_verify_before_real_git() {
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        let temp = tempfile::tempdir().unwrap();
-        let wrapper = temp.path().join("git");
-        write_executable(&wrapper, git_wrapper_script());
-
-        let fake_git = temp.path().join("real-git");
-        let marker = temp.path().join("called");
-        write_executable(
-            &fake_git,
-            format!(
-                "#!/usr/bin/env bash\necho called > '{}'\n",
-                marker.display()
-            ),
-        );
-
-        let output = std::process::Command::new(&wrapper)
-            .arg("commit")
-            .arg("--no-verify")
-            .env("CSA_REAL_GIT", &fake_git)
-            .output()
-            .unwrap();
-
-        assert!(!output.status.success());
-        assert!(!marker.exists(), "real git must not run after --no-verify");
-        assert!(String::from_utf8_lossy(&output.stderr).contains("--no-verify"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wrapper_blocks_lefthook_bypass_env_before_real_git() {
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        let temp = tempfile::tempdir().unwrap();
-        let wrapper = temp.path().join("git");
-        write_executable(&wrapper, git_wrapper_script());
-
-        let fake_git = temp.path().join("real-git");
-        let marker = temp.path().join("called");
-        write_executable(
-            &fake_git,
-            format!(
-                "#!/usr/bin/env bash\necho called > '{}'\n",
-                marker.display()
-            ),
-        );
-
-        let output = std::process::Command::new(&wrapper)
-            .arg("commit")
-            .arg("-m")
-            .arg("test")
-            .env("CSA_REAL_GIT", &fake_git)
-            .env("LEFTHOOK", "0")
-            .output()
-            .unwrap();
-
-        assert!(!output.status.success());
-        assert!(!marker.exists(), "real git must not run after LEFTHOOK=0");
-        assert!(String::from_utf8_lossy(&output.stderr).contains("LEFTHOOK=0"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wrapper_allows_pre_push_only_lefthook_config_without_pre_commit() {
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        let temp = tempfile::tempdir().unwrap();
-        let wrapper = temp.path().join("git");
-        write_executable(&wrapper, git_wrapper_script());
-
-        let repo = temp.path().join("repo");
-        std::fs::create_dir_all(repo.join(".git/hooks")).unwrap();
-        std::fs::write(
-            repo.join("lefthook.yml"),
-            "pre-push:\n  commands:\n    review:\n      run: echo ok\n",
-        )
-        .unwrap();
-        write_executable(
-            repo.join(".git/hooks/pre-push").as_path(),
-            "#!/usr/bin/env bash\n",
-        );
-
-        let fake_git = temp.path().join("real-git");
-        write_fake_worktree_git(&fake_git);
-
-        let output = std::process::Command::new(&wrapper)
-            .arg("commit")
-            .arg("-m")
-            .arg("test")
-            .current_dir(&repo)
-            .env("CSA_REAL_GIT", &fake_git)
-            .env("FAKE_TOP", &repo)
-            .output()
-            .unwrap();
-
-        assert!(
-            output.status.success(),
-            "{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        assert_eq!(
-            String::from_utf8_lossy(&output.stdout).trim(),
-            "commit -m test"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wrapper_blocks_missing_defined_pre_push_lefthook_hook() {
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        let temp = tempfile::tempdir().unwrap();
-        let wrapper = temp.path().join("git");
-        write_executable(&wrapper, git_wrapper_script());
-
-        let repo = temp.path().join("repo");
-        std::fs::create_dir_all(repo.join(".git/hooks")).unwrap();
-        std::fs::write(repo.join("lefthook.yml"), "pre-push:\n").unwrap();
-
-        let fake_git = temp.path().join("real-git");
-        write_fake_worktree_git(&fake_git);
-
-        let output = std::process::Command::new(&wrapper)
-            .arg("commit")
-            .arg("-m")
-            .arg("test")
-            .current_dir(&repo)
-            .env("CSA_REAL_GIT", &fake_git)
-            .env("FAKE_TOP", &repo)
-            .output()
-            .unwrap();
-
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(!output.status.success());
-        assert!(stderr.contains("pre-push"), "{stderr}");
-        assert!(stderr.contains("lefthook install"), "{stderr}");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wrapper_requires_pre_commit_when_lefthook_config_defines_it() {
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        let temp = tempfile::tempdir().unwrap();
-        let wrapper = temp.path().join("git");
-        write_executable(&wrapper, git_wrapper_script());
-
-        let repo = temp.path().join("repo");
-        std::fs::create_dir_all(repo.join(".git/hooks")).unwrap();
-        std::fs::write(repo.join("lefthook.yml"), "pre-commit:\npre-push:\n").unwrap();
-        write_executable(
-            repo.join(".git/hooks/pre-push").as_path(),
-            "#!/usr/bin/env bash\n",
-        );
-
-        let fake_git = temp.path().join("real-git");
-        write_fake_worktree_git(&fake_git);
-
-        let output = std::process::Command::new(&wrapper)
-            .arg("commit")
-            .arg("-m")
-            .arg("test")
-            .current_dir(&repo)
-            .env("CSA_REAL_GIT", &fake_git)
-            .env("FAKE_TOP", &repo)
-            .output()
-            .unwrap();
-
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(!output.status.success());
-        assert!(stderr.contains("pre-commit"), "{stderr}");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wrapper_allows_long_commit_options_containing_n() {
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        let temp = tempfile::tempdir().unwrap();
-        let wrapper = temp.path().join("git");
-        write_executable(&wrapper, git_wrapper_script());
-
-        let fake_git = temp.path().join("real-git");
-        write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
-
-        let output = std::process::Command::new(&wrapper)
-            .arg("commit")
-            .arg("--amend")
-            .env("CSA_REAL_GIT", &fake_git)
-            .output()
-            .unwrap();
-
-        assert!(output.status.success());
-        assert_eq!(
-            String::from_utf8_lossy(&output.stdout).trim(),
-            "commit --amend"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wrapper_allows_markdown_bullet_after_long_message_option() {
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        let temp = tempfile::tempdir().unwrap();
-        let wrapper = temp.path().join("git");
-        write_executable(&wrapper, git_wrapper_script());
-
-        let fake_git = temp.path().join("real-git");
-        write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
-
-        // Commit message body intentionally starts with "- " (markdown bullet),
-        // which is NOT a separate flag — bind to a variable so clippy does not
-        // misinterpret the leading dash as a split-args candidate.
-        let body_msg = "- **Design Intent**: count failed reads as skipped";
-        let output = std::process::Command::new(&wrapper)
-            .arg("commit")
-            .arg("--message")
-            .arg("fix(batch): count read failures as skipped")
-            .arg("--message")
-            .arg(body_msg)
-            .env("CSA_REAL_GIT", &fake_git)
-            .output()
-            .unwrap();
-
-        assert!(output.status.success());
-        assert_eq!(
-            String::from_utf8_lossy(&output.stdout).trim(),
-            "commit --message fix(batch): count read failures as skipped --message - **Design Intent**: count failed reads as skipped"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wrapper_allows_leading_dash_after_short_message_option() {
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        let temp = tempfile::tempdir().unwrap();
-        let wrapper = temp.path().join("git");
-        write_executable(&wrapper, git_wrapper_script());
-
-        let fake_git = temp.path().join("real-git");
-        write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
-
-        // Message intentionally starts with "- " (markdown bullet); bind to a
-        // variable so clippy does not flag suspicious_command_arg_space.
-        let msg = "- leading dash is message text";
-        let output = std::process::Command::new(&wrapper)
-            .arg("commit")
-            .arg("-m")
-            .arg(msg)
-            .env("CSA_REAL_GIT", &fake_git)
-            .output()
-            .unwrap();
-
-        assert!(output.status.success());
-        assert_eq!(
-            String::from_utf8_lossy(&output.stdout).trim(),
-            "commit -m - leading dash is message text"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wrapper_allows_leading_dash_after_file_option() {
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        let temp = tempfile::tempdir().unwrap();
-        let wrapper = temp.path().join("git");
-        write_executable(&wrapper, git_wrapper_script());
-
-        let fake_git = temp.path().join("real-git");
-        write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
-
-        let output = std::process::Command::new(&wrapper)
-            .arg("commit")
-            .arg("-F")
-            .arg("-")
-            .env("CSA_REAL_GIT", &fake_git)
-            .output()
-            .unwrap();
-
-        assert!(output.status.success());
-        assert_eq!(
-            String::from_utf8_lossy(&output.stdout).trim(),
-            "commit -F -"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wrapper_forwards_non_commit_commands() {
-        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-        let temp = tempfile::tempdir().unwrap();
-        let wrapper = temp.path().join("git");
-        write_executable(&wrapper, git_wrapper_script());
-
-        let fake_git = temp.path().join("real-git");
-        write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
-
-        let output = std::process::Command::new(&wrapper)
-            .arg("status")
-            .env("CSA_REAL_GIT", &fake_git)
-            .output()
-            .unwrap();
-
-        assert!(output.status.success());
-        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "status");
-    }
 }

--- a/crates/csa-hooks/src/git_guard_tests.rs
+++ b/crates/csa-hooks/src/git_guard_tests.rs
@@ -1,0 +1,539 @@
+#[cfg(unix)]
+use crate::test_support::ENV_LOCK;
+
+use crate::{git_wrapper_script, inject_git_guard_env};
+use std::collections::HashMap;
+#[cfg(unix)]
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::path::Path;
+#[cfg(unix)]
+use std::time::Duration;
+
+#[cfg(unix)]
+fn write_executable(path: &Path, contents: impl AsRef<[u8]>) {
+    let mut file = std::fs::File::create(path).unwrap();
+    file.write_all(contents.as_ref()).unwrap();
+    file.sync_all().unwrap();
+    drop(file);
+
+    for attempt in 0..5 {
+        match std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)) {
+            Ok(()) => return,
+            Err(err) if err.raw_os_error() == Some(libc::ETXTBSY) && attempt < 4 => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(err) => panic!("failed to mark {} executable: {err}", path.display()),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn write_fake_worktree_git(path: &Path) {
+    write_executable(
+        path,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "rev-parse --is-inside-work-tree") exit 0 ;;
+  "rev-parse --show-toplevel") printf '%s\n' "${FAKE_TOP}" ; exit 0 ;;
+  "config --path --get core.hooksPath") exit 1 ;;
+esac
+if [ "${1:-}" = "rev-parse" ] && [ "${2:-}" = "--git-path" ]; then
+  printf '%s\n' "${FAKE_TOP}/.git/${3}"
+  exit 0
+fi
+printf '%s\n' "$*"
+"#,
+    );
+}
+
+#[test]
+fn inject_git_guard_env_sets_real_git_and_path() {
+    let mut env = HashMap::new();
+    inject_git_guard_env(&mut env);
+
+    assert!(env.contains_key("PATH"));
+    assert!(
+        env.get("PATH")
+            .is_some_and(|value| value.contains("guards"))
+    );
+    assert!(env.contains_key("CSA_REAL_GIT"));
+}
+
+#[cfg(unix)]
+#[test]
+fn inject_git_guard_env_uses_session_bin_when_session_dir_is_present() {
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let mut env = HashMap::from([(
+        "CSA_SESSION_DIR".to_string(),
+        session_dir.display().to_string(),
+    )]);
+
+    inject_git_guard_env(&mut env);
+
+    let expected_bin = session_dir.join("bin");
+    let path = env.get("PATH").expect("PATH should be set");
+    assert!(
+        path.starts_with(expected_bin.to_string_lossy().as_ref()),
+        "session bin should be prepended to PATH, got: {path}"
+    );
+    assert!(
+        expected_bin.join("git").exists(),
+        "git wrapper should be written into CSA_SESSION_DIR/bin"
+    );
+    let mode = std::fs::metadata(expected_bin.join("git"))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o755, "git wrapper should be executable");
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_script_parses_with_sh_n() {
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let output = std::process::Command::new("sh")
+        .arg("-n")
+        .arg(&wrapper)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_strips_no_verify_before_real_git() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("commit")
+        .arg("--no-verify")
+        .arg("-m")
+        .arg("test")
+        .env("CSA_REAL_GIT", &fake_git)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "commit -m test"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr).trim(),
+        "CSA git-guard: stripped --no-verify from git commit (hook bypass forbidden)"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_strips_short_no_verify_before_real_git() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("commit")
+        .arg("-n")
+        .arg("-m")
+        .arg("test")
+        .env("CSA_REAL_GIT", &fake_git)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "commit -m test"
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("stripped --no-verify"));
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_strips_combined_short_no_verify_before_real_git() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    for flag in ["-anm", "-nam"] {
+        let output = std::process::Command::new(&wrapper)
+            .arg("commit")
+            .arg(flag)
+            .arg("test")
+            .env("CSA_REAL_GIT", &fake_git)
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "commit -am test"
+        );
+        assert!(String::from_utf8_lossy(&output.stderr).contains("stripped --no-verify"));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_unsets_hook_bypass_env_for_any_git_command() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(
+        &fake_git,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+for name in LEFTHOOK LEFTHOOK_DISABLED HUSKY HUSKY_DISABLE SKIP_HOOKS SKIP_GIT_HOOKS PRE_COMMIT_ALLOW_NO_CONFIG LEFTHOOK_SKIP_PRE_COMMIT; do
+  if env | grep -q "^${name}="; then
+echo "${name} still set"
+exit 3
+  fi
+done
+echo "$@"
+"#,
+    );
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("status")
+        .env("CSA_REAL_GIT", &fake_git)
+        .env("LEFTHOOK", "0")
+        .env("LEFTHOOK_DISABLED", "1")
+        .env("HUSKY", "0")
+        .env("HUSKY_DISABLE", "1")
+        .env("SKIP_HOOKS", "1")
+        .env("SKIP_GIT_HOOKS", "1")
+        .env("PRE_COMMIT_ALLOW_NO_CONFIG", "1")
+        .env("LEFTHOOK_SKIP_PRE_COMMIT", "1")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "status");
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_push_without_permission() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("push")
+        .env("CSA_REAL_GIT", &fake_git)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(128));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr).trim(),
+        "CSA git-guard: git push blocked for leaf-worker sessions."
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_push_with_permission() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("push")
+        .env("CSA_REAL_GIT", &fake_git)
+        .env("CSA_GIT_PUSH_ALLOWED", "true")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "push");
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_pre_push_only_lefthook_config_without_pre_commit() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(repo.join(".git/hooks")).unwrap();
+    std::fs::write(
+        repo.join("lefthook.yml"),
+        "pre-push:\n  commands:\n    review:\n      run: echo ok\n",
+    )
+    .unwrap();
+    write_executable(
+        repo.join(".git/hooks/pre-push").as_path(),
+        "#!/usr/bin/env bash\n",
+    );
+
+    let fake_git = temp.path().join("real-git");
+    write_fake_worktree_git(&fake_git);
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("commit")
+        .arg("-m")
+        .arg("test")
+        .current_dir(&repo)
+        .env("CSA_REAL_GIT", &fake_git)
+        .env("FAKE_TOP", &repo)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "commit -m test"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_missing_defined_pre_push_lefthook_hook() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(repo.join(".git/hooks")).unwrap();
+    std::fs::write(repo.join("lefthook.yml"), "pre-push:\n").unwrap();
+
+    let fake_git = temp.path().join("real-git");
+    write_fake_worktree_git(&fake_git);
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("commit")
+        .arg("-m")
+        .arg("test")
+        .current_dir(&repo)
+        .env("CSA_REAL_GIT", &fake_git)
+        .env("FAKE_TOP", &repo)
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success());
+    assert!(stderr.contains("pre-push"), "{stderr}");
+    assert!(stderr.contains("lefthook install"), "{stderr}");
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_requires_pre_commit_when_lefthook_config_defines_it() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(repo.join(".git/hooks")).unwrap();
+    std::fs::write(repo.join("lefthook.yml"), "pre-commit:\npre-push:\n").unwrap();
+    write_executable(
+        repo.join(".git/hooks/pre-push").as_path(),
+        "#!/usr/bin/env bash\n",
+    );
+
+    let fake_git = temp.path().join("real-git");
+    write_fake_worktree_git(&fake_git);
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("commit")
+        .arg("-m")
+        .arg("test")
+        .current_dir(&repo)
+        .env("CSA_REAL_GIT", &fake_git)
+        .env("FAKE_TOP", &repo)
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success());
+    assert!(stderr.contains("pre-commit"), "{stderr}");
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_long_commit_options_containing_n() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("commit")
+        .arg("--amend")
+        .env("CSA_REAL_GIT", &fake_git)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "commit --amend"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_markdown_bullet_after_long_message_option() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    // Commit message body intentionally starts with "- " (markdown bullet),
+    // which is NOT a separate flag — bind to a variable so clippy does not
+    // misinterpret the leading dash as a split-args candidate.
+    let body_msg = "- **Design Intent**: count failed reads as skipped";
+    let output = std::process::Command::new(&wrapper)
+        .arg("commit")
+        .arg("--message")
+        .arg("fix(batch): count read failures as skipped")
+        .arg("--message")
+        .arg(body_msg)
+        .env("CSA_REAL_GIT", &fake_git)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "commit --message fix(batch): count read failures as skipped --message - **Design Intent**: count failed reads as skipped"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_leading_dash_after_short_message_option() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    // Message intentionally starts with "- " (markdown bullet); bind to a
+    // variable so clippy does not flag suspicious_command_arg_space.
+    let msg = "- leading dash is message text";
+    let output = std::process::Command::new(&wrapper)
+        .arg("commit")
+        .arg("-m")
+        .arg(msg)
+        .env("CSA_REAL_GIT", &fake_git)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "commit -m - leading dash is message text"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_leading_dash_after_file_option() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("commit")
+        .arg("-F")
+        .arg("-")
+        .env("CSA_REAL_GIT", &fake_git)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "commit -F -"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_forwards_non_commit_commands() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    for subcommand in ["status", "add", "diff"] {
+        let output = std::process::Command::new(&wrapper)
+            .arg(subcommand)
+            .env("CSA_REAL_GIT", &fake_git)
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), subcommand);
+    }
+}

--- a/crates/csa-hooks/src/guard_tests.rs
+++ b/crates/csa-hooks/src/guard_tests.rs
@@ -171,13 +171,13 @@ mod unix_tests {
     }
 
     fn command_output(command: &mut std::process::Command) -> std::process::Output {
-        for attempt in 0..5 {
+        for attempt in 0..25 {
             match command.output() {
                 Ok(output) => return output,
-                Err(err) if err.raw_os_error() == Some(libc::ETXTBSY) && attempt < 4 => {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
+                Err(err) if err.raw_os_error() == Some(libc::ETXTBSY) && attempt < 24 => {
+                    std::thread::sleep(std::time::Duration::from_millis(20));
                 }
-                Err(err) => panic!("failed to run command: {err}"),
+                Err(err) => panic!("command failed: {err}"),
             }
         }
         unreachable!("bounded retry loop always returns or panics")

--- a/crates/csa-hooks/src/lib.rs
+++ b/crates/csa-hooks/src/lib.rs
@@ -53,6 +53,8 @@ pub mod directive;
 pub mod event;
 pub mod event_bus;
 pub mod git_guard;
+#[cfg(test)]
+mod git_guard_tests;
 pub mod guard;
 pub mod mempal_capture;
 pub mod merge_guard;

--- a/crates/weave/src/package_tests.rs
+++ b/crates/weave/src/package_tests.rs
@@ -158,11 +158,12 @@ fn cas_dir_differs_for_different_urls() {
 #[test]
 fn ensure_cached_fetch_updates_default_head_commit() {
     fn run_git(current_dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(current_dir)
-            .output()
-            .unwrap();
+        let mut command = Command::new("git");
+        command.args(args).current_dir(current_dir);
+        if args.first() == Some(&"push") {
+            command.env("CSA_GIT_PUSH_ALLOWED", "true");
+        }
+        let output = command.output().unwrap();
         assert!(
             output.status.success(),
             "git {:?} failed: {}",

--- a/crates/weave/src/package_upgrade_tests.rs
+++ b/crates/weave/src/package_upgrade_tests.rs
@@ -97,11 +97,12 @@ fn manual_install(
 /// Push a new commit to the remote, returning the new commit hash.
 fn push_new_version(work: &Path, version: &str) -> String {
     fn run_git(dir: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .unwrap();
+        let mut command = Command::new("git");
+        command.args(args).current_dir(dir);
+        if args.first() == Some(&"push") {
+            command.env("CSA_GIT_PUSH_ALLOWED", "true");
+        }
+        let output = command.output().unwrap();
         assert!(output.status.success());
         String::from_utf8_lossy(&output.stdout).trim().to_string()
     }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.924"
-weave = "0.1.924"
+csa = "0.1.925"
+weave = "0.1.925"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Create git-guard wrapper script injected into child tool sessions via PATH
- Strip `--no-verify`/`-n` flags from `git commit` commands to ensure lefthook hooks always run
- Block `git push` for leaf-worker sessions (`sa_mode=false`) via `CSA_GIT_PUSH_ALLOWED` env var
- Strip hook-bypass environment variables (LEFTHOOK, HUSKY, SKIP_HOOKS, etc.) before delegating to real git
- Handle combined short flags (e.g., `-anm` → `-am`)
- Add comprehensive tests for wrapper generation and env setup

Closes #1667

## Test plan

- [x] Wrapper strips `--no-verify` from git commit
- [x] Wrapper blocks git push for leaf workers (CSA_GIT_PUSH_ALLOWED unset)
- [x] Wrapper allows git push for orchestrators (CSA_GIT_PUSH_ALLOWED=true)
- [x] Other git subcommands pass through unchanged
- [x] Hook-bypass env vars stripped
- [x] Combined short flag handling
- [x] `just pre-commit` passes (fmt + clippy + test + monolith gate)
- [x] Review PASS (gemini-cli, 0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)