### PR TITLE
fix(csa-review): harden fallback verdict diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.938"
+version = "0.1.939"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.938"
+version = "0.1.939"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -403,6 +403,7 @@ pub(crate) async fn handle_review(
         let verdict = resolved.verdict;
         let decision = resolved.decision;
         let auth_prompt_failure = resolved.auth_prompt_failure;
+        let failure_reason = resolved.failure_reason;
         print!(
             "{}",
             diff_size::add_review_diff_size_line(&sanitized, diff.as_ref())
@@ -432,7 +433,7 @@ pub(crate) async fn handle_review(
             status_reason: result.status_reason.clone(),
             routed_to: result.routed_to.clone(),
             primary_failure: result.primary_failure.clone(),
-            failure_reason: result.failure_reason.clone(),
+            failure_reason,
             tool: result.executed_tool.to_string(),
             scope: scope.clone(),
             exit_code: effective_exit_code,

--- a/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
@@ -1,0 +1,30 @@
+use super::super::*;
+
+#[test]
+fn classify_review_failover_reason_uses_summary_http_400_for_review_fallback() {
+    let execution = crate::pipeline::SessionExecutionResult {
+        execution: csa_process::ExecutionResult {
+            output: String::new(),
+            stderr_output: String::new(),
+            summary: "Gemini request failed: status: 400 Bad Request".to_string(),
+            exit_code: 1,
+            peak_memory_mb: None,
+            ..Default::default()
+        },
+        meta_session_id: "01TESTHTTP400SUMMARY".to_string(),
+        provider_session_id: None,
+        changed_paths: None,
+    };
+
+    let failure = classify_review_failover_reason(
+        ToolName::GeminiCli,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        &execution,
+        None,
+        Some(std::time::Duration::from_secs(2)),
+    )
+    .expect("HTTP 400 summary should be failover eligible during init window");
+
+    assert_eq!(failure.reason, "HTTP 400");
+    assert_eq!(failure.quota_exhausted, Some(false));
+}

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -31,10 +31,14 @@ pub(super) fn classify_review_failover_reason(
         });
     }
 
+    let stdout_with_summary = format!(
+        "{}\n{}",
+        execution.execution.summary, execution.execution.output
+    );
     classify_next_model_failure_with_elapsed(
         tool.as_str(),
         &execution.execution.stderr_output,
-        &execution.execution.output,
+        &stdout_with_summary,
         execution.execution.exit_code,
         model_spec,
         attempt_elapsed,

--- a/crates/cli-sub-agent/src/review_cmd_execute_readonly_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_readonly_tests.rs
@@ -24,3 +24,6 @@ fn with_readonly_session_env_injects_flag() {
         Some("1")
     );
 }
+
+#[path = "review_cmd_execute_failover_classification_tests.rs"]
+mod failover_classification_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -569,5 +569,8 @@ pub(in crate::review_cmd) use clean_detection::is_review_output_empty;
 #[path = "review_cmd_output_fix_reuse_tests.rs"]
 mod fix_reuse_tests;
 #[cfg(test)]
+#[path = "review_cmd_output_terminal_error_reason_tests.rs"]
+mod terminal_error_reason_tests;
+#[cfg(test)]
 #[path = "review_cmd_output_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -25,6 +25,8 @@ mod prose_signals;
 mod sections;
 #[path = "review_cmd_output_summary.rs"]
 mod summary_artifact;
+#[path = "review_cmd_output_terminal_error.rs"]
+mod terminal_error;
 #[path = "review_cmd_output_text.rs"]
 mod text;
 #[path = "review_cmd_output_tool_failure.rs"]
@@ -52,11 +54,14 @@ pub(super) use sections::{
 pub(super) use summary_artifact::{
     ensure_review_summary_artifact, is_edit_restriction_summary, truncate_review_result_summary,
 };
+use terminal_error::terminal_error_artifact_from_full_output;
 use text::{
     derive_decision_from_text, parse_overall_risk_from_text, severity_counts_from_text,
     zero_severity_counts,
 };
-pub(super) use text::{extract_review_text, stream_started_without_terminal_event};
+pub(super) use text::{
+    extract_review_text, stream_started_without_terminal_event, terminal_tool_error_reason,
+};
 pub(super) use tool_failure::{ToolReviewFailureKind, detect_tool_review_failure};
 
 const REVIEW_RESULT_SUMMARY_MAX_CHARS: usize = 200;
@@ -111,7 +116,7 @@ pub(super) fn persist_review_verdict_artifact(
             };
             artifact.routed_to = meta.routed_to.clone();
             artifact.primary_failure = meta.primary_failure.clone();
-            artifact.failure_reason = meta.failure_reason.clone();
+            artifact.failure_reason = meta.failure_reason.clone().or(artifact.failure_reason);
             artifact.review_mode = meta.review_mode.clone();
             if let Err(error) = enforce_final_verdict_consistency(&session_dir, &mut artifact) {
                 warn!(
@@ -216,6 +221,10 @@ fn derive_review_verdict_artifact(
     meta: &ReviewSessionMeta,
     findings: &[Finding],
 ) -> Result<ReviewVerdictArtifact, anyhow::Error> {
+    if let Some(artifact) = terminal_error_artifact_from_full_output(session_dir, meta, findings)? {
+        return Ok(artifact);
+    }
+
     let prose_signals = review_prose_signals(session_dir)?;
     let mut synthetic_empty_findings_counts = None;
     if let Some(findings_file) = load_findings_toml_from_output(session_dir)? {

--- a/crates/cli-sub-agent/src/review_cmd_output_terminal_error.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_terminal_error.rs
@@ -1,0 +1,41 @@
+use std::{fs, path::Path};
+
+use anyhow::Result;
+use csa_core::types::ReviewDecision;
+use csa_session::{Finding, ReviewVerdictArtifact, state::ReviewSessionMeta};
+
+use super::text::terminal_tool_error_reason;
+
+fn unavailable_terminal_error_artifact(
+    meta: &ReviewSessionMeta,
+    findings: &[Finding],
+    reason: String,
+) -> ReviewVerdictArtifact {
+    let mut artifact = ReviewVerdictArtifact::from_parts(
+        meta.session_id.clone(),
+        ReviewDecision::Unavailable,
+        "UNAVAILABLE",
+        findings,
+        Vec::new(),
+    );
+    artifact.routed_to = meta.routed_to.clone();
+    artifact.primary_failure = meta.primary_failure.clone();
+    artifact.failure_reason = meta.failure_reason.clone().or(Some(reason));
+    artifact.review_mode = meta.review_mode.clone();
+    artifact
+}
+
+pub(in crate::review_cmd) fn terminal_error_artifact_from_full_output(
+    session_dir: &Path,
+    meta: &ReviewSessionMeta,
+    findings: &[Finding],
+) -> Result<Option<ReviewVerdictArtifact>> {
+    let full_output_path = session_dir.join("output").join("full.md");
+    if !full_output_path.exists() {
+        return Ok(None);
+    }
+    let raw_output = fs::read_to_string(&full_output_path)
+        .map_err(|error| anyhow::anyhow!("read {}: {error}", full_output_path.display()))?;
+    Ok(terminal_tool_error_reason(&raw_output)
+        .map(|reason| unavailable_terminal_error_artifact(meta, findings, reason)))
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_terminal_error_reason_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_terminal_error_reason_tests.rs
@@ -18,3 +18,18 @@ fn terminal_tool_error_reason_survives_trailing_stream_noise() {
         Some("HTTP 403 Forbidden: authentication failed")
     );
 }
+
+#[test]
+fn terminal_tool_error_reason_updates_after_prior_terminal_error() {
+    let transcript = [
+        r#"{"type":"system","subtype":"init"}"#,
+        r#"{"type":"result","subtype":"error_api","is_error":true,"result":"transient backend error"}"#,
+        r#"{"type":"turn.failed","error":{"message":"HTTP 403 Forbidden: authentication failed"}}"#,
+    ]
+    .join("\n");
+
+    assert_eq!(
+        terminal_tool_error_reason(&transcript).as_deref(),
+        Some("HTTP 403 Forbidden: authentication failed")
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_terminal_error_reason_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_terminal_error_reason_tests.rs
@@ -1,0 +1,20 @@
+use super::terminal_tool_error_reason;
+
+#[test]
+fn terminal_tool_error_reason_survives_trailing_stream_noise() {
+    let transcript = [
+        r#"{"type":"system","subtype":"init"}"#,
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"PASS"}}"#,
+        r#"{"type":"result","subtype":"error_api","is_error":true,"result":"HTTP 403 Forbidden: authentication failed"}"#,
+        "",
+        r#"{"type":"item.completed","item":{"type":"tool_call","text":"ignored"}}"#,
+        r#"{"type":"usage","input_tokens":1}"#,
+        "Usage: provider emitted a diagnostic after the crash",
+    ]
+    .join("\n");
+
+    assert_eq!(
+        terminal_tool_error_reason(&transcript).as_deref(),
+        Some("HTTP 403 Forbidden: authentication failed")
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_terminal_error_reason_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_terminal_error_reason_tests.rs
@@ -33,3 +33,18 @@ fn terminal_tool_error_reason_updates_after_prior_terminal_error() {
         Some("HTTP 403 Forbidden: authentication failed")
     );
 }
+
+#[test]
+fn terminal_tool_error_reason_ignores_fenced_stream_fixture() {
+    let transcript = [
+        "Reviewer prose quotes a terminal stream fixture:",
+        "```json",
+        r#"{"type":"system","subtype":"init"}"#,
+        r#"{"type":"result","subtype":"error_api","is_error":true,"result":"HTTP 403 Forbidden: authentication failed"}"#,
+        "```",
+        "The quoted fixture is evidence, not the live reviewer stream.",
+    ]
+    .join("\n");
+
+    assert_eq!(terminal_tool_error_reason(&transcript), None);
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_text.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_text.rs
@@ -67,6 +67,62 @@ pub(in crate::review_cmd) fn extract_review_text(raw_output: &str) -> Option<Str
     transcript_messages.pop()
 }
 
+pub(in crate::review_cmd) fn terminal_tool_error_reason(raw_output: &str) -> Option<String> {
+    for line in raw_output.lines().rev() {
+        let line = line.trim();
+        if !(line.starts_with('{') && line.ends_with('}')) {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some("result") if claude_result_is_error(&value) => {
+                return Some(json_error_summary(&value));
+            }
+            Some("result") => return None,
+            Some("turn.failed") => return Some(json_error_summary(&value)),
+            Some("turn.completed") => return None,
+            _ => {}
+        }
+    }
+    None
+}
+
+fn claude_result_is_error(value: &serde_json::Value) -> bool {
+    value
+        .get("is_error")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+        || value
+            .get("subtype")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|subtype| subtype.starts_with("error"))
+}
+
+fn json_error_summary(value: &serde_json::Value) -> String {
+    for pointer in [
+        "/error/message",
+        "/message",
+        "/result",
+        "/subtype",
+        "/error",
+    ] {
+        let Some(field) = value.pointer(pointer) else {
+            continue;
+        };
+        if let Some(text) = field.as_str()
+            && !text.trim().is_empty()
+        {
+            return text.trim().chars().take(240).collect();
+        }
+        if field.is_object() || field.is_array() {
+            return field.to_string().chars().take(240).collect();
+        }
+    }
+    "stream terminal error".to_string()
+}
+
 /// Minimal stream-event view used to detect turn completion without depending on the shape
 /// of unrelated event payloads. Reading only `type` (serde ignores all other fields) keeps
 /// detection robust against schema drift in `result`/`item`/`usage` bodies.

--- a/crates/cli-sub-agent/src/review_cmd_output_text.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_text.rs
@@ -70,10 +70,19 @@ pub(in crate::review_cmd) fn extract_review_text(raw_output: &str) -> Option<Str
 pub(in crate::review_cmd) fn terminal_tool_error_reason(raw_output: &str) -> Option<String> {
     let mut stream_segment_started = false;
     let mut terminal_error_reason = None;
+    let mut in_code_fence = false;
 
     for line in raw_output.lines() {
         let line = line.trim();
         if line.is_empty() {
+            continue;
+        }
+        if line.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            stream_segment_started = false;
+            continue;
+        }
+        if in_code_fence {
             continue;
         }
         if !(line.starts_with('{') && line.ends_with('}')) {

--- a/crates/cli-sub-agent/src/review_cmd_output_text.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_text.rs
@@ -68,7 +68,7 @@ pub(in crate::review_cmd) fn extract_review_text(raw_output: &str) -> Option<Str
 }
 
 pub(in crate::review_cmd) fn terminal_tool_error_reason(raw_output: &str) -> Option<String> {
-    let mut current_segment_started = false;
+    let mut stream_segment_started = false;
     let mut terminal_error_reason = None;
 
     for line in raw_output.lines() {
@@ -77,43 +77,38 @@ pub(in crate::review_cmd) fn terminal_tool_error_reason(raw_output: &str) -> Opt
             continue;
         }
         if !(line.starts_with('{') && line.ends_with('}')) {
-            current_segment_started = false;
+            stream_segment_started = false;
             continue;
         }
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-            current_segment_started = false;
+            stream_segment_started = false;
             continue;
         };
         let Some(event_type) = value.get("type").and_then(serde_json::Value::as_str) else {
-            current_segment_started = false;
+            stream_segment_started = false;
             continue;
         };
         if !STREAM_EVENT_TYPES.contains(&event_type) {
-            current_segment_started = false;
+            stream_segment_started = false;
             continue;
         }
         if STREAM_START_EVENT_TYPES.contains(&event_type) {
-            current_segment_started = true;
+            stream_segment_started = true;
             terminal_error_reason = None;
             continue;
         }
 
         match event_type {
-            "result" if current_segment_started && claude_result_is_error(&value) => {
+            "result" if stream_segment_started && claude_result_is_error(&value) => {
                 terminal_error_reason = Some(json_error_summary(&value));
-                current_segment_started = false;
             }
-            "turn.failed" if current_segment_started => {
+            "turn.failed" if stream_segment_started => {
                 terminal_error_reason = Some(json_error_summary(&value));
-                current_segment_started = false;
             }
             "result" | "turn.completed" => {
                 terminal_error_reason = None;
-                current_segment_started = false;
             }
-            "turn.failed" => {
-                current_segment_started = false;
-            }
+            "turn.failed" => {}
             _ => {}
         }
     }

--- a/crates/cli-sub-agent/src/review_cmd_output_text.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_text.rs
@@ -73,24 +73,23 @@ pub(in crate::review_cmd) fn terminal_tool_error_reason(raw_output: &str) -> Opt
 
     for line in raw_output.lines() {
         let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
         if !(line.starts_with('{') && line.ends_with('}')) {
             current_segment_started = false;
-            terminal_error_reason = None;
             continue;
         }
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
             current_segment_started = false;
-            terminal_error_reason = None;
             continue;
         };
         let Some(event_type) = value.get("type").and_then(serde_json::Value::as_str) else {
             current_segment_started = false;
-            terminal_error_reason = None;
             continue;
         };
         if !STREAM_EVENT_TYPES.contains(&event_type) {
             current_segment_started = false;
-            terminal_error_reason = None;
             continue;
         }
         if STREAM_START_EVENT_TYPES.contains(&event_type) {
@@ -108,13 +107,14 @@ pub(in crate::review_cmd) fn terminal_tool_error_reason(raw_output: &str) -> Opt
                 terminal_error_reason = Some(json_error_summary(&value));
                 current_segment_started = false;
             }
-            "result" | "turn.completed" | "turn.failed" => {
+            "result" | "turn.completed" => {
                 terminal_error_reason = None;
                 current_segment_started = false;
             }
-            _ => {
-                terminal_error_reason = None;
+            "turn.failed" => {
+                current_segment_started = false;
             }
+            _ => {}
         }
     }
 

--- a/crates/cli-sub-agent/src/review_cmd_output_text.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_text.rs
@@ -68,25 +68,57 @@ pub(in crate::review_cmd) fn extract_review_text(raw_output: &str) -> Option<Str
 }
 
 pub(in crate::review_cmd) fn terminal_tool_error_reason(raw_output: &str) -> Option<String> {
-    for line in raw_output.lines().rev() {
+    let mut current_segment_started = false;
+    let mut terminal_error_reason = None;
+
+    for line in raw_output.lines() {
         let line = line.trim();
         if !(line.starts_with('{') && line.ends_with('}')) {
+            current_segment_started = false;
+            terminal_error_reason = None;
             continue;
         }
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            current_segment_started = false;
+            terminal_error_reason = None;
             continue;
         };
-        match value.get("type").and_then(serde_json::Value::as_str) {
-            Some("result") if claude_result_is_error(&value) => {
-                return Some(json_error_summary(&value));
+        let Some(event_type) = value.get("type").and_then(serde_json::Value::as_str) else {
+            current_segment_started = false;
+            terminal_error_reason = None;
+            continue;
+        };
+        if !STREAM_EVENT_TYPES.contains(&event_type) {
+            current_segment_started = false;
+            terminal_error_reason = None;
+            continue;
+        }
+        if STREAM_START_EVENT_TYPES.contains(&event_type) {
+            current_segment_started = true;
+            terminal_error_reason = None;
+            continue;
+        }
+
+        match event_type {
+            "result" if current_segment_started && claude_result_is_error(&value) => {
+                terminal_error_reason = Some(json_error_summary(&value));
+                current_segment_started = false;
             }
-            Some("result") => return None,
-            Some("turn.failed") => return Some(json_error_summary(&value)),
-            Some("turn.completed") => return None,
-            _ => {}
+            "turn.failed" if current_segment_started => {
+                terminal_error_reason = Some(json_error_summary(&value));
+                current_segment_started = false;
+            }
+            "result" | "turn.completed" | "turn.failed" => {
+                terminal_error_reason = None;
+                current_segment_started = false;
+            }
+            _ => {
+                terminal_error_reason = None;
+            }
         }
     }
-    None
+
+    terminal_error_reason
 }
 
 fn claude_result_is_error(value: &serde_json::Value) -> bool {
@@ -137,6 +169,10 @@ struct StreamEventType {
 /// `{"type":"turn.completed",...}`. Their presence proves the turn ran to completion,
 /// independent of the verdict it reached.
 const STREAM_TERMINAL_EVENT_TYPES: &[&str] = &["result", "turn.completed"];
+
+/// Events that prove a contiguous JSON object segment is a tool transport stream rather
+/// than reviewer prose quoting a JSON fixture.
+const STREAM_START_EVENT_TYPES: &[&str] = &["system", "thread.started", "turn.started"];
 
 /// Event types that positively identify a JSON streaming transcript (claude-code / codex).
 /// Used to keep [`stream_started_without_terminal_event`] from misclassifying non-streaming

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1716_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1716_tests.rs
@@ -86,6 +86,46 @@ fn issue_1716_unavailable_nonzero_empty_failure_metadata_is_unavailable() {
 }
 
 #[test]
+fn issue_1930_terminal_tool_error_after_pass_text_persists_unavailable() {
+    let session_id = "01TEST1930ISERRORPASS0000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1930-terminal-error-pass", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        [
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n<!-- CSA:SECTION:details -->\nNo blocking issues found.\n<!-- CSA:SECTION:details:END -->"}}"#,
+            r#"{"type":"result","subtype":"error_api","is_error":true,"result":"HTTP 403 Forbidden: authentication failed"}"#,
+        ]
+        .join("\n"),
+    )
+    .expect("write full.md");
+
+    let mut meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    meta.exit_code = 0;
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
+            .expect("read verdict"),
+    )
+    .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Unavailable);
+    assert_eq!(artifact.verdict_legacy, "UNAVAILABLE");
+    assert_ne!(artifact.decision, ReviewDecision::Pass);
+    assert_ne!(artifact.verdict_legacy, "CLEAN");
+    assert!(
+        artifact
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("HTTP 403"))
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_1716_successful_zero_findings_fallback_with_prior_failure_still_passes() {
     let session_id = "01TEST1716SUCCESSFALLBACK00";
     let (_env_lock, project_root, session_dir) =

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1716_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1716_tests.rs
@@ -95,6 +95,7 @@ fn issue_1930_terminal_tool_error_after_pass_text_persists_unavailable() {
     fs::write(
         session_dir.join("output").join("full.md"),
         [
+            r#"{"type":"system","subtype":"init"}"#,
             r#"{"type":"item.completed","item":{"type":"agent_message","text":"<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n<!-- CSA:SECTION:details -->\nNo blocking issues found.\n<!-- CSA:SECTION:details:END -->"}}"#,
             r#"{"type":"result","subtype":"error_api","is_error":true,"result":"HTTP 403 Forbidden: authentication failed"}"#,
         ]
@@ -121,6 +122,48 @@ fn issue_1930_terminal_tool_error_after_pass_text_persists_unavailable() {
             .as_deref()
             .is_some_and(|reason| reason.contains("HTTP 403"))
     );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1930_plain_prose_quoted_terminal_error_payload_persists_pass() {
+    let session_id = "01TEST1930QUOTEDJSONPASS";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-1930-quoted-json-pass", session_id);
+
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        [
+            "<!-- CSA:SECTION:summary -->",
+            "PASS",
+            "<!-- CSA:SECTION:summary:END -->",
+            "<!-- CSA:SECTION:details -->",
+            "No blocking issues found. The reviewed code quotes this terminal-error payload:",
+            "```json",
+            r#"{"type":"result","subtype":"error_api","is_error":true,"result":"HTTP 403 Forbidden: authentication failed"}"#,
+            "```",
+            "<!-- CSA:SECTION:details:END -->",
+        ]
+        .join("\n"),
+    )
+    .expect("write full.md");
+
+    let mut meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    meta.exit_code = 0;
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
+            .expect("read verdict"),
+    )
+    .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert_ne!(artifact.decision, ReviewDecision::Unavailable);
+    assert_ne!(artifact.verdict_legacy, "UNAVAILABLE");
+    assert!(artifact.failure_reason.is_none());
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1716_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1716_tests.rs
@@ -142,6 +142,7 @@ fn issue_1930_plain_prose_quoted_terminal_error_payload_persists_pass() {
             "<!-- CSA:SECTION:details -->",
             "No blocking issues found. The reviewed code quotes this terminal-error payload:",
             "```json",
+            r#"{"type":"system","subtype":"init"}"#,
             r#"{"type":"result","subtype":"error_api","is_error":true,"result":"HTTP 403 Forbidden: authentication failed"}"#,
             "```",
             "<!-- CSA:SECTION:details:END -->",

--- a/crates/cli-sub-agent/src/review_cmd_resolve_selection.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve_selection.rs
@@ -11,6 +11,25 @@ pub(crate) struct ResolvedReviewSelection {
     pub(crate) tier_preference_order: Vec<String>,
 }
 
+fn force_resolve_review_tool_from_tier(
+    tier: &str,
+    config: &ProjectConfig,
+    tool: ToolName,
+) -> Option<crate::run_helpers::TierToolResolution> {
+    let tier_config = config.tiers.get(tier)?;
+    tier_config.models.iter().find_map(|model_spec| {
+        let parts: Vec<&str> = model_spec.splitn(4, '/').collect();
+        if parts.len() == 4 && parts[0] == tool.as_str() {
+            Some(crate::run_helpers::TierToolResolution {
+                tool,
+                model_spec: model_spec.clone(),
+            })
+        } else {
+            None
+        }
+    })
+}
+
 pub(crate) fn validate_review_direct_tool_tier_restriction(
     direct_tool_requested: bool,
     project_config: Option<&ProjectConfig>,
@@ -101,13 +120,28 @@ pub(crate) fn resolve_review_selection(
             && let Some(cfg) = project_config
         {
             let tier_preference_order = vec![tool.as_str().to_string()];
-            let resolution = crate::run_helpers::resolve_preferred_tool_from_tier(
-                tier,
-                cfg,
-                parent_tool,
-                &tier_preference_order,
-                &[],
-            )?;
+            let resolution = if force_override_user_config {
+                force_resolve_review_tool_from_tier(tier, cfg, tool).map_or_else(
+                    || {
+                        crate::run_helpers::resolve_preferred_tool_from_tier(
+                            tier,
+                            cfg,
+                            parent_tool,
+                            &tier_preference_order,
+                            &[],
+                        )
+                    },
+                    Ok,
+                )?
+            } else {
+                crate::run_helpers::resolve_preferred_tool_from_tier(
+                    tier,
+                    cfg,
+                    parent_tool,
+                    &tier_preference_order,
+                    &[],
+                )?
+            };
             return Ok(ResolvedReviewSelection {
                 tool: resolution.tool,
                 model_spec: Some(resolution.model_spec),

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -86,6 +86,7 @@ pub(super) struct SingleReviewResolution {
     pub decision: ReviewDecision,
     pub effective_exit_code: i32,
     pub auth_prompt_failure: bool,
+    pub failure_reason: Option<String>,
 }
 
 pub(super) fn resolve_single_review_result(
@@ -184,6 +185,9 @@ pub(super) fn resolve_single_review_result(
     };
     let verdict = verdict_from_decision(decision);
     let effective_exit_code = crate::verdict_exit_code::exit_code_from_review_decision(decision);
+    let failure_reason = terminal_tool_error
+        .clone()
+        .or_else(|| result.failure_reason.clone());
 
     SingleReviewResolution {
         sanitized,
@@ -192,6 +196,7 @@ pub(super) fn resolve_single_review_result(
         decision,
         effective_exit_code,
         auth_prompt_failure,
+        failure_reason,
     }
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -17,6 +17,7 @@ use super::execute::ReviewExecutionOutcome;
 use super::output::{
     GEMINI_AUTH_PROMPT_STATUS_REASON, ReviewerOutcome, detect_tool_diagnostic, extract_review_text,
     is_review_output_empty, sanitize_review_output, stream_started_without_terminal_event,
+    terminal_tool_error_reason,
 };
 
 const AUTH_PROMPT_REVIEW_UNAVAILABLE: &str = "Review unavailable: gemini-cli OAuth prompt detected; authentication required (no review verdict produced).\n";
@@ -96,6 +97,7 @@ pub(super) fn resolve_single_review_result(
     let auth_prompt_failure =
         result.status_reason.as_deref() == Some(GEMINI_AUTH_PROMPT_STATUS_REASON);
     let forced_unavailable = matches!(result.forced_decision, Some(ReviewDecision::Unavailable));
+    let terminal_tool_error = terminal_tool_error_reason(&result.execution.execution.output);
     let tool_unavailable_reason = tool_unavailable_failure_reason(result, tool);
     let opaque_total_exhaustion = opaque_total_exhaustion_message(
         result.primary_failure.as_deref(),
@@ -113,6 +115,12 @@ pub(super) fn resolve_single_review_result(
                 .as_deref()
                 .unwrap_or("all configured tier models failed")
         )
+    } else if let Some(reason) = terminal_tool_error.as_deref() {
+        format!(
+            "{REVIEW_UNAVAILABLE_PREFIX}{} tool failure: {}\n",
+            tool.as_str(),
+            truncate_single_line(reason, 240)
+        )
     } else if let Some(reason) = tool_unavailable_reason.as_deref() {
         format!("{REVIEW_UNAVAILABLE_PREFIX}{reason}\n")
     } else {
@@ -120,6 +128,7 @@ pub(super) fn resolve_single_review_result(
     };
     let empty_output = !auth_prompt_failure
         && !forced_unavailable
+        && terminal_tool_error.is_none()
         && tool_unavailable_reason.is_none()
         && is_review_output_empty(&result.execution.execution.output);
     let tool_diagnostic = if opaque_total_exhaustion.is_some() {
@@ -150,7 +159,9 @@ pub(super) fn resolve_single_review_result(
         load_summary_fallback(project_root, &result.execution.meta_session_id).as_deref(),
     );
 
-    let decision = if reviewer_killed_before_completion(
+    let decision = if terminal_tool_error.is_some() {
+        ReviewDecision::Unavailable
+    } else if reviewer_killed_before_completion(
         &result.execution.execution.output,
         result.execution.execution.exit_code,
     ) {
@@ -196,6 +207,7 @@ pub(super) fn build_reviewer_outcome(
         session_result.forced_decision,
         Some(ReviewDecision::Unavailable)
     );
+    let terminal_tool_error = terminal_tool_error_reason(&result.execution.output);
     let tool_unavailable_reason = tool_unavailable_failure_reason(session_result, reviewer_tool);
     let opaque_total_exhaustion = opaque_total_exhaustion_message(
         session_result.primary_failure.as_deref(),
@@ -203,6 +215,7 @@ pub(super) fn build_reviewer_outcome(
     );
     let empty = !auth_prompt_failure
         && !forced_unavailable
+        && terminal_tool_error.is_none()
         && tool_unavailable_reason.is_none()
         && is_review_output_empty(&result.execution.output);
     let diagnostic =
@@ -221,7 +234,9 @@ pub(super) fn build_reviewer_outcome(
         result.execution.exit_code,
         None,
     );
-    let decision = if reviewer_killed_before_completion(
+    let decision = if terminal_tool_error.is_some() {
+        ReviewDecision::Unavailable
+    } else if reviewer_killed_before_completion(
         &result.execution.output,
         result.execution.exit_code,
     ) {
@@ -263,6 +278,12 @@ pub(super) fn build_reviewer_outcome(
                     .as_deref()
                     .unwrap_or("all configured tier models failed")
             )
+        } else if let Some(reason) = terminal_tool_error.as_deref() {
+            format!(
+                "{REVIEW_UNAVAILABLE_PREFIX}{} tool failure: {}\n",
+                reviewer_tool.as_str(),
+                truncate_single_line(reason, 240)
+            )
         } else if let Some(reason) = tool_unavailable_reason.as_deref() {
             format!("{REVIEW_UNAVAILABLE_PREFIX}{reason}\n")
         } else {
@@ -274,6 +295,7 @@ pub(super) fn build_reviewer_outcome(
         } else {
             diagnostic
                 .or_else(|| auth_prompt_failure.then(|| AUTH_PROMPT_DIAGNOSTIC.to_string()))
+                .or_else(|| terminal_tool_error.clone())
                 .or_else(|| tool_unavailable_reason.clone())
         },
     })

--- a/crates/cli-sub-agent/src/review_cmd_result_terminal_error_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_terminal_error_tests.rs
@@ -1,0 +1,78 @@
+use std::path::Path;
+
+use csa_core::types::{ReviewDecision, ToolName};
+use csa_process::ExecutionResult;
+
+use super::super::*;
+use crate::pipeline::SessionExecutionResult;
+
+fn outcome(output: &str, exit_code: i32) -> ReviewExecutionOutcome {
+    ReviewExecutionOutcome {
+        execution: SessionExecutionResult {
+            execution: ExecutionResult {
+                output: output.to_string(),
+                stderr_output: String::new(),
+                summary: String::new(),
+                exit_code,
+                peak_memory_mb: None,
+                ..Default::default()
+            },
+            meta_session_id: "01TESTRESULT".to_string(),
+            provider_session_id: None,
+            changed_paths: None,
+        },
+        persistable_session_id: Some("01TESTRESULT".to_string()),
+        executed_tool: ToolName::Codex,
+        status_reason: None,
+        forced_decision: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+    }
+}
+
+#[test]
+fn resolve_single_review_result_rejects_terminal_is_error_after_pass_message() {
+    let transcript = [
+        r#"{"type":"system","subtype":"init"}"#,
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n<!-- CSA:SECTION:details -->\nNo blocking issues found.\n<!-- CSA:SECTION:details:END -->"}}"#,
+        r#"{"type":"result","subtype":"error_api","is_error":true,"result":"HTTP 403 Forbidden: authentication failed"}"#,
+    ]
+    .join("\n");
+    let mut result = outcome(&transcript, 0);
+    result.executed_tool = ToolName::ClaudeCode;
+
+    let resolved =
+        resolve_single_review_result(&result, ToolName::ClaudeCode, "uncommitted", Path::new("."));
+
+    assert_eq!(resolved.decision, ReviewDecision::Unavailable);
+    assert_eq!(resolved.verdict, UNAVAILABLE);
+    assert_eq!(resolved.effective_exit_code, 1);
+    assert!(resolved.sanitized.contains("Review unavailable:"));
+    assert!(resolved.sanitized.contains("HTTP 403"));
+
+    let reviewer =
+        build_reviewer_outcome(0, ToolName::ClaudeCode, &result).expect("reviewer outcome");
+    assert_eq!(reviewer.verdict, UNAVAILABLE);
+    assert_eq!(reviewer.exit_code, 1);
+}
+
+#[test]
+fn resolve_single_review_result_ignores_nonterminal_prior_error() {
+    let transcript = [
+        r#"{"type":"system","subtype":"init"}"#,
+        r#"{"type":"result","subtype":"error_api","is_error":true,"result":"transient backend error"}"#,
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n<!-- CSA:SECTION:details -->\nNo blocking issues found.\n<!-- CSA:SECTION:details:END -->"}}"#,
+        r#"{"type":"result","subtype":"success","is_error":false,"result":"done"}"#,
+    ]
+    .join("\n");
+    let mut result = outcome(&transcript, 0);
+    result.executed_tool = ToolName::ClaudeCode;
+
+    let resolved =
+        resolve_single_review_result(&result, ToolName::ClaudeCode, "uncommitted", Path::new("."));
+
+    assert_eq!(resolved.decision, ReviewDecision::Pass);
+    assert_eq!(resolved.verdict, CLEAN);
+    assert_eq!(resolved.effective_exit_code, 0);
+}

--- a/crates/cli-sub-agent/src/review_cmd_result_terminal_error_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_terminal_error_tests.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{fs, path::Path};
 
 use csa_core::types::{ReviewDecision, ToolName};
 use csa_process::ExecutionResult;
@@ -55,6 +55,93 @@ fn resolve_single_review_result_rejects_terminal_is_error_after_pass_message() {
         build_reviewer_outcome(0, ToolName::ClaudeCode, &result).expect("reviewer outcome");
     assert_eq!(reviewer.verdict, UNAVAILABLE);
     assert_eq!(reviewer.exit_code, 1);
+}
+
+#[test]
+fn terminal_tool_error_reason_persists_through_real_sidecars() {
+    let transcript = [
+        r#"{"type":"system","subtype":"init"}"#,
+        r#"{"type":"item.completed","item":{"type":"agent_message","text":"<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n<!-- CSA:SECTION:details -->\nNo blocking issues found.\n<!-- CSA:SECTION:details:END -->"}}"#,
+        r#"{"type":"result","subtype":"error_api","is_error":true,"result":"HTTP 403 Forbidden: authentication failed"}"#,
+    ]
+    .join("\n");
+    let mut result = outcome(&transcript, 0);
+    result.executed_tool = ToolName::ClaudeCode;
+
+    let project_root = tempfile::tempdir().expect("temp project");
+    let session_dir = csa_session::get_session_root(project_root.path())
+        .expect("session root")
+        .join("sessions")
+        .join(&result.execution.meta_session_id);
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    fs::write(session_dir.join("output").join("full.md"), &transcript).expect("write full.md");
+
+    let resolved = resolve_single_review_result(
+        &result,
+        ToolName::ClaudeCode,
+        "uncommitted",
+        project_root.path(),
+    );
+
+    assert_eq!(resolved.decision, ReviewDecision::Unavailable);
+    assert!(
+        resolved
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("HTTP 403 Forbidden"))
+    );
+
+    let meta = csa_session::state::ReviewSessionMeta {
+        session_id: result.execution.meta_session_id.clone(),
+        head_sha: "HEAD".to_string(),
+        decision: resolved.decision.as_str().to_string(),
+        verdict: resolved.verdict.to_string(),
+        status_reason: result.status_reason.clone(),
+        routed_to: result.routed_to.clone(),
+        primary_failure: result.primary_failure.clone(),
+        failure_reason: resolved.failure_reason.clone(),
+        tool: ToolName::ClaudeCode.to_string(),
+        scope: "uncommitted".to_string(),
+        exit_code: resolved.effective_exit_code,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 0,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        review_mode: None,
+        fix_convergence: None,
+    };
+
+    let persisted_exit_code = crate::review_cmd::persist_review_sidecars_if_session_exists(
+        project_root.path(),
+        &meta,
+        result.persistable_session_id.as_deref(),
+    );
+    assert_eq!(persisted_exit_code, Some(1));
+
+    let persisted_meta: csa_session::state::ReviewSessionMeta = serde_json::from_str(
+        &fs::read_to_string(session_dir.join("review_meta.json")).expect("read review meta"),
+    )
+    .expect("parse review meta");
+    assert!(
+        persisted_meta
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("HTTP 403 Forbidden"))
+    );
+
+    let artifact: csa_session::ReviewVerdictArtifact = serde_json::from_str(
+        &fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
+            .expect("read review verdict"),
+    )
+    .expect("parse review verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Unavailable);
+    assert!(
+        artifact
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("HTTP 403 Forbidden"))
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_result_terminal_error_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_terminal_error_tests.rs
@@ -173,6 +173,7 @@ fn resolve_single_review_result_ignores_fenced_terminal_error_payload_in_plain_p
         "<!-- CSA:SECTION:details -->",
         "No blocking issues found. The reviewed code contains this JSON fixture:",
         "```json",
+        r#"{"type":"system","subtype":"init"}"#,
         r#"{"type":"result","subtype":"error_api","is_error":true,"result":"HTTP 403 Forbidden: authentication failed"}"#,
         "```",
         "<!-- CSA:SECTION:details:END -->",

--- a/crates/cli-sub-agent/src/review_cmd_result_terminal_error_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_terminal_error_tests.rs
@@ -76,3 +76,31 @@ fn resolve_single_review_result_ignores_nonterminal_prior_error() {
     assert_eq!(resolved.verdict, CLEAN);
     assert_eq!(resolved.effective_exit_code, 0);
 }
+
+#[test]
+fn resolve_single_review_result_ignores_fenced_terminal_error_payload_in_plain_prose() {
+    let review = [
+        "<!-- CSA:SECTION:summary -->",
+        "PASS",
+        "<!-- CSA:SECTION:summary:END -->",
+        "<!-- CSA:SECTION:details -->",
+        "No blocking issues found. The reviewed code contains this JSON fixture:",
+        "```json",
+        r#"{"type":"result","subtype":"error_api","is_error":true,"result":"HTTP 403 Forbidden: authentication failed"}"#,
+        "```",
+        "<!-- CSA:SECTION:details:END -->",
+    ]
+    .join("\n");
+    let result = outcome(&review, 0);
+
+    let resolved =
+        resolve_single_review_result(&result, ToolName::Codex, "uncommitted", Path::new("."));
+
+    assert_eq!(resolved.decision, ReviewDecision::Pass);
+    assert_eq!(resolved.verdict, CLEAN);
+    assert_eq!(resolved.effective_exit_code, 0);
+
+    let reviewer = build_reviewer_outcome(0, ToolName::Codex, &result).expect("reviewer outcome");
+    assert_eq!(reviewer.verdict, CLEAN);
+    assert_eq!(reviewer.exit_code, 0);
+}

--- a/crates/cli-sub-agent/src/review_cmd_result_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_tests.rs
@@ -602,3 +602,6 @@ fn all_killed_reviewers_persist_unavailable_decision_on_disk() {
         1
     );
 }
+
+#[path = "review_cmd_result_terminal_error_tests.rs"]
+mod terminal_error_tests;

--- a/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
@@ -208,6 +208,39 @@ fn test_review_tool_plus_tier_resolves_requested_tool_from_tier() {
 }
 
 #[test]
+fn test_review_tool_plus_tier_force_override_resolves_disabled_requested_tool() {
+    let _tool_availability = assume_tier_tools_available();
+    let global = GlobalConfig::default();
+    let cfg = review_config_with_tier(
+        "quality",
+        vec![
+            "gemini-cli/google/default/xhigh",
+            "codex/openai/gpt-5.4/high",
+        ],
+        &["gemini-cli"],
+    );
+    let selection = resolve_review_selection(
+        Some(ToolName::Codex),
+        None,
+        Some(&cfg),
+        &global,
+        Some("claude-code"),
+        std::path::Path::new("/tmp/test-project"),
+        true,
+        Some("quality"),
+        false,
+    )
+    .expect("force override should honor disabled requested review tool");
+
+    assert_eq!(selection.tool, ToolName::Codex);
+    assert_eq!(
+        selection.model_spec.as_deref(),
+        Some("codex/openai/gpt-5.4/high")
+    );
+    assert_eq!(selection.tier_preference_order, vec!["codex"]);
+}
+
+#[test]
 fn test_review_tool_plus_tier_keeps_full_tier_failover_chain() {
     let _tool_availability = assume_tier_tools_available();
     let global = GlobalConfig::default();

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -607,18 +607,9 @@ where
             trigger = %trigger,
             reconciliation_reason = "daemon_completion",
             error = %err,
-            "Failed to persist retired daemon-completed session state during reconciliation; removing daemon completion result and leaving session state unchanged"
+            "Failed to persist retired daemon-completed session state during reconciliation; preserving daemon completion result so callers can recover the terminal outcome"
         );
-        rollback_reconciliation_artifacts(result_path, result_contents.as_bytes(), None).map_err(
-            |cleanup_err| {
-                anyhow!(
-                    "Failed to persist retired daemon-completed session state for {session_id}: {err}; additionally failed to remove daemon completion result: {cleanup_err}"
-                )
-            },
-        )?;
-        return Err(anyhow!(
-            "Failed to persist retired daemon-completed session state for {session_id}: {err}"
-        ));
+        return Ok(DeadActiveSessionReconciliation::DaemonCompletionFinalized);
     }
     csa_session::write_cooldown_marker_from_session_dir(session_dir, session_id, completed_at);
     warn!(

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
@@ -1,7 +1,11 @@
 use super::*;
 use crate::test_session_sandbox::ScopedSessionSandbox;
-use csa_session::{create_session, get_session_dir, load_result, load_session};
+use anyhow::{Result, anyhow};
+use csa_session::{
+    MetaSessionState, SessionPhase, create_session, get_session_dir, load_result, load_session,
+};
 use std::fs;
+use std::path::Path;
 
 struct SessionTestEnv {
     _sandbox: ScopedSessionSandbox,
@@ -178,4 +182,58 @@ fn daemon_completion_packet_present_finalizes_dead_active_session() {
         persisted.termination_reason.as_deref(),
         Some("daemon_completion")
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_completion_result_survives_state_save_failure() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session =
+        create_session(project, Some("daemon-completion-save-failure"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    let state_path = session_dir.join("state.toml");
+    let original_state = fs::read_to_string(&state_path).unwrap();
+    fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+    let persist_fail = |_: &Path, _: &MetaSessionState| -> Result<()> { Err(anyhow!("boom")) };
+
+    let reconciled = ensure_terminal_result_for_dead_active_session_impl(
+        project,
+        &session_id,
+        "session wait",
+        &session_dir,
+        SyntheticResultHooks {
+            before_write: &noop_path,
+            after_publish: &noop_path,
+        },
+        |_| {},
+        &persist_fail,
+    )
+    .unwrap();
+
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::DaemonCompletionFinalized
+    );
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("daemon completion result must remain recoverable");
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.summary.contains("daemon completion recorded"),
+        "unexpected daemon completion summary: {}",
+        result.summary
+    );
+    let persisted = load_session(project, &session_id).unwrap();
+    assert_eq!(persisted.phase, SessionPhase::Active);
+    assert_eq!(persisted.termination_reason, None);
+    assert_eq!(fs::read_to_string(&state_path).unwrap(), original_state);
 }

--- a/justfile
+++ b/justfile
@@ -213,7 +213,11 @@ deny:
     # Hide the inclusion graph to keep duplicate-crate warnings bounded.
     # The full graph is useful interactively, but in AI-driven commit workflows
     # it can explode into gigabytes of output and crash ACP-backed tools.
-    cargo deny check --hide-inclusion-graph
+    deny_args="--hide-inclusion-graph"; \
+    if [ "${CARGO_DENY_DISABLE_FETCH:-}" = "1" ] || [ "${CARGO_DENY_OFFLINE:-}" = "1" ]; then \
+        deny_args="$deny_args --disable-fetch"; \
+    fi; \
+    cargo deny check $deny_args
 
 # ==============================================================================
 # 🧪 Testing

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.938"
-weave = "0.1.938"
+csa = "0.1.939"
+weave = "0.1.939"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- harden CSA review fallback verdict handling so terminal provider/tool failures stay fail-closed with concrete diagnostics
- preserve daemon completion `result.toml` when retiring active session state cannot be persisted
- add a supported no-fetch mode for local cargo-deny hook runs when advisory DB fetch is unavailable
- ignore fenced Markdown JSON fixtures when detecting live terminal stream errors

## Verification

- `cargo fmt --check`
- `cargo test -p cli-sub-agent review_cmd --locked`
- `cargo test -p cli-sub-agent daemon_completion --locked`
- `cargo test -p cli-sub-agent ensure_terminal_result_for_dead_active_session_removes_synthetic_result_on_save_failure --locked`
- `cargo test -p cli-sub-agent state_save_failure --locked`
- `cargo test -p cli-sub-agent rollback_does_not_delete_late_real_result --locked`
- `CARGO_DENY_DISABLE_FETCH=1 just pre-commit-fast`
- CSA tier-4 full-diff review: `01KTJCCN40YYE9R0P8XDW8QZFB` PASS/CLEAN for `range:main...HEAD` at `4aad8900`

Closes #1927
Closes #1930
Closes #1931
Closes #1934
Closes #1937
Closes #1941
