### PR TITLE
feat(cli-sub-agent): add IMPL_TIER/IMPL_TOOL override to dev2merge workflow (#1639)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.935"
+version = "0.1.936"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
@@ -55,6 +55,59 @@ fn dev2merge_workflow_marks_mktsk_step_manual() {
 }
 
 #[test]
+fn dev2merge_forwards_impl_executor_overrides_to_mktd() {
+    let workflow_path = workspace_root().join("patterns/dev2merge/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+
+    for name in ["IMPL_TIER", "IMPL_TOOL"] {
+        let variable = plan
+            .variables
+            .iter()
+            .find(|variable| variable.name == name)
+            .unwrap_or_else(|| panic!("dev2merge must declare {name}"));
+        assert_eq!(
+            variable.default.as_deref(),
+            Some(""),
+            "{name} must default to empty so callers keep existing behavior unless they opt in"
+        );
+    }
+
+    let plan_step = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Plan with mktd")
+        .expect("missing dev2merge plan step");
+    for required in [
+        r#"--var IMPL_TIER="${IMPL_TIER:-}""#,
+        r#"--var IMPL_TOOL="${IMPL_TOOL:-}""#,
+    ] {
+        assert!(
+            plan_step.prompt.contains(required),
+            "Step 7 must forward implementation override to mktd: {required}"
+        );
+    }
+
+    let mktsk_step = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Execute Plan with mktsk")
+        .expect("missing dev2merge mktsk step");
+    for required in [
+        "impl `${IMPL_TIER}`/`${IMPL_TOOL}`",
+        "`[CSA:<value>]` impl tasks use `csa run`",
+        "tier-*→`--tier`",
+        "other→`--tool`",
+        "Implementation override: csa run ...",
+    ] {
+        assert!(
+            mktsk_step.prompt.contains(required),
+            "Step 8 must tell mktsk how to honor implementation override tags: {required}"
+        );
+    }
+}
+
+#[test]
 fn mktd_light_mode_skips_recon_dimensions() {
     let workflow_path = workspace_root().join("patterns/mktd/workflow.toml");
     let workflow = std::fs::read_to_string(&workflow_path).unwrap();
@@ -82,6 +135,83 @@ fn mktd_light_mode_skips_recon_dimensions() {
         4,
         "PATTERN.md must stay synced with workflow RECON conditions"
     );
+}
+
+#[test]
+fn mktd_generates_impl_executor_tags_from_overrides() {
+    let workflow_path = workspace_root().join("patterns/mktd/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+
+    for name in ["IMPL_TIER", "IMPL_TOOL"] {
+        let variable = plan
+            .variables
+            .iter()
+            .find(|variable| variable.name == name)
+            .unwrap_or_else(|| panic!("mktd must declare {name}"));
+        assert_eq!(
+            variable.default.as_deref(),
+            Some(""),
+            "{name} must default to empty so non-dev2merge callers keep existing executor tags"
+        );
+    }
+    for name in ["IMPL_EXECUTOR_TAG", "IMPL_EXECUTOR_DIRECTIVE"] {
+        assert!(
+            plan.variables.iter().any(|variable| variable.name == name),
+            "mktd must declare generated variable {name}"
+        );
+    }
+
+    let language_step = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Phase 1.5 — Language Detection")
+        .expect("missing mktd language step");
+    for required in [
+        "[CSA:${IMPL_TIER}]",
+        "[CSA:${IMPL_TOOL}]",
+        "[Sub:developer]",
+        "CSA_VAR:IMPL_EXECUTOR_TAG=${IMPL_EXECUTOR_TAG}",
+        "Implementation override: csa run",
+        "--tier ${IMPL_TIER}",
+        "--tool ${IMPL_TOOL}",
+    ] {
+        assert!(
+            language_step.prompt.contains(required),
+            "mktd Step 1.5 must compute implementation executor overrides: {required}"
+        );
+    }
+
+    let draft_step = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Phase 2 — DRAFT TODO")
+        .expect("missing mktd draft step");
+    for required in [
+        "Pre-assign: [Main], ${IMPL_EXECUTOR_TAG}, [Skill:commit], [CSA:tool].",
+        "Use `${IMPL_EXECUTOR_TAG}` for implementation tasks;",
+        "include that line in each such task",
+    ] {
+        assert!(
+            draft_step.prompt.contains(required),
+            "mktd draft prompt must require override-aware implementation task tags: {required}"
+        );
+    }
+
+    let pattern = std::fs::read_to_string(workspace_root().join("patterns/mktd/PATTERN.md"))
+        .expect("read mktd pattern");
+    for required in [
+        "IMPL_TIER",
+        "IMPL_TOOL",
+        "IMPL_EXECUTOR_TAG",
+        "IMPL_EXECUTOR_DIRECTIVE",
+        "Use `${IMPL_EXECUTOR_TAG}` for implementation tasks;",
+    ] {
+        assert!(
+            pattern.contains(required),
+            "PATTERN.md must stay synced with mktd implementation override workflow contract: {required}"
+        );
+    }
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
@@ -108,6 +108,59 @@ fn dev2merge_forwards_impl_executor_overrides_to_mktd() {
 }
 
 #[test]
+fn mktsk_consumes_impl_executor_tier_and_override_contract() {
+    let workflow_path = workspace_root().join("patterns/mktsk/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+    let execute_step = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Execute Checklist Serially")
+        .expect("missing mktsk execution step");
+    let pattern = std::fs::read_to_string(workspace_root().join("patterns/mktsk/PATTERN.md"))
+        .expect("read mktsk pattern");
+
+    for required in [
+        "optional Implementation override directive",
+        "Priority: Implementation override > [CSA:tier-*] > [CSA:<tool>] > default",
+        "Implementation override: csa run ... => run that exact csa run command; it wins over any executor tag",
+        "[CSA:tier-*] => csa run --tier <tier-name>",
+        "[CSA:<tool>] => csa run --tool <tool-name>",
+    ] {
+        assert!(
+            workflow.contains(required),
+            "mktsk workflow must consume implementation override dispatch contract: {required}"
+        );
+    }
+
+    for required in [
+        "optional `Implementation override: csa run ...` directive",
+        "Priority: `Implementation override:` > `[CSA:tier-*]` > `[CSA:<tool>]` > default.",
+        "`[CSA:tier-*]`: run `csa run --tier <tier-name>`",
+        "`[CSA:<tool>]`: run `csa run --tool <tool-name>`",
+        "`Implementation override: csa run --tier tier-4-critical --tool claude-code` dispatches `csa run --tier tier-4-critical --tool claude-code`.",
+    ] {
+        assert!(
+            pattern.contains(required),
+            "mktsk PATTERN.md must document implementation override dispatch contract: {required}"
+        );
+    }
+
+    assert!(
+        execute_step
+            .prompt
+            .contains("[CSA:tier-4-critical] => csa run --tier tier-4-critical"),
+        "`[CSA:tier-4-critical]` tasks must dispatch as `csa run --tier tier-4-critical`"
+    );
+    assert!(
+        execute_step.prompt.contains(
+            "Implementation override: csa run --tier tier-4-critical --tool claude-code => run csa run --tier tier-4-critical --tool claude-code"
+        ),
+        "`Implementation override: csa run --tier tier-4-critical --tool claude-code` must dispatch that exact command"
+    );
+}
+
+#[test]
 fn mktd_light_mode_skips_recon_dimensions() {
     let workflow_path = workspace_root().join("patterns/mktd/workflow.toml");
     let workflow = std::fs::read_to_string(&workflow_path).unwrap();

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -15,15 +15,17 @@ Pipeline: Already-Resolved Check → Branch Validation → FAST_PATH Detection �
 mktsk N*(implement → commit) → Self-Review Gate → Pre-PR Cumulative Review → Push →
 Pre-PR Verdict Check → PR Creation → **pr-bot Hard Gate** → Post-Merge Sync.
 
-**CRITICAL PIPELINE INVARIANT**: PR creation (Step 14) and pr-bot (Step 15) are
-**two separate hard gates**. Creating a PR does NOT complete the pipeline. You
-MUST run pr-bot (Step 15) after PR creation. NEVER skip Step 15. NEVER merge
-the PR manually or via raw `gh pr merge`. The pr-bot workflow handles the merge.
-If an explicitly approved emergency path requires a manual merge after a
-recorded pr-bot pass, use `csa merge <PR_NUMBER>` so the local pr-bot gate
-still executes.
-Agents that stop after Step 14 leave the PR unmerged — this is a known failure
-mode that this invariant exists to prevent.
+**CRITICAL PIPELINE INVARIANT**: Step 14 PR creation and Step 15 pr-bot are
+separate hard gates. Creating a PR is not completion: run pr-bot after PR
+creation, never skip Step 15, and never raw `gh pr merge`. If an approved
+emergency requires manual merge after a recorded pr-bot pass, use
+`csa merge <PR_NUMBER>` so the local gate still runs. Stopping after Step 14
+leaves the PR unmerged.
+
+### Implementation Executor Override
+
+`IMPL_TIER`/`IMPL_TOOL` default empty (`[Sub:developer]`); set them so mktd
+emits `[CSA:<tier-or-tool>]` plus Step 8 `csa run` override flags.
 
 ### ABSOLUTE PROHIBITIONS
 
@@ -318,6 +320,8 @@ MKTD_OUTPUT="$(timeout -k 30 "${MKTD_TIMEOUT_SECONDS}" csa plan run --sa-mode tr
   --var USER_LANGUAGE="${USER_LANGUAGE_OVERRIDE}" \
   --var TIER="${TIER:-}" \
   --var PLAN_TIER="${MKTD_PLAN_TIER}" \
+  --var IMPL_TIER="${IMPL_TIER:-}" \
+  --var IMPL_TOOL="${IMPL_TOOL:-}" \
   --var INTENSITY="${MKTD_INTENSITY}" 2>&1)"
 MKTD_EXIT=$?
 set -e
@@ -383,14 +387,10 @@ echo "CSA_VAR:MKTD_TODO_PATH=${TODO_PATH}"
 OnFail: abort
 Tool: manual (main agent action)
 
-Invoke the mktsk skill directly (NOT via `csa run`). mktsk MUST run in the
-main agent context so it can use TaskCreate/TaskUpdate for progress tracking.
-
-Pass the TODO timestamp: `${MKTD_TODO_TIMESTAMP}`
-Set env: `CSA_SKIP_PUBLISH=true` (dev2merge handles publish in Steps 12-13).
-
-mktsk reads the TODO plan, registers tasks via TaskCreate, and executes each
-item serially: implement → quality gates → review → commit → next.
+Run mktsk in main context with TODO `${MKTD_TODO_TIMESTAMP}` and
+`CSA_SKIP_PUBLISH=true`; impl `${IMPL_TIER}`/`${IMPL_TOOL}`.
+`[CSA:<value>]` impl tasks use `csa run`; `Implementation override: csa run ...`
+wins, else tier-*→`--tier`, other→`--tool`.
 
 ## Step 9: Ensure Version Bumped
 Tool: bash

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -38,6 +38,12 @@ name = "HEAD_SHA"
 [[workflow.variables]]
 name = "HOME"
 [[workflow.variables]]
+name = "IMPL_TIER"
+default = ""
+[[workflow.variables]]
+name = "IMPL_TOOL"
+default = ""
+[[workflow.variables]]
 name = "ISSUE_NUMBER"
 [[workflow.variables]]
 name = "LATEST_TS"
@@ -374,6 +380,8 @@ MKTD_OUTPUT="$(timeout -k 30 "${MKTD_TIMEOUT_SECONDS}" csa plan run --sa-mode tr
   --var USER_LANGUAGE="${USER_LANGUAGE_OVERRIDE}" \
   --var TIER="${TIER:-}" \
   --var PLAN_TIER="${MKTD_PLAN_TIER}" \
+  --var IMPL_TIER="${IMPL_TIER:-}" \
+  --var IMPL_TOOL="${IMPL_TOOL:-}" \
   --var INTENSITY="${MKTD_INTENSITY}" 2>&1)"
 MKTD_EXIT=$?
 set -e
@@ -441,14 +449,10 @@ id = 8
 title = "Execute Plan with mktsk"
 tool = "manual"
 prompt = """
-Invoke the mktsk skill directly (NOT via `csa run`). mktsk MUST run in the
-main agent context so it can use TaskCreate/TaskUpdate for progress tracking.
-
-Pass the TODO timestamp: `${MKTD_TODO_TIMESTAMP}`
-Set env: `CSA_SKIP_PUBLISH=true` (dev2merge handles publish in Steps 12-13).
-
-mktsk reads the TODO plan, registers tasks via TaskCreate, and executes each
-item serially: implement → quality gates → review → commit → next."""
+Run mktsk in main context with TODO `${MKTD_TODO_TIMESTAMP}` and
+`CSA_SKIP_PUBLISH=true`; impl `${IMPL_TIER}`/`${IMPL_TOOL}`.
+`[CSA:<value>]` impl tasks use `csa run`; `Implementation override: csa run ...`
+wins, else tier-*→`--tier`, other→`--tool`."""
 on_fail = "abort"
 condition = "(!(${DEV2MERGE_SKIP})) && (!(${FAST_PATH}))"
 

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -55,6 +55,9 @@ Revise TODO) and defaults to `tier-3-complex`. Example:
 csa plan run patterns/mktd/workflow.toml --var PLAN_TIER=tier-4-critical
 ```
 
+`IMPL_TIER`/`IMPL_TOOL` default empty (`[Sub:developer]`); set them to produce
+`IMPL_EXECUTOR_TAG`/`IMPL_EXECUTOR_DIRECTIVE` for mktsk dispatch.
+
 Debate remains step-level `tier-2-standard`.
 
 ## Step 0: Phase 0.5 — Auto Session Discovery
@@ -133,6 +136,19 @@ if [[ -n "${TIER:-}" ]]; then
 else
   echo "CSA_VAR:RECON_TIER=tier-1-quick"
 fi
+
+IMPL_EXECUTOR_TAG="[Sub:developer]"
+[[ -n "${IMPL_TOOL:-}" ]] && IMPL_EXECUTOR_TAG="[CSA:${IMPL_TOOL}]"
+[[ -n "${IMPL_TIER:-}" ]] && IMPL_EXECUTOR_TAG="[CSA:${IMPL_TIER}]"
+echo "CSA_VAR:IMPL_EXECUTOR_TAG=${IMPL_EXECUTOR_TAG}"
+
+IMPL_EXECUTOR_DIRECTIVE="Implementation override: none"
+if [[ -n "${IMPL_TIER:-}" || -n "${IMPL_TOOL:-}" ]]; then
+  IMPL_EXECUTOR_DIRECTIVE="Implementation override: csa run"
+  [[ -z "${IMPL_TIER:-}" ]] || IMPL_EXECUTOR_DIRECTIVE+=" --tier ${IMPL_TIER}"
+  [[ -z "${IMPL_TOOL:-}" ]] || IMPL_EXECUTOR_DIRECTIVE+=" --tool ${IMPL_TOOL}"
+fi
+echo "CSA_VAR:IMPL_EXECUTOR_DIRECTIVE=${IMPL_EXECUTOR_DIRECTIVE}"
 
 # --- Language detection (result is the step's logical output) ---
 if [[ -n "${USER_LANGUAGE:-}" ]]; then
@@ -372,53 +388,19 @@ Status: Proposed
 Each item is a [ ] checkbox with executor tag.
 Write all TODO descriptions, section headers, and task names in `${STEP_2_OUTPUT}`.
 Technical terms, code snippets, commit scope strings, and executor tags remain in English.
-Pre-assign executors: [Main], [Sub:developer], [Skill:commit], [CSA:tool].
+Pre-assign: [Main], ${IMPL_EXECUTOR_TAG}, [Skill:commit], [CSA:tool].
+Use `${IMPL_EXECUTOR_TAG}` for implementation tasks; if `${IMPL_EXECUTOR_DIRECTIVE}`
+is not `Implementation override: none`, include that line in each such task.
 Every checkbox item MUST include a mechanically verifiable `DONE WHEN:` line.
 
 ### Epic Scale Detection
 
-Before drafting, assess whether this task is epic-scale. Count how many of these signals appear in the RECON findings:
-
-1. New crate/module count > 2
-2. New public API surface > 5 new pub fn/trait
-3. New config schema sections > 2
-4. New CLI subcommands > 1
-5. Cross-crate dependency edges > 3
-6. Whitepaper/RFC/design-doc exceeds 5 logical pages
-
-If >= 3 signals fire, this is an EPIC. Produce BOTH:
-(A) A summary TODO.md that lists the epic's stories as checkbox items
-(B) An epic-plan.toml section enclosed in a fenced code block tagged ```epic-plan.toml
-
-The epic-plan.toml MUST follow this schema:
-```toml
-[epic]
-name = "feature-name"
-prefix = "feat/feature-name"
-summary = "One-line description"
-
-[[stories]]
-id = "phase-1"
-branch = "feat/feature-name/phase-1-description"
-depends_on = []
-summary = "What this story delivers"
-
-[[stories]]
-id = "phase-2"
-branch = "feat/feature-name/phase-2-description"
-depends_on = ["phase-1"]
-summary = "What this story delivers"
-```
-
-Each story MUST have:
-- Unique id (short kebab-case, e.g. "phase-1a", "core-types")
-- Branch name under the epic prefix
-- Explicit depends_on (empty array if independent)
-- Summary describing what the story delivers
-
-The summary TODO.md should reference `epic-plan.toml` and list each story as a checkbox item with its branch and dependencies.
-
-If < 3 signals fire, produce a regular TODO.md as before (no epic plan).
+Before drafting, count epic signals: >2 new crates/modules; >5 public APIs; >2
+config sections; >1 CLI subcommand; >3 cross-crate edges; source doc >5 pages.
+If >=3, output summary TODO stories plus fenced `epic-plan.toml`; otherwise
+regular TODO only. `epic-plan.toml` schema: `[epic]` name/prefix/summary and
+`[[stories]]` id/branch/depends_on/summary, with unique kebab ids, branches
+under the epic prefix, explicit dependency arrays, and story summaries.
 
 ### Output
 

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -22,13 +22,20 @@ name = "FINAL_TODO"
 
 [[workflow.variables]]
 name = "EPIC_PLAN"
-
 [[workflow.variables]]
 name = "EPIC_ARTIFACT"
-
 [[workflow.variables]]
 name = "FEATURE"
-
+[[workflow.variables]]
+name = "IMPL_EXECUTOR_DIRECTIVE"
+[[workflow.variables]]
+name = "IMPL_EXECUTOR_TAG"
+[[workflow.variables]]
+name = "IMPL_TIER"
+default = ""
+[[workflow.variables]]
+name = "IMPL_TOOL"
+default = ""
 [[workflow.variables]]
 name = "KEY_POINTS"
 
@@ -208,6 +215,19 @@ if [[ -n "${TIER:-}" ]]; then
 else
   echo "CSA_VAR:RECON_TIER=tier-1-quick"
 fi
+
+IMPL_EXECUTOR_TAG="[Sub:developer]"
+[[ -n "${IMPL_TOOL:-}" ]] && IMPL_EXECUTOR_TAG="[CSA:${IMPL_TOOL}]"
+[[ -n "${IMPL_TIER:-}" ]] && IMPL_EXECUTOR_TAG="[CSA:${IMPL_TIER}]"
+echo "CSA_VAR:IMPL_EXECUTOR_TAG=${IMPL_EXECUTOR_TAG}"
+
+IMPL_EXECUTOR_DIRECTIVE="Implementation override: none"
+if [[ -n "${IMPL_TIER:-}" || -n "${IMPL_TOOL:-}" ]]; then
+  IMPL_EXECUTOR_DIRECTIVE="Implementation override: csa run"
+  [[ -z "${IMPL_TIER:-}" ]] || IMPL_EXECUTOR_DIRECTIVE+=" --tier ${IMPL_TIER}"
+  [[ -z "${IMPL_TOOL:-}" ]] || IMPL_EXECUTOR_DIRECTIVE+=" --tool ${IMPL_TOOL}"
+fi
+echo "CSA_VAR:IMPL_EXECUTOR_DIRECTIVE=${IMPL_EXECUTOR_DIRECTIVE}"
 
 # --- Language detection (result is the step's logical output) ---
 if [[ -n "${USER_LANGUAGE:-}" ]]; then
@@ -422,53 +442,19 @@ Status: Proposed
 Each item is a [ ] checkbox with executor tag.
 Write all TODO descriptions, section headers, and task names in `${STEP_2_OUTPUT}`.
 Technical terms, code snippets, commit scope strings, and executor tags remain in English.
-Pre-assign executors: [Main], [Sub:developer], [Skill:commit], [CSA:tool].
+Pre-assign: [Main], ${IMPL_EXECUTOR_TAG}, [Skill:commit], [CSA:tool].
+Use `${IMPL_EXECUTOR_TAG}` for implementation tasks; if `${IMPL_EXECUTOR_DIRECTIVE}`
+is not `Implementation override: none`, include that line in each such task.
 Every checkbox item MUST include a mechanically verifiable `DONE WHEN:` line.
 
 ### Epic Scale Detection
 
-Before drafting, assess whether this task is epic-scale. Count how many of these signals appear in the RECON findings:
-
-1. New crate/module count > 2
-2. New public API surface > 5 new pub fn/trait
-3. New config schema sections > 2
-4. New CLI subcommands > 1
-5. Cross-crate dependency edges > 3
-6. Whitepaper/RFC/design-doc exceeds 5 logical pages
-
-If >= 3 signals fire, this is an EPIC. Produce BOTH:
-(A) A summary TODO.md that lists the epic's stories as checkbox items
-(B) An epic-plan.toml section enclosed in a fenced code block tagged ```epic-plan.toml
-
-The epic-plan.toml MUST follow this schema:
-```toml
-[epic]
-name = "feature-name"
-prefix = "feat/feature-name"
-summary = "One-line description"
-
-[[stories]]
-id = "phase-1"
-branch = "feat/feature-name/phase-1-description"
-depends_on = []
-summary = "What this story delivers"
-
-[[stories]]
-id = "phase-2"
-branch = "feat/feature-name/phase-2-description"
-depends_on = ["phase-1"]
-summary = "What this story delivers"
-```
-
-Each story MUST have:
-- Unique id (short kebab-case, e.g. "phase-1a", "core-types")
-- Branch name under the epic prefix
-- Explicit depends_on (empty array if independent)
-- Summary describing what the story delivers
-
-The summary TODO.md should reference `epic-plan.toml` and list each story as a checkbox item with its branch and dependencies.
-
-If < 3 signals fire, produce a regular TODO.md as before (no epic plan).
+Before drafting, count epic signals: >2 new crates/modules; >5 public APIs; >2
+config sections; >1 CLI subcommand; >3 cross-crate edges; source doc >5 pages.
+If >=3, output summary TODO stories plus fenced `epic-plan.toml`; otherwise
+regular TODO only. `epic-plan.toml` schema: `[epic]` name/prefix/summary and
+`[[stories]]` id/branch/depends_on/summary, with unique kebab ids, branches
+under the epic prefix, explicit dependency arrays, and story summaries.
 
 ### Output
 

--- a/patterns/mktsk/PATTERN.md
+++ b/patterns/mktsk/PATTERN.md
@@ -21,7 +21,8 @@ Choose exactly one mode:
 
 Read the TODO plan file from mktd output or a user-provided path. Extract all
 unchecked checklist items (`- [ ]`) with:
-- executor tag (`[Sub:developer]`, `[Skill:commit]`, `[CSA:tool]`, or `[Main]`)
+- executor tag (`[Sub:developer]`, `[Skill:commit]`, `[CSA:tier-*]`, `[CSA:<tool>]`, or `[Main]`)
+- optional `Implementation override: csa run ...` directive
 - task description
 - `DONE WHEN:` condition
 
@@ -69,6 +70,7 @@ Each TODO task MUST include:
 - stable item id
 - source TODO line reference
 - executor tag
+- optional `Implementation override: csa run ...` directive
 - concrete action
 - mechanically verifiable `DONE WHEN`
 
@@ -104,7 +106,10 @@ Treat each task as an atomic transaction:
 4. Persist checkpoint before next item.
 
 Dispatch policy by executor tag:
-- `[CSA:tool]`: run `csa run` with the item objective and `DONE WHEN`.
+- Priority: `Implementation override:` > `[CSA:tier-*]` > `[CSA:<tool>]` > default.
+- `Implementation override: csa run ...`: run the exact `csa run` command from the TODO directive with the item objective and `DONE WHEN`; it wins over any executor tag. Example: `Implementation override: csa run --tier tier-4-critical --tool claude-code` dispatches `csa run --tier tier-4-critical --tool claude-code`.
+- `[CSA:tier-*]`: run `csa run --tier <tier-name>` with the item objective and `DONE WHEN`.
+- `[CSA:<tool>]`: run `csa run --tool <tool-name>` with the item objective and `DONE WHEN`.
 - `[Sub:developer]`: execute directly as implementation work in current session.
 - `[Skill:xxx]`: invoke the corresponding skill directly.
 - `[Main]` or no tag: execute directly in current session.

--- a/patterns/mktsk/workflow.toml
+++ b/patterns/mktsk/workflow.toml
@@ -15,7 +15,8 @@ prompt = """
 Choose exactly one input mode.
 
 TODO mode is the default. Read the TODO plan file from mktd output or a user-provided path.
-Extract every unchecked checklist item with executor tag and DONE WHEN.
+Extract every unchecked checklist item with executor tag, optional Implementation override directive,
+and DONE WHEN.
 Record the resolved TODO path explicitly in the output.
 
 Issue mode applies when the user passes --from-issues or asks to process all open issues.
@@ -53,6 +54,7 @@ Each TODO task must include:
 - stable item id
 - source TODO line reference
 - executor tag
+- optional Implementation override directive
 - concrete action
 - mechanically verifiable DONE WHEN
 
@@ -87,7 +89,11 @@ Treat each task as an atomic transaction:
 4) write progress checkpoint before moving to next item
 
 Dispatch by executor tag:
-- [CSA:tool] => csa run
+- Priority: Implementation override > [CSA:tier-*] > [CSA:<tool>] > default
+- Implementation override: csa run ... => run that exact csa run command; it wins over any executor tag
+- [CSA:tier-*] => csa run --tier <tier-name>
+- [CSA:<tool>] => csa run --tool <tool-name>
+- Example: [CSA:tier-4-critical] => csa run --tier tier-4-critical; Implementation override: csa run --tier tier-4-critical --tool claude-code => run csa run --tier tier-4-critical --tool claude-code
 - [Sub:developer] => execute directly
 - [Skill:xxx] => invoke skill
 - [Main]/no tag => execute directly

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.935"
-weave = "0.1.935"
+csa = "0.1.936"
+weave = "0.1.936"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Add `IMPL_TIER` and `IMPL_TOOL` workflow variables to dev2merge, threaded into mktd executor tag generation and mktsk step-8 routing
- mktd now emits tier/tool-aware executor tags (`[CSA:tier-4-critical]`) and `Implementation override:` directives when these variables are set
- Updated mktsk dispatch contract to consume the new override directives with explicit priority: `Implementation override:` > `[CSA:tier-*]` > `[CSA:<tool>]` > default
- Synced all PATTERN.md files with workflow.toml changes (rule 027)
- Added tests for both producer (mktd) and consumer (mktsk) contract

Closes #1639

## Test plan

- [x] `just pre-commit` passes
- [x] Round 1 review caught P1: mktsk consumer contract missing — fixed in commit 2
- [x] Round 2 review PASS (session 01KTHCNM4M54CFPMQR14HMC0Q8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>