### PR TITLE
fix(cli-sub-agent): inject no-background-task hint into claude-code daemon-child prompts (#1712)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.933"
+version = "0.1.934"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.933"
+version = "0.1.934"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec_prompt_inject.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_prompt_inject.rs
@@ -13,6 +13,11 @@ use tracing::info;
 
 use crate::pipeline::prompt_cache::PromptAssembly;
 
+const DAEMON_SESSION_ID_ENV: &str = "CSA_DAEMON_SESSION_ID";
+const CLAUDE_DAEMON_CHILD_BACKGROUND_GUARD: &str = r#"<claude-code-daemon-child-background-guard issue="1712">
+This CSA daemon-child is running under Claude Code. Do not start Bash tools with run_in_background: true in this inner session; Claude Code task-notification events are not reliably relayed through the daemon-child transport. Run shell work in the foreground and let CSA's outer session wait/attach mechanism handle backgrounding.
+</claude-code-daemon-child-background-guard>"#;
+
 /// Append the review-aware writer guard and structured-output markers to an
 /// already-guarded `prompt_assembly`, then finalize and return the prompt.
 ///
@@ -24,11 +29,17 @@ use crate::pipeline::prompt_cache::PromptAssembly;
 /// the same caller-injection env signal the post-exec path uses.
 pub(super) fn finalize_effective_prompt(
     mut prompt_assembly: PromptAssembly,
+    tool_name: &str,
     task_type: Option<&str>,
     is_first_turn: bool,
     project_root: &Path,
     config: Option<&ProjectConfig>,
 ) -> String {
+    if should_prepend_claude_daemon_child_background_guard(tool_name) {
+        info!("Injecting claude-code daemon-child background-task guard (#1712)");
+        prompt_assembly.prepend_dynamic(&format!("{CLAUDE_DAEMON_CHILD_BACKGROUND_GUARD}\n\n"));
+    }
+
     let caller_sa_mode =
         std::env::var(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)
             .ok()
@@ -57,4 +68,56 @@ pub(super) fn finalize_effective_prompt(
     }
 
     prompt_assembly.finish()
+}
+
+fn should_prepend_claude_daemon_child_background_guard(tool_name: &str) -> bool {
+    tool_name == "claude-code" && std::env::var_os(DAEMON_SESSION_ID_ENV).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finish_prompt(tool_name: &str) -> String {
+        finalize_effective_prompt(
+            PromptAssembly::new("user task".to_string(), false),
+            tool_name,
+            Some("run"),
+            true,
+            Path::new("."),
+            None,
+        )
+    }
+
+    #[test]
+    fn claude_code_daemon_child_prompt_disables_inner_background_bash() {
+        let _daemon_guard =
+            crate::test_env_lock::ScopedTestEnvVar::set(DAEMON_SESSION_ID_ENV, "01KDAEMON");
+
+        let prompt = finish_prompt("claude-code");
+
+        assert!(prompt.starts_with("<claude-code-daemon-child-background-guard issue=\"1712\">"));
+        assert!(prompt.contains("Do not start Bash tools with run_in_background: true"));
+        assert!(prompt.contains("user task"));
+    }
+
+    #[test]
+    fn foreground_claude_code_prompt_does_not_get_background_guard() {
+        let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
+        let _daemon_guard = crate::test_env_lock::ScopedEnvVarRestore::unset(DAEMON_SESSION_ID_ENV);
+
+        let prompt = finish_prompt("claude-code");
+
+        assert!(!prompt.contains("claude-code-daemon-child-background-guard"));
+    }
+
+    #[test]
+    fn daemon_child_background_guard_is_limited_to_claude_code() {
+        let _daemon_guard =
+            crate::test_env_lock::ScopedTestEnvVar::set(DAEMON_SESSION_ID_ENV, "01KDAEMON");
+
+        let prompt = finish_prompt("codex");
+
+        assert!(!prompt.contains("claude-code-daemon-child-background-guard"));
+    }
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -277,6 +277,7 @@ pub(super) async fn prepare_session_runtime(
     );
     let effective_prompt = session_exec_prompt_inject::finalize_effective_prompt(
         prompt_assembly,
+        input.executor.tool_name(),
         input.task_type,
         is_first_turn,
         input.project_root,

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.933"
-weave = "0.1.933"
+csa = "0.1.934"
+weave = "0.1.934"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Inject a prompt hint into claude-code daemon-child sessions telling the inner agent to run all Bash tasks in the foreground (without `run_in_background: true`)
- When claude-code runs as a CSA daemon-child, background task completion notifications are never delivered back to the inner agent, causing indefinite hangs (observed 95x wall-clock amplification: 74s job → 103min session)
- This is the cheapest safe fix (approach C from the issue) — a prompt-level workaround that prevents the pathological hang without modifying transport internals

Closes #1712

## Test plan

- [x] `just pre-commit` passes
- [x] `csa review --range main...HEAD` verdict PASS (session 01KTGY9GK9RK8SEH7X76S45AZD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>