### PR TITLE
refactor(cli-sub-agent): split pipeline_session_exec.rs monolith (#1668)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.931"
+version = "0.1.932"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.931"
+version = "0.1.932"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -1,11 +1,5 @@
-use super::prompt_cache::PromptAssembly;
-use super::result_contract::{
-    clear_expected_result_artifacts_for_prompt, enforce_result_toml_path_contract,
-};
-use super::session_exec_failover::apply_transport_failover_overrides;
 use super::{
     MemoryInjectionOptions, ParentSessionSource, SessionCreationMode, SessionExecutionResult,
-    resolve_liveness_dead_seconds, resolve_mcp_servers, run_pipeline_hook,
 };
 use crate::pipeline_project_key::resolve_memory_project_key;
 use crate::run_helpers::truncate_prompt;
@@ -15,20 +9,21 @@ use anyhow::{Context, Result};
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::{OutputFormat, ToolName};
 use csa_executor::Executor;
-use csa_hooks::{HookEvent, global_hooks_path, load_hooks_config};
 use csa_lock::acquire_lock;
 use csa_session::get_session_dir;
 use std::{
     path::{Path, PathBuf},
     time::Duration,
 };
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 #[path = "pipeline_session_exec_api.rs"]
 mod session_exec_api;
 #[path = "pipeline_session_exec_audit.rs"]
 mod session_exec_audit;
 #[path = "pipeline_session_exec_bootstrap.rs"]
 mod session_exec_bootstrap;
+#[path = "pipeline_session_exec_completion.rs"]
+mod session_exec_completion;
 #[path = "pipeline_session_exec_memory.rs"]
 mod session_exec_memory;
 #[path = "pipeline_session_exec_metadata.rs"]
@@ -41,6 +36,8 @@ mod session_exec_prompt_guard;
 mod session_exec_prompt_inject;
 #[path = "pipeline_session_exec_review_guard.rs"]
 mod session_exec_review_guard;
+#[path = "pipeline_session_exec_runtime.rs"]
+mod session_exec_runtime;
 #[path = "pipeline_session_exec_tool_state.rs"]
 mod session_exec_tool_state;
 #[path = "pipeline_session_exec_write_guard.rs"]
@@ -53,8 +50,6 @@ use self::session_exec_pre_exec::{
     check_resources_before_spawn, persist_pipeline_pre_exec_failure,
     write_fatal_error_marker_sidecar,
 };
-use self::session_exec_tool_state::ensure_tool_state_initialized;
-use self::session_exec_write_guard::apply_write_restriction_violations;
 pub(crate) use session_exec_api::{execute_with_session, execute_with_session_and_meta};
 
 #[allow(clippy::too_many_arguments)]
@@ -206,259 +201,54 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         }
     }
     info!("Executing in session: {}", session.meta_session_id);
-    let can_edit = config.is_none_or(|cfg| cfg.can_tool_edit_existing(executor.tool_name()));
-    let can_write_new = config.is_none_or(|cfg| cfg.can_tool_write_new(executor.tool_name()));
-    debug!(tool = %executor.tool_name(), can_edit, can_write_new, "Restriction flags resolved");
-    let raw_prompt = prompt.to_string();
-    let prompt_caching_enabled =
-        global_config.is_some_and(|cfg| cfg.experimental.enable_prompt_caching);
-    let mut prompt_assembly = PromptAssembly::new(raw_prompt.clone(), prompt_caching_enabled);
-    let state_dir_warning = match state_preflight::run(
-        global_config,
-        &session.meta_session_id,
-        startup_env.session_id(),
-        session_arg.is_none() || fresh_spawn_preflight_override,
-    ) {
-        Ok(warning) => warning,
-        Err(err) => {
-            return Err(persist_pipeline_pre_exec_failure(
-                project_root,
-                &mut session,
-                executor.tool_name(),
-                err,
-                &mut cleanup_guard,
-                None,
-            ));
-        }
-    };
-    if let Some(w) = state_dir_warning {
-        prompt_assembly.prepend_dynamic(&w);
-    }
-    let is_first_turn = session
-        .tools
-        .get(executor.tool_name())
-        .is_none_or(|ts| ts.provider_session_id.is_none());
-    if is_first_turn {
-        let first_turn_context = super::design_context::load_first_turn_context(
-            &session.project_path,
+    let runtime = session_exec_runtime::prepare_session_runtime(
+        session_exec_runtime::SessionRuntimeInput {
+            executor,
+            tool,
+            prompt,
+            session_arg: session_arg.as_deref(),
+            fresh_spawn_preflight_override,
             project_root,
+            session_dir: &session_dir,
+            config,
+            extra_env,
+            subtree_pin,
+            task_type,
             context_load_options,
-            config.is_none_or(|cfg| cfg.session.resolved_plan_injection()),
-        );
-        prompt_assembly.add_first_turn_context(first_turn_context);
-    }
-    let is_review_or_debate = matches!(task_type, Some("review" | "debate"));
-    if !is_review_or_debate {
-        let memory_cfg = config
-            .map(|cfg| &cfg.memory)
-            .filter(|m| !m.is_default())
-            .or_else(|| global_config.map(|cfg| &cfg.memory));
-        session_exec_memory::append_memory_section(
-            memory_cfg,
+            stream_mode,
+            idle_timeout_seconds,
+            initial_response_timeout_seconds,
             memory_injection,
-            raw_prompt.as_str(),
-            memory_project_key.as_deref(),
-            project_root,
-            executor.tool_name(),
-            prompt_assembly.dynamic_prompt_mut(),
-        );
-    }
-    if !can_edit || !can_write_new {
-        info!(
-            tool = %executor.tool_name(),
-            can_edit,
-            can_write_new,
-            "Applying filesystem restrictions via prompt injection"
-        );
-        prompt_assembly.add_restriction_instructions(
-            executor.restriction_instructions(can_edit, can_write_new),
-        );
-    }
-    let edit_guard = if !can_edit {
-        crate::edit_restriction_guard::maybe_capture_tracked_file_guard(project_root)?
-    } else {
-        None
-    };
-    // NOTE: new_file_guard captured AFTER PreRun hooks to avoid false positives.
-    let commit_guard_enabled = matches!(task_type, Some("run"));
-    let require_commit_on_mutation =
-        commit_guard_enabled && config.is_some_and(|cfg| cfg.session.require_commit_on_mutation);
-    // Check git status for both commit_guard and hook changed_paths variable.
-    let is_git = crate::run_cmd::is_git_worktree(project_root);
-    let inside_git_worktree = commit_guard_enabled && is_git;
-    let capture_snapshot = session_exec_audit::capture_git_workspace_snapshot_if_needed;
-    let pre_run_workspace = capture_snapshot(is_git, project_root, require_commit_on_mutation);
-    let tool_state =
-        ensure_tool_state_initialized(&mut session, executor, &resolved_provider_session_id)
-            .await?;
-    let result_file_cleared = clear_expected_result_artifacts_for_prompt(prompt, &session_dir);
-    let execution_start_time = chrono::Utc::now();
-    let sa_mode =
-        std::env::var_os(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)
-            .is_some_and(|value| value == "true" || value == "1");
-    let session_config = global_config.map(|gc| {
-        let mcp_servers = resolve_mcp_servers(project_root, gc);
-        if !mcp_servers.is_empty() {
-            info!(
-                count = mcp_servers.len(),
-                servers = %mcp_servers.iter().map(|s| s.name.as_str()).collect::<Vec<_>>().join(", "),
-                "Injecting MCP servers into tool session"
-            );
-        }
-        csa_executor::SessionConfig {
-            mcp_servers,
-            mcp_proxy_socket: gc.mcp_proxy_socket.clone(),
-            ..Default::default()
-        }
-    });
-    let mut merged_env = crate::pipeline_env::build_merged_env(
-        extra_env,
-        config,
-        global_config,
-        executor.tool_name(),
-        startup_env.current_depth(),
-        startup_env.pattern_internal(),
-        sa_mode,
-    );
-    crate::pipeline_env::apply_task_target_dir_guards(
-        task_type,
-        executor.tool_name(),
-        project_root,
-        &mut merged_env,
-    );
-    let merged_env_ref = (!merged_env.is_empty()).then_some(&merged_env);
-    // Project [hooks] overrides take priority over hooks.toml entries.
-    let project_hook_overrides =
-        super::session_hooks::build_project_hook_overrides(config, task_type);
-    // Load hooks config once, reused by PreRun, PostRun, and SessionComplete hooks.
-    let hooks_config = load_hooks_config(
-        csa_session::get_session_root(project_root)
-            .ok()
-            .map(|r| r.join("hooks.toml"))
-            .as_deref(),
-        global_hooks_path().as_deref(),
-        project_hook_overrides.as_ref(),
-    );
-    let sessions_root = session_dir
-        .parent()
-        .unwrap_or(&session_dir)
-        .display()
-        .to_string();
-    let pre_run_vars = std::collections::HashMap::from([
-        ("session_id".to_string(), session.meta_session_id.clone()),
-        ("session_dir".to_string(), session_dir.display().to_string()),
-        ("sessions_root".to_string(), sessions_root.clone()),
-        ("tool".to_string(), executor.tool_name().to_string()),
-        ("project_root".to_string(), session.project_path.clone()),
-        // Empty at PreRun; populated at PostRun after git diff.
-        ("CHANGED_PATHS".to_string(), "[]".to_string()),
-        ("CHANGED_CRATES".to_string(), String::new()),
-        ("CHANGED_CRATES_FLAGS".to_string(), String::new()),
-    ]);
-    run_pipeline_hook(HookEvent::PreRun, &hooks_config, &pre_run_vars)?;
-    // New-file guard captured AFTER PreRun hooks (baseline includes hook-created files).
-    let new_file_guard = if !can_write_new {
-        crate::edit_restriction_guard::maybe_capture_new_file_guard(project_root)?
-    } else {
-        None
-    };
-    session_exec_prompt_guard::inject_prompt_guards_if_needed(
-        task_type,
-        &hooks_config,
-        &session,
-        executor,
-        session_arg.is_some(),
-        &mut prompt_assembly,
-        startup_env.current_depth(),
-    );
-    let effective_prompt = session_exec_prompt_inject::finalize_effective_prompt(
-        prompt_assembly,
-        task_type,
-        is_first_turn,
-        project_root,
-        config,
-    );
-    // Resolve sandbox configuration from project config and enforcement mode.
-    let liveness_dead_seconds = resolve_liveness_dead_seconds(config);
-    let mut execute_options = match crate::pipeline_sandbox::resolve_sandbox_options(
-        config,
-        executor.tool_name(),
-        &session.meta_session_id,
-        project_root,
-        stream_mode,
-        idle_timeout_seconds,
-        liveness_dead_seconds,
-        initial_response_timeout_seconds,
-        no_fs_sandbox,
-        readonly_project_root,
-        extra_writable,
-        extra_readable,
-    ) {
-        crate::pipeline_sandbox::SandboxResolution::Ok(opts) => *opts,
-        crate::pipeline_sandbox::SandboxResolution::RequiredButUnavailable(msg) => {
-            let err = anyhow::anyhow!(msg);
-            return Err(persist_pipeline_pre_exec_failure(
-                project_root,
-                &mut session,
-                executor.tool_name(),
-                err,
-                &mut cleanup_guard,
-                None,
-            ));
-        }
-    };
-    super::ensure_tool_runtime_prerequisites(
-        executor.tool_name(),
-        super::resolved_filesystem_capability(&execute_options),
+            global_config,
+            pre_session_hook,
+            no_fs_sandbox,
+            readonly_project_root,
+            extra_writable,
+            extra_readable,
+            error_marker_scan_override,
+            cli_no_hook_bypass_scan,
+            startup_env,
+            resolved_provider_session_id: &resolved_provider_session_id,
+            memory_project_key: memory_project_key.as_deref(),
+        },
+        &mut session,
+        &mut cleanup_guard,
     )
     .await?;
-    let spool_max_mb = config
-        .map(|cfg| cfg.session.resolved_spool_max_mb())
-        .unwrap_or((csa_process::DEFAULT_SPOOL_MAX_BYTES / (1024 * 1024)) as u32);
-    let spool_max_bytes = u64::from(spool_max_mb).saturating_mul(1024 * 1024);
-    let spool_keep_rotated = config
-        .map(|cfg| cfg.session.resolved_spool_keep_rotated())
-        .unwrap_or(csa_process::DEFAULT_SPOOL_KEEP_ROTATED);
-    execute_options =
-        execute_options.with_output_spool_rotation(spool_max_bytes, spool_keep_rotated);
-    execute_options.output_spool = Some(session_dir.join("output.log"));
-    // Resolve the #1652 fatal-error-marker scan default (#1745/#1847); precedence
-    // (CLI flag > CSA_PATTERN_INTERNAL marker > config) lives in the resolver.
-    let error_marker_scan_enabled = crate::error_marker_scan::resolve_error_marker_scan_enabled(
-        error_marker_scan_override,
-        startup_env.pattern_internal(),
-        config.map(|cfg| cfg.resources.error_marker_scan),
-    );
-    execute_options = execute_options.with_error_marker_scan_enabled(error_marker_scan_enabled);
-    let hook_bypass_scan_enabled = crate::run_cmd::resolve_hook_bypass_scan_enabled(
-        cli_no_hook_bypass_scan,
-        config.map(|cfg| cfg.resources.hook_bypass_scan),
-    );
-    // #1741: carry CSA's trusted subtree pin via the typed ExecuteOptions
-    // channel (never via the generic env map), so it is the sole writer of the
-    // pin keys at the spawn boundary.
-    execute_options = execute_options.with_subtree_pin(subtree_pin.cloned());
-    apply_transport_failover_overrides(&mut execute_options, merged_env_ref);
-    if let Some(pre_session_hook) = pre_session_hook {
-        execute_options = execute_options.with_pre_session_hook(pre_session_hook);
-    }
-    crate::pipeline_sandbox::record_sandbox_telemetry(&execute_options, &mut session);
-    crate::pipeline_sandbox::maybe_inflate_balloon(tool.as_str());
-    if let Err(err) = session_exec_metadata::persist_session_runtime_binary(&session_dir, executor)
-    {
-        warn!(
-            session = %session.meta_session_id,
-            error = %err,
-            "Failed to persist session runtime binary metadata"
-        );
-    }
-    let pre_exec_snapshot = session_exec_audit::capture_pre_execution_snapshot(project_root);
+    let session_exec_runtime::SessionRuntimePlan {
+        effective_prompt,
+        tool_state,
+        execute_options,
+        session_config,
+        completion,
+    } = runtime;
+    let execution_start_time = completion.execution_start_time;
     let transport_result = crate::pipeline_execute::execute_transport_with_signal(
         executor,
         &effective_prompt,
         tool_state.as_ref(),
         &session,
-        merged_env_ref,
+        completion.merged_env_ref(),
         execute_options,
         session_config,
         project_root,
@@ -471,131 +261,24 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     if let Some(ref mut guard) = cleanup_guard {
         guard.defuse();
     }
-    let provider_session_id =
-        csa_executor::extract_session_id_from_transport(tool, &transport_result);
-    let events_count = transport_result
-        .metadata
-        .total_events_count
-        .max(transport_result.events.len()) as u64;
-    let execute_events_observed = crate::run_cmd::execute_tool_calls_observed(
-        &transport_result.metadata,
-        &transport_result.events,
-    );
-    let mut executed_shell_commands = crate::run_cmd::extract_executed_shell_commands(
-        &transport_result.metadata,
-        &transport_result.events,
-    );
-    // Re-inject --no-verify commit if evicted from ring buffer.
-    if transport_result.metadata.has_no_verify_commit
-        && crate::run_cmd::detect_no_verify_commit_commands(&executed_shell_commands).is_empty()
-    {
-        executed_shell_commands.push("git commit --no-verify".to_string());
-    }
-    let transcript_artifacts =
-        crate::pipeline_transcript::persist_if_enabled(config, &session_dir, &transport_result);
-    let mut result = transport_result.execution;
-    // Best-effort EACCES diagnostic when filesystem sandbox is active.
-    crate::pipeline_sandbox::check_sandbox_permission_errors(
-        &result.stderr_output,
-        session.sandbox_info.as_ref(),
-    );
-    enforce_result_toml_path_contract(
-        prompt,
-        &effective_prompt,
-        &session_dir,
-        result_file_cleared,
-        &mut result,
-    );
-    apply_write_restriction_violations(edit_guard, new_file_guard, executor, &mut result)?;
-    if result.exit_code != 0 {
-        crate::error_hints::append_sandbox_fs_denial_hint(
-            &mut result.stderr_output,
-            &result.output,
-            crate::pipeline_sandbox::filesystem_sandbox_active(session.sandbox_info.as_ref()),
-            &session.meta_session_id,
-        );
-    }
-    // Post-run git snapshot for commit guard + changed_paths hook vars.
-    let post_run_workspace = capture_snapshot(is_git, project_root, require_commit_on_mutation);
-    let pre_fingerprints = pre_run_workspace
-        .as_ref()
-        .map(session_exec_audit::snapshot_to_fingerprints);
-    let post_fingerprints = post_run_workspace
-        .as_ref()
-        .map(session_exec_audit::snapshot_to_fingerprints);
-    let changed_paths = crate::pipeline::changed_paths::compute_changed_paths(
-        pre_run_workspace.as_ref().map(|s| s.status.as_str()),
-        post_run_workspace.as_ref().map(|s| s.status.as_str()),
-        pre_fingerprints.as_ref(),
-        post_fingerprints.as_ref(),
-    );
-    let snapshots_available = pre_run_workspace.is_some() && post_run_workspace.is_some();
-    if commit_guard_enabled {
-        let commit_guard = crate::run_cmd::evaluate_post_run_commit_guard(
-            pre_run_workspace.as_ref(),
-            post_run_workspace.as_ref(),
-        );
-        let policy_evaluation_failed = require_commit_on_mutation
-            && (!inside_git_worktree
-                || pre_run_workspace.is_none()
-                || post_run_workspace.is_none());
-        crate::run_cmd::apply_post_session_commit_policies(
-            &mut result,
-            crate::run_cmd::PostSessionCommitPolicyArgs {
-                output_format: &output_format,
-                prompt,
-                require_commit_on_mutation,
-                commit_guard: commit_guard.as_ref(),
-                policy_evaluation_failed,
-                hook_bypass_scan_enabled,
-                executed_shell_commands: &executed_shell_commands,
-                merged_env_ref,
-                execute_events_observed,
-            },
-        );
-    }
-    let post_ctx = crate::pipeline_post_exec::PostExecContext {
-        executor,
-        prompt,
-        effective_prompt: &effective_prompt,
-        task_type,
-        readonly_project_root,
-        project_root,
-        config,
-        global_config,
-        session_dir,
-        sessions_root,
-        execution_start_time,
-        hooks_config: &hooks_config,
-        memory_project_key,
-        provider_session_id: provider_session_id.clone(),
-        events_count,
-        transcript_artifacts,
-        changed_paths: changed_paths.clone(),
-        pre_exec_snapshot,
-        has_tool_calls: transport_result.metadata.has_tool_calls
-            || transport_result.metadata.has_execute_tool_calls,
-        turn_count: transport_result.metadata.turn_count,
-        output_tokens: transport_result.metadata.output_tokens,
-        sa_mode,
-    };
-    if let Err(err) =
-        crate::pipeline_post_exec::process_execution_result(post_ctx, &mut session, &mut result)
-            .await
-    {
-        crate::pipeline_post_exec::ensure_terminal_result_on_post_exec_error(
+    session_exec_completion::complete_session_execution(
+        session_exec_completion::CompletionInput {
+            executor,
+            tool,
+            prompt,
+            output_format: &output_format,
+            task_type,
+            readonly_project_root,
             project_root,
-            &mut session,
-            executor.tool_name(),
-            execution_start_time,
-            &err,
-        );
-        return Err(err).with_context(|| format!("meta_session_id={}", session.meta_session_id));
-    }
-    Ok(SessionExecutionResult {
-        execution: result,
-        meta_session_id: session.meta_session_id.clone(),
-        provider_session_id,
-        changed_paths: snapshots_available.then_some(changed_paths),
-    })
+            config,
+            global_config,
+            session_dir: &session_dir,
+            memory_project_key,
+            effective_prompt,
+            plan: completion,
+            transport_result,
+        },
+        &mut session,
+    )
+    .await
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -1,0 +1,188 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use csa_config::{GlobalConfig, ProjectConfig};
+use csa_core::types::{OutputFormat, ToolName};
+use csa_executor::{Executor, TransportResult};
+use csa_session::MetaSessionState;
+
+use super::super::result_contract::enforce_result_toml_path_contract;
+use super::session_exec_audit;
+use super::session_exec_runtime::SessionCompletionPlan;
+use super::session_exec_write_guard::apply_write_restriction_violations;
+use crate::pipeline::SessionExecutionResult;
+
+pub(super) struct CompletionInput<'a> {
+    pub(super) executor: &'a Executor,
+    pub(super) tool: &'a ToolName,
+    pub(super) prompt: &'a str,
+    pub(super) output_format: &'a OutputFormat,
+    pub(super) task_type: Option<&'a str>,
+    pub(super) readonly_project_root: bool,
+    pub(super) project_root: &'a Path,
+    pub(super) config: Option<&'a ProjectConfig>,
+    pub(super) global_config: Option<&'a GlobalConfig>,
+    pub(super) session_dir: &'a Path,
+    pub(super) memory_project_key: Option<String>,
+    pub(super) effective_prompt: String,
+    pub(super) plan: SessionCompletionPlan,
+    pub(super) transport_result: TransportResult,
+}
+
+pub(super) async fn complete_session_execution(
+    input: CompletionInput<'_>,
+    session: &mut MetaSessionState,
+) -> Result<SessionExecutionResult> {
+    let SessionCompletionPlan {
+        merged_env,
+        hooks_config,
+        sessions_root,
+        edit_guard,
+        new_file_guard,
+        result_file_cleared,
+        execution_start_time,
+        commit_guard_enabled,
+        require_commit_on_mutation,
+        hook_bypass_scan_enabled,
+        is_git,
+        inside_git_worktree,
+        pre_run_workspace,
+        pre_exec_snapshot,
+        sa_mode,
+    } = input.plan;
+    let merged_env_ref = (!merged_env.is_empty()).then_some(&merged_env);
+    let transport_result = input.transport_result;
+    let provider_session_id =
+        csa_executor::extract_session_id_from_transport(input.tool, &transport_result);
+    let events_count = transport_result
+        .metadata
+        .total_events_count
+        .max(transport_result.events.len()) as u64;
+    let execute_events_observed = crate::run_cmd::execute_tool_calls_observed(
+        &transport_result.metadata,
+        &transport_result.events,
+    );
+    let mut executed_shell_commands = crate::run_cmd::extract_executed_shell_commands(
+        &transport_result.metadata,
+        &transport_result.events,
+    );
+    if transport_result.metadata.has_no_verify_commit
+        && crate::run_cmd::detect_no_verify_commit_commands(&executed_shell_commands).is_empty()
+    {
+        executed_shell_commands.push("git commit --no-verify".to_string());
+    }
+    let transcript_artifacts = crate::pipeline_transcript::persist_if_enabled(
+        input.config,
+        input.session_dir,
+        &transport_result,
+    );
+    let has_tool_calls = transport_result.metadata.has_tool_calls
+        || transport_result.metadata.has_execute_tool_calls;
+    let turn_count = transport_result.metadata.turn_count;
+    let output_tokens = transport_result.metadata.output_tokens;
+    let mut result = transport_result.execution;
+    crate::pipeline_sandbox::check_sandbox_permission_errors(
+        &result.stderr_output,
+        session.sandbox_info.as_ref(),
+    );
+    enforce_result_toml_path_contract(
+        input.prompt,
+        &input.effective_prompt,
+        input.session_dir,
+        result_file_cleared,
+        &mut result,
+    );
+    apply_write_restriction_violations(edit_guard, new_file_guard, input.executor, &mut result)?;
+    if result.exit_code != 0 {
+        crate::error_hints::append_sandbox_fs_denial_hint(
+            &mut result.stderr_output,
+            &result.output,
+            crate::pipeline_sandbox::filesystem_sandbox_active(session.sandbox_info.as_ref()),
+            &session.meta_session_id,
+        );
+    }
+    let post_run_workspace = session_exec_audit::capture_git_workspace_snapshot_if_needed(
+        is_git,
+        input.project_root,
+        require_commit_on_mutation,
+    );
+    let pre_fingerprints = pre_run_workspace
+        .as_ref()
+        .map(session_exec_audit::snapshot_to_fingerprints);
+    let post_fingerprints = post_run_workspace
+        .as_ref()
+        .map(session_exec_audit::snapshot_to_fingerprints);
+    let changed_paths = crate::pipeline::changed_paths::compute_changed_paths(
+        pre_run_workspace.as_ref().map(|s| s.status.as_str()),
+        post_run_workspace.as_ref().map(|s| s.status.as_str()),
+        pre_fingerprints.as_ref(),
+        post_fingerprints.as_ref(),
+    );
+    let snapshots_available = pre_run_workspace.is_some() && post_run_workspace.is_some();
+    if commit_guard_enabled {
+        let commit_guard = crate::run_cmd::evaluate_post_run_commit_guard(
+            pre_run_workspace.as_ref(),
+            post_run_workspace.as_ref(),
+        );
+        let policy_evaluation_failed = require_commit_on_mutation
+            && (!inside_git_worktree
+                || pre_run_workspace.is_none()
+                || post_run_workspace.is_none());
+        crate::run_cmd::apply_post_session_commit_policies(
+            &mut result,
+            crate::run_cmd::PostSessionCommitPolicyArgs {
+                output_format: input.output_format,
+                prompt: input.prompt,
+                require_commit_on_mutation,
+                commit_guard: commit_guard.as_ref(),
+                policy_evaluation_failed,
+                hook_bypass_scan_enabled,
+                executed_shell_commands: &executed_shell_commands,
+                merged_env_ref,
+                execute_events_observed,
+            },
+        );
+    }
+    let post_ctx = crate::pipeline_post_exec::PostExecContext {
+        executor: input.executor,
+        prompt: input.prompt,
+        effective_prompt: &input.effective_prompt,
+        task_type: input.task_type,
+        readonly_project_root: input.readonly_project_root,
+        project_root: input.project_root,
+        config: input.config,
+        global_config: input.global_config,
+        session_dir: input.session_dir.to_path_buf(),
+        sessions_root,
+        execution_start_time,
+        hooks_config: &hooks_config,
+        memory_project_key: input.memory_project_key,
+        provider_session_id: provider_session_id.clone(),
+        events_count,
+        transcript_artifacts,
+        changed_paths: changed_paths.clone(),
+        pre_exec_snapshot,
+        has_tool_calls,
+        turn_count,
+        output_tokens,
+        sa_mode,
+    };
+    if let Err(err) =
+        crate::pipeline_post_exec::process_execution_result(post_ctx, session, &mut result).await
+    {
+        crate::pipeline_post_exec::ensure_terminal_result_on_post_exec_error(
+            input.project_root,
+            session,
+            input.executor.tool_name(),
+            execution_start_time,
+            &err,
+        );
+        return Err(err).with_context(|| format!("meta_session_id={}", session.meta_session_id));
+    }
+    Ok(SessionExecutionResult {
+        execution: result,
+        meta_session_id: session.meta_session_id.clone(),
+        provider_session_id,
+        changed_paths: snapshots_available.then_some(changed_paths),
+    })
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -1,0 +1,384 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+use csa_config::{GlobalConfig, ProjectConfig};
+use csa_core::types::ToolName;
+use csa_executor::{ExecuteOptions, Executor, SessionConfig};
+use csa_hooks::{HookEvent, HooksConfig, global_hooks_path, load_hooks_config};
+use csa_session::{MetaSessionState, ToolState};
+use tracing::{debug, info, warn};
+
+use super::super::prompt_cache::PromptAssembly;
+use super::super::result_contract::clear_expected_result_artifacts_for_prompt;
+use super::super::session_exec_failover::apply_transport_failover_overrides;
+use super::session_exec_pre_exec::persist_pipeline_pre_exec_failure;
+use super::session_exec_tool_state::ensure_tool_state_initialized;
+use super::{
+    session_exec_audit, session_exec_memory, session_exec_metadata, session_exec_prompt_guard,
+    session_exec_prompt_inject, state_preflight,
+};
+use crate::edit_restriction_guard::{NewFileGuard, TrackedFileEditGuard};
+use crate::pipeline::{
+    MemoryInjectionOptions, resolve_liveness_dead_seconds, resolve_mcp_servers, run_pipeline_hook,
+};
+use crate::session_guard::SessionCleanupGuard;
+use crate::startup_env::StartupSubtreeEnv;
+
+pub(super) struct SessionRuntimeInput<'a> {
+    pub(super) executor: &'a Executor,
+    pub(super) tool: &'a ToolName,
+    pub(super) prompt: &'a str,
+    pub(super) session_arg: Option<&'a str>,
+    pub(super) fresh_spawn_preflight_override: bool,
+    pub(super) project_root: &'a Path,
+    pub(super) session_dir: &'a Path,
+    pub(super) config: Option<&'a ProjectConfig>,
+    pub(super) extra_env: Option<&'a HashMap<String, String>>,
+    pub(super) subtree_pin: Option<&'a csa_core::env::SubtreeModelPin>,
+    pub(super) task_type: Option<&'a str>,
+    pub(super) context_load_options: Option<&'a csa_executor::ContextLoadOptions>,
+    pub(super) stream_mode: csa_process::StreamMode,
+    pub(super) idle_timeout_seconds: u64,
+    pub(super) initial_response_timeout_seconds: Option<u64>,
+    pub(super) memory_injection: Option<&'a MemoryInjectionOptions>,
+    pub(super) global_config: Option<&'a GlobalConfig>,
+    pub(super) pre_session_hook: Option<csa_hooks::PreSessionHookInvocation>,
+    pub(super) no_fs_sandbox: bool,
+    pub(super) readonly_project_root: bool,
+    pub(super) extra_writable: &'a [PathBuf],
+    pub(super) extra_readable: &'a [PathBuf],
+    pub(super) error_marker_scan_override: Option<bool>,
+    pub(super) cli_no_hook_bypass_scan: bool,
+    pub(super) startup_env: &'a StartupSubtreeEnv,
+    pub(super) resolved_provider_session_id: &'a Option<String>,
+    pub(super) memory_project_key: Option<&'a str>,
+}
+
+pub(super) struct SessionRuntimePlan {
+    pub(super) effective_prompt: String,
+    pub(super) tool_state: Option<ToolState>,
+    pub(super) execute_options: ExecuteOptions,
+    pub(super) session_config: Option<SessionConfig>,
+    pub(super) completion: SessionCompletionPlan,
+}
+
+pub(super) struct SessionCompletionPlan {
+    pub(super) merged_env: HashMap<String, String>,
+    pub(super) hooks_config: HooksConfig,
+    pub(super) sessions_root: String,
+    pub(super) edit_guard: Option<TrackedFileEditGuard>,
+    pub(super) new_file_guard: Option<NewFileGuard>,
+    pub(super) result_file_cleared: bool,
+    pub(super) execution_start_time: chrono::DateTime<chrono::Utc>,
+    pub(super) commit_guard_enabled: bool,
+    pub(super) require_commit_on_mutation: bool,
+    pub(super) hook_bypass_scan_enabled: bool,
+    pub(super) is_git: bool,
+    pub(super) inside_git_worktree: bool,
+    pub(super) pre_run_workspace: Option<crate::run_cmd::GitWorkspaceSnapshot>,
+    pub(super) pre_exec_snapshot: Option<crate::pipeline_post_exec::PreExecutionSnapshot>,
+    pub(super) sa_mode: bool,
+}
+
+impl SessionCompletionPlan {
+    pub(super) fn merged_env_ref(&self) -> Option<&HashMap<String, String>> {
+        (!self.merged_env.is_empty()).then_some(&self.merged_env)
+    }
+}
+
+pub(super) async fn prepare_session_runtime(
+    input: SessionRuntimeInput<'_>,
+    session: &mut MetaSessionState,
+    cleanup_guard: &mut Option<SessionCleanupGuard>,
+) -> Result<SessionRuntimePlan> {
+    let can_edit = input
+        .config
+        .is_none_or(|cfg| cfg.can_tool_edit_existing(input.executor.tool_name()));
+    let can_write_new = input
+        .config
+        .is_none_or(|cfg| cfg.can_tool_write_new(input.executor.tool_name()));
+    debug!(
+        tool = %input.executor.tool_name(),
+        can_edit,
+        can_write_new,
+        "Restriction flags resolved"
+    );
+    let raw_prompt = input.prompt.to_string();
+    let prompt_caching_enabled = input
+        .global_config
+        .is_some_and(|cfg| cfg.experimental.enable_prompt_caching);
+    let mut prompt_assembly = PromptAssembly::new(raw_prompt.clone(), prompt_caching_enabled);
+    let state_dir_warning = match state_preflight::run(
+        input.global_config,
+        &session.meta_session_id,
+        input.startup_env.session_id(),
+        input.session_arg.is_none() || input.fresh_spawn_preflight_override,
+    ) {
+        Ok(warning) => warning,
+        Err(err) => {
+            return Err(persist_pipeline_pre_exec_failure(
+                input.project_root,
+                session,
+                input.executor.tool_name(),
+                err,
+                cleanup_guard,
+                None,
+            ));
+        }
+    };
+    if let Some(w) = state_dir_warning {
+        prompt_assembly.prepend_dynamic(&w);
+    }
+    let is_first_turn = session
+        .tools
+        .get(input.executor.tool_name())
+        .is_none_or(|ts| ts.provider_session_id.is_none());
+    if is_first_turn {
+        let first_turn_context = crate::pipeline::design_context::load_first_turn_context(
+            &session.project_path,
+            input.project_root,
+            input.context_load_options,
+            input
+                .config
+                .is_none_or(|cfg| cfg.session.resolved_plan_injection()),
+        );
+        prompt_assembly.add_first_turn_context(first_turn_context);
+    }
+    let is_review_or_debate = matches!(input.task_type, Some("review" | "debate"));
+    if !is_review_or_debate {
+        let memory_cfg = input
+            .config
+            .map(|cfg| &cfg.memory)
+            .filter(|m| !m.is_default())
+            .or_else(|| input.global_config.map(|cfg| &cfg.memory));
+        session_exec_memory::append_memory_section(
+            memory_cfg,
+            input.memory_injection,
+            raw_prompt.as_str(),
+            input.memory_project_key,
+            input.project_root,
+            input.executor.tool_name(),
+            prompt_assembly.dynamic_prompt_mut(),
+        );
+    }
+    if !can_edit || !can_write_new {
+        info!(
+            tool = %input.executor.tool_name(),
+            can_edit,
+            can_write_new,
+            "Applying filesystem restrictions via prompt injection"
+        );
+        prompt_assembly.add_restriction_instructions(
+            input
+                .executor
+                .restriction_instructions(can_edit, can_write_new),
+        );
+    }
+    let edit_guard = if !can_edit {
+        crate::edit_restriction_guard::maybe_capture_tracked_file_guard(input.project_root)?
+    } else {
+        None
+    };
+    let commit_guard_enabled = matches!(input.task_type, Some("run"));
+    let require_commit_on_mutation = commit_guard_enabled
+        && input
+            .config
+            .is_some_and(|cfg| cfg.session.require_commit_on_mutation);
+    let is_git = crate::run_cmd::is_git_worktree(input.project_root);
+    let inside_git_worktree = commit_guard_enabled && is_git;
+    let capture_snapshot = session_exec_audit::capture_git_workspace_snapshot_if_needed;
+    let pre_run_workspace =
+        capture_snapshot(is_git, input.project_root, require_commit_on_mutation);
+    let tool_state =
+        ensure_tool_state_initialized(session, input.executor, input.resolved_provider_session_id)
+            .await?;
+    let result_file_cleared =
+        clear_expected_result_artifacts_for_prompt(input.prompt, input.session_dir);
+    let execution_start_time = chrono::Utc::now();
+    let sa_mode =
+        std::env::var_os(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)
+            .is_some_and(|value| value == "true" || value == "1");
+    let session_config = input.global_config.map(|gc| {
+        let mcp_servers = resolve_mcp_servers(input.project_root, gc);
+        if !mcp_servers.is_empty() {
+            info!(
+                count = mcp_servers.len(),
+                servers = %mcp_servers.iter().map(|s| s.name.as_str()).collect::<Vec<_>>().join(", "),
+                "Injecting MCP servers into tool session"
+            );
+        }
+        csa_executor::SessionConfig {
+            mcp_servers,
+            mcp_proxy_socket: gc.mcp_proxy_socket.clone(),
+            ..Default::default()
+        }
+    });
+    let mut merged_env = crate::pipeline_env::build_merged_env(
+        input.extra_env,
+        input.config,
+        input.global_config,
+        input.executor.tool_name(),
+        input.startup_env.current_depth(),
+        input.startup_env.pattern_internal(),
+        sa_mode,
+    );
+    crate::pipeline_env::apply_task_target_dir_guards(
+        input.task_type,
+        input.executor.tool_name(),
+        input.project_root,
+        &mut merged_env,
+    );
+    let project_hook_overrides =
+        crate::pipeline::session_hooks::build_project_hook_overrides(input.config, input.task_type);
+    let hooks_config = load_hooks_config(
+        csa_session::get_session_root(input.project_root)
+            .ok()
+            .map(|r| r.join("hooks.toml"))
+            .as_deref(),
+        global_hooks_path().as_deref(),
+        project_hook_overrides.as_ref(),
+    );
+    let sessions_root = input
+        .session_dir
+        .parent()
+        .unwrap_or(input.session_dir)
+        .display()
+        .to_string();
+    let pre_run_vars = std::collections::HashMap::from([
+        ("session_id".to_string(), session.meta_session_id.clone()),
+        (
+            "session_dir".to_string(),
+            input.session_dir.display().to_string(),
+        ),
+        ("sessions_root".to_string(), sessions_root.clone()),
+        ("tool".to_string(), input.executor.tool_name().to_string()),
+        ("project_root".to_string(), session.project_path.clone()),
+        ("CHANGED_PATHS".to_string(), "[]".to_string()),
+        ("CHANGED_CRATES".to_string(), String::new()),
+        ("CHANGED_CRATES_FLAGS".to_string(), String::new()),
+    ]);
+    run_pipeline_hook(HookEvent::PreRun, &hooks_config, &pre_run_vars)?;
+    let new_file_guard = if !can_write_new {
+        crate::edit_restriction_guard::maybe_capture_new_file_guard(input.project_root)?
+    } else {
+        None
+    };
+    session_exec_prompt_guard::inject_prompt_guards_if_needed(
+        input.task_type,
+        &hooks_config,
+        session,
+        input.executor,
+        input.session_arg.is_some(),
+        &mut prompt_assembly,
+        input.startup_env.current_depth(),
+    );
+    let effective_prompt = session_exec_prompt_inject::finalize_effective_prompt(
+        prompt_assembly,
+        input.task_type,
+        is_first_turn,
+        input.project_root,
+        input.config,
+    );
+    let liveness_dead_seconds = resolve_liveness_dead_seconds(input.config);
+    let mut execute_options = match crate::pipeline_sandbox::resolve_sandbox_options(
+        input.config,
+        input.executor.tool_name(),
+        &session.meta_session_id,
+        input.project_root,
+        input.stream_mode,
+        input.idle_timeout_seconds,
+        liveness_dead_seconds,
+        input.initial_response_timeout_seconds,
+        input.no_fs_sandbox,
+        input.readonly_project_root,
+        input.extra_writable,
+        input.extra_readable,
+    ) {
+        crate::pipeline_sandbox::SandboxResolution::Ok(opts) => *opts,
+        crate::pipeline_sandbox::SandboxResolution::RequiredButUnavailable(msg) => {
+            let err = anyhow::anyhow!(msg);
+            return Err(persist_pipeline_pre_exec_failure(
+                input.project_root,
+                session,
+                input.executor.tool_name(),
+                err,
+                cleanup_guard,
+                None,
+            ));
+        }
+    };
+    crate::pipeline::ensure_tool_runtime_prerequisites(
+        input.executor.tool_name(),
+        crate::pipeline::resolved_filesystem_capability(&execute_options),
+    )
+    .await?;
+    let spool_max_mb = input
+        .config
+        .map(|cfg| cfg.session.resolved_spool_max_mb())
+        .unwrap_or((csa_process::DEFAULT_SPOOL_MAX_BYTES / (1024 * 1024)) as u32);
+    let spool_max_bytes = u64::from(spool_max_mb).saturating_mul(1024 * 1024);
+    let spool_keep_rotated = input
+        .config
+        .map(|cfg| cfg.session.resolved_spool_keep_rotated())
+        .unwrap_or(csa_process::DEFAULT_SPOOL_KEEP_ROTATED);
+    execute_options =
+        execute_options.with_output_spool_rotation(spool_max_bytes, spool_keep_rotated);
+    execute_options.output_spool = Some(input.session_dir.join("output.log"));
+    let error_marker_scan_enabled = crate::error_marker_scan::resolve_error_marker_scan_enabled(
+        input.error_marker_scan_override,
+        input.startup_env.pattern_internal(),
+        input.config.map(|cfg| cfg.resources.error_marker_scan),
+    );
+    execute_options = execute_options.with_error_marker_scan_enabled(error_marker_scan_enabled);
+    let hook_bypass_scan_enabled = crate::run_cmd::resolve_hook_bypass_scan_enabled(
+        input.cli_no_hook_bypass_scan,
+        input.config.map(|cfg| cfg.resources.hook_bypass_scan),
+    );
+    execute_options = execute_options.with_subtree_pin(input.subtree_pin.cloned());
+    apply_transport_failover_overrides(
+        &mut execute_options,
+        (!merged_env.is_empty()).then_some(&merged_env),
+    );
+    if let Some(pre_session_hook) = input.pre_session_hook {
+        execute_options = execute_options.with_pre_session_hook(pre_session_hook);
+    }
+    crate::pipeline_sandbox::record_sandbox_telemetry(&execute_options, session);
+    crate::pipeline_sandbox::maybe_inflate_balloon(input.tool.as_str());
+    if let Err(err) =
+        session_exec_metadata::persist_session_runtime_binary(input.session_dir, input.executor)
+    {
+        warn!(
+            session = %session.meta_session_id,
+            error = %err,
+            "Failed to persist session runtime binary metadata"
+        );
+    }
+    let pre_exec_snapshot = session_exec_audit::capture_pre_execution_snapshot(input.project_root);
+
+    Ok(SessionRuntimePlan {
+        effective_prompt,
+        tool_state,
+        execute_options,
+        session_config,
+        completion: SessionCompletionPlan {
+            merged_env,
+            hooks_config,
+            sessions_root,
+            edit_guard,
+            new_file_guard,
+            result_file_cleared,
+            execution_start_time,
+            commit_guard_enabled,
+            require_commit_on_mutation,
+            hook_bypass_scan_enabled,
+            is_git,
+            inside_git_worktree,
+            pre_run_workspace,
+            pre_exec_snapshot,
+            sa_mode,
+        },
+    })
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.931"
-weave = "0.1.931"
+csa = "0.1.932"
+weave = "0.1.932"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Split `pipeline_session_exec.rs` (7965/8000 token ceiling) into 3 focused modules
- Extracted `pipeline_session_exec_completion.rs` (completion/finalization handling)
- Extracted `pipeline_session_exec_runtime.rs` (runtime execution/transport logic)
- Original file retains the entry point and orchestration, now well under budget

## Changes

Pure refactoring — no behavior changes. Public API surface preserved via re-exports.

Closes #1668

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>