### PR TITLE
fix(cli-sub-agent): add earlyoom/OOM memory pressure diagnostic to session signal handler (#1840)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.926"
+version = "0.1.927"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.926"
+version = "0.1.927"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_dry_run.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_dry_run.rs
@@ -51,13 +51,7 @@ pub(crate) fn create_debate_dry_run_session(
         completed_at: now,
         events_count: 0,
         artifacts: vec![SessionArtifact::new("dry-run")],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     csa_session::save_result(project_root, &session.meta_session_id, &result)?;
     Ok(session.meta_session_id)

--- a/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
@@ -81,13 +81,7 @@ fn setup_unrelated_debate_session(
                 SessionArtifact::new("output/debate-verdict.json"),
                 SessionArtifact::new("output/debate-transcript.md"),
             ],
-            peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();
@@ -132,13 +126,7 @@ fn seed_debate_result(
             completed_at: chrono::Utc::now(),
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();
@@ -646,13 +634,7 @@ fn debate_nonzero_with_explicit_verdict_is_reclassified_success() {
             completed_at: chrono::Utc::now(),
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();
@@ -730,13 +712,7 @@ fn debate_finalize_persists_categorized_fallback_chain_for_multi_skip() {
             completed_at: chrono::Utc::now(),
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();
@@ -840,13 +816,7 @@ fn debate_finalize_persists_build_time_exclusions_without_runtime_failures() {
             completed_at: chrono::Utc::now(),
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();
@@ -932,13 +902,7 @@ fn debate_finalize_non_success_omits_after_final_disabled_tier_spec() {
             completed_at: chrono::Utc::now(),
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();

--- a/crates/cli-sub-agent/src/debate_cmd_round4_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_round4_tests.rs
@@ -77,13 +77,7 @@ fn debate_tier_all_fail_does_not_overwrite_unrelated_latest_session() {
                 SessionArtifact::new("output/debate-verdict.json"),
                 SessionArtifact::new("output/debate-transcript.md"),
             ],
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();
@@ -215,13 +209,7 @@ fn debate_pre_session_all_fail_yields_unavailable() {
                 SessionArtifact::new("output/debate-verdict.json"),
                 SessionArtifact::new("output/debate-transcript.md"),
             ],
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -661,13 +661,7 @@ fn append_debate_artifacts_to_result_updates_summary_and_artifacts() {
             completed_at: chrono::Utc::now(),
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();

--- a/crates/cli-sub-agent/src/gc_runtime_tests.rs
+++ b/crates/cli-sub-agent/src/gc_runtime_tests.rs
@@ -197,13 +197,7 @@ fn seed_runtime_session(
             completed_at: now,
             events_count: 0,
             artifacts: vec![SessionArtifact::new("output/summary.md")],
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -91,6 +91,7 @@ mod session_cmds_result;
 mod session_cmds_result_measure;
 mod session_dispatch;
 mod session_guard;
+mod session_kill_diagnostics;
 mod session_observability;
 mod session_outcome;
 mod session_result_publish;

--- a/crates/cli-sub-agent/src/pipeline_execute.rs
+++ b/crates/cli-sub-agent/src/pipeline_execute.rs
@@ -55,7 +55,7 @@ pub(crate) async fn execute_transport_with_signal(
                         wall_timeout_secs = ?wall_timeout.map(|timeout| timeout.as_secs()),
                         "Session received SIGTERM; classifying as external signal, not CSA idle or wall-clock timeout"
                     );
-                    record_session_termination(
+                    let diagnostic = record_session_termination(
                         project_root,
                         session,
                         executor.tool_name(),
@@ -66,10 +66,13 @@ pub(crate) async fn execute_transport_with_signal(
                         "Execution interrupted by SIGTERM",
                         cleanup_guard,
                     );
-                    return Err(anyhow::anyhow!("Execution interrupted by SIGTERM"));
+                    return Err(anyhow::anyhow!(
+                        "{}",
+                        diagnostic.unwrap_or_else(|| "Execution interrupted by SIGTERM".to_string())
+                    ));
                 }
                 _ = sigint.recv() => {
-                    record_session_termination(
+                    let _ = record_session_termination(
                         project_root,
                         session,
                         executor.tool_name(),
@@ -92,7 +95,7 @@ pub(crate) async fn execute_transport_with_signal(
                         timeout_secs,
                         "Session wall-clock timeout fired"
                     );
-                    record_session_termination(
+                    let _ = record_session_termination(
                         project_root,
                         session,
                         executor.tool_name(),
@@ -137,7 +140,7 @@ pub(crate) async fn execute_transport_with_signal(
                     Err(_) => {
                         let timeout_secs = timeout.as_secs().max(1);
                         let summary = format!("Execution timed out after {timeout_secs}s");
-                        record_session_termination(
+                        let _ = record_session_termination(
                             project_root,
                             session,
                             executor.tool_name(),
@@ -215,12 +218,10 @@ pub(crate) async fn execute_transport_with_signal(
                 events_count: 0,
                 artifacts: Vec::new(),
                 peak_memory_mb,
+                kill_hint: None,
+                last_item: None,
                 fallback_chain: None,
-                gate_timeout: false,
-                warnings: Vec::new(),
-                raw_process_exit_code: None,
-                uncommitted_changes: None,
-                manager_fields: Default::default(),
+                ..Default::default()
             };
             if let Err(save_err) = save_result(project_root, &session.meta_session_id, &result) {
                 warn!("Failed to save transport error result: {}", save_err);
@@ -327,11 +328,11 @@ fn record_session_termination(
     exit_code: i32,
     summary: &str,
     cleanup_guard: &mut Option<SessionCleanupGuard>,
-) {
+) -> Option<String> {
     let completed_at = chrono::Utc::now();
     let mut updated_session = session.clone();
     updated_session.termination_reason = Some(termination_reason.to_string());
-    let updated_result = SessionResult {
+    let mut updated_result = SessionResult {
         post_exec_gate: None,
         status: status.to_string(),
         exit_code,
@@ -344,20 +345,25 @@ fn record_session_termination(
         completed_at,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
-    if let Err(e) = save_result(project_root, &session.meta_session_id, &updated_result) {
-        warn!(
-            "Failed to save session result after {}: {}",
-            termination_reason, e
-        );
-    }
+    let diagnostic_line = match crate::session_kill_diagnostics::save_result_with_signal_diagnostic(
+        project_root,
+        session,
+        tool_name,
+        &mut updated_result,
+        Some(termination_reason),
+        None,
+    ) {
+        Ok(line) => line,
+        Err(e) => {
+            warn!(
+                "Failed to save session result after {}: {}",
+                termination_reason, e
+            );
+            None
+        }
+    };
     // Best-effort cooldown marker
     csa_session::write_cooldown_marker_for_project(
         project_root,
@@ -373,4 +379,5 @@ fn record_session_termination(
     if let Some(cg) = cleanup_guard {
         cg.defuse();
     }
+    diagnostic_line
 }

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -11,12 +11,11 @@ use tracing::{info, warn};
 use csa_config::{GlobalConfig, MemoryBackend, ProjectConfig};
 use csa_executor::{CODEX_EXEC_INITIAL_STALL_REASON, Executor};
 use csa_hooks::{HookEvent, run_hooks_for_event};
-#[cfg(test)]
-use csa_session::load_result;
 use csa_session::{
-    MetaSessionState, PhaseEvent, SessionArtifact, SessionPhase, SessionResult, save_result,
-    save_session,
+    MetaSessionState, PhaseEvent, SessionArtifact, SessionPhase, SessionResult, save_session,
 };
+#[cfg(test)]
+use csa_session::{load_result, save_result};
 
 use crate::memory_capture;
 use crate::pipeline_handoff::write_handoff_artifact;
@@ -176,12 +175,10 @@ pub(crate) async fn process_execution_result(
         events_count: ctx.events_count,
         artifacts: ctx.transcript_artifacts.clone(),
         peak_memory_mb: result.peak_memory_mb,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     if let Err(err) = crate::session_observability::enrich_result_from_session_dir(
         ctx.project_root,
@@ -407,7 +404,14 @@ pub(crate) async fn process_execution_result(
         result,
     );
     audit::maybe_record_repo_write_audit(&ctx, session, &mut session_result);
-    if let Err(e) = save_result(ctx.project_root, &session.meta_session_id, &session_result) {
+    if let Err(e) = crate::session_kill_diagnostics::save_result_with_signal_diagnostic(
+        ctx.project_root,
+        session,
+        ctx.executor.tool_name(),
+        &mut session_result,
+        result.terminal_reason.as_deref(),
+        Some(&mut result.stderr_output),
+    ) {
         warn!("Failed to save session result: {}", e);
     }
     // Best-effort cooldown marker (ctx already holds session_dir)

--- a/crates/cli-sub-agent/src/pipeline_post_exec_fallback.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_fallback.rs
@@ -122,13 +122,7 @@ pub(crate) fn ensure_terminal_result_on_post_exec_error(
         completed_at,
         events_count: 0,
         artifacts,
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     if let Err(save_err) = save_result(project_root, &session.meta_session_id, &fallback_result) {

--- a/crates/cli-sub-agent/src/pipeline_post_exec_lefthook.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_lefthook.rs
@@ -47,13 +47,7 @@ mod tests {
             completed_at: now,
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         }
     }
 

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -339,6 +339,8 @@ mod tests {
                 events_count: 0,
                 artifacts: Vec::new(),
                 peak_memory_mb: None,
+                kill_hint: None,
+                last_item: None,
                 fallback_chain: None,
                 gate_timeout: false,
                 warnings: Vec::new(),

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec.rs
@@ -71,13 +71,7 @@ fn ensure_terminal_result_on_post_exec_error_keeps_existing_result() {
         completed_at: now,
         events_count: 1,
         artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result(project_root, &session.meta_session_id, &existing).expect("write existing result");
 
@@ -385,13 +379,7 @@ fn codex_exec_initial_stall_summary_forces_failure_status_in_result_toml() {
         completed_at: now,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     if is_codex_exec_initial_stall_summary(&result.tool, result.exit_code, &result.summary) {
@@ -416,6 +404,79 @@ fn codex_exec_initial_stall_detection_rejects_plain_substring_collisions() {
         137,
         "codex_exec_initial_stall: no stdout within 300s (effort=high, retry_attempted=true)"
     ));
+}
+
+#[tokio::test]
+async fn process_execution_result_persists_signal_kill_hint() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let executor = csa_executor::Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: csa_executor::CodexRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let mut session =
+        create_session(project_root, Some("signal"), None, Some("codex")).expect("create session");
+    let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let ctx = PostExecContext {
+        executor: &executor,
+        prompt: "test prompt",
+        effective_prompt: "test prompt",
+        task_type: Some("run"),
+        readonly_project_root: false,
+        project_root,
+        config: None,
+        global_config: None,
+        session_dir: session_dir.clone(),
+        sessions_root: "test-root".to_string(),
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+        hooks_config: &hooks_config,
+        memory_project_key: None,
+        provider_session_id: None,
+        events_count: 0,
+        transcript_artifacts: Vec::new(),
+        changed_paths: Vec::new(),
+        pre_exec_snapshot: None,
+        has_tool_calls: true,
+        turn_count: 1,
+        output_tokens: None,
+        sa_mode: false,
+    };
+    let mut result = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: "killed by signal 9".to_string(),
+        exit_code: 137,
+        peak_memory_mb: None,
+        ..Default::default()
+    };
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process result");
+
+    let raw = fs::read_to_string(session_dir.join("result.toml")).expect("read result");
+    let value = toml::from_str::<toml::Value>(&raw).expect("parse result");
+    let kill_hint = value
+        .get("kill_hint")
+        .and_then(toml::Value::as_str)
+        .expect("kill_hint should be persisted");
+    assert!(matches!(
+        kill_hint,
+        "unknown_signal" | "possible_memory_pressure" | "memory_pressure" | "earlyoom"
+    ));
+    assert_eq!(
+        value.get("last_item").and_then(toml::Value::as_str),
+        Some("killed by signal 9")
+    );
+
+    let loaded = csa_session::load_result(project_root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should exist");
+    assert_eq!(loaded.kill_hint.as_deref(), Some(kill_hint));
+    assert_eq!(loaded.last_item.as_deref(), Some("killed by signal 9"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec_audit.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec_audit.rs
@@ -118,13 +118,7 @@ fn apply_repo_write_audit_to_result_populates_manager_sidecar_sections() {
         completed_at: chrono::Utc::now(),
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     let audit = RepoWriteAudit {
         added: vec![PathBuf::from("new.txt")],
@@ -440,13 +434,7 @@ fn audit_failure_does_not_fail_execution() {
         completed_at: chrono::Utc::now(),
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     let buffer = SharedLogBuffer::default();
@@ -569,13 +557,7 @@ fn reused_session_audit_uses_per_execution_baseline_not_session_creation() {
         completed_at: chrono::Utc::now(),
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     maybe_record_repo_write_audit(&ctx, &session, &mut session_result);
@@ -677,13 +659,7 @@ fn writer_run_does_not_emit_repo_write_audit_artifact() {
         completed_at: chrono::Utc::now(),
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     maybe_record_repo_write_audit(&ctx, &session, &mut session_result);
@@ -786,13 +762,7 @@ fn first_execution_falls_back_to_session_creation_baseline_when_per_exec_capture
         completed_at: chrono::Utc::now(),
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     let buffer = SharedLogBuffer::default();

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -389,6 +389,8 @@ async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
             events_count: 0,
             artifacts: Vec::new(),
             peak_memory_mb: None,
+            kill_hint: None,
+            last_item: None,
             fallback_chain: None,
             gate_timeout: false,
             warnings: Vec::new(),

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -369,13 +369,7 @@ pub(crate) async fn handle_plan_run_daemon_child(
         completed_at,
         events_count: 0,
         artifacts: vec![SessionArtifact::new(workflow_label.clone())],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     if let Err(save_err) = save_result(&project_root, session_id, &session_result) {
         warn!(

--- a/crates/cli-sub-agent/src/preflight_state_dir.rs
+++ b/crates/cli-sub-agent/src/preflight_state_dir.rs
@@ -717,13 +717,7 @@ mod tests {
                 completed_at: now,
                 events_count: 0,
                 artifacts: vec![SessionArtifact::new("output/summary.md")],
-                peak_memory_mb: None,
-                fallback_chain: None,
-                gate_timeout: false,
-                warnings: Vec::new(),
-                raw_process_exit_code: None,
-                uncommitted_changes: None,
-                manager_fields: Default::default(),
+                ..Default::default()
             },
         )
         .expect("save result");

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -220,13 +220,7 @@ fn exact_test_wait_result(exit_code: i32, summary: &str) -> csa_session::Session
         completed_at: now + chrono::TimeDelta::seconds(1),
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     }
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -131,12 +131,10 @@ pub(super) fn maybe_synthesize_missing_review_result(
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     if let Err(save_err) = save_result(project_root, &session_id, &fallback_result) {

--- a/crates/cli-sub-agent/src/review_cmd_fix_convergence_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_convergence_tests.rs
@@ -118,14 +118,7 @@ fn seed_session_result(project_root: &Path, session_id: &str, summary: &str) {
         completed_at: now,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        post_exec_gate: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     csa_session::save_result(project_root, session_id, &result).expect("save result.toml");
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -121,13 +121,7 @@ fn write_success_result_for(project_root: &Path, session_id: &str) {
         completed_at: now,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result(project_root, session_id, &result).expect("write success result");
 }

--- a/crates/cli-sub-agent/src/run_cmd_post_gate_failure_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_gate_failure_tests.rs
@@ -18,13 +18,7 @@ fn write_success_result_for(project_root: &Path, session_id: &str) {
         completed_at: now,
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result(project_root, session_id, &result).unwrap();
 }

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -396,13 +396,7 @@ mod tests {
             completed_at: now,
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         }
     }
 

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -169,13 +169,7 @@ pub(crate) fn daemon_completion_result(
             project_root,
             &session.meta_session_id,
         ),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     }
 }
 
@@ -316,13 +310,7 @@ mod tests {
             completed_at: now,
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         };
         save_result(project, &session_id, &existing)?;
         let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -87,6 +87,10 @@ pub(crate) fn render_wait_result_summary(
         lines.push(format!("Failover: {failover}"));
     }
 
+    if let Some(kill_hint) = format_kill_hint_label(session_dir, result) {
+        lines.push(kill_hint);
+    }
+
     if let Some(changes) = result.uncommitted_changes.as_ref() {
         lines.push(crate::run_cmd::format_uncommitted_warning(changes));
     }
@@ -170,6 +174,7 @@ fn render_wait_result_json(
         "tokens": tokens,
         "review_verdict": read_review_verdict_label(session_dir, result),
         "failover": format_failover_chain_label(session_dir, result),
+        "kill_hint": result.kill_hint.as_deref(),
         "warnings": result.warnings,
         "summary": crate::session_summary_text::human_session_summary(session_dir, &result.summary)
             .and_then(|text| compact_wait_summary_text(&text)),
@@ -184,6 +189,24 @@ fn wait_result_tool_label(result: &csa_session::SessionResult) -> String {
         }
         _ => result.tool.clone(),
     }
+}
+
+fn format_kill_hint_label(
+    session_dir: &Path,
+    result: &csa_session::SessionResult,
+) -> Option<String> {
+    let kill_hint = result.kill_hint.as_deref()?.trim();
+    if kill_hint.is_empty() {
+        return None;
+    }
+    let summary = crate::session_summary_text::human_session_summary(session_dir, &result.summary)
+        .and_then(|text| compact_wait_summary_text(&text));
+    if let Some(summary) = summary
+        && summary.starts_with("CSA diagnostic:")
+    {
+        return Some(format!("Kill hint: {kill_hint} ({summary})"));
+    }
+    Some(format!("Kill hint: {kill_hint}"))
 }
 
 fn wait_elapsed_seconds(result: &csa_session::SessionResult) -> i64 {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -77,13 +77,7 @@ fn compact_summary_includes_usage_and_review_verdict() {
         completed_at: now + chrono::TimeDelta::seconds(65),
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     let summary = render_wait_result_summary(temp.path(), "01TESTWAITSUMMARY", &result);
@@ -93,6 +87,37 @@ fn compact_summary_includes_usage_and_review_verdict() {
     assert!(summary.contains("Elapsed: 1m 5s"));
     assert!(summary.contains("Tokens: input=100, output=25, total=125, cache_read=40"));
     assert!(summary.contains("Review verdict: PASS"));
+}
+
+#[test]
+fn compact_summary_includes_signal_kill_hint() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let now = Utc::now();
+    let diagnostic = "CSA diagnostic: signal kill hint: memory pressure (MemAvailable: 512 MB / MemTotal: 8192 MB, earlyoom running). Re-dispatch when host memory frees.";
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "signal".to_string(),
+        exit_code: 143,
+        summary: diagnostic.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        kill_hint: Some("memory_pressure".to_string()),
+        last_item: None,
+        fallback_chain: None,
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITKILL", &result);
+
+    assert!(summary.contains("Kill hint: memory_pressure"));
+    assert!(summary.contains("CSA diagnostic: signal kill hint: memory pressure"));
 }
 
 #[test]
@@ -144,6 +169,8 @@ fn compact_summary_labels_fix_loop_noop_from_review_meta() {
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: None,
         gate_timeout: false,
         warnings: vec!["fix loop did not engage: head_unchanged_worktree_clean".to_string()],
@@ -184,6 +211,8 @@ fn compact_summary_uses_primary_failure_and_opaque_total_exhaustion_failover() {
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: Some(vec![
             csa_core::types::FallbackAttempt {
                 tool: "gemini-cli".to_string(),
@@ -200,11 +229,7 @@ fn compact_summary_uses_primary_failure_and_opaque_total_exhaustion_failover() {
                 timestamp: now,
             },
         ]),
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     let summary = render_wait_result_summary(temp.path(), "01TESTWAITQUOTA", &result);
@@ -241,13 +266,7 @@ fn compact_summary_prints_pass_from_canonical_artifact_when_result_succeeded() {
         completed_at: now + chrono::TimeDelta::seconds(65),
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     let summary = render_wait_result_summary(temp.path(), "01TESTWAITARTPASS", &result);
@@ -273,6 +292,8 @@ fn compact_summary_includes_writer_uncommitted_warning() {
         events_count: 0,
         artifacts: Vec::new(),
         peak_memory_mb: None,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: None,
         gate_timeout: false,
         warnings: Vec::new(),
@@ -318,13 +339,7 @@ fn compact_summary_does_not_print_pass_when_result_failed() {
         completed_at: now + chrono::TimeDelta::seconds(65),
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     let summary = render_wait_result_summary(temp.path(), "01TESTWAITFAILPASS", &result);
@@ -382,13 +397,7 @@ fn compact_summary_does_not_print_pass_for_failed_fix_convergence() {
         completed_at: now + chrono::TimeDelta::seconds(65),
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     let summary = render_wait_result_summary(temp.path(), "01TESTWAITFAILED", &result);

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -421,13 +421,7 @@ where
         completed_at: now,
         events_count: 0,
         artifacts,
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     #[rustfmt::skip]
     let result_contents = toml::to_string_pretty(&fallback).map_err(|err| anyhow!("Failed to serialize synthetic result for {session_id}: {err}"))?;
@@ -562,7 +556,7 @@ where
         completed_at,
     );
     #[rustfmt::skip]
-    let result_contents = toml::to_string_pretty(&result).map_err(|err| anyhow!("Failed to serialize daemon completion result for {session_id}: {err}"))?;
+    let result_contents = crate::session_kill_diagnostics::signal_toml(&result, &session, session_id, packet.exit_code).context("serialize result")?;
     match persist_new_result_file(result_path, &result_contents, before_write)? {
         SyntheticResultPersistOutcome::AlreadyExists => {
             let retired = retire_if_dead_with_result_impl(

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
@@ -162,7 +162,17 @@ fn daemon_completion_packet_present_finalizes_dead_active_session() {
         .expect("daemon completion result");
     assert_eq!(result.status, "failure");
     assert_eq!(result.exit_code, 137);
-    assert!(result.summary.contains("daemon completion recorded"));
+    assert!(
+        result.summary.contains("daemon completion recorded")
+            || result.summary.starts_with("CSA diagnostic:"),
+        "unexpected daemon completion summary: {}",
+        result.summary
+    );
+    let raw_result = fs::read_to_string(session_dir.join("result.toml")).unwrap();
+    assert!(
+        raw_result.contains("kill_hint = "),
+        "daemon completion result should include signal kill_hint: {raw_result}"
+    );
     let persisted = load_session(project, &session_id).unwrap();
     assert_eq!(
         persisted.termination_reason.as_deref(),

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -119,13 +119,7 @@ fn make_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
         completed_at: now,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     }
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests.rs
@@ -75,13 +75,7 @@ fn make_result(status: &str, exit_code: i32) -> SessionResult {
         completed_at: now,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     }
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -37,13 +37,7 @@ fn make_result(status: &str, exit_code: i32) -> SessionResult {
         completed_at: now,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     }
 }
 
@@ -478,13 +472,7 @@ fn late_real_result_already_exists_cleans_up_reconcile_owned_sidecar() {
         completed_at: now,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     })
     .unwrap();
 
@@ -542,13 +530,7 @@ fn retire_if_dead_with_result_preserves_pr_bot_handoff_for_real_results() {
             completed_at: now,
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
     )
     .unwrap();

--- a/crates/cli-sub-agent/src/session_cmds_result_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests.rs
@@ -524,13 +524,7 @@ fn build_result_json_payload_includes_review_iterations() {
         completed_at: now,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     let review_meta = ReviewSessionMeta {
         session_id: "01JTESTPAYLOAD00000000000001".to_string(),
@@ -585,13 +579,7 @@ fn build_result_json_payload_includes_result_sidecars() {
             completed_at: now,
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
         manager_sidecar: Some(
             toml::toml! {
@@ -634,13 +622,7 @@ fn build_result_json_payload_redacts_result_sidecars() {
             completed_at: now,
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         },
         manager_sidecar: Some(
             toml::toml! {

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -139,13 +139,7 @@ fn make_result(status: &str, exit_code: i32) -> SessionResult {
         completed_at: now,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     }
 }
 

--- a/crates/cli-sub-agent/src/session_guard.rs
+++ b/crates/cli-sub-agent/src/session_guard.rs
@@ -94,13 +94,7 @@ pub(crate) fn write_pre_exec_error_result(
         completed_at: now,
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     if let Err(e) = save_result_with_options(
         project_root,

--- a/crates/cli-sub-agent/src/session_kill_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics.rs
@@ -1,0 +1,596 @@
+//! Best-effort diagnostics for signal exits that often mean host OOM pressure.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use csa_session::{
+    MetaSessionState, SessionResult, SignalResultMetadata, save_result,
+    save_result_with_signal_metadata,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MemInfo {
+    pub(crate) total_kb: u64,
+    pub(crate) available_kb: u64,
+}
+
+impl MemInfo {
+    fn available_below_five_percent(&self) -> bool {
+        self.available_kb.saturating_mul(20) < self.total_kb
+    }
+
+    fn available_below_ten_percent(&self) -> bool {
+        self.available_kb.saturating_mul(10) < self.total_kb
+    }
+
+    fn total_mb(&self) -> u64 {
+        kb_to_mb(self.total_kb)
+    }
+
+    fn available_mb(&self) -> u64 {
+        kb_to_mb(self.available_kb)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CgroupMemoryEvents {
+    pub(crate) oom: u64,
+    pub(crate) oom_kill: u64,
+}
+
+impl CgroupMemoryEvents {
+    fn has_oom_event(self) -> bool {
+        self.oom > 0 || self.oom_kill > 0
+    }
+
+    fn has_oom_kill_event(self) -> bool {
+        self.oom_kill > 0
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct KillSignalObservations {
+    pub(crate) meminfo: Option<MemInfo>,
+    pub(crate) earlyoom_running: bool,
+    pub(crate) cgroup_memory_events: Option<CgroupMemoryEvents>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KillHint {
+    CsaTimeout,
+    Earlyoom,
+    MemoryPressure,
+    PossibleMemoryPressure,
+    UnknownSignal,
+}
+
+impl KillHint {
+    pub(crate) fn as_result_hint(self) -> &'static str {
+        match self {
+            Self::CsaTimeout => "csa_timeout",
+            Self::Earlyoom => "earlyoom",
+            Self::MemoryPressure => "memory_pressure",
+            Self::PossibleMemoryPressure => "possible_memory_pressure",
+            Self::UnknownSignal => "unknown_signal",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct KillDiagnostic {
+    pub(crate) hint: KillHint,
+    pub(crate) observations: KillSignalObservations,
+}
+
+impl KillDiagnostic {
+    pub(crate) fn stderr_line(&self) -> Option<String> {
+        let hint = match self.hint {
+            KillHint::Earlyoom => "earlyoom",
+            KillHint::MemoryPressure => "memory pressure",
+            KillHint::PossibleMemoryPressure => "possible memory pressure",
+            KillHint::CsaTimeout | KillHint::UnknownSignal => return None,
+        };
+
+        let mut details = Vec::new();
+        if let Some(meminfo) = &self.observations.meminfo {
+            details.push(format!(
+                "MemAvailable: {} MB / MemTotal: {} MB",
+                meminfo.available_mb(),
+                meminfo.total_mb()
+            ));
+        } else {
+            details.push("MemAvailable: unavailable".to_string());
+        }
+        if self.observations.earlyoom_running {
+            details.push("earlyoom running".to_string());
+        }
+        if let Some(events) = self.observations.cgroup_memory_events
+            && events.has_oom_event()
+        {
+            details.push(format!(
+                "cgroup memory.events oom={} oom_kill={}",
+                events.oom, events.oom_kill
+            ));
+        }
+
+        Some(format!(
+            "CSA diagnostic: signal kill hint: {hint} ({}). Re-dispatch when host memory frees.",
+            details.join(", ")
+        ))
+    }
+}
+
+pub(crate) fn diagnose_signal_kill(
+    exit_code: i32,
+    terminal_reason: Option<&str>,
+    tool_name: &str,
+    session_id: &str,
+) -> Option<KillDiagnostic> {
+    diagnose_signal_kill_with(exit_code, terminal_reason, || {
+        collect_signal_observations(tool_name, session_id)
+    })
+}
+
+pub(crate) fn diagnose_signal_kill_with(
+    exit_code: i32,
+    terminal_reason: Option<&str>,
+    collect: impl FnOnce() -> KillSignalObservations,
+) -> Option<KillDiagnostic> {
+    if !matches!(exit_code, 137 | 143) {
+        return None;
+    }
+    if csa_timeout_reason(terminal_reason) {
+        return Some(KillDiagnostic {
+            hint: KillHint::CsaTimeout,
+            observations: KillSignalObservations::default(),
+        });
+    }
+    Some(classify_signal_kill(collect()))
+}
+
+pub(crate) fn last_known_work_item<'a>(
+    session: &'a csa_session::MetaSessionState,
+    tool_name: &str,
+) -> Option<&'a str> {
+    session
+        .tools
+        .get(tool_name)
+        .map(|tool_state| tool_state.last_action_summary.trim())
+        .filter(|summary| !summary.is_empty())
+}
+
+pub(crate) fn save_result_with_signal_diagnostic(
+    project_root: &Path,
+    session: &MetaSessionState,
+    tool_name: &str,
+    result: &mut SessionResult,
+    terminal_reason: Option<&str>,
+    stderr_output: Option<&mut String>,
+) -> Result<Option<String>> {
+    let diagnostic = diagnose_signal_kill(
+        result.exit_code,
+        terminal_reason,
+        tool_name,
+        &session.meta_session_id,
+    );
+    let diagnostic_line = diagnostic.as_ref().and_then(KillDiagnostic::stderr_line);
+    if let Some(line) = &diagnostic_line {
+        append_stderr_line(stderr_output, line);
+        result.summary = line.clone();
+    }
+
+    if let Some(diagnostic) = diagnostic {
+        save_result_with_signal_metadata(
+            project_root,
+            &session.meta_session_id,
+            result,
+            SignalResultMetadata {
+                kill_hint: diagnostic.hint.as_result_hint(),
+                last_item: last_known_work_item(session, tool_name),
+            },
+        )?;
+    } else {
+        save_result(project_root, &session.meta_session_id, result)?;
+    }
+
+    Ok(diagnostic_line)
+}
+
+pub(crate) fn render_result_toml_with_signal_diagnostic(
+    result: &SessionResult,
+    diagnostic: Option<&KillDiagnostic>,
+    last_item: Option<&str>,
+) -> Result<String> {
+    let mut rendered_result = result.clone();
+    if let Some(diagnostic) = diagnostic {
+        rendered_result.kill_hint = Some(diagnostic.hint.as_result_hint().to_string());
+        if let Some(line) = diagnostic.stderr_line() {
+            rendered_result.summary = line;
+        }
+        rendered_result.last_item = last_item
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+    }
+    toml::to_string_pretty(&rendered_result).context("Failed to render session result")
+}
+
+pub(crate) fn signal_toml(
+    result: &SessionResult,
+    session: &MetaSessionState,
+    session_id: &str,
+    exit_code: i32,
+) -> Result<String> {
+    let diagnostic = diagnose_signal_kill(
+        exit_code,
+        session.termination_reason.as_deref(),
+        &result.tool,
+        session_id,
+    );
+    render_result_toml_with_signal_diagnostic(
+        result,
+        diagnostic.as_ref(),
+        last_known_work_item(session, &result.tool),
+    )
+}
+
+fn append_stderr_line(stderr_output: Option<&mut String>, line: &str) {
+    let Some(stderr_output) = stderr_output else {
+        return;
+    };
+    if !stderr_output.is_empty() && !stderr_output.ends_with('\n') {
+        stderr_output.push('\n');
+    }
+    stderr_output.push_str(line);
+    stderr_output.push('\n');
+}
+
+fn csa_timeout_reason(reason: Option<&str>) -> bool {
+    matches!(reason, Some("idle_timeout" | "initial_response_timeout"))
+}
+
+fn classify_signal_kill(observations: KillSignalObservations) -> KillDiagnostic {
+    let very_low_memory = observations
+        .meminfo
+        .as_ref()
+        .is_some_and(MemInfo::available_below_five_percent);
+    let possible_low_memory = observations
+        .meminfo
+        .as_ref()
+        .is_some_and(MemInfo::available_below_ten_percent);
+    let cgroup_oom_kill = observations
+        .cgroup_memory_events
+        .is_some_and(CgroupMemoryEvents::has_oom_kill_event);
+    let strong_memory_pressure = very_low_memory || cgroup_oom_kill;
+    let hint = if observations.earlyoom_running && strong_memory_pressure {
+        KillHint::Earlyoom
+    } else if strong_memory_pressure {
+        KillHint::MemoryPressure
+    } else if possible_low_memory {
+        KillHint::PossibleMemoryPressure
+    } else {
+        KillHint::UnknownSignal
+    };
+
+    KillDiagnostic { hint, observations }
+}
+
+#[cfg(target_os = "linux")]
+fn collect_signal_observations(tool_name: &str, session_id: &str) -> KillSignalObservations {
+    KillSignalObservations {
+        meminfo: read_meminfo_from_path(Path::new("/proc/meminfo")),
+        earlyoom_running: earlyoom_running(),
+        cgroup_memory_events: read_session_cgroup_memory_events(tool_name, session_id),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn collect_signal_observations(_tool_name: &str, _session_id: &str) -> KillSignalObservations {
+    KillSignalObservations::default()
+}
+
+pub(crate) fn parse_meminfo(content: &str) -> Option<MemInfo> {
+    let mut total_kb = None;
+    let mut available_kb = None;
+
+    for line in content.lines() {
+        let mut fields = line.split_whitespace();
+        match fields.next() {
+            Some("MemTotal:") => total_kb = fields.next().and_then(|value| value.parse().ok()),
+            Some("MemAvailable:") => {
+                available_kb = fields.next().and_then(|value| value.parse().ok());
+            }
+            _ => {}
+        }
+    }
+
+    Some(MemInfo {
+        total_kb: total_kb?,
+        available_kb: available_kb?,
+    })
+}
+
+fn parse_memory_events(content: &str) -> CgroupMemoryEvents {
+    let mut events = CgroupMemoryEvents {
+        oom: 0,
+        oom_kill: 0,
+    };
+    for line in content.lines() {
+        let mut fields = line.split_whitespace();
+        let key = fields.next();
+        let value = fields.next().and_then(|raw| raw.parse::<u64>().ok());
+        match (key, value) {
+            (Some("oom"), Some(value)) => events.oom = value,
+            (Some("oom_kill"), Some(value)) => events.oom_kill = value,
+            _ => {}
+        }
+    }
+    events
+}
+
+#[cfg(target_os = "linux")]
+fn read_meminfo_from_path(path: &Path) -> Option<MemInfo> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|content| parse_meminfo(&content))
+}
+
+#[cfg(target_os = "linux")]
+fn earlyoom_running() -> bool {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            return false;
+        };
+        if !name.as_bytes().iter().all(u8::is_ascii_digit) {
+            return false;
+        }
+        std::fs::read_to_string(entry.path().join("comm"))
+            .is_ok_and(|comm| comm.trim() == "earlyoom")
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn read_session_cgroup_memory_events(
+    tool_name: &str,
+    session_id: &str,
+) -> Option<CgroupMemoryEvents> {
+    let scope = csa_resource::cgroup::scope_unit_name(tool_name, session_id);
+    cgroup_memory_event_candidates(&scope)
+        .into_iter()
+        .filter_map(|path| std::fs::read_to_string(path).ok())
+        .map(|content| parse_memory_events(&content))
+        .find(|events| events.has_oom_event())
+}
+
+#[cfg(target_os = "linux")]
+fn cgroup_memory_event_candidates(scope: &str) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(uid) = effective_uid_from_proc_status() {
+        candidates.push(PathBuf::from(format!(
+            "/sys/fs/cgroup/user.slice/user-{uid}.slice/user@{uid}.service/app.slice/{scope}/memory.events"
+        )));
+        candidates.push(PathBuf::from(format!(
+            "/sys/fs/cgroup/user.slice/user-{uid}.slice/user@{uid}.service/{scope}/memory.events"
+        )));
+    }
+    candidates.push(PathBuf::from(format!(
+        "/sys/fs/cgroup/system.slice/{scope}/memory.events"
+    )));
+    candidates
+}
+
+#[cfg(target_os = "linux")]
+fn effective_uid_from_proc_status() -> Option<u32> {
+    let content = std::fs::read_to_string("/proc/self/status").ok()?;
+    content.lines().find_map(|line| {
+        let rest = line.strip_prefix("Uid:")?;
+        rest.split_whitespace()
+            .next()
+            .and_then(|value| value.parse().ok())
+    })
+}
+
+fn kb_to_mb(kb: u64) -> u64 {
+    kb / 1024
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn parses_meminfo_available_and_total() {
+        let meminfo = parse_meminfo(
+            "\
+MemTotal:       16384000 kB
+MemFree:         1000000 kB
+MemAvailable:    900000 kB
+",
+        )
+        .expect("meminfo should parse");
+
+        assert_eq!(meminfo.total_kb, 16_384_000);
+        assert_eq!(meminfo.available_kb, 900_000);
+        assert!(meminfo.available_below_ten_percent());
+        assert!(!meminfo.available_below_five_percent());
+    }
+
+    #[test]
+    fn classifies_signal_exit_under_possible_memory_pressure() {
+        let diagnostic = diagnose_signal_kill_with(143, None, || KillSignalObservations {
+            meminfo: Some(MemInfo {
+                total_kb: 10_000,
+                available_kb: 999,
+            }),
+            earlyoom_running: false,
+            cgroup_memory_events: None,
+        })
+        .expect("signal exit should produce diagnostic");
+
+        assert_eq!(diagnostic.hint, KillHint::PossibleMemoryPressure);
+        assert!(
+            diagnostic
+                .stderr_line()
+                .expect("memory pressure should render")
+                .contains("MemAvailable: 0 MB / MemTotal: 9 MB")
+        );
+    }
+
+    #[test]
+    fn classifies_signal_exit_under_strong_memory_pressure() {
+        let diagnostic = diagnose_signal_kill_with(143, None, || KillSignalObservations {
+            meminfo: Some(MemInfo {
+                total_kb: 10_000,
+                available_kb: 499,
+            }),
+            earlyoom_running: false,
+            cgroup_memory_events: None,
+        })
+        .expect("signal exit should produce diagnostic");
+
+        assert_eq!(diagnostic.hint, KillHint::MemoryPressure);
+        assert!(
+            diagnostic
+                .stderr_line()
+                .expect("memory pressure should render")
+                .contains("memory pressure")
+        );
+    }
+
+    #[test]
+    fn classifies_unknown_when_earlyoom_runs_without_memory_pressure() {
+        let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
+            meminfo: Some(MemInfo {
+                total_kb: 10_000,
+                available_kb: 5_000,
+            }),
+            earlyoom_running: true,
+            cgroup_memory_events: None,
+        })
+        .expect("signal exit should produce diagnostic");
+
+        assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
+        assert!(diagnostic.stderr_line().is_none());
+    }
+
+    #[test]
+    fn classifies_earlyoom_when_daemon_runs_with_strong_memory_pressure() {
+        let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
+            meminfo: Some(MemInfo {
+                total_kb: 10_000,
+                available_kb: 499,
+            }),
+            earlyoom_running: true,
+            cgroup_memory_events: None,
+        })
+        .expect("signal exit should produce diagnostic");
+
+        assert_eq!(diagnostic.hint, KillHint::Earlyoom);
+        assert!(
+            diagnostic
+                .stderr_line()
+                .expect("earlyoom should render")
+                .contains("earlyoom running")
+        );
+    }
+
+    #[test]
+    fn classifies_earlyoom_when_daemon_runs_with_cgroup_oom_kill() {
+        let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
+            meminfo: Some(MemInfo {
+                total_kb: 10_000,
+                available_kb: 5_000,
+            }),
+            earlyoom_running: true,
+            cgroup_memory_events: Some(CgroupMemoryEvents {
+                oom: 0,
+                oom_kill: 1,
+            }),
+        })
+        .expect("signal exit should produce diagnostic");
+
+        assert_eq!(diagnostic.hint, KillHint::Earlyoom);
+    }
+
+    #[test]
+    fn does_not_classify_earlyoom_from_oom_without_oom_kill() {
+        let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
+            meminfo: Some(MemInfo {
+                total_kb: 10_000,
+                available_kb: 5_000,
+            }),
+            earlyoom_running: true,
+            cgroup_memory_events: Some(CgroupMemoryEvents {
+                oom: 1,
+                oom_kill: 0,
+            }),
+        })
+        .expect("signal exit should produce diagnostic");
+
+        assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
+        assert!(diagnostic.stderr_line().is_none());
+    }
+
+    #[test]
+    fn csa_timeout_terminal_reasons_take_precedence_over_earlyoom() {
+        for terminal_reason in ["idle_timeout", "initial_response_timeout"] {
+            let called = Cell::new(false);
+            let diagnostic = diagnose_signal_kill_with(137, Some(terminal_reason), || {
+                called.set(true);
+                KillSignalObservations {
+                    meminfo: Some(MemInfo {
+                        total_kb: 10_000,
+                        available_kb: 999,
+                    }),
+                    earlyoom_running: true,
+                    cgroup_memory_events: Some(CgroupMemoryEvents {
+                        oom: 1,
+                        oom_kill: 1,
+                    }),
+                }
+            })
+            .expect("signal exit should produce diagnostic");
+
+            assert_eq!(diagnostic.hint, KillHint::CsaTimeout);
+            assert!(!called.get(), "{terminal_reason} should skip memory checks");
+            assert!(diagnostic.stderr_line().is_none());
+        }
+    }
+
+    #[test]
+    fn classifies_unknown_signal_without_memory_evidence() {
+        let diagnostic = diagnose_signal_kill_with(143, None, KillSignalObservations::default)
+            .expect("signal exit should produce diagnostic");
+
+        assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
+        assert!(diagnostic.stderr_line().is_none());
+    }
+
+    #[test]
+    fn non_signal_exits_do_not_collect_observations() {
+        for exit_code in [0, 1, 2] {
+            let called = Cell::new(false);
+            let diagnostic = diagnose_signal_kill_with(exit_code, None, || {
+                called.set(true);
+                KillSignalObservations::default()
+            });
+            assert!(diagnostic.is_none());
+            assert!(!called.get(), "exit {exit_code} should not trigger checks");
+        }
+    }
+
+    #[test]
+    fn parses_cgroup_memory_events() {
+        let events = parse_memory_events("low 2\nhigh 3\nmax 4\noom 1\noom_kill 1\n");
+
+        assert_eq!(events.oom, 1);
+        assert_eq!(events.oom_kill, 1);
+        assert!(events.has_oom_event());
+        assert!(events.has_oom_kill_event());
+    }
+}

--- a/crates/cli-sub-agent/src/todo_errors_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_errors_cmd.rs
@@ -236,13 +236,7 @@ mod tests {
             completed_at: started_at + Duration::seconds(2),
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         }
     }
 

--- a/crates/csa-executor/src/transport_fork.rs
+++ b/crates/csa-executor/src/transport_fork.rs
@@ -454,13 +454,7 @@ mod tests {
             completed_at: now,
             events_count: 0,
             artifacts: vec![],
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         };
         std::fs::write(
             tmp.path().join(RESULT_FILE_NAME),

--- a/crates/csa-executor/src/transport_tests_extra.rs
+++ b/crates/csa-executor/src/transport_tests_extra.rs
@@ -324,14 +324,7 @@ fn test_apply_codex_exec_initial_stall_summary_renders_reason_for_result_toml() 
         completed_at: chrono::Utc::now(),
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        post_exec_gate: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     let toml = toml::to_string_pretty(&result).expect("serialize session result");
 

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -91,16 +91,17 @@ pub use vcs_backends::{GitBackend, JjBackend, create_vcs_backend};
 // Re-export manager functions
 pub use manager::{
     CONTRACT_RESULT_ARTIFACT_PATH, LEGACY_USER_RESULT_ARTIFACT_PATH, RESULT_TOML_PATH_CONTRACT_ENV,
-    RepoWriteAudit, SaveOptions, clear_manager_sidecar, complete_session, compute_repo_write_audit,
-    contract_result_path, create_session, create_session_fresh, create_session_with_daemon_env,
-    decode_session_created_at, delete_session, delete_session_from_root, detect_git_head,
-    find_sessions, get_session_dir, get_session_dir_global, get_session_root,
-    legacy_user_result_path, list_all_project_session_roots, list_all_sessions,
-    list_all_sessions_all_projects, list_artifacts, list_sessions, list_sessions_from_root,
-    list_sessions_from_root_readonly, list_sessions_readonly, load_metadata, load_result,
-    load_result_view, load_session, load_session_global_exact, redact_result_sidecar_value,
-    render_redacted_result_sidecar, resolve_fork_source, resolve_resume_session, save_result,
-    save_result_with_options, save_session, save_session_in, update_last_accessed,
+    RepoWriteAudit, SaveOptions, SignalResultMetadata, clear_manager_sidecar, complete_session,
+    compute_repo_write_audit, contract_result_path, create_session, create_session_fresh,
+    create_session_with_daemon_env, decode_session_created_at, delete_session,
+    delete_session_from_root, detect_git_head, find_sessions, get_session_dir,
+    get_session_dir_global, get_session_root, legacy_user_result_path,
+    list_all_project_session_roots, list_all_sessions, list_all_sessions_all_projects,
+    list_artifacts, list_sessions, list_sessions_from_root, list_sessions_from_root_readonly,
+    list_sessions_readonly, load_metadata, load_result, load_result_view, load_session,
+    load_session_global_exact, redact_result_sidecar_value, render_redacted_result_sidecar,
+    resolve_fork_source, resolve_resume_session, save_result, save_result_with_options,
+    save_result_with_signal_metadata, save_session, save_session_in, update_last_accessed,
     validate_tool_access, write_audit_warning_artifact,
 };
 

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -43,14 +43,15 @@ use manager_paths::{get_session_dir_in, resolve_read_base_dir, resolve_write_bas
 use manager_paths::{legacy_session_root, normalize_project_path};
 pub use manager_result::{
     CONTRACT_RESULT_ARTIFACT_PATH, LEGACY_USER_RESULT_ARTIFACT_PATH, RESULT_TOML_PATH_CONTRACT_ENV,
-    SaveOptions, SessionResultView, clear_manager_sidecar, contract_result_path,
-    legacy_user_result_path, list_artifacts, load_result, load_result_view,
+    SaveOptions, SessionResultView, SignalResultMetadata, clear_manager_sidecar,
+    contract_result_path, legacy_user_result_path, list_artifacts, load_result, load_result_view,
     redact_result_sidecar_value, render_redacted_result_sidecar, save_result,
-    save_result_with_options,
+    save_result_with_options, save_result_with_signal_metadata,
 };
 #[cfg(test)]
 pub(crate) use manager_result::{
     list_artifacts_in, load_result_in, load_result_view_in, save_result_in,
+    save_result_with_signal_metadata_in,
 };
 pub use manager_vcs::detect_git_head;
 use manager_vcs::{detect_change_id, detect_current_branch, detect_git_status_porcelain};

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -11,7 +11,8 @@ const USER_RESULT_FILE_NAME: &str = "user-result.toml";
 pub const RESULT_TOML_PATH_CONTRACT_ENV: &str = "CSA_RESULT_TOML_PATH_CONTRACT";
 pub const CONTRACT_RESULT_ARTIFACT_PATH: &str = "output/result.toml";
 pub const LEGACY_USER_RESULT_ARTIFACT_PATH: &str = "output/user-result.toml";
-const RUNTIME_RESULT_KEYS: [&str; 14] = [
+const LEGACY_KILL_REASON_KEY: &str = "kill_reason";
+const RUNTIME_RESULT_KEYS: [&str; 17] = [
     "status",
     "exit_code",
     "summary",
@@ -26,6 +27,9 @@ const RUNTIME_RESULT_KEYS: [&str; 14] = [
     "fallback_chain",
     "peak_memory_mb",
     "post_exec_gate",
+    "kill_hint",
+    LEGACY_KILL_REASON_KEY,
+    "last_item",
 ];
 
 #[path = "manager_result_spillover.rs"]
@@ -63,6 +67,23 @@ pub fn save_result(project_path: &Path, session_id: &str, result: &SessionResult
     save_result_with_options(project_path, session_id, result, SaveOptions::default())
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct SignalResultMetadata<'a> {
+    pub kill_hint: &'a str,
+    pub last_item: Option<&'a str>,
+}
+
+/// Write a session result with signal-only diagnostic fields.
+pub fn save_result_with_signal_metadata(
+    project_path: &Path,
+    session_id: &str,
+    result: &mut SessionResult,
+    metadata: SignalResultMetadata<'_>,
+) -> Result<()> {
+    apply_signal_metadata(result, metadata);
+    save_result(project_path, session_id, result)
+}
+
 /// Write a session result to disk with explicit sidecar preservation semantics.
 pub fn save_result_with_options(
     project_path: &Path,
@@ -96,6 +117,27 @@ pub(crate) fn save_result_in(
         options,
         csa_config::DEFAULT_RESULT_REPORT_SPILL_THRESHOLD_BYTES,
     )
+}
+
+#[cfg(test)]
+pub(crate) fn save_result_with_signal_metadata_in(
+    base_dir: &Path,
+    session_id: &str,
+    result: &mut SessionResult,
+    options: SaveOptions,
+    metadata: SignalResultMetadata<'_>,
+) -> Result<()> {
+    apply_signal_metadata(result, metadata);
+    save_result_in(base_dir, session_id, result, options)
+}
+
+fn apply_signal_metadata(result: &mut SessionResult, metadata: SignalResultMetadata<'_>) {
+    result.kill_hint = Some(metadata.kill_hint.to_string());
+    result.last_item = metadata
+        .last_item
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
 }
 
 fn save_result_in_with_threshold(
@@ -366,7 +408,9 @@ fn table_has_custom_schema(table: &toml::Table) -> bool {
 
 fn value_matches_runtime_schema(key: &str, value: &toml::Value) -> bool {
     match key {
-        "status" | "summary" | "tool" | "started_at" | "completed_at" => value.is_str(),
+        "status" | "summary" | "tool" | "started_at" | "completed_at" | "kill_hint"
+        | "last_item" => value.is_str(),
+        LEGACY_KILL_REASON_KEY => value.is_str(),
         "exit_code" | "events_count" => value.is_integer(),
         "artifacts" => artifacts_value_matches_runtime_schema(value),
         "post_exec_gate" => value.is_table(),

--- a/crates/csa-session/src/manager_result_spillover.rs
+++ b/crates/csa-session/src/manager_result_spillover.rs
@@ -332,6 +332,8 @@ mod tests {
             events_count: 1,
             artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
             peak_memory_mb: None,
+            kill_hint: None,
+            last_item: None,
             fallback_chain: None,
             gate_timeout: false,
             warnings: Vec::new(),
@@ -359,11 +361,6 @@ mod tests {
         let turn_2_result = SessionResult {
             summary: "turn 2".to_string(),
             fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
             ..turn_1_result
         };
         save_result_in(
@@ -481,13 +478,7 @@ mod tests {
             completed_at: now,
             events_count: 1,
             artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         };
         save_result_in_with_threshold(
             td.path(),

--- a/crates/csa-session/src/manager_tests_audit.rs
+++ b/crates/csa-session/src/manager_tests_audit.rs
@@ -16,6 +16,8 @@ fn test_save_result_persists_manager_fields_sidecar() {
         events_count: 0,
         artifacts: vec![],
         peak_memory_mb: None,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: None,
         gate_timeout: false,
         warnings: Vec::new(),

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -64,13 +64,7 @@ fn test_load_result_view_ignores_orphaned_manager_sidecar() {
         completed_at: now,
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
-        peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result_in(
         td.path(),
@@ -126,13 +120,7 @@ fn test_load_result_merges_manager_sidecar_sections_into_runtime_result() {
         completed_at: now,
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     std::fs::write(
         session_dir.join(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
@@ -250,13 +238,7 @@ fn test_manager_sidecar_roundtrip_preserves_full_sa_schema() {
         completed_at: now,
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     let input_sidecar = toml::Value::Table(toml::toml! {
         [result]
@@ -405,13 +387,7 @@ fn test_load_result_without_sidecar_keeps_manager_fields_empty() {
         completed_at: now,
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result_in(
         td.path(),
@@ -448,6 +424,8 @@ fn test_save_result_with_empty_manager_fields_preserves_existing_sidecar() {
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
         peak_memory_mb: None,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: None,
         gate_timeout: false,
         warnings: Vec::new(),
@@ -479,10 +457,6 @@ fn test_save_result_with_empty_manager_fields_preserves_existing_sidecar() {
 
     let clean_result = crate::result::SessionResult {
         fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
         manager_fields: Default::default(),
         ..populated_result.clone()
     };
@@ -530,6 +504,8 @@ fn test_clear_manager_sidecar_removes_existing_sidecar() {
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
         peak_memory_mb: None,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: None,
         gate_timeout: false,
         warnings: Vec::new(),
@@ -586,13 +562,7 @@ fn test_load_result_with_malformed_manager_sidecar_is_non_fatal() {
         completed_at: now,
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     std::fs::write(
         session_dir.join(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
@@ -671,11 +641,7 @@ fn test_fallback_chain_not_retained_after_save_without_fallback() {
         artifacts: vec![],
         peak_memory_mb: None,
         fallback_chain,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     // First save: with a non-empty fallback_chain.
@@ -751,13 +717,7 @@ fn test_post_exec_gate_not_retained_after_save_without_gate() {
         completed_at: now,
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
 
     // First save: a failed-gate result carrying a [post_exec_gate] table.

--- a/crates/csa-session/src/manager_tests_sidecar_preservation.rs
+++ b/crates/csa-session/src/manager_tests_sidecar_preservation.rs
@@ -21,13 +21,7 @@ fn test_save_result_preserves_existing_contract_result_artifact_when_output_resu
         completed_at: now,
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result_in(
         td.path(),
@@ -78,6 +72,8 @@ fn sidecar_write_failure_leaves_envelope_unchanged() {
         events_count: 1,
         artifacts: vec![],
         peak_memory_mb: None,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: None,
         gate_timeout: false,
         warnings: Vec::new(),
@@ -169,6 +165,8 @@ fn sidecar_clear_failure_or_crash_leaves_envelope_consistent() {
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
         peak_memory_mb: None,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: None,
         gate_timeout: false,
         warnings: Vec::new(),
@@ -200,10 +198,6 @@ fn sidecar_clear_failure_or_crash_leaves_envelope_consistent() {
 
     let clear_result = crate::result::SessionResult {
         fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
         manager_fields: Default::default(),
         ..populated_result
     };
@@ -246,6 +240,8 @@ fn sidecar_clear_happy_path_publishes_envelope_then_unlinks() {
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
         peak_memory_mb: None,
+        kill_hint: None,
+        last_item: None,
         fallback_chain: None,
         gate_timeout: false,
         warnings: Vec::new(),
@@ -273,10 +269,6 @@ fn sidecar_clear_happy_path_publishes_envelope_then_unlinks() {
 
     let clear_result = crate::result::SessionResult {
         fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
         manager_fields: Default::default(),
         ..populated_result
     };

--- a/crates/csa-session/src/manager_tests_tail.rs
+++ b/crates/csa-session/src/manager_tests_tail.rs
@@ -43,13 +43,7 @@ fn test_save_and_load_result() {
         completed_at: chrono::Utc::now(),
         events_count: 0,
         artifacts: vec![crate::result::SessionArtifact::new("output/result.txt")],
-        peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result_in(td.path(), &state.meta_session_id, &result, crate::SaveOptions::default())
         .unwrap();
@@ -60,6 +54,63 @@ fn test_save_and_load_result() {
     assert_eq!(loaded.exit_code, 0);
     assert_eq!(loaded.tool, "codex");
     assert_eq!(loaded.artifacts.len(), 1);
+}
+
+#[test]
+fn test_save_result_with_signal_metadata_writes_kill_hint_and_last_item() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let mut result = crate::result::SessionResult {
+        post_exec_gate: None,
+        status: "signal".to_string(),
+        exit_code: 143,
+        summary: "Execution interrupted by SIGTERM".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: chrono::Utc::now(),
+        completed_at: chrono::Utc::now(),
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    };
+
+    save_result_with_signal_metadata_in(
+        td.path(),
+        &state.meta_session_id,
+        &mut result,
+        crate::SaveOptions::default(),
+        crate::SignalResultMetadata {
+            kill_hint: "memory_pressure",
+            last_item: Some("running tests"),
+        },
+    )
+    .unwrap();
+
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let persisted = std::fs::read_to_string(session_dir.join("result.toml")).unwrap();
+    assert!(persisted.contains("kill_hint = \"memory_pressure\""));
+    assert!(persisted.contains("last_item = \"running tests\""));
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(loaded.status, "signal");
+    assert_eq!(loaded.exit_code, 143);
+    assert_eq!(loaded.kill_hint.as_deref(), Some("memory_pressure"));
+    assert_eq!(loaded.last_item.as_deref(), Some("running tests"));
+
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &loaded,
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+    let resaved = std::fs::read_to_string(session_dir.join("result.toml")).unwrap();
+    assert!(resaved.contains("kill_hint = \"memory_pressure\""));
+    assert!(resaved.contains("last_item = \"running tests\""));
 }
 
 #[cfg(unix)]
@@ -99,13 +150,7 @@ fn test_save_session_and_result_preserve_legacy_symlink_root() {
         completed_at: chrono::Utc::now(),
         events_count: 0,
         artifacts: Vec::new(),
-        peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+        ..Default::default()
     };
     let canonical_project = project.canonicalize().unwrap();
     let mut loaded = load_session(&canonical_project, &state.meta_session_id).unwrap();
@@ -165,13 +210,7 @@ name = "gemini-cli"
         completed_at: now,
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
-        peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result_in(
         td.path(),
@@ -236,13 +275,7 @@ artifacts = [1, 2]
         completed_at: now,
         events_count: 1,
         artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
-        peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result_in(
         td.path(),
@@ -302,13 +335,7 @@ name = "gemini-cli"
         completed_at: now,
         events_count: 1,
         artifacts: vec![],
-        peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result_in(
         td.path(),
@@ -331,13 +358,7 @@ name = "gemini-cli"
         completed_at: now,
         events_count: 2,
         artifacts: vec![],
-        peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result_in(
         td.path(),
@@ -396,13 +417,7 @@ done = false
         completed_at: now,
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+        ..Default::default()
     };
     let err = save_result_in(
         td.path(),
@@ -433,13 +448,7 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
         completed_at: now,
         events_count: 7,
         artifacts: vec![crate::result::SessionArtifact::new("output/old-artifact.txt")],
-        peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+        ..Default::default()
     };
     save_result_in(
         td.path(),
@@ -462,14 +471,27 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
         completed_at: now,
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-            fallback_chain: None,
-        gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+        ..Default::default()
     };
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let result_path = session_dir.join("result.toml");
+    let mut persisted = toml::from_str::<toml::Value>(
+        &std::fs::read_to_string(&result_path).unwrap(),
+    )
+    .unwrap();
+    let table = persisted
+        .as_table_mut()
+        .expect("saved result should be a TOML table");
+    table.insert(
+        "kill_hint".to_string(),
+        toml::Value::String("memory_pressure".to_string()),
+    );
+    table.insert(
+        "last_item".to_string(),
+        toml::Value::String("old work".to_string()),
+    );
+    std::fs::write(&result_path, toml::to_string_pretty(&persisted).unwrap()).unwrap();
+
     save_result_in(
         td.path(),
         &state.meta_session_id,
@@ -478,16 +500,19 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
     )
     .unwrap();
 
-    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
     let persisted = std::fs::read_to_string(session_dir.join("result.toml")).unwrap();
     assert!(!persisted.contains("events_count"));
     assert!(!persisted.contains("artifacts"));
+    assert!(!persisted.contains("kill_hint"));
+    assert!(!persisted.contains("last_item"));
 
     let loaded = load_result_in(td.path(), &state.meta_session_id)
         .unwrap()
         .unwrap();
     assert_eq!(loaded.events_count, 0);
     assert!(loaded.artifacts.is_empty());
+    assert!(loaded.kill_hint.is_none());
+    assert!(loaded.last_item.is_none());
 }
 
 #[test]

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -174,7 +174,7 @@ pub struct UncommittedChanges {
 
 /// Structured result of a session execution.
 /// Written to `sessions/{id}/result.toml` after each tool invocation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SessionResult {
     /// Execution status: "success", "failure", "timeout", "signal"
     pub status: String,
@@ -211,6 +211,12 @@ pub struct SessionResult {
     /// `None` when cgroup monitoring is unavailable or the scope was already removed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub peak_memory_mb: Option<u64>,
+    /// Best-effort signal-exit diagnostic hint, not a definitive kill cause.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kill_hint: Option<String>,
+    /// Last known work item when the signal diagnostic was recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_item: Option<String>,
     /// Ordered list of tools skipped due to quota/rate-limit failover before the final tool ran.
     /// `None` when no failover occurred; non-empty only when `csa run` cycled through alternatives.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -286,12 +292,10 @@ mod tests {
             events_count: 4,
             artifacts: vec![SessionArtifact::new("output/diff.patch")],
             peak_memory_mb: None,
+            kill_hint: Some("memory_pressure".to_string()),
+            last_item: Some("running tests".to_string()),
             fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         };
 
         let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
@@ -304,6 +308,8 @@ mod tests {
         assert_eq!(loaded.events_count, 4);
         assert_eq!(loaded.artifacts.len(), 1);
         assert_eq!(loaded.artifacts[0].path, "output/diff.patch");
+        assert_eq!(loaded.kill_hint.as_deref(), Some("memory_pressure"));
+        assert_eq!(loaded.last_item.as_deref(), Some("running tests"));
     }
 
     #[test]
@@ -322,13 +328,7 @@ mod tests {
             completed_at: now,
             events_count: 0,
             artifacts: vec![],
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         };
 
         let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
@@ -343,6 +343,14 @@ mod tests {
         assert!(
             !toml_str.contains("uncommitted_changes"),
             "Clean sessions should omit uncommitted_changes"
+        );
+        assert!(
+            !toml_str.contains("kill_hint"),
+            "Missing kill hint should be omitted from serialization"
+        );
+        assert!(
+            !toml_str.contains("last_item"),
+            "Missing last_item should be omitted from serialization"
         );
 
         let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
@@ -368,6 +376,8 @@ mod tests {
             events_count: 0,
             artifacts: vec![],
             peak_memory_mb: None,
+            kill_hint: None,
+            last_item: None,
             fallback_chain: None,
             gate_timeout: false,
             warnings: Vec::new(),
@@ -446,13 +456,7 @@ completed_at = "2026-01-01T00:00:00Z"
             completed_at: now,
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         };
         let toml_str = toml::to_string_pretty(&result).expect("serialize");
         assert!(
@@ -483,13 +487,7 @@ completed_at = "2026-01-01T00:00:00Z"
             completed_at: now,
             events_count: 0,
             artifacts: Vec::new(),
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         };
         let toml_str = toml::to_string_pretty(&result).expect("serialize");
         let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
@@ -546,13 +544,7 @@ completed_at = "2026-01-01T00:00:00Z"
                 SessionArtifact::new("output/a.txt"),
                 SessionArtifact::with_stats("output/acp-events.jsonl", 10, 256),
             ],
-            peak_memory_mb: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: None,
-            manager_fields: Default::default(),
+            ..Default::default()
         };
 
         let contents = toml::to_string_pretty(&result).unwrap();

--- a/crates/csa-session/src/soft_fork_tests.rs
+++ b/crates/csa-session/src/soft_fork_tests.rs
@@ -25,13 +25,7 @@ fn test_soft_fork_full_parent_session() {
         completed_at: now,
         events_count: 0,
         artifacts: vec![SessionArtifact::new("output/diff.patch")],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     let result_toml = toml::to_string_pretty(&result).unwrap();
     std::fs::write(session_dir.join(RESULT_FILE_NAME), &result_toml).unwrap();
@@ -78,13 +72,7 @@ fn test_soft_fork_truncation_on_large_summary() {
         completed_at: now,
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     std::fs::write(
         session_dir.join(RESULT_FILE_NAME),
@@ -145,13 +133,7 @@ fn test_soft_fork_result_only_no_output() {
         completed_at: now,
         events_count: 0,
         artifacts: vec![],
-        peak_memory_mb: None,
-        fallback_chain: None,
-        gate_timeout: false,
-        warnings: Vec::new(),
-        raw_process_exit_code: None,
-        uncommitted_changes: None,
-        manager_fields: Default::default(),
+        ..Default::default()
     };
     std::fs::write(
         session_dir.join(RESULT_FILE_NAME),

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.926"
-weave = "0.1.926"
+csa = "0.1.927"
+weave = "0.1.927"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Add memory pressure diagnostic to session SIGTERM/SIGKILL handler
- Detect earlyoom presence, cgroup OOM events, and low MemAvailable on signal exit
- Use `kill_hint` (not `kill_reason`) to make it clear these are observations, not definitive causes
- Require strong provenance: earlyoom classification needs both daemon presence AND cgroup OOM or very low memory (<5%)
- Skip OOM classification when terminal_reason is idle_timeout/initial_response_timeout (CSA-owned causes take precedence)
- Add typed `kill_hint`/`last_item` fields to SessionResult so they survive result save round-trips
- Surface diagnostics in session wait summary for immediate orchestrator visibility

Closes #1840

## Test plan

- [x] earlyoom running + healthy memory = NOT classified as earlyoom (provenance gate)
- [x] earlyoom running + cgroup OOM = classified as earlyoom
- [x] Low memory alone = memory_pressure hint (not earlyoom)
- [x] exit 137 + terminal_reason=idle_timeout = timeout, not OOM
- [x] kill_hint/last_item survive SessionResult save round-trips
- [x] `just pre-commit` passes (3 review rounds: R1 provenance overclaim, R2 persistence erasure + weak provenance, R3 PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)