### PR TITLE
fix(cli-sub-agent): skip dev2merge version bump for non-Rust repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.937"
+version = "0.1.938"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.937"
+version = "0.1.938"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -279,8 +279,16 @@ echo "CSA_VAR:FAST_PATH_COMMITTED=true"
 ## Step 5: FAST_PATH Version Bump
 Tool: bash
 OnFail: abort
+Version bump is Rust-only (`just bump-patch` + `cargo metadata`). Repos without
+a `Cargo.toml` (e.g. Python/Node) skip this step with a warning instead of
+aborting the pipeline (#1658).
+
 ```bash
 set -euo pipefail
+if [ ! -f Cargo.toml ]; then
+  echo "Version bump skipped: no Cargo.toml found"
+  exit 0
+fi
 if ! just check-version-bumped 2>/dev/null; then
   just bump-patch
   cargo run -p weave -- lock 2>/dev/null || true
@@ -469,8 +477,16 @@ git commit -m "${COMMIT_MSG}"
 ## Step 10: Ensure Version Bumped
 Tool: bash
 OnFail: abort
+Version bump is Rust-only (`just bump-patch` + `cargo metadata`). Repos without
+a `Cargo.toml` (e.g. Python/Node) skip this step with a warning instead of
+aborting the pipeline (#1658).
+
 ```bash
 set -euo pipefail
+if [ ! -f Cargo.toml ]; then
+  echo "Version bump skipped: no Cargo.toml found"
+  exit 0
+fi
 if ! just check-version-bumped 2>/dev/null; then
   just bump-patch
   cargo run -p weave -- lock 2>/dev/null || true

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -183,16 +183,16 @@ All steps use `on_fail = "abort"`. Variables propagate via `CSA_VAR:KEY=value`.
 |------|------|------|------|
 | 1 | Validate Branch | Not default branch/dev | bash |
 | 2 | FAST_PATH Detection | Diff-stat heuristic | bash |
-| 3 | L1/L2 Quality Gates | `just fmt && just clippy` | bash |
+| 3 | L1/L2 Quality Gates | language-aware lint/test gate | bash |
 | **IF FAST_PATH** | | | |
 | 4 | Simplified Commit | `just test && git commit` | bash |
-| 5 | Version Bump | `just bump-patch` if needed | bash |
+| 5 | Version Bump | Rust-only `just bump-patch` if needed; non-Rust skips | bash |
 | 6 | Pre-PR Review | `csa review --range` then `csa review --check-verdict --range` | bash |
 | **ELSE (Full Pipeline)** | | | |
 | 7 | Plan with mktd | `csa plan run patterns/mktd/workflow.toml` (skipped in resume mode) | bash |
 | 8 | Execute with mktsk | Follow mktsk PATTERN.md directly, TaskCreate/TaskUpdate (skipped in resume mode) | main agent |
 | 9 | Resume Commit | resume mode only: L2 tests + commit uncommitted remainder | bash |
-| 10 | Version Bump | `just bump-patch` if needed | bash |
+| 10 | Version Bump | Rust-only `just bump-patch` if needed; non-Rust skips | bash |
 | 11 | Self-Review Gate | Main agent checks and fixes the full branch diff before CSA review | main agent |
 | 12 | Pre-PR Cumulative Review Gate | `csa review --range ${DEFAULT_BRANCH}...HEAD` then `csa review --check-verdict --range ${DEFAULT_BRANCH}...HEAD` | bash |
 | **ENDIF** | | | |
@@ -243,10 +243,10 @@ ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
 
 1. Feature branch validated (not default branch/dev).
 2. FAST_PATH detection completed (heuristic applied).
-3. `just fmt` and `just clippy` exit 0 (L1/L2 gates).
+3. Language-aware L1/L2 gates exit 0.
 4. If full pipeline: mktd plan saved with `DONE WHEN` clauses, mktsk executed all tasks via main agent.
 5. If FAST_PATH: simplified commit created with tests passing.
-6. Version bumped if needed.
+6. Rust repos have version bumped if needed; non-Rust repos skip version bump without aborting.
 7. Pre-PR cumulative review passed the PASS/CLEAN verdict check before setting `REVIEW_COMPLETED=true`.
 8. Push completed via `--force-with-lease` (pre-push hook verified review HEAD).
 9. Pre-PR review verdict check passed (`csa review --check-verdict --range ${DEFAULT_BRANCH}...HEAD`).

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -317,8 +317,16 @@ id = 5
 title = "FAST_PATH Version Bump"
 tool = "bash"
 prompt = '''
+Version bump is Rust-only (`just bump-patch` + `cargo metadata`). Repos without
+a `Cargo.toml` (e.g. Python/Node) skip this step with a warning instead of
+aborting the pipeline (#1658).
+
 ```bash
 set -euo pipefail
+if [ ! -f Cargo.toml ]; then
+  echo "Version bump skipped: no Cargo.toml found"
+  exit 0
+fi
 if ! just check-version-bumped 2>/dev/null; then
   just bump-patch
   cargo run -p weave -- lock 2>/dev/null || true
@@ -529,8 +537,16 @@ id = 10
 title = "Ensure Version Bumped"
 tool = "bash"
 prompt = '''
+Version bump is Rust-only (`just bump-patch` + `cargo metadata`). Repos without
+a `Cargo.toml` (e.g. Python/Node) skip this step with a warning instead of
+aborting the pipeline (#1658).
+
 ```bash
 set -euo pipefail
+if [ ! -f Cargo.toml ]; then
+  echo "Version bump skipped: no Cargo.toml found"
+  exit 0
+fi
 if ! just check-version-bumped 2>/dev/null; then
   just bump-patch
   cargo run -p weave -- lock 2>/dev/null || true

--- a/scripts/monolith/baseline.toml
+++ b/scripts/monolith/baseline.toml
@@ -732,18 +732,18 @@ rationale = "pre-existing monolith debt grandfathered by #1880 calibration; no-g
 [[files]]
 path = "patterns/dev2merge/PATTERN.md"
 kind = "doc"
-baseline_tokens = 10711
-baseline_lines = 771
+baseline_tokens = 10897
+baseline_lines = 787
 issue = "1880"
-rationale = "pre-existing monolith debt grandfathered by #1880; cap re-baselined for dev2merge resume mode (#1662); no-growth ratchet"
+rationale = "pre-existing monolith debt grandfathered by #1880; cap re-baselined for dev2merge resume mode (#1662) and language-aware version bump for non-Rust repos (#1658); no-growth ratchet"
 
 [[files]]
 path = "patterns/dev2merge/workflow.toml"
 kind = "config"
-baseline_tokens = 10392
-baseline_lines = 858
+baseline_tokens = 10578
+baseline_lines = 874
 issue = "1880"
-rationale = "pre-existing monolith debt grandfathered by #1880; cap re-baselined for dev2merge resume mode (#1662); no-growth ratchet"
+rationale = "pre-existing monolith debt grandfathered by #1880; cap re-baselined for dev2merge resume mode (#1662) and language-aware version bump for non-Rust repos (#1658); no-growth ratchet"
 
 [[files]]
 path = "patterns/mktd/PATTERN.md"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.937"
-weave = "0.1.937"
+csa = "0.1.938"
+weave = "0.1.938"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- skip dev2merge version bump steps when `Cargo.toml` is absent instead of aborting non-Rust repos
- keep Rust version bump behavior unchanged
- sync PATTERN/workflow/skill docs and bump workspace version to `0.1.938`

## Verification

- pre-commit hook passed on commits
- `python3 -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("patterns/dev2merge/workflow.toml").read_text())'`
- non-Rust version-bump shell snippet exits 0 with `Version bump skipped: no Cargo.toml found`
- `csa review --check-verdict --range main...HEAD` passed for codex session `01KTHP3BJN3F2WVEABA8K684JF`

Fixes #1658
