### PR TITLE
fix(cli-sub-agent): document and guard #[path]-included module constraints for test crates (#1858)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.927"
+version = "0.1.928"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.927"
+version = "0.1.928"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/bug_class.rs
+++ b/crates/cli-sub-agent/src/bug_class.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::Write;
@@ -131,8 +132,7 @@ impl BugClassCandidate {
                     file_path: finding.file.clone(),
                     line_range: finding.line.map(|line| (line, line)),
                     code_snippet: None,
-                    // Finding currently carries only the issue summary, so reuse it as the
-                    // best available fix note until review artifacts expose structured remediation.
+                    // Review artifacts expose no structured remediation yet; reuse the summary.
                     fix_description: finding.summary.clone(),
                 };
                 let key = CandidateKey {
@@ -168,12 +168,10 @@ impl BugClassCandidate {
     }
 }
 
-/// Load persisted review artifacts for the given project from CSA session storage.
+/// Load review artifacts from `{state_root}/{project_key}/sessions/{session_id}`.
 ///
-/// Session artifacts are read from `{state_root}/{project_key}/sessions/{session_id}`.
-/// Consolidated review output takes precedence; single-reviewer artifacts are used
-/// as a fallback for older or non-consolidated sessions. Missing artifacts are
-/// skipped silently so partially-populated session directories do not abort mining.
+/// Consolidated output wins; missing artifacts are skipped so partial session
+/// directories do not abort mining.
 pub(crate) fn load_review_artifacts_for_project(
     project_path: &Path,
 ) -> Result<Vec<ReviewArtifact>> {

--- a/crates/cli-sub-agent/src/bug_class_sanitization.rs
+++ b/crates/cli-sub-agent/src/bug_class_sanitization.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use super::{BugClassCandidate, CaseStudy};
 
 const SKILL_SHORT_FIELD_MAX_CHARS: usize = 200;

--- a/crates/cli-sub-agent/src/bug_class_tests.rs
+++ b/crates/cli-sub-agent/src/bug_class_tests.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use std::fs;
 use std::path::Path;
 
@@ -5,7 +6,7 @@ use chrono::Utc;
 use csa_session::review_artifact::{ReviewArtifact, Severity, SeveritySummary};
 use csa_session::{create_session, get_session_dir};
 
-use crate::test_session_sandbox::ScopedSessionSandbox;
+use super::super::test_session_sandbox::ScopedSessionSandbox;
 
 use super::{
     BugClassCandidate, CONSOLIDATED_REVIEW_ARTIFACT_FILE, CaseStudy, SkillExtractor,

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
@@ -97,7 +98,7 @@ pub enum Commands {
         /// Read prompt from a file; use `-` or `/dev/stdin` for stdin.
         #[arg(long, value_name = "PATH", conflicts_with = "prompt")]
         prompt_file: Option<PathBuf>,
-        /// Prepend summary/details/findings from a prior review session into the employee prompt
+        /// Add prior review context to the prompt
         #[arg(long, value_name = "SESSION_ID", value_parser = validate_ulid)]
         inline_context_from_review_session: Option<String>,
         /// Resume existing session (ULID or prefix match) [DEPRECATED: use --fork-from]
@@ -215,13 +216,11 @@ pub enum Commands {
         #[arg(long)]
         no_stream_stdout: bool,
 
-        /// Disable the #1652 fatal-error-marker scan (for CSA code/fixtures that
-        /// carry provider markers, #1745). Default on; OFF under
-        /// CSA_PATTERN_INTERNAL (#1847).
+        /// Disable provider fatal-marker scan (#1652/#1745); default on except CSA_PATTERN_INTERNAL.
         #[arg(long)]
         no_error_marker_scan: bool,
 
-        /// Force-enable the scan despite CSA_PATTERN_INTERNAL (#1847).
+        /// Force-enable the fatal-marker scan.
         #[arg(long, conflicts_with = "no_error_marker_scan")]
         error_marker_scan: bool,
 
@@ -233,7 +232,7 @@ pub enum Commands {
         #[arg(long)]
         no_preflight: bool,
 
-        /// Skip only the post-exec shell gate; external verification remains required.
+        /// Skip only the post-exec shell gate; external verification still applies.
         #[arg(long)]
         no_post_exec_gate: bool,
 
@@ -327,7 +326,7 @@ pub enum Commands {
     },
 
     /// Garbage collect stale session artifacts
-    Gc(crate::gc::GcArgs),
+    Gc(super::gc::GcArgs),
 
     /// Show/manage configuration
     Config {

--- a/crates/cli-sub-agent/src/cli_arch.rs
+++ b/crates/cli-sub-agent/src/cli_arch.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 #[derive(clap::Args)]
 pub struct ArchArgs {
     /// Architecture analysis description

--- a/crates/cli-sub-agent/src/cli_checklist.rs
+++ b/crates/cli-sub-agent/src/cli_checklist.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use clap::Subcommand;
 
 #[derive(Subcommand)]

--- a/crates/cli-sub-agent/src/cli_common.rs
+++ b/crates/cli-sub-agent/src/cli_common.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use anyhow::Result;
 
 /// Build version string combining Cargo.toml version and git describe.

--- a/crates/cli-sub-agent/src/cli_doctor.rs
+++ b/crates/cli-sub-agent/src/cli_doctor.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use clap::Subcommand;
 
 #[derive(Debug, Subcommand)]

--- a/crates/cli-sub-agent/src/cli_health.rs
+++ b/crates/cli-sub-agent/src/cli_health.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 //! Workspace token health analysis.
 
 use std::path::{Path, PathBuf};

--- a/crates/cli-sub-agent/src/cli_memory.rs
+++ b/crates/cli-sub-agent/src/cli_memory.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use clap::{Subcommand, ValueEnum};
 
 #[derive(Subcommand, Debug)]

--- a/crates/cli-sub-agent/src/cli_mktsk.rs
+++ b/crates/cli-sub-agent/src/cli_mktsk.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 #[derive(clap::Args)]
 pub struct MktskArgs {
     /// Task decomposition request

--- a/crates/cli-sub-agent/src/cli_plan.rs
+++ b/crates/cli-sub-agent/src/cli_plan.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 //! CLI subcommands for the `csa plan` command group.
 
 use clap::Subcommand;

--- a/crates/cli-sub-agent/src/cli_recall.rs
+++ b/crates/cli-sub-agent/src/cli_recall.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 //! CLI subcommand for recall-based main-agent context recovery.
 
 use clap::{Args, Subcommand};

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use std::path::PathBuf;
 
 use clap::{ArgGroup, ValueEnum};

--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 //! CLI subcommands for the `csa session` command group.
 
 use std::path::PathBuf;

--- a/crates/cli-sub-agent/src/cli_skill.rs
+++ b/crates/cli-sub-agent/src/cli_skill.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 //! Clap definitions for the `csa skill` subcommand group.
 
 use clap::Subcommand;

--- a/crates/cli-sub-agent/src/cli_todo.rs
+++ b/crates/cli-sub-agent/src/cli_todo.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 //! CLI subcommands for the `csa todo` command group.
 
 use std::ffi::OsString;

--- a/crates/cli-sub-agent/src/cli_tokuin.rs
+++ b/crates/cli-sub-agent/src/cli_tokuin.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 #![allow(dead_code)]
 //! CLI subcommand for token estimation via tokuin.
 

--- a/crates/cli-sub-agent/src/cli_triage.rs
+++ b/crates/cli-sub-agent/src/cli_triage.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 #[derive(clap::Args)]
 pub struct HuntArgs {
     /// Bug description

--- a/crates/cli-sub-agent/src/cli_verify.rs
+++ b/crates/cli-sub-agent/src/cli_verify.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use std::path::PathBuf;
 
 use clap::{Args, ValueEnum};

--- a/crates/cli-sub-agent/src/cli_xurl.rs
+++ b/crates/cli-sub-agent/src/cli_xurl.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 #![allow(dead_code)]
 //! CLI subcommand for xurl thread queries.
 

--- a/crates/cli-sub-agent/src/gc_args.rs
+++ b/crates/cli-sub-agent/src/gc_args.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 #[derive(Debug, clap::Args, Clone)]
 pub struct GcArgs {
     /// Show what would be removed without actually removing

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -1,5 +1,6 @@
-use crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE;
-use crate::review_prior_rounds::{PRIOR_ROUNDS_SECTION_HEADING, REVIEW_FINDINGS_TOML_INSTRUCTION};
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
+use super::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE;
+use super::review_prior_rounds::{PRIOR_ROUNDS_SECTION_HEADING, REVIEW_FINDINGS_TOML_INSTRUCTION};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::fs;
@@ -48,13 +49,13 @@ fn reviewer_tool_binary_available(tool_name: &str, config: Option<&ProjectConfig
     }
 
     if tool_name == "codex" {
-        let transport = crate::run_helpers::resolved_codex_transport(config);
+        let transport = super::run_helpers::resolved_codex_transport(config);
         if matches!(transport, CodexTransport::Acp) && !CodexRuntimeMetadata::acp_compiled_in() {
             return false;
         }
     }
 
-    let Some(binary_name) = crate::run_helpers::resolved_tool_binary_name(tool_name, config) else {
+    let Some(binary_name) = super::run_helpers::resolved_tool_binary_name(tool_name, config) else {
         return false;
     };
 
@@ -172,10 +173,10 @@ When spec/contract context is provided, use rule_id values: \
 Reviewer tool hint: {}.",
         tool.as_str()
     );
-    crate::review_design_anchor::append_design_anchor(&mut prompt);
+    super::review_design_anchor::append_design_anchor(&mut prompt);
     if !prompt.contains("## Review iteration context")
         && let Some(branch) =
-            crate::review_design_anchor::resolve_current_branch_via_vcs(project_root)
+            super::review_design_anchor::resolve_current_branch_via_vcs(project_root)
         && let Some(iteration_context) = review_iteration::render_review_iteration_context(
             project_root,
             &branch,

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -1,6 +1,6 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
+use super::super::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use super::*;
-use crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE;
-use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use csa_config::{GlobalConfig, ProjectMeta, ResourcesConfig, ToolConfig};
 use csa_core::env::{CSA_PARENT_SESSION_DIR_ENV_KEY, CSA_SESSION_DIR_ENV_KEY};
 use csa_session::review_artifact::{Finding, ReviewArtifact, Severity, SeveritySummary};
@@ -843,7 +843,6 @@ fn parse_review_decision_four_values() {
 fn parse_review_decision_fail_takes_priority() {
     use csa_core::types::ReviewDecision;
 
-    // When both FAIL and PASS tokens present, FAIL wins
     assert_eq!(
         parse_review_decision("PASS but also HAS_ISSUES", 0),
         ReviewDecision::Fail
@@ -854,7 +853,6 @@ fn parse_review_decision_fail_takes_priority() {
 fn parse_review_decision_exit_code_fallback() {
     use csa_core::types::ReviewDecision;
 
-    // No verdict token: fail closed unless the review explicitly says it is clean.
     assert_eq!(
         parse_review_decision("no verdict here", 0),
         ReviewDecision::Fail

--- a/crates/cli-sub-agent/src/review_design_anchor.rs
+++ b/crates/cli-sub-agent/src/review_design_anchor.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 pub(crate) const REVIEW_DESIGN_PREFERENCE_ANCHOR: &str = r#"## Design preferences vs correctness bugs
 
 When reviewing diffs that touch design-level choices (preserve-vs-overwrite semantics, where to persist artifacts, API surface shapes, which lifecycle stages trigger which side-effects), treat the current choice as a DESIGN PREFERENCE if it has a coherent rationale, not as a correctness bug.

--- a/crates/cli-sub-agent/src/review_iteration.rs
+++ b/crates/cli-sub-agent/src/review_iteration.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use std::path::Path;
 
 use super::review_iteration_resolver::try_max_review_iterations_for_branch;

--- a/crates/cli-sub-agent/src/review_iteration_resolver.rs
+++ b/crates/cli-sub-agent/src/review_iteration_resolver.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use std::path::Path;
 
 use anyhow::{Context, Result};

--- a/crates/cli-sub-agent/src/review_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_prior_rounds.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use std::fs;
 use std::path::Path;
 

--- a/crates/cli-sub-agent/src/test_env_lock.rs
+++ b/crates/cli-sub-agent/src/test_env_lock.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use std::ffi::OsString;
 use std::sync::{Arc, LazyLock};
 use tokio::sync::{Mutex, OwnedMutexGuard};

--- a/crates/cli-sub-agent/src/test_session_sandbox.rs
+++ b/crates/cli-sub-agent/src/test_session_sandbox.rs
@@ -1,3 +1,4 @@
+// NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 /// Redirect session state/cache I/O into a tempdir so tests work in sandboxed
 /// CI environments (avoids read-only host XDG paths leaking into test runs).
 ///
@@ -9,7 +10,7 @@
 use std::ffi::OsString;
 use tokio::sync::OwnedMutexGuard;
 
-use crate::test_env_lock::TEST_ENV_LOCK;
+use super::test_env_lock::TEST_ENV_LOCK;
 
 /// RAII guard that sandboxes session env vars and restores them on drop.
 ///

--- a/justfile
+++ b/justfile
@@ -134,6 +134,7 @@ check-version-bumped:
 pre-commit-fast:
     just find-monolith-files
     just monolith-test
+    just check-path-includes
     just check-generated-artifacts
     just check-version-bumped
     just check-chinese
@@ -147,6 +148,13 @@ pre-commit:
     just pre-commit-fast
     just test
     just test-e2e
+
+# ==============================================================================
+
+# Ensure src modules pulled into integration test crates stay crate-root agnostic.
+check-path-includes:
+    ./scripts/hooks/check-path-included-src.sh --self-test
+    ./scripts/hooks/check-path-included-src.sh
 
 # ==============================================================================
 

--- a/scripts/hooks/check-path-included-src.sh
+++ b/scripts/hooks/check-path-included-src.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# Pre-commit: path-included src modules compile under the integration test crate root.
+set -euo pipefail
+
+repo_root="$(realpath "$(git rev-parse --show-toplevel)")"
+cd "$repo_root"
+
+declare -a queue_files=()
+declare -a queue_tests=()
+declare -a violations=()
+seen_entries=""
+resolved_path_attr=""
+path_attr_violation=""
+self_test_sandbox=""
+
+relative_path() {
+    local path="$1"
+    path="${path#$repo_root/}"
+    printf '%s' "$path"
+}
+
+resolve_path_attr() {
+    local including_file="$1"
+    local path_attr="$2"
+    local base_dir
+    local resolved_path
+    local canonical_path
+    local including_rel
+
+    resolved_path_attr=""
+    path_attr_violation=""
+
+    if [[ "$path_attr" = /* ]]; then
+        resolved_path="$path_attr"
+    else
+        base_dir="$(dirname "$including_file")"
+        resolved_path="$base_dir/$path_attr"
+    fi
+
+    if [ ! -e "$resolved_path" ]; then
+        return
+    fi
+
+    if ! canonical_path="$(realpath "$resolved_path" 2>/dev/null)"; then
+        return
+    fi
+
+    case "$canonical_path" in
+        "$repo_root"/*)
+            if [ -f "$canonical_path" ]; then
+                resolved_path_attr="$canonical_path"
+            fi
+            ;;
+        *)
+            including_rel="$(relative_path "$including_file")"
+            path_attr_violation="file $canonical_path is referenced by #[path = \"$path_attr\"] from $including_rel but resolves outside repository root"
+            ;;
+    esac
+}
+
+enqueue_file() {
+    local file="$1"
+    local origin_test="$2"
+    local key
+
+    key="$file	$origin_test"
+    if printf '%s' "$seen_entries" | grep -Fqx "$key"; then
+        return
+    fi
+
+    seen_entries="${seen_entries}${key}"$'\n'
+    queue_files+=("$file")
+    queue_tests+=("$origin_test")
+}
+
+extract_path_attr() {
+    sed -E 's/.*#\[path[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/'
+}
+
+enqueue_test_src_includes() {
+    local test_file="$1"
+    local line=""
+    local path_attr=""
+    local src_file=""
+
+    while IFS=: read -r _line line; do
+        path_attr="$(printf '%s\n' "$line" | extract_path_attr)"
+        resolve_path_attr "$test_file" "$path_attr"
+        if [ -n "$path_attr_violation" ]; then
+            violations+=("$path_attr_violation")
+            continue
+        fi
+        src_file="$resolved_path_attr"
+        if [ -z "$src_file" ]; then
+            continue
+        fi
+        enqueue_file "$src_file" "$test_file"
+    done < <(grep -nE '#\[path[[:space:]]*=[[:space:]]*"\.\./src/[^"]+"' "$test_file" || true)
+}
+
+enqueue_transitive_includes() {
+    local src_file="$1"
+    local origin_test="$2"
+    local line=""
+    local path_attr=""
+    local child_file=""
+
+    while IFS=: read -r _line line; do
+        path_attr="$(printf '%s\n' "$line" | extract_path_attr)"
+        resolve_path_attr "$src_file" "$path_attr"
+        if [ -n "$path_attr_violation" ]; then
+            violations+=("$path_attr_violation")
+            continue
+        fi
+        child_file="$resolved_path_attr"
+        if [ -z "$child_file" ]; then
+            continue
+        fi
+        enqueue_file "$child_file" "$origin_test"
+    done < <(grep -nE '#\[path[[:space:]]*=[[:space:]]*"[^"]+"' "$src_file" || true)
+}
+
+check_no_crate_root_references() {
+    local src_file="$1"
+    local origin_test="$2"
+    local crate_refs=""
+    local src_rel=""
+    local test_rel=""
+
+    src_rel="$(relative_path "$src_file")"
+    test_rel="$(relative_path "$origin_test")"
+
+    if [ ! -f "$src_file" ]; then
+        return
+    fi
+
+    crate_refs="$(
+        awk '
+            index($0, "crate::") && $0 !~ /^[[:space:]]*\/\// {
+                print FNR ":" $0
+            }
+        ' "$src_file"
+    )"
+
+    if [ -n "$crate_refs" ]; then
+        violations+=("file $src_rel is #[path]-included by test $test_rel but contains \`crate::\` references which will fail in the test crate context"$'\n'"$crate_refs")
+    fi
+}
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local label="$3"
+
+    if [ "$expected" != "$actual" ]; then
+        printf 'self-test failed: %s\nexpected: %s\nactual:   %s\n' "$label" "$expected" "$actual" >&2
+        exit 1
+    fi
+}
+
+assert_empty() {
+    local actual="$1"
+    local label="$2"
+
+    if [ -n "$actual" ]; then
+        printf 'self-test failed: %s\nexpected empty, got: %s\n' "$label" "$actual" >&2
+        exit 1
+    fi
+}
+
+assert_violation_count() {
+    local expected="$1"
+    local label="$2"
+
+    if [ "${#violations[@]}" -ne "$expected" ]; then
+        printf 'self-test failed: %s\nexpected %s violation(s), got %s\n' "$label" "$expected" "${#violations[@]}" >&2
+        printf '%s\n' "${violations[@]}" >&2
+        exit 1
+    fi
+}
+
+append_path_attr_violation() {
+    if [ -n "$path_attr_violation" ]; then
+        violations+=("$path_attr_violation")
+    fi
+}
+
+run_self_tests() {
+    local original_repo_root="$repo_root"
+    local sandbox=""
+    local resolved=""
+
+    sandbox="$(mktemp -d "${TMPDIR:-/tmp}/check-path-included-src.XXXXXX")"
+    self_test_sandbox="$sandbox"
+    trap 'rm -rf "$self_test_sandbox"' EXIT
+
+    mkdir -p "$sandbox/repo/a/b" "$sandbox/repo/crates/cli-sub-agent/src" "$sandbox/repo/crates/cli-sub-agent/tests" "$sandbox/etc"
+    printf 'pub struct Cli;\n' > "$sandbox/repo/crates/cli-sub-agent/src/cli.rs"
+    printf 'root:x:0:0:root:/root:/bin/sh\ncrate::outside\n' > "$sandbox/etc/passwd"
+
+    repo_root="$(realpath "$sandbox/repo")"
+
+    violations=()
+    resolve_path_attr "$repo_root/a/b/test.rs" "../../../etc/passwd"
+    append_path_attr_violation
+    resolved="$resolved_path_attr"
+    assert_empty "$resolved" "relative traversal outside repo is not resolved"
+    assert_violation_count 1 "relative traversal outside repo is reported"
+
+    violations=()
+    resolve_path_attr "$repo_root/a/b/test.rs" "/etc/passwd"
+    append_path_attr_violation
+    resolved="$resolved_path_attr"
+    assert_empty "$resolved" "absolute path outside repo is not resolved"
+    assert_violation_count 1 "absolute path outside repo is reported"
+
+    violations=()
+    resolve_path_attr "$repo_root/crates/cli-sub-agent/tests/e2e.rs" "../src/cli.rs"
+    append_path_attr_violation
+    resolved="$resolved_path_attr"
+    assert_eq "$repo_root/crates/cli-sub-agent/src/cli.rs" "$resolved" "relative path inside repo is allowed"
+    assert_violation_count 0 "relative path inside repo has no violation"
+
+    violations=()
+    resolve_path_attr "$repo_root/a/b/test.rs" "../src/missing.rs"
+    append_path_attr_violation
+    resolved="$resolved_path_attr"
+    assert_empty "$resolved" "missing target is skipped"
+    assert_violation_count 0 "missing target has no violation"
+
+    printf '#[path = "../src/../../../../etc/passwd"]\nmod passwd;\n' > "$repo_root/crates/cli-sub-agent/tests/e2e.rs"
+    queue_files=()
+    queue_tests=()
+    seen_entries=""
+    violations=()
+    enqueue_test_src_includes "$repo_root/crates/cli-sub-agent/tests/e2e.rs"
+    assert_violation_count 1 "test include traversal is reported"
+    assert_eq "0" "${#queue_files[@]}" "test include traversal is not enqueued"
+
+    printf '#[path = "../../../etc/passwd"]\nmod passwd;\n' > "$repo_root/a/b/source.rs"
+    queue_files=()
+    queue_tests=()
+    seen_entries=""
+    violations=()
+    enqueue_transitive_includes "$repo_root/a/b/source.rs" "$repo_root/a/b/test.rs"
+    assert_violation_count 1 "transitive traversal is reported"
+    assert_eq "0" "${#queue_files[@]}" "transitive traversal is not enqueued"
+
+    repo_root="$original_repo_root"
+    rm -rf "$self_test_sandbox"
+    self_test_sandbox=""
+    trap - EXIT
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    run_self_tests
+    exit 0
+fi
+
+while IFS= read -r test_file; do
+    enqueue_test_src_includes "$test_file"
+done < <(
+    {
+        find crates -path '*/tests/*.rs' -type f -print 2>/dev/null || true
+        find tests -maxdepth 1 -name '*.rs' -type f -print 2>/dev/null || true
+    } | sort -u
+)
+
+index=0
+while [ "$index" -lt "${#queue_files[@]}" ]; do
+    src_file="${queue_files[$index]}"
+    origin_test="${queue_tests[$index]}"
+
+    check_no_crate_root_references "$src_file" "$origin_test"
+    if [ -f "$src_file" ]; then
+        enqueue_transitive_includes "$src_file" "$origin_test"
+    fi
+
+    index=$((index + 1))
+done
+
+if [ "${#violations[@]}" -gt 0 ]; then
+    printf 'ERROR: #[path]-included src modules must be test-crate compatible.\n\n' >&2
+    printf '%s\n\n' "${violations[@]}" >&2
+    exit 1
+fi

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.927"
-weave = "0.1.927"
+csa = "0.1.928"
+weave = "0.1.928"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Document `#[path]`-included module constraints at source (comments in affected files)
- Add `scripts/hooks/check-path-included-src.sh` pre-commit guard that catches `crate::` references in `#[path]`-included files before they break integration test crates
- Path traversal protection: all resolved paths validated to stay within repo root
- Self-test uses temp directories (not `target/`), works on fresh/cleaned checkouts
- Wire into `just pre-commit` via lefthook

Closes #1858

## Test plan

- [x] Guard detects `crate::` in `#[path]`-included files
- [x] Path traversal rejected (absolute paths, `../../` escapes)
- [x] Self-test works on fresh checkout (no `target/` dependency)
- [x] `just pre-commit` passes
- [x] Review PASS (3 rounds: R1 path traversal, R2 self-test target/ assumption, R3 PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)