### PR TITLE
fix(cli-sub-agent): allow inherited subtree model pin through tier bypass gate (#1837)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.925"
+version = "0.1.926"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.925"
+version = "0.1.926"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_helpers_tier_bypass_gate.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_bypass_gate.rs
@@ -15,6 +15,9 @@ pub(crate) struct TierBypassGateCtx<'a> {
     pub(crate) project_config: Option<&'a ProjectConfig>,
     pub(crate) global_config: &'a GlobalConfig,
     pub(crate) flags: TierBypassGateFlags,
+    /// True only for CSA-injected subtree pins already validated from startup
+    /// env. It exempts the inherited model-spec pin and its paired force-ignore
+    /// marker, not unrelated user bypass flags.
     pub(crate) inherited_trusted_pin: bool,
 }
 
@@ -23,7 +26,7 @@ pub(crate) fn enforce_tier_bypass_gate(ctx: TierBypassGateCtx<'_>) -> Result<()>
         return Ok(());
     };
 
-    if tier_bypass_allowed(Some(cfg), ctx.global_config, ctx.inherited_trusted_pin) {
+    if ctx.global_config.tier_policy.allow_force_bypass {
         return Ok(());
     }
 
@@ -61,13 +64,13 @@ pub(crate) fn tier_bypass_allowed(
 
 fn refused_tier_bypass_flags(ctx: &TierBypassGateCtx<'_>) -> Vec<&'static str> {
     let mut flags = Vec::new();
-    if ctx.flags.model_spec {
+    if ctx.flags.model_spec && !ctx.inherited_trusted_pin {
         flags.push("--model-spec");
     }
     if ctx.flags.force {
         flags.push("--force");
     }
-    if ctx.flags.force_ignore_tier_setting {
+    if ctx.flags.force_ignore_tier_setting && !ctx.inherited_trusted_pin {
         flags.push("--force-ignore-tier-setting");
     }
     if ctx.flags.model {

--- a/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
@@ -153,7 +153,7 @@ fn tier_bypass_gate_allows_inherited_trusted_pin() {
         project_config: Some(&cfg),
         global_config: &GlobalConfig::default(),
         flags: super::TierBypassGateFlags {
-            model_spec: false,
+            model_spec: true,
             force: false,
             force_ignore_tier_setting: true,
             model: false,
@@ -162,6 +162,30 @@ fn tier_bypass_gate_allows_inherited_trusted_pin() {
         inherited_trusted_pin: true,
     })
     .expect("trusted inherited #1741 subtree pins should continue under gate-off");
+}
+
+#[test]
+fn tier_bypass_gate_rejects_user_force_with_inherited_trusted_pin() {
+    let cfg = config_with_tier("tier-1", vec!["codex/openai/gpt-4/high"], &["codex"]);
+
+    let err = super::enforce_tier_bypass_gate(super::TierBypassGateCtx {
+        project_config: Some(&cfg),
+        global_config: &GlobalConfig::default(),
+        flags: super::TierBypassGateFlags {
+            model_spec: true,
+            force: true,
+            force_ignore_tier_setting: true,
+            model: false,
+            thinking: false,
+        },
+        inherited_trusted_pin: true,
+    })
+    .expect_err("inherited subtree pins must not allow unrelated user bypass flags");
+    let msg = err.to_string();
+
+    assert!(msg.contains("Refused flags: --force"), "{msg}");
+    assert!(!msg.contains("--model-spec"), "{msg}");
+    assert!(!msg.contains("--force-ignore-tier-setting"), "{msg}");
 }
 
 #[test]
@@ -370,6 +394,45 @@ fn resolve_tool_and_model_allows_model_spec_when_global_tier_bypass_opted_in() {
 
     assert_eq!(result.0, ToolName::Codex);
     assert_eq!(result.1.as_deref(), Some("codex/openai/gpt-5.4/high"));
+    assert!(result.2.is_none());
+}
+
+#[test]
+fn resolve_tool_and_model_uses_inherited_model_spec_when_gate_default() {
+    let _guard = assume_tier_tools_available();
+    let cfg = config_with_tier(
+        "tier-1",
+        vec!["gemini-cli/google/gemini-3/high"],
+        &["gemini-cli", "codex"],
+    );
+    let global = GlobalConfig::default();
+    let inherited_spec = "codex/openai/gpt-5.5/xhigh";
+
+    super::enforce_tier_bypass_gate(super::TierBypassGateCtx {
+        project_config: Some(&cfg),
+        global_config: &global,
+        flags: super::TierBypassGateFlags {
+            model_spec: true,
+            force: false,
+            force_ignore_tier_setting: true,
+            model: false,
+            thinking: false,
+        },
+        inherited_trusted_pin: true,
+    })
+    .expect("inherited subtree model-spec should pass the gate without global opt-in");
+
+    let result = super::resolve_tool_and_model(super::RoutingRequest {
+        model_spec: Some(inherited_spec),
+        config: Some(&cfg),
+        force_ignore_tier_setting: true,
+        tier_bypass_allowed: super::tier_bypass_allowed(Some(&cfg), &global, true),
+        ..super::RoutingRequest::new(std::path::Path::new("/tmp"))
+    })
+    .expect("trusted inherited model-spec should resolve exactly");
+
+    assert_eq!(result.0, ToolName::Codex);
+    assert_eq!(result.1.as_deref(), Some(inherited_spec));
     assert!(result.2.is_none());
 }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.925"
-weave = "0.1.925"
+csa = "0.1.926"
+weave = "0.1.926"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Narrow the tier bypass gate so inherited subtree model pins pass through without requiring `allow_force_bypass=true`
- Previously, `inherited_trusted_pin` granted a blanket exemption to ALL bypass flags; now it only exempts `--model-spec` and `--force-ignore-tier-setting` (the pin components)
- Unrelated user bypass flags (`--force`, `--model`, `--thinking`) are still correctly rejected
- Add tests verifying both the intended exemption and the intended rejection

Closes #1837

## Test plan

- [x] Inherited subtree pin passes through tier bypass gate
- [x] User CLI `--force`/`--model`/`--thinking` still blocked when gate active
- [x] `just pre-commit` passes
- [x] Review PASS (gemini-cli, 0 findings, 2 rounds — R1 false-FAIL from prose parser, R2 PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)